### PR TITLE
[ts2pant] Patch 3: Type-check over-each aggregate expressions

### DIFF
--- a/lib/check.ml
+++ b/lib/check.ml
@@ -27,6 +27,10 @@ type type_error =
       (** function name, context names *)
   | BoolParam of string * string * loc  (** param name, declaration name *)
   | ComprehensionNeedEach of ty * loc
+  | AggregateRequiresNumeric of string * ty * loc
+      (** combiner symbol, actual body type *)
+  | AggregateRequiresBool of string * ty * loc
+      (** combiner symbol, actual body type *)
 [@@deriving show]
 
 let type_warnings : type_error list ref = ref []
@@ -158,13 +162,26 @@ let rec infer_type ctx (expr : expr) : (ty, type_error) result =
       | CombAdd ->
           if is_numeric body_ty then
             Ok (match body_ty with TyNat -> TyNat0 | ty -> ty)
-          else Error (NotNumeric (body_ty, ctx.loc))
-      | CombMul | CombMin | CombMax ->
+          else Error (AggregateRequiresNumeric ("+", body_ty, ctx.loc))
+      | CombMul ->
           if is_numeric body_ty then Ok body_ty
-          else Error (NotNumeric (body_ty, ctx.loc))
+          else Error (AggregateRequiresNumeric ("*", body_ty, ctx.loc))
+      | CombMin | CombMax ->
+          if is_numeric body_ty then Ok body_ty
+          else
+            Error
+              (AggregateRequiresNumeric
+                 ( (match comb with CombMin -> "min" | _ -> "max"),
+                   body_ty,
+                   ctx.loc ))
       | CombAnd | CombOr ->
           if equal_ty body_ty TyBool then Ok TyBool
-          else Error (ExpectedBool (body_ty, ctx.loc)))
+          else
+            Error
+              (AggregateRequiresBool
+                 ( (match comb with CombAnd -> "and" | _ -> "or"),
+                   body_ty,
+                   ctx.loc )))
   | ECond arms ->
       let* _ =
         map_result

--- a/lib/error.ml
+++ b/lib/error.ml
@@ -76,6 +76,14 @@ let format_type_error err =
            "Body of 'all'/'some' must be Bool, got %s; use 'each' for \
             comprehensions"
            (Types.format_ty ty))
+  | AggregateRequiresNumeric (sym, ty, loc) ->
+      fmt loc
+        (Printf.sprintf "Aggregate combiner %s requires numeric body, got %s"
+           sym (Types.format_ty ty))
+  | AggregateRequiresBool (sym, ty, loc) ->
+      fmt loc
+        (Printf.sprintf "Aggregate combiner %s requires Bool body, got %s" sym
+           (Types.format_ty ty))
 
 (** Format a collection error with location prefix *)
 let format_collect_error err =

--- a/test/test_check.ml
+++ b/test/test_check.ml
@@ -999,11 +999,11 @@ active u: User => Bool.
 (+ over each u: User | active u) >= 0.
 |}
     (function
-    | Check.NotNumeric _ -> true
+    | Check.AggregateRequiresNumeric _ -> true
     | _ -> false)
 
 let test_combiner_bool_on_numeric_fails () =
-  (* and over each with Nat body → ExpectedBool *)
+  (* and over each with Nat body → AggregateRequiresBool *)
   check_error
     {|module TEST.
 
@@ -1013,7 +1013,7 @@ score u: User => Nat.
 and over each u: User | score u.
 |}
     (function
-    | Check.ExpectedBool _ -> true
+    | Check.AggregateRequiresBool _ -> true
     | _ -> false)
 
 (* --- Closure tests --- *)
@@ -1338,6 +1338,66 @@ items => [Item].
 all i: Nat | items i in Item.
 |}
 
