### PR TITLE
[ts2pant] Patch 4: SMT encoding for over-each aggregates

### DIFF
--- a/test/test_smt.ml
+++ b/test/test_smt.ml
@@ -2096,8 +2096,8 @@ let test_aggregate_empty_domain () =
   (* Domain with bound=0 should return identity element *)
   let env = make_aggregate_env () in
   let zero_config =
-    Smt.make_config ~bound:0 ~steps:0
-      ~domain_bounds:Env.StringMap.empty ~inject_guards:true
+    Smt.make_config ~bound:0 ~steps:0 ~domain_bounds:Env.StringMap.empty
+      ~inject_guards:true
   in
   let expr =
     Ast.EEach
@@ -2112,8 +2112,8 @@ let test_aggregate_empty_domain () =
 let test_aggregate_empty_domain_mul () =
   let env = make_aggregate_env () in
   let zero_config =
-    Smt.make_config ~bound:0 ~steps:0
-      ~domain_bounds:Env.StringMap.empty ~inject_guards:true
+    Smt.make_config ~bound:0 ~steps:0 ~domain_bounds:Env.StringMap.empty
+      ~inject_guards:true
   in
   let expr =
     Ast.EEach
@@ -2128,8 +2128,8 @@ let test_aggregate_empty_domain_mul () =
 let test_aggregate_empty_domain_and () =
   let env = make_aggregate_env () in
   let zero_config =
-    Smt.make_config ~bound:0 ~steps:0
-      ~domain_bounds:Env.StringMap.empty ~inject_guards:true
+    Smt.make_config ~bound:0 ~steps:0 ~domain_bounds:Env.StringMap.empty
+      ~inject_guards:true
   in
   let expr =
     Ast.EEach
@@ -2144,8 +2144,8 @@ let test_aggregate_empty_domain_and () =
 let test_aggregate_empty_domain_or () =
   let env = make_aggregate_env () in
   let zero_config =
-    Smt.make_config ~bound:0 ~steps:0
-      ~domain_bounds:Env.StringMap.empty ~inject_guards:true
+    Smt.make_config ~bound:0 ~steps:0 ~domain_bounds:Env.StringMap.empty
+      ~inject_guards:true
   in
   let expr =
     Ast.EEach
@@ -2161,8 +2161,8 @@ let test_aggregate_empty_domain_min () =
   (* min/max have no identity element; empty domain should raise *)
   let env = make_aggregate_env () in
   let zero_config =
-    Smt.make_config ~bound:0 ~steps:0
-      ~domain_bounds:Env.StringMap.empty ~inject_guards:true
+    Smt.make_config ~bound:0 ~steps:0 ~domain_bounds:Env.StringMap.empty
+      ~inject_guards:true
   in
   let expr =
     Ast.EEach
@@ -2171,14 +2171,15 @@ let test_aggregate_empty_domain_min () =
         Some CombMin,
         EApp (EVar "price", [ EVar "i" ]) )
   in
-  check_raises "empty domain min raises" (Failure "SMT: min/max over empty domain")
-    (fun () -> ignore (Smt.translate_expr zero_config env expr))
+  check_raises "empty domain min raises"
+    (Failure "SMT: min/max over empty domain") (fun () ->
+      ignore (Smt.translate_expr zero_config env expr))
 
 let test_aggregate_empty_domain_max () =
   let env = make_aggregate_env () in
   let zero_config =
-    Smt.make_config ~bound:0 ~steps:0
-      ~domain_bounds:Env.StringMap.empty ~inject_guards:true
+    Smt.make_config ~bound:0 ~steps:0 ~domain_bounds:Env.StringMap.empty
+      ~inject_guards:true
   in
   let expr =
     Ast.EEach
@@ -2187,8 +2188,9 @@ let test_aggregate_empty_domain_max () =
         Some CombMax,
         EApp (EVar "price", [ EVar "i" ]) )
   in
-  check_raises "empty domain max raises" (Failure "SMT: min/max over empty domain")
-    (fun () -> ignore (Smt.translate_expr zero_config env expr))
+  check_raises "empty domain max raises"
+    (Failure "SMT: min/max over empty domain") (fun () ->
+      ignore (Smt.translate_expr zero_config env expr))
 
 let test_aggregate_integration () =
   (* Full integration test: parse, collect, type-check, then generate SMT *)

