### PR TITLE
[ts2pant] Patch 5: Add over-each integration tests with pant --check

### DIFF
--- a/samples/11-over-each.pant
+++ b/samples/11-over-each.pant
@@ -1,0 +1,71 @@
+module OverEach.
+
+> Over-each: aggregate quantifiers that combine values across a domain.
+> Six combiners are available: +, *, and, or, min, max.
+> Syntax: COMBINER over each VAR: DOMAIN [, GUARD]* | BODY.
+
+> ══════════════════════════════════════════
+> Arithmetic combiners
+> ══════════════════════════════════════════
+
+Student.
+score s: Student => Nat.
+weight s: Student => Nat.
+active? s: Student => Bool.
+
+total-score => Nat.
+product-of-weights => Nat.
+min-score => Nat.
+max-score => Nat.
+
+---
+
+> Sum: add up all scores.
+total-score = (+ over each s: Student | score s).
+
+> Product: multiply all weights.
+product-of-weights = (* over each s: Student | weight s).
+
+> Min and max: find extremes.
+min-score = (min over each s: Student | score s).
+max-score = (max over each s: Student | score s).
+
+where
+
+> ══════════════════════════════════════════
+> Boolean combiners
+> ══════════════════════════════════════════
+
+Item.
+valid? i: Item => Bool.
+available? i: Item => Bool.
+
+---
+
+> And: conjunction over a domain (true iff all items are valid).
+and over each i: Item | valid? i.
+
+> Or: disjunction over a domain (true iff some item is available).
+or over each i: Item | available? i.
+
+where
+
+> ══════════════════════════════════════════
+> Guards on over-each
+> ══════════════════════════════════════════
+> Guards filter which elements participate in the aggregate.
+
+Widget.
+cost w: Widget => Nat.
+enabled? w: Widget => Bool.
+
+---
+
+> Sum only active students' scores.
+(+ over each s: Student, active? s | score s) >= 0.
+
+> Max over active students.
+(max over each s: Student, active? s | score s) >= 0.
+
+> Sum of costs for enabled widgets.
+(+ over each w: Widget, enabled? w | cost w) >= 0.

--- a/samples/11-over-each.pant
+++ b/samples/11-over-each.pant
@@ -13,7 +13,7 @@ score s: Student => Nat.
 weight s: Student => Nat.
 active? s: Student => Bool.
 
-total-score => Nat.
+total-score => Nat0.
 product-of-weights => Nat.
 min-score => Nat.
 max-score => Nat.

--- a/samples/smt-examples/over-each-ok.pant
+++ b/samples/smt-examples/over-each-ok.pant
@@ -1,0 +1,21 @@
+> Banking spec: total balance defined via + over each.
+> The invariant total >= 0 is verifiable because balance returns Nat0.
+module OverEachOk.
+context Accounts.
+
+Account.
+{Accounts} balance a: Account => Nat0.
+total-balance => Nat0.
+
+---
+total-balance = (+ over each a: Account | balance a).
+all a: Account | balance a >= 0.
+total-balance >= 0.
+initially all a: Account | balance a = 0.
+
+where
+
+Accounts ~> Deposit @ a: Account, amount: Nat.
+---
+balance' a = balance a + amount.
+all b: Account | b != a -> balance' b = balance b.


### PR DESCRIPTION
## Patch 5: Add over-each integration tests with pant --check

- Create over-each-ok.pant: a banking spec where totalBalance is defined via + over each, with an invariant that total >= 0, verifiable by pant --check
- Create 11-over-each.pant: a tutorial sample showing all six combiners with doc comments
- Run pant --check on over-each-ok.pant to verify end-to-end SMT encoding works
- Run dune test to verify all existing tests still pass

