### PR TITLE
Introduce PantExpr AST for composable translation

### DIFF
--- a/tools/ts2pant/src/emit.ts
+++ b/tools/ts2pant/src/emit.ts
@@ -9,8 +9,8 @@ import {
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import process from "node:process";
-import type { PantDocument } from "./types.js";
 import { renderExpr, renderProp } from "./pant-expr.js";
+import type { PantDocument } from "./types.js";
 
 export interface CheckResult {
   passed: boolean;

--- a/tools/ts2pant/src/emit.ts
+++ b/tools/ts2pant/src/emit.ts
@@ -10,6 +10,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import process from "node:process";
 import type { PantDocument } from "./types.js";
+import { renderExpr, renderProp } from "./pant-expr.js";
 
 export interface CheckResult {
   passed: boolean;
@@ -48,7 +49,7 @@ export function emitDocument(doc: PantDocument): string {
         const params = decl.params
           .map((p) => `${p.name}: ${p.type}`)
           .join(", ");
-        const guard = decl.guard ? `, ${decl.guard}` : "";
+        const guard = decl.guard ? `, ${renderExpr(decl.guard)}` : "";
         lines.push(`${decl.name} ${params}${guard} => ${decl.returnType}.`);
         break;
       }
@@ -59,7 +60,7 @@ export function emitDocument(doc: PantDocument): string {
           const params = decl.params
             .map((p) => `${p.name}: ${p.type}`)
             .join(", ");
-          const guard = decl.guard ? `, ${decl.guard}` : "";
+          const guard = decl.guard ? `, ${renderExpr(decl.guard)}` : "";
           lines.push(`~> ${decl.label} @ ${params}${guard}.`);
         }
         break;
@@ -81,7 +82,7 @@ export function emitDocument(doc: PantDocument): string {
     lines.push("true.");
   } else {
     for (const prop of doc.propositions) {
-      lines.push(`${prop.text}.`);
+      lines.push(`${renderProp(prop)}.`);
     }
   }
 

--- a/tools/ts2pant/src/index.ts
+++ b/tools/ts2pant/src/index.ts
@@ -5,6 +5,7 @@ import { Command } from "commander";
 import { extractFunctionAnnotations } from "./annotations.js";
 import { emitDocument, runCheck } from "./emit.js";
 import { createProgram, extractReferencedTypes } from "./extract.js";
+import { RawProp } from "./pant-expr.js";
 import { translateBody as translateFunctionBody } from "./translate-body.js";
 import { translateSignature } from "./translate-signature.js";
 import {
@@ -132,7 +133,7 @@ export function addAnnotations(
     opts.functionName,
   );
 
-  const annotationProps = annotations.map((text) => ({ text }));
+  const annotationProps = annotations.map((text) => RawProp(text));
   return { ...doc, propositions: [...doc.propositions, ...annotationProps] };
 }
 

--- a/tools/ts2pant/src/pant-expr.ts
+++ b/tools/ts2pant/src/pant-expr.ts
@@ -87,8 +87,11 @@ export function renderExpr(expr: PantExpr): string {
       if (expr.args.length === 0) return `${expr.fn}'`;
       return `${expr.fn}' ${expr.args.map(renderArg).join(" ")}`;
     }
-    case "binop":
-      return `${renderExpr(expr.left)} ${expr.op} ${renderExpr(expr.right)}`;
+    case "binop": {
+      const left = expr.left.kind === "binop" ? `(${renderExpr(expr.left)})` : renderExpr(expr.left);
+      const right = expr.right.kind === "binop" ? `(${renderExpr(expr.right)})` : renderExpr(expr.right);
+      return `${left} ${expr.op} ${right}`;
+    }
     case "unop":
       return `${expr.op}(${renderExpr(expr.operand)})`;
     case "cardinality":

--- a/tools/ts2pant/src/pant-expr.ts
+++ b/tools/ts2pant/src/pant-expr.ts
@@ -1,0 +1,128 @@
+// Pantagruel expression and proposition AST.
+//
+// Translation produces this AST; rendering to Pantagruel source text
+// is a separate, purely structural pass via renderExpr / renderProp.
+
+// ---------------------------------------------------------------------------
+// Expression AST
+// ---------------------------------------------------------------------------
+
+export type PantExpr =
+  | { kind: "var"; name: string }
+  | { kind: "literal"; value: string }
+  | { kind: "apply"; fn: string; args: PantExpr[] }
+  | { kind: "primed-apply"; fn: string; args: PantExpr[] }
+  | { kind: "binop"; op: string; left: PantExpr; right: PantExpr }
+  | { kind: "unop"; op: string; operand: PantExpr }
+  | { kind: "cardinality"; expr: PantExpr }
+  | { kind: "membership"; element: PantExpr; collection: PantExpr }
+  | { kind: "cond"; arms: { guard: PantExpr; value: PantExpr }[]; fallback: PantExpr }
+  | { kind: "comprehension"; binder: string; type: string; predicate?: PantExpr; body: PantExpr }
+  | { kind: "unsupported"; reason: string };
+
+// ---------------------------------------------------------------------------
+// Proposition AST
+// ---------------------------------------------------------------------------
+
+export interface Binding {
+  name: string;
+  type: string;
+}
+
+export type PantProp =
+  | { kind: "equation"; quantifiers: Binding[]; lhs: PantExpr; rhs: PantExpr }
+  | { kind: "unsupported"; reason: string }
+  | { kind: "raw"; text: string };
+
+// ---------------------------------------------------------------------------
+// Constructors
+// ---------------------------------------------------------------------------
+
+export const Var = (name: string): PantExpr => ({ kind: "var", name });
+export const Lit = (value: string): PantExpr => ({ kind: "literal", value });
+export const Apply = (fn: string, ...args: PantExpr[]): PantExpr => ({ kind: "apply", fn, args });
+export const PrimedApply = (fn: string, ...args: PantExpr[]): PantExpr => ({ kind: "primed-apply", fn, args });
+export const Binop = (op: string, left: PantExpr, right: PantExpr): PantExpr => ({ kind: "binop", op, left, right });
+export const Unop = (op: string, operand: PantExpr): PantExpr => ({ kind: "unop", op, operand });
+export const Cardinality = (expr: PantExpr): PantExpr => ({ kind: "cardinality", expr });
+export const Membership = (element: PantExpr, collection: PantExpr): PantExpr => ({ kind: "membership", element, collection });
+export const Cond = (arms: { guard: PantExpr; value: PantExpr }[], fallback: PantExpr): PantExpr => ({ kind: "cond", arms, fallback });
+export const Comprehension = (binder: string, type: string, body: PantExpr, predicate?: PantExpr): PantExpr => ({
+  kind: "comprehension", binder, type, predicate, body,
+});
+export const Unsupported = (reason: string): PantExpr => ({ kind: "unsupported", reason });
+
+export const Equation = (quantifiers: Binding[], lhs: PantExpr, rhs: PantExpr): PantProp => ({
+  kind: "equation", quantifiers, lhs, rhs,
+});
+export const UnsupportedProp = (reason: string): PantProp => ({ kind: "unsupported", reason });
+export const RawProp = (text: string): PantProp => ({ kind: "raw", text });
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+/** True when the expression is compound and needs parens as an apply argument. */
+function needsParens(expr: PantExpr): boolean {
+  return expr.kind === "binop" || expr.kind === "cond" || expr.kind === "membership";
+}
+
+/** Render a PantExpr argument, wrapping in parens if compound. */
+function renderArg(expr: PantExpr): string {
+  const s = renderExpr(expr);
+  return needsParens(expr) ? `(${s})` : s;
+}
+
+export function renderExpr(expr: PantExpr): string {
+  switch (expr.kind) {
+    case "var":
+      return expr.name;
+    case "literal":
+      return expr.value;
+    case "apply": {
+      if (expr.args.length === 0) return expr.fn;
+      return `${expr.fn} ${expr.args.map(renderArg).join(" ")}`;
+    }
+    case "primed-apply": {
+      if (expr.args.length === 0) return `${expr.fn}'`;
+      return `${expr.fn}' ${expr.args.map(renderArg).join(" ")}`;
+    }
+    case "binop":
+      return `${renderExpr(expr.left)} ${expr.op} ${renderExpr(expr.right)}`;
+    case "unop":
+      return `${expr.op}(${renderExpr(expr.operand)})`;
+    case "cardinality":
+      return `#${renderArg(expr.expr)}`;
+    case "membership":
+      return `${renderExpr(expr.element)} in ${renderExpr(expr.collection)}`;
+    case "cond": {
+      const arms = expr.arms.map((a) => `${renderExpr(a.guard)} => ${renderExpr(a.value)}`);
+      arms.push(`true => ${renderExpr(expr.fallback)}`);
+      return `cond ${arms.join(", ")}`;
+    }
+    case "comprehension": {
+      const pred = expr.predicate ? `, ${renderExpr(expr.predicate)}` : "";
+      return `(each ${expr.binder}: ${expr.type}${pred} | ${renderExpr(expr.body)})`;
+    }
+    case "unsupported":
+      return `> UNSUPPORTED: ${expr.reason}`;
+  }
+}
+
+export function renderProp(prop: PantProp): string {
+  switch (prop.kind) {
+    case "equation": {
+      const lhs = renderExpr(prop.lhs);
+      const rhs = renderExpr(prop.rhs);
+      if (prop.quantifiers.length === 0) {
+        return `${lhs} = ${rhs}`;
+      }
+      const bindings = prop.quantifiers.map((b) => `${b.name}: ${b.type}`).join(", ");
+      return `all ${bindings} | ${lhs} = ${rhs}`;
+    }
+    case "unsupported":
+      return `> UNSUPPORTED: ${prop.reason}`;
+    case "raw":
+      return prop.text;
+  }
+}

--- a/tools/ts2pant/src/pant-expr.ts
+++ b/tools/ts2pant/src/pant-expr.ts
@@ -16,8 +16,18 @@ export type PantExpr =
   | { kind: "unop"; op: string; operand: PantExpr }
   | { kind: "cardinality"; expr: PantExpr }
   | { kind: "membership"; element: PantExpr; collection: PantExpr }
-  | { kind: "cond"; arms: { guard: PantExpr; value: PantExpr }[]; fallback: PantExpr }
-  | { kind: "comprehension"; binder: string; type: string; predicate?: PantExpr; body: PantExpr }
+  | {
+      kind: "cond";
+      arms: { guard: PantExpr; value: PantExpr }[];
+      fallback: PantExpr;
+    }
+  | {
+      kind: "comprehension";
+      binder: string;
+      type: string;
+      predicate?: PantExpr;
+      body: PantExpr;
+    }
   | { kind: "unsupported"; reason: string };
 
 // ---------------------------------------------------------------------------
@@ -40,23 +50,66 @@ export type PantProp =
 
 export const Var = (name: string): PantExpr => ({ kind: "var", name });
 export const Lit = (value: string): PantExpr => ({ kind: "literal", value });
-export const Apply = (fn: string, ...args: PantExpr[]): PantExpr => ({ kind: "apply", fn, args });
-export const PrimedApply = (fn: string, ...args: PantExpr[]): PantExpr => ({ kind: "primed-apply", fn, args });
-export const Binop = (op: string, left: PantExpr, right: PantExpr): PantExpr => ({ kind: "binop", op, left, right });
-export const Unop = (op: string, operand: PantExpr): PantExpr => ({ kind: "unop", op, operand });
-export const Cardinality = (expr: PantExpr): PantExpr => ({ kind: "cardinality", expr });
-export const Membership = (element: PantExpr, collection: PantExpr): PantExpr => ({ kind: "membership", element, collection });
-export const Cond = (arms: { guard: PantExpr; value: PantExpr }[], fallback: PantExpr): PantExpr => ({ kind: "cond", arms, fallback });
-export const Comprehension = (binder: string, type: string, body: PantExpr, predicate?: PantExpr): PantExpr => {
+export const Apply = (fn: string, ...args: PantExpr[]): PantExpr => ({
+  kind: "apply",
+  fn,
+  args,
+});
+export const PrimedApply = (fn: string, ...args: PantExpr[]): PantExpr => ({
+  kind: "primed-apply",
+  fn,
+  args,
+});
+export const Binop = (
+  op: string,
+  left: PantExpr,
+  right: PantExpr,
+): PantExpr => ({ kind: "binop", op, left, right });
+export const Unop = (op: string, operand: PantExpr): PantExpr => ({
+  kind: "unop",
+  op,
+  operand,
+});
+export const Cardinality = (expr: PantExpr): PantExpr => ({
+  kind: "cardinality",
+  expr,
+});
+export const Membership = (
+  element: PantExpr,
+  collection: PantExpr,
+): PantExpr => ({ kind: "membership", element, collection });
+export const Cond = (
+  arms: { guard: PantExpr; value: PantExpr }[],
+  fallback: PantExpr,
+): PantExpr => ({ kind: "cond", arms, fallback });
+export const Comprehension = (
+  binder: string,
+  type: string,
+  body: PantExpr,
+  predicate?: PantExpr,
+): PantExpr => {
   const base = { kind: "comprehension" as const, binder, type, body };
   return predicate !== undefined ? { ...base, predicate } : base;
 };
-export const Unsupported = (reason: string): PantExpr => ({ kind: "unsupported", reason });
-
-export const Equation = (quantifiers: Binding[], lhs: PantExpr, rhs: PantExpr): PantProp => ({
-  kind: "equation", quantifiers, lhs, rhs,
+export const Unsupported = (reason: string): PantExpr => ({
+  kind: "unsupported",
+  reason,
 });
-export const UnsupportedProp = (reason: string): PantProp => ({ kind: "unsupported", reason });
+
+export const Equation = (
+  quantifiers: Binding[],
+  lhs: PantExpr,
+  rhs: PantExpr,
+): PantProp => ({
+  kind: "equation",
+  quantifiers,
+  lhs,
+  rhs,
+});
+export const UnsupportedProp = (reason: string): PantProp => ({
+  kind: "unsupported",
+  reason,
+});
 export const RawProp = (text: string): PantProp => ({ kind: "raw", text });
 
 // ---------------------------------------------------------------------------
@@ -65,7 +118,9 @@ export const RawProp = (text: string): PantProp => ({ kind: "raw", text });
 
 /** True when the expression is compound and needs parens as an apply argument. */
 function needsParens(expr: PantExpr): boolean {
-  return expr.kind === "binop" || expr.kind === "cond" || expr.kind === "membership";
+  return (
+    expr.kind === "binop" || expr.kind === "cond" || expr.kind === "membership"
+  );
 }
 
 /** Render a PantExpr argument, wrapping in parens if compound. */
@@ -81,11 +136,15 @@ export function renderExpr(expr: PantExpr): string {
     case "literal":
       return expr.value;
     case "apply": {
-      if (expr.args.length === 0) return expr.fn;
+      if (expr.args.length === 0) {
+        return expr.fn;
+      }
       return `${expr.fn} ${expr.args.map(renderArg).join(" ")}`;
     }
     case "primed-apply": {
-      if (expr.args.length === 0) return `${expr.fn}'`;
+      if (expr.args.length === 0) {
+        return `${expr.fn}'`;
+      }
       return `${expr.fn}' ${expr.args.map(renderArg).join(" ")}`;
     }
     case "binop":
@@ -97,7 +156,8 @@ export function renderExpr(expr: PantExpr): string {
     case "membership":
       return `${renderArg(expr.element)} in ${renderArg(expr.collection)}`;
     case "cond": {
-      const rc = (e: PantExpr) => e.kind === "cond" ? `(${renderExpr(e)})` : renderExpr(e);
+      const rc = (e: PantExpr) =>
+        e.kind === "cond" ? `(${renderExpr(e)})` : renderExpr(e);
       const arms = expr.arms.map((a) => `${rc(a.guard)} => ${rc(a.value)}`);
       arms.push(`true => ${rc(expr.fallback)}`);
       return `cond ${arms.join(", ")}`;
@@ -108,6 +168,8 @@ export function renderExpr(expr: PantExpr): string {
     }
     case "unsupported":
       return `> UNSUPPORTED: ${expr.reason}`;
+    default:
+      throw new Error(`Unhandled expr kind: ${(expr as PantExpr).kind}`);
   }
 }
 
@@ -119,12 +181,16 @@ export function renderProp(prop: PantProp): string {
       if (prop.quantifiers.length === 0) {
         return `${lhs} = ${rhs}`;
       }
-      const bindings = prop.quantifiers.map((b) => `${b.name}: ${b.type}`).join(", ");
+      const bindings = prop.quantifiers
+        .map((b) => `${b.name}: ${b.type}`)
+        .join(", ");
       return `all ${bindings} | ${lhs} = ${rhs}`;
     }
     case "unsupported":
       return `> UNSUPPORTED: ${prop.reason}`;
     case "raw":
       return prop.text;
+    default:
+      throw new Error(`Unhandled prop kind: ${(prop as PantProp).kind}`);
   }
 }

--- a/tools/ts2pant/src/pant-expr.ts
+++ b/tools/ts2pant/src/pant-expr.ts
@@ -87,17 +87,14 @@ export function renderExpr(expr: PantExpr): string {
       if (expr.args.length === 0) return `${expr.fn}'`;
       return `${expr.fn}' ${expr.args.map(renderArg).join(" ")}`;
     }
-    case "binop": {
-      const left = expr.left.kind === "binop" ? `(${renderExpr(expr.left)})` : renderExpr(expr.left);
-      const right = expr.right.kind === "binop" ? `(${renderExpr(expr.right)})` : renderExpr(expr.right);
-      return `${left} ${expr.op} ${right}`;
-    }
+    case "binop":
+      return `${renderArg(expr.left)} ${expr.op} ${renderArg(expr.right)}`;
     case "unop":
       return `${expr.op}(${renderExpr(expr.operand)})`;
     case "cardinality":
       return `#${renderArg(expr.expr)}`;
     case "membership":
-      return `${renderExpr(expr.element)} in ${renderExpr(expr.collection)}`;
+      return `${renderArg(expr.element)} in ${renderArg(expr.collection)}`;
     case "cond": {
       const arms = expr.arms.map((a) => `${renderExpr(a.guard)} => ${renderExpr(a.value)}`);
       arms.push(`true => ${renderExpr(expr.fallback)}`);

--- a/tools/ts2pant/src/pant-expr.ts
+++ b/tools/ts2pant/src/pant-expr.ts
@@ -47,9 +47,10 @@ export const Unop = (op: string, operand: PantExpr): PantExpr => ({ kind: "unop"
 export const Cardinality = (expr: PantExpr): PantExpr => ({ kind: "cardinality", expr });
 export const Membership = (element: PantExpr, collection: PantExpr): PantExpr => ({ kind: "membership", element, collection });
 export const Cond = (arms: { guard: PantExpr; value: PantExpr }[], fallback: PantExpr): PantExpr => ({ kind: "cond", arms, fallback });
-export const Comprehension = (binder: string, type: string, body: PantExpr, predicate?: PantExpr): PantExpr => ({
-  kind: "comprehension", binder, type, predicate, body,
-});
+export const Comprehension = (binder: string, type: string, body: PantExpr, predicate?: PantExpr): PantExpr => {
+  const base = { kind: "comprehension" as const, binder, type, body };
+  return predicate !== undefined ? { ...base, predicate } : base;
+};
 export const Unsupported = (reason: string): PantExpr => ({ kind: "unsupported", reason });
 
 export const Equation = (quantifiers: Binding[], lhs: PantExpr, rhs: PantExpr): PantProp => ({
@@ -96,8 +97,9 @@ export function renderExpr(expr: PantExpr): string {
     case "membership":
       return `${renderArg(expr.element)} in ${renderArg(expr.collection)}`;
     case "cond": {
-      const arms = expr.arms.map((a) => `${renderExpr(a.guard)} => ${renderExpr(a.value)}`);
-      arms.push(`true => ${renderExpr(expr.fallback)}`);
+      const rc = (e: PantExpr) => e.kind === "cond" ? `(${renderExpr(e)})` : renderExpr(e);
+      const arms = expr.arms.map((a) => `${rc(a.guard)} => ${rc(a.value)}`);
+      arms.push(`true => ${rc(expr.fallback)}`);
       return `cond ${arms.join(", ")}`;
     }
     case "comprehension": {

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -47,11 +47,11 @@ function substituteBinder(expr: PantExpr, name: string, replacement: PantExpr): 
       };
     case "comprehension":
       if (expr.binder === name) return expr;
-      return {
-        ...expr,
-        body: substituteBinder(expr.body, name, replacement),
-        predicate: expr.predicate ? substituteBinder(expr.predicate, name, replacement) : undefined,
-      };
+      return Comprehension(
+        expr.binder, expr.type,
+        substituteBinder(expr.body, name, replacement),
+        expr.predicate ? substituteBinder(expr.predicate, name, replacement) : undefined,
+      );
   }
 }
 
@@ -147,7 +147,7 @@ function extractReturnExpression(body: ts.Block): ts.Expression | ts.IfStatement
   const stmts = body.statements.filter((s) => !isGuardStatement(s));
 
   if (stmts.length === 1) {
-    const stmt = stmts[0];
+    const stmt = stmts[0]!;
     if (ts.isReturnStatement(stmt) && stmt.expression) {
       return stmt.expression;
     }
@@ -170,7 +170,7 @@ function describeRejectedBody(body: ts.Block): string {
   const stmts = body.statements.filter((s) => !isGuardStatement(s));
   if (stmts.length === 0) return "empty body";
   if (stmts.length > 1) return "local bindings or multiple statements before return";
-  const stmt = stmts[0];
+  const stmt = stmts[0]!;
   if (ts.isReturnStatement(stmt) && !stmt.expression) return "return without expression";
   return "non-translatable control flow";
 }
@@ -210,7 +210,7 @@ function blockThrows(node: ts.Statement): boolean {
     if (stmts.length === 0) return false;
     // Last statement must be a throw; all preceding must be side-effect-free
     // (variable declarations for building the error message, etc.)
-    if (!ts.isThrowStatement(stmts[stmts.length - 1])) return false;
+    if (!ts.isThrowStatement(stmts[stmts.length - 1]!)) return false;
     return stmts
       .slice(0, -1)
       .every((s) => ts.isVariableStatement(s) && variableStatementHasNoSideEffects(s));
@@ -401,7 +401,7 @@ function extractReturnFromBranch(stmt: ts.Statement): ts.Expression | null {
     // branch-scoped bindings into the generated proposition.
     const nonGuard = stmt.statements.filter((s) => !isGuardStatement(s));
     if (nonGuard.length === 1) {
-      const s = nonGuard[0];
+      const s = nonGuard[0]!;
       if (ts.isReturnStatement(s) && s.expression) return s.expression;
     }
   }
@@ -417,7 +417,7 @@ function getArrayElementType(
   const sourceType = checker.getTypeAtLocation(tsExpr);
   if (!checker.isArrayType(sourceType)) return null;
   const typeArgs = checker.getTypeArguments(sourceType as ts.TypeReference);
-  return typeArgs.length === 1 ? mapTsType(typeArgs[0], checker, strategy) : "?";
+  return typeArgs.length === 1 ? mapTsType(typeArgs[0]!, checker, strategy) : "?";
 }
 
 /**
@@ -445,9 +445,12 @@ function translateArrayMethod(
     ? freshBinder(new Map([...paramNames, [sourceBinder, sourceBinder]]))
     : sourceBinder;
   const extendedParams = new Map(paramNames);
+  if (isComposing) {
+    extendedParams.set(sourceBinder, sourceBinder);
+  }
   extendedParams.set(callbackBinder, callbackBinder);
 
-  const rawBody = extractArrowBody(expr.arguments[0], callbackBinder, extendedParams, checker, strategy);
+  const rawBody = extractArrowBody(expr.arguments[0]!, callbackBinder, extendedParams, checker, strategy);
   if (!rawBody) return Unsupported(expr.getText());
   if (rawBody.kind === "unsupported") return rawBody;
 
@@ -486,7 +489,7 @@ function translateCallExpr(
       if (!checker.isArrayType(receiverType)) {
         return Unsupported("non-array .includes()");
       }
-      const arg = translateBodyExpr(expr.arguments[0], checker, strategy, paramNames);
+      const arg = translateBodyExpr(expr.arguments[0]!, checker, strategy, paramNames);
       if (arg.kind === "unsupported") return arg;
       const objExpr = translateBodyExpr(tsReceiver, checker, strategy, paramNames);
       if (objExpr.kind === "unsupported") return objExpr;
@@ -512,13 +515,14 @@ function extractArrowBody(
   strategy: NumericStrategy,
 ): PantExpr | null {
   if (!ts.isArrowFunction(expr)) return null;
-  if (expr.parameters.length !== 1 || !ts.isIdentifier(expr.parameters[0].name)) {
+  if (expr.parameters.length !== 1 || !ts.isIdentifier(expr.parameters[0]!.name)) {
     return Unsupported("filter/map callback must have exactly one identifier parameter");
   }
 
   // Map arrow param to the fresh binder
+  const param = expr.parameters[0]!;
   const arrowParams = new Map(paramNames);
-  arrowParams.set(expr.parameters[0].name.text, binderName);
+  arrowParams.set((param.name as ts.Identifier).text, binderName);
 
   if (ts.isBlock(expr.body)) {
     // Only allow a single return (after filtering guards), same rule as
@@ -526,7 +530,7 @@ function extractArrowBody(
     // would introduce free variables in the generated comprehension.
     const nonGuard = expr.body.statements.filter((s) => !isGuardStatement(s));
     if (nonGuard.length === 1) {
-      const s = nonGuard[0];
+      const s = nonGuard[0]!;
       if (ts.isReturnStatement(s) && s.expression) {
         return translateBodyExpr(s.expression, checker, strategy, arrowParams);
       }
@@ -606,7 +610,14 @@ function collectAssignments(
         }
         propositions.push(Equation([], PrimedApply(prop, obj), val));
         modifiedRules.add(prop);
+        continue;
       }
+    }
+
+    if (ts.isExpressionStatement(stmt) && expressionHasSideEffects(stmt.expression)) {
+      propositions.push(UnsupportedProp("side-effectful expression"));
+      hasUnsupportedMutation = true;
+      continue;
     }
 
     // Recurse into nested blocks
@@ -627,11 +638,14 @@ function collectAssignments(
       propositions.push(UnsupportedProp("loop assignment"));
       hasUnsupportedMutation = true;
     } else if (ts.isTryStatement(stmt)) {
-      if (collectAssignments(stmt.tryBlock, checker, strategy, paramNames, propositions, modifiedRules)) {
-        hasUnsupportedMutation = true;
-      }
+      // try/catch branches are mutually exclusive; collecting from both would
+      // produce contradictory conjunctions. Only the finally block executes
+      // unconditionally.
       if (stmt.catchClause) {
-        if (collectAssignments(stmt.catchClause.block, checker, strategy, paramNames, propositions, modifiedRules)) {
+        propositions.push(UnsupportedProp("try/catch assignment"));
+        hasUnsupportedMutation = true;
+      } else {
+        if (collectAssignments(stmt.tryBlock, checker, strategy, paramNames, propositions, modifiedRules)) {
           hasUnsupportedMutation = true;
         }
       }

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -1,26 +1,51 @@
 import ts from "typescript";
-import type { PantDeclaration } from "./types.js";
-import { mapTsType, type NumericStrategy } from "./translate-types.js";
-import { translateExpr, translateOperator, findFunction, classifyFunction, shortParamName } from "./translate-signature.js";
 import {
-  type PantExpr, type PantProp,
-  Var, Apply, PrimedApply, Binop, Unop, Cardinality, Membership, Cond, Comprehension, Unsupported,
-  Equation, UnsupportedProp,
+  Apply,
+  Binop,
+  Cardinality,
+  Comprehension,
+  Cond,
+  Equation,
+  Membership,
+  type PantExpr,
+  type PantProp,
+  PrimedApply,
+  Unop,
+  Unsupported,
+  UnsupportedProp,
+  Var,
 } from "./pant-expr.js";
+import {
+  classifyFunction,
+  findFunction,
+  shortParamName,
+  translateExpr,
+  translateOperator,
+} from "./translate-signature.js";
+import { mapTsType, type NumericStrategy } from "./translate-types.js";
+import type { PantDeclaration } from "./types.js";
 
 /** Generate a binder name not already used by params. */
 function freshBinder(paramNames: Map<string, string>): string {
   const used = new Set(paramNames.values());
   for (const candidate of ["x", "y", "z", "w", "v", "u", "t"]) {
-    if (!used.has(candidate)) return candidate;
+    if (!used.has(candidate)) {
+      return candidate;
+    }
   }
   let i = 0;
-  while (used.has(`x${i}`)) i++;
+  while (used.has(`x${i}`)) {
+    i++;
+  }
   return `x${i}`;
 }
 
 /** Replace every Var(name) in expr with replacement (for composing comprehension chains). */
-function substituteBinder(expr: PantExpr, name: string, replacement: PantExpr): PantExpr {
+function substituteBinder(
+  expr: PantExpr,
+  name: string,
+  replacement: PantExpr,
+): PantExpr {
   switch (expr.kind) {
     case "var":
       return expr.name === name ? replacement : expr;
@@ -28,30 +53,57 @@ function substituteBinder(expr: PantExpr, name: string, replacement: PantExpr): 
     case "unsupported":
       return expr;
     case "apply":
-      return { ...expr, args: expr.args.map((a) => substituteBinder(a, name, replacement)) };
+      return {
+        ...expr,
+        args: expr.args.map((a) => substituteBinder(a, name, replacement)),
+      };
     case "primed-apply":
-      return { ...expr, args: expr.args.map((a) => substituteBinder(a, name, replacement)) };
+      return {
+        ...expr,
+        args: expr.args.map((a) => substituteBinder(a, name, replacement)),
+      };
     case "binop":
-      return { ...expr, left: substituteBinder(expr.left, name, replacement), right: substituteBinder(expr.right, name, replacement) };
+      return {
+        ...expr,
+        left: substituteBinder(expr.left, name, replacement),
+        right: substituteBinder(expr.right, name, replacement),
+      };
     case "unop":
-      return { ...expr, operand: substituteBinder(expr.operand, name, replacement) };
+      return {
+        ...expr,
+        operand: substituteBinder(expr.operand, name, replacement),
+      };
     case "cardinality":
       return { ...expr, expr: substituteBinder(expr.expr, name, replacement) };
     case "membership":
-      return { ...expr, element: substituteBinder(expr.element, name, replacement), collection: substituteBinder(expr.collection, name, replacement) };
+      return {
+        ...expr,
+        element: substituteBinder(expr.element, name, replacement),
+        collection: substituteBinder(expr.collection, name, replacement),
+      };
     case "cond":
       return {
         ...expr,
-        arms: expr.arms.map((a) => ({ guard: substituteBinder(a.guard, name, replacement), value: substituteBinder(a.value, name, replacement) })),
+        arms: expr.arms.map((a) => ({
+          guard: substituteBinder(a.guard, name, replacement),
+          value: substituteBinder(a.value, name, replacement),
+        })),
         fallback: substituteBinder(expr.fallback, name, replacement),
       };
     case "comprehension":
-      if (expr.binder === name) return expr;
+      if (expr.binder === name) {
+        return expr;
+      }
       return Comprehension(
-        expr.binder, expr.type,
+        expr.binder,
+        expr.type,
         substituteBinder(expr.body, name, replacement),
-        expr.predicate ? substituteBinder(expr.predicate, name, replacement) : undefined,
+        expr.predicate
+          ? substituteBinder(expr.predicate, name, replacement)
+          : undefined,
       );
+    default:
+      throw new Error(`Unhandled expr kind: ${(expr as PantExpr).kind}`);
   }
 }
 
@@ -84,7 +136,9 @@ export function translateBody(opts: TranslateBodyOptions): PantProp[] {
   const sig = checker.getSignatureFromDeclaration(node);
 
   if (className) {
-    const existingParamNames = new Set(sig ? sig.getParameters().map((p) => p.name) : []);
+    const existingParamNames = new Set(
+      sig ? sig.getParameters().map((p) => p.name) : [],
+    );
     const pName = shortParamName(className, existingParamNames);
     paramNames.set("this", pName);
     paramList.push({ name: pName, type: className });
@@ -99,12 +153,27 @@ export function translateBody(opts: TranslateBodyOptions): PantProp[] {
     }
   }
 
-  if (!node.body) return [];
+  if (!node.body) {
+    return [];
+  }
 
   if (classification === "pure") {
-    return translatePureBody(node, functionName, paramList, checker, strategy, paramNames);
+    return translatePureBody(
+      node,
+      functionName,
+      paramList,
+      checker,
+      strategy,
+      paramNames,
+    );
   } else {
-    return translateMutatingBody(node, checker, strategy, paramNames, declarations ?? []);
+    return translateMutatingBody(
+      node,
+      checker,
+      strategy,
+      paramNames,
+      declarations ?? [],
+    );
   }
 }
 
@@ -116,7 +185,9 @@ function translatePureBody(
   strategy: NumericStrategy,
   paramNames: Map<string, string>,
 ): PantProp[] {
-  if (!node.body) return [];
+  if (!node.body) {
+    return [];
+  }
 
   const returnExpr = extractReturnExpression(node.body);
   if (!returnExpr) {
@@ -131,7 +202,10 @@ function translatePureBody(
   }
 
   const argExprs = params.map((p) => Var(p.name));
-  const lhs = argExprs.length > 0 ? Apply(functionName, ...argExprs) : Apply(functionName);
+  const lhs =
+    argExprs.length > 0
+      ? Apply(functionName, ...argExprs)
+      : Apply(functionName);
   const quantifiers = params.map((p) => ({ name: p.name, type: p.type }));
   return [Equation(quantifiers, lhs, body)];
 }
@@ -142,7 +216,9 @@ function translatePureBody(
  *   - Single return statement
  *   - if/else with returns in both branches (produces a synthetic conditional)
  */
-function extractReturnExpression(body: ts.Block): ts.Expression | ts.IfStatement | null {
+function extractReturnExpression(
+  body: ts.Block,
+): ts.Expression | ts.IfStatement | null {
   // Skip guard statements (if-throw patterns) and find the meaningful return
   const stmts = body.statements.filter((s) => !isGuardStatement(s));
 
@@ -168,15 +244,23 @@ function extractReturnExpression(body: ts.Block): ts.Expression | ts.IfStatement
 
 function describeRejectedBody(body: ts.Block): string {
   const stmts = body.statements.filter((s) => !isGuardStatement(s));
-  if (stmts.length === 0) return "empty body";
-  if (stmts.length > 1) return "local bindings or multiple statements before return";
+  if (stmts.length === 0) {
+    return "empty body";
+  }
+  if (stmts.length > 1) {
+    return "local bindings or multiple statements before return";
+  }
   const stmt = stmts[0]!;
-  if (ts.isReturnStatement(stmt) && !stmt.expression) return "return without expression";
+  if (ts.isReturnStatement(stmt) && !stmt.expression) {
+    return "return without expression";
+  }
   return "non-translatable control flow";
 }
 
 function isGuardStatement(stmt: ts.Statement): boolean {
-  if (!ts.isIfStatement(stmt)) return false;
+  if (!ts.isIfStatement(stmt)) {
+    return false;
+  }
   // if (...) { throw } without else
   if (!stmt.elseStatement && blockThrows(stmt.thenStatement)) {
     return !expressionHasSideEffects(stmt.expression);
@@ -196,24 +280,34 @@ function isGuardStatement(stmt: ts.Statement): boolean {
   return false;
 }
 
-function variableStatementHasNoSideEffects(stmt: ts.VariableStatement): boolean {
+function variableStatementHasNoSideEffects(
+  stmt: ts.VariableStatement,
+): boolean {
   return stmt.declarationList.declarations.every(
-    (decl) =>
-      !decl.initializer || !expressionHasSideEffects(decl.initializer),
+    (decl) => !decl.initializer || !expressionHasSideEffects(decl.initializer),
   );
 }
 
 function blockThrows(node: ts.Statement): boolean {
-  if (ts.isThrowStatement(node)) return true;
+  if (ts.isThrowStatement(node)) {
+    return true;
+  }
   if (ts.isBlock(node)) {
     const stmts = node.statements;
-    if (stmts.length === 0) return false;
+    if (stmts.length === 0) {
+      return false;
+    }
     // Last statement must be a throw; all preceding must be side-effect-free
     // (variable declarations for building the error message, etc.)
-    if (!ts.isThrowStatement(stmts[stmts.length - 1]!)) return false;
+    if (!ts.isThrowStatement(stmts[stmts.length - 1]!)) {
+      return false;
+    }
     return stmts
       .slice(0, -1)
-      .every((s) => ts.isVariableStatement(s) && variableStatementHasNoSideEffects(s));
+      .every(
+        (s) =>
+          ts.isVariableStatement(s) && variableStatementHasNoSideEffects(s),
+      );
   }
   return false;
 }
@@ -270,8 +364,12 @@ function expressionHasSideEffects(expr: ts.Expression): boolean {
       expressionHasSideEffects(expr.right)
     );
   }
-  if (ts.isCallExpression(expr)) return true;
-  if (ts.isNewExpression(expr) || ts.isAwaitExpression(expr)) return true;
+  if (ts.isCallExpression(expr)) {
+    return true;
+  }
+  if (ts.isNewExpression(expr) || ts.isAwaitExpression(expr)) {
+    return true;
+  }
   if (ts.isPrefixUnaryExpression(expr) || ts.isPostfixUnaryExpression(expr)) {
     const op = expr.operator;
     return (
@@ -280,10 +378,11 @@ function expressionHasSideEffects(expr: ts.Expression): boolean {
       expressionHasSideEffects(expr.operand)
     );
   }
-  return ts.forEachChild(
-    expr,
-    (child) => (ts.isExpression(child) ? expressionHasSideEffects(child) : false),
-  ) ?? false;
+  return (
+    ts.forEachChild(expr, (child) =>
+      ts.isExpression(child) ? expressionHasSideEffects(child) : false,
+    ) ?? false
+  );
 }
 
 /**
@@ -307,20 +406,48 @@ export function translateBodyExpr(
 
   // Ternary: a ? b : c -> Cond([{guard: a, value: b}], c)
   if (ts.isConditionalExpression(expr)) {
-    const cond = translateBodyExpr(expr.condition, checker, strategy, paramNames);
-    if (cond.kind === "unsupported") return cond;
-    const whenTrue = translateBodyExpr(expr.whenTrue, checker, strategy, paramNames);
-    if (whenTrue.kind === "unsupported") return whenTrue;
-    const whenFalse = translateBodyExpr(expr.whenFalse, checker, strategy, paramNames);
-    if (whenFalse.kind === "unsupported") return whenFalse;
+    const cond = translateBodyExpr(
+      expr.condition,
+      checker,
+      strategy,
+      paramNames,
+    );
+    if (cond.kind === "unsupported") {
+      return cond;
+    }
+    const whenTrue = translateBodyExpr(
+      expr.whenTrue,
+      checker,
+      strategy,
+      paramNames,
+    );
+    if (whenTrue.kind === "unsupported") {
+      return whenTrue;
+    }
+    const whenFalse = translateBodyExpr(
+      expr.whenFalse,
+      checker,
+      strategy,
+      paramNames,
+    );
+    if (whenFalse.kind === "unsupported") {
+      return whenFalse;
+    }
     return Cond([{ guard: cond, value: whenTrue }], whenFalse);
   }
 
   // Property access with special array operations
   if (ts.isPropertyAccessExpression(expr)) {
     const prop = expr.name.text;
-    const obj = translateBodyExpr(expr.expression, checker, strategy, paramNames);
-    if (obj.kind === "unsupported") return obj;
+    const obj = translateBodyExpr(
+      expr.expression,
+      checker,
+      strategy,
+      paramNames,
+    );
+    if (obj.kind === "unsupported") {
+      return obj;
+    }
     // .length -> #obj (array only)
     if (prop === "length") {
       const receiverType = checker.getTypeAtLocation(expr.expression);
@@ -339,8 +466,15 @@ export function translateBodyExpr(
 
   // Prefix unary: !x -> Unop("~", x), -x -> Unop("-", x)
   if (ts.isPrefixUnaryExpression(expr)) {
-    const operand = translateBodyExpr(expr.operand, checker, strategy, paramNames);
-    if (operand.kind === "unsupported") return operand;
+    const operand = translateBodyExpr(
+      expr.operand,
+      checker,
+      strategy,
+      paramNames,
+    );
+    if (operand.kind === "unsupported") {
+      return operand;
+    }
     if (expr.operator === ts.SyntaxKind.ExclamationToken) {
       return Unop("~", operand);
     }
@@ -352,11 +486,17 @@ export function translateBodyExpr(
   // Binary expression
   if (ts.isBinaryExpression(expr)) {
     const op = translateOperator(expr.operatorToken.kind);
-    if (op === "?") return Unsupported(`operator ${ts.SyntaxKind[expr.operatorToken.kind]}`);
+    if (op === "?") {
+      return Unsupported(`operator ${ts.SyntaxKind[expr.operatorToken.kind]}`);
+    }
     const left = translateBodyExpr(expr.left, checker, strategy, paramNames);
-    if (left.kind === "unsupported") return left;
+    if (left.kind === "unsupported") {
+      return left;
+    }
     const right = translateBodyExpr(expr.right, checker, strategy, paramNames);
-    if (right.kind === "unsupported") return right;
+    if (right.kind === "unsupported") {
+      return right;
+    }
     return Binop(op, left, right);
   }
 
@@ -374,8 +514,15 @@ function translateIfStatement(
   strategy: NumericStrategy,
   paramNames: Map<string, string>,
 ): PantExpr {
-  const cond = translateBodyExpr(stmt.expression, checker, strategy, paramNames);
-  if (cond.kind === "unsupported") return cond;
+  const cond = translateBodyExpr(
+    stmt.expression,
+    checker,
+    strategy,
+    paramNames,
+  );
+  if (cond.kind === "unsupported") {
+    return cond;
+  }
   const thenExpr = extractReturnFromBranch(stmt.thenStatement);
   const elseExpr = stmt.elseStatement
     ? extractReturnFromBranch(stmt.elseStatement)
@@ -383,9 +530,13 @@ function translateIfStatement(
 
   if (thenExpr && elseExpr) {
     const thenVal = translateBodyExpr(thenExpr, checker, strategy, paramNames);
-    if (thenVal.kind === "unsupported") return thenVal;
+    if (thenVal.kind === "unsupported") {
+      return thenVal;
+    }
     const elseVal = translateBodyExpr(elseExpr, checker, strategy, paramNames);
-    if (elseVal.kind === "unsupported") return elseVal;
+    if (elseVal.kind === "unsupported") {
+      return elseVal;
+    }
     return Cond([{ guard: cond, value: thenVal }], elseVal);
   }
 
@@ -393,7 +544,9 @@ function translateIfStatement(
 }
 
 function extractReturnFromBranch(stmt: ts.Statement): ts.Expression | null {
-  if (ts.isReturnStatement(stmt) && stmt.expression) return stmt.expression;
+  if (ts.isReturnStatement(stmt) && stmt.expression) {
+    return stmt.expression;
+  }
   if (ts.isBlock(stmt)) {
     // Apply the same rule as extractReturnExpression: only allow a single
     // return (after filtering guards). Blocks with local declarations or
@@ -402,7 +555,9 @@ function extractReturnFromBranch(stmt: ts.Statement): ts.Expression | null {
     const nonGuard = stmt.statements.filter((s) => !isGuardStatement(s));
     if (nonGuard.length === 1) {
       const s = nonGuard[0]!;
-      if (ts.isReturnStatement(s) && s.expression) return s.expression;
+      if (ts.isReturnStatement(s) && s.expression) {
+        return s.expression;
+      }
     }
   }
   return null;
@@ -415,9 +570,13 @@ function getArrayElementType(
   strategy: NumericStrategy,
 ): string | null {
   const sourceType = checker.getTypeAtLocation(tsExpr);
-  if (!checker.isArrayType(sourceType)) return null;
+  if (!checker.isArrayType(sourceType)) {
+    return null;
+  }
   const typeArgs = checker.getTypeArguments(sourceType as ts.TypeReference);
-  return typeArgs.length === 1 ? mapTsType(typeArgs[0]!, checker, strategy) : "?";
+  return typeArgs.length === 1
+    ? mapTsType(typeArgs[0]!, checker, strategy)
+    : "?";
 }
 
 /**
@@ -433,10 +592,14 @@ function translateArrayMethod(
   paramNames: Map<string, string>,
 ): PantExpr | null {
   const elemType = getArrayElementType(tsReceiver, checker, strategy);
-  if (!elemType) return null;
+  if (!elemType) {
+    return null;
+  }
 
   const receiver = translateBodyExpr(tsReceiver, checker, strategy, paramNames);
-  if (receiver.kind === "unsupported") return receiver;
+  if (receiver.kind === "unsupported") {
+    return receiver;
+  }
 
   const isComposing = receiver.kind === "comprehension";
   const sourceBinder = isComposing ? receiver.binder : freshBinder(paramNames);
@@ -450,17 +613,31 @@ function translateArrayMethod(
   }
   extendedParams.set(callbackBinder, callbackBinder);
 
-  const rawBody = extractArrowBody(expr.arguments[0]!, callbackBinder, extendedParams, checker, strategy);
-  if (!rawBody) return Unsupported(expr.getText());
-  if (rawBody.kind === "unsupported") return rawBody;
+  const rawBody = extractArrowBody(
+    expr.arguments[0]!,
+    callbackBinder,
+    extendedParams,
+    checker,
+    strategy,
+  );
+  if (!rawBody) {
+    return Unsupported(expr.getText());
+  }
+  if (rawBody.kind === "unsupported") {
+    return rawBody;
+  }
 
   // When composing, substitute the callback's binder with the prior step's body
   // so that e.g. xs.map(f).map(g) becomes (each x: T | g(f(x))) not (each x: T | g(x))
-  const body = isComposing ? substituteBinder(rawBody, callbackBinder, receiver.body) : rawBody;
+  const body = isComposing
+    ? substituteBinder(rawBody, callbackBinder, receiver.body)
+    : rawBody;
 
   if (methodName === "filter") {
     if (isComposing) {
-      const combined = receiver.predicate ? Binop("and", receiver.predicate, body) : body;
+      const combined = receiver.predicate
+        ? Binop("and", receiver.predicate, body)
+        : body;
       return { ...receiver, predicate: combined };
     }
     return Comprehension(sourceBinder, elemType, Var(sourceBinder), body);
@@ -489,17 +666,43 @@ function translateCallExpr(
       if (!checker.isArrayType(receiverType)) {
         return Unsupported("non-array .includes()");
       }
-      const arg = translateBodyExpr(expr.arguments[0]!, checker, strategy, paramNames);
-      if (arg.kind === "unsupported") return arg;
-      const objExpr = translateBodyExpr(tsReceiver, checker, strategy, paramNames);
-      if (objExpr.kind === "unsupported") return objExpr;
+      const arg = translateBodyExpr(
+        expr.arguments[0]!,
+        checker,
+        strategy,
+        paramNames,
+      );
+      if (arg.kind === "unsupported") {
+        return arg;
+      }
+      const objExpr = translateBodyExpr(
+        tsReceiver,
+        checker,
+        strategy,
+        paramNames,
+      );
+      if (objExpr.kind === "unsupported") {
+        return objExpr;
+      }
       return Membership(arg, objExpr);
     }
 
     // .filter(pred) / .map(fn) — each independently produces or refines a comprehension
-    if ((methodName === "filter" || methodName === "map") && expr.arguments.length === 1) {
-      const result = translateArrayMethod(methodName, tsReceiver, expr, checker, strategy, paramNames);
-      if (result) return result;
+    if (
+      (methodName === "filter" || methodName === "map") &&
+      expr.arguments.length === 1
+    ) {
+      const result = translateArrayMethod(
+        methodName,
+        tsReceiver,
+        expr,
+        checker,
+        strategy,
+        paramNames,
+      );
+      if (result) {
+        return result;
+      }
     }
   }
 
@@ -514,9 +717,16 @@ function extractArrowBody(
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
 ): PantExpr | null {
-  if (!ts.isArrowFunction(expr)) return null;
-  if (expr.parameters.length !== 1 || !ts.isIdentifier(expr.parameters[0]!.name)) {
-    return Unsupported("filter/map callback must have exactly one identifier parameter");
+  if (!ts.isArrowFunction(expr)) {
+    return null;
+  }
+  if (
+    expr.parameters.length !== 1 ||
+    !ts.isIdentifier(expr.parameters[0]!.name)
+  ) {
+    return Unsupported(
+      "filter/map callback must have exactly one identifier parameter",
+    );
   }
 
   // Map arrow param to the fresh binder
@@ -551,13 +761,22 @@ function translateMutatingBody(
   paramNames: Map<string, string>,
   declarations: PantDeclaration[],
 ): PantProp[] {
-  if (!node.body) return [];
+  if (!node.body) {
+    return [];
+  }
 
   const propositions: PantProp[] = [];
   const modifiedRules = new Set<string>();
 
   // Collect property assignments
-  const hasUnsupportedMutation = collectAssignments(node.body, checker, strategy, paramNames, propositions, modifiedRules);
+  const hasUnsupportedMutation = collectAssignments(
+    node.body,
+    checker,
+    strategy,
+    paramNames,
+    propositions,
+    modifiedRules,
+  );
 
   // Only generate frame conditions when all mutation shapes were translatable;
   // unsupported control flow (if/loop/switch) makes frames unsound.
@@ -587,16 +806,26 @@ function collectAssignments(
 
   for (const stmt of stmts) {
     // Skip guard statements (if-throw patterns)
-    if (isGuardStatement(stmt)) continue;
+    if (isGuardStatement(stmt)) {
+      continue;
+    }
 
-    if (ts.isExpressionStatement(stmt) && ts.isBinaryExpression(unwrapExpression(stmt.expression))) {
+    if (
+      ts.isExpressionStatement(stmt) &&
+      ts.isBinaryExpression(unwrapExpression(stmt.expression))
+    ) {
       const bin = unwrapExpression(stmt.expression) as ts.BinaryExpression;
       if (
         bin.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
         ts.isPropertyAccessExpression(bin.left)
       ) {
         const prop = bin.left.name.text;
-        const obj = translateBodyExpr(bin.left.expression, checker, strategy, paramNames);
+        const obj = translateBodyExpr(
+          bin.left.expression,
+          checker,
+          strategy,
+          paramNames,
+        );
         const val = translateBodyExpr(bin.right, checker, strategy, paramNames);
         if (obj.kind === "unsupported") {
           hasUnsupportedMutation = true;
@@ -614,7 +843,10 @@ function collectAssignments(
       }
     }
 
-    if (ts.isExpressionStatement(stmt) && expressionHasSideEffects(stmt.expression)) {
+    if (
+      ts.isExpressionStatement(stmt) &&
+      expressionHasSideEffects(stmt.expression)
+    ) {
       propositions.push(UnsupportedProp("side-effectful expression"));
       hasUnsupportedMutation = true;
       continue;
@@ -622,7 +854,16 @@ function collectAssignments(
 
     // Recurse into nested blocks
     if (ts.isBlock(stmt)) {
-      if (collectAssignments(stmt, checker, strategy, paramNames, propositions, modifiedRules)) {
+      if (
+        collectAssignments(
+          stmt,
+          checker,
+          strategy,
+          paramNames,
+          propositions,
+          modifiedRules,
+        )
+      ) {
         hasUnsupportedMutation = true;
       }
     } else if (ts.isIfStatement(stmt)) {
@@ -645,12 +886,30 @@ function collectAssignments(
         propositions.push(UnsupportedProp("try/catch assignment"));
         hasUnsupportedMutation = true;
       } else {
-        if (collectAssignments(stmt.tryBlock, checker, strategy, paramNames, propositions, modifiedRules)) {
+        if (
+          collectAssignments(
+            stmt.tryBlock,
+            checker,
+            strategy,
+            paramNames,
+            propositions,
+            modifiedRules,
+          )
+        ) {
           hasUnsupportedMutation = true;
         }
       }
       if (stmt.finallyBlock) {
-        if (collectAssignments(stmt.finallyBlock, checker, strategy, paramNames, propositions, modifiedRules)) {
+        if (
+          collectAssignments(
+            stmt.finallyBlock,
+            checker,
+            strategy,
+            paramNames,
+            propositions,
+            modifiedRules,
+          )
+        ) {
           hasUnsupportedMutation = true;
         }
       }
@@ -674,13 +933,21 @@ function generateFrameConditions(
   const frames: PantProp[] = [];
 
   for (const decl of declarations) {
-    if (decl.kind !== "rule") continue;
-    if (modifiedRules.has(decl.name)) continue;
+    if (decl.kind !== "rule") {
+      continue;
+    }
+    if (modifiedRules.has(decl.name)) {
+      continue;
+    }
 
     const paramArgs = decl.params.map((p) => Var(p.name));
     const lhs = PrimedApply(decl.name, ...paramArgs);
-    const rhs = paramArgs.length > 0 ? Apply(decl.name, ...paramArgs) : Apply(decl.name);
-    const quantifiers = decl.params.map((p) => ({ name: p.name, type: p.type }));
+    const rhs =
+      paramArgs.length > 0 ? Apply(decl.name, ...paramArgs) : Apply(decl.name);
+    const quantifiers = decl.params.map((p) => ({
+      name: p.name,
+      type: p.type,
+    }));
     frames.push(Equation(quantifiers, lhs, rhs));
   }
 

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -1,30 +1,21 @@
 import ts from "typescript";
-import {
-  classifyFunction,
-  findFunction,
-  shortParamName,
-  translateExpr,
-  translateOperator,
-} from "./translate-signature.js";
+import type { PantDeclaration } from "./types.js";
 import { mapTsType, type NumericStrategy } from "./translate-types.js";
-import type { PantDeclaration, PantProposition } from "./types.js";
-
-function isUnsupported(s: string): boolean {
-  return s.startsWith("> UNSUPPORTED:");
-}
+import { translateExpr, translateOperator, findFunction, classifyFunction, shortParamName } from "./translate-signature.js";
+import {
+  type PantExpr, type PantProp,
+  Var, Apply, PrimedApply, Binop, Unop, Cardinality, Membership, Cond, Comprehension, Unsupported,
+  Equation, UnsupportedProp,
+} from "./pant-expr.js";
 
 /** Generate a binder name not already used by params. */
 function freshBinder(paramNames: Map<string, string>): string {
   const used = new Set(paramNames.values());
   for (const candidate of ["x", "y", "z", "w", "v", "u", "t"]) {
-    if (!used.has(candidate)) {
-      return candidate;
-    }
+    if (!used.has(candidate)) return candidate;
   }
   let i = 0;
-  while (used.has(`x${i}`)) {
-    i++;
-  }
+  while (used.has(`x${i}`)) i++;
   return `x${i}`;
 }
 
@@ -44,7 +35,7 @@ export interface TranslateBodyOptions {
  * Mutating functions: property assignments become primed propositions,
  * plus frame conditions for unmodified rules.
  */
-export function translateBody(opts: TranslateBodyOptions): PantProposition[] {
+export function translateBody(opts: TranslateBodyOptions): PantProp[] {
   const { program, fileName, functionName, strategy, declarations } = opts;
   const checker = program.getTypeChecker();
   const { node, className } = findFunction(program, fileName, functionName);
@@ -57,9 +48,7 @@ export function translateBody(opts: TranslateBodyOptions): PantProposition[] {
   const sig = checker.getSignatureFromDeclaration(node);
 
   if (className) {
-    const existingParamNames = new Set(
-      sig ? sig.getParameters().map((p) => p.name) : [],
-    );
+    const existingParamNames = new Set(sig ? sig.getParameters().map((p) => p.name) : []);
     const pName = shortParamName(className, existingParamNames);
     paramNames.set("this", pName);
     paramList.push({ name: pName, type: className });
@@ -74,29 +63,13 @@ export function translateBody(opts: TranslateBodyOptions): PantProposition[] {
     }
   }
 
-  if (!node.body) {
-    return [];
-  }
+  if (!node.body) return [];
 
   if (classification === "pure") {
-    return translatePureBody(
-      node,
-      functionName,
-      paramList,
-      checker,
-      strategy,
-      paramNames,
-    );
+    return translatePureBody(node, functionName, paramList, checker, strategy, paramNames);
+  } else {
+    return translateMutatingBody(node, checker, strategy, paramNames, declarations ?? []);
   }
-  return translateMutatingBody(
-    node,
-    functionName,
-    paramList,
-    checker,
-    strategy,
-    paramNames,
-    declarations ?? [],
-  );
 }
 
 function translatePureBody(
@@ -106,28 +79,25 @@ function translatePureBody(
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
   paramNames: Map<string, string>,
-): PantProposition[] {
-  if (!node.body) {
-    return [];
-  }
+): PantProp[] {
+  if (!node.body) return [];
 
   const returnExpr = extractReturnExpression(node.body);
   if (!returnExpr) {
     const reason = describeRejectedBody(node.body);
-    return [{ text: `> UNSUPPORTED: ${functionName} — ${reason}` }];
+    return [UnsupportedProp(`${functionName} — ${reason}`)];
   }
 
-  const args = params.map((p) => p.name).join(" ");
-  const bindings = params.map((p) => `${p.name}: ${p.type}`).join(", ");
   const body = translateBodyExpr(returnExpr, checker, strategy, paramNames);
 
-  if (body.startsWith("> UNSUPPORTED:")) {
-    return [{ text: body }];
+  if (body.kind === "unsupported") {
+    return [UnsupportedProp(body.reason)];
   }
 
-  const head = bindings ? `all ${bindings} | ` : "";
-  const call = args ? `${functionName} ${args}` : functionName;
-  return [{ text: `${head}${call} = ${body}` }];
+  const argExprs = params.map((p) => Var(p.name));
+  const lhs = argExprs.length > 0 ? Apply(functionName, ...argExprs) : Apply(functionName);
+  const quantifiers = params.map((p) => ({ name: p.name, type: p.type }));
+  return [Equation(quantifiers, lhs, body)];
 }
 
 /**
@@ -136,14 +106,12 @@ function translatePureBody(
  *   - Single return statement
  *   - if/else with returns in both branches (produces a synthetic conditional)
  */
-function extractReturnExpression(
-  body: ts.Block,
-): ts.Expression | ts.IfStatement | null {
+function extractReturnExpression(body: ts.Block): ts.Expression | ts.IfStatement | null {
   // Skip guard statements (if-throw patterns) and find the meaningful return
   const stmts = body.statements.filter((s) => !isGuardStatement(s));
 
   if (stmts.length === 1) {
-    const stmt = stmts[0]!;
+    const stmt = stmts[0];
     if (ts.isReturnStatement(stmt) && stmt.expression) {
       return stmt.expression;
     }
@@ -164,23 +132,15 @@ function extractReturnExpression(
 
 function describeRejectedBody(body: ts.Block): string {
   const stmts = body.statements.filter((s) => !isGuardStatement(s));
-  if (stmts.length === 0) {
-    return "empty body";
-  }
-  if (stmts.length > 1) {
-    return "local bindings or multiple statements before return";
-  }
-  const stmt = stmts[0]!;
-  if (ts.isReturnStatement(stmt) && !stmt.expression) {
-    return "return without expression";
-  }
+  if (stmts.length === 0) return "empty body";
+  if (stmts.length > 1) return "local bindings or multiple statements before return";
+  const stmt = stmts[0];
+  if (ts.isReturnStatement(stmt) && !stmt.expression) return "return without expression";
   return "non-translatable control flow";
 }
 
 function isGuardStatement(stmt: ts.Statement): boolean {
-  if (!ts.isIfStatement(stmt)) {
-    return false;
-  }
+  if (!ts.isIfStatement(stmt)) return false;
   // if (...) { throw } without else
   if (!stmt.elseStatement && blockThrows(stmt.thenStatement)) {
     return !expressionHasSideEffects(stmt.expression);
@@ -200,34 +160,24 @@ function isGuardStatement(stmt: ts.Statement): boolean {
   return false;
 }
 
-function variableStatementHasNoSideEffects(
-  stmt: ts.VariableStatement,
-): boolean {
+function variableStatementHasNoSideEffects(stmt: ts.VariableStatement): boolean {
   return stmt.declarationList.declarations.every(
-    (decl) => !(decl.initializer && expressionHasSideEffects(decl.initializer)),
+    (decl) =>
+      !decl.initializer || !expressionHasSideEffects(decl.initializer),
   );
 }
 
 function blockThrows(node: ts.Statement): boolean {
-  if (ts.isThrowStatement(node)) {
-    return true;
-  }
+  if (ts.isThrowStatement(node)) return true;
   if (ts.isBlock(node)) {
     const stmts = node.statements;
-    if (stmts.length === 0) {
-      return false;
-    }
+    if (stmts.length === 0) return false;
     // Last statement must be a throw; all preceding must be side-effect-free
     // (variable declarations for building the error message, etc.)
-    if (!ts.isThrowStatement(stmts.at(-1)!)) {
-      return false;
-    }
+    if (!ts.isThrowStatement(stmts[stmts.length - 1])) return false;
     return stmts
       .slice(0, -1)
-      .every(
-        (s) =>
-          ts.isVariableStatement(s) && variableStatementHasNoSideEffects(s),
-      );
+      .every((s) => ts.isVariableStatement(s) && variableStatementHasNoSideEffects(s));
   }
   return false;
 }
@@ -284,12 +234,8 @@ function expressionHasSideEffects(expr: ts.Expression): boolean {
       expressionHasSideEffects(expr.right)
     );
   }
-  if (ts.isCallExpression(expr)) {
-    return true;
-  }
-  if (ts.isNewExpression(expr) || ts.isAwaitExpression(expr)) {
-    return true;
-  }
+  if (ts.isCallExpression(expr)) return true;
+  if (ts.isNewExpression(expr) || ts.isAwaitExpression(expr)) return true;
   if (ts.isPrefixUnaryExpression(expr) || ts.isPostfixUnaryExpression(expr)) {
     const op = expr.operator;
     return (
@@ -298,15 +244,14 @@ function expressionHasSideEffects(expr: ts.Expression): boolean {
       expressionHasSideEffects(expr.operand)
     );
   }
-  return (
-    ts.forEachChild(expr, (child) =>
-      ts.isExpression(child) ? expressionHasSideEffects(child) : false,
-    ) ?? false
-  );
+  return ts.forEachChild(
+    expr,
+    (child) => (ts.isExpression(child) ? expressionHasSideEffects(child) : false),
+  ) ?? false;
 }
 
 /**
- * Translate a TS expression to Pantagruel syntax, extending the base
+ * Translate a TS expression to a PantExpr AST node, extending the base
  * translateExpr with support for ternary, array ops, and if/else as cond.
  */
 export function translateBodyExpr(
@@ -314,7 +259,7 @@ export function translateBodyExpr(
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
   paramNames: Map<string, string>,
-): string {
+): PantExpr {
   if (ts.isExpression(expr)) {
     expr = unwrapExpression(expr);
   }
@@ -324,59 +269,31 @@ export function translateBodyExpr(
     return translateIfStatement(expr, checker, strategy, paramNames);
   }
 
-  // Ternary: a ? b : c -> cond a => b, true => c
+  // Ternary: a ? b : c -> Cond([{guard: a, value: b}], c)
   if (ts.isConditionalExpression(expr)) {
-    const cond = translateBodyExpr(
-      expr.condition,
-      checker,
-      strategy,
-      paramNames,
-    );
-    if (isUnsupported(cond)) {
-      return cond;
-    }
-    const whenTrue = translateBodyExpr(
-      expr.whenTrue,
-      checker,
-      strategy,
-      paramNames,
-    );
-    if (isUnsupported(whenTrue)) {
-      return whenTrue;
-    }
-    const whenFalse = translateBodyExpr(
-      expr.whenFalse,
-      checker,
-      strategy,
-      paramNames,
-    );
-    if (isUnsupported(whenFalse)) {
-      return whenFalse;
-    }
-    return `cond ${cond} => ${whenTrue}, true => ${whenFalse}`;
+    const cond = translateBodyExpr(expr.condition, checker, strategy, paramNames);
+    if (cond.kind === "unsupported") return cond;
+    const whenTrue = translateBodyExpr(expr.whenTrue, checker, strategy, paramNames);
+    if (whenTrue.kind === "unsupported") return whenTrue;
+    const whenFalse = translateBodyExpr(expr.whenFalse, checker, strategy, paramNames);
+    if (whenFalse.kind === "unsupported") return whenFalse;
+    return Cond([{ guard: cond, value: whenTrue }], whenFalse);
   }
 
   // Property access with special array operations
   if (ts.isPropertyAccessExpression(expr)) {
     const prop = expr.name.text;
-    const obj = translateBodyExpr(
-      expr.expression,
-      checker,
-      strategy,
-      paramNames,
-    );
-    if (isUnsupported(obj)) {
-      return obj;
-    }
+    const obj = translateBodyExpr(expr.expression, checker, strategy, paramNames);
+    if (obj.kind === "unsupported") return obj;
     // .length -> #obj (array only)
     if (prop === "length") {
       const receiverType = checker.getTypeAtLocation(expr.expression);
       if (checker.isArrayType(receiverType)) {
-        return `#${obj}`;
+        return Cardinality(obj);
       }
     }
-    // Regular property access: a.balance -> balance a
-    return `${prop} ${obj}`;
+    // Regular property access: a.balance -> Apply("balance", obj)
+    return Apply(prop, obj);
   }
 
   // Call expression: handle .includes(), .filter().map(), etc.
@@ -384,40 +301,27 @@ export function translateBodyExpr(
     return translateCallExpr(expr, checker, strategy, paramNames);
   }
 
-  // Prefix unary: !x -> ~(x), -x -> -(x)
+  // Prefix unary: !x -> Unop("~", x), -x -> Unop("-", x)
   if (ts.isPrefixUnaryExpression(expr)) {
-    const operand = translateBodyExpr(
-      expr.operand,
-      checker,
-      strategy,
-      paramNames,
-    );
-    if (isUnsupported(operand)) {
-      return operand;
-    }
+    const operand = translateBodyExpr(expr.operand, checker, strategy, paramNames);
+    if (operand.kind === "unsupported") return operand;
     if (expr.operator === ts.SyntaxKind.ExclamationToken) {
-      return `~(${operand})`;
+      return Unop("~", operand);
     }
     if (expr.operator === ts.SyntaxKind.MinusToken) {
-      return `-(${operand})`;
+      return Unop("-", operand);
     }
   }
 
   // Binary expression
   if (ts.isBinaryExpression(expr)) {
     const op = translateOperator(expr.operatorToken.kind);
-    if (op === "?") {
-      return `> UNSUPPORTED: operator ${ts.SyntaxKind[expr.operatorToken.kind]}`;
-    }
+    if (op === "?") return Unsupported(`operator ${ts.SyntaxKind[expr.operatorToken.kind]}`);
     const left = translateBodyExpr(expr.left, checker, strategy, paramNames);
-    if (isUnsupported(left)) {
-      return left;
-    }
+    if (left.kind === "unsupported") return left;
     const right = translateBodyExpr(expr.right, checker, strategy, paramNames);
-    if (isUnsupported(right)) {
-      return right;
-    }
-    return `${left} ${op} ${right}`;
+    if (right.kind === "unsupported") return right;
+    return Binop(op, left, right);
   }
 
   // Fall through to base translateExpr for identifiers, literals, this, etc.
@@ -425,7 +329,7 @@ export function translateBodyExpr(
     return translateExpr(expr, checker, strategy, paramNames);
   }
 
-  return "> UNSUPPORTED: non-expression statement";
+  return Unsupported("non-expression statement");
 }
 
 function translateIfStatement(
@@ -433,40 +337,27 @@ function translateIfStatement(
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
   paramNames: Map<string, string>,
-): string {
-  const cond = translateBodyExpr(
-    stmt.expression,
-    checker,
-    strategy,
-    paramNames,
-  );
-  if (isUnsupported(cond)) {
-    return cond;
-  }
+): PantExpr {
+  const cond = translateBodyExpr(stmt.expression, checker, strategy, paramNames);
+  if (cond.kind === "unsupported") return cond;
   const thenExpr = extractReturnFromBranch(stmt.thenStatement);
   const elseExpr = stmt.elseStatement
     ? extractReturnFromBranch(stmt.elseStatement)
     : null;
 
   if (thenExpr && elseExpr) {
-    const thenStr = translateBodyExpr(thenExpr, checker, strategy, paramNames);
-    if (isUnsupported(thenStr)) {
-      return thenStr;
-    }
-    const elseStr = translateBodyExpr(elseExpr, checker, strategy, paramNames);
-    if (isUnsupported(elseStr)) {
-      return elseStr;
-    }
-    return `cond ${cond} => ${thenStr}, true => ${elseStr}`;
+    const thenVal = translateBodyExpr(thenExpr, checker, strategy, paramNames);
+    if (thenVal.kind === "unsupported") return thenVal;
+    const elseVal = translateBodyExpr(elseExpr, checker, strategy, paramNames);
+    if (elseVal.kind === "unsupported") return elseVal;
+    return Cond([{ guard: cond, value: thenVal }], elseVal);
   }
 
-  return "> UNSUPPORTED: if statement without return in both branches";
+  return Unsupported("if statement without return in both branches");
 }
 
 function extractReturnFromBranch(stmt: ts.Statement): ts.Expression | null {
-  if (ts.isReturnStatement(stmt) && stmt.expression) {
-    return stmt.expression;
-  }
+  if (ts.isReturnStatement(stmt) && stmt.expression) return stmt.expression;
   if (ts.isBlock(stmt)) {
     // Apply the same rule as extractReturnExpression: only allow a single
     // return (after filtering guards). Blocks with local declarations or
@@ -474,13 +365,63 @@ function extractReturnFromBranch(stmt: ts.Statement): ts.Expression | null {
     // branch-scoped bindings into the generated proposition.
     const nonGuard = stmt.statements.filter((s) => !isGuardStatement(s));
     if (nonGuard.length === 1) {
-      const s = nonGuard[0]!;
-      if (ts.isReturnStatement(s) && s.expression) {
-        return s.expression;
-      }
+      const s = nonGuard[0];
+      if (ts.isReturnStatement(s) && s.expression) return s.expression;
     }
   }
   return null;
+}
+
+/** Get element type name for an array-typed TS expression, or null. */
+function getArrayElementType(
+  tsExpr: ts.Expression,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+): string | null {
+  const sourceType = checker.getTypeAtLocation(tsExpr);
+  if (!checker.isArrayType(sourceType)) return null;
+  const typeArgs = checker.getTypeArguments(sourceType as ts.TypeReference);
+  return typeArgs.length === 1 ? mapTsType(typeArgs[0], checker, strategy) : "?";
+}
+
+/**
+ * Translate a .filter() or .map() call on an array to a comprehension,
+ * composing with any existing comprehension from a prior chain step.
+ */
+function translateArrayMethod(
+  methodName: "filter" | "map",
+  tsReceiver: ts.Expression,
+  expr: ts.CallExpression,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  paramNames: Map<string, string>,
+): PantExpr | null {
+  const elemType = getArrayElementType(tsReceiver, checker, strategy);
+  if (!elemType) return null;
+
+  const receiver = translateBodyExpr(tsReceiver, checker, strategy, paramNames);
+  if (receiver.kind === "unsupported") return receiver;
+
+  const varName = freshBinder(paramNames);
+  const extendedParams = new Map(paramNames);
+  extendedParams.set(varName, varName);
+
+  const body = extractArrowBody(expr.arguments[0], varName, extendedParams, checker, strategy);
+  if (!body) return Unsupported(expr.getText());
+  if (body.kind === "unsupported") return body;
+
+  if (methodName === "filter") {
+    if (receiver.kind === "comprehension") {
+      const combined = receiver.predicate ? Binop("and", receiver.predicate, body) : body;
+      return { ...receiver, predicate: combined };
+    }
+    return Comprehension(varName, elemType, Var(varName), body);
+  } else {
+    if (receiver.kind === "comprehension") {
+      return { ...receiver, body };
+    }
+    return Comprehension(varName, elemType, body);
+  }
 }
 
 function translateCallExpr(
@@ -488,116 +429,34 @@ function translateCallExpr(
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
   paramNames: Map<string, string>,
-): string {
+): PantExpr {
   // Method calls: obj.method(args)
   if (ts.isPropertyAccessExpression(expr.expression)) {
     const methodName = expr.expression.name.text;
-    const obj = expr.expression.expression;
+    const tsReceiver = expr.expression.expression;
 
     // .includes(x) -> x in obj (array only)
     if (methodName === "includes" && expr.arguments.length === 1) {
-      const receiverType = checker.getTypeAtLocation(obj);
+      const receiverType = checker.getTypeAtLocation(tsReceiver);
       if (!checker.isArrayType(receiverType)) {
-        return "> UNSUPPORTED: non-array .includes()";
+        return Unsupported("non-array .includes()");
       }
-      const arg = translateBodyExpr(
-        expr.arguments[0]!,
-        checker,
-        strategy,
-        paramNames,
-      );
-      if (isUnsupported(arg)) {
-        return arg;
-      }
-      const objStr = translateBodyExpr(obj, checker, strategy, paramNames);
-      if (isUnsupported(objStr)) {
-        return objStr;
-      }
-      return `${arg} in ${objStr}`;
+      const arg = translateBodyExpr(expr.arguments[0], checker, strategy, paramNames);
+      if (arg.kind === "unsupported") return arg;
+      const objExpr = translateBodyExpr(tsReceiver, checker, strategy, paramNames);
+      if (objExpr.kind === "unsupported") return objExpr;
+      return Membership(arg, objExpr);
     }
 
-    // .filter(p).map(f) -> each x: T, p x | f x
-    if (methodName === "map" && ts.isCallExpression(obj)) {
-      const filterResult = tryTranslateFilterMap(
-        obj,
-        expr,
-        checker,
-        strategy,
-        paramNames,
-      );
-      if (filterResult) {
-        return filterResult;
-      }
+    // .filter(pred) / .map(fn) — each independently produces or refines a comprehension
+    if ((methodName === "filter" || methodName === "map") && expr.arguments.length === 1) {
+      const result = translateArrayMethod(methodName, tsReceiver, expr, checker, strategy, paramNames);
+      if (result) return result;
     }
   }
 
   // Unsupported call
-  return `> UNSUPPORTED: ${expr.getText()}`;
-}
-
-function tryTranslateFilterMap(
-  filterCall: ts.CallExpression,
-  mapCall: ts.CallExpression,
-  checker: ts.TypeChecker,
-  strategy: NumericStrategy,
-  paramNames: Map<string, string>,
-): string | null {
-  if (!ts.isPropertyAccessExpression(filterCall.expression)) {
-    return null;
-  }
-  if (filterCall.expression.name.text !== "filter") {
-    return null;
-  }
-  if (filterCall.arguments.length !== 1 || mapCall.arguments.length !== 1) {
-    return null;
-  }
-
-  const sourceObj = filterCall.expression.expression;
-  const filterArg = filterCall.arguments[0]!;
-  const mapArg = mapCall.arguments[0]!;
-
-  // Only translate filter/map on actual arrays
-  const sourceType = checker.getTypeAtLocation(sourceObj);
-  if (!checker.isArrayType(sourceType)) {
-    return null;
-  }
-  let elemTypeName = "?";
-  const typeArgs = checker.getTypeArguments(sourceType as ts.TypeReference);
-  if (typeArgs.length === 1) {
-    elemTypeName = mapTsType(typeArgs[0]!, checker, strategy);
-  }
-
-  const varName = freshBinder(paramNames);
-  const extendedParams = new Map(paramNames);
-  extendedParams.set(varName, varName);
-
-  // Extract predicate body from arrow function
-  const filterBody = extractArrowBody(
-    filterArg,
-    varName,
-    extendedParams,
-    checker,
-    strategy,
-  );
-  const mapBody = extractArrowBody(
-    mapArg,
-    varName,
-    extendedParams,
-    checker,
-    strategy,
-  );
-
-  if (filterBody && mapBody) {
-    if (isUnsupported(filterBody)) {
-      return filterBody;
-    }
-    if (isUnsupported(mapBody)) {
-      return mapBody;
-    }
-    return `(each ${varName}: ${elemTypeName}, ${filterBody} | ${mapBody})`;
-  }
-
-  return null;
+  return Unsupported(expr.getText());
 }
 
 function extractArrowBody(
@@ -606,20 +465,15 @@ function extractArrowBody(
   paramNames: Map<string, string>,
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
-): string | null {
-  if (!ts.isArrowFunction(expr)) {
-    return null;
-  }
-  if (
-    expr.parameters.length !== 1 ||
-    !ts.isIdentifier(expr.parameters[0]!.name)
-  ) {
-    return "> UNSUPPORTED: filter/map callback must have exactly one identifier parameter";
+): PantExpr | null {
+  if (!ts.isArrowFunction(expr)) return null;
+  if (expr.parameters.length !== 1 || !ts.isIdentifier(expr.parameters[0].name)) {
+    return Unsupported("filter/map callback must have exactly one identifier parameter");
   }
 
   // Map arrow param to the fresh binder
   const arrowParams = new Map(paramNames);
-  arrowParams.set((expr.parameters[0]?.name as ts.Identifier).text, binderName);
+  arrowParams.set(expr.parameters[0].name.text, binderName);
 
   if (ts.isBlock(expr.body)) {
     // Only allow a single return (after filtering guards), same rule as
@@ -627,7 +481,7 @@ function extractArrowBody(
     // would introduce free variables in the generated comprehension.
     const nonGuard = expr.body.statements.filter((s) => !isGuardStatement(s));
     if (nonGuard.length === 1) {
-      const s = nonGuard[0]!;
+      const s = nonGuard[0];
       if (ts.isReturnStatement(s) && s.expression) {
         return translateBodyExpr(s.expression, checker, strategy, arrowParams);
       }
@@ -643,29 +497,18 @@ function extractArrowBody(
 
 function translateMutatingBody(
   node: ts.FunctionDeclaration | ts.MethodDeclaration,
-  _functionName: string,
-  _params: Array<{ name: string; type: string }>,
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
   paramNames: Map<string, string>,
   declarations: PantDeclaration[],
-): PantProposition[] {
-  if (!node.body) {
-    return [];
-  }
+): PantProp[] {
+  if (!node.body) return [];
 
-  const propositions: PantProposition[] = [];
+  const propositions: PantProp[] = [];
   const modifiedRules = new Set<string>();
 
   // Collect property assignments
-  const hasUnsupportedMutation = collectAssignments(
-    node.body,
-    checker,
-    strategy,
-    paramNames,
-    propositions,
-    modifiedRules,
-  );
+  const hasUnsupportedMutation = collectAssignments(node.body, checker, strategy, paramNames, propositions, modifiedRules);
 
   // Only generate frame conditions when all mutation shapes were translatable;
   // unsupported control flow (if/loop/switch) makes frames unsound.
@@ -687,7 +530,7 @@ function collectAssignments(
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
   paramNames: Map<string, string>,
-  propositions: PantProposition[],
+  propositions: PantProp[],
   modifiedRules: Set<string>,
 ): boolean {
   let hasUnsupportedMutation = false;
@@ -695,60 +538,39 @@ function collectAssignments(
 
   for (const stmt of stmts) {
     // Skip guard statements (if-throw patterns)
-    if (isGuardStatement(stmt)) {
-      continue;
-    }
+    if (isGuardStatement(stmt)) continue;
 
-    if (
-      ts.isExpressionStatement(stmt) &&
-      ts.isBinaryExpression(unwrapExpression(stmt.expression))
-    ) {
+    if (ts.isExpressionStatement(stmt) && ts.isBinaryExpression(unwrapExpression(stmt.expression))) {
       const bin = unwrapExpression(stmt.expression) as ts.BinaryExpression;
       if (
         bin.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
         ts.isPropertyAccessExpression(bin.left)
       ) {
         const prop = bin.left.name.text;
-        const obj = translateBodyExpr(
-          bin.left.expression,
-          checker,
-          strategy,
-          paramNames,
-        );
+        const obj = translateBodyExpr(bin.left.expression, checker, strategy, paramNames);
         const val = translateBodyExpr(bin.right, checker, strategy, paramNames);
-        if (
-          obj.startsWith("> UNSUPPORTED:") ||
-          val.startsWith("> UNSUPPORTED:")
-        ) {
+        if (obj.kind === "unsupported") {
           hasUnsupportedMutation = true;
-          propositions.push({
-            text: obj.startsWith("> UNSUPPORTED:") ? obj : val,
-          });
+          propositions.push(UnsupportedProp(obj.reason));
           continue;
         }
-        propositions.push({ text: `${prop}' ${obj} = ${val}` });
+        if (val.kind === "unsupported") {
+          hasUnsupportedMutation = true;
+          propositions.push(UnsupportedProp(val.reason));
+          continue;
+        }
+        propositions.push(Equation([], PrimedApply(prop, obj), val));
         modifiedRules.add(prop);
       }
     }
 
     // Recurse into nested blocks
     if (ts.isBlock(stmt)) {
-      if (
-        collectAssignments(
-          stmt,
-          checker,
-          strategy,
-          paramNames,
-          propositions,
-          modifiedRules,
-        )
-      ) {
+      if (collectAssignments(stmt, checker, strategy, paramNames, propositions, modifiedRules)) {
         hasUnsupportedMutation = true;
       }
     } else if (ts.isIfStatement(stmt)) {
-      propositions.push({
-        text: "> UNSUPPORTED: conditional assignment (if/else)",
-      });
+      propositions.push(UnsupportedProp("conditional assignment (if/else)"));
       hasUnsupportedMutation = true;
     } else if (
       ts.isForStatement(stmt) ||
@@ -757,49 +579,24 @@ function collectAssignments(
       ts.isWhileStatement(stmt) ||
       ts.isDoStatement(stmt)
     ) {
-      propositions.push({ text: "> UNSUPPORTED: loop assignment" });
+      propositions.push(UnsupportedProp("loop assignment"));
       hasUnsupportedMutation = true;
     } else if (ts.isTryStatement(stmt)) {
-      if (
-        collectAssignments(
-          stmt.tryBlock,
-          checker,
-          strategy,
-          paramNames,
-          propositions,
-          modifiedRules,
-        )
-      ) {
+      if (collectAssignments(stmt.tryBlock, checker, strategy, paramNames, propositions, modifiedRules)) {
         hasUnsupportedMutation = true;
       }
-      if (
-        stmt.catchClause &&
-        collectAssignments(
-          stmt.catchClause.block,
-          checker,
-          strategy,
-          paramNames,
-          propositions,
-          modifiedRules,
-        )
-      ) {
-        hasUnsupportedMutation = true;
+      if (stmt.catchClause) {
+        if (collectAssignments(stmt.catchClause.block, checker, strategy, paramNames, propositions, modifiedRules)) {
+          hasUnsupportedMutation = true;
+        }
       }
-      if (
-        stmt.finallyBlock &&
-        collectAssignments(
-          stmt.finallyBlock,
-          checker,
-          strategy,
-          paramNames,
-          propositions,
-          modifiedRules,
-        )
-      ) {
-        hasUnsupportedMutation = true;
+      if (stmt.finallyBlock) {
+        if (collectAssignments(stmt.finallyBlock, checker, strategy, paramNames, propositions, modifiedRules)) {
+          hasUnsupportedMutation = true;
+        }
       }
     } else if (ts.isSwitchStatement(stmt)) {
-      propositions.push({ text: "> UNSUPPORTED: switch assignment" });
+      propositions.push(UnsupportedProp("switch assignment"));
       hasUnsupportedMutation = true;
     }
   }
@@ -814,28 +611,18 @@ function collectAssignments(
 function generateFrameConditions(
   modifiedRules: Set<string>,
   declarations: PantDeclaration[],
-): PantProposition[] {
-  const frames: PantProposition[] = [];
+): PantProp[] {
+  const frames: PantProp[] = [];
 
   for (const decl of declarations) {
-    if (decl.kind !== "rule") {
-      continue;
-    }
-    if (modifiedRules.has(decl.name)) {
-      continue;
-    }
+    if (decl.kind !== "rule") continue;
+    if (modifiedRules.has(decl.name)) continue;
 
-    if (decl.params.length === 0) {
-      frames.push({ text: `${decl.name}' = ${decl.name}` });
-    } else {
-      const paramBindings = decl.params
-        .map((p) => `${p.name}: ${p.type}`)
-        .join(", ");
-      const paramArgs = decl.params.map((p) => p.name).join(" ");
-      frames.push({
-        text: `all ${paramBindings} | ${decl.name}' ${paramArgs} = ${decl.name} ${paramArgs}`,
-      });
-    }
+    const paramArgs = decl.params.map((p) => Var(p.name));
+    const lhs = PrimedApply(decl.name, ...paramArgs);
+    const rhs = paramArgs.length > 0 ? Apply(decl.name, ...paramArgs) : Apply(decl.name);
+    const quantifiers = decl.params.map((p) => ({ name: p.name, type: p.type }));
+    frames.push(Equation(quantifiers, lhs, rhs));
   }
 
   return frames;

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -402,7 +402,9 @@ function translateArrayMethod(
   const receiver = translateBodyExpr(tsReceiver, checker, strategy, paramNames);
   if (receiver.kind === "unsupported") return receiver;
 
-  const varName = freshBinder(paramNames);
+  // When composing with an existing comprehension, reuse its binder
+  const isComposing = receiver.kind === "comprehension";
+  const varName = isComposing ? receiver.binder : freshBinder(paramNames);
   const extendedParams = new Map(paramNames);
   extendedParams.set(varName, varName);
 
@@ -411,13 +413,13 @@ function translateArrayMethod(
   if (body.kind === "unsupported") return body;
 
   if (methodName === "filter") {
-    if (receiver.kind === "comprehension") {
+    if (isComposing) {
       const combined = receiver.predicate ? Binop("and", receiver.predicate, body) : body;
       return { ...receiver, predicate: combined };
     }
     return Comprehension(varName, elemType, Var(varName), body);
   } else {
-    if (receiver.kind === "comprehension") {
+    if (isComposing) {
       return { ...receiver, body };
     }
     return Comprehension(varName, elemType, body);

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -852,6 +852,29 @@ function collectAssignments(
       continue;
     }
 
+    if (
+      ts.isVariableStatement(stmt) &&
+      stmt.declarationList.declarations.some(
+        (d) => d.initializer && expressionHasSideEffects(d.initializer),
+      )
+    ) {
+      propositions.push(UnsupportedProp("side-effectful variable initializer"));
+      hasUnsupportedMutation = true;
+      continue;
+    }
+
+    if (
+      (ts.isReturnStatement(stmt) || ts.isThrowStatement(stmt)) &&
+      stmt.expression &&
+      expressionHasSideEffects(stmt.expression)
+    ) {
+      propositions.push(
+        UnsupportedProp("side-effectful control-flow expression"),
+      );
+      hasUnsupportedMutation = true;
+      continue;
+    }
+
     // Recurse into nested blocks
     if (ts.isBlock(stmt)) {
       if (

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -19,6 +19,42 @@ function freshBinder(paramNames: Map<string, string>): string {
   return `x${i}`;
 }
 
+/** Replace every Var(name) in expr with replacement (for composing comprehension chains). */
+function substituteBinder(expr: PantExpr, name: string, replacement: PantExpr): PantExpr {
+  switch (expr.kind) {
+    case "var":
+      return expr.name === name ? replacement : expr;
+    case "literal":
+    case "unsupported":
+      return expr;
+    case "apply":
+      return { ...expr, args: expr.args.map((a) => substituteBinder(a, name, replacement)) };
+    case "primed-apply":
+      return { ...expr, args: expr.args.map((a) => substituteBinder(a, name, replacement)) };
+    case "binop":
+      return { ...expr, left: substituteBinder(expr.left, name, replacement), right: substituteBinder(expr.right, name, replacement) };
+    case "unop":
+      return { ...expr, operand: substituteBinder(expr.operand, name, replacement) };
+    case "cardinality":
+      return { ...expr, expr: substituteBinder(expr.expr, name, replacement) };
+    case "membership":
+      return { ...expr, element: substituteBinder(expr.element, name, replacement), collection: substituteBinder(expr.collection, name, replacement) };
+    case "cond":
+      return {
+        ...expr,
+        arms: expr.arms.map((a) => ({ guard: substituteBinder(a.guard, name, replacement), value: substituteBinder(a.value, name, replacement) })),
+        fallback: substituteBinder(expr.fallback, name, replacement),
+      };
+    case "comprehension":
+      if (expr.binder === name) return expr;
+      return {
+        ...expr,
+        body: substituteBinder(expr.body, name, replacement),
+        predicate: expr.predicate ? substituteBinder(expr.predicate, name, replacement) : undefined,
+      };
+  }
+}
+
 export interface TranslateBodyOptions {
   program: ts.Program;
   fileName: string;
@@ -402,27 +438,34 @@ function translateArrayMethod(
   const receiver = translateBodyExpr(tsReceiver, checker, strategy, paramNames);
   if (receiver.kind === "unsupported") return receiver;
 
-  // When composing with an existing comprehension, reuse its binder
   const isComposing = receiver.kind === "comprehension";
-  const varName = isComposing ? receiver.binder : freshBinder(paramNames);
+  const sourceBinder = isComposing ? receiver.binder : freshBinder(paramNames);
+  // Use a fresh binder for the callback so it doesn't collide with sourceBinder
+  const callbackBinder = isComposing
+    ? freshBinder(new Map([...paramNames, [sourceBinder, sourceBinder]]))
+    : sourceBinder;
   const extendedParams = new Map(paramNames);
-  extendedParams.set(varName, varName);
+  extendedParams.set(callbackBinder, callbackBinder);
 
-  const body = extractArrowBody(expr.arguments[0], varName, extendedParams, checker, strategy);
-  if (!body) return Unsupported(expr.getText());
-  if (body.kind === "unsupported") return body;
+  const rawBody = extractArrowBody(expr.arguments[0], callbackBinder, extendedParams, checker, strategy);
+  if (!rawBody) return Unsupported(expr.getText());
+  if (rawBody.kind === "unsupported") return rawBody;
+
+  // When composing, substitute the callback's binder with the prior step's body
+  // so that e.g. xs.map(f).map(g) becomes (each x: T | g(f(x))) not (each x: T | g(x))
+  const body = isComposing ? substituteBinder(rawBody, callbackBinder, receiver.body) : rawBody;
 
   if (methodName === "filter") {
     if (isComposing) {
       const combined = receiver.predicate ? Binop("and", receiver.predicate, body) : body;
       return { ...receiver, predicate: combined };
     }
-    return Comprehension(varName, elemType, Var(varName), body);
+    return Comprehension(sourceBinder, elemType, Var(sourceBinder), body);
   } else {
     if (isComposing) {
       return { ...receiver, body };
     }
-    return Comprehension(varName, elemType, body);
+    return Comprehension(sourceBinder, elemType, body);
   }
 }
 

--- a/tools/ts2pant/src/translate-signature.ts
+++ b/tools/ts2pant/src/translate-signature.ts
@@ -254,10 +254,10 @@ function capitalize(s: string): string {
 }
 
 export function shortParamName(typeName: string, existingNames: Set<string>): string {
-  let name = typeName[0].toLowerCase();
+  let name = typeName[0]!.toLowerCase();
   let suffix = 1;
   while (existingNames.has(name)) {
-    name = typeName[0].toLowerCase() + suffix;
+    name = typeName[0]!.toLowerCase() + suffix;
     suffix++;
   }
   return name;

--- a/tools/ts2pant/src/translate-signature.ts
+++ b/tools/ts2pant/src/translate-signature.ts
@@ -204,6 +204,9 @@ export function translateExpr(
     const left = translateExpr(expr.left, _checker, _strategy, paramNames);
     const right = translateExpr(expr.right, _checker, _strategy, paramNames);
     const op = translateOperator(expr.operatorToken.kind);
+    if (op === "?") {
+      return Lit(expr.getText());
+    }
     return Binop(op, left, right);
   }
 

--- a/tools/ts2pant/src/translate-signature.ts
+++ b/tools/ts2pant/src/translate-signature.ts
@@ -1,6 +1,7 @@
 import ts from "typescript";
+import type { PantRule, PantAction, PantDeclaration } from "./types.js";
 import { mapTsType, type NumericStrategy } from "./translate-types.js";
-import type { PantAction, PantDeclaration, PantRule } from "./types.js";
+import { type PantExpr, Var, Lit, Apply, Binop, Unop, renderExpr } from "./pant-expr.js";
 
 export type Classification = "pure" | "mutating";
 
@@ -19,23 +20,16 @@ export function findFunction(
   functionName: string,
 ): { node: ts.FunctionDeclaration | ts.MethodDeclaration; className?: string } {
   const sourceFile = program.getSourceFile(fileName);
-  if (!sourceFile) {
-    throw new Error(`Source file not found: ${fileName}`);
-  }
+  if (!sourceFile) throw new Error(`Source file not found: ${fileName}`);
 
   let match:
-    | {
-        node: ts.FunctionDeclaration | ts.MethodDeclaration;
-        className?: string;
-      }
+    | { node: ts.FunctionDeclaration | ts.MethodDeclaration; className?: string }
     | undefined;
 
   // Search top-level functions
   for (const stmt of sourceFile.statements) {
     if (ts.isFunctionDeclaration(stmt) && stmt.name?.text === functionName) {
-      if (stmt.body) {
-        return { node: stmt };
-      }
+      if (stmt.body) return { node: stmt };
       match ??= { node: stmt };
     }
   }
@@ -49,18 +43,14 @@ export function findFunction(
           ts.isIdentifier(member.name) &&
           member.name.text === functionName
         ) {
-          if (member.body) {
-            return { node: member, className: stmt.name.text };
-          }
+          if (member.body) return { node: member, className: stmt.name.text };
           match ??= { node: member, className: stmt.name.text };
         }
       }
     }
   }
 
-  if (match) {
-    return match;
-  }
+  if (match) return match;
   throw new Error(`Function not found: ${functionName}`);
 }
 
@@ -74,18 +64,12 @@ export function classifyFunction(
   checker: ts.TypeChecker,
 ): Classification {
   const sig = checker.getSignatureFromDeclaration(node);
-  if (!sig) {
-    throw new Error("Cannot get signature for classification");
-  }
+  if (!sig) throw new Error("Cannot get signature for classification");
 
   const returnType = sig.getReturnType();
-  if (returnType.flags & ts.TypeFlags.Void) {
-    return "mutating";
-  }
+  if (returnType.flags & ts.TypeFlags.Void) return "mutating";
 
-  if (node.body && hasPropertyAssignment(node.body)) {
-    return "mutating";
-  }
+  if (node.body && hasPropertyAssignment(node.body)) return "mutating";
 
   return "pure";
 }
@@ -93,16 +77,10 @@ export function classifyFunction(
 function hasPropertyAssignment(node: ts.Node): boolean {
   let found = false;
   function visit(n: ts.Node) {
-    if (found) {
-      return;
-    }
+    if (found) return;
     // Don't recurse into nested functions or classes
-    if (ts.isFunctionLike(n) && n !== node) {
-      return;
-    }
-    if (ts.isClassDeclaration(n) || ts.isClassExpression(n)) {
-      return;
-    }
+    if (ts.isFunctionLike(n) && n !== node) return;
+    if (ts.isClassDeclaration(n) || ts.isClassExpression(n)) return;
     if (
       ts.isBinaryExpression(n) &&
       n.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
@@ -128,16 +106,12 @@ export function detectGuard(
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
   paramNames: Map<string, string>,
-): string | undefined {
-  if (!node.body) {
-    return;
-  }
+): PantExpr | undefined {
+  if (!node.body) return undefined;
 
   for (const stmt of node.body.statements) {
     // Only extract guards from leading precondition checks
-    if (!ts.isIfStatement(stmt)) {
-      break;
-    }
+    if (!ts.isIfStatement(stmt)) break;
 
     // Pattern 1: if (cond) { ... } else { throw }
     if (stmt.elseStatement && blockThrows(stmt.elseStatement)) {
@@ -163,12 +137,14 @@ export function detectGuard(
         );
       }
       // Otherwise negate the whole expression
-      return `~(${translateExpr(stmt.expression, checker, strategy, paramNames)})`;
+      return Unop("~", translateExpr(stmt.expression, checker, strategy, paramNames));
     }
 
     // If it's an if-statement but doesn't match a guard pattern, stop scanning
     break;
   }
+
+  return undefined;
 }
 
 function blockThrows(node: ts.Statement): boolean {
@@ -179,66 +155,65 @@ function blockThrows(node: ts.Statement): boolean {
 }
 
 /**
- * Translate a TypeScript expression to Pantagruel syntax (best-effort).
+ * Translate a TypeScript expression to a PantExpr AST node (best-effort).
  */
 export function translateExpr(
   expr: ts.Expression,
-  _checker: ts.TypeChecker,
-  _strategy: NumericStrategy,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
   paramNames: Map<string, string>,
-): string {
-  // Property access: a.balance -> balance a
+): PantExpr {
+  // Property access: a.balance -> Apply("balance", obj)
   if (ts.isPropertyAccessExpression(expr)) {
-    const obj = translateExpr(expr.expression, _checker, _strategy, paramNames);
-    const prop = expr.name.text;
-    return `${prop} ${obj}`;
+    const obj = translateExpr(expr.expression, checker, strategy, paramNames);
+    return Apply(expr.name.text, obj);
   }
 
-  // Binary expression: a >= b -> a >= b
+  // Binary expression: a >= b -> Binop(">=", a, b)
   if (ts.isBinaryExpression(expr)) {
-    const left = translateExpr(expr.left, _checker, _strategy, paramNames);
-    const right = translateExpr(expr.right, _checker, _strategy, paramNames);
+    const left = translateExpr(expr.left, checker, strategy, paramNames);
+    const right = translateExpr(expr.right, checker, strategy, paramNames);
     const op = translateOperator(expr.operatorToken.kind);
-    return `${left} ${op} ${right}`;
+    return Binop(op, left, right);
   }
 
-  // Prefix unary: !x -> ~x, -x -> -x
+  // Prefix unary: !x -> Unop("~", x), -x -> Unop("-", x)
   if (ts.isPrefixUnaryExpression(expr)) {
     if (expr.operator === ts.SyntaxKind.ExclamationToken) {
-      return `~(${translateExpr(expr.operand, _checker, _strategy, paramNames)})`;
+      return Unop("~", translateExpr(expr.operand, checker, strategy, paramNames));
     }
     if (expr.operator === ts.SyntaxKind.MinusToken) {
-      return `-${translateExpr(expr.operand, _checker, _strategy, paramNames)}`;
+      return Unop("-", translateExpr(expr.operand, checker, strategy, paramNames));
     }
   }
 
-  // Parenthesized
+  // Parenthesized — unwrap (parens are a rendering concern)
   if (ts.isParenthesizedExpression(expr)) {
-    return `(${translateExpr(expr.expression, _checker, _strategy, paramNames)})`;
+    return translateExpr(expr.expression, checker, strategy, paramNames);
   }
 
   // `this` keyword
   if (expr.kind === ts.SyntaxKind.ThisKeyword) {
-    return paramNames.get("this") ?? "this";
+    return Var(paramNames.get("this") ?? "this");
   }
 
   // Identifier — use param name mapping if available
   if (ts.isIdentifier(expr)) {
-    return paramNames.get(expr.text) ?? expr.text;
+    return Var(paramNames.get(expr.text) ?? expr.text);
   }
 
   // Numeric literal
   if (ts.isNumericLiteral(expr)) {
-    return expr.text;
+    return Lit(expr.text);
   }
 
   // String literal
   if (ts.isStringLiteral(expr)) {
-    return `"${expr.text.replace(/\\/gu, "\\\\").replace(/"/gu, '\\"')}"`;
+    return Lit(`"${expr.text.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`);
   }
 
   // Fallback
-  return expr.getText();
+  return Lit(expr.getText());
 }
 
 export function translateOperator(kind: ts.SyntaxKind): string {
@@ -278,14 +253,11 @@ function capitalize(s: string): string {
   return s.charAt(0).toUpperCase() + s.slice(1);
 }
 
-export function shortParamName(
-  typeName: string,
-  existingNames: Set<string>,
-): string {
-  let name = typeName[0]!.toLowerCase();
+export function shortParamName(typeName: string, existingNames: Set<string>): string {
+  let name = typeName[0].toLowerCase();
   let suffix = 1;
   while (existingNames.has(name)) {
-    name = typeName[0]!.toLowerCase() + suffix;
+    name = typeName[0].toLowerCase() + suffix;
     suffix++;
   }
   return name;
@@ -304,9 +276,7 @@ export function translateSignature(
   const { node, className } = findFunction(program, fileName, functionName);
   const classification = classifyFunction(node, checker);
   const sig = checker.getSignatureFromDeclaration(node);
-  if (!sig) {
-    throw new Error(`Cannot get signature for: ${functionName}`);
-  }
+  if (!sig) throw new Error(`Cannot get signature for: ${functionName}`);
 
   // Build params, prepending `this` for class methods
   const params: Array<{ name: string; type: string }> = [];
@@ -339,18 +309,15 @@ export function translateSignature(
       params,
       returnType,
     };
-    if (guard) {
-      decl.guard = guard;
-    }
+    if (guard) decl.guard = guard;
+    return { declaration: decl, classification };
+  } else {
+    const decl: PantAction = {
+      kind: "action",
+      label: capitalize(functionName),
+      params,
+    };
+    if (guard) decl.guard = guard;
     return { declaration: decl, classification };
   }
-  const decl: PantAction = {
-    kind: "action",
-    label: capitalize(functionName),
-    params,
-  };
-  if (guard) {
-    decl.guard = guard;
-  }
-  return { declaration: decl, classification };
 }

--- a/tools/ts2pant/src/translate-signature.ts
+++ b/tools/ts2pant/src/translate-signature.ts
@@ -1,7 +1,7 @@
 import ts from "typescript";
-import type { PantRule, PantAction, PantDeclaration } from "./types.js";
+import { Apply, Binop, Lit, type PantExpr, Unop, Var } from "./pant-expr.js";
 import { mapTsType, type NumericStrategy } from "./translate-types.js";
-import { type PantExpr, Var, Lit, Apply, Binop, Unop, renderExpr } from "./pant-expr.js";
+import type { PantAction, PantDeclaration, PantRule } from "./types.js";
 
 export type Classification = "pure" | "mutating";
 
@@ -20,16 +20,23 @@ export function findFunction(
   functionName: string,
 ): { node: ts.FunctionDeclaration | ts.MethodDeclaration; className?: string } {
   const sourceFile = program.getSourceFile(fileName);
-  if (!sourceFile) throw new Error(`Source file not found: ${fileName}`);
+  if (!sourceFile) {
+    throw new Error(`Source file not found: ${fileName}`);
+  }
 
   let match:
-    | { node: ts.FunctionDeclaration | ts.MethodDeclaration; className?: string }
+    | {
+        node: ts.FunctionDeclaration | ts.MethodDeclaration;
+        className?: string;
+      }
     | undefined;
 
   // Search top-level functions
   for (const stmt of sourceFile.statements) {
     if (ts.isFunctionDeclaration(stmt) && stmt.name?.text === functionName) {
-      if (stmt.body) return { node: stmt };
+      if (stmt.body) {
+        return { node: stmt };
+      }
       match ??= { node: stmt };
     }
   }
@@ -43,14 +50,18 @@ export function findFunction(
           ts.isIdentifier(member.name) &&
           member.name.text === functionName
         ) {
-          if (member.body) return { node: member, className: stmt.name.text };
+          if (member.body) {
+            return { node: member, className: stmt.name.text };
+          }
           match ??= { node: member, className: stmt.name.text };
         }
       }
     }
   }
 
-  if (match) return match;
+  if (match) {
+    return match;
+  }
   throw new Error(`Function not found: ${functionName}`);
 }
 
@@ -64,12 +75,18 @@ export function classifyFunction(
   checker: ts.TypeChecker,
 ): Classification {
   const sig = checker.getSignatureFromDeclaration(node);
-  if (!sig) throw new Error("Cannot get signature for classification");
+  if (!sig) {
+    throw new Error("Cannot get signature for classification");
+  }
 
   const returnType = sig.getReturnType();
-  if (returnType.flags & ts.TypeFlags.Void) return "mutating";
+  if (returnType.flags & ts.TypeFlags.Void) {
+    return "mutating";
+  }
 
-  if (node.body && hasPropertyAssignment(node.body)) return "mutating";
+  if (node.body && hasPropertyAssignment(node.body)) {
+    return "mutating";
+  }
 
   return "pure";
 }
@@ -77,10 +94,16 @@ export function classifyFunction(
 function hasPropertyAssignment(node: ts.Node): boolean {
   let found = false;
   function visit(n: ts.Node) {
-    if (found) return;
+    if (found) {
+      return;
+    }
     // Don't recurse into nested functions or classes
-    if (ts.isFunctionLike(n) && n !== node) return;
-    if (ts.isClassDeclaration(n) || ts.isClassExpression(n)) return;
+    if (ts.isFunctionLike(n) && n !== node) {
+      return;
+    }
+    if (ts.isClassDeclaration(n) || ts.isClassExpression(n)) {
+      return;
+    }
     if (
       ts.isBinaryExpression(n) &&
       n.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
@@ -107,11 +130,15 @@ export function detectGuard(
   strategy: NumericStrategy,
   paramNames: Map<string, string>,
 ): PantExpr | undefined {
-  if (!node.body) return undefined;
+  if (!node.body) {
+    return undefined;
+  }
 
   for (const stmt of node.body.statements) {
     // Only extract guards from leading precondition checks
-    if (!ts.isIfStatement(stmt)) break;
+    if (!ts.isIfStatement(stmt)) {
+      break;
+    }
 
     // Pattern 1: if (cond) { ... } else { throw }
     if (stmt.elseStatement && blockThrows(stmt.elseStatement)) {
@@ -137,7 +164,10 @@ export function detectGuard(
         );
       }
       // Otherwise negate the whole expression
-      return Unop("~", translateExpr(stmt.expression, checker, strategy, paramNames));
+      return Unop(
+        "~",
+        translateExpr(stmt.expression, checker, strategy, paramNames),
+      );
     }
 
     // If it's an if-statement but doesn't match a guard pattern, stop scanning
@@ -159,20 +189,20 @@ function blockThrows(node: ts.Statement): boolean {
  */
 export function translateExpr(
   expr: ts.Expression,
-  checker: ts.TypeChecker,
-  strategy: NumericStrategy,
+  _checker: ts.TypeChecker,
+  _strategy: NumericStrategy,
   paramNames: Map<string, string>,
 ): PantExpr {
   // Property access: a.balance -> Apply("balance", obj)
   if (ts.isPropertyAccessExpression(expr)) {
-    const obj = translateExpr(expr.expression, checker, strategy, paramNames);
+    const obj = translateExpr(expr.expression, _checker, _strategy, paramNames);
     return Apply(expr.name.text, obj);
   }
 
   // Binary expression: a >= b -> Binop(">=", a, b)
   if (ts.isBinaryExpression(expr)) {
-    const left = translateExpr(expr.left, checker, strategy, paramNames);
-    const right = translateExpr(expr.right, checker, strategy, paramNames);
+    const left = translateExpr(expr.left, _checker, _strategy, paramNames);
+    const right = translateExpr(expr.right, _checker, _strategy, paramNames);
     const op = translateOperator(expr.operatorToken.kind);
     return Binop(op, left, right);
   }
@@ -180,16 +210,22 @@ export function translateExpr(
   // Prefix unary: !x -> Unop("~", x), -x -> Unop("-", x)
   if (ts.isPrefixUnaryExpression(expr)) {
     if (expr.operator === ts.SyntaxKind.ExclamationToken) {
-      return Unop("~", translateExpr(expr.operand, checker, strategy, paramNames));
+      return Unop(
+        "~",
+        translateExpr(expr.operand, _checker, _strategy, paramNames),
+      );
     }
     if (expr.operator === ts.SyntaxKind.MinusToken) {
-      return Unop("-", translateExpr(expr.operand, checker, strategy, paramNames));
+      return Unop(
+        "-",
+        translateExpr(expr.operand, _checker, _strategy, paramNames),
+      );
     }
   }
 
   // Parenthesized — unwrap (parens are a rendering concern)
   if (ts.isParenthesizedExpression(expr)) {
-    return translateExpr(expr.expression, checker, strategy, paramNames);
+    return translateExpr(expr.expression, _checker, _strategy, paramNames);
   }
 
   // `this` keyword
@@ -209,7 +245,7 @@ export function translateExpr(
 
   // String literal
   if (ts.isStringLiteral(expr)) {
-    return Lit(`"${expr.text.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`);
+    return Lit(`"${expr.text.replace(/\\/gu, "\\\\").replace(/"/gu, '\\"')}"`);
   }
 
   // Fallback
@@ -253,7 +289,10 @@ function capitalize(s: string): string {
   return s.charAt(0).toUpperCase() + s.slice(1);
 }
 
-export function shortParamName(typeName: string, existingNames: Set<string>): string {
+export function shortParamName(
+  typeName: string,
+  existingNames: Set<string>,
+): string {
   let name = typeName[0]!.toLowerCase();
   let suffix = 1;
   while (existingNames.has(name)) {
@@ -276,7 +315,9 @@ export function translateSignature(
   const { node, className } = findFunction(program, fileName, functionName);
   const classification = classifyFunction(node, checker);
   const sig = checker.getSignatureFromDeclaration(node);
-  if (!sig) throw new Error(`Cannot get signature for: ${functionName}`);
+  if (!sig) {
+    throw new Error(`Cannot get signature for: ${functionName}`);
+  }
 
   // Build params, prepending `this` for class methods
   const params: Array<{ name: string; type: string }> = [];
@@ -309,7 +350,9 @@ export function translateSignature(
       params,
       returnType,
     };
-    if (guard) decl.guard = guard;
+    if (guard) {
+      decl.guard = guard;
+    }
     return { declaration: decl, classification };
   } else {
     const decl: PantAction = {
@@ -317,7 +360,9 @@ export function translateSignature(
       label: capitalize(functionName),
       params,
     };
-    if (guard) decl.guard = guard;
+    if (guard) {
+      decl.guard = guard;
+    }
     return { declaration: decl, classification };
   }
 }

--- a/tools/ts2pant/src/types.ts
+++ b/tools/ts2pant/src/types.ts
@@ -1,4 +1,4 @@
-import type { PantExpr } from "./pant-expr.js";
+import type { PantExpr, PantProp } from "./pant-expr.js";
 
 /** Pantagruel numeric type strategy. */
 export type NumericType = "Int" | "Real" | "Nat0";
@@ -43,7 +43,7 @@ export interface PantAction {
 export type PantDeclaration = PantDomain | PantAlias | PantRule | PantAction;
 
 /** Re-export PantProp as the proposition type used in documents. */
-export type { PantProp } from "./pant-expr.js";
+export type { PantProp };
 
 /** A complete Pantagruel document ready for emission. */
 export interface PantDocument {

--- a/tools/ts2pant/src/types.ts
+++ b/tools/ts2pant/src/types.ts
@@ -1,3 +1,5 @@
+import type { PantExpr } from "./pant-expr.js";
+
 /** Pantagruel numeric type strategy. */
 export type NumericType = "Int" | "Real" | "Nat0";
 
@@ -26,7 +28,7 @@ export interface PantRule {
   name: string;
   params: PantParam[];
   returnType: string;
-  guard?: string;
+  guard?: PantExpr;
 }
 
 /** A Pantagruel action declaration (e.g. `~> Withdraw @ u: User.`). */
@@ -34,22 +36,20 @@ export interface PantAction {
   kind: "action";
   label: string;
   params: PantParam[];
-  guard?: string;
+  guard?: PantExpr;
 }
 
 /** A declaration in a Pantagruel document. */
 export type PantDeclaration = PantDomain | PantAlias | PantRule | PantAction;
 
-/** A Pantagruel proposition (a boolean expression in the body section). */
-export interface PantProposition {
-  text: string;
-}
+/** Re-export PantProp as the proposition type used in documents. */
+export type { PantProp } from "./pant-expr.js";
 
 /** A complete Pantagruel document ready for emission. */
 export interface PantDocument {
   moduleName: string;
   declarations: PantDeclaration[];
-  propositions: PantProposition[];
+  propositions: PantProp[];
 }
 
 /** CLI options parsed from command-line arguments. */

--- a/tools/ts2pant/tests/e2e.test.ts
+++ b/tools/ts2pant/tests/e2e.test.ts
@@ -8,6 +8,7 @@ import { translateBody } from "../src/translate-body.js";
 import { extractFunctionAnnotations } from "../src/annotations.js";
 import { emitDocument, runCheck } from "../src/emit.js";
 import type { PantDocument } from "../src/types.js";
+import { RawProp } from "../src/pant-expr.js";
 
 const FIXTURES = resolve(__dirname, "fixtures");
 const PROJECT_ROOT = resolve(__dirname, "../../..");
@@ -64,7 +65,7 @@ function buildDocument(
 
   // Annotations
   const annotations = extractFunctionAnnotations(program, fileName, functionName);
-  const annotationProps = annotations.map((text) => ({ text }));
+  const annotationProps = annotations.map((text) => RawProp(text));
   doc = { ...doc, propositions: [...doc.propositions, ...annotationProps] };
 
   return doc;

--- a/tools/ts2pant/tests/pant-expr.test.ts
+++ b/tools/ts2pant/tests/pant-expr.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from "vitest";
+import {
+  Var, Lit, Apply, PrimedApply, Binop, Unop, Cardinality,
+  Membership, Cond, Comprehension, Unsupported,
+  Equation, UnsupportedProp, RawProp,
+  renderExpr, renderProp,
+} from "../src/pant-expr.js";
+
+describe("renderExpr", () => {
+  it("renders var", () => {
+    expect(renderExpr(Var("x"))).toBe("x");
+  });
+
+  it("renders literal", () => {
+    expect(renderExpr(Lit("42"))).toBe("42");
+  });
+
+  it("renders zero-arg apply", () => {
+    expect(renderExpr(Apply("getVersion"))).toBe("getVersion");
+  });
+
+  it("renders single-arg apply (property access)", () => {
+    expect(renderExpr(Apply("balance", Var("a")))).toBe("balance a");
+  });
+
+  it("renders multi-arg apply", () => {
+    expect(renderExpr(Apply("add", Var("a"), Var("b")))).toBe("add a b");
+  });
+
+  it("renders nested apply (nested property access)", () => {
+    expect(renderExpr(Apply("name", Apply("owner", Var("a"))))).toBe("name owner a");
+  });
+
+  it("wraps compound args in parens", () => {
+    const expr = Apply("f", Binop("+", Var("a"), Var("b")));
+    expect(renderExpr(expr)).toBe("f (a + b)");
+  });
+
+  it("renders primed-apply zero args", () => {
+    expect(renderExpr(PrimedApply("balance"))).toBe("balance'");
+  });
+
+  it("renders primed-apply with args", () => {
+    expect(renderExpr(PrimedApply("balance", Var("a")))).toBe("balance' a");
+  });
+
+  it("renders binop", () => {
+    expect(renderExpr(Binop("+", Var("a"), Lit("2")))).toBe("a + 2");
+  });
+
+  it("renders nested binop without extra parens", () => {
+    expect(renderExpr(Binop("and", Var("a"), Binop("or", Var("b"), Var("c"))))).toBe(
+      "a and b or c",
+    );
+  });
+
+  it("renders unop ~", () => {
+    expect(renderExpr(Unop("~", Var("b")))).toBe("~(b)");
+  });
+
+  it("renders unop -", () => {
+    expect(renderExpr(Unop("-", Var("x")))).toBe("-(x)");
+  });
+
+  it("renders cardinality", () => {
+    expect(renderExpr(Cardinality(Var("items")))).toBe("#items");
+  });
+
+  it("renders cardinality with compound expr in parens", () => {
+    expect(renderExpr(Cardinality(Binop("+", Var("a"), Var("b"))))).toBe("#(a + b)");
+  });
+
+  it("renders membership", () => {
+    expect(renderExpr(Membership(Var("x"), Var("items")))).toBe("x in items");
+  });
+
+  it("renders cond with one arm", () => {
+    expect(renderExpr(Cond(
+      [{ guard: Binop(">=", Var("a"), Var("b")), value: Var("a") }],
+      Var("b"),
+    ))).toBe("cond a >= b => a, true => b");
+  });
+
+  it("renders cond with multiple arms", () => {
+    expect(renderExpr(Cond(
+      [
+        { guard: Binop(">", Var("x"), Lit("0")), value: Lit("1") },
+        { guard: Binop("<", Var("x"), Lit("0")), value: Lit("-1") },
+      ],
+      Lit("0"),
+    ))).toBe("cond x > 0 => 1, x < 0 => -1, true => 0");
+  });
+
+  it("renders comprehension without predicate", () => {
+    expect(renderExpr(Comprehension("x", "User", Apply("name", Var("x"))))).toBe(
+      "(each x: User | name x)",
+    );
+  });
+
+  it("renders comprehension with predicate", () => {
+    expect(renderExpr(Comprehension(
+      "x", "User", Apply("name", Var("x")), Apply("active", Var("x")),
+    ))).toBe("(each x: User, active x | name x)");
+  });
+
+  it("renders unsupported", () => {
+    expect(renderExpr(Unsupported("foo()"))).toBe("> UNSUPPORTED: foo()");
+  });
+});
+
+describe("renderProp", () => {
+  it("renders equation with quantifiers", () => {
+    expect(renderProp(Equation(
+      [{ name: "a", type: "Int" }, { name: "b", type: "Int" }],
+      Apply("add", Var("a"), Var("b")),
+      Binop("+", Var("a"), Var("b")),
+    ))).toBe("all a: Int, b: Int | add a b = a + b");
+  });
+
+  it("renders equation without quantifiers", () => {
+    expect(renderProp(Equation(
+      [],
+      Apply("getVersion"),
+      Lit("42"),
+    ))).toBe("getVersion = 42");
+  });
+
+  it("renders primed equation (mutation)", () => {
+    expect(renderProp(Equation(
+      [],
+      PrimedApply("balance", Var("a")),
+      Binop("+", Apply("balance", Var("a")), Var("amount")),
+    ))).toBe("balance' a = balance a + amount");
+  });
+
+  it("renders frame condition", () => {
+    expect(renderProp(Equation(
+      [{ name: "a", type: "Account" }],
+      PrimedApply("owner", Var("a")),
+      Apply("owner", Var("a")),
+    ))).toBe("all a: Account | owner' a = owner a");
+  });
+
+  it("renders unsupported prop", () => {
+    expect(renderProp(UnsupportedProp("conditional assignment (if/else)"))).toBe(
+      "> UNSUPPORTED: conditional assignment (if/else)",
+    );
+  });
+
+  it("renders raw prop", () => {
+    expect(renderProp(RawProp("all a: Account | balance' a >= 0"))).toBe(
+      "all a: Account | balance' a >= 0",
+    );
+  });
+});

--- a/tools/ts2pant/tests/pant-expr.test.ts
+++ b/tools/ts2pant/tests/pant-expr.test.ts
@@ -48,9 +48,9 @@ describe("renderExpr", () => {
     expect(renderExpr(Binop("+", Var("a"), Lit("2")))).toBe("a + 2");
   });
 
-  it("renders nested binop without extra parens", () => {
+  it("renders nested binop with parens to preserve grouping", () => {
     expect(renderExpr(Binop("and", Var("a"), Binop("or", Var("b"), Var("c"))))).toBe(
-      "a and b or c",
+      "a and (b or c)",
     );
   });
 

--- a/tools/ts2pant/tests/translate-body.test.ts
+++ b/tools/ts2pant/tests/translate-body.test.ts
@@ -233,7 +233,7 @@ describe("array operations", () => {
     const source = `
       interface User { name: string; active: boolean; }
       interface Named { label: string; }
-      function labels(users: User[]): string[] {
+      function labels(users: User[]): number[] {
         return users.map((u) => u.name).map((n) => n.length);
       }
     `;

--- a/tools/ts2pant/tests/translate-body.test.ts
+++ b/tools/ts2pant/tests/translate-body.test.ts
@@ -228,6 +228,37 @@ describe("array operations", () => {
       "all users: [User] | activeNames users = (each x: User, active x | name x)",
     );
   });
+
+  it("translates .map(f).map(g) composing projections", () => {
+    const source = `
+      interface User { name: string; active: boolean; }
+      interface Named { label: string; }
+      function labels(users: User[]): string[] {
+        return users.map((u) => u.name).map((n) => n.length);
+      }
+    `;
+    const props = translate(source, "labels");
+
+    // g(f(x)): the second map should compose with the first
+    expect(props[0].text).toBe(
+      "all users: [User] | labels users = (each x: User | length name x)",
+    );
+  });
+
+  it("translates .map(f).filter(g) composing projection into predicate", () => {
+    const source = `
+      interface User { name: string; score: number; }
+      function highScores(users: User[]): number[] {
+        return users.map((u) => u.score).filter((s) => s > 0);
+      }
+    `;
+    const props = translate(source, "highScores");
+
+    // filter predicate should reference f(x), not raw binder
+    expect(props[0].text).toBe(
+      "all users: [User] | highScores users = (each x: User, score x > 0 | score x)",
+    );
+  });
 });
 
 describe("mutating function: assignment -> primed proposition", () => {

--- a/tools/ts2pant/tests/translate-body.test.ts
+++ b/tools/ts2pant/tests/translate-body.test.ts
@@ -3,6 +3,7 @@ import { createProgramFromSource } from "../src/extract.js";
 import { IntStrategy } from "../src/translate-types.js";
 import { translateBody } from "../src/translate-body.js";
 import type { PantDeclaration } from "../src/types.js";
+import { renderProp } from "../src/pant-expr.js";
 
 function translate(
   source: string,
@@ -11,13 +12,15 @@ function translate(
 ) {
   const fileName = "test.ts";
   const program = createProgramFromSource(source, fileName);
-  return translateBody({
+  const props = translateBody({
     program,
     fileName,
     functionName,
     strategy: IntStrategy,
     declarations,
   });
+  // Render to text for assertion compatibility
+  return props.map((p) => ({ text: renderProp(p) }));
 }
 
 describe("pure function: return expression -> proposition", () => {

--- a/tools/ts2pant/tests/translate-signature.test.ts
+++ b/tools/ts2pant/tests/translate-signature.test.ts
@@ -6,6 +6,7 @@ import {
   classifyFunction,
   findFunction,
 } from "../src/translate-signature.js";
+import { renderExpr } from "../src/pant-expr.js";
 
 function translate(source: string, functionName: string, strategy = IntStrategy) {
   const fileName = "test.ts";
@@ -189,7 +190,7 @@ describe("guarded mutator -> action with guard", () => {
     expect(result.declaration.kind).toBe("action");
     if (result.declaration.kind === "action") {
       expect(result.declaration.label).toBe("Withdraw");
-      expect(result.declaration.guard).toBe("balance a >= amount");
+      expect(renderExpr(result.declaration.guard!)).toBe("balance a >= amount");
     }
   });
 
@@ -226,7 +227,7 @@ describe("guarded mutator -> action with guard", () => {
 
     expect(result.declaration.kind).toBe("action");
     if (result.declaration.kind === "action") {
-      expect(result.declaration.guard).toBe("(balance a >= amount)");
+      expect(renderExpr(result.declaration.guard!)).toBe("balance a >= amount");
     }
   });
 });
@@ -345,7 +346,7 @@ describe("class method -> declaration with this param", () => {
     expect(result.declaration.kind).toBe("action");
     if (result.declaration.kind === "action") {
       expect(result.declaration.label).toBe("Withdraw");
-      expect(result.declaration.guard).toBe("balance a >= amount");
+      expect(renderExpr(result.declaration.guard!)).toBe("balance a >= amount");
       expect(result.declaration.params[0]).toEqual({
         name: "a",
         type: "Account",


### PR DESCRIPTION
## Summary

- Introduces `PantExpr` (11-variant expression AST) and `PantProp` (3-variant proposition AST) in new `pant-expr.ts` module, with `renderExpr`/`renderProp` for final-pass rendering
- Converts `translateExpr` and `translateBodyExpr` to return `PantExpr` instead of raw strings, and proposition-building functions to return `PantProp`
- `.filter()` and `.map()` are now independent, composable handlers that each produce or refine comprehension nodes — eliminates the brittle `tryTranslateFilterMap` chain-detection pattern
- `PantProp` flows end-to-end through `PantDocument`; `PantProposition` removed

## Motivation

The old string-based translation made composition impossible — translating `.filter(p).map(f)` required detecting the exact two-call chain as a single pattern. Reversing the order or adding new chainable methods each required a new bespoke pattern matcher. With AST nodes, each method translates itself given any receiver, inspecting its structure for composition.

## Test plan

- [ ] All 119 existing tests pass (27 new render unit tests + 92 existing)
- [ ] E2E: `deposit.ts` and `max.ts` fixtures produce correct Pantagruel and pass `pant --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features / Refactor**
  * Introduced structured expression and proposition handling with deterministic rendering; annotations are now captured as structured propositions.

* **Bug Fixes**
  * More consistent guard/action/proposition formatting and parenthesization; unsupported constructs are flagged explicitly; pure vs. mutating translations and frame/update propositions standardized.

* **Tests**
  * Added and updated tests covering expression/proposition rendering and array-operation translation/composition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->