--- a/test/test_smt.ml
+++ b/test/test_smt.ml
@@ -1970,7 +1970,7 @@ let make_aggregate_env () =
        (Types.TyFunc ([ Types.TyDomain "Item" ], Some Types.TyBool))
        Ast.dummy_loc ~chapter:0
 
-let test_aggregate_add () =
+let test_aggregate_add_item () =
   let env = make_aggregate_env () in
   let expr =
     Ast.EEach
@@ -2012,7 +2012,7 @@ let test_aggregate_mul () =
   let result = Smt.translate_expr config env expr in
   check bool "uses *" true (contains result "(*")
 
-let test_aggregate_and () =
+let test_aggregate_and_item () =
   let env = make_aggregate_env () in
   let expr =
     Ast.EEach
@@ -2023,6 +2023,36 @@ let test_aggregate_and () =
   in
   let result = Smt.translate_expr config env expr in
   check bool "uses and" true (contains result "(and")
+
+let test_aggregate_and_guarded () =
+  let env = make_aggregate_env () in
+  let expr =
+    Ast.EEach
+      ( [ { param_name = "i"; param_type = TName "Item" } ],
+        [ GExpr (EApp (EVar "available?", [ EVar "i" ])) ],
+        Some CombAnd,
+        EApp (EVar "available?", [ EVar "i" ]) )
+  in
+  let result = Smt.translate_expr config env expr in
+  check bool "uses and" true (contains result "(and");
+  check bool "uses ite" true (contains result "(ite");
+  (* Guarded-out elements contribute true (identity for and) *)
+  check bool "identity true" true (contains result " true)")
+
+let test_aggregate_or_guarded () =
+  let env = make_aggregate_env () in
+  let expr =
+    Ast.EEach
+      ( [ { param_name = "i"; param_type = TName "Item" } ],
+        [ GExpr (EApp (EVar "available?", [ EVar "i" ])) ],
+        Some CombOr,
+        EApp (EVar "available?", [ EVar "i" ]) )
+  in
+  let result = Smt.translate_expr config env expr in
+  check bool "uses or" true (contains result "(or");
+  check bool "uses ite" true (contains result "(ite");
+  (* Guarded-out elements contribute false (identity for or) *)
+  check bool "identity false" true (contains result " false)")
 
 let test_aggregate_or () =
   let env = make_aggregate_env () in
@@ -2127,6 +2157,39 @@ let test_aggregate_empty_domain_or () =
   let result = Smt.translate_expr zero_config env expr in
   check string "empty domain returns false" "false" result
 
+let test_aggregate_empty_domain_min () =
+  (* min/max have no identity element; empty domain should raise *)
+  let env = make_aggregate_env () in
+  let zero_config =
+    Smt.make_config ~bound:0 ~steps:0
+      ~domain_bounds:Env.StringMap.empty ~inject_guards:true
+  in
+  let expr =
+    Ast.EEach
+      ( [ { param_name = "i"; param_type = TName "Item" } ],
+        [],
+        Some CombMin,
+        EApp (EVar "price", [ EVar "i" ]) )
+  in
+  check_raises "empty domain min raises" (Failure "SMT: min/max over empty domain")
+    (fun () -> ignore (Smt.translate_expr zero_config env expr))
+
+let test_aggregate_empty_domain_max () =
+  let env = make_aggregate_env () in
+  let zero_config =
+    Smt.make_config ~bound:0 ~steps:0
+      ~domain_bounds:Env.StringMap.empty ~inject_guards:true
+  in
+  let expr =
+    Ast.EEach
+      ( [ { param_name = "i"; param_type = TName "Item" } ],
+        [],
+        Some CombMax,
+        EApp (EVar "price", [ EVar "i" ]) )
+  in
+  check_raises "empty domain max raises" (Failure "SMT: min/max over empty domain")
+    (fun () -> ignore (Smt.translate_expr zero_config env expr))
+
 let test_aggregate_integration () =
   (* Full integration test: parse, collect, type-check, then generate SMT *)
   let env, doc =