+let test_over_each_add_numeric () =
+  check_ok
+    {|module TEST.
+
+Item.
+weight i: Item => Nat.
+---
+(+ over each i: Item | weight i) >= 0.
+|}
+
+let test_over_each_add_bool_fails () =
+  check_fails
+    {|module TEST.
+
+Item.
+active? i: Item => Bool.
+---
+(+ over each i: Item | active? i) >= 0.
+|}
+
+let test_over_each_and_bool () =
+  check_ok
+    {|module TEST.
+
+Item.
+valid? i: Item => Bool.
+---
+and over each i: Item | valid? i.
+|}
+
+let test_over_each_and_numeric_fails () =
+  check_fails
+    {|module TEST.
+
+Item.
+weight i: Item => Nat.
+---
+and over each i: Item | weight i.
+|}
+
+let test_over_each_min_nat () =
+  check_ok
+    {|module TEST.
+
+Item.
+weight i: Item => Nat.
+---
+(min over each i: Item | weight i) >= 0.
+|}
+
+let test_over_each_bare_unchanged () =
+  check_ok
+    {|module TEST.
+
+Item.
+weight i: Item => Nat.
+---
+#(each i: Item | weight i) >= 0.
+|}
+
 let () =
   run "Check"
     [
@@ -1502,5 +1562,21 @@ let () =
           test_case "chained comparison error" `Quick
             test_chained_comparison_error;
           test_case "list indexing nat" `Quick test_list_indexing_nat0;
+        ] );
+      ( "over-each typecheck",
+        [
+          test_case
+            "+ over each with numeric body should return same numeric type"
+            `Quick test_over_each_add_numeric;
+          test_case "+ over each with Bool body should be type error" `Quick
+            test_over_each_add_bool_fails;
+          test_case "and over each with Bool body should return Bool" `Quick
+            test_over_each_and_bool;
+          test_case "and over each with numeric body should be type error"
+            `Quick test_over_each_and_numeric_fails;
+          test_case "min over each with Nat body should return Nat" `Quick
+            test_over_each_min_nat;
+          test_case "bare each behavior unchanged" `Quick
+            test_over_each_bare_unchanged;
         ] );
     ]

--- a/test/test_check.ml
+++ b/test/test_check.ml
@@ -1568,9 +1568,8 @@ let () =
         ] );
       ( "over-each typecheck",
         [
-          test_case
-            "+ over each with Nat body should return Nat0"
-            `Quick test_over_each_add_numeric;
+          test_case "+ over each with Nat body should return Nat0" `Quick
+            test_over_each_add_numeric;
           test_case "+ over each with Bool body should be type error" `Quick
             test_over_each_add_bool_fails;
           test_case "and over each with Bool body should return Bool" `Quick

--- a/test/test_check.ml
+++ b/test/test_check.ml
@@ -1352,7 +1352,7 @@ check_nat0 (+ over each i: Item | weight i).
 |}
 
 let test_over_each_add_bool_fails () =
-  check_fails
+  check_error
     {|module TEST.
 
 Item.
@@ -1360,6 +1360,32 @@ active? i: Item => Bool.
 ---
 (+ over each i: Item | active? i) >= 0.
 |}
+    (function
+    | Check.AggregateRequiresNumeric ("+", _, _) -> true
+    | _ -> false)
+
+let test_over_each_mul_nat () =
+  check_ok
+    {|module TEST.
+
+Item.
+weight i: Item => Nat.
+---
+(* over each i: Item | weight i) >= 0.
+|}
+
+let test_over_each_mul_bool_fails () =
+  check_error
+    {|module TEST.
+
+Item.
+active? i: Item => Bool.
+---
+(* over each i: Item | active? i) >= 0.
+|}
+    (function
+    | Check.AggregateRequiresNumeric ("*", _, _) -> true
+    | _ -> false)
 
 let test_over_each_and_bool () =
   check_ok
@@ -1372,7 +1398,7 @@ and over each i: Item | valid? i.
 |}
 
 let test_over_each_and_numeric_fails () =
-  check_fails
+  check_error
     {|module TEST.
 
 Item.
@@ -1380,6 +1406,32 @@ weight i: Item => Nat.
 ---
 and over each i: Item | weight i.
 |}
+    (function
+    | Check.AggregateRequiresBool ("and", _, _) -> true
+    | _ -> false)
+
+let test_over_each_or_bool () =
+  check_ok
+    {|module TEST.
+
+Item.
+valid? i: Item => Bool.
+---
+or over each i: Item | valid? i.
+|}
+
+let test_over_each_or_numeric_fails () =
+  check_error
+    {|module TEST.
+
+Item.
+weight i: Item => Nat.
+---
+or over each i: Item | weight i.
+|}
+    (function
+    | Check.AggregateRequiresBool ("or", _, _) -> true
+    | _ -> false)
 
 let test_over_each_min_nat () =
   check_ok
@@ -1390,6 +1442,42 @@ weight i: Item => Nat.
 ---
 (min over each i: Item | weight i) >= 0.
 |}
