### PR TITLE
[ts2pant-general-calls] Patch 3: Create purity oracle module with allowlist and Effect-TS tier

### DIFF
--- a/tools/ts2pant/package-lock.json
+++ b/tools/ts2pant/package-lock.json
@@ -18,6 +18,7 @@
       "devDependencies": {
         "@biomejs/biome": "^2.4.11",
         "@types/node": "^20.0.0",
+        "effect": "^3.21.0",
         "tsx": "^4.21.0"
       }
     },
@@ -638,6 +639,13 @@
         "node": ">=18"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@ts-morph/common": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.28.1.tgz",
@@ -695,6 +703,17 @@
         "node": ">=18"
       }
     },
+    "node_modules/effect": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.21.0.tgz",
+      "integrity": "sha512-PPN80qRokCd1f015IANNhrwOnLO7GrrMQfk4/lnZRE/8j7UPWrNNjPV0uBrZutI/nHzernbW+J0hdqQysHiSnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "fast-check": "^3.23.1"
+      }
+    },
     "node_modules/esbuild": {
       "version": "0.27.7",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
@@ -735,6 +754,29 @@
         "@esbuild/win32-arm64": "0.27.7",
         "@esbuild/win32-ia32": "0.27.7",
         "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/fast-check": {
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
+      "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/fdir": {
@@ -814,6 +856,23 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",

--- a/tools/ts2pant/package.json
+++ b/tools/ts2pant/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.11",
     "@types/node": "^20.0.0",
+    "effect": "^3.21.0",
     "tsx": "^4.21.0"
   }
 }

--- a/tools/ts2pant/src/purity.ts
+++ b/tools/ts2pant/src/purity.ts
@@ -152,22 +152,43 @@ const HO_PURE_ARRAY_METHODS: ReadonlySet<string> = new Set([
 
 // ---------------------------------------------------------------------------
 // Tier 1b — Effect-TS awareness
+//
+// Standard name: Callee symbol resolution (Dietl et al., ICSE 2011).
+// The effect library's type declarations serve as implicit @Pure annotations.
+// We verify each call by tracing the callee symbol back to its declaration
+// file. If it originates from the `effect` package and is not in the impure
+// set, the library's referential transparency guarantee applies.
+//
+// Fallback: bare-name matching for pipe/flow/identity with argument purity
+// checking, for test environments where the `effect` package is not installed.
 // ---------------------------------------------------------------------------
 
-/** Known-pure Effect-TS combinators (from effect/Function). */
+/** Known-pure Effect-TS combinators (from effect/Function) — name-based fallback. */
 const EFFECT_PURE_COMBINATORS: ReadonlySet<string> = new Set([
   "pipe",
   "flow",
   "identity",
 ]);
 
-/** Known-impure Effect-TS runners — excluded even though they return Effect. */
-const EFFECT_IMPURE_RUNNERS: ReadonlySet<string> = new Set([
+/**
+ * Known-impure Effect-TS exports — runners and mutable allocators.
+ *
+ * Runners (@category Running Effects): execute an Effect, producing side effects.
+ * Mutable allocators: create synchronization primitives with observable state.
+ */
+const EFFECT_IMPURE_EXPORTS: ReadonlySet<string> = new Set([
+  // Runners
   "runSync",
-  "runPromise",
   "runSyncExit",
+  "runPromise",
   "runPromiseExit",
   "runFork",
+  "runCallback",
+  // Mutable allocators
+  "makeSemaphore",
+  "unsafeMakeSemaphore",
+  "makeLatch",
+  "unsafeMakeLatch",
 ]);
 
 // ---------------------------------------------------------------------------
@@ -237,13 +258,29 @@ export function isKnownPureCall(
       }
     }
 
-    // Tier 1b: Effect-TS impure runners
-    if (EFFECT_IMPURE_RUNNERS.has(methodName)) {
+    // Tier 1b: Effect-TS impure runners (early exit before symbol resolution)
+    if (EFFECT_IMPURE_EXPORTS.has(methodName)) {
       return false;
     }
   }
 
-  // Tier 1b: bare identifier calls — pure combinators with pure arguments.
+  // --- Tier 1b: Effect-TS symbol resolution ---
+  // Trace the callee symbol to its declaration file. If it originates from
+  // the `effect` package and is not an impure export, the library's
+  // referential transparency guarantee applies: constructing an Effect
+  // value is always pure; only running it causes effects.
+  const effectExport = resolveEffectLibraryExport(expr.expression, checker);
+  if (effectExport !== null) {
+    if (EFFECT_IMPURE_EXPORTS.has(effectExport.name)) {
+      return false;
+    }
+    // All non-impure effect library exports are pure constructors/combinators.
+    // Arguments are still eagerly evaluated, so check their purity.
+    return expr.arguments.every((arg) => expressionIsPure(arg, checker));
+  }
+
+  // Tier 1b fallback: bare-name combinator matching for environments where
+  // the `effect` package is not installed (e.g. tests with `declare function`).
   // Arguments must be checked: identity(sideEffect()) is impure.
   if (ts.isIdentifier(expr.expression)) {
     if (EFFECT_PURE_COMBINATORS.has(expr.expression.text)) {
@@ -258,6 +295,71 @@ export function isKnownPureCall(
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * Resolve a callee expression to an Effect-TS library export.
+ *
+ * Uses TypeChecker symbol resolution (getSymbolAtLocation + getAliasedSymbol)
+ * to trace the callee through import aliases back to its original declaration.
+ * Returns { module, name } if the declaration originates from the `effect`
+ * package, or null if it doesn't (user code, other packages, unresolvable).
+ *
+ * This is the sound alternative to return-type detection. A user function
+ * that returns Effect<A,E,R> will resolve to the user's source file, not
+ * to the effect package — so it correctly falls through to the conservative
+ * default.
+ *
+ * Handles: Effect.succeed(x), E.map(fn) (aliased import), pipe(x, ...) (bare).
+ */
+function resolveEffectLibraryExport(
+  callee: ts.Expression,
+  checker: ts.TypeChecker,
+): { module: string; name: string } | null {
+  try {
+    let symbol: ts.Symbol | undefined;
+
+    if (ts.isPropertyAccessExpression(callee)) {
+      // Effect.succeed, Effect.map, etc.
+      symbol = checker.getSymbolAtLocation(callee.name);
+    } else if (ts.isIdentifier(callee)) {
+      // pipe, flow, identity (bare imports)
+      symbol = checker.getSymbolAtLocation(callee);
+    }
+
+    if (!symbol) {
+      return null;
+    }
+
+    // Follow import aliases to the original declaration
+    let resolved = symbol;
+    while (resolved.flags & ts.SymbolFlags.Alias) {
+      resolved = checker.getAliasedSymbol(resolved);
+    }
+
+    const decls = resolved.getDeclarations();
+    if (!decls || decls.length === 0) {
+      return null;
+    }
+
+    const fileName = decls[0]!.getSourceFile().fileName;
+
+    // Match effect package declaration files.
+    // Patterns: node_modules/effect/dist/dts/Effect.d.ts
+    //           node_modules/effect/src/Effect.ts
+    //           node_modules/.pnpm/effect@.../node_modules/effect/dist/dts/Effect.d.ts
+    const match = fileName.match(
+      /node_modules\/effect\/(?:dist\/dts|src)\/(\w+)\.(?:d\.ts|ts)$/u,
+    );
+    if (!match) {
+      return null;
+    }
+
+    return { module: match[1]!, name: resolved.getName() };
+  } catch {
+    // TypeChecker can throw on malformed AST — conservative fallback
+    return null;
+  }
+}
 
 /**
  * Check whether an arrow function callback is side-effect-free.

--- a/tools/ts2pant/src/purity.ts
+++ b/tools/ts2pant/src/purity.ts
@@ -376,6 +376,12 @@ function isArrowPure(
     return false;
   }
 
+  // Check parameter initializers: default values are eagerly evaluated
+  // when the argument is undefined, e.g. (x = sideEffect()) => x.
+  if (!parameterInitializersArePure(callback.parameters, checker)) {
+    return false;
+  }
+
   if (ts.isBlock(callback.body)) {
     // Block body: only pure if it's a single return statement
     const stmts = callback.body.statements;
@@ -391,6 +397,63 @@ function isArrowPure(
 
   // Expression body
   return expressionIsPure(callback.body, checker);
+}
+
+/**
+ * Check that all parameter default initializers are side-effect-free.
+ * Handles both simple defaults ((x = expr) => ...) and destructuring
+ * defaults (({a = expr}) => ..., ([a = expr]) => ...).
+ */
+function parameterInitializersArePure(
+  params: ts.NodeArray<ts.ParameterDeclaration>,
+  checker: ts.TypeChecker,
+): boolean {
+  for (const param of params) {
+    // Simple default: (x = expr)
+    if (param.initializer && !expressionIsPure(param.initializer, checker)) {
+      return false;
+    }
+    // Destructuring: check binding element initializers recursively
+    if (
+      ts.isObjectBindingPattern(param.name) ||
+      ts.isArrayBindingPattern(param.name)
+    ) {
+      if (!bindingPatternInitializersArePure(param.name, checker)) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+/**
+ * Recursively check initializers in destructuring binding patterns.
+ */
+function bindingPatternInitializersArePure(
+  pattern: ts.BindingPattern,
+  checker: ts.TypeChecker,
+): boolean {
+  for (const element of pattern.elements) {
+    if (ts.isOmittedExpression(element)) {
+      continue;
+    }
+    if (
+      element.initializer &&
+      !expressionIsPure(element.initializer, checker)
+    ) {
+      return false;
+    }
+    // Nested destructuring: ({a: {b = expr}}) => ...
+    if (
+      ts.isObjectBindingPattern(element.name) ||
+      ts.isArrayBindingPattern(element.name)
+    ) {
+      if (!bindingPatternInitializersArePure(element.name, checker)) {
+        return false;
+      }
+    }
+  }
+  return true;
 }
 
 /**
@@ -496,10 +559,18 @@ function expressionIsPure(
 
   if (ts.isArrayLiteralExpression(expr)) {
     return expr.elements.every((el) => {
-      // Spread elements: [...arr] is pure if arr is pure (array iteration
-      // is pure for built-in arrays). Per Talpin & Jouvelot 1994,
-      // allocation effects are maskable — the fresh array is local.
+      // Spread elements: [...arr] is pure only for built-in arrays/tuples.
+      // Custom iterables invoke Symbol.iterator/next() which can execute
+      // arbitrary code. Per Talpin & Jouvelot 1994, allocation effects
+      // are maskable — the fresh array is local.
       if (ts.isSpreadElement(el)) {
+        const spreadType = checker.getTypeAtLocation(el.expression);
+        if (
+          !checker.isArrayType(spreadType) &&
+          !checker.isTupleType(spreadType)
+        ) {
+          return false;
+        }
         return expressionIsPure(el.expression, checker);
       }
       return expressionIsPure(el, checker);

--- a/tools/ts2pant/src/purity.ts
+++ b/tools/ts2pant/src/purity.ts
@@ -4,8 +4,8 @@
  * Three-tier analysis (trivial instance of abstract interpretation over
  * a {pure, effectful} lattice — Cousot & Cousot, POPL 1977):
  *
- *   Tier 1a: Known-pure builtin allowlist (Math.*, non-mutating String/Array methods)
- *   Tier 1b: Effect-TS awareness (Effect<A,E,R> construction is always pure)
+ *   Tier 1a: Known-pure builtin allowlist (Math methods, non-mutating String/Array methods)
+ *   Tier 1b: Effect-TS combinator allowlist (pipe, flow, identity)
  *   Tier 1c: Conservative default (unknown = effectful)
  *
  * Ref: Lucassen & Gifford, Polymorphic Effect Systems, POPL 1988.
@@ -16,10 +16,54 @@ import ts from "typescript";
 // Tier 1a — Known-pure builtin allowlists
 // ---------------------------------------------------------------------------
 
-/** Namespaces where ALL methods are pure (e.g. Math.max, Math.abs). */
-const PURE_NAMESPACES: ReadonlySet<string> = new Set(["Math"]);
+/**
+ * Pure Math methods (enumerated, not blanket namespace).
+ * Math.random() is excluded — it is non-deterministic.
+ */
+const PURE_MATH_METHODS: ReadonlySet<string> = new Set([
+  "abs",
+  "acos",
+  "acosh",
+  "asin",
+  "asinh",
+  "atan",
+  "atan2",
+  "atanh",
+  "cbrt",
+  "ceil",
+  "clz32",
+  "cos",
+  "cosh",
+  "exp",
+  "expm1",
+  "floor",
+  "fround",
+  "hypot",
+  "imul",
+  "log",
+  "log10",
+  "log1p",
+  "log2",
+  "max",
+  "min",
+  "pow",
+  "round",
+  "sign",
+  "sin",
+  "sinh",
+  "sqrt",
+  "tan",
+  "tanh",
+  "trunc",
+]);
 
-/** Pure methods by primitive receiver type. */
+/**
+ * Pure methods by primitive receiver type.
+ *
+ * String methods that accept RegExp or replacement callbacks are excluded
+ * (split, replace, replaceAll, match, search) — these can execute user code
+ * via RegExp Symbol.replace/Symbol.match hooks.
+ */
 const PURE_METHODS_BY_TYPE: ReadonlyMap<string, ReadonlySet<string>> = new Map([
   [
     "string",
@@ -35,14 +79,9 @@ const PURE_METHODS_BY_TYPE: ReadonlyMap<string, ReadonlySet<string>> = new Map([
       "toUpperCase",
       "charAt",
       "charCodeAt",
-      "split",
-      "replace",
-      "replaceAll",
       "repeat",
       "padStart",
       "padEnd",
-      "match",
-      "search",
       "concat",
       "normalize",
     ]),
@@ -127,8 +166,13 @@ export function isKnownPureCall(
     const methodName = expr.expression.name.text;
     const receiver = expr.expression.expression;
 
-    // Pure namespace: Math.max(...), Math.abs(...), etc.
-    if (ts.isIdentifier(receiver) && PURE_NAMESPACES.has(receiver.text)) {
+    // Pure Math methods: Math.max(...), Math.abs(...), etc.
+    // Math.random() is excluded (non-deterministic).
+    if (
+      ts.isIdentifier(receiver) &&
+      receiver.text === "Math" &&
+      PURE_MATH_METHODS.has(methodName)
+    ) {
       return true;
     }
 
@@ -157,33 +201,30 @@ export function isKnownPureCall(
         return true;
       }
 
-      // Higher-order array methods: pure if callback is side-effect-free
+      // Higher-order array methods: pure if callback AND all eagerly-evaluated
+      // args (thisArg, initialValue) are side-effect-free.
       if (HO_PURE_ARRAY_METHODS.has(methodName) && expr.arguments.length >= 1) {
-        const callback = expr.arguments[0]!;
-        if (isArrowPure(callback, checker)) {
-          return true;
-        }
-        // Non-arrow callback (function expression, identifier) → conservative
-        return false;
+        const [callback, ...restArgs] = expr.arguments;
+        return (
+          callback !== undefined &&
+          isArrowPure(callback, checker) &&
+          restArgs.every((arg) => expressionIsPure(arg, checker))
+        );
       }
     }
 
-    // Tier 1b: Effect-TS impure runners (check before return-type detection)
+    // Tier 1b: Effect-TS impure runners
     if (EFFECT_IMPURE_RUNNERS.has(methodName)) {
       return false;
     }
   }
 
-  // Tier 1a: bare identifier calls — check if it's a pure combinator
+  // Tier 1b: bare identifier calls — pure combinators with pure arguments.
+  // Arguments must be checked: identity(sideEffect()) is impure.
   if (ts.isIdentifier(expr.expression)) {
     if (EFFECT_PURE_COMBINATORS.has(expr.expression.text)) {
-      return true;
+      return expr.arguments.every((arg) => expressionIsPure(arg, checker));
     }
-  }
-
-  // --- Tier 1b: Effect-TS return type detection ---
-  if (isEffectReturningCall(expr, checker)) {
-    return true;
   }
 
   // --- Tier 1c: conservative default ---
@@ -260,10 +301,21 @@ function expressionIsPure(
     return true;
   }
 
-  if (
-    ts.isPropertyAccessExpression(expr) ||
-    ts.isElementAccessExpression(expr)
-  ) {
+  if (ts.isPropertyAccessExpression(expr)) {
+    return expressionIsPure(expr.expression, checker);
+  }
+
+  if (ts.isElementAccessExpression(expr)) {
+    return (
+      expressionIsPure(expr.expression, checker) &&
+      expr.argumentExpression !== undefined &&
+      expressionIsPure(expr.argumentExpression, checker)
+    );
+  }
+
+  // Arrow functions and function expressions are pure value-creating
+  // expressions — the function body is not executed at evaluation time.
+  if (ts.isArrowFunction(expr) || ts.isFunctionExpression(expr)) {
     return true;
   }
 
@@ -323,59 +375,5 @@ function expressionIsPure(
   }
 
   // Unknown expression kind → conservative
-  return false;
-}
-
-/**
- * Tier 1b: Check if a call returns an Effect<A,E,R> value.
- *
- * Detection: the return type has the EffectTypeId branded property.
- * This is structural and version-resilient — avoids source-path heuristics.
- *
- * Known-impure runners (runSync, runPromise, etc.) are excluded upstream.
- */
-function isEffectReturningCall(
-  expr: ts.CallExpression,
-  checker: ts.TypeChecker,
-): boolean {
-  try {
-    const signature = checker.getResolvedSignature(expr);
-    if (!signature) {
-      return false;
-    }
-
-    const returnType = checker.getReturnTypeOfSignature(signature);
-    return hasEffectTypeId(returnType);
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Check whether a type has the EffectTypeId branded property,
- * which is the structural marker for Effect<A,E,R>.
- */
-function hasEffectTypeId(type: ts.Type): boolean {
-  // biome-ignore lint/security/noSecrets: EffectTypeId is an Effect-TS branded property name, not a secret
-  const EFFECT_TYPE_ID = "EffectTypeId";
-
-  // Check direct properties for the EffectTypeId branded property
-  const props = type.getProperties();
-  for (const prop of props) {
-    if (prop.name === EFFECT_TYPE_ID) {
-      return true;
-    }
-  }
-
-  // Check alias: Effect types might be aliased
-  if (type.aliasSymbol?.name === "Effect") {
-    return true;
-  }
-
-  // Check symbol name
-  if (type.symbol?.name === "Effect") {
-    return true;
-  }
-
   return false;
 }

--- a/tools/ts2pant/src/purity.ts
+++ b/tools/ts2pant/src/purity.ts
@@ -1,0 +1,376 @@
+/**
+ * Conservative purity oracle for TypeScript call expressions.
+ *
+ * Three-tier analysis (trivial instance of abstract interpretation over
+ * a {pure, effectful} lattice — Cousot & Cousot, POPL 1977):
+ *
+ *   Tier 1a: Known-pure builtin allowlist (Math.*, non-mutating String/Array methods)
+ *   Tier 1b: Effect-TS awareness (Effect<A,E,R> construction is always pure)
+ *   Tier 1c: Conservative default (unknown = effectful)
+ *
+ * Ref: Lucassen & Gifford, Polymorphic Effect Systems, POPL 1988.
+ */
+import ts from "typescript";
+
+// ---------------------------------------------------------------------------
+// Tier 1a — Known-pure builtin allowlists
+// ---------------------------------------------------------------------------
+
+/** Namespaces where ALL methods are pure (e.g. Math.max, Math.abs). */
+const PURE_NAMESPACES: ReadonlySet<string> = new Set(["Math"]);
+
+/** Pure methods by primitive receiver type. */
+const PURE_METHODS_BY_TYPE: ReadonlyMap<string, ReadonlySet<string>> = new Map([
+  [
+    "string",
+    new Set([
+      "indexOf",
+      "slice",
+      "substring",
+      "includes",
+      "startsWith",
+      "endsWith",
+      "trim",
+      "toLowerCase",
+      "toUpperCase",
+      "charAt",
+      "charCodeAt",
+      "split",
+      "replace",
+      "replaceAll",
+      "repeat",
+      "padStart",
+      "padEnd",
+      "match",
+      "search",
+      "concat",
+      "normalize",
+    ]),
+  ],
+  [
+    "number",
+    new Set([
+      "toFixed",
+      "toPrecision",
+      "toString",
+      "toExponential",
+      "toLocaleString",
+    ]),
+  ],
+]);
+
+/** Non-mutating array methods that take no callback. */
+const PURE_ARRAY_METHODS: ReadonlySet<string> = new Set([
+  "at",
+  "concat",
+  "flat",
+  "includes",
+  "indexOf",
+  "join",
+  "keys",
+  "lastIndexOf",
+  "slice",
+  "toString",
+  "values",
+]);
+
+/** Array methods that are pure if their callback argument is side-effect-free. */
+const HO_PURE_ARRAY_METHODS: ReadonlySet<string> = new Set([
+  "every",
+  "filter",
+  "find",
+  "findIndex",
+  "flatMap",
+  "map",
+  "reduce",
+  "reduceRight",
+  "some",
+]);
+
+// ---------------------------------------------------------------------------
+// Tier 1b — Effect-TS awareness
+// ---------------------------------------------------------------------------
+
+/** Known-pure Effect-TS combinators (from effect/Function). */
+const EFFECT_PURE_COMBINATORS: ReadonlySet<string> = new Set([
+  "pipe",
+  "flow",
+  "identity",
+]);
+
+/** Known-impure Effect-TS runners — excluded even though they return Effect. */
+const EFFECT_IMPURE_RUNNERS: ReadonlySet<string> = new Set([
+  "runSync",
+  "runPromise",
+  "runSyncExit",
+  "runPromiseExit",
+  "runFork",
+]);
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Determine whether a call expression is known to be pure (no side effects).
+ *
+ * Returns `true` only when there is positive evidence of purity.
+ * Returns `false` (conservative) for any unknown call.
+ */
+export function isKnownPureCall(
+  expr: ts.CallExpression,
+  checker: ts.TypeChecker,
+): boolean {
+  // --- Tier 1a: builtin allowlist ---
+
+  if (ts.isPropertyAccessExpression(expr.expression)) {
+    const methodName = expr.expression.name.text;
+    const receiver = expr.expression.expression;
+
+    // Pure namespace: Math.max(...), Math.abs(...), etc.
+    if (ts.isIdentifier(receiver) && PURE_NAMESPACES.has(receiver.text)) {
+      return true;
+    }
+
+    // Method on a typed receiver
+    const receiverType = checker.getTypeAtLocation(receiver);
+
+    // String methods
+    if (receiverType.flags & ts.TypeFlags.StringLike) {
+      const pureMethods = PURE_METHODS_BY_TYPE.get("string");
+      if (pureMethods?.has(methodName)) {
+        return true;
+      }
+    }
+
+    // Number methods
+    if (receiverType.flags & ts.TypeFlags.NumberLike) {
+      const pureMethods = PURE_METHODS_BY_TYPE.get("number");
+      if (pureMethods?.has(methodName)) {
+        return true;
+      }
+    }
+
+    // Array methods
+    if (checker.isArrayType(receiverType)) {
+      if (PURE_ARRAY_METHODS.has(methodName)) {
+        return true;
+      }
+
+      // Higher-order array methods: pure if callback is side-effect-free
+      if (HO_PURE_ARRAY_METHODS.has(methodName) && expr.arguments.length >= 1) {
+        const callback = expr.arguments[0]!;
+        if (isArrowPure(callback, checker)) {
+          return true;
+        }
+        // Non-arrow callback (function expression, identifier) → conservative
+        return false;
+      }
+    }
+
+    // Tier 1b: Effect-TS impure runners (check before return-type detection)
+    if (EFFECT_IMPURE_RUNNERS.has(methodName)) {
+      return false;
+    }
+  }
+
+  // Tier 1a: bare identifier calls — check if it's a pure combinator
+  if (ts.isIdentifier(expr.expression)) {
+    if (EFFECT_PURE_COMBINATORS.has(expr.expression.text)) {
+      return true;
+    }
+  }
+
+  // --- Tier 1b: Effect-TS return type detection ---
+  if (isEffectReturningCall(expr, checker)) {
+    return true;
+  }
+
+  // --- Tier 1c: conservative default ---
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Check whether an arrow function callback is side-effect-free.
+ *
+ * For expression-bodied arrows: check the expression.
+ * For block-bodied arrows with a single return: check the return expression.
+ * All other shapes are conservatively treated as impure.
+ */
+function isArrowPure(
+  callback: ts.Expression,
+  checker: ts.TypeChecker,
+): boolean {
+  if (!ts.isArrowFunction(callback)) {
+    return false;
+  }
+
+  if (ts.isBlock(callback.body)) {
+    // Block body: only pure if it's a single return statement
+    const stmts = callback.body.statements;
+    if (
+      stmts.length === 1 &&
+      ts.isReturnStatement(stmts[0]!) &&
+      stmts[0]!.expression
+    ) {
+      return expressionIsPure(stmts[0]!.expression, checker);
+    }
+    return false;
+  }
+
+  // Expression body
+  return expressionIsPure(callback.body, checker);
+}
+
+/**
+ * Recursively check whether an expression is free of side effects.
+ *
+ * This mirrors the logic of expressionHasSideEffects in translate-body.ts,
+ * but inverted: known-pure calls return true, unknown calls return false.
+ */
+function expressionIsPure(
+  expr: ts.Expression,
+  checker: ts.TypeChecker,
+): boolean {
+  // Unwrap parentheses, type assertions, non-null assertions
+  while (
+    ts.isParenthesizedExpression(expr) ||
+    ts.isAsExpression(expr) ||
+    ts.isSatisfiesExpression(expr) ||
+    ts.isNonNullExpression(expr)
+  ) {
+    expr = expr.expression;
+  }
+
+  // Literals, identifiers, property access are pure
+  if (
+    ts.isIdentifier(expr) ||
+    ts.isNumericLiteral(expr) ||
+    ts.isStringLiteral(expr) ||
+    ts.isNoSubstitutionTemplateLiteral(expr) ||
+    expr.kind === ts.SyntaxKind.TrueKeyword ||
+    expr.kind === ts.SyntaxKind.FalseKeyword ||
+    expr.kind === ts.SyntaxKind.NullKeyword ||
+    expr.kind === ts.SyntaxKind.UndefinedKeyword
+  ) {
+    return true;
+  }
+
+  if (ts.isPropertyAccessExpression(expr) || ts.isElementAccessExpression(expr)) {
+    return true;
+  }
+
+  if (ts.isBinaryExpression(expr)) {
+    // Assignment operators are side-effectful
+    if (
+      expr.operatorToken.kind >= ts.SyntaxKind.EqualsToken &&
+      expr.operatorToken.kind <= ts.SyntaxKind.CaretEqualsToken
+    ) {
+      return false;
+    }
+    return (
+      expressionIsPure(expr.left, checker) &&
+      expressionIsPure(expr.right, checker)
+    );
+  }
+
+  if (ts.isPrefixUnaryExpression(expr) || ts.isPostfixUnaryExpression(expr)) {
+    if (
+      expr.operator === ts.SyntaxKind.PlusPlusToken ||
+      expr.operator === ts.SyntaxKind.MinusMinusToken
+    ) {
+      return false;
+    }
+    return expressionIsPure(expr.operand, checker);
+  }
+
+  if (ts.isConditionalExpression(expr)) {
+    return (
+      expressionIsPure(expr.condition, checker) &&
+      expressionIsPure(expr.whenTrue, checker) &&
+      expressionIsPure(expr.whenFalse, checker)
+    );
+  }
+
+  if (ts.isCallExpression(expr)) {
+    return isKnownPureCall(expr, checker);
+  }
+
+  if (ts.isArrayLiteralExpression(expr)) {
+    return expr.elements.every((el) => expressionIsPure(el, checker));
+  }
+
+  if (ts.isTemplateExpression(expr)) {
+    return expr.templateSpans.every((span) =>
+      expressionIsPure(span.expression, checker),
+    );
+  }
+
+  // Side-effectful by default
+  if (
+    ts.isDeleteExpression(expr) ||
+    ts.isNewExpression(expr) ||
+    ts.isAwaitExpression(expr)
+  ) {
+    return false;
+  }
+
+  // Unknown expression kind → conservative
+  return false;
+}
+
+/**
+ * Tier 1b: Check if a call returns an Effect<A,E,R> value.
+ *
+ * Detection: the return type has the EffectTypeId branded property.
+ * This is structural and version-resilient — avoids source-path heuristics.
+ *
+ * Known-impure runners (runSync, runPromise, etc.) are excluded upstream.
+ */
+function isEffectReturningCall(
+  expr: ts.CallExpression,
+  checker: ts.TypeChecker,
+): boolean {
+  try {
+    const signature = checker.getResolvedSignature(expr);
+    if (!signature) return false;
+
+    const returnType = checker.getReturnTypeOfSignature(signature);
+    return hasEffectTypeId(returnType);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check whether a type has the EffectTypeId branded property,
+ * which is the structural marker for Effect<A,E,R>.
+ */
+function hasEffectTypeId(type: ts.Type): boolean {
+  // Check direct properties for EffectTypeId
+  const props = type.getProperties();
+  for (const prop of props) {
+    if (prop.name === "_tag" || prop.name === "EffectTypeId" || prop.name === "_op") {
+      // Heuristic: if it has EffectTypeId, it's an Effect type
+      if (prop.name === "EffectTypeId") {
+        return true;
+      }
+    }
+  }
+
+  // Check alias: Effect types might be aliased
+  if (type.aliasSymbol?.name === "Effect") {
+    return true;
+  }
+
+  // Check symbol name
+  if (type.symbol?.name === "Effect") {
+    return true;
+  }
+
+  return false;
+}

--- a/tools/ts2pant/src/purity.ts
+++ b/tools/ts2pant/src/purity.ts
@@ -156,8 +156,11 @@ const HO_PURE_ARRAY_METHODS: ReadonlySet<string> = new Set([
 // Standard name: Callee symbol resolution (Dietl et al., ICSE 2011).
 // The effect library's type declarations serve as implicit @Pure annotations.
 // We verify each call by tracing the callee symbol back to its declaration
-// file. If it originates from the `effect` package and is not in the impure
-// set, the library's referential transparency guarantee applies.
+// file. Only exports explicitly listed in the pure allowlist are accepted.
+//
+// Approach: Explicit allowlist (not denylist). Only Effect-TS exports with
+// known purity guarantees are listed. Unknown exports default to impure,
+// consistent with the conservative must-analysis principle.
 //
 // Fallback: bare-name matching for pipe/flow/identity with argument purity
 // checking, for test environments where the `effect` package is not installed.
@@ -171,24 +174,228 @@ const EFFECT_PURE_COMBINATORS: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * Known-impure Effect-TS exports — runners and mutable allocators.
+ * Explicit allowlist of known-pure Effect-TS exports, keyed by module.
  *
- * Runners (@category Running Effects): execute an Effect, producing side effects.
- * Mutable allocators: create synchronization primitives with observable state.
+ * Only exports listed here are classified as pure. Unknown exports default
+ * to impure (conservative). This is an allowlist, not a denylist — adding
+ * a new Effect-TS version's exports requires updating this list.
+ *
+ * Source: Effect-TS API docs, @category annotations in Effect.d.ts.
+ * All constructors and combinators that return Effect<A,E,R> are pure
+ * (referential transparency by design). Runners and mutable allocators
+ * are excluded.
  */
-const EFFECT_IMPURE_EXPORTS: ReadonlySet<string> = new Set([
-  // Runners
-  "runSync",
-  "runSyncExit",
-  "runPromise",
-  "runPromiseExit",
-  "runFork",
-  "runCallback",
-  // Mutable allocators
-  "makeSemaphore",
-  "unsafeMakeSemaphore",
-  "makeLatch",
-  "unsafeMakeLatch",
+const EFFECT_PURE_EXPORTS: ReadonlyMap<string, ReadonlySet<string>> = new Map([
+  [
+    "Effect",
+    new Set([
+      // Constructors (@category Creating Effects)
+      "succeed",
+      "fail",
+      "sync",
+      "promise",
+      "tryPromise",
+      "failSync",
+      "failCause",
+      "failCauseSync",
+      "die",
+      "dieSync",
+      "dieMessage",
+      "gen",
+      "suspend",
+      "never",
+      "void",
+      "succeedNone",
+      "succeedSome",
+      "yieldNow",
+      // Mapping
+      "map",
+      "mapBoth",
+      "mapError",
+      "mapErrorCause",
+      "as",
+      "asSome",
+      "asSomeError",
+      "asVoid",
+      "flip",
+      "negate",
+      "merge",
+      // Sequencing
+      "flatMap",
+      "flatten",
+      "andThen",
+      "tap",
+      "tapBoth",
+      "tapDefect",
+      "tapError",
+      "tapErrorCause",
+      "tapErrorTag",
+      // Error handling
+      "catchAll",
+      "catchAllCause",
+      "catchAllDefect",
+      "catchIf",
+      "catchSome",
+      "catchSomeCause",
+      "catchSomeDefect",
+      "catchTag",
+      "catchTags",
+      "cause",
+      "eventually",
+      "ignore",
+      "ignoreLogged",
+      "retry",
+      "retryOrElse",
+      "sandbox",
+      "unsandbox",
+      "orDie",
+      "orDieWith",
+      // Fallback
+      "orElse",
+      "orElseFail",
+      "orElseSucceed",
+      "firstSuccessOf",
+      // Zipping
+      "zip",
+      "zipLeft",
+      "zipRight",
+      "zipWith",
+      // Matching
+      "match",
+      "matchCause",
+      "matchCauseEffect",
+      "matchEffect",
+      // Filtering
+      "filter",
+      "filterMap",
+      "filterOrDie",
+      "filterOrDieMessage",
+      "filterOrElse",
+      "filterOrFail",
+      // Conditional
+      "when",
+      "whenEffect",
+      "unless",
+      "unlessEffect",
+      "if",
+      // Collecting
+      "all",
+      "allSuccesses",
+      "allWith",
+      "forEach",
+      "reduce",
+      "reduceEffect",
+      "reduceRight",
+      // Outcome
+      "either",
+      "exit",
+      "option",
+      // Optional
+      "fromNullable",
+      "optionFromOptional",
+      // Condition checking
+      "every",
+      "exists",
+      "isFailure",
+      "isSuccess",
+      "liftPredicate",
+      // Do notation
+      "Do",
+      "bind",
+      "bindAll",
+      "bindTo",
+      // Context/provide
+      "provide",
+      "provideService",
+      "provideServiceEffect",
+      "contextWith",
+      "contextWithEffect",
+      "mapInputContext",
+      "updateService",
+      // Timing
+      "delay",
+      "sleep",
+      "timed",
+      "timeout",
+      "timeoutFail",
+      "timeoutFailCause",
+      "timeoutTo",
+      // Repetition
+      "repeat",
+      "repeatN",
+      "repeatOrElse",
+      "forever",
+      "iterate",
+      "loop",
+      "schedule",
+      // Racing
+      "race",
+      "raceAll",
+      "raceFirst",
+      "raceWith",
+      // Validation
+      "validate",
+      "validateAll",
+      "validateFirst",
+      "validateWith",
+      // Scoping
+      "acquireRelease",
+      "acquireUseRelease",
+      "addFinalizer",
+      "ensuring",
+      "onError",
+      "onExit",
+      "scope",
+      "scoped",
+      // Logging (return Effect<void>)
+      "log",
+      "logDebug",
+      "logError",
+      "logFatal",
+      "logInfo",
+      "logTrace",
+      "logWarning",
+      // Tracing
+      "annotateCurrentSpan",
+      "currentSpan",
+      "withSpan",
+      // Interruption
+      "allowInterrupt",
+      "interrupt",
+      "interruptible",
+      "uninterruptible",
+      // Forking (returns Effect<Fiber>)
+      "fork",
+      "forkDaemon",
+      "forkScoped",
+      "forkAll",
+      // Caching
+      "cached",
+      "cachedWithTTL",
+      "once",
+      // Summarized
+      "summarized",
+      // Miscellaneous
+      "fn",
+      "partition",
+    ]),
+  ],
+  [
+    "Function",
+    new Set([
+      "pipe",
+      "flow",
+      "identity",
+      "dual",
+      "constTrue",
+      "constFalse",
+      "constVoid",
+      "constUndefined",
+      "absurd",
+      "hole",
+    ]),
+  ],
+  ["Pipeable", new Set(["pipe"])],
 ]);
 
 // ---------------------------------------------------------------------------
@@ -202,6 +409,19 @@ const EFFECT_IMPURE_EXPORTS: ReadonlySet<string> = new Set([
  * Returns `false` (conservative) for any unknown call.
  */
 export function isKnownPureCall(
+  expr: ts.CallExpression,
+  checker: ts.TypeChecker,
+): boolean {
+  try {
+    return isKnownPureCallInner(expr, checker);
+  } catch {
+    // TypeChecker can throw on malformed/incomplete ASTs.
+    // Conservative fallback: treat as effectful.
+    return false;
+  }
+}
+
+function isKnownPureCallInner(
   expr: ts.CallExpression,
   checker: ts.TypeChecker,
 ): boolean {
@@ -221,7 +441,7 @@ export function isKnownPureCall(
       return true;
     }
 
-    // Method on a typed receiver
+    // Method on a typed receiver (getTypeAtLocation may throw)
     const receiverType = checker.getTypeAtLocation(receiver);
 
     // String methods
@@ -257,26 +477,22 @@ export function isKnownPureCall(
         );
       }
     }
-
-    // Tier 1b: Effect-TS impure runners (early exit before symbol resolution)
-    if (EFFECT_IMPURE_EXPORTS.has(methodName)) {
-      return false;
-    }
   }
 
   // --- Tier 1b: Effect-TS symbol resolution ---
-  // Trace the callee symbol to its declaration file. If it originates from
-  // the `effect` package and is not an impure export, the library's
-  // referential transparency guarantee applies: constructing an Effect
-  // value is always pure; only running it causes effects.
+  // Trace the callee symbol to its declaration file. Only exports
+  // explicitly listed in EFFECT_PURE_EXPORTS are accepted as pure.
+  // Unknown effect exports default to impure (conservative).
   const effectExport = resolveEffectLibraryExport(expr.expression, checker);
   if (effectExport !== null) {
-    if (EFFECT_IMPURE_EXPORTS.has(effectExport.name)) {
-      return false;
+    const moduleAllowlist = EFFECT_PURE_EXPORTS.get(effectExport.module);
+    if (moduleAllowlist?.has(effectExport.name)) {
+      // Known-pure effect library export. Arguments are still eagerly
+      // evaluated, so check their purity.
+      return expr.arguments.every((arg) => expressionIsPure(arg, checker));
     }
-    // All non-impure effect library exports are pure constructors/combinators.
-    // Arguments are still eagerly evaluated, so check their purity.
-    return expr.arguments.every((arg) => expressionIsPure(arg, checker));
+    // Effect library export not in allowlist → conservative (impure)
+    return false;
   }
 
   // Tier 1b fallback: bare-name combinator matching for environments where

--- a/tools/ts2pant/src/purity.ts
+++ b/tools/ts2pant/src/purity.ts
@@ -1,14 +1,38 @@
 /**
  * Conservative purity oracle for TypeScript call expressions.
  *
- * Three-tier analysis (trivial instance of abstract interpretation over
- * a {pure, effectful} lattice — Cousot & Cousot, POPL 1977):
+ * Standard name: Allowlist-based must-analysis over a {pure, effectful}
+ * abstract domain (trivial two-point lattice).
  *
- *   Tier 1a: Known-pure builtin allowlist (Math methods, non-mutating String/Array methods)
- *   Tier 1b: Effect-TS combinator allowlist (pipe, flow, identity)
- *   Tier 1c: Conservative default (unknown = effectful)
+ * Framework: Abstract interpretation (Cousot & Cousot, POPL 1977).
+ *   - Domain: {pure, effectful} with pure ⊑ effectful.
+ *   - Default: effectful (⊤). Only positive evidence yields pure (⊥).
+ *   - This is a must-analysis: returns "pure" only when provably so.
  *
- * Ref: Lucassen & Gifford, Polymorphic Effect Systems, POPL 1988.
+ * Allowlist approach: Equivalent to the stub annotation technique used by
+ * the Checker Framework (@Pure/@SideEffectFree, Dietl et al. ICSE 2011)
+ * and Closure Compiler externs. The allowlist encodes the effect signature
+ * of known library functions without requiring whole-program inference.
+ *
+ * Higher-order functions: Call-site callback specialization per
+ * Lucassen & Gifford (POPL 1988). The effect of arr.map(f) depends on
+ * the effect of f at each call site, not on a fixed effect for map.
+ *
+ * Pragmatic assumptions (shared with Webpack, Rollup, Closure Compiler):
+ *   - Property access does not trigger effectful getters.
+ *   - Implicit toString()/valueOf() coercions in template literals are pure.
+ *   - Combinator names (pipe, flow, identity) match by identifier text,
+ *     not by import source. Argument purity checking provides a safety net.
+ *
+ * Tiers:
+ *   1a: Known-pure builtin allowlist (Math methods, String/Array methods)
+ *   1b: Effect-TS combinator allowlist (pipe, flow, identity)
+ *   1c: Conservative default (unknown = effectful)
+ *
+ * Ref: Cousot & Cousot, "Abstract Interpretation", POPL 1977.
+ * Ref: Lucassen & Gifford, "Polymorphic Effect Systems", POPL 1988.
+ * Ref: Dietl et al., "Building and Using Pluggable Type-Checkers", ICSE 2011.
+ * Ref: Talpin & Jouvelot, "The Type and Effect Discipline", I&C 1994.
  */
 import ts from "typescript";
 
@@ -268,10 +292,21 @@ function isArrowPure(
 }
 
 /**
- * Recursively check whether an expression is free of side effects.
+ * Compositional purity analysis over the expression AST.
  *
- * This mirrors the logic of expressionHasSideEffects in translate-body.ts,
- * but inverted: known-pure calls return true, unknown calls return false.
+ * Standard name: Structural induction over expression forms, classifying
+ * each into the {pure, effectful} lattice. This is the standard recursive
+ * descent approach described in Nielson, Nielson & Hankin, "Principles of
+ * Program Analysis" (Springer 1999), Ch. 2 — instantiated for a trivial
+ * two-point effect domain rather than a full type-and-effect system.
+ *
+ * Soundness invariant: returns true only when the expression is provably
+ * side-effect-free. Returns false (conservative) for any unknown form.
+ *
+ * Pragmatic assumption: property access is assumed pure (no effectful
+ * getters). This matches the universal assumption in JavaScript bundler
+ * tree-shaking (Webpack, Rollup, Closure Compiler). Getter-bearing types
+ * in specification-relevant code are out of scope for ts2pant.
  */
 function expressionIsPure(
   expr: ts.Expression,
@@ -301,6 +336,8 @@ function expressionIsPure(
     return true;
   }
 
+  // Property access: recurse into receiver. Assumes no effectful getters
+  // (see module-level pragmatic assumptions documentation).
   if (ts.isPropertyAccessExpression(expr)) {
     return expressionIsPure(expr.expression, checker);
   }
@@ -356,10 +393,39 @@ function expressionIsPure(
   }
 
   if (ts.isArrayLiteralExpression(expr)) {
-    return expr.elements.every((el) => expressionIsPure(el, checker));
+    return expr.elements.every((el) => {
+      // Spread elements: [...arr] is pure if arr is pure (array iteration
+      // is pure for built-in arrays). Per Talpin & Jouvelot 1994,
+      // allocation effects are maskable — the fresh array is local.
+      if (ts.isSpreadElement(el)) {
+        return expressionIsPure(el.expression, checker);
+      }
+      return expressionIsPure(el, checker);
+    });
+  }
+
+  // Object literals: { a: expr } is pure if all property values are pure.
+  // Allocation is a maskable effect (Talpin & Jouvelot, I&C 1994) — the
+  // fresh object is local and does not escape to observable state.
+  if (ts.isObjectLiteralExpression(expr)) {
+    return expr.properties.every((prop) => {
+      if (ts.isPropertyAssignment(prop)) {
+        return expressionIsPure(prop.initializer, checker);
+      }
+      if (ts.isShorthandPropertyAssignment(prop)) {
+        return true; // { x } just reads a variable
+      }
+      if (ts.isSpreadAssignment(prop)) {
+        return expressionIsPure(prop.expression, checker);
+      }
+      // Computed property names, method declarations, accessors → conservative
+      return false;
+    });
   }
 
   if (ts.isTemplateExpression(expr)) {
+    // Assumes implicit toString() on interpolated values is pure
+    // (see module-level pragmatic assumptions documentation).
     return expr.templateSpans.every((span) =>
       expressionIsPure(span.expression, checker),
     );

--- a/tools/ts2pant/src/purity.ts
+++ b/tools/ts2pant/src/purity.ts
@@ -512,6 +512,13 @@ function expressionIsPure(
   if (ts.isObjectLiteralExpression(expr)) {
     return expr.properties.every((prop) => {
       if (ts.isPropertyAssignment(prop)) {
+        // Computed property names: { [expr]: value } evaluates expr eagerly
+        if (
+          ts.isComputedPropertyName(prop.name) &&
+          !expressionIsPure(prop.name.expression, checker)
+        ) {
+          return false;
+        }
         return expressionIsPure(prop.initializer, checker);
       }
       if (ts.isShorthandPropertyAssignment(prop)) {
@@ -520,7 +527,7 @@ function expressionIsPure(
       if (ts.isSpreadAssignment(prop)) {
         return expressionIsPure(prop.expression, checker);
       }
-      // Computed property names, method declarations, accessors → conservative
+      // Method declarations, accessors → conservative
       return false;
     });
   }

--- a/tools/ts2pant/src/purity.ts
+++ b/tools/ts2pant/src/purity.ts
@@ -260,7 +260,10 @@ function expressionIsPure(
     return true;
   }
 
-  if (ts.isPropertyAccessExpression(expr) || ts.isElementAccessExpression(expr)) {
+  if (
+    ts.isPropertyAccessExpression(expr) ||
+    ts.isElementAccessExpression(expr)
+  ) {
     return true;
   }
 
@@ -337,7 +340,9 @@ function isEffectReturningCall(
 ): boolean {
   try {
     const signature = checker.getResolvedSignature(expr);
-    if (!signature) return false;
+    if (!signature) {
+      return false;
+    }
 
     const returnType = checker.getReturnTypeOfSignature(signature);
     return hasEffectTypeId(returnType);
@@ -351,14 +356,14 @@ function isEffectReturningCall(
  * which is the structural marker for Effect<A,E,R>.
  */
 function hasEffectTypeId(type: ts.Type): boolean {
-  // Check direct properties for EffectTypeId
+  // biome-ignore lint/security/noSecrets: EffectTypeId is an Effect-TS branded property name, not a secret
+  const EFFECT_TYPE_ID = "EffectTypeId";
+
+  // Check direct properties for the EffectTypeId branded property
   const props = type.getProperties();
   for (const prop of props) {
-    if (prop.name === "_tag" || prop.name === "EffectTypeId" || prop.name === "_op") {
-      // Heuristic: if it has EffectTypeId, it's an Effect type
-      if (prop.name === "EffectTypeId") {
-        return true;
-      }
+    if (prop.name === EFFECT_TYPE_ID) {
+      return true;
     }
   }
 

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -174,6 +174,22 @@ exports[`expressions-const-bindings.ts > simpleConst 1`] = `
 "module SimpleConst.\\n\\nsimpleConst a: Int, b: Int => Int.\\n\\n---\\n\\nsimpleConst a b = a + b.\\n"
 `;
 
+exports[`expressions-const-pure-calls.ts > constChainedPure 1`] = `
+"module ConstChainedPure.\\n\\nconstChainedPure x: Int, y: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: constChainedPure — const binding with side-effectful initializer.\\n"
+`;
+
+exports[`expressions-const-pure-calls.ts > constImpureCall 1`] = `
+"module ConstImpureCall.\\n\\nconstImpureCall x: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: constImpureCall — const binding with side-effectful initializer.\\n"
+`;
+
+exports[`expressions-const-pure-calls.ts > constMathMax 1`] = `
+"module ConstMathMax.\\n\\nconstMathMax a: Int, b: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: constMathMax — const binding with side-effectful initializer.\\n"
+`;
+
+exports[`expressions-const-pure-calls.ts > constStringMethod 1`] = `
+"module ConstStringMethod.\\n\\nconstStringMethod s: String => Int.\\n\\n---\\n\\n> UNSUPPORTED: constStringMethod — const binding with side-effectful initializer.\\n"
+`;
+
 exports[`expressions-literals.ts > fortyTwo 1`] = `
 "module FortyTwo.\\n\\nfortyTwo  => Int.\\n\\n---\\n\\nfortyTwo = 42.\\n"
 `;

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-const-pure-calls.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-const-pure-calls.ts
@@ -1,0 +1,26 @@
+// Fixture: const bindings initialized with pure function calls.
+// These patterns exercise the purity oracle — pure calls should eventually
+// be inlineable (wired in Patch 4), impure calls should remain rejected.
+
+export function constMathMax(a: number, b: number): number {
+  const m = Math.max(a, b);
+  return m + 1;
+}
+
+export function constStringMethod(s: string): number {
+  const i = s.indexOf("x");
+  return i;
+}
+
+export function constChainedPure(x: number, y: number): number {
+  const a = Math.abs(x);
+  const b = Math.max(a, y);
+  return b;
+}
+
+declare function unknownFn(x: number): number;
+
+export function constImpureCall(x: number): number {
+  const r = unknownFn(x);
+  return r;
+}

--- a/tools/ts2pant/tests/fixtures/effect-ts-purity.ts
+++ b/tools/ts2pant/tests/fixtures/effect-ts-purity.ts
@@ -1,0 +1,54 @@
+// Fixture: Effect-TS purity detection via callee symbol resolution.
+// These functions import from the real `effect` package so the TypeChecker
+// can trace callee symbols back to their declaration files.
+
+import { Effect, pipe } from "effect";
+
+// --- Pure Effect-TS constructors (symbol resolves to effect package) ---
+
+export function effectSucceed(x: number) {
+  return Effect.succeed(x);
+}
+
+export function effectMap(eff: Effect.Effect<number>) {
+  return Effect.map(eff, (n) => n + 1);
+}
+
+export function effectFlatMap(eff: Effect.Effect<number>) {
+  return Effect.flatMap(eff, (n) => Effect.succeed(n + 1));
+}
+
+export function effectPipe(eff: Effect.Effect<number>) {
+  return pipe(
+    eff,
+    Effect.map((n) => n + 1),
+  );
+}
+
+export function effectSync() {
+  return Effect.sync(() => 42);
+}
+
+export function effectFail(msg: string) {
+  return Effect.fail(msg);
+}
+
+// --- Impure Effect-TS runners ---
+
+export function effectRunSync(eff: Effect.Effect<number>) {
+  return Effect.runSync(eff);
+}
+
+export function effectRunPromise(eff: Effect.Effect<number>) {
+  return Effect.runPromise(eff);
+}
+
+// --- User function returning Effect (NOT from effect package → impure) ---
+
+function myHelper(): Effect.Effect<number> {
+  return Effect.succeed(42);
+}
+
+export function userEffectReturning() {
+  return myHelper();
+}

--- a/tools/ts2pant/tests/purity.test.mts
+++ b/tools/ts2pant/tests/purity.test.mts
@@ -1,7 +1,12 @@
+import { resolve } from "node:path";
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import ts from "typescript";
-import { createSourceFileFromSource, getChecker } from "../src/extract.js";
+import {
+  createSourceFile,
+  createSourceFileFromSource,
+  getChecker,
+} from "../src/extract.js";
 import { isKnownPureCall } from "../src/purity.js";
 
 /**
@@ -281,5 +286,105 @@ describe("isKnownPureCall", () => {
       `),
       false,
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Effect-TS symbol resolution tests (Tier 1b with real `effect` package)
+//
+// These tests use a real fixture file that imports from `effect`, so the
+// TypeChecker can resolve callee symbols back to node_modules/effect/.
+// This exercises the resolveEffectLibraryExport path (not the bare-name
+// fallback used in the declare-function tests above).
+// ---------------------------------------------------------------------------
+
+/**
+ * Find the first CallExpression inside a named exported function.
+ */
+function findCallInFunction(
+  sourceFile: ts.SourceFile,
+  funcName: string,
+): ts.CallExpression | undefined {
+  let result: ts.CallExpression | undefined;
+  function visit(node: ts.Node) {
+    if (result) return;
+    if (
+      ts.isFunctionDeclaration(node) &&
+      node.name?.text === funcName &&
+      node.body
+    ) {
+      // Find first call in this function's body
+      function findCall(n: ts.Node) {
+        if (result) return;
+        if (ts.isCallExpression(n)) {
+          result = n;
+          return;
+        }
+        ts.forEachChild(n, findCall);
+      }
+      ts.forEachChild(node.body, findCall);
+    }
+    ts.forEachChild(node, visit);
+  }
+  ts.forEachChild(sourceFile, visit);
+  return result;
+}
+
+describe("isKnownPureCall (Effect-TS symbol resolution)", () => {
+  const fixturePath = resolve(
+    import.meta.dirname,
+    "fixtures/effect-ts-purity.ts",
+  );
+  const sourceFile = createSourceFile(fixturePath);
+  const checker = getChecker(sourceFile);
+
+  function checkFixturePurity(funcName: string): boolean {
+    const callExpr = findCallInFunction(sourceFile.compilerNode, funcName);
+    if (!callExpr) {
+      throw new Error(`No CallExpression found in function ${funcName}`);
+    }
+    return isKnownPureCall(callExpr, checker);
+  }
+
+  // --- Pure constructors (symbol resolves to effect package) ---
+
+  it("Effect.succeed is pure (library constructor)", () => {
+    assert.equal(checkFixturePurity("effectSucceed"), true);
+  });
+
+  it("Effect.map is pure (library combinator)", () => {
+    assert.equal(checkFixturePurity("effectMap"), true);
+  });
+
+  it("Effect.flatMap is pure (library combinator)", () => {
+    assert.equal(checkFixturePurity("effectFlatMap"), true);
+  });
+
+  it("pipe from effect is pure (library combinator)", () => {
+    assert.equal(checkFixturePurity("effectPipe"), true);
+  });
+
+  it("Effect.sync is pure (library constructor)", () => {
+    assert.equal(checkFixturePurity("effectSync"), true);
+  });
+
+  it("Effect.fail is pure (library constructor)", () => {
+    assert.equal(checkFixturePurity("effectFail"), true);
+  });
+
+  // --- Impure runners ---
+
+  it("Effect.runSync is impure (runner)", () => {
+    assert.equal(checkFixturePurity("effectRunSync"), false);
+  });
+
+  it("Effect.runPromise is impure (runner)", () => {
+    assert.equal(checkFixturePurity("effectRunPromise"), false);
+  });
+
+  // --- User function returning Effect ---
+
+  it("user function returning Effect is impure (not a library export)", () => {
+    assert.equal(checkFixturePurity("userEffectReturning"), false);
   });
 });

--- a/tools/ts2pant/tests/purity.test.mts
+++ b/tools/ts2pant/tests/purity.test.mts
@@ -59,6 +59,24 @@ describe("isKnownPureCall", () => {
     );
   });
 
+  it("should return false for Math.random", () => {
+    assert.equal(
+      checkPurity(`
+        function f() { return Math.random(); }
+      `),
+      false,
+    );
+  });
+
+  it("should return true for nested pure calls", () => {
+    assert.equal(
+      checkPurity(`
+        function f(x: number, y: number) { return Math.max(Math.abs(x), y); }
+      `),
+      true,
+    );
+  });
+
   // --- Tier 1a: String methods ---
 
   it("should return true for String.prototype.indexOf", () => {
@@ -144,8 +162,10 @@ describe("isKnownPureCall", () => {
 
   // --- Tier 1b: Effect-TS ---
 
-  it("should return true for Effect-returning function", () => {
-    // Simulate Effect type via structural branded type
+  it("should return false for Effect-returning function", () => {
+    // Generic return-type detection is unsound for user-defined functions
+    // whose body may have side effects before returning Effect.
+    // Conservative: treat unknown functions as impure regardless of return type.
     assert.equal(
       checkPurity(`
         interface Effect<A, E, R> {
@@ -157,12 +177,11 @@ describe("isKnownPureCall", () => {
         declare function succeed<A>(value: A): Effect<A, never, never>;
         function f(x: number) { return succeed(x); }
       `),
-      true,
+      false,
     );
   });
 
   it("should return false for Effect.runSync", () => {
-    // Even if it returns Effect, runSync is impure
     assert.equal(
       checkPurity(`
         interface Effect<A, E, R> {
@@ -188,6 +207,28 @@ describe("isKnownPureCall", () => {
         function f(x: number) { return pipe(x, n => n + 1); }
       `),
       true,
+    );
+  });
+
+  it("should return false for pipe with impure argument", () => {
+    assert.equal(
+      checkPurity(`
+        declare function pipe<A, B>(a: A, f: (a: A) => B): B;
+        declare function sideEffect(): number;
+        function f() { return pipe(sideEffect(), n => n + 1); }
+      `),
+      false,
+    );
+  });
+
+  it("should return false for identity with impure argument", () => {
+    assert.equal(
+      checkPurity(`
+        declare function identity<A>(a: A): A;
+        declare function sideEffect(): number;
+        function f() { return identity(sideEffect()); }
+      `),
+      false,
     );
   });
 

--- a/tools/ts2pant/tests/purity.test.mts
+++ b/tools/ts2pant/tests/purity.test.mts
@@ -161,11 +161,23 @@ describe("isKnownPureCall", () => {
   });
 
   // --- Tier 1b: Effect-TS ---
+  //
+  // Two detection paths:
+  // (1) Symbol resolution: when `effect` package is installed, the callee is
+  //     traced to its declaration file via getAliasedSymbol. If it originates
+  //     from node_modules/effect/, it's classified by the library's purity
+  //     guarantee (all non-runner/non-allocator exports are pure).
+  // (2) Bare-name fallback: for test environments without `effect` installed,
+  //     pipe/flow/identity are matched by identifier name + argument purity.
+  //
+  // Tests below use `declare function` which exercises the fallback path.
+  // The symbol resolution path is exercised in integration tests with the
+  // real `effect` package.
 
-  it("should return false for Effect-returning function", () => {
-    // Generic return-type detection is unsound for user-defined functions
-    // whose body may have side effects before returning Effect.
-    // Conservative: treat unknown functions as impure regardless of return type.
+  it("should return false for user-defined Effect-returning function", () => {
+    // A user function returning Effect is NOT guaranteed pure — its body may
+    // have side effects. Only Effect library exports have the purity guarantee.
+    // Symbol resolution correctly distinguishes: user file != effect package.
     assert.equal(
       checkPurity(`
         interface Effect<A, E, R> {
@@ -182,6 +194,8 @@ describe("isKnownPureCall", () => {
   });
 
   it("should return false for Effect.runSync", () => {
+    // Runners are in the EFFECT_IMPURE_EXPORTS set — impure regardless of
+    // whether detected via symbol resolution or name matching.
     assert.equal(
       checkPurity(`
         interface Effect<A, E, R> {
@@ -200,7 +214,20 @@ describe("isKnownPureCall", () => {
     );
   });
 
-  it("should return true for pipe from effect/Function", () => {
+  it("should return false for Effect.runPromise", () => {
+    assert.equal(
+      checkPurity(`
+        declare const Effect: {
+          runPromise<A>(effect: any): Promise<A>;
+        };
+        function f(eff: any) { return Effect.runPromise(eff); }
+      `),
+      false,
+    );
+  });
+
+  it("should return true for pipe from effect/Function (fallback path)", () => {
+    // bare-name fallback: pipe matched by identifier + args checked for purity
     assert.equal(
       checkPurity(`
         declare function pipe<A, B>(a: A, f: (a: A) => B): B;
@@ -227,6 +254,18 @@ describe("isKnownPureCall", () => {
         declare function identity<A>(a: A): A;
         declare function sideEffect(): number;
         function f() { return identity(sideEffect()); }
+      `),
+      false,
+    );
+  });
+
+  it("should return false for makeSemaphore (mutable allocator)", () => {
+    assert.equal(
+      checkPurity(`
+        declare const Effect: {
+          makeSemaphore(permits: number): any;
+        };
+        function f() { return Effect.makeSemaphore(1); }
       `),
       false,
     );

--- a/tools/ts2pant/tests/purity.test.mts
+++ b/tools/ts2pant/tests/purity.test.mts
@@ -1,0 +1,205 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import ts from "typescript";
+import { createSourceFileFromSource, getChecker } from "../src/extract.js";
+import { isKnownPureCall } from "../src/purity.js";
+
+/**
+ * Find the first CallExpression in a source file's function body.
+ * Searches depth-first through all function declarations.
+ */
+function findCallExpression(
+  sourceFile: ts.SourceFile,
+): ts.CallExpression | undefined {
+  let result: ts.CallExpression | undefined;
+  function visit(node: ts.Node) {
+    if (result) return;
+    if (ts.isCallExpression(node)) {
+      result = node;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  }
+  ts.forEachChild(sourceFile, visit);
+  return result;
+}
+
+/**
+ * Helper: create a source with a function containing the expression,
+ * extract the call expression and checker, and return isKnownPureCall result.
+ */
+function checkPurity(source: string): boolean {
+  const sf = createSourceFileFromSource(source);
+  const checker = getChecker(sf);
+  const callExpr = findCallExpression(sf.compilerNode);
+  if (!callExpr) {
+    throw new Error("No CallExpression found in source");
+  }
+  return isKnownPureCall(callExpr, checker);
+}
+
+describe("isKnownPureCall", () => {
+  // --- Tier 1a: Pure namespaces ---
+
+  it("should return true for Math.max", () => {
+    assert.equal(
+      checkPurity(`
+        function f(a: number, b: number) { return Math.max(a, b); }
+      `),
+      true,
+    );
+  });
+
+  it("should return true for Math.abs", () => {
+    assert.equal(
+      checkPurity(`
+        function f(x: number) { return Math.abs(x); }
+      `),
+      true,
+    );
+  });
+
+  // --- Tier 1a: String methods ---
+
+  it("should return true for String.prototype.indexOf", () => {
+    assert.equal(
+      checkPurity(`
+        function f(s: string) { return s.indexOf("x"); }
+      `),
+      true,
+    );
+  });
+
+  // --- Tier 1a: Array methods (no callback) ---
+
+  it("should return true for Array.prototype.includes", () => {
+    assert.equal(
+      checkPurity(`
+        function f(arr: number[]) { return arr.includes(1); }
+      `),
+      true,
+    );
+  });
+
+  // --- Tier 1a: Higher-order array methods with arrow callbacks ---
+
+  it("should return true for array.filter with pure callback", () => {
+    assert.equal(
+      checkPurity(`
+        function f(arr: number[]) { return arr.filter(x => x > 0); }
+      `),
+      true,
+    );
+  });
+
+  it("should return false for array.filter with impure callback", () => {
+    assert.equal(
+      checkPurity(`
+        declare function sideEffect(x: number): boolean;
+        function f(arr: number[]) { return arr.filter(x => sideEffect(x)); }
+      `),
+      false,
+    );
+  });
+
+  it("should return true for array.map with pure arrow callback", () => {
+    assert.equal(
+      checkPurity(`
+        function f(arr: number[]) { return arr.map(x => x * 2); }
+      `),
+      true,
+    );
+  });
+
+  it("should return false for array.map with impure arrow callback", () => {
+    assert.equal(
+      checkPurity(`
+        declare function transform(x: number): number;
+        function f(arr: number[]) { return arr.map(x => transform(x)); }
+      `),
+      false,
+    );
+  });
+
+  it("should return true for array.filter with expression-bodied arrow", () => {
+    assert.equal(
+      checkPurity(`
+        function f(arr: string[]) { return arr.filter(s => s.length > 0); }
+      `),
+      true,
+    );
+  });
+
+  it("should return false for array.filter with block-bodied arrow containing side effect", () => {
+    assert.equal(
+      checkPurity(`
+        declare function log(x: number): void;
+        function f(arr: number[]) {
+          return arr.filter(x => { log(x); return x > 0; });
+        }
+      `),
+      false,
+    );
+  });
+
+  // --- Tier 1b: Effect-TS ---
+
+  it("should return true for Effect-returning function", () => {
+    // Simulate Effect type via structural branded type
+    assert.equal(
+      checkPurity(`
+        interface Effect<A, E, R> {
+          readonly EffectTypeId: unique symbol;
+          readonly _A: A;
+          readonly _E: E;
+          readonly _R: R;
+        }
+        declare function succeed<A>(value: A): Effect<A, never, never>;
+        function f(x: number) { return succeed(x); }
+      `),
+      true,
+    );
+  });
+
+  it("should return false for Effect.runSync", () => {
+    // Even if it returns Effect, runSync is impure
+    assert.equal(
+      checkPurity(`
+        interface Effect<A, E, R> {
+          readonly EffectTypeId: unique symbol;
+          readonly _A: A;
+          readonly _E: E;
+          readonly _R: R;
+        }
+        declare const Effect: {
+          runSync<A>(effect: Effect<A, never, never>): A;
+        };
+        declare const eff: Effect<number, never, never>;
+        function f() { return Effect.runSync(eff); }
+      `),
+      false,
+    );
+  });
+
+  it("should return true for pipe from effect/Function", () => {
+    assert.equal(
+      checkPurity(`
+        declare function pipe<A, B>(a: A, f: (a: A) => B): B;
+        function f(x: number) { return pipe(x, n => n + 1); }
+      `),
+      true,
+    );
+  });
+
+  // --- Tier 1c: Conservative default ---
+
+  it("should return false for unknown function", () => {
+    assert.equal(
+      checkPurity(`
+        declare function unknownFn(x: number): number;
+        function f(x: number) { return unknownFn(x); }
+      `),
+      false,
+    );
+  });
+});


### PR DESCRIPTION
## Patch 3: Create purity oracle module with allowlist and Effect-TS tier

- Create src/purity.ts with isKnownPureCall(expr: ts.CallExpression, checker: ts.TypeChecker): boolean
- Tier 1a — PURE_NAMESPACES: Set(['Math']) — all methods on these namespaces are pure
- Tier 1a — PURE_METHODS_BY_TYPE: Map with entries for 'string' (indexOf, slice, substring, includes, startsWith, endsWith, trim, toLowerCase, toUpperCase, charAt, charCodeAt, split, replace, replaceAll, repeat, padStart, padEnd, match, search, concat, normalize), 'number' (toFixed, toPrecision, toString, toExponential, toLocaleString)
- Tier 1a — PURE_ARRAY_METHODS: Set(['at', 'concat', 'flat', 'includes', 'indexOf', 'join', 'keys', 'lastIndexOf', 'slice', 'toString', 'values']) — non-mutating, no callback
- Tier 1a — HO_PURE_ARRAY_METHODS: Set(['every', 'filter', 'find', 'findIndex', 'flatMap', 'map', 'reduce', 'reduceRight', 'some']) — pure if callback arg is side-effect-free. For arrow function callbacks, recurse into the body: expression-bodied arrows check the expression; block-bodied arrows with a single return check the return expression. Other callback shapes (function expressions, identifiers) are conservatively treated as impure
- Tier 1b — isEffectReturningCall: check if the callee's return type has the EffectTypeId branded property (structural detection via checker). Known-pure Effect combinators: pipe, flow, identity from effect/Function. Known-IMPURE runners: Effect.runSync, runPromise, runSyncExit, runPromiseExit, runFork — if callee matches a runner, return false even though it may return Effect
- Tier 1c — default: return false (conservative, treat as effectful)
- Use ts.TypeFlags.StringLike and ts.TypeFlags.NumberLike for primitive type detection; checker.isArrayType for arrays
- For namespace detection: check ts.isIdentifier(receiver) && PURE_NAMESPACES.has(receiver.text)
- Create tests/purity.test.mts with unit tests covering each tier
- Create expressions-const-pure-calls.ts fixture with 4+ exported functions: constMathMax (const m = Math.max(a,b); return m+1), constStringMethod (const i = s.indexOf('x'); return i), constChainedPure (const a = Math.abs(x); const b = Math.max(a, y); return b), constImpureCall (const r = unknownFn(x); return r — should still UNSUPPORTED)
- Run npm run test:update-snapshots (pure-call fixtures will initially show rejected-const-binding expectations since purity oracle is not yet wired in)

## Changes
- Create src/purity.ts with isKnownPureCall(expr: ts.CallExpression, checker: ts.TypeChecker): boolean
- Tier 1a — PURE_NAMESPACES: Set(['Math']) — all methods on these namespaces are pure
- Tier 1a — PURE_METHODS_BY_TYPE: Map with entries for 'string' (indexOf, slice, substring, includes, startsWith, endsWith, trim, toLowerCase, toUpperCase, charAt, charCodeAt, split, replace, replaceAll, repeat, padStart, padEnd, match, search, concat, normalize), 'number' (toFixed, toPrecision, toString, toExponential, toLocaleString)
- Tier 1a — PURE_ARRAY_METHODS: Set(['at', 'concat', 'flat', 'includes', 'indexOf', 'join', 'keys', 'lastIndexOf', 'slice', 'toString', 'values']) — non-mutating, no callback
- Tier 1a — HO_PURE_ARRAY_METHODS: Set(['every', 'filter', 'find', 'findIndex', 'flatMap', 'map', 'reduce', 'reduceRight', 'some']) — pure if callback arg is side-effect-free. For arrow function callbacks, recurse into the body: expression-bodied arrows check the expression; block-bodied arrows with a single return check the return expression. Other callback shapes (function expressions, identifiers) are conservatively treated as impure
- Tier 1b — isEffectReturningCall: check if the callee's return type has the EffectTypeId branded property (structural detection via checker). Known-pure Effect combinators: pipe, flow, identity from effect/Function. Known-IMPURE runners: Effect.runSync, runPromise, runSyncExit, runPromiseExit, runFork — if callee matches a runner, return false even though it may return Effect
- Tier 1c — default: return false (conservative, treat as effectful)
- Use ts.TypeFlags.StringLike and ts.TypeFlags.NumberLike for primitive type detection; checker.isArrayType for arrays
- For namespace detection: check ts.isIdentifier(receiver) && PURE_NAMESPACES.has(receiver.text)
- Create tests/purity.test.mts with unit tests covering each tier
- Create expressions-const-pure-calls.ts fixture with 4+ exported functions: constMathMax (const m = Math.max(a,b); return m+1), constStringMethod (const i = s.indexOf('x'); return i), constChainedPure (const a = Math.abs(x); const b = Math.max(a, y); return b), constImpureCall (const r = unknownFn(x); return r — should still UNSUPPORTED)
- Run npm run test:update-snapshots (pure-call fixtures will initially show rejected-const-binding expectations since purity oracle is not yet wired in)

## Implementation Notes

- **`expressionIsPure` is a separate recursive checker, not a wrapper around `expressionHasSideEffects`.** The existing `expressionHasSideEffects` in translate-body.ts returns `true` for all calls unconditionally. Rather than modifying it here (Patch 4's job), the purity module has its own `expressionIsPure` that mirrors the same structure but inverts the polarity: it returns `true` for known-pure expressions and recurses into `isKnownPureCall` for nested calls. This avoids coupling the oracle to translate-body internals.
- **Effect-TS detection uses a three-pronged heuristic** (`EffectTypeId` property, `aliasSymbol.name`, `symbol.name`) rather than just the branded property. In test scenarios with synthetic Effect types (no real `effect` package), the `EffectTypeId` property check alone would suffice, but the symbol/alias fallbacks make detection more robust against aliased or re-exported Effect types in real codebases.
- **Impure runner exclusion is checked early, before return-type detection.** `Effect.runSync(eff)` technically returns a value, not an Effect — but even if a future refactor changed the return type, the runner names are categorically impure. Checking method name against `EFFECT_IMPURE_RUNNERS` before falling through to `isEffectReturningCall` avoids any false-positive risk.
- **`isEffectReturningCall` wraps TypeChecker calls in try/catch.** `getResolvedSignature` can throw on malformed or incomplete AST nodes; the conservative fallback is `false` (impure).
- **No deviations from the plan.** All spec clauses map directly: tier dispatch in `isKnownPureCall` → `pure?`/`tier` rules; `expressionIsPure` recursion on arrow bodies → the arrow-purity opinion; fixture snapshots showing UNSUPPORTED → correct pre-wiring state for Patch 4.

## Gameplan Specification

```
module TS2PANT_GENERAL_CALLS.

> After milestone 2: general call translation + purity oracle.
> Ref: Kroening & Strichman, Decision Procedures, Ch. 4 (EUF).
> Ref: Cousot & Cousot, Abstract Interpretation, POPL 1977.
> Ref: Lucassen & Gifford, Polymorphic Effect Systems, POPL 1988.

CallExpression.
ConstBinding.
PurityTier.

builtin-allowlist => PurityTier.
effect-ts-aware => PurityTier.
conservative-default => PurityTier.

special-cased? c: CallExpression => Bool.
has-spread? c: CallExpression => Bool.
identifier-callee? c: CallExpression => Bool.
prop-access-callee? c: CallExpression => Bool.
translated? c: CallExpression => Bool.
rejected? c: CallExpression => Bool.
tier c: CallExpression => PurityTier.
pure? c: CallExpression => Bool.
initializer b: ConstBinding => CallExpression.
inlineable? b: ConstBinding => Bool.

---

> Every call expression has a definite translation outcome.
all c: CallExpression |
  translated? c or rejected? c.

> Special cases always translate.
all c: CallExpression, special-cased? c |
  translated? c.

> General calls with known callee shape and no spread translate.
all c: CallExpression, ~special-cased? c, ~has-spread? c |
  (identifier-callee? c or prop-access-callee? c)
  -> translated? c.

> Spread in non-special calls is rejected.
all c: CallExpression, has-spread? c, ~special-cased? c |
  rejected? c.

> Purity tiers: allowlist and effect-ts are pure.
all c: CallExpression, tier c = builtin-allowlist |
  pure? c.

all c: CallExpression, tier c = effect-ts-aware |
  pure? c.

> Conservative default is not pure.
all c: CallExpression, tier c = conservative-default |
  ~pure? c.

> Const bindings with pure call initializers are inlineable.
all b: ConstBinding, pure? (initializer b) |
  inlineable? b.

> Const bindings with impure initializers are not inlineable.
all b: ConstBinding, ~pure? (initializer b) |
  ~inlineable? b.

```

## Patch Specification

```
module TS2PANT_GENERAL_CALLS_PATCH_3.

> Purity oracle: conservative syntactic effect analysis.
> Ref: Cousot & Cousot, Abstract Interpretation, POPL 1977.
> Trivial instance: lattice {pure, effectful}, default = effectful.

CallExpression.
PurityTier.

builtin-allowlist => PurityTier.
effect-ts-aware => PurityTier.
conservative-default => PurityTier.

tier c: CallExpression => PurityTier.
pure? c: CallExpression => Bool.

---

all c: CallExpression, tier c = builtin-allowlist |
  pure? c.

all c: CallExpression, tier c = effect-ts-aware |
  pure? c.

all c: CallExpression, tier c = conservative-default |
  ~pure? c.

```

## Files to Modify
- tools/ts2pant/src/purity.ts (create): Conservative purity oracle. Three tiers: (1a) known-pure builtins allowlist, (1b) Effect-TS type detection, (1c) conservative default. Exports isKnownPureCall.
- tools/ts2pant/tests/purity.test.mts (create): Unit tests for purity oracle: allowlist entries, Effect-TS detection, conservative default, impure runners
- tools/ts2pant/tests/fixtures/constructs/expressions-const-pure-calls.ts (create): Fixture file for pure-call const inlining patterns: Math.max, String.indexOf, chained pure, impure-still-rejected