@@ -2154,17 +2217,21 @@ let test_aggregate_integration () =
 
 let aggregate_tests =
   [
-    test_case "add combiner" `Quick test_aggregate_add;
+    test_case "add combiner" `Quick test_aggregate_add_item;
     test_case "add guarded" `Quick test_aggregate_add_guarded;
     test_case "mul combiner" `Quick test_aggregate_mul;
-    test_case "and combiner" `Quick test_aggregate_and;
+    test_case "and combiner" `Quick test_aggregate_and_item;
+    test_case "and guarded" `Quick test_aggregate_and_guarded;
     test_case "or combiner" `Quick test_aggregate_or;
+    test_case "or guarded" `Quick test_aggregate_or_guarded;
     test_case "min combiner" `Quick test_aggregate_min;
     test_case "max combiner" `Quick test_aggregate_max;
     test_case "empty domain add" `Quick test_aggregate_empty_domain;
     test_case "empty domain mul" `Quick test_aggregate_empty_domain_mul;
     test_case "empty domain and" `Quick test_aggregate_empty_domain_and;
     test_case "empty domain or" `Quick test_aggregate_empty_domain_or;
+    test_case "empty domain min" `Quick test_aggregate_empty_domain_min;
+    test_case "empty domain max" `Quick test_aggregate_empty_domain_max;
     test_case "integration" `Quick test_aggregate_integration;
   ]
 

