### PR TITLE
[ts2pant] Patch 9: Translate function bodies to propositions

### DIFF
--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -459,12 +459,13 @@ function extractArrowBody(
   strategy: NumericStrategy,
 ): string | null {
   if (!ts.isArrowFunction(expr)) return null;
+  if (expr.parameters.length !== 1 || !ts.isIdentifier(expr.parameters[0].name)) {
+    return `> UNSUPPORTED: filter/map callback must have exactly one identifier parameter`;
+  }
 
   // Map arrow param to the fresh binder
   const arrowParams = new Map(paramNames);
-  if (expr.parameters.length === 1) {
-    arrowParams.set(expr.parameters[0].name.getText(), binderName);
-  }
+  arrowParams.set(expr.parameters[0].name.text, binderName);
 
   if (ts.isBlock(expr.body)) {
     // Only allow a single return (after filtering guards), same rule as

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -30,7 +30,17 @@ export function translateBody(opts: TranslateBodyOptions): PantProposition[] {
   const paramList: Array<{ name: string; type: string }> = [];
 
   if (className) {
-    const pName = className[0].toLowerCase();
+    const baseName =
+      className.charAt(0).toLowerCase() + className.slice(1);
+    let pName = baseName;
+    const existing = new Set(
+      node.parameters
+        .map((p) => (ts.isIdentifier(p.name) ? p.name.text : null))
+        .filter((name): name is string => name !== null),
+    );
+    while (existing.has(pName)) {
+      pName = `${pName}_this`;
+    }
     paramNames.set("this", pName);
     paramList.push({ name: pName, type: className });
   }
@@ -104,15 +114,10 @@ function extractReturnExpression(body: ts.Block): ts.Expression | null {
     }
   }
 
-  // Multiple statements: look for if/else-return or trailing return
-  if (stmts.length >= 1) {
-    const last = stmts[stmts.length - 1];
-    if (ts.isReturnStatement(last) && last.expression) {
-      return last.expression;
-    }
-    if (ts.isIfStatement(last) && last.elseStatement) {
-      return last;
-    }
+  // Multiple non-guard statements are not representable yet without
+  // translating local bindings/control flow.
+  if (stmts.length > 1) {
+    return null;
   }
 
   return null;
@@ -298,8 +303,7 @@ function tryTranslateFilterMap(
   if (checker.isArrayType(sourceType)) {
     const typeArgs = checker.getTypeArguments(sourceType as ts.TypeReference);
     if (typeArgs.length === 1) {
-      const sym = typeArgs[0].aliasSymbol ?? typeArgs[0].symbol;
-      elemTypeName = sym ? sym.getName() : checker.typeToString(typeArgs[0]);
+      elemTypeName = mapTsType(typeArgs[0], checker, strategy);
     }
   }
 
@@ -373,14 +377,16 @@ function translateMutatingBody(
 }
 
 function collectAssignments(
-  block: ts.Block,
+  body: ts.Block | ts.Statement,
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
   paramNames: Map<string, string>,
   propositions: PantProposition[],
   modifiedRules: Set<string>,
 ): void {
-  for (const stmt of block.statements) {
+  const stmts = ts.isBlock(body) ? Array.from(body.statements) : [body];
+
+  for (const stmt of stmts) {
     // Skip guard statements (if-throw patterns)
     if (isGuardStatement(stmt)) continue;
 
@@ -393,15 +399,37 @@ function collectAssignments(
         const prop = bin.left.name.text;
         const obj = translateBodyExpr(bin.left.expression, checker, strategy, paramNames);
         const val = translateBodyExpr(bin.right, checker, strategy, paramNames);
+        if (
+          obj.startsWith("> UNSUPPORTED:") ||
+          val.startsWith("> UNSUPPORTED:")
+        ) {
+          propositions.push({
+            text: obj.startsWith("> UNSUPPORTED:") ? obj : val,
+          });
+          continue;
+        }
         propositions.push({ text: `${prop}' ${obj} = ${val}` });
         modifiedRules.add(prop);
       }
     }
 
-    // Conditional assignments — emit UNSUPPORTED comment rather than
-    // silently dropping the predicate.
-    if (ts.isIfStatement(stmt)) {
+    // Recurse into nested blocks
+    if (ts.isBlock(stmt)) {
+      collectAssignments(stmt, checker, strategy, paramNames, propositions, modifiedRules);
+    } else if (ts.isIfStatement(stmt)) {
       propositions.push({ text: `> UNSUPPORTED: conditional assignment (if/else)` });
+    } else if (
+      ts.isForStatement(stmt) ||
+      ts.isForOfStatement(stmt) ||
+      ts.isForInStatement(stmt) ||
+      ts.isWhileStatement(stmt) ||
+      ts.isDoStatement(stmt)
+    ) {
+      propositions.push({ text: `> UNSUPPORTED: loop assignment` });
+    } else if (ts.isTryStatement(stmt)) {
+      collectAssignments(stmt.tryBlock, checker, strategy, paramNames, propositions, modifiedRules);
+    } else if (ts.isSwitchStatement(stmt)) {
+      propositions.push({ text: `> UNSUPPORTED: switch assignment` });
     }
   }
 }

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -317,7 +317,7 @@ export function translateBodyExpr(
     return translateExpr(expr, checker, strategy, paramNames);
   }
 
-  return `/* unsupported */`;
+  return `> UNSUPPORTED: non-expression statement`;
 }
 
 function translateIfStatement(

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -145,13 +145,20 @@ function describeRejectedBody(body: ts.Block): string {
 function isGuardStatement(stmt: ts.Statement): boolean {
   if (!ts.isIfStatement(stmt)) return false;
   // if (...) { throw } without else
-  if (!stmt.elseStatement && blockThrows(stmt.thenStatement)) return true;
+  if (!stmt.elseStatement && blockThrows(stmt.thenStatement)) {
+    return !expressionHasSideEffects(stmt.expression);
+  }
   // if (...) { ... } else { throw }
   if (stmt.elseStatement && blockThrows(stmt.elseStatement)) {
-    // Only a guard if the then-block has no side effects (no assignments/mutations).
-    // A mutating then-branch like `if (ok) { a.balance = 1; } else { throw e; }`
+    // Only a guard if the condition and then-block have no side effects.
+    // A side-effectful condition like `if (audit(a)) { throw ... }` must not be
+    // skipped. A mutating then-branch like `if (ok) { a.balance = 1; } else { throw e; }`
     // must NOT be classified as a guard — collectAssignments() needs to see it.
-    return blockHasNoSideEffects(stmt.thenStatement) && !blockReturns(stmt.thenStatement);
+    return (
+      !expressionHasSideEffects(stmt.expression) &&
+      blockHasNoSideEffects(stmt.thenStatement) &&
+      !blockReturns(stmt.thenStatement)
+    );
   }
   return false;
 }
@@ -281,9 +288,12 @@ export function translateBodyExpr(
     const prop = expr.name.text;
     const obj = translateBodyExpr(expr.expression, checker, strategy, paramNames);
     if (isUnsupported(obj)) return obj;
-    // .length -> #obj
+    // .length -> #obj (array only)
     if (prop === "length") {
-      return `#${obj}`;
+      const receiverType = checker.getTypeAtLocation(expr.expression);
+      if (checker.isArrayType(receiverType)) {
+        return `#${obj}`;
+      }
     }
     // Regular property access: a.balance -> balance a
     return `${prop} ${obj}`;
@@ -376,8 +386,12 @@ function translateCallExpr(
     const methodName = expr.expression.name.text;
     const obj = expr.expression.expression;
 
-    // .includes(x) -> x in obj
+    // .includes(x) -> x in obj (array only)
     if (methodName === "includes" && expr.arguments.length === 1) {
+      const receiverType = checker.getTypeAtLocation(obj);
+      if (!checker.isArrayType(receiverType)) {
+        return `> UNSUPPORTED: non-array .includes()`;
+      }
       const arg = translateBodyExpr(expr.arguments[0], checker, strategy, paramNames);
       if (isUnsupported(arg)) return arg;
       const objStr = translateBodyExpr(obj, checker, strategy, paramNames);
@@ -411,14 +425,13 @@ function tryTranslateFilterMap(
   const filterArg = filterCall.arguments[0];
   const mapArg = mapCall.arguments[0];
 
-  // Try to extract the element type from the source array
+  // Only translate filter/map on actual arrays
   const sourceType = checker.getTypeAtLocation(sourceObj);
+  if (!checker.isArrayType(sourceType)) return null;
   let elemTypeName = "?";
-  if (checker.isArrayType(sourceType)) {
-    const typeArgs = checker.getTypeArguments(sourceType as ts.TypeReference);
-    if (typeArgs.length === 1) {
-      elemTypeName = mapTsType(typeArgs[0], checker, strategy);
-    }
+  const typeArgs = checker.getTypeArguments(sourceType as ts.TypeReference);
+  if (typeArgs.length === 1) {
+    elemTypeName = mapTsType(typeArgs[0], checker, strategy);
   }
 
   const varName = freshBinder(paramNames);

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -1,7 +1,7 @@
 import ts from "typescript";
 import type { PantProposition, PantDeclaration } from "./types.js";
 import { mapTsType, type NumericStrategy } from "./translate-types.js";
-import { translateExpr, translateOperator, findFunction, classifyFunction } from "./translate-signature.js";
+import { translateExpr, translateOperator, findFunction, classifyFunction, shortParamName } from "./translate-signature.js";
 
 function isUnsupported(s: string): boolean {
   return s.startsWith("> UNSUPPORTED:");
@@ -44,23 +44,15 @@ export function translateBody(opts: TranslateBodyOptions): PantProposition[] {
   const paramNames = new Map<string, string>();
   const paramList: Array<{ name: string; type: string }> = [];
 
+  const sig = checker.getSignatureFromDeclaration(node);
+
   if (className) {
-    const baseName =
-      className.charAt(0).toLowerCase() + className.slice(1);
-    let pName = baseName;
-    const existing = new Set(
-      node.parameters
-        .map((p) => (ts.isIdentifier(p.name) ? p.name.text : null))
-        .filter((name): name is string => name !== null),
-    );
-    while (existing.has(pName)) {
-      pName = `${pName}_this`;
-    }
+    const existingParamNames = new Set(sig ? sig.getParameters().map((p) => p.name) : []);
+    const pName = shortParamName(className, existingParamNames);
     paramNames.set("this", pName);
     paramList.push({ name: pName, type: className });
   }
 
-  const sig = checker.getSignatureFromDeclaration(node);
   if (sig) {
     for (const param of sig.getParameters()) {
       const typeName = mapTsType(
@@ -427,7 +419,7 @@ function tryTranslateFilterMap(
   if (filterBody && mapBody) {
     if (isUnsupported(filterBody)) return filterBody;
     if (isUnsupported(mapBody)) return mapBody;
-    return `each ${varName}: ${elemTypeName}, ${filterBody} | ${mapBody}`;
+    return `(each ${varName}: ${elemTypeName}, ${filterBody} | ${mapBody})`;
   }
 
   return null;

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -219,17 +219,31 @@ function unwrapExpression(expr: ts.Expression): ts.Expression {
 }
 
 function expressionHasSideEffects(expr: ts.Expression): boolean {
+  expr = unwrapExpression(expr);
+
   if (ts.isBinaryExpression(expr)) {
     // Any assignment operator
-    return expr.operatorToken.kind >= ts.SyntaxKind.EqualsToken &&
-           expr.operatorToken.kind <= ts.SyntaxKind.CaretEqualsToken;
+    return (
+      (expr.operatorToken.kind >= ts.SyntaxKind.EqualsToken &&
+        expr.operatorToken.kind <= ts.SyntaxKind.CaretEqualsToken) ||
+      expressionHasSideEffects(expr.left) ||
+      expressionHasSideEffects(expr.right)
+    );
   }
   if (ts.isCallExpression(expr)) return true;
+  if (ts.isNewExpression(expr) || ts.isAwaitExpression(expr)) return true;
   if (ts.isPrefixUnaryExpression(expr) || ts.isPostfixUnaryExpression(expr)) {
     const op = expr.operator;
-    return op === ts.SyntaxKind.PlusPlusToken || op === ts.SyntaxKind.MinusMinusToken;
+    return (
+      op === ts.SyntaxKind.PlusPlusToken ||
+      op === ts.SyntaxKind.MinusMinusToken ||
+      expressionHasSideEffects(expr.operand)
+    );
   }
-  return false;
+  return ts.forEachChild(
+    expr,
+    (child) => (ts.isExpression(child) ? expressionHasSideEffects(child) : false),
+  ) ?? false;
 }
 
 /**
@@ -242,6 +256,10 @@ export function translateBodyExpr(
   strategy: NumericStrategy,
   paramNames: Map<string, string>,
 ): string {
+  if (ts.isExpression(expr)) {
+    expr = unwrapExpression(expr);
+  }
+
   // if/else statement -> cond
   if (ts.isIfStatement(expr)) {
     return translateIfStatement(expr, checker, strategy, paramNames);
@@ -297,11 +315,6 @@ export function translateBodyExpr(
     const right = translateBodyExpr(expr.right, checker, strategy, paramNames);
     if (isUnsupported(right)) return right;
     return `${left} ${op} ${right}`;
-  }
-
-  // Parenthesized
-  if (ts.isParenthesizedExpression(expr)) {
-    return translateBodyExpr(expr.expression, checker, strategy, paramNames);
   }
 
   // Fall through to base translateExpr for identifiers, literals, this, etc.

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -1,0 +1,432 @@
+import ts from "typescript";
+import type { PantProposition, PantDeclaration } from "./types.js";
+import type { NumericStrategy } from "./translate-types.js";
+import { translateExpr, translateOperator, findFunction, classifyFunction } from "./translate-signature.js";
+
+export interface TranslateBodyOptions {
+  program: ts.Program;
+  fileName: string;
+  functionName: string;
+  strategy: NumericStrategy;
+  /** Declarations in scope — used for frame condition generation. */
+  declarations?: PantDeclaration[];
+}
+
+/**
+ * Translate a TypeScript function body to Pantagruel propositions.
+ *
+ * Pure functions: return expression becomes `all params | f args = <expr>`.
+ * Mutating functions: property assignments become primed propositions,
+ * plus frame conditions for unmodified rules.
+ */
+export function translateBody(opts: TranslateBodyOptions): PantProposition[] {
+  const { program, fileName, functionName, strategy, declarations } = opts;
+  const checker = program.getTypeChecker();
+  const { node, className } = findFunction(program, fileName, functionName);
+  const classification = classifyFunction(node, checker);
+
+  // Build param name map (same logic as translateSignature)
+  const paramNames = new Map<string, string>();
+  const paramList: Array<{ name: string; type: string }> = [];
+
+  if (className) {
+    const pName = className[0].toLowerCase();
+    paramNames.set("this", pName);
+    paramList.push({ name: pName, type: className });
+  }
+
+  const sig = checker.getSignatureFromDeclaration(node);
+  if (sig) {
+    for (const param of sig.getParameters()) {
+      const decl = param.valueDeclaration;
+      let typeName = "?";
+      if (decl && ts.isParameter(decl) && decl.type) {
+        typeName = decl.type.getText();
+      } else {
+        const t = checker.getTypeOfSymbol(param);
+        typeName = checker.typeToString(t);
+      }
+      paramNames.set(param.name, param.name);
+      paramList.push({ name: param.name, type: typeName });
+    }
+  }
+
+  if (!node.body) return [];
+
+  if (classification === "pure") {
+    return translatePureBody(node, functionName, paramList, checker, strategy, paramNames);
+  } else {
+    return translateMutatingBody(node, functionName, paramList, checker, strategy, paramNames, declarations ?? []);
+  }
+}
+
+function translatePureBody(
+  node: ts.FunctionDeclaration | ts.MethodDeclaration,
+  functionName: string,
+  params: Array<{ name: string; type: string }>,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  paramNames: Map<string, string>,
+): PantProposition[] {
+  if (!node.body) return [];
+
+  const returnExpr = extractReturnExpression(node.body);
+  if (!returnExpr) return [];
+
+  const args = params.map((p) => p.name).join(" ");
+  const bindings = params.map((p) => `${p.name}: ${p.type}`).join(", ");
+  const body = translateBodyExpr(returnExpr, checker, strategy, paramNames);
+
+  return [{ text: `all ${bindings} | ${functionName} ${args} = ${body}` }];
+}
+
+/**
+ * Extract the return expression from a function body.
+ * Handles:
+ *   - Single return statement
+ *   - if/else with returns in both branches (produces a synthetic conditional)
+ */
+function extractReturnExpression(body: ts.Block): ts.Expression | null {
+  // Skip guard statements (if-throw patterns) and find the meaningful return
+  const stmts = body.statements.filter((s) => !isGuardStatement(s));
+
+  if (stmts.length === 1) {
+    const stmt = stmts[0];
+    if (ts.isReturnStatement(stmt) && stmt.expression) {
+      return stmt.expression;
+    }
+    // if/else with returns
+    if (ts.isIfStatement(stmt) && stmt.elseStatement) {
+      return stmt;
+    }
+  }
+
+  // Multiple statements: look for if/else-return or trailing return
+  if (stmts.length >= 1) {
+    const last = stmts[stmts.length - 1];
+    if (ts.isReturnStatement(last) && last.expression) {
+      return last.expression;
+    }
+    if (ts.isIfStatement(last) && last.elseStatement) {
+      return last;
+    }
+  }
+
+  return null;
+}
+
+function isGuardStatement(stmt: ts.Statement): boolean {
+  if (!ts.isIfStatement(stmt)) return false;
+  // if (...) { throw } without else
+  if (!stmt.elseStatement && blockThrows(stmt.thenStatement)) return true;
+  // if (...) { ... } else { throw }
+  if (stmt.elseStatement && blockThrows(stmt.elseStatement)) {
+    // Only a guard if the then-block is NOT a return (i.e., body continues)
+    // Actually for pure functions, if-else-throw is a guard handled by signature
+    return blockThrows(stmt.elseStatement) && !blockReturns(stmt.thenStatement);
+  }
+  return false;
+}
+
+function blockThrows(node: ts.Statement): boolean {
+  if (ts.isBlock(node)) {
+    return node.statements.some((s) => ts.isThrowStatement(s));
+  }
+  return ts.isThrowStatement(node);
+}
+
+function blockReturns(node: ts.Statement): boolean {
+  if (ts.isBlock(node)) {
+    return node.statements.some((s) => ts.isReturnStatement(s));
+  }
+  return ts.isReturnStatement(node);
+}
+
+/**
+ * Translate a TS expression to Pantagruel syntax, extending the base
+ * translateExpr with support for ternary, array ops, and if/else as cond.
+ */
+export function translateBodyExpr(
+  expr: ts.Expression | ts.Statement,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  paramNames: Map<string, string>,
+): string {
+  // if/else statement -> cond
+  if (ts.isIfStatement(expr)) {
+    return translateIfStatement(expr, checker, strategy, paramNames);
+  }
+
+  // Ternary: a ? b : c -> cond a => b, true => c
+  if (ts.isConditionalExpression(expr)) {
+    const cond = translateBodyExpr(expr.condition, checker, strategy, paramNames);
+    const whenTrue = translateBodyExpr(expr.whenTrue, checker, strategy, paramNames);
+    const whenFalse = translateBodyExpr(expr.whenFalse, checker, strategy, paramNames);
+    return `cond ${cond} => ${whenTrue}, true => ${whenFalse}`;
+  }
+
+  // Property access with special array operations
+  if (ts.isPropertyAccessExpression(expr)) {
+    const prop = expr.name.text;
+    // .length -> #obj
+    if (prop === "length") {
+      const obj = translateBodyExpr(expr.expression, checker, strategy, paramNames);
+      return `#${obj}`;
+    }
+    // Regular property access: a.balance -> balance a
+    const obj = translateBodyExpr(expr.expression, checker, strategy, paramNames);
+    return `${prop} ${obj}`;
+  }
+
+  // Call expression: handle .includes(), .filter().map(), etc.
+  if (ts.isCallExpression(expr)) {
+    return translateCallExpr(expr, checker, strategy, paramNames);
+  }
+
+  // Prefix unary: !x -> ~(x), -x -> -(x)
+  if (ts.isPrefixUnaryExpression(expr)) {
+    if (expr.operator === ts.SyntaxKind.ExclamationToken) {
+      return `~(${translateBodyExpr(expr.operand, checker, strategy, paramNames)})`;
+    }
+    if (expr.operator === ts.SyntaxKind.MinusToken) {
+      return `-(${translateBodyExpr(expr.operand, checker, strategy, paramNames)})`;
+    }
+  }
+
+  // Binary expression
+  if (ts.isBinaryExpression(expr)) {
+    const left = translateBodyExpr(expr.left, checker, strategy, paramNames);
+    const right = translateBodyExpr(expr.right, checker, strategy, paramNames);
+    const op = translateOperator(expr.operatorToken.kind);
+    return `${left} ${op} ${right}`;
+  }
+
+  // Parenthesized
+  if (ts.isParenthesizedExpression(expr)) {
+    return translateBodyExpr(expr.expression, checker, strategy, paramNames);
+  }
+
+  // Fall through to base translateExpr for identifiers, literals, this, etc.
+  if (ts.isExpression(expr)) {
+    return translateExpr(expr, checker, strategy, paramNames);
+  }
+
+  return `/* unsupported */`;
+}
+
+function translateIfStatement(
+  stmt: ts.IfStatement,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  paramNames: Map<string, string>,
+): string {
+  const cond = translateBodyExpr(stmt.expression, checker, strategy, paramNames);
+  const thenExpr = extractReturnFromBranch(stmt.thenStatement);
+  const elseExpr = stmt.elseStatement
+    ? extractReturnFromBranch(stmt.elseStatement)
+    : null;
+
+  if (thenExpr && elseExpr) {
+    const thenStr = translateBodyExpr(thenExpr, checker, strategy, paramNames);
+    const elseStr = translateBodyExpr(elseExpr, checker, strategy, paramNames);
+    return `cond ${cond} => ${thenStr}, true => ${elseStr}`;
+  }
+
+  return `> UNSUPPORTED: if statement without return in both branches`;
+}
+
+function extractReturnFromBranch(stmt: ts.Statement): ts.Expression | null {
+  if (ts.isReturnStatement(stmt) && stmt.expression) return stmt.expression;
+  if (ts.isBlock(stmt)) {
+    for (const s of stmt.statements) {
+      if (ts.isReturnStatement(s) && s.expression) return s.expression;
+    }
+  }
+  return null;
+}
+
+function translateCallExpr(
+  expr: ts.CallExpression,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  paramNames: Map<string, string>,
+): string {
+  // Method calls: obj.method(args)
+  if (ts.isPropertyAccessExpression(expr.expression)) {
+    const methodName = expr.expression.name.text;
+    const obj = expr.expression.expression;
+
+    // .includes(x) -> x in obj
+    if (methodName === "includes" && expr.arguments.length === 1) {
+      const arg = translateBodyExpr(expr.arguments[0], checker, strategy, paramNames);
+      const objStr = translateBodyExpr(obj, checker, strategy, paramNames);
+      return `${arg} in ${objStr}`;
+    }
+
+    // .filter(p).map(f) -> each x: T, p x | f x
+    if (methodName === "map" && ts.isCallExpression(obj)) {
+      const filterResult = tryTranslateFilterMap(obj, expr, checker, strategy, paramNames);
+      if (filterResult) return filterResult;
+    }
+  }
+
+  // Unsupported call
+  return `> UNSUPPORTED: ${expr.getText()}`;
+}
+
+function tryTranslateFilterMap(
+  filterCall: ts.CallExpression,
+  mapCall: ts.CallExpression,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  paramNames: Map<string, string>,
+): string | null {
+  if (!ts.isPropertyAccessExpression(filterCall.expression)) return null;
+  if (filterCall.expression.name.text !== "filter") return null;
+  if (filterCall.arguments.length !== 1 || mapCall.arguments.length !== 1) return null;
+
+  const sourceObj = filterCall.expression.expression;
+  const filterArg = filterCall.arguments[0];
+  const mapArg = mapCall.arguments[0];
+
+  // Try to extract the element type from the source array
+  const sourceType = checker.getTypeAtLocation(sourceObj);
+  let elemTypeName = "?";
+  if (checker.isArrayType(sourceType)) {
+    const typeArgs = checker.getTypeArguments(sourceType as ts.TypeReference);
+    if (typeArgs.length === 1) {
+      const sym = typeArgs[0].aliasSymbol ?? typeArgs[0].symbol;
+      elemTypeName = sym ? sym.getName() : checker.typeToString(typeArgs[0]);
+    }
+  }
+
+  const varName = "x";
+  const extendedParams = new Map(paramNames);
+  extendedParams.set(varName, varName);
+
+  // Extract predicate body from arrow function
+  const filterBody = extractArrowBody(filterArg, extendedParams, checker, strategy);
+  const mapBody = extractArrowBody(mapArg, extendedParams, checker, strategy);
+
+  if (filterBody && mapBody) {
+    return `each ${varName}: ${elemTypeName}, ${filterBody} | ${mapBody}`;
+  }
+
+  return null;
+}
+
+function extractArrowBody(
+  expr: ts.Expression,
+  paramNames: Map<string, string>,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+): string | null {
+  if (!ts.isArrowFunction(expr)) return null;
+
+  // Map arrow param to "x"
+  const arrowParams = new Map(paramNames);
+  if (expr.parameters.length === 1) {
+    arrowParams.set(expr.parameters[0].name.getText(), "x");
+  }
+
+  if (ts.isBlock(expr.body)) {
+    // { return expr; }
+    for (const s of expr.body.statements) {
+      if (ts.isReturnStatement(s) && s.expression) {
+        return translateBodyExpr(s.expression, checker, strategy, arrowParams);
+      }
+    }
+    return null;
+  }
+
+  // Expression body
+  return translateBodyExpr(expr.body, checker, strategy, arrowParams);
+}
+
+// --- Mutating function body translation ---
+
+function translateMutatingBody(
+  node: ts.FunctionDeclaration | ts.MethodDeclaration,
+  functionName: string,
+  params: Array<{ name: string; type: string }>,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  paramNames: Map<string, string>,
+  declarations: PantDeclaration[],
+): PantProposition[] {
+  if (!node.body) return [];
+
+  const propositions: PantProposition[] = [];
+  const modifiedRules = new Set<string>();
+
+  // Collect property assignments
+  collectAssignments(node.body, checker, strategy, paramNames, propositions, modifiedRules);
+
+  // Generate frame conditions
+  const frames = generateFrameConditions(modifiedRules, declarations);
+  propositions.push(...frames);
+
+  return propositions;
+}
+
+function collectAssignments(
+  block: ts.Block,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  paramNames: Map<string, string>,
+  propositions: PantProposition[],
+  modifiedRules: Set<string>,
+): void {
+  for (const stmt of block.statements) {
+    // Skip guard statements (if-throw patterns)
+    if (isGuardStatement(stmt)) continue;
+
+    if (ts.isExpressionStatement(stmt) && ts.isBinaryExpression(stmt.expression)) {
+      const bin = stmt.expression;
+      if (
+        bin.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+        ts.isPropertyAccessExpression(bin.left)
+      ) {
+        const prop = bin.left.name.text;
+        const obj = translateBodyExpr(bin.left.expression, checker, strategy, paramNames);
+        const val = translateBodyExpr(bin.right, checker, strategy, paramNames);
+        propositions.push({ text: `${prop}' ${obj} = ${val}` });
+        modifiedRules.add(prop);
+      }
+    }
+
+    // Recurse into if blocks (for conditional assignments)
+    if (ts.isIfStatement(stmt)) {
+      if (stmt.thenStatement && ts.isBlock(stmt.thenStatement)) {
+        collectAssignments(stmt.thenStatement, checker, strategy, paramNames, propositions, modifiedRules);
+      }
+      if (stmt.elseStatement && ts.isBlock(stmt.elseStatement)) {
+        collectAssignments(stmt.elseStatement, checker, strategy, paramNames, propositions, modifiedRules);
+      }
+    }
+  }
+}
+
+/**
+ * Generate frame conditions: for each rule in declarations not explicitly
+ * modified, emit `all x: T | rule' x = rule x`.
+ */
+function generateFrameConditions(
+  modifiedRules: Set<string>,
+  declarations: PantDeclaration[],
+): PantProposition[] {
+  const frames: PantProposition[] = [];
+
+  for (const decl of declarations) {
+    if (decl.kind !== "rule") continue;
+    if (modifiedRules.has(decl.name)) continue;
+
+    const paramBindings = decl.params.map((p) => `${p.name}: ${p.type}`).join(", ");
+    const paramArgs = decl.params.map((p) => p.name).join(" ");
+    frames.push({
+      text: `all ${paramBindings} | ${decl.name}' ${paramArgs} = ${decl.name} ${paramArgs}`,
+    });
+  }
+
+  return frames;
+}

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -3,6 +3,21 @@ import type { PantProposition, PantDeclaration } from "./types.js";
 import { mapTsType, type NumericStrategy } from "./translate-types.js";
 import { translateExpr, translateOperator, findFunction, classifyFunction } from "./translate-signature.js";
 
+function isUnsupported(s: string): boolean {
+  return s.startsWith("> UNSUPPORTED:");
+}
+
+/** Generate a binder name not already used by params. */
+function freshBinder(paramNames: Map<string, string>): string {
+  const used = new Set(paramNames.values());
+  for (const candidate of ["x", "y", "z", "w", "v", "u", "t"]) {
+    if (!used.has(candidate)) return candidate;
+  }
+  let i = 0;
+  while (used.has(`x${i}`)) i++;
+  return `x${i}`;
+}
+
 export interface TranslateBodyOptions {
   program: ts.Program;
   fileName: string;
@@ -78,7 +93,10 @@ function translatePureBody(
   if (!node.body) return [];
 
   const returnExpr = extractReturnExpression(node.body);
-  if (!returnExpr) return [];
+  if (!returnExpr) {
+    const reason = describeRejectedBody(node.body);
+    return [{ text: `> UNSUPPORTED: ${functionName} — ${reason}` }];
+  }
 
   const args = params.map((p) => p.name).join(" ");
   const bindings = params.map((p) => `${p.name}: ${p.type}`).join(", ");
@@ -121,6 +139,15 @@ function extractReturnExpression(body: ts.Block): ts.Expression | null {
   }
 
   return null;
+}
+
+function describeRejectedBody(body: ts.Block): string {
+  const stmts = body.statements.filter((s) => !isGuardStatement(s));
+  if (stmts.length === 0) return "empty body";
+  if (stmts.length > 1) return "local bindings or multiple statements before return";
+  const stmt = stmts[0];
+  if (ts.isReturnStatement(stmt) && !stmt.expression) return "return without expression";
+  return "non-translatable control flow";
 }
 
 function isGuardStatement(stmt: ts.Statement): boolean {
@@ -168,8 +195,11 @@ export function translateBodyExpr(
   // Ternary: a ? b : c -> cond a => b, true => c
   if (ts.isConditionalExpression(expr)) {
     const cond = translateBodyExpr(expr.condition, checker, strategy, paramNames);
+    if (isUnsupported(cond)) return cond;
     const whenTrue = translateBodyExpr(expr.whenTrue, checker, strategy, paramNames);
+    if (isUnsupported(whenTrue)) return whenTrue;
     const whenFalse = translateBodyExpr(expr.whenFalse, checker, strategy, paramNames);
+    if (isUnsupported(whenFalse)) return whenFalse;
     return `cond ${cond} => ${whenTrue}, true => ${whenFalse}`;
   }
 
@@ -203,9 +233,12 @@ export function translateBodyExpr(
 
   // Binary expression
   if (ts.isBinaryExpression(expr)) {
-    const left = translateBodyExpr(expr.left, checker, strategy, paramNames);
-    const right = translateBodyExpr(expr.right, checker, strategy, paramNames);
     const op = translateOperator(expr.operatorToken.kind);
+    if (op === "?") return `> UNSUPPORTED: operator ${ts.SyntaxKind[expr.operatorToken.kind]}`;
+    const left = translateBodyExpr(expr.left, checker, strategy, paramNames);
+    if (isUnsupported(left)) return left;
+    const right = translateBodyExpr(expr.right, checker, strategy, paramNames);
+    if (isUnsupported(right)) return right;
     return `${left} ${op} ${right}`;
   }
 
@@ -236,7 +269,9 @@ function translateIfStatement(
 
   if (thenExpr && elseExpr) {
     const thenStr = translateBodyExpr(thenExpr, checker, strategy, paramNames);
+    if (isUnsupported(thenStr)) return thenStr;
     const elseStr = translateBodyExpr(elseExpr, checker, strategy, paramNames);
+    if (isUnsupported(elseStr)) return elseStr;
     return `cond ${cond} => ${thenStr}, true => ${elseStr}`;
   }
 
@@ -246,7 +281,13 @@ function translateIfStatement(
 function extractReturnFromBranch(stmt: ts.Statement): ts.Expression | null {
   if (ts.isReturnStatement(stmt) && stmt.expression) return stmt.expression;
   if (ts.isBlock(stmt)) {
-    for (const s of stmt.statements) {
+    // Apply the same rule as extractReturnExpression: only allow a single
+    // return (after filtering guards). Blocks with local declarations or
+    // multiple non-guard statements are rejected so we don't leak
+    // branch-scoped bindings into the generated proposition.
+    const nonGuard = stmt.statements.filter((s) => !isGuardStatement(s));
+    if (nonGuard.length === 1) {
+      const s = nonGuard[0];
       if (ts.isReturnStatement(s) && s.expression) return s.expression;
     }
   }
@@ -307,13 +348,13 @@ function tryTranslateFilterMap(
     }
   }
 
-  const varName = "x";
+  const varName = freshBinder(paramNames);
   const extendedParams = new Map(paramNames);
   extendedParams.set(varName, varName);
 
   // Extract predicate body from arrow function
-  const filterBody = extractArrowBody(filterArg, extendedParams, checker, strategy);
-  const mapBody = extractArrowBody(mapArg, extendedParams, checker, strategy);
+  const filterBody = extractArrowBody(filterArg, varName, extendedParams, checker, strategy);
+  const mapBody = extractArrowBody(mapArg, varName, extendedParams, checker, strategy);
 
   if (filterBody && mapBody) {
     return `each ${varName}: ${elemTypeName}, ${filterBody} | ${mapBody}`;
@@ -324,16 +365,17 @@ function tryTranslateFilterMap(
 
 function extractArrowBody(
   expr: ts.Expression,
+  binderName: string,
   paramNames: Map<string, string>,
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
 ): string | null {
   if (!ts.isArrowFunction(expr)) return null;
 
-  // Map arrow param to "x"
+  // Map arrow param to the fresh binder
   const arrowParams = new Map(paramNames);
   if (expr.parameters.length === 1) {
-    arrowParams.set(expr.parameters[0].name.getText(), "x");
+    arrowParams.set(expr.parameters[0].name.getText(), binderName);
   }
 
   if (ts.isBlock(expr.body)) {
@@ -428,6 +470,12 @@ function collectAssignments(
       propositions.push({ text: `> UNSUPPORTED: loop assignment` });
     } else if (ts.isTryStatement(stmt)) {
       collectAssignments(stmt.tryBlock, checker, strategy, paramNames, propositions, modifiedRules);
+      if (stmt.catchClause) {
+        collectAssignments(stmt.catchClause.block, checker, strategy, paramNames, propositions, modifiedRules);
+      }
+      if (stmt.finallyBlock) {
+        collectAssignments(stmt.finallyBlock, checker, strategy, paramNames, propositions, modifiedRules);
+      }
     } else if (ts.isSwitchStatement(stmt)) {
       propositions.push({ text: `> UNSUPPORTED: switch assignment` });
     }

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -164,6 +164,13 @@ function isGuardStatement(stmt: ts.Statement): boolean {
   return false;
 }
 
+function variableStatementHasNoSideEffects(stmt: ts.VariableStatement): boolean {
+  return stmt.declarationList.declarations.every(
+    (decl) =>
+      !decl.initializer || !expressionHasSideEffects(decl.initializer),
+  );
+}
+
 function blockThrows(node: ts.Statement): boolean {
   if (ts.isThrowStatement(node)) return true;
   if (ts.isBlock(node)) {
@@ -172,7 +179,9 @@ function blockThrows(node: ts.Statement): boolean {
     // Last statement must be a throw; all preceding must be side-effect-free
     // (variable declarations for building the error message, etc.)
     if (!ts.isThrowStatement(stmts[stmts.length - 1])) return false;
-    return stmts.slice(0, -1).every((s) => ts.isVariableStatement(s));
+    return stmts
+      .slice(0, -1)
+      .every((s) => ts.isVariableStatement(s) && variableStatementHasNoSideEffects(s));
   }
   return false;
 }
@@ -192,12 +201,29 @@ function blockHasNoSideEffects(node: ts.Statement): boolean {
   if (ts.isExpressionStatement(node)) {
     return !expressionHasSideEffects(node.expression);
   }
-  // Variable declarations, return statements, throw statements are fine
-  if (ts.isVariableStatement(node) || ts.isReturnStatement(node) || ts.isThrowStatement(node)) {
+  // Variable declarations are fine only if initializers have no side effects
+  if (ts.isVariableStatement(node)) {
+    return variableStatementHasNoSideEffects(node);
+  }
+  // Return statements, throw statements are fine
+  if (ts.isReturnStatement(node) || ts.isThrowStatement(node)) {
     return true;
   }
   // if/for/while/switch may contain mutations — treat as side-effectful
   return false;
+}
+
+/** Unwrap parentheses, type assertions, and non-null assertions to get the inner expression. */
+function unwrapExpression(expr: ts.Expression): ts.Expression {
+  while (
+    ts.isParenthesizedExpression(expr) ||
+    ts.isAsExpression(expr) ||
+    ts.isSatisfiesExpression(expr) ||
+    ts.isNonNullExpression(expr)
+  ) {
+    expr = expr.expression;
+  }
+  return expr;
 }
 
 function expressionHasSideEffects(expr: ts.Expression): boolean {
@@ -489,8 +515,8 @@ function collectAssignments(
     // Skip guard statements (if-throw patterns)
     if (isGuardStatement(stmt)) continue;
 
-    if (ts.isExpressionStatement(stmt) && ts.isBinaryExpression(stmt.expression)) {
-      const bin = stmt.expression;
+    if (ts.isExpressionStatement(stmt) && ts.isBinaryExpression(unwrapExpression(stmt.expression))) {
+      const bin = unwrapExpression(stmt.expression) as ts.BinaryExpression;
       if (
         bin.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
         ts.isPropertyAccessExpression(bin.left)

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -164,10 +164,16 @@ function isGuardStatement(stmt: ts.Statement): boolean {
 }
 
 function blockThrows(node: ts.Statement): boolean {
+  if (ts.isThrowStatement(node)) return true;
   if (ts.isBlock(node)) {
-    return node.statements.some((s) => ts.isThrowStatement(s));
+    const stmts = node.statements;
+    if (stmts.length === 0) return false;
+    // Last statement must be a throw; all preceding must be side-effect-free
+    // (variable declarations for building the error message, etc.)
+    if (!ts.isThrowStatement(stmts[stmts.length - 1])) return false;
+    return stmts.slice(0, -1).every((s) => ts.isVariableStatement(s));
   }
-  return ts.isThrowStatement(node);
+  return false;
 }
 
 function blockReturns(node: ts.Statement): boolean {
@@ -206,13 +212,13 @@ export function translateBodyExpr(
   // Property access with special array operations
   if (ts.isPropertyAccessExpression(expr)) {
     const prop = expr.name.text;
+    const obj = translateBodyExpr(expr.expression, checker, strategy, paramNames);
+    if (isUnsupported(obj)) return obj;
     // .length -> #obj
     if (prop === "length") {
-      const obj = translateBodyExpr(expr.expression, checker, strategy, paramNames);
       return `#${obj}`;
     }
     // Regular property access: a.balance -> balance a
-    const obj = translateBodyExpr(expr.expression, checker, strategy, paramNames);
     return `${prop} ${obj}`;
   }
 
@@ -223,11 +229,13 @@ export function translateBodyExpr(
 
   // Prefix unary: !x -> ~(x), -x -> -(x)
   if (ts.isPrefixUnaryExpression(expr)) {
+    const operand = translateBodyExpr(expr.operand, checker, strategy, paramNames);
+    if (isUnsupported(operand)) return operand;
     if (expr.operator === ts.SyntaxKind.ExclamationToken) {
-      return `~(${translateBodyExpr(expr.operand, checker, strategy, paramNames)})`;
+      return `~(${operand})`;
     }
     if (expr.operator === ts.SyntaxKind.MinusToken) {
-      return `-(${translateBodyExpr(expr.operand, checker, strategy, paramNames)})`;
+      return `-(${operand})`;
     }
   }
 
@@ -262,6 +270,7 @@ function translateIfStatement(
   paramNames: Map<string, string>,
 ): string {
   const cond = translateBodyExpr(stmt.expression, checker, strategy, paramNames);
+  if (isUnsupported(cond)) return cond;
   const thenExpr = extractReturnFromBranch(stmt.thenStatement);
   const elseExpr = stmt.elseStatement
     ? extractReturnFromBranch(stmt.elseStatement)
@@ -308,7 +317,9 @@ function translateCallExpr(
     // .includes(x) -> x in obj
     if (methodName === "includes" && expr.arguments.length === 1) {
       const arg = translateBodyExpr(expr.arguments[0], checker, strategy, paramNames);
+      if (isUnsupported(arg)) return arg;
       const objStr = translateBodyExpr(obj, checker, strategy, paramNames);
+      if (isUnsupported(objStr)) return objStr;
       return `${arg} in ${objStr}`;
     }
 
@@ -379,8 +390,12 @@ function extractArrowBody(
   }
 
   if (ts.isBlock(expr.body)) {
-    // { return expr; }
-    for (const s of expr.body.statements) {
+    // Only allow a single return (after filtering guards), same rule as
+    // extractReturnExpression — blocks with locals or multiple statements
+    // would introduce free variables in the generated comprehension.
+    const nonGuard = expr.body.statements.filter((s) => !isGuardStatement(s));
+    if (nonGuard.length === 1) {
+      const s = nonGuard[0];
       if (ts.isReturnStatement(s) && s.expression) {
         return translateBodyExpr(s.expression, checker, strategy, arrowParams);
       }
@@ -409,15 +424,23 @@ function translateMutatingBody(
   const modifiedRules = new Set<string>();
 
   // Collect property assignments
-  collectAssignments(node.body, checker, strategy, paramNames, propositions, modifiedRules);
+  const hasUnsupportedMutation = collectAssignments(node.body, checker, strategy, paramNames, propositions, modifiedRules);
 
-  // Generate frame conditions
-  const frames = generateFrameConditions(modifiedRules, declarations);
-  propositions.push(...frames);
+  // Only generate frame conditions when all mutation shapes were translatable;
+  // unsupported control flow (if/loop/switch) makes frames unsound.
+  if (!hasUnsupportedMutation) {
+    const frames = generateFrameConditions(modifiedRules, declarations);
+    propositions.push(...frames);
+  }
 
   return propositions;
 }
 
+/**
+ * Collect property assignments from a block. Returns true if any unsupported
+ * mutating control flow (if/loop/switch) was encountered, signalling that
+ * frame condition generation should be suppressed.
+ */
 function collectAssignments(
   body: ts.Block | ts.Statement,
   checker: ts.TypeChecker,
@@ -425,7 +448,8 @@ function collectAssignments(
   paramNames: Map<string, string>,
   propositions: PantProposition[],
   modifiedRules: Set<string>,
-): void {
+): boolean {
+  let hasUnsupportedMutation = false;
   const stmts = ts.isBlock(body) ? Array.from(body.statements) : [body];
 
   for (const stmt of stmts) {
@@ -457,9 +481,12 @@ function collectAssignments(
 
     // Recurse into nested blocks
     if (ts.isBlock(stmt)) {
-      collectAssignments(stmt, checker, strategy, paramNames, propositions, modifiedRules);
+      if (collectAssignments(stmt, checker, strategy, paramNames, propositions, modifiedRules)) {
+        hasUnsupportedMutation = true;
+      }
     } else if (ts.isIfStatement(stmt)) {
       propositions.push({ text: `> UNSUPPORTED: conditional assignment (if/else)` });
+      hasUnsupportedMutation = true;
     } else if (
       ts.isForStatement(stmt) ||
       ts.isForOfStatement(stmt) ||
@@ -468,18 +495,28 @@ function collectAssignments(
       ts.isDoStatement(stmt)
     ) {
       propositions.push({ text: `> UNSUPPORTED: loop assignment` });
+      hasUnsupportedMutation = true;
     } else if (ts.isTryStatement(stmt)) {
-      collectAssignments(stmt.tryBlock, checker, strategy, paramNames, propositions, modifiedRules);
+      if (collectAssignments(stmt.tryBlock, checker, strategy, paramNames, propositions, modifiedRules)) {
+        hasUnsupportedMutation = true;
+      }
       if (stmt.catchClause) {
-        collectAssignments(stmt.catchClause.block, checker, strategy, paramNames, propositions, modifiedRules);
+        if (collectAssignments(stmt.catchClause.block, checker, strategy, paramNames, propositions, modifiedRules)) {
+          hasUnsupportedMutation = true;
+        }
       }
       if (stmt.finallyBlock) {
-        collectAssignments(stmt.finallyBlock, checker, strategy, paramNames, propositions, modifiedRules);
+        if (collectAssignments(stmt.finallyBlock, checker, strategy, paramNames, propositions, modifiedRules)) {
+          hasUnsupportedMutation = true;
+        }
       }
     } else if (ts.isSwitchStatement(stmt)) {
       propositions.push({ text: `> UNSUPPORTED: switch assignment` });
+      hasUnsupportedMutation = true;
     }
   }
+
+  return hasUnsupportedMutation;
 }
 
 /**

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -156,9 +156,10 @@ function isGuardStatement(stmt: ts.Statement): boolean {
   if (!stmt.elseStatement && blockThrows(stmt.thenStatement)) return true;
   // if (...) { ... } else { throw }
   if (stmt.elseStatement && blockThrows(stmt.elseStatement)) {
-    // Only a guard if the then-block is NOT a return (i.e., body continues)
-    // Actually for pure functions, if-else-throw is a guard handled by signature
-    return blockThrows(stmt.elseStatement) && !blockReturns(stmt.thenStatement);
+    // Only a guard if the then-block has no side effects (no assignments/mutations).
+    // A mutating then-branch like `if (ok) { a.balance = 1; } else { throw e; }`
+    // must NOT be classified as a guard — collectAssignments() needs to see it.
+    return blockHasNoSideEffects(stmt.thenStatement) && !blockReturns(stmt.thenStatement);
   }
   return false;
 }
@@ -181,6 +182,36 @@ function blockReturns(node: ts.Statement): boolean {
     return node.statements.some((s) => ts.isReturnStatement(s));
   }
   return ts.isReturnStatement(node);
+}
+
+/** Check that a statement/block contains no assignments or property writes. */
+function blockHasNoSideEffects(node: ts.Statement): boolean {
+  if (ts.isBlock(node)) {
+    return node.statements.every((s) => blockHasNoSideEffects(s));
+  }
+  if (ts.isExpressionStatement(node)) {
+    return !expressionHasSideEffects(node.expression);
+  }
+  // Variable declarations, return statements, throw statements are fine
+  if (ts.isVariableStatement(node) || ts.isReturnStatement(node) || ts.isThrowStatement(node)) {
+    return true;
+  }
+  // if/for/while/switch may contain mutations — treat as side-effectful
+  return false;
+}
+
+function expressionHasSideEffects(expr: ts.Expression): boolean {
+  if (ts.isBinaryExpression(expr)) {
+    // Any assignment operator
+    return expr.operatorToken.kind >= ts.SyntaxKind.EqualsToken &&
+           expr.operatorToken.kind <= ts.SyntaxKind.CaretEqualsToken;
+  }
+  if (ts.isCallExpression(expr)) return true;
+  if (ts.isPrefixUnaryExpression(expr) || ts.isPostfixUnaryExpression(expr)) {
+    const op = expr.operator;
+    return op === ts.SyntaxKind.PlusPlusToken || op === ts.SyntaxKind.MinusMinusToken;
+  }
+  return false;
 }
 
 /**
@@ -368,6 +399,8 @@ function tryTranslateFilterMap(
   const mapBody = extractArrowBody(mapArg, varName, extendedParams, checker, strategy);
 
   if (filterBody && mapBody) {
+    if (isUnsupported(filterBody)) return filterBody;
+    if (isUnsupported(mapBody)) return mapBody;
     return `each ${varName}: ${elemTypeName}, ${filterBody} | ${mapBody}`;
   }
 
@@ -469,6 +502,7 @@ function collectAssignments(
           obj.startsWith("> UNSUPPORTED:") ||
           val.startsWith("> UNSUPPORTED:")
         ) {
+          hasUnsupportedMutation = true;
           propositions.push({
             text: obj.startsWith("> UNSUPPORTED:") ? obj : val,
           });

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -1,6 +1,6 @@
 import ts from "typescript";
 import type { PantProposition, PantDeclaration } from "./types.js";
-import type { NumericStrategy } from "./translate-types.js";
+import { mapTsType, type NumericStrategy } from "./translate-types.js";
 import { translateExpr, translateOperator, findFunction, classifyFunction } from "./translate-signature.js";
 
 export interface TranslateBodyOptions {
@@ -38,14 +38,11 @@ export function translateBody(opts: TranslateBodyOptions): PantProposition[] {
   const sig = checker.getSignatureFromDeclaration(node);
   if (sig) {
     for (const param of sig.getParameters()) {
-      const decl = param.valueDeclaration;
-      let typeName = "?";
-      if (decl && ts.isParameter(decl) && decl.type) {
-        typeName = decl.type.getText();
-      } else {
-        const t = checker.getTypeOfSymbol(param);
-        typeName = checker.typeToString(t);
-      }
+      const typeName = mapTsType(
+        checker.getTypeOfSymbol(param),
+        checker,
+        strategy,
+      );
       paramNames.set(param.name, param.name);
       paramList.push({ name: param.name, type: typeName });
     }
@@ -77,7 +74,13 @@ function translatePureBody(
   const bindings = params.map((p) => `${p.name}: ${p.type}`).join(", ");
   const body = translateBodyExpr(returnExpr, checker, strategy, paramNames);
 
-  return [{ text: `all ${bindings} | ${functionName} ${args} = ${body}` }];
+  if (body.startsWith("> UNSUPPORTED:")) {
+    return [{ text: body }];
+  }
+
+  const head = bindings ? `all ${bindings} | ` : "";
+  const call = args ? `${functionName} ${args}` : functionName;
+  return [{ text: `${head}${call} = ${body}` }];
 }
 
 /**
@@ -395,14 +398,10 @@ function collectAssignments(
       }
     }
 
-    // Recurse into if blocks (for conditional assignments)
+    // Conditional assignments — emit UNSUPPORTED comment rather than
+    // silently dropping the predicate.
     if (ts.isIfStatement(stmt)) {
-      if (stmt.thenStatement && ts.isBlock(stmt.thenStatement)) {
-        collectAssignments(stmt.thenStatement, checker, strategy, paramNames, propositions, modifiedRules);
-      }
-      if (stmt.elseStatement && ts.isBlock(stmt.elseStatement)) {
-        collectAssignments(stmt.elseStatement, checker, strategy, paramNames, propositions, modifiedRules);
-      }
+      propositions.push({ text: `> UNSUPPORTED: conditional assignment (if/else)` });
     }
   }
 }
@@ -421,11 +420,15 @@ function generateFrameConditions(
     if (decl.kind !== "rule") continue;
     if (modifiedRules.has(decl.name)) continue;
 
-    const paramBindings = decl.params.map((p) => `${p.name}: ${p.type}`).join(", ");
-    const paramArgs = decl.params.map((p) => p.name).join(" ");
-    frames.push({
-      text: `all ${paramBindings} | ${decl.name}' ${paramArgs} = ${decl.name} ${paramArgs}`,
-    });
+    if (decl.params.length === 0) {
+      frames.push({ text: `${decl.name}' = ${decl.name}` });
+    } else {
+      const paramBindings = decl.params.map((p) => `${p.name}: ${p.type}`).join(", ");
+      const paramArgs = decl.params.map((p) => p.name).join(" ");
+      frames.push({
+        text: `all ${paramBindings} | ${decl.name}' ${paramArgs} = ${decl.name} ${paramArgs}`,
+      });
+    }
   }
 
   return frames;

--- a/tools/ts2pant/src/translate-signature.ts
+++ b/tools/ts2pant/src/translate-signature.ts
@@ -156,7 +156,7 @@ function blockThrows(node: ts.Statement): boolean {
 /**
  * Translate a TypeScript expression to Pantagruel syntax (best-effort).
  */
-function translateExpr(
+export function translateExpr(
   expr: ts.Expression,
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
@@ -216,7 +216,7 @@ function translateExpr(
   return expr.getText();
 }
 
-function translateOperator(kind: ts.SyntaxKind): string {
+export function translateOperator(kind: ts.SyntaxKind): string {
   switch (kind) {
     case ts.SyntaxKind.GreaterThanEqualsToken:
       return ">=";

--- a/tools/ts2pant/src/translate-signature.ts
+++ b/tools/ts2pant/src/translate-signature.ts
@@ -253,7 +253,7 @@ function capitalize(s: string): string {
   return s.charAt(0).toUpperCase() + s.slice(1);
 }
 
-function shortParamName(typeName: string, existingNames: Set<string>): string {
+export function shortParamName(typeName: string, existingNames: Set<string>): string {
   let name = typeName[0].toLowerCase();
   let suffix = 1;
   while (existingNames.has(name)) {

--- a/tools/ts2pant/tests/translate-body.test.ts
+++ b/tools/ts2pant/tests/translate-body.test.ts
@@ -222,7 +222,7 @@ describe("array operations", () => {
     const props = translate(source, "activeNames");
 
     expect(props[0].text).toBe(
-      "all users: [User] | activeNames users = each x: User, active x | name x",
+      "all users: [User] | activeNames users = (each x: User, active x | name x)",
     );
   });
 });
@@ -355,7 +355,7 @@ describe("class method body translation", () => {
     `;
     const props = translate(source, "getBalance");
 
-    expect(props[0].text).toBe("all account: Account | getBalance account = balance account");
+    expect(props[0].text).toBe("all a: Account | getBalance a = balance a");
   });
 
   it("translates mutating class method", () => {
@@ -369,7 +369,7 @@ describe("class method body translation", () => {
     `;
     const props = translate(source, "deposit");
 
-    expect(props.some((p) => p.text === "balance' account = balance account + amount")).toBe(
+    expect(props.some((p) => p.text === "balance' a = balance a + amount")).toBe(
       true,
     );
   });

--- a/tools/ts2pant/tests/translate-body.test.ts
+++ b/tools/ts2pant/tests/translate-body.test.ts
@@ -1,0 +1,376 @@
+import { describe, it, expect } from "vitest";
+import { createProgramFromSource } from "../src/extract.js";
+import { IntStrategy } from "../src/translate-types.js";
+import { translateBody } from "../src/translate-body.js";
+import type { PantDeclaration } from "../src/types.js";
+
+function translate(
+  source: string,
+  functionName: string,
+  declarations: PantDeclaration[] = [],
+) {
+  const fileName = "test.ts";
+  const program = createProgramFromSource(source, fileName);
+  return translateBody({
+    program,
+    fileName,
+    functionName,
+    strategy: IntStrategy,
+    declarations,
+  });
+}
+
+describe("pure function: return expression -> proposition", () => {
+  it("translates simple return to defining proposition", () => {
+    const source = `
+      interface Account { balance: number; }
+      function getBalance(a: Account): number {
+        return a.balance;
+      }
+    `;
+    const props = translate(source, "getBalance");
+
+    expect(props).toHaveLength(1);
+    expect(props[0].text).toBe("all a: Account | getBalance a = balance a");
+  });
+
+  it("translates arithmetic return expression", () => {
+    const source = `
+      function double(n: number): number {
+        return n * 2;
+      }
+    `;
+    const props = translate(source, "double");
+
+    expect(props).toHaveLength(1);
+    expect(props[0].text).toBe("all n: number | double n = n * 2");
+  });
+
+  it("translates multi-param pure function", () => {
+    const source = `
+      function add(a: number, b: number): number {
+        return a + b;
+      }
+    `;
+    const props = translate(source, "add");
+
+    expect(props).toHaveLength(1);
+    expect(props[0].text).toBe("all a: number, b: number | add a b = a + b");
+  });
+});
+
+describe("property access -> rule application", () => {
+  it("translates property access to rule application", () => {
+    const source = `
+      interface Account { balance: number; owner: string; }
+      function getOwner(a: Account): string {
+        return a.owner;
+      }
+    `;
+    const props = translate(source, "getOwner");
+
+    expect(props[0].text).toBe("all a: Account | getOwner a = owner a");
+  });
+
+  it("translates nested property access", () => {
+    const source = `
+      interface User { name: string; }
+      interface Account { owner: User; }
+      function getOwnerName(a: Account): string {
+        return a.owner.name;
+      }
+    `;
+    const props = translate(source, "getOwnerName");
+
+    expect(props[0].text).toBe(
+      "all a: Account | getOwnerName a = name owner a",
+    );
+  });
+});
+
+describe("ternary -> cond", () => {
+  it("translates ternary to cond expression", () => {
+    const source = `
+      function max(a: number, b: number): number {
+        return a >= b ? a : b;
+      }
+    `;
+    const props = translate(source, "max");
+
+    expect(props[0].text).toBe(
+      "all a: number, b: number | max a b = cond a >= b => a, true => b",
+    );
+  });
+
+  it("translates ternary with property access in condition", () => {
+    const source = `
+      interface Account { active: boolean; balance: number; }
+      function effectiveBalance(a: Account): number {
+        return a.active ? a.balance : 0;
+      }
+    `;
+    const props = translate(source, "effectiveBalance");
+
+    expect(props[0].text).toBe(
+      "all a: Account | effectiveBalance a = cond active a => balance a, true => 0",
+    );
+  });
+});
+
+describe("if/else with returns -> cond", () => {
+  it("translates if/else return to cond", () => {
+    const source = `
+      function abs(n: number): number {
+        if (n >= 0) {
+          return n;
+        } else {
+          return 0 - n;
+        }
+      }
+    `;
+    const props = translate(source, "abs");
+
+    expect(props[0].text).toBe(
+      "all n: number | abs n = cond n >= 0 => n, true => 0 - n",
+    );
+  });
+});
+
+describe("boolean operators", () => {
+  it("translates && to and, || to or, ! to ~", () => {
+    const source = `
+      function check(a: boolean, b: boolean): boolean {
+        return a && !b;
+      }
+    `;
+    const props = translate(source, "check");
+
+    expect(props[0].text).toBe(
+      "all a: boolean, b: boolean | check a b = a and ~(b)",
+    );
+  });
+
+  it("translates === to = and !== to ~=", () => {
+    const source = `
+      function eq(a: number, b: number): boolean {
+        return a === b;
+      }
+    `;
+    const props = translate(source, "eq");
+
+    expect(props[0].text).toBe(
+      "all a: number, b: number | eq a b = a = b",
+    );
+  });
+});
+
+describe("array operations", () => {
+  it("translates .length to #", () => {
+    const source = `
+      function count(items: string[]): number {
+        return items.length;
+      }
+    `;
+    const props = translate(source, "count");
+
+    expect(props[0].text).toBe("all items: string[] | count items = #items");
+  });
+
+  it("translates .includes(x) to x in", () => {
+    const source = `
+      function contains(items: string[], x: string): boolean {
+        return items.includes(x);
+      }
+    `;
+    const props = translate(source, "contains");
+
+    expect(props[0].text).toBe(
+      "all items: string[], x: string | contains items x = x in items",
+    );
+  });
+
+  it("translates .filter(p).map(f) to each comprehension", () => {
+    const source = `
+      interface User { name: string; active: boolean; }
+      function activeNames(users: User[]): string[] {
+        return users.filter((u) => u.active).map((u) => u.name);
+      }
+    `;
+    const props = translate(source, "activeNames");
+
+    expect(props[0].text).toBe(
+      "all users: User[] | activeNames users = each x: User, active x | name x",
+    );
+  });
+});
+
+describe("mutating function: assignment -> primed proposition", () => {
+  it("translates property assignment to primed expression", () => {
+    const source = `
+      interface Account { balance: number; }
+      function deposit(a: Account, amount: number): void {
+        a.balance = a.balance + amount;
+      }
+    `;
+    const props = translate(source, "deposit");
+
+    expect(props.some((p) => p.text === "balance' a = balance a + amount")).toBe(
+      true,
+    );
+  });
+
+  it("translates multiple assignments", () => {
+    const source = `
+      interface Account { balance: number; owner: string; }
+      function transfer(a: Account, newOwner: string, fee: number): void {
+        a.balance = a.balance - fee;
+        a.owner = newOwner;
+      }
+    `;
+    const props = translate(source, "transfer");
+
+    expect(props.some((p) => p.text === "balance' a = balance a - fee")).toBe(true);
+    expect(props.some((p) => p.text === "owner' a = newOwner")).toBe(true);
+  });
+});
+
+describe("frame conditions", () => {
+  it("generates frame conditions for unmodified rules", () => {
+    const source = `
+      interface Account { balance: number; }
+      function deposit(a: Account, amount: number): void {
+        a.balance = a.balance + amount;
+      }
+    `;
+    const declarations: PantDeclaration[] = [
+      { kind: "domain", name: "Account" },
+      {
+        kind: "rule",
+        name: "balance",
+        params: [{ name: "a", type: "Account" }],
+        returnType: "Int",
+      },
+      {
+        kind: "rule",
+        name: "owner",
+        params: [{ name: "a", type: "Account" }],
+        returnType: "String",
+      },
+    ];
+
+    const props = translate(source, "deposit", declarations);
+
+    // balance is modified, so no frame condition for it
+    expect(
+      props.some((p) => p.text.includes("balance'") && p.text.includes("balance a + amount")),
+    ).toBe(true);
+
+    // owner is NOT modified, so frame condition generated
+    expect(
+      props.some((p) => p.text === "all a: Account | owner' a = owner a"),
+    ).toBe(true);
+
+    // No frame condition for balance (it's modified)
+    expect(
+      props.some((p) => p.text === "all a: Account | balance' a = balance a"),
+    ).toBe(false);
+  });
+
+  it("skips domains and actions in frame conditions", () => {
+    const source = `
+      interface Account { balance: number; }
+      function reset(a: Account): void {
+        a.balance = 0;
+      }
+    `;
+    const declarations: PantDeclaration[] = [
+      { kind: "domain", name: "Account" },
+      {
+        kind: "action",
+        label: "OtherAction",
+        params: [{ name: "a", type: "Account" }],
+      },
+      {
+        kind: "rule",
+        name: "balance",
+        params: [{ name: "a", type: "Account" }],
+        returnType: "Int",
+      },
+    ];
+
+    const props = translate(source, "reset", declarations);
+
+    // Only the assignment proposition, no frame for action/domain
+    expect(props.some((p) => p.text === "balance' a = 0")).toBe(true);
+    expect(props).toHaveLength(1); // just the assignment, no frames since balance is the only rule
+  });
+});
+
+describe("class method body translation", () => {
+  it("translates class method with this -> param mapping", () => {
+    const source = `
+      class Account {
+        balance: number = 0;
+        getBalance(): number {
+          return this.balance;
+        }
+      }
+    `;
+    const props = translate(source, "getBalance");
+
+    expect(props[0].text).toBe("all a: Account | getBalance a = balance a");
+  });
+
+  it("translates mutating class method", () => {
+    const source = `
+      class Account {
+        balance: number = 0;
+        deposit(amount: number): void {
+          this.balance = this.balance + amount;
+        }
+      }
+    `;
+    const props = translate(source, "deposit");
+
+    expect(props.some((p) => p.text === "balance' a = balance a + amount")).toBe(
+      true,
+    );
+  });
+});
+
+describe("unsupported patterns", () => {
+  it("returns empty for function with no body", () => {
+    const source = `
+      declare function external(x: number): number;
+    `;
+    const fileName = "test.ts";
+    const program = createProgramFromSource(source, fileName);
+    const props = translateBody({
+      program,
+      fileName,
+      functionName: "external",
+      strategy: IntStrategy,
+    });
+
+    expect(props).toHaveLength(0);
+  });
+});
+
+describe("guarded function body", () => {
+  it("skips guard (if-throw) and translates remaining body", () => {
+    const source = `
+      interface Account { balance: number; }
+      function withdraw(a: Account, amount: number): void {
+        if (!(a.balance >= amount)) {
+          throw new Error("Insufficient funds");
+        }
+        a.balance = a.balance - amount;
+      }
+    `;
+    const props = translate(source, "withdraw");
+
+    expect(props.some((p) => p.text === "balance' a = balance a - amount")).toBe(true);
+    // Should not contain anything about the guard/throw
+    expect(props.some((p) => p.text.includes("throw"))).toBe(false);
+  });
+});

--- a/tools/ts2pant/tests/translate-body.test.ts
+++ b/tools/ts2pant/tests/translate-body.test.ts
@@ -510,6 +510,32 @@ describe("arrow function body rejection", () => {
     expect(props).toHaveLength(1);
     expect(props[0].text).toMatch(/UNSUPPORTED/);
   });
+
+  it("rejects destructuring parameter in filter callback", () => {
+    const source = `
+      interface User { name: string; active: boolean; }
+      function activeNames(users: User[]): string[] {
+        return users.filter(({ active }) => active).map((u) => u.name);
+      }
+    `;
+    const props = translate(source, "activeNames");
+
+    expect(props).toHaveLength(1);
+    expect(props[0].text).toMatch(/UNSUPPORTED/);
+  });
+
+  it("rejects multi-parameter callback in map", () => {
+    const source = `
+      interface Item { value: number; }
+      function indexed(items: Item[]): number[] {
+        return items.filter((x) => x.value > 0).map((x, i) => x.value + i);
+      }
+    `;
+    const props = translate(source, "indexed");
+
+    expect(props).toHaveLength(1);
+    expect(props[0].text).toMatch(/UNSUPPORTED/);
+  });
 });
 
 describe("frame condition suppression", () => {

--- a/tools/ts2pant/tests/translate-body.test.ts
+++ b/tools/ts2pant/tests/translate-body.test.ts
@@ -373,4 +373,140 @@ describe("guarded function body", () => {
     // Should not contain anything about the guard/throw
     expect(props.some((p) => p.text.includes("throw"))).toBe(false);
   });
+
+  it("does not treat branch with effects before throw as a guard", () => {
+    const source = `
+      interface Account { balance: number; }
+      function riskyWithdraw(a: Account, amount: number): void {
+        if (amount > 1000) {
+          a.balance = 0;
+          throw new Error("too large");
+        }
+        a.balance = a.balance - amount;
+      }
+    `;
+    const props = translate(source, "riskyWithdraw");
+
+    // The if-branch has a real assignment before the throw, so it should NOT
+    // be skipped as a guard — it should appear as unsupported conditional assignment.
+    expect(props.some((p) => p.text.includes("UNSUPPORTED"))).toBe(true);
+  });
+
+  it("treats guard with variable declaration before throw as a guard", () => {
+    const source = `
+      interface Account { balance: number; }
+      function withdraw(a: Account, amount: number): void {
+        if (!(a.balance >= amount)) {
+          const msg = "Insufficient: " + amount;
+          throw new Error(msg);
+        }
+        a.balance = a.balance - amount;
+      }
+    `;
+    const props = translate(source, "withdraw");
+
+    expect(props.some((p) => p.text === "balance' a = balance a - amount")).toBe(true);
+    expect(props.some((p) => p.text.includes("throw"))).toBe(false);
+  });
+});
+
+describe("unsupported child bubbling", () => {
+  it("bubbles unsupported through .length", () => {
+    const source = `
+      function test(): number {
+        return foo().length;
+      }
+      declare function foo(): string[];
+    `;
+    const props = translate(source, "test");
+
+    expect(props).toHaveLength(1);
+    expect(props[0].text).toMatch(/UNSUPPORTED/);
+  });
+
+  it("bubbles unsupported through negation", () => {
+    const source = `
+      function test(): boolean {
+        return !foo();
+      }
+      declare function foo(): boolean;
+    `;
+    const props = translate(source, "test");
+
+    expect(props).toHaveLength(1);
+    expect(props[0].text).toMatch(/UNSUPPORTED/);
+    // Should not contain ~( wrapping unsupported
+    expect(props[0].text).not.toMatch(/^~\(/);
+  });
+
+  it("bubbles unsupported through if condition", () => {
+    const source = `
+      function test(): number {
+        if (foo()) {
+          return 1;
+        } else {
+          return 2;
+        }
+      }
+      declare function foo(): boolean;
+    `;
+    const props = translate(source, "test");
+
+    expect(props).toHaveLength(1);
+    expect(props[0].text).toMatch(/UNSUPPORTED/);
+    // Should not contain cond wrapping unsupported
+    expect(props[0].text).not.toMatch(/^all.*cond/);
+  });
+});
+
+describe("arrow function body rejection", () => {
+  it("rejects block-bodied arrow with locals before return", () => {
+    const source = `
+      interface User { name: string; active: boolean; score: number; }
+      function highScoreNames(users: User[]): string[] {
+        return users.filter((u) => u.active).map((u) => { const s = u.score; return u.name; });
+      }
+    `;
+    const props = translate(source, "highScoreNames");
+
+    // The map arrow has a local variable, so the comprehension should not be emitted
+    expect(props).toHaveLength(1);
+    expect(props[0].text).toMatch(/UNSUPPORTED/);
+  });
+});
+
+describe("frame condition suppression", () => {
+  it("suppresses frame conditions when unsupported mutation is present", () => {
+    const source = `
+      interface Account { balance: number; owner: string; }
+      function conditionalUpdate(a: Account): void {
+        if (true) {
+          a.balance = 1;
+        }
+      }
+    `;
+    const declarations: PantDeclaration[] = [
+      { kind: "domain", name: "Account" },
+      {
+        kind: "rule",
+        name: "balance",
+        params: [{ name: "a", type: "Account" }],
+        returnType: "Int",
+      },
+      {
+        kind: "rule",
+        name: "owner",
+        params: [{ name: "a", type: "Account" }],
+        returnType: "String",
+      },
+    ];
+
+    const props = translate(source, "conditionalUpdate", declarations);
+
+    // Should have unsupported marker
+    expect(props.some((p) => p.text.includes("UNSUPPORTED"))).toBe(true);
+    // Should NOT have frame conditions — they'd be unsound
+    expect(props.some((p) => p.text.includes("owner'"))).toBe(false);
+    expect(props.some((p) => p.text.includes("balance'"))).toBe(false);
+  });
 });

--- a/tools/ts2pant/tests/translate-body.test.ts
+++ b/tools/ts2pant/tests/translate-body.test.ts
@@ -43,7 +43,7 @@ describe("pure function: return expression -> proposition", () => {
     const props = translate(source, "double");
 
     expect(props).toHaveLength(1);
-    expect(props[0].text).toBe("all n: number | double n = n * 2");
+    expect(props[0].text).toBe("all n: Int | double n = n * 2");
   });
 
   it("translates multi-param pure function", () => {
@@ -55,7 +55,7 @@ describe("pure function: return expression -> proposition", () => {
     const props = translate(source, "add");
 
     expect(props).toHaveLength(1);
-    expect(props[0].text).toBe("all a: number, b: number | add a b = a + b");
+    expect(props[0].text).toBe("all a: Int, b: Int | add a b = a + b");
   });
 });
 
@@ -98,7 +98,7 @@ describe("ternary -> cond", () => {
     const props = translate(source, "max");
 
     expect(props[0].text).toBe(
-      "all a: number, b: number | max a b = cond a >= b => a, true => b",
+      "all a: Int, b: Int | max a b = cond a >= b => a, true => b",
     );
   });
 
@@ -131,7 +131,7 @@ describe("if/else with returns -> cond", () => {
     const props = translate(source, "abs");
 
     expect(props[0].text).toBe(
-      "all n: number | abs n = cond n >= 0 => n, true => 0 - n",
+      "all n: Int | abs n = cond n >= 0 => n, true => 0 - n",
     );
   });
 });
@@ -146,7 +146,7 @@ describe("boolean operators", () => {
     const props = translate(source, "check");
 
     expect(props[0].text).toBe(
-      "all a: boolean, b: boolean | check a b = a and ~(b)",
+      "all a: Bool, b: Bool | check a b = a and ~(b)",
     );
   });
 
@@ -159,7 +159,7 @@ describe("boolean operators", () => {
     const props = translate(source, "eq");
 
     expect(props[0].text).toBe(
-      "all a: number, b: number | eq a b = a = b",
+      "all a: Int, b: Int | eq a b = a = b",
     );
   });
 });
@@ -173,7 +173,7 @@ describe("array operations", () => {
     `;
     const props = translate(source, "count");
 
-    expect(props[0].text).toBe("all items: string[] | count items = #items");
+    expect(props[0].text).toBe("all items: [String] | count items = #items");
   });
 
   it("translates .includes(x) to x in", () => {
@@ -185,7 +185,7 @@ describe("array operations", () => {
     const props = translate(source, "contains");
 
     expect(props[0].text).toBe(
-      "all items: string[], x: string | contains items x = x in items",
+      "all items: [String], x: String | contains items x = x in items",
     );
   });
 
@@ -199,7 +199,7 @@ describe("array operations", () => {
     const props = translate(source, "activeNames");
 
     expect(props[0].text).toBe(
-      "all users: User[] | activeNames users = each x: User, active x | name x",
+      "all users: [User] | activeNames users = each x: User, active x | name x",
     );
   });
 });

--- a/tools/ts2pant/tests/translate-body.test.ts
+++ b/tools/ts2pant/tests/translate-body.test.ts
@@ -57,6 +57,18 @@ describe("pure function: return expression -> proposition", () => {
     expect(props).toHaveLength(1);
     expect(props[0].text).toBe("all a: Int, b: Int | add a b = a + b");
   });
+
+  it("translates zero-argument pure function", () => {
+    const source = `
+      function getVersion(): number {
+        return 42;
+      }
+    `;
+    const props = translate(source, "getVersion");
+
+    expect(props).toHaveLength(1);
+    expect(props[0].text).toBe("getVersion = 42");
+  });
 });
 
 describe("property access -> rule application", () => {
@@ -160,6 +172,17 @@ describe("boolean operators", () => {
 
     expect(props[0].text).toBe(
       "all a: Int, b: Int | eq a b = a = b",
+    );
+
+    const source2 = `
+      function neq(a: number, b: number): boolean {
+        return a !== b;
+      }
+    `;
+    const props2 = translate(source2, "neq");
+
+    expect(props2[0].text).toBe(
+      "all a: Int, b: Int | neq a b = a ~= b",
     );
   });
 });

--- a/tools/ts2pant/tests/translate-body.test.ts
+++ b/tools/ts2pant/tests/translate-body.test.ts
@@ -232,6 +232,20 @@ describe("mutating function: assignment -> primed proposition", () => {
     expect(props.some((p) => p.text === "balance' a = balance a - fee")).toBe(true);
     expect(props.some((p) => p.text === "owner' a = newOwner")).toBe(true);
   });
+
+  it("translates wrapped (parenthesized) assignment", () => {
+    const source = `
+      interface Account { balance: number; }
+      function deposit(a: Account, amount: number): void {
+        (a.balance = a.balance + amount);
+      }
+    `;
+    const props = translate(source, "deposit");
+
+    expect(props.some((p) => p.text === "balance' a = balance a + amount")).toBe(
+      true,
+    );
+  });
 });
 
 describe("frame conditions", () => {

--- a/tools/ts2pant/tests/translate-body.test.ts
+++ b/tools/ts2pant/tests/translate-body.test.ts
@@ -318,7 +318,7 @@ describe("class method body translation", () => {
     `;
     const props = translate(source, "getBalance");
 
-    expect(props[0].text).toBe("all a: Account | getBalance a = balance a");
+    expect(props[0].text).toBe("all account: Account | getBalance account = balance account");
   });
 
   it("translates mutating class method", () => {
@@ -332,7 +332,7 @@ describe("class method body translation", () => {
     `;
     const props = translate(source, "deposit");
 
-    expect(props.some((p) => p.text === "balance' a = balance a + amount")).toBe(
+    expect(props.some((p) => p.text === "balance' account = balance account + amount")).toBe(
       true,
     );
   });


### PR DESCRIPTION
## Patch 9: Translate function bodies to propositions

- For pure functions: translate the return expression to a defining proposition `all params | f args = <translated return expr>`
- Translate TS expression patterns: ternary -> cond, === -> =, !== -> !=, &&/|| -> and/or, ! -> ~, +/-/*// -> arithmetic ops
- Translate property access: `a.balance` -> `balance a` (rule application)
- Translate array operations: `.length` -> `#`, `.includes(x)` -> `x in`, `.filter(p).map(f)` -> `each x: T, p x | f x`
- For mutating functions: translate each `obj.prop = val` to a primed proposition `prop' obj = val`
- Generate frame conditions for actions: for each rule in scope not explicitly assigned, emit `all x: T | rule' x = rule x`
- Translate conditionals in bodies: `if (g) return a; else return b` -> `cond g => a, true => b`
- Handle unsupported patterns gracefully: emit a comment `> UNSUPPORTED: <pattern description>` and skip
- Tests: return expression -> proposition, property access -> rule app, ternary -> cond, assignment -> primed, frame conditions generated

## Changes
- For pure functions: translate the return expression to a defining proposition `all params | f args = <translated return expr>`
- Translate TS expression patterns: ternary -> cond, === -> =, !== -> !=, &&/|| -> and/or, ! -> ~, +/-/*// -> arithmetic ops
- Translate property access: `a.balance` -> `balance a` (rule application)
- Translate array operations: `.length` -> `#`, `.includes(x)` -> `x in`, `.filter(p).map(f)` -> `each x: T, p x | f x`
- For mutating functions: translate each `obj.prop = val` to a primed proposition `prop' obj = val`
- Generate frame conditions for actions: for each rule in scope not explicitly assigned, emit `all x: T | rule' x = rule x`
- Translate conditionals in bodies: `if (g) return a; else return b` -> `cond g => a, true => b`
- Handle unsupported patterns gracefully: emit a comment `> UNSUPPORTED: <pattern description>` and skip
- Tests: return expression -> proposition, property access -> rule app, ternary -> cond, assignment -> primed, frame conditions generated

## Implementation Notes

- **Reused expression translator from patch 8**: Exported `translateExpr` and `translateOperator` from `translate-signature.ts` rather than duplicating. The body translator wraps these with `translateBodyExpr` which adds ternary, array ops, and if-statement handling before falling through to the base.
- **Guard filtering in body translation**: Guard statements (if-throw patterns) are detected and skipped during body traversal so they don't produce spurious propositions — the guard is already captured in the declaration by `translateSignature`.
- **`.filter().map()` → `each` comprehension**: Arrow function parameters are remapped to a fresh `x` variable, and the source array's element type is extracted via the TS type checker to produce typed bindings (e.g., `each x: User, active x | name x`).
- **Frame conditions require caller-provided declarations**: The `declarations` parameter is optional — frame conditions are only generated when the caller passes in-scope declarations. This keeps the body translator decoupled from the extraction pipeline.
- **Mutating body translation recurses into if-blocks**: Property assignments inside conditional branches are collected, though the conditional structure itself is not yet preserved in the primed propositions (assignments are flattened). This is a known simplification.

## Gameplan Specification

```
module TS2PANT.

> ══════════════════════════════════════════
> AGGREGATE QUANTIFIERS
> ══════════════════════════════════════════
> Pantagruel's quantifier family is extended with
> arithmetic combiners: COMBINER over each GUARDS | BODY.

Combiner.
Type.
Expression.

comb-add => Combiner.
comb-mul => Combiner.
comb-and => Combiner.
comb-or => Combiner.
comb-min => Combiner.
comb-max => Combiner.

has-over? e: Expression => Bool.
body-type e: Expression => Type.
result-type e: Expression => Type.
numeric? t: Type => Bool.
bool => Type.

---

> Arithmetic combiners require numeric body; result type = body type.
all e: Expression, has-over? e, numeric? (body-type e) |
  result-type e = body-type e.

where

> ══════════════════════════════════════════
> TRANSLATION PIPELINE
> ══════════════════════════════════════════
> Given a TypeScript function and its participating types,
> ts2pant produces a checkable Pantagruel document.

TSFunction.
TSType.
PantDocument.
PantDeclaration.
PantProposition.
Annotation.
CheckResult.

> Extraction: every referenced TS type becomes declarations.
referenced-types f: TSFunction => [TSType].
translated-types t: TSType => [PantDeclaration].

> Classification: pure functions -> rules, mutating -> actions.
pure? f: TSFunction => Bool.
mutating? f: TSFunction => Bool.

> Translation: function -> declaration + propositions.
translated-sig f: TSFunction => PantDeclaration.
translated-body f: TSFunction => [PantProposition].

> Annotations: user-provided assertions.
annotations f: TSFunction => [Annotation].

> Assembly: combined document.
generated-doc f: TSFunction => PantDocument.
check-result f: TSFunction => CheckResult.
passed? r: CheckResult => Bool.

---

> Every function is either pure or mutating.
all f: TSFunction | pure? f or mutating? f.
~(some f: TSFunction | pure? f and mutating? f).

> Every referenced type produces at least one declaration.
all t: TSType | #(translated-types t) >= 1.

> Every function with annotations produces a checkable document.
all f: TSFunction, #(annotations f) > 0 |
  generated-doc f in PantDocument.

```

## Patch Specification

```
module TS2PANT_PATCH_9.

> Body translation: TS expressions become Pantagruel propositions.

TSExpression.
PantProposition.

supported? e: TSExpression => Bool.
translated e: TSExpression, supported? e => PantProposition.

---

> Supported expressions translate to propositions.
all e: TSExpression, supported? e |
  translated e in PantProposition.

```

## Files to Modify
- tools/ts2pant/src/translate-body.ts (create): Translate TS expression patterns to Pantagruel propositions
- tools/ts2pant/tests/translate-body.test.ts (create): Tests for body translation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End-to-end translation of TypeScript function and method bodies into Pant propositions, covering pure returns, conditionals/ternaries, property access, array patterns, boolean logic, class-method handling, mutations, and frame-preservation with suppression for unsupported mutations.

* **API**
  * Exposes a program-driven body translation interface and makes core expression/operator/parameter utilities publicly reusable.

* **Tests**
  * Adds comprehensive tests validating pure and mutating translations, class-method handling, array/conditional patterns, frame behavior, and unsupported-case handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->