### PR TITLE
[ts2pant] Patch 8: Translate function signatures to rules or actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
         run: |
           opam install . --deps-only --with-test --with-doc
           opam install ocamlformat.0.28.1
-          opam install crowbar
 
       - name: Build
         run: opam exec -- dune build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
         run: |
           opam install . --deps-only --with-test --with-doc
           opam install ocamlformat.0.28.1
+          opam install crowbar
 
       - name: Build
         run: opam exec -- dune build

--- a/dune-project
+++ b/dune-project
@@ -19,4 +19,5 @@
   sexplib0
   parsexp
   (alcotest :with-test)
-  (qcheck-alcotest :with-test)))
+  (qcheck-alcotest :with-test)
+  (crowbar :with-test)))

--- a/pantagruel.opam
+++ b/pantagruel.opam
@@ -13,6 +13,7 @@ depends: [
   "parsexp"
   "alcotest" {with-test}
   "qcheck-alcotest" {with-test}
+  "crowbar" {with-test}
   "odoc" {with-doc}
 ]
 build: [

--- a/tools/ts2pant/src/index.ts
+++ b/tools/ts2pant/src/index.ts
@@ -60,7 +60,8 @@ function emit(doc: PantDocument): string {
         break;
       case "rule": {
         const params = decl.params.map((p) => `${p.name}: ${p.type}`).join(", ");
-        lines.push(`${decl.name} ${params} => ${decl.returnType}.`);
+        const guard = decl.guard ? `, ${decl.guard}` : "";
+        lines.push(`${decl.name} ${params}${guard} => ${decl.returnType}.`);
         break;
       }
       case "action": {
@@ -68,7 +69,8 @@ function emit(doc: PantDocument): string {
           lines.push(`~> ${decl.label}.`);
         } else {
           const params = decl.params.map((p) => `${p.name}: ${p.type}`).join(", ");
-          lines.push(`~> ${decl.label} @ ${params}.`);
+          const guard = decl.guard ? `, ${decl.guard}` : "";
+          lines.push(`~> ${decl.label} @ ${params}${guard}.`);
         }
         break;
       }

--- a/tools/ts2pant/src/translate-signature.ts
+++ b/tools/ts2pant/src/translate-signature.ts
@@ -172,7 +172,7 @@ function translateExpr(
 
   // Parenthesized
   if (ts.isParenthesizedExpression(expr)) {
-    return translateExpr(expr.expression, checker, strategy, paramNames);
+    return `(${translateExpr(expr.expression, checker, strategy, paramNames)})`;
   }
 
   // `this` keyword
@@ -225,6 +225,8 @@ function translateOperator(kind: ts.SyntaxKind): string {
       return "-";
     case ts.SyntaxKind.AsteriskToken:
       return "*";
+    case ts.SyntaxKind.SlashToken:
+      return "/";
     default:
       return "?";
   }
@@ -234,8 +236,14 @@ function capitalize(s: string): string {
   return s.charAt(0).toUpperCase() + s.slice(1);
 }
 
-function shortParamName(typeName: string): string {
-  return typeName[0].toLowerCase();
+function shortParamName(typeName: string, existingNames: Set<string>): string {
+  let name = typeName[0].toLowerCase();
+  let suffix = 1;
+  while (existingNames.has(name)) {
+    name = typeName[0].toLowerCase() + suffix;
+    suffix++;
+  }
+  return name;
 }
 
 /**
@@ -258,7 +266,8 @@ export function translateSignature(
   const paramNameMap = new Map<string, string>();
 
   if (className) {
-    const pName = shortParamName(className);
+    const existingParamNames = new Set(sig.getParameters().map((p) => p.name));
+    const pName = shortParamName(className, existingParamNames);
     params.push({ name: pName, type: className });
     paramNameMap.set("this", pName);
   }

--- a/tools/ts2pant/src/translate-signature.ts
+++ b/tools/ts2pant/src/translate-signature.ts
@@ -163,10 +163,13 @@ function translateExpr(
     return `${left} ${op} ${right}`;
   }
 
-  // Prefix unary: !x -> ~x
+  // Prefix unary: !x -> ~x, -x -> -x
   if (ts.isPrefixUnaryExpression(expr)) {
     if (expr.operator === ts.SyntaxKind.ExclamationToken) {
       return `~(${translateExpr(expr.operand, checker, strategy, paramNames)})`;
+    }
+    if (expr.operator === ts.SyntaxKind.MinusToken) {
+      return `-${translateExpr(expr.operand, checker, strategy, paramNames)}`;
     }
   }
 

--- a/tools/ts2pant/src/translate-signature.ts
+++ b/tools/ts2pant/src/translate-signature.ts
@@ -56,7 +56,7 @@ export function classifyFunction(
   checker: ts.TypeChecker,
 ): Classification {
   const sig = checker.getSignatureFromDeclaration(node);
-  if (!sig) return "pure";
+  if (!sig) throw new Error("Cannot get signature for classification");
 
   const returnType = sig.getReturnType();
   if (returnType.flags & ts.TypeFlags.Void) return "mutating";
@@ -195,7 +195,7 @@ function translateExpr(
 
   // String literal
   if (ts.isStringLiteral(expr)) {
-    return `"${expr.text.replace(/"/g, '\\"')}"`;
+    return `"${expr.text.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
   }
 
   // Fallback

--- a/tools/ts2pant/src/translate-signature.ts
+++ b/tools/ts2pant/src/translate-signature.ts
@@ -21,10 +21,15 @@ export function findFunction(
   const sourceFile = program.getSourceFile(fileName);
   if (!sourceFile) throw new Error(`Source file not found: ${fileName}`);
 
+  let match:
+    | { node: ts.FunctionDeclaration | ts.MethodDeclaration; className?: string }
+    | undefined;
+
   // Search top-level functions
   for (const stmt of sourceFile.statements) {
     if (ts.isFunctionDeclaration(stmt) && stmt.name?.text === functionName) {
-      return { node: stmt };
+      if (stmt.body) return { node: stmt };
+      match ??= { node: stmt };
     }
   }
 
@@ -37,12 +42,14 @@ export function findFunction(
           ts.isIdentifier(member.name) &&
           member.name.text === functionName
         ) {
-          return { node: member, className: stmt.name.text };
+          if (member.body) return { node: member, className: stmt.name.text };
+          match ??= { node: member, className: stmt.name.text };
         }
       }
     }
   }
 
+  if (match) return match;
   throw new Error(`Function not found: ${functionName}`);
 }
 
@@ -70,6 +77,9 @@ function hasPropertyAssignment(node: ts.Node): boolean {
   let found = false;
   function visit(n: ts.Node) {
     if (found) return;
+    // Don't recurse into nested functions or classes
+    if (ts.isFunctionLike(n) && n !== node) return;
+    if (ts.isClassDeclaration(n) || ts.isClassExpression(n)) return;
     if (
       ts.isBinaryExpression(n) &&
       n.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
@@ -99,7 +109,8 @@ export function detectGuard(
   if (!node.body) return undefined;
 
   for (const stmt of node.body.statements) {
-    if (!ts.isIfStatement(stmt)) continue;
+    // Only extract guards from leading precondition checks
+    if (!ts.isIfStatement(stmt)) break;
 
     // Pattern 1: if (cond) { ... } else { throw }
     if (stmt.elseStatement && blockThrows(stmt.elseStatement)) {
@@ -127,6 +138,9 @@ export function detectGuard(
       // Otherwise negate the whole expression
       return `~(${translateExpr(stmt.expression, checker, strategy, paramNames)})`;
     }
+
+    // If it's an if-statement but doesn't match a guard pattern, stop scanning
+    break;
   }
 
   return undefined;

--- a/tools/ts2pant/src/translate-signature.ts
+++ b/tools/ts2pant/src/translate-signature.ts
@@ -195,7 +195,7 @@ function translateExpr(
 
   // String literal
   if (ts.isStringLiteral(expr)) {
-    return `"${expr.text}"`;
+    return `"${expr.text.replace(/"/g, '\\"')}"`;
   }
 
   // Fallback

--- a/tools/ts2pant/src/translate-signature.ts
+++ b/tools/ts2pant/src/translate-signature.ts
@@ -1,0 +1,297 @@
+import ts from "typescript";
+import type { PantRule, PantAction, PantDeclaration } from "./types.js";
+import { mapTsType, type NumericStrategy } from "./translate-types.js";
+
+export type Classification = "pure" | "mutating";
+
+export interface TranslatedSignature {
+  declaration: PantDeclaration;
+  classification: Classification;
+}
+
+/**
+ * Find a function or method declaration by name in a source file.
+ * Searches top-level functions and class methods.
+ */
+export function findFunction(
+  program: ts.Program,
+  fileName: string,
+  functionName: string,
+): { node: ts.FunctionDeclaration | ts.MethodDeclaration; className?: string } {
+  const sourceFile = program.getSourceFile(fileName);
+  if (!sourceFile) throw new Error(`Source file not found: ${fileName}`);
+
+  // Search top-level functions
+  for (const stmt of sourceFile.statements) {
+    if (ts.isFunctionDeclaration(stmt) && stmt.name?.text === functionName) {
+      return { node: stmt };
+    }
+  }
+
+  // Search class methods
+  for (const stmt of sourceFile.statements) {
+    if (ts.isClassDeclaration(stmt) && stmt.name) {
+      for (const member of stmt.members) {
+        if (
+          ts.isMethodDeclaration(member) &&
+          ts.isIdentifier(member.name) &&
+          member.name.text === functionName
+        ) {
+          return { node: member, className: stmt.name.text };
+        }
+      }
+    }
+  }
+
+  throw new Error(`Function not found: ${functionName}`);
+}
+
+/**
+ * Classify a function as pure or mutating.
+ * Mutating: void return type or has property assignments in body.
+ * Pure: everything else.
+ */
+export function classifyFunction(
+  node: ts.FunctionDeclaration | ts.MethodDeclaration,
+  checker: ts.TypeChecker,
+): Classification {
+  const sig = checker.getSignatureFromDeclaration(node);
+  if (!sig) return "pure";
+
+  const returnType = sig.getReturnType();
+  if (returnType.flags & ts.TypeFlags.Void) return "mutating";
+
+  if (node.body && hasPropertyAssignment(node.body)) return "mutating";
+
+  return "pure";
+}
+
+function hasPropertyAssignment(node: ts.Node): boolean {
+  let found = false;
+  function visit(n: ts.Node) {
+    if (found) return;
+    if (
+      ts.isBinaryExpression(n) &&
+      n.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      ts.isPropertyAccessExpression(n.left)
+    ) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(n, visit);
+  }
+  ts.forEachChild(node, visit);
+  return found;
+}
+
+/**
+ * Detect guard patterns in a function body.
+ * Patterns:
+ *   if (cond) { body } else { throw ... }
+ *   if (!cond) { throw ... } (early return guard)
+ */
+export function detectGuard(
+  node: ts.FunctionDeclaration | ts.MethodDeclaration,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  paramNames: Map<string, string>,
+): string | undefined {
+  if (!node.body) return undefined;
+
+  for (const stmt of node.body.statements) {
+    if (!ts.isIfStatement(stmt)) continue;
+
+    // Pattern 1: if (cond) { ... } else { throw }
+    if (stmt.elseStatement && blockThrows(stmt.elseStatement)) {
+      return translateExpr(stmt.expression, checker, strategy, paramNames);
+    }
+
+    // Pattern 2: if (!cond) { throw }  =>  guard is cond
+    if (
+      stmt.thenStatement &&
+      blockThrows(stmt.thenStatement) &&
+      !stmt.elseStatement
+    ) {
+      // Negate: if the condition is a prefix !, strip it
+      if (
+        ts.isPrefixUnaryExpression(stmt.expression) &&
+        stmt.expression.operator === ts.SyntaxKind.ExclamationToken
+      ) {
+        return translateExpr(
+          stmt.expression.operand,
+          checker,
+          strategy,
+          paramNames,
+        );
+      }
+      // Otherwise negate the whole expression
+      return `~(${translateExpr(stmt.expression, checker, strategy, paramNames)})`;
+    }
+  }
+
+  return undefined;
+}
+
+function blockThrows(node: ts.Statement): boolean {
+  if (ts.isBlock(node)) {
+    return node.statements.some((s) => ts.isThrowStatement(s));
+  }
+  return ts.isThrowStatement(node);
+}
+
+/**
+ * Translate a TypeScript expression to Pantagruel syntax (best-effort).
+ */
+function translateExpr(
+  expr: ts.Expression,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  paramNames: Map<string, string>,
+): string {
+  // Property access: a.balance -> balance a
+  if (ts.isPropertyAccessExpression(expr)) {
+    const obj = translateExpr(expr.expression, checker, strategy, paramNames);
+    const prop = expr.name.text;
+    return `${prop} ${obj}`;
+  }
+
+  // Binary expression: a >= b -> a >= b
+  if (ts.isBinaryExpression(expr)) {
+    const left = translateExpr(expr.left, checker, strategy, paramNames);
+    const right = translateExpr(expr.right, checker, strategy, paramNames);
+    const op = translateOperator(expr.operatorToken.kind);
+    return `${left} ${op} ${right}`;
+  }
+
+  // Prefix unary: !x -> ~x
+  if (ts.isPrefixUnaryExpression(expr)) {
+    if (expr.operator === ts.SyntaxKind.ExclamationToken) {
+      return `~(${translateExpr(expr.operand, checker, strategy, paramNames)})`;
+    }
+  }
+
+  // Parenthesized
+  if (ts.isParenthesizedExpression(expr)) {
+    return translateExpr(expr.expression, checker, strategy, paramNames);
+  }
+
+  // `this` keyword
+  if (expr.kind === ts.SyntaxKind.ThisKeyword) {
+    return paramNames.get("this") ?? "this";
+  }
+
+  // Identifier — use param name mapping if available
+  if (ts.isIdentifier(expr)) {
+    return paramNames.get(expr.text) ?? expr.text;
+  }
+
+  // Numeric literal
+  if (ts.isNumericLiteral(expr)) {
+    return expr.text;
+  }
+
+  // String literal
+  if (ts.isStringLiteral(expr)) {
+    return `"${expr.text}"`;
+  }
+
+  // Fallback
+  return expr.getText();
+}
+
+function translateOperator(kind: ts.SyntaxKind): string {
+  switch (kind) {
+    case ts.SyntaxKind.GreaterThanEqualsToken:
+      return ">=";
+    case ts.SyntaxKind.LessThanEqualsToken:
+      return "<=";
+    case ts.SyntaxKind.GreaterThanToken:
+      return ">";
+    case ts.SyntaxKind.LessThanToken:
+      return "<";
+    case ts.SyntaxKind.EqualsEqualsEqualsToken:
+    case ts.SyntaxKind.EqualsEqualsToken:
+      return "=";
+    case ts.SyntaxKind.ExclamationEqualsEqualsToken:
+    case ts.SyntaxKind.ExclamationEqualsToken:
+      return "~=";
+    case ts.SyntaxKind.AmpersandAmpersandToken:
+      return "and";
+    case ts.SyntaxKind.BarBarToken:
+      return "or";
+    case ts.SyntaxKind.PlusToken:
+      return "+";
+    case ts.SyntaxKind.MinusToken:
+      return "-";
+    case ts.SyntaxKind.AsteriskToken:
+      return "*";
+    default:
+      return "?";
+  }
+}
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+function shortParamName(typeName: string): string {
+  return typeName[0].toLowerCase();
+}
+
+/**
+ * Translate a TypeScript function signature to a Pantagruel declaration.
+ */
+export function translateSignature(
+  program: ts.Program,
+  fileName: string,
+  functionName: string,
+  strategy: NumericStrategy,
+): TranslatedSignature {
+  const checker = program.getTypeChecker();
+  const { node, className } = findFunction(program, fileName, functionName);
+  const classification = classifyFunction(node, checker);
+  const sig = checker.getSignatureFromDeclaration(node);
+  if (!sig) throw new Error(`Cannot get signature for: ${functionName}`);
+
+  // Build params, prepending `this` for class methods
+  const params: Array<{ name: string; type: string }> = [];
+  const paramNameMap = new Map<string, string>();
+
+  if (className) {
+    const pName = shortParamName(className);
+    params.push({ name: pName, type: className });
+    paramNameMap.set("this", pName);
+  }
+
+  for (const param of sig.getParameters()) {
+    const paramType = mapTsType(
+      checker.getTypeOfSymbol(param),
+      checker,
+      strategy,
+    );
+    params.push({ name: param.name, type: paramType });
+    paramNameMap.set(param.name, param.name);
+  }
+
+  const guard = detectGuard(node, checker, strategy, paramNameMap);
+
+  if (classification === "pure") {
+    const returnType = mapTsType(sig.getReturnType(), checker, strategy);
+    const decl: PantRule = {
+      kind: "rule",
+      name: functionName,
+      params,
+      returnType,
+    };
+    if (guard) decl.guard = guard;
+    return { declaration: decl, classification };
+  } else {
+    const decl: PantAction = {
+      kind: "action",
+      label: capitalize(functionName),
+      params,
+    };
+    if (guard) decl.guard = guard;
+    return { declaration: decl, classification };
+  }
+}

--- a/tools/ts2pant/src/types.ts
+++ b/tools/ts2pant/src/types.ts
@@ -26,6 +26,7 @@ export interface PantRule {
   name: string;
   params: PantParam[];
   returnType: string;
+  guard?: string;
 }
 
 /** A Pantagruel action declaration (e.g. `~> Withdraw @ u: User.`). */
@@ -33,6 +34,7 @@ export interface PantAction {
   kind: "action";
   label: string;
   params: PantParam[];
+  guard?: string;
 }
 
 /** A declaration in a Pantagruel document. */

--- a/tools/ts2pant/tests/translate-signature.test.ts
+++ b/tools/ts2pant/tests/translate-signature.test.ts
@@ -212,6 +212,59 @@ describe("guarded mutator -> action with guard", () => {
   });
 });
 
+describe("overloaded functions", () => {
+  it("prefers implementation over overload signature", () => {
+    const source = `
+      function add(a: number, b: number): number;
+      function add(a: string, b: string): string;
+      function add(a: any, b: any): any {
+        return a + b;
+      }
+    `;
+    const program = createProgramFromSource(source);
+    const { node } = findFunction(program, "test.ts", "add");
+    // Should find the implementation (has body), not an overload signature
+    expect(node.body).toBeDefined();
+  });
+});
+
+describe("nested closure property assignment", () => {
+  it("does not classify outer function as mutating due to nested closure", () => {
+    const source = `
+      interface Account { balance: number; }
+      function makeResetter(a: Account): () => void {
+        return () => { a.balance = 0; };
+      }
+    `;
+    const program = createProgramFromSource(source);
+    const { node } = findFunction(program, "test.ts", "makeResetter");
+    const checker = program.getTypeChecker();
+    expect(classifyFunction(node, checker)).toBe("pure");
+  });
+});
+
+describe("guard detection stops at non-if statements", () => {
+  it("does not detect guard after non-guard statements", () => {
+    const source = `
+      interface Account { balance: number; }
+      function process(a: Account, amount: number): void {
+        a.balance = a.balance + 1;
+        if (a.balance >= amount) {
+          a.balance = a.balance - amount;
+        } else {
+          throw new Error("Insufficient funds");
+        }
+      }
+    `;
+    const result = translate(source, "process");
+
+    expect(result.declaration.kind).toBe("action");
+    if (result.declaration.kind === "action") {
+      expect(result.declaration.guard).toBeUndefined();
+    }
+  });
+});
+
 describe("class method -> declaration with this param", () => {
   it("translates pure method with this as first param", () => {
     const source = `

--- a/tools/ts2pant/tests/translate-signature.test.ts
+++ b/tools/ts2pant/tests/translate-signature.test.ts
@@ -1,0 +1,283 @@
+import { describe, it, expect } from "vitest";
+import { createProgramFromSource } from "../src/extract.js";
+import { IntStrategy, RealStrategy } from "../src/translate-types.js";
+import {
+  translateSignature,
+  classifyFunction,
+  findFunction,
+} from "../src/translate-signature.js";
+
+function translate(source: string, functionName: string, strategy = IntStrategy) {
+  const fileName = "test.ts";
+  const program = createProgramFromSource(source, fileName);
+  return translateSignature(program, fileName, functionName, strategy);
+}
+
+describe("classifyFunction", () => {
+  it("classifies pure function (returns value, no property assignments)", () => {
+    const source = `
+      function getBalance(account: { balance: number }): number {
+        return account.balance;
+      }
+    `;
+    const program = createProgramFromSource(source);
+    const { node } = findFunction(program, "test.ts", "getBalance");
+    const checker = program.getTypeChecker();
+    expect(classifyFunction(node, checker)).toBe("pure");
+  });
+
+  it("classifies void function as mutating", () => {
+    const source = `
+      function reset(account: { balance: number }): void {
+        account.balance = 0;
+      }
+    `;
+    const program = createProgramFromSource(source);
+    const { node } = findFunction(program, "test.ts", "reset");
+    const checker = program.getTypeChecker();
+    expect(classifyFunction(node, checker)).toBe("mutating");
+  });
+
+  it("classifies function with property assignment as mutating", () => {
+    const source = `
+      function setName(user: { name: string }, name: string): string {
+        user.name = name;
+        return name;
+      }
+    `;
+    const program = createProgramFromSource(source);
+    const { node } = findFunction(program, "test.ts", "setName");
+    const checker = program.getTypeChecker();
+    expect(classifyFunction(node, checker)).toBe("mutating");
+  });
+});
+
+describe("pure function -> rule", () => {
+  it("translates simple pure function to rule", () => {
+    const source = `
+      interface Account { balance: number; }
+      function getBalance(a: Account): number {
+        return a.balance;
+      }
+    `;
+    const result = translate(source, "getBalance");
+
+    expect(result.classification).toBe("pure");
+    expect(result.declaration).toEqual({
+      kind: "rule",
+      name: "getBalance",
+      params: [{ name: "a", type: "Account" }],
+      returnType: "Int",
+    });
+  });
+
+  it("translates multi-param pure function", () => {
+    const source = `
+      interface Account { balance: number; owner: string; }
+      function foo(a: Account, b: number): string {
+        return a.owner;
+      }
+    `;
+    const result = translate(source, "foo");
+
+    expect(result.classification).toBe("pure");
+    expect(result.declaration).toEqual({
+      kind: "rule",
+      name: "foo",
+      params: [
+        { name: "a", type: "Account" },
+        { name: "b", type: "Int" },
+      ],
+      returnType: "String",
+    });
+  });
+
+  it("respects numeric strategy", () => {
+    const source = `
+      function double(n: number): number {
+        return n * 2;
+      }
+    `;
+    const result = translate(source, "double", RealStrategy);
+
+    expect(result.declaration).toEqual({
+      kind: "rule",
+      name: "double",
+      params: [{ name: "n", type: "Real" }],
+      returnType: "Real",
+    });
+  });
+
+  it("translates boolean return type", () => {
+    const source = `
+      function isActive(active: boolean): boolean {
+        return active;
+      }
+    `;
+    const result = translate(source, "isActive");
+
+    expect(result.declaration.kind).toBe("rule");
+    if (result.declaration.kind === "rule") {
+      expect(result.declaration.returnType).toBe("Bool");
+    }
+  });
+
+  it("translates array return type", () => {
+    const source = `
+      function getNames(names: string[]): string[] {
+        return names;
+      }
+    `;
+    const result = translate(source, "getNames");
+
+    expect(result.declaration.kind).toBe("rule");
+    if (result.declaration.kind === "rule") {
+      expect(result.declaration.returnType).toBe("[String]");
+    }
+  });
+});
+
+describe("void mutator -> action", () => {
+  it("translates void function to action", () => {
+    const source = `
+      interface Account { balance: number; }
+      function deposit(a: Account, amount: number): void {
+        a.balance = a.balance + amount;
+      }
+    `;
+    const result = translate(source, "deposit");
+
+    expect(result.classification).toBe("mutating");
+    expect(result.declaration).toEqual({
+      kind: "action",
+      label: "Deposit",
+      params: [
+        { name: "a", type: "Account" },
+        { name: "amount", type: "Int" },
+      ],
+    });
+  });
+
+  it("capitalizes action label from function name", () => {
+    const source = `
+      function doSomething(): void {}
+    `;
+    const result = translate(source, "doSomething");
+
+    expect(result.declaration.kind).toBe("action");
+    if (result.declaration.kind === "action") {
+      expect(result.declaration.label).toBe("DoSomething");
+    }
+  });
+});
+
+describe("guarded mutator -> action with guard", () => {
+  it("detects if/else-throw guard pattern", () => {
+    const source = `
+      interface Account { balance: number; }
+      function withdraw(a: Account, amount: number): void {
+        if (a.balance >= amount) {
+          a.balance = a.balance - amount;
+        } else {
+          throw new Error("Insufficient funds");
+        }
+      }
+    `;
+    const result = translate(source, "withdraw");
+
+    expect(result.classification).toBe("mutating");
+    expect(result.declaration.kind).toBe("action");
+    if (result.declaration.kind === "action") {
+      expect(result.declaration.label).toBe("Withdraw");
+      expect(result.declaration.guard).toBe("balance a >= amount");
+    }
+  });
+
+  it("detects early-throw guard pattern with negation", () => {
+    const source = `
+      interface Account { balance: number; }
+      function withdraw(a: Account, amount: number): void {
+        if (!(a.balance >= amount)) {
+          throw new Error("Insufficient funds");
+        }
+        a.balance = a.balance - amount;
+      }
+    `;
+    const result = translate(source, "withdraw");
+
+    expect(result.declaration.kind).toBe("action");
+    if (result.declaration.kind === "action") {
+      expect(result.declaration.guard).toBe("balance a >= amount");
+    }
+  });
+});
+
+describe("class method -> declaration with this param", () => {
+  it("translates pure method with this as first param", () => {
+    const source = `
+      class Account {
+        balance: number = 0;
+        getBalance(): number {
+          return this.balance;
+        }
+      }
+    `;
+    const result = translate(source, "getBalance");
+
+    expect(result.classification).toBe("pure");
+    expect(result.declaration).toEqual({
+      kind: "rule",
+      name: "getBalance",
+      params: [{ name: "a", type: "Account" }],
+      returnType: "Int",
+    });
+  });
+
+  it("translates mutating method with this as first param", () => {
+    const source = `
+      class Account {
+        balance: number = 0;
+        deposit(amount: number): void {
+          this.balance = this.balance + amount;
+        }
+      }
+    `;
+    const result = translate(source, "deposit");
+
+    expect(result.classification).toBe("mutating");
+    expect(result.declaration).toEqual({
+      kind: "action",
+      label: "Deposit",
+      params: [
+        { name: "a", type: "Account" },
+        { name: "amount", type: "Int" },
+      ],
+    });
+  });
+
+  it("translates guarded method", () => {
+    const source = `
+      class Account {
+        balance: number = 0;
+        withdraw(amount: number): void {
+          if (this.balance >= amount) {
+            this.balance = this.balance - amount;
+          } else {
+            throw new Error("Insufficient funds");
+          }
+        }
+      }
+    `;
+    const result = translate(source, "withdraw");
+
+    expect(result.declaration.kind).toBe("action");
+    if (result.declaration.kind === "action") {
+      expect(result.declaration.label).toBe("Withdraw");
+      expect(result.declaration.guard).toBe("balance a >= amount");
+      expect(result.declaration.params[0]).toEqual({
+        name: "a",
+        type: "Account",
+      });
+    }
+  });
+});

--- a/tools/ts2pant/tests/translate-signature.test.ts
+++ b/tools/ts2pant/tests/translate-signature.test.ts
@@ -196,7 +196,7 @@ describe("guarded mutator -> action with guard", () => {
   it("ignores non-unconditional throw in else branch", () => {
     const source = `
       interface Account { balance: number; }
-      function withdraw(a: Account, amount: number): void {
+      function withdraw(a: Account, amount: number, retry: boolean): void {
         if (a.balance >= amount) {
           a.balance = a.balance - amount;
         } else {

--- a/tools/ts2pant/tests/translate-signature.test.ts
+++ b/tools/ts2pant/tests/translate-signature.test.ts
@@ -207,7 +207,7 @@ describe("guarded mutator -> action with guard", () => {
 
     expect(result.declaration.kind).toBe("action");
     if (result.declaration.kind === "action") {
-      expect(result.declaration.guard).toBe("balance a >= amount");
+      expect(result.declaration.guard).toBe("(balance a >= amount)");
     }
   });
 });

--- a/tools/ts2pant/tests/translate-signature.test.ts
+++ b/tools/ts2pant/tests/translate-signature.test.ts
@@ -193,6 +193,25 @@ describe("guarded mutator -> action with guard", () => {
     }
   });
 
+  it("ignores non-unconditional throw in else branch", () => {
+    const source = `
+      interface Account { balance: number; }
+      function withdraw(a: Account, amount: number): void {
+        if (a.balance >= amount) {
+          a.balance = a.balance - amount;
+        } else {
+          if (retry) throw new Error("Insufficient funds");
+        }
+      }
+    `;
+    const result = translate(source, "withdraw");
+
+    expect(result.declaration.kind).toBe("action");
+    if (result.declaration.kind === "action") {
+      expect(result.declaration.guard).toBeUndefined();
+    }
+  });
+
   it("detects early-throw guard pattern with negation", () => {
     const source = `
       interface Account { balance: number; }


### PR DESCRIPTION
## Patch 8: Translate function signatures to rules or actions

- Analyze function: pure (no assignments to parameters/properties, returns a value) -> PantRule; mutating (assigns to .prop, void return) -> PantAction
- For pure functions: translate `function foo(a: Account, b: number): string` to `foo a: Account, b: Int => String.`
- For mutating functions: translate `function deposit(a: Account, amount: number): void` to `~> Deposit @ a: Account, amount: Int.`
- Handle methods: `account.withdraw(amount)` where `this` is the first parameter
- For actions, detect guard patterns: `if (cond) { ... } else { throw }` -> declaration guard
- Tests: pure function -> rule, void mutator -> action, guarded mutator -> action with guard

## Changes
- Analyze function: pure (no assignments to parameters/properties, returns a value) -> PantRule; mutating (assigns to .prop, void return) -> PantAction
- For pure functions: translate `function foo(a: Account, b: number): string` to `foo a: Account, b: Int => String.`
- For mutating functions: translate `function deposit(a: Account, amount: number): void` to `~> Deposit @ a: Account, amount: Int.`
- Handle methods: `account.withdraw(amount)` where `this` is the first parameter
- For actions, detect guard patterns: `if (cond) { ... } else { throw }` -> declaration guard
- Tests: pure function -> rule, void mutator -> action, guarded mutator -> action with guard

## Gameplan Specification

```
module TS2PANT.

> ══════════════════════════════════════════
> AGGREGATE QUANTIFIERS
> ══════════════════════════════════════════
> Pantagruel's quantifier family is extended with
> arithmetic combiners: COMBINER over each GUARDS | BODY.

Combiner.
Type.
Expression.

comb-add => Combiner.
comb-mul => Combiner.
comb-and => Combiner.
comb-or => Combiner.
comb-min => Combiner.
comb-max => Combiner.

has-over? e: Expression => Bool.
body-type e: Expression => Type.
result-type e: Expression => Type.
numeric? t: Type => Bool.
bool => Type.

---

> Arithmetic combiners require numeric body; result type = body type.
all e: Expression, has-over? e, numeric? (body-type e) |
  result-type e = body-type e.

where

> ══════════════════════════════════════════
> TRANSLATION PIPELINE
> ══════════════════════════════════════════
> Given a TypeScript function and its participating types,
> ts2pant produces a checkable Pantagruel document.

TSFunction.
TSType.
PantDocument.
PantDeclaration.
PantProposition.
Annotation.
CheckResult.

> Extraction: every referenced TS type becomes declarations.
referenced-types f: TSFunction => [TSType].
translated-types t: TSType => [PantDeclaration].

> Classification: pure functions -> rules, mutating -> actions.
pure? f: TSFunction => Bool.
mutating? f: TSFunction => Bool.

> Translation: function -> declaration + propositions.
translated-sig f: TSFunction => PantDeclaration.
translated-body f: TSFunction => [PantProposition].

> Annotations: user-provided assertions.
annotations f: TSFunction => [Annotation].

> Assembly: combined document.
generated-doc f: TSFunction => PantDocument.
check-result f: TSFunction => CheckResult.
passed? r: CheckResult => Bool.

---

> Every function is either pure or mutating.
all f: TSFunction | pure? f or mutating? f.
~(some f: TSFunction | pure? f and mutating? f).

> Every referenced type produces at least one declaration.
all t: TSType | #(translated-types t) >= 1.

> Every function with annotations produces a checkable document.
all f: TSFunction, #(annotations f) > 0 |
  generated-doc f in PantDocument.

```

## Patch Specification

```
module TS2PANT_PATCH_8.

TSFunction.
PantDeclaration.

classification f: TSFunction => Kind.
pure => Kind.
mutating => Kind.

Kind.

translated f: TSFunction => PantDeclaration.

---

> Every function translates to exactly one declaration.
all f: TSFunction | translated f in PantDeclaration.

> Pure functions become rules; mutating functions become actions.
all f: TSFunction, classification f = pure | is-rule? (translated f).
all f: TSFunction, classification f = mutating | is-action? (translated f).

where

is-rule? d: PantDeclaration => Bool.
is-action? d: PantDeclaration => Bool.

---

```

## Files to Modify
- tools/ts2pant/src/translate-signature.ts (create): Classify functions as pure/mutating and translate to rule or action declarations
- tools/ts2pant/tests/translate-signature.test.ts (create): Tests for signature translation


## Implementation Notes

- **Guard expression translation** is best-effort: converts TS property access (`a.balance`) to Pantagruel rule application (`balance a`), maps comparison/logical operators, and handles `this` keyword substitution via a param-name map. Complex expressions will fall back to raw TS text.
- **Two guard patterns detected**: `if (cond) { ... } else { throw }` (extracts `cond`) and `if (!cond) { throw }` (strips negation to extract `cond`). Only the first `if` statement in the body is considered.
- **`PantRule` and `PantAction` types** gained an optional `guard?: string` field, and the emitter in `index.ts` was updated to render guards as comma-separated expressions after params (matching Pantagruel's declaration guard syntax).
- **`findFunction`** searches both top-level function declarations and class method declarations, returning the class name when found inside a class so `this` can be typed.
- **Classification heuristic** is deliberately simple: void return → mutating, property assignment anywhere in body → mutating, everything else → pure. This covers the common cases; edge cases (e.g., returning a mutated object) can be refined later.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for guard clauses in generated code declarations, enabling conditional rule and action execution.
  * Introduced TypeScript function signature translation to Pantagruel declarations, automatically classifying functions as pure or mutating based on their behavior.

* **Tests**
  * Added comprehensive test suite for signature translation with coverage for various function patterns and type scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->