--- a/test/test_smt.ml
+++ b/test/test_smt.ml
@@ -1955,6 +1955,219 @@ let bug_finding_tests =
     test_case "domain closure bound=1" `Quick test_domain_closure_bound_one;
   ]
 
+(* --- Aggregate (over-each) tests --- *)
+
+let make_aggregate_env () =
+  Env.empty ""
+  |> Env.add_domain "Item" Ast.dummy_loc ~chapter:0
+  |> Env.add_rule "price"
+       (Types.TyFunc ([ Types.TyDomain "Item" ], Some Types.TyNat))
+       Ast.dummy_loc ~chapter:0
+  |> Env.add_rule "weight"
+       (Types.TyFunc ([ Types.TyDomain "Item" ], Some Types.TyInt))
+       Ast.dummy_loc ~chapter:0
+  |> Env.add_rule "available?"
+       (Types.TyFunc ([ Types.TyDomain "Item" ], Some Types.TyBool))
+       Ast.dummy_loc ~chapter:0
+
+let test_aggregate_add () =
+  let env = make_aggregate_env () in
+  let expr =
+    Ast.EEach
+      ( [ { param_name = "i"; param_type = TName "Item" } ],
+        [],
+        Some CombAdd,
+        EApp (EVar "price", [ EVar "i" ]) )
+  in
+  let result = Smt.translate_expr config env expr in
+  check bool "uses +" true (contains result "(+");
+  check bool "has price Item_0" true (contains result "(price Item_0)");
+  check bool "has price Item_1" true (contains result "(price Item_1)");
+  check bool "has price Item_2" true (contains result "(price Item_2)")
+
+let test_aggregate_add_guarded () =
+  let env = make_aggregate_env () in
+  let expr =
+    Ast.EEach
+      ( [ { param_name = "i"; param_type = TName "Item" } ],
+        [ GExpr (EApp (EVar "available?", [ EVar "i" ])) ],
+        Some CombAdd,
+        EApp (EVar "price", [ EVar "i" ]) )
+  in
+  let result = Smt.translate_expr config env expr in
+  check bool "uses +" true (contains result "(+");
+  check bool "uses ite" true (contains result "(ite");
+  (* Guarded-out elements contribute 0 *)
+  check bool "identity 0" true (contains result " 0)")
+
+let test_aggregate_mul () =
+  let env = make_aggregate_env () in
+  let expr =
+    Ast.EEach
+      ( [ { param_name = "i"; param_type = TName "Item" } ],
+        [],
+        Some CombMul,
+        EApp (EVar "price", [ EVar "i" ]) )
+  in
+  let result = Smt.translate_expr config env expr in
+  check bool "uses *" true (contains result "(*")
+
+let test_aggregate_and () =
+  let env = make_aggregate_env () in
+  let expr =
+    Ast.EEach
+      ( [ { param_name = "i"; param_type = TName "Item" } ],
+        [],
+        Some CombAnd,
+        EApp (EVar "available?", [ EVar "i" ]) )
+  in
+  let result = Smt.translate_expr config env expr in
+  check bool "uses and" true (contains result "(and")
+
+let test_aggregate_or () =
+  let env = make_aggregate_env () in
+  let expr =
+    Ast.EEach
+      ( [ { param_name = "i"; param_type = TName "Item" } ],
+        [],
+        Some CombOr,
+        EApp (EVar "available?", [ EVar "i" ]) )
+  in
+  let result = Smt.translate_expr config env expr in
+  check bool "uses or" true (contains result "(or")
+
+let test_aggregate_min () =
+  let env = make_aggregate_env () in
+  let expr =
+    Ast.EEach
+      ( [ { param_name = "i"; param_type = TName "Item" } ],
+        [],
+        Some CombMin,
+        EApp (EVar "price", [ EVar "i" ]) )
+  in
+  let result = Smt.translate_expr config env expr in
+  check bool "uses <" true (contains result "(<");
+  check bool "uses ite" true (contains result "(ite")
+
+let test_aggregate_max () =
+  let env = make_aggregate_env () in
+  let expr =
+    Ast.EEach
+      ( [ { param_name = "i"; param_type = TName "Item" } ],
+        [],
+        Some CombMax,
+        EApp (EVar "price", [ EVar "i" ]) )
+  in
+  let result = Smt.translate_expr config env expr in
+  check bool "uses >" true (contains result "(>");
+  check bool "uses ite" true (contains result "(ite")
+
+let test_aggregate_empty_domain () =
+  (* Domain with bound=0 should return identity element *)
+  let env = make_aggregate_env () in
+  let zero_config =
+    Smt.make_config ~bound:0 ~steps:0
+      ~domain_bounds:Env.StringMap.empty ~inject_guards:true
+  in
+  let expr =
+    Ast.EEach
+      ( [ { param_name = "i"; param_type = TName "Item" } ],
+        [],
+        Some CombAdd,
+        EApp (EVar "price", [ EVar "i" ]) )
+  in
+  let result = Smt.translate_expr zero_config env expr in
+  check string "empty domain returns 0" "0" result
+
+let test_aggregate_empty_domain_mul () =
+  let env = make_aggregate_env () in
+  let zero_config =
+    Smt.make_config ~bound:0 ~steps:0
+      ~domain_bounds:Env.StringMap.empty ~inject_guards:true
+  in
+  let expr =
+    Ast.EEach
+      ( [ { param_name = "i"; param_type = TName "Item" } ],
+        [],
+        Some CombMul,
+        EApp (EVar "price", [ EVar "i" ]) )
+  in
+  let result = Smt.translate_expr zero_config env expr in
+  check string "empty domain returns 1" "1" result
+
+let test_aggregate_empty_domain_and () =
+  let env = make_aggregate_env () in
+  let zero_config =
+    Smt.make_config ~bound:0 ~steps:0
+      ~domain_bounds:Env.StringMap.empty ~inject_guards:true
+  in
+  let expr =
+    Ast.EEach
+      ( [ { param_name = "i"; param_type = TName "Item" } ],
+        [],
+        Some CombAnd,
+        EApp (EVar "available?", [ EVar "i" ]) )
+  in
+  let result = Smt.translate_expr zero_config env expr in
+  check string "empty domain returns true" "true" result
+
+let test_aggregate_empty_domain_or () =
+  let env = make_aggregate_env () in
+  let zero_config =
+    Smt.make_config ~bound:0 ~steps:0
+      ~domain_bounds:Env.StringMap.empty ~inject_guards:true
+  in
+  let expr =
+    Ast.EEach
+      ( [ { param_name = "i"; param_type = TName "Item" } ],
+        [],
+        Some CombOr,
+        EApp (EVar "available?", [ EVar "i" ]) )
+  in
+  let result = Smt.translate_expr zero_config env expr in
+  check string "empty domain returns false" "false" result
+
+let test_aggregate_integration () =
+  (* Full integration test: parse, collect, type-check, then generate SMT *)
+  let env, doc =
+    parse_and_collect
+      "module Test.\n\
+       Item.\n\
+       price i: Item => Nat.\n\
+       available? i: Item => Bool.\n\
+       ---\n\
+       and over each i: Item | available? i.\n"
+  in
+  let small_config =
+    Smt.make_config ~bound:2 ~steps:0 ~domain_bounds:Env.StringMap.empty
+      ~inject_guards:true
+  in
+  let queries = Smt.generate_queries small_config env doc in
+  let inv =
+    List.find (fun (q : Smt.query) -> q.kind = Smt.InvariantConsistency) queries
+  in
+  check bool "has and combiner" true (contains inv.smt2 "(and");
+  check bool "has availablep Item_0" true
+    (contains inv.smt2 "(availablep Item_0)");
+  check bool "has availablep Item_1" true
+    (contains inv.smt2 "(availablep Item_1)")
+
+let aggregate_tests =
+  [
+    test_case "add combiner" `Quick test_aggregate_add;
+    test_case "add guarded" `Quick test_aggregate_add_guarded;
+    test_case "mul combiner" `Quick test_aggregate_mul;
+    test_case "and combiner" `Quick test_aggregate_and;
+    test_case "or combiner" `Quick test_aggregate_or;
+    test_case "min combiner" `Quick test_aggregate_min;
+    test_case "max combiner" `Quick test_aggregate_max;
+    test_case "empty domain add" `Quick test_aggregate_empty_domain;
+    test_case "empty domain mul" `Quick test_aggregate_empty_domain_mul;
+    test_case "empty domain and" `Quick test_aggregate_empty_domain_and;
+    test_case "empty domain or" `Quick test_aggregate_empty_domain_or;
+    test_case "integration" `Quick test_aggregate_integration;
+  ]
+
 let () =
   run "SMT"
     [
@@ -1971,4 +2184,5 @@ let () =
       ("guard_injection", guard_injection_tests);
       ("cond", cond_tests);
       ("bug_finding", bug_finding_tests);
+      ("aggregates", aggregate_tests);
     ]


### PR DESCRIPTION
## Patch 4: SMT encoding for over-each aggregates

- Add translate_aggregate function: expand comprehension over domain elements (reusing expand_comprehension), then combine with SMT operation
- For CombAdd: combine expanded values with (+ v0 v1 ... vN), applying guards via ite (guarded ? value : 0)
- For CombMul: combine with (* ...), identity 1
- For CombMin: combine with nested (ite (< a b) a b), or use SMT theory min if available
- For CombMax: combine with nested (ite (> a b) a b)
- For CombAnd: combine with (and ...) — note this should produce same result as translate_quantifier forall
- For CombOr: combine with (or ...) — same as exists
- In translate_expr EEach branch: dispatch to translate_aggregate when combiner is Some
- Handle empty domain case: return identity element for the combiner
- Add SMT tests: generate queries for simple aggregate expressions and verify they produce expected SMT-LIB2

## Changes
- Add translate_aggregate function: expand comprehension over domain elements (reusing expand_comprehension), then combine with SMT operation
- For CombAdd: combine expanded values with (+ v0 v1 ... vN), applying guards via ite (guarded ? value : 0)
- For CombMul: combine with (* ...), identity 1
- For CombMin: combine with nested (ite (< a b) a b), or use SMT theory min if available
- For CombMax: combine with nested (ite (> a b) a b)
- For CombAnd: combine with (and ...) — note this should produce same result as translate_quantifier forall
- For CombOr: combine with (or ...) — same as exists
- In translate_expr EEach branch: dispatch to translate_aggregate when combiner is Some
- Handle empty domain case: return identity element for the combiner
- Add SMT tests: generate queries for simple aggregate expressions and verify they produce expected SMT-LIB2

## Gameplan Specification

```
module TS2PANT.

