### PR TITLE
[local-const-inlining] Patch 1: Add fixture files and test stubs for const binding patterns

### DIFF
--- a/tools/ts2pant/tests/fixtures/constructs/expressions-const-bindings.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-const-bindings.ts
@@ -1,0 +1,36 @@
+interface Account {
+  balance: number;
+}
+
+export function simpleConst(a: number, b: number): number {
+  const x = a + b;
+  return x;
+}
+
+export function chainedConst(a: number): number {
+  const x = a;
+  const y = x + 1;
+  return y;
+}
+
+export function constWithPropAccess(a: Account): number {
+  const b = a.balance;
+  return b + 1;
+}
+
+export function constInTernary(a: number, b: number): number {
+  const x = a + b;
+  return x > 0 ? x : 0;
+}
+
+export function effectfulConstRejected(): number {
+  const x = foo();
+  return x;
+}
+
+declare function foo(): number;
+
+export function letRejected(): number {
+  let x = 1;
+  return x;
+}

--- a/tools/ts2pant/tests/fixtures/constructs/functions-mutating-const.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/functions-mutating-const.ts
@@ -1,0 +1,13 @@
+interface Account {
+  balance: number;
+}
+
+export function depositWithConst(a: Account, amount: number): void {
+  const newBal = a.balance + amount;
+  a.balance = newBal;
+}
+
+export function multiConstMutating(a: Account, amount: number, rate: number): void {
+  const fee = amount * rate;
+  a.balance = a.balance - fee;
+}


### PR DESCRIPTION
## Patch 1: Add fixture files and test stubs for const binding patterns

- Create expressions-const-bindings.ts with 6 exported functions covering supported and rejected const binding patterns for pure functions
- Create functions-mutating-const.ts with 2 exported functions covering const bindings in mutating functions
- The new fixtures will be auto-discovered by constructs.test.ts and will produce initial snapshot entries showing UNSUPPORTED markers (since the implementation isn't done yet)

## Changes
- Create expressions-const-bindings.ts with 6 exported functions covering supported and rejected const binding patterns for pure functions
- Create functions-mutating-const.ts with 2 exported functions covering const bindings in mutating functions
- The new fixtures will be auto-discovered by constructs.test.ts and will produce initial snapshot entries showing UNSUPPORTED markers (since the implementation isn't done yet)

## Gameplan Specification

```
module LOCAL_CONST_INLINING.

> ts2pant translates function bodies with leading const bindings.

TsFunction.
has_pure_const_bindings f: TsFunction => Bool.
has_effectful_const f: TsFunction => Bool.
has_let_binding f: TsFunction => Bool.
has_return f: TsFunction => Bool.
has_assignment f: TsFunction => Bool.
is_pure f: TsFunction => Bool.
is_mutating f: TsFunction => Bool.
translates_successfully f: TsFunction => Bool.

---

> Pure functions: pure const bindings + return => success.
all f: TsFunction |
  is_pure f
  and has_pure_const_bindings f
  and has_return f
  -> translates_successfully f.

> Mutating functions: pure const bindings + assignment => success.
all f: TsFunction |
  is_mutating f
  and has_pure_const_bindings f
  and has_assignment f
  -> translates_successfully f.

> let/var bindings always rejected.
all f: TsFunction |
  has_let_binding f -> ~(translates_successfully f).

> Effectful const initializers rejected.
all f: TsFunction |
  has_effectful_const f -> ~(translates_successfully f).
```

## Patch Specification

```
module LOCAL_CONST_INLINING_PATCH_1.

Placeholder.

---

true.
```

## Files to Modify
- tools/ts2pant/tests/fixtures/constructs/expressions-const-bindings.ts (create): Fixture file with exported functions: simpleConst (const x = a + b; return x), chainedConst (const x = a; const y = x + 1; return y), constWithPropAccess (const b = a.balance; return b + 1), constInTernary (const x = a + b; return x > 0 ? x : 0), effectfulConstRejected (const x = foo(); return x — should produce UNSUPPORTED), letRejected (let x = 1; return x — should produce UNSUPPORTED)
- tools/ts2pant/tests/fixtures/constructs/functions-mutating-const.ts (create): Fixture file with exported mutating functions: depositWithConst (const newBal = a.balance + amount; a.balance = newBal), multiConstMutating (const fee = amount * rate; a.balance = a.balance - fee)


## Implementation Notes

- Added a `declare function foo(): number` forward declaration in expressions-const-bindings.ts so the `effectfulConstRejected` fixture type-checks without needing to import or define a real effectful function
- `constInTernary` uses the const binding in both the condition and one branch of the ternary, exercising the case where a single binding is referenced multiple times (important for future inlining — need to decide if it gets inlined at each use site or hoisted)
- `chainedConst` tests const-to-const dependency chains (`y` depends on `x`), which will require topological ordering during inlining
- Mutating fixtures use `void` return type and property assignment (`a.balance = ...`) to exercise the action/primed-expression path separately from the pure return path
- No deviations from the plan — all 8 functions match the spec exactly