+
+let test_over_each_max_nat () =
+  check_ok
+    {|module TEST.
+
+Item.
+weight i: Item => Nat.
+---
+(max over each i: Item | weight i) >= 0.
+|}
+
+let test_over_each_max_bool_fails () =
+  check_error
+    {|module TEST.
+
+Item.
+active? i: Item => Bool.
+---
+(max over each i: Item | active? i) >= 0.
+|}
+    (function
+    | Check.AggregateRequiresNumeric ("max", _, _) -> true
+    | _ -> false)
+
+let test_over_each_min_bool_fails () =
+  check_error
+    {|module TEST.
+
+Item.
+active? i: Item => Bool.
+---
+(min over each i: Item | active? i) >= 0.
+|}
+    (function
+    | Check.AggregateRequiresNumeric ("min", _, _) -> true
+    | _ -> false)
 
 let test_over_each_bare_unchanged () =
   check_ok
@@ -1572,12 +1660,25 @@ let () =
             test_over_each_add_numeric;
           test_case "+ over each with Bool body should be type error" `Quick
             test_over_each_add_bool_fails;
+          test_case "* over each with Nat body" `Quick test_over_each_mul_nat;
+          test_case "* over each with Bool body should be type error" `Quick
+            test_over_each_mul_bool_fails;
           test_case "and over each with Bool body should return Bool" `Quick
             test_over_each_and_bool;
           test_case "and over each with numeric body should be type error"
             `Quick test_over_each_and_numeric_fails;
+          test_case "or over each with Bool body should return Bool" `Quick
+            test_over_each_or_bool;
+          test_case "or over each with numeric body should be type error" `Quick
+            test_over_each_or_numeric_fails;
           test_case "min over each with Nat body should return Nat" `Quick
             test_over_each_min_nat;
+          test_case "max over each with Nat body should return Nat" `Quick
+            test_over_each_max_nat;
+          test_case "max over each with Bool body should be type error" `Quick
+            test_over_each_max_bool_fails;
+          test_case "min over each with Bool body should be type error" `Quick
+            test_over_each_min_bool_fails;
           test_case "bare each behavior unchanged" `Quick
             test_over_each_bare_unchanged;
         ] );

--- a/test/test_check.ml
+++ b/test/test_check.ml
@@ -1339,13 +1339,16 @@ all i: Nat | items i in Item.
 |}
 
 let test_over_each_add_numeric () =
+  (* + over each widens Nat to Nat0 (empty sum = 0).
+     Verify by passing the aggregate to a Nat0-typed parameter. *)
   check_ok
     {|module TEST.
 
 Item.
 weight i: Item => Nat.
+check_nat0 n: Nat0 => Bool.
 ---
-(+ over each i: Item | weight i) >= 0.
+check_nat0 (+ over each i: Item | weight i).
 |}
 
 let test_over_each_add_bool_fails () =