> ══════════════════════════════════════════
> AGGREGATE QUANTIFIERS
> ══════════════════════════════════════════
> Pantagruel's quantifier family is extended with
> arithmetic combiners: COMBINER over each GUARDS | BODY.

Combiner.
Type.
Expression.

comb-add => Combiner.
comb-mul => Combiner.
comb-and => Combiner.
comb-or => Combiner.
comb-min => Combiner.
comb-max => Combiner.

has-over? e: Expression => Bool.
body-type e: Expression => Type.
result-type e: Expression => Type.
numeric? t: Type => Bool.
bool => Type.

---

> Arithmetic combiners require numeric body; result type = body type.
all e: Expression, has-over? e, numeric? (body-type e) |
  result-type e = body-type e.

where

> ══════════════════════════════════════════
> TRANSLATION PIPELINE
> ══════════════════════════════════════════
> Given a TypeScript function and its participating types,
> ts2pant produces a checkable Pantagruel document.

TSFunction.
TSType.
PantDocument.
PantDeclaration.
PantProposition.
Annotation.
CheckResult.

> Extraction: every referenced TS type becomes declarations.
referenced-types f: TSFunction => [TSType].
translated-types t: TSType => [PantDeclaration].

> Classification: pure functions -> rules, mutating -> actions.
pure? f: TSFunction => Bool.
mutating? f: TSFunction => Bool.

