### PR TITLE
[local-const-inlining] Patch 2: Implement const binding extraction and inline substitution

### DIFF
--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -81,15 +81,26 @@ function translatePureBody(
 ): PantProposition[] {
   if (!node.body) return [];
 
-  const returnExpr = extractReturnExpression(node.body);
-  if (!returnExpr) {
+  const extracted = extractReturnExpression(node.body);
+  if (!extracted) {
     const reason = describeRejectedBody(node.body);
     return [{ text: `> UNSUPPORTED: ${functionName} — ${reason}` }];
   }
 
+  // Translate const bindings and add to paramNames for inline substitution
+  const extendedParams = new Map(paramNames);
+  for (const binding of extracted.bindings) {
+    const translated = translateBodyExpr(binding.initializer, checker, strategy, extendedParams);
+    if (isUnsupported(translated)) {
+      return [{ text: translated }];
+    }
+    // Wrap compound expressions in parens to preserve grouping
+    extendedParams.set(binding.name, translated.includes(" ") ? `(${translated})` : translated);
+  }
+
   const args = params.map((p) => p.name).join(" ");
   const bindings = params.map((p) => `${p.name}: ${p.type}`).join(", ");
-  const body = translateBodyExpr(returnExpr, checker, strategy, paramNames);
+  const body = translateBodyExpr(extracted.returnExpr, checker, strategy, extendedParams);
 
   if (body.startsWith("> UNSUPPORTED:")) {
     return [{ text: body }];
@@ -100,31 +111,57 @@ function translatePureBody(
   return [{ text: `${head}${call} = ${body}` }];
 }
 
+interface ExtractedBody {
+  bindings: Array<{ name: string; initializer: ts.Expression }>;
+  returnExpr: ts.Expression;
+}
+
 /**
- * Extract the return expression from a function body.
+ * Extract the return expression from a function body, collecting any leading
+ * const bindings with pure initializers for inline substitution.
  * Handles:
  *   - Single return statement
+ *   - Leading const bindings + return statement
  *   - if/else with returns in both branches (produces a synthetic conditional)
+ * Returns null if the body contains let/var bindings or effectful const initializers.
  */
-function extractReturnExpression(body: ts.Block): ts.Expression | null {
+function extractReturnExpression(body: ts.Block): ExtractedBody | null {
   // Skip guard statements (if-throw patterns) and find the meaningful return
   const stmts = body.statements.filter((s) => !isGuardStatement(s));
 
-  if (stmts.length === 1) {
-    const stmt = stmts[0];
-    if (ts.isReturnStatement(stmt) && stmt.expression) {
-      return stmt.expression;
-    }
-    // if/else with returns
-    if (ts.isIfStatement(stmt) && stmt.elseStatement) {
-      return stmt;
+  if (stmts.length === 0) return null;
+
+  const bindings: Array<{ name: string; initializer: ts.Expression }> = [];
+  let i = 0;
+
+  // Collect leading const bindings
+  for (; i < stmts.length - 1; i++) {
+    const stmt = stmts[i];
+    if (!ts.isVariableStatement(stmt)) break;
+
+    const declList = stmt.declarationList;
+    // Reject let/var
+    if (!(declList.flags & ts.NodeFlags.Const)) return null;
+
+    for (const decl of declList.declarations) {
+      // Must have a simple identifier name and an initializer
+      if (!ts.isIdentifier(decl.name) || !decl.initializer) return null;
+      // Reject effectful initializers
+      if (expressionHasSideEffects(decl.initializer)) return null;
+      bindings.push({ name: decl.name.text, initializer: decl.initializer });
     }
   }
 
-  // Multiple non-guard statements are not representable yet without
-  // translating local bindings/control flow.
-  if (stmts.length > 1) {
-    return null;
+  // The last statement must be a return or if/else-with-returns
+  const last = stmts[i];
+  // If we didn't consume all preceding statements as const bindings, reject
+  if (i < stmts.length - 1) return null;
+
+  if (ts.isReturnStatement(last) && last.expression) {
+    return { bindings, returnExpr: last.expression };
+  }
+  if (ts.isIfStatement(last) && last.elseStatement) {
+    return { bindings, returnExpr: last };
   }
 
   return null;
@@ -133,7 +170,23 @@ function extractReturnExpression(body: ts.Block): ts.Expression | null {
 function describeRejectedBody(body: ts.Block): string {
   const stmts = body.statements.filter((s) => !isGuardStatement(s));
   if (stmts.length === 0) return "empty body";
-  if (stmts.length > 1) return "local bindings or multiple statements before return";
+  if (stmts.length > 1) {
+    // Check for specific rejection reasons in leading statements
+    for (const stmt of stmts) {
+      if (ts.isVariableStatement(stmt)) {
+        const declList = stmt.declarationList;
+        if (!(declList.flags & ts.NodeFlags.Const)) {
+          return "let/var bindings not supported";
+        }
+        for (const decl of declList.declarations) {
+          if (decl.initializer && expressionHasSideEffects(decl.initializer)) {
+            return "const binding with side-effectful initializer";
+          }
+        }
+      }
+    }
+    return "local bindings or multiple statements before return";
+  }
   const stmt = stmts[0];
   if (ts.isReturnStatement(stmt) && !stmt.expression) return "return without expression";
   return "non-translatable control flow";
@@ -530,6 +583,34 @@ function collectAssignments(
   for (const stmt of stmts) {
     // Skip guard statements (if-throw patterns)
     if (isGuardStatement(stmt)) continue;
+
+    // Handle const bindings: translate initializer and add to paramNames
+    if (ts.isVariableStatement(stmt)) {
+      const declList = stmt.declarationList;
+      if (declList.flags & ts.NodeFlags.Const) {
+        let allPure = true;
+        for (const decl of declList.declarations) {
+          if (!ts.isIdentifier(decl.name) || !decl.initializer || expressionHasSideEffects(decl.initializer)) {
+            allPure = false;
+            break;
+          }
+        }
+        if (allPure) {
+          for (const decl of declList.declarations) {
+            const name = (decl.name as ts.Identifier).text;
+            const translated = translateBodyExpr(decl.initializer!, checker, strategy, paramNames);
+            if (isUnsupported(translated)) {
+              hasUnsupportedMutation = true;
+              propositions.push({ text: translated });
+              continue;
+            }
+            paramNames.set(name, translated.includes(" ") ? `(${translated})` : translated);
+          }
+          continue;
+        }
+      }
+      // let/var or effectful const — fall through to existing rejection
+    }
 
     if (ts.isExpressionStatement(stmt) && ts.isBinaryExpression(unwrapExpression(stmt.expression))) {
       const bin = unwrapExpression(stmt.expression) as ts.BinaryExpression;

--- a/tools/ts2pant/tests/__snapshots__/constructs.test.ts.snap
+++ b/tools/ts2pant/tests/__snapshots__/constructs.test.ts.snap
@@ -1,0 +1,65 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`expressions-const-bindings > chainedConst 1`] = `
+[
+  {
+    "text": "all a: Int | chainedConst a = (a + 1)",
+  },
+]
+`;
+
+exports[`expressions-const-bindings > constInTernary 1`] = `
+[
+  {
+    "text": "all a: Int, b: Int | constInTernary a b = cond (a + b) > 0 => (a + b), true => 0",
+  },
+]
+`;
+
+exports[`expressions-const-bindings > constWithPropAccess 1`] = `
+[
+  {
+    "text": "all a: Account | constWithPropAccess a = (balance a) + 1",
+  },
+]
+`;
+
+exports[`expressions-const-bindings > effectfulConstRejected 1`] = `
+[
+  {
+    "text": "> UNSUPPORTED: effectfulConstRejected — const binding with side-effectful initializer",
+  },
+]
+`;
+
+exports[`expressions-const-bindings > letRejected 1`] = `
+[
+  {
+    "text": "> UNSUPPORTED: letRejected — let/var bindings not supported",
+  },
+]
+`;
+
+exports[`expressions-const-bindings > simpleConst 1`] = `
+[
+  {
+    "text": "all a: Int, b: Int | simpleConst a b = (a + b)",
+  },
+]
+`;
+
+exports[`functions-mutating-const > depositWithConst 1`] = `
+[
+  {
+    "text": "balance' a = (balance a + amount)",
+  },
+]
+`;
+
+exports[`functions-mutating-const > multiConstMutating 1`] = `
+[
+  {
+    "text": "balance' a = balance a - (amount * rate)",
+  },
+]
+`;

--- a/tools/ts2pant/tests/constructs.test.ts
+++ b/tools/ts2pant/tests/constructs.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { resolve } from "path";
+import { createProgram } from "../src/extract.js";
+import { IntStrategy } from "../src/translate-types.js";
+import { translateBody } from "../src/translate-body.js";
+
+const FIXTURES = resolve(__dirname, "fixtures/constructs");
+
+function translateFixture(fixtureName: string, functionName: string) {
+  const fileName = resolve(FIXTURES, fixtureName);
+  const program = createProgram(fileName);
+  return translateBody({
+    program,
+    fileName,
+    functionName,
+    strategy: IntStrategy,
+  });
+}
+
+describe("expressions-const-bindings", () => {
+  const fixture = "expressions-const-bindings.ts";
+
+  it("simpleConst", () => {
+    const props = translateFixture(fixture, "simpleConst");
+    expect(props).toMatchSnapshot();
+  });
+
+  it("chainedConst", () => {
+    const props = translateFixture(fixture, "chainedConst");
+    expect(props).toMatchSnapshot();
+  });
+
+  it("constWithPropAccess", () => {
+    const props = translateFixture(fixture, "constWithPropAccess");
+    expect(props).toMatchSnapshot();
+  });
+
+  it("constInTernary", () => {
+    const props = translateFixture(fixture, "constInTernary");
+    expect(props).toMatchSnapshot();
+  });
+
+  it("effectfulConstRejected", () => {
+    const props = translateFixture(fixture, "effectfulConstRejected");
+    expect(props).toMatchSnapshot();
+  });
+
+  it("letRejected", () => {
+    const props = translateFixture(fixture, "letRejected");
+    expect(props).toMatchSnapshot();
+  });
+});
+
+describe("functions-mutating-const", () => {
+  const fixture = "functions-mutating-const.ts";
+
+  it("depositWithConst", () => {
+    const props = translateFixture(fixture, "depositWithConst");
+    expect(props).toMatchSnapshot();
+  });
+
+  it("multiConstMutating", () => {
+    const props = translateFixture(fixture, "multiConstMutating");
+    expect(props).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
## Patch 2: Implement const binding extraction and inline substitution

- Refactor extractReturnExpression to return { bindings: Array<{name, initializer}>, returnExpr } instead of just the expression. Iterate non-guard statements: collect leading VariableStatements where every declaration is const with a pure (non-side-effectful) initializer and a simple Identifier name. Stop collecting at the first non-const statement. The last statement must be a return or if/else-with-returns (existing logic). If any binding uses let/var or has an effectful initializer, return null (reject the body).
- In translatePureBody: after extracting bindings + returnExpr, translate each binding's initializer to a PantExpr using translateBodyExpr with the current paramNames. Build a substitution list. Translate the returnExpr to a PantExpr. Then apply substituteBinder for each binding (in order) to replace Var(name) with the translated initializer in the body expression.
- Update describeRejectedBody to check whether the multi-statement body has let/var bindings (message: 'let/var bindings not supported') or effectful const initializers (message: 'const binding with side-effectful initializer') vs other unsupported patterns.
- In collectAssignments (mutating bodies): when encountering a VariableStatement where all declarations are const with pure initializers and Identifier names, translate each initializer and add the binding to paramNames (name -> translated name) so subsequent assignment RHS expressions can reference the const. If any declaration is let/var or effectful, fall through to existing rejection logic.
- Run vitest -u to update snapshots for the new const binding fixtures

## Changes
- Refactor extractReturnExpression to return { bindings: Array<{name, initializer}>, returnExpr } instead of just the expression. Iterate non-guard statements: collect leading VariableStatements where every declaration is const with a pure (non-side-effectful) initializer and a simple Identifier name. Stop collecting at the first non-const statement. The last statement must be a return or if/else-with-returns (existing logic). If any binding uses let/var or has an effectful initializer, return null (reject the body).
- In translatePureBody: after extracting bindings + returnExpr, translate each binding's initializer to a PantExpr using translateBodyExpr with the current paramNames. Build a substitution list. Translate the returnExpr to a PantExpr. Then apply substituteBinder for each binding (in order) to replace Var(name) with the translated initializer in the body expression.
- Update describeRejectedBody to check whether the multi-statement body has let/var bindings (message: 'let/var bindings not supported') or effectful const initializers (message: 'const binding with side-effectful initializer') vs other unsupported patterns.
- In collectAssignments (mutating bodies): when encountering a VariableStatement where all declarations are const with pure initializers and Identifier names, translate each initializer and add the binding to paramNames (name -> translated name) so subsequent assignment RHS expressions can reference the const. If any declaration is let/var or effectful, fall through to existing rejection logic.
- Run vitest -u to update snapshots for the new const binding fixtures

## Gameplan Specification

```
module LOCAL_CONST_INLINING.

> ts2pant translates function bodies with leading const bindings.

TsFunction.
has_pure_const_bindings f: TsFunction => Bool.
has_effectful_const f: TsFunction => Bool.
has_let_binding f: TsFunction => Bool.
has_return f: TsFunction => Bool.
has_assignment f: TsFunction => Bool.
is_pure f: TsFunction => Bool.
is_mutating f: TsFunction => Bool.
translates_successfully f: TsFunction => Bool.

---

> Pure functions: pure const bindings + return => success.
all f: TsFunction |
  is_pure f
  and has_pure_const_bindings f
  and has_return f
  -> translates_successfully f.

> Mutating functions: pure const bindings + assignment => success.
all f: TsFunction |
  is_mutating f
  and has_pure_const_bindings f
  and has_assignment f
  -> translates_successfully f.

> let/var bindings always rejected.
all f: TsFunction |
  has_let_binding f -> ~(translates_successfully f).

> Effectful const initializers rejected.
all f: TsFunction |
  has_effectful_const f -> ~(translates_successfully f).
```

## Patch Specification

```
module LOCAL_CONST_INLINING_PATCH_2.

> After this patch, pure and mutating functions with leading
> const bindings that have pure initializers translate successfully.

TsFunction.
has_pure_const_bindings f: TsFunction => Bool.
has_return f: TsFunction => Bool.
has_assignment f: TsFunction => Bool.
is_pure f: TsFunction => Bool.
is_mutating f: TsFunction => Bool.
translates_successfully f: TsFunction => Bool.

---

> Pure functions: pure const bindings + return => success.
all f: TsFunction |
  is_pure f
  and has_pure_const_bindings f
  and has_return f
  -> translates_successfully f.

> Mutating functions: pure const bindings + assignment => success.
all f: TsFunction |
  is_mutating f
  and has_pure_const_bindings f
  and has_assignment f
  -> translates_successfully f.
```

## Files to Modify
- tools/ts2pant/src/translate-body.ts (modify): Modify extractReturnExpression to accept leading const statements with pure initializers; modify translatePureBody to translate and substitute bindings; update describeRejectedBody; update collectAssignments for mutating bodies
- tools/ts2pant/tests/__snapshots__/constructs.test.ts.snap (modify): Update snapshots: const binding fixtures now produce real translations instead of UNSUPPORTED; effectful/let fixtures still show UNSUPPORTED


## Implementation Notes

- **Inline substitution via `paramNames`**: Rather than introducing a separate substitution pass over the PantExpr AST, const bindings are resolved by extending the `paramNames` map (which already maps TS parameter names to Pant short names). Each const's translated initializer is added to the map, so subsequent `translateBodyExpr` calls naturally resolve references. This reuses existing infrastructure and avoids needing a `substituteBinder` function as the gameplan originally suggested.
- **Parenthesization of compound initializers**: Translated initializers containing spaces (i.e., compound expressions) are wrapped in parens before insertion into `paramNames` to preserve grouping when substituted into larger expressions (e.g., `(a + b)` rather than `a + b`).
- **Two-pass validation in `collectAssignments`**: For mutating bodies, const bindings are validated in a two-pass loop — first check all declarations are pure, then translate. This avoids partially extending `paramNames` if a later declaration in the same `const a = ..., b = ...` statement is effectful.
- **`describeRejectedBody` gives specific reasons**: Rather than a generic "multiple statements" message, the rejection diagnostics distinguish let/var from effectful const, which makes test fixture snapshots more informative and debugging easier.
- **No deviation from plan**: The implementation follows the patch spec closely. The only notable choice was using `paramNames` extension instead of a post-hoc `substituteBinder`, which is simpler and equivalent for this use case since const bindings are non-recursive and ordered.