@@ -1566,7 +1569,7 @@ let () =
       ( "over-each typecheck",
         [
           test_case
-            "+ over each with numeric body should return same numeric type"
+            "+ over each with Nat body should return Nat0"
             `Quick test_over_each_add_numeric;
           test_case "+ over each with Bool body should be type error" `Quick
             test_over_each_add_bool_fails;


### PR DESCRIPTION
## Patch 3: Type-check over-each aggregate expressions

- In the EEach type-checking branch: when combiner is None, use existing logic (body type T, result [T])
- When combiner is Some CombAdd or CombMul: body must be numeric (Nat, Nat0, Int, or Real); result type = body type
- When combiner is Some CombMin or CombMax: body must be numeric; result type = body type
- When combiner is Some CombAnd or CombOr: body must be Bool; result type = Bool
- Add error messages: 'aggregate combiner + requires numeric body, got T' etc.
- Ensure existing each-without-combiner tests still pass

## Changes
- In the EEach type-checking branch: when combiner is None, use existing logic (body type T, result [T])
- When combiner is Some CombAdd or CombMul: body must be numeric (Nat, Nat0, Int, or Real); result type = body type
- When combiner is Some CombMin or CombMax: body must be numeric; result type = body type
- When combiner is Some CombAnd or CombOr: body must be Bool; result type = Bool
- Add error messages: 'aggregate combiner + requires numeric body, got T' etc.
- Ensure existing each-without-combiner tests still pass

## Gameplan Specification

```
module TS2PANT.

> ══════════════════════════════════════════
> AGGREGATE QUANTIFIERS
> ══════════════════════════════════════════
> Pantagruel's quantifier family is extended with
> arithmetic combiners: COMBINER over each GUARDS | BODY.

Combiner.
Type.
Expression.

comb-add => Combiner.
comb-mul => Combiner.
comb-and => Combiner.
comb-or => Combiner.
comb-min => Combiner.
comb-max => Combiner.

has-over? e: Expression => Bool.
body-type e: Expression => Type.
result-type e: Expression => Type.
numeric? t: Type => Bool.
bool => Type.

---

> Arithmetic combiners require numeric body; result type = body type.
all e: Expression, has-over? e, numeric? (body-type e) |
  result-type e = body-type e.

where

> ══════════════════════════════════════════
> TRANSLATION PIPELINE
> ══════════════════════════════════════════
> Given a TypeScript function and its participating types,
> ts2pant produces a checkable Pantagruel document.

TSFunction.
TSType.
PantDocument.
PantDeclaration.
PantProposition.
Annotation.
CheckResult.

> Extraction: every referenced TS type becomes declarations.
referenced-types f: TSFunction => [TSType].
translated-types t: TSType => [PantDeclaration].

> Classification: pure functions -> rules, mutating -> actions.
pure? f: TSFunction => Bool.
mutating? f: TSFunction => Bool.

> Translation: function -> declaration + propositions.
translated-sig f: TSFunction => PantDeclaration.
translated-body f: TSFunction => [PantProposition].

> Annotations: user-provided assertions.
annotations f: TSFunction => [Annotation].

> Assembly: combined document.
generated-doc f: TSFunction => PantDocument.
check-result f: TSFunction => CheckResult.
passed? r: CheckResult => Bool.

---

> Every function is either pure or mutating.
all f: TSFunction | pure? f or mutating? f.
~(some f: TSFunction | pure? f and mutating? f).

> Every referenced type produces at least one declaration.
all t: TSType | #(translated-types t) >= 1.

> Every function with annotations produces a checkable document.
all f: TSFunction, #(annotations f) > 0 |
  generated-doc f in PantDocument.

```

## Patch Specification

```
module TS2PANT_PATCH_3.

> Type checking rules for aggregate quantifiers.

Combiner.
Type.

numeric? t: Type => Bool.

comb-add => Combiner.
comb-mul => Combiner.
comb-and => Combiner.
comb-or => Combiner.
comb-min => Combiner.
comb-max => Combiner.

bool => Type.

body-type c: Combiner => Type.
result-type c: Combiner, t: Type => Type.
requires-numeric? c: Combiner => Bool.
requires-bool? c: Combiner => Bool.

---

> Arithmetic combiners require numeric body.
all c: Combiner, requires-numeric? c |
  cond numeric? (body-type c) => result-type c (body-type c) = body-type c,
  true => false.

> Logical combiners require Bool body.
all c: Combiner, requires-bool? c |
  body-type c = bool.

requires-numeric? comb-add.
requires-numeric? comb-mul.
requires-numeric? comb-min.
requires-numeric? comb-max.
requires-bool? comb-and.
requires-bool? comb-or.

```

## Files to Modify
- lib/check.ml (modify): Add type checking logic for aggregate combiners


## Implementation Notes

- Added two new error variants (`AggregateRequiresNumeric`, `AggregateRequiresBool`) rather than reusing `NotNumeric`/`ExpectedBool`, so error messages include the combiner symbol (e.g., "aggregate combiner + requires numeric body, got Bool") — more actionable for users
- Grouped `CombAdd|CombMul` and `CombMin|CombMax` into shared numeric-checking arms since they have identical type rules; same for `CombAnd|CombOr` on the Bool side
- The combiner match is nested inside the `EEach` arm after `check_quantifier` returns `body_ty`, so parameter binding and guard checking are shared with bare `each` — no duplication of quantifier infrastructure
- Existing `is_numeric` from `Types` covers the full hierarchy (Nat, Nat0, Int, Real) without needing changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved aggregate operation error messages to clearly state which combiner (e.g., +, *, min/max, and/or) requires a numeric or boolean body and show the offending type.
* **Tests**
  * Added comprehensive "over-each" type-check tests covering numeric vs boolean body expectations and ensuring unchanged bare-each behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->