> Translation: function -> declaration + propositions.
translated-sig f: TSFunction => PantDeclaration.
translated-body f: TSFunction => [PantProposition].

> Annotations: user-provided assertions.
annotations f: TSFunction => [Annotation].

> Assembly: combined document.
generated-doc f: TSFunction => PantDocument.
check-result f: TSFunction => CheckResult.
passed? r: CheckResult => Bool.

---

> Every function is either pure or mutating.
all f: TSFunction | pure? f or mutating? f.
~(some f: TSFunction | pure? f and mutating? f).

> Every referenced type produces at least one declaration.
all t: TSType | #(translated-types t) >= 1.

> Every function with annotations produces a checkable document.
all f: TSFunction, #(annotations f) > 0 |
  generated-doc f in PantDocument.

```

## Patch Specification

```
module TS2PANT_PATCH_4.

> SMT encoding: aggregates expand over finite domain elements.

DomainElement.
Combiner.

elements d: DomainElement => [DomainElement].

> The SMT encoding of an aggregate over a domain with N elements
> produces a combination of N values (one per element, guarded by
> the element's guard condition).

---

> For + combiner, unguarded elements contribute their value;
> guarded-out elements contribute the identity (0).
> Result: (+ (ite g0 v0 0) (ite g1 v1 0) ... (ite gN vN 0))
true.

```

## Files to Modify
- lib/smt.ml (modify): Implement SMT translation for aggregate quantifiers
- test/test_smt.ml (modify): Add SMT generation tests for over-each


## Implementation Notes

- Guard encoding differs by combiner type: arithmetic combiners (`+`, `*`) use `ite` with identity fallback (0 or 1); boolean combiners use implication (`=>`) for `and` and conjunction for `or`, which is logically equivalent to the `ite` approach but produces cleaner SMT
- Min/max have special handling for guards: instead of an identity fallback (there's no useful identity for min/max over an arbitrary domain), guarded elements are conditionally excluded from the nested comparison chain via `ite` on the guard
- Min/max don't use SMT theory functions — they fold into nested `(ite (< a b) a b)` chains, which is sufficient for bounded model checking with small domain sizes
- The integration test uses `and over each` rather than `+ over each` because the grammar's precedence rules make `total = + over each ...` unparseable (the `+` after `=` is captured by the arithmetic `term` production before the `quantified` production can match). This is a grammar limitation, not an SMT encoding issue — users would write the aggregate at expression-top-level or parenthesized
- 12 tests total: one per combiner (6), guarded add, empty domain identity for add/mul/and/or (4), and one end-to-end parse-to-SMT integration test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for aggregate operations with multiple combiner types (addition, multiplication, logical operations, and min/max comparisons).
  * Included tests for empty domain identity validation and SMT translation verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->