## Changes
- Create over-each-ok.pant: a banking spec where totalBalance is defined via + over each, with an invariant that total >= 0, verifiable by pant --check
- Create 11-over-each.pant: a tutorial sample showing all six combiners with doc comments
- Run pant --check on over-each-ok.pant to verify end-to-end SMT encoding works
- Run dune test to verify all existing tests still pass

## Gameplan Specification

```
module TS2PANT.

> ══════════════════════════════════════════
> AGGREGATE QUANTIFIERS
> ══════════════════════════════════════════
> Pantagruel's quantifier family is extended with
> arithmetic combiners: COMBINER over each GUARDS | BODY.

Combiner.
Type.
Expression.

comb-add => Combiner.
comb-mul => Combiner.
comb-and => Combiner.
comb-or => Combiner.
comb-min => Combiner.
comb-max => Combiner.

has-over? e: Expression => Bool.
body-type e: Expression => Type.
result-type e: Expression => Type.
numeric? t: Type => Bool.
bool => Type.

---

> Arithmetic combiners require numeric body; result type = body type.
all e: Expression, has-over? e, numeric? (body-type e) |
  result-type e = body-type e.

where

> ══════════════════════════════════════════
> TRANSLATION PIPELINE
> ══════════════════════════════════════════
> Given a TypeScript function and its participating types,
> ts2pant produces a checkable Pantagruel document.

TSFunction.
TSType.
PantDocument.
PantDeclaration.
PantProposition.
Annotation.
CheckResult.

> Extraction: every referenced TS type becomes declarations.
referenced-types f: TSFunction => [TSType].
translated-types t: TSType => [PantDeclaration].

> Classification: pure functions -> rules, mutating -> actions.
pure? f: TSFunction => Bool.
mutating? f: TSFunction => Bool.

> Translation: function -> declaration + propositions.
translated-sig f: TSFunction => PantDeclaration.
translated-body f: TSFunction => [PantProposition].

> Annotations: user-provided assertions.
annotations f: TSFunction => [Annotation].

> Assembly: combined document.
generated-doc f: TSFunction => PantDocument.
check-result f: TSFunction => CheckResult.
passed? r: CheckResult => Bool.

---

> Every function is either pure or mutating.
all f: TSFunction | pure? f or mutating? f.
~(some f: TSFunction | pure? f and mutating? f).

> Every referenced type produces at least one declaration.
all t: TSType | #(translated-types t) >= 1.

> Every function with annotations produces a checkable document.
all f: TSFunction, #(annotations f) > 0 |
  generated-doc f in PantDocument.

```

## Patch Specification

```
module TS2PANT_PATCH_5.

> Integration verification. over-each works end-to-end with pant --check.

Account.
balance a: Account => Nat0.

---

true.

```

## Files to Modify
- samples/smt-examples/over-each-ok.pant (create): SMT-checkable example using over-each aggregates
- samples/11-over-each.pant (create): Sample file demonstrating over-each syntax


## Implementation Notes

- Over-each expressions used on the RHS of `=` require parenthesization (e.g., `total-balance = (+ over each a: Account | balance a).`) because the `+`/`*` combiner tokens conflict with infix arithmetic at the parser level. This is consistent with how the test suite uses them.
- The tutorial sample (`11-over-each.pant`) uses three chapters to separate arithmetic combiners, boolean combiners, and guarded examples. The third chapter needed a dummy domain declaration (`Widget`) since Pantagruel requires a non-empty head section per chapter.
- No SMT solver (z3/cvc5) was available in the build environment, so `pant --check` could not run end-to-end. Both files parse and type-check successfully. The SMT encoding itself is validated by unit tests in `test_smt.ml` (Patch 4).
- All existing tests pass with no modifications needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New sample modules demonstrating "over each" aggregate quantifiers with arithmetic combiners, logical (and/or) aggregates, and selection functions (min/max).
  * Examples show guarded-aggregate usage (filters on participation) and constraints over aggregate results.
  * Added a banking-style example illustrating total-balance computation and a deposit transition preserving other accounts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->