### PR TITLE
[ts2pant-general-calls] Patch 1: Add test fixtures and unit test stubs for general function calls

### DIFF
--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -103,7 +103,7 @@ exports[`expressions-calls.ts > callInComparison 1`] = `
 `;
 
 exports[`expressions-calls.ts > callWithPropArg 1`] = `
-"module CallWithPropArg.\\n\\nAccount.\\nbalance a1: Account => Int.\\nowner a1: Account => String.\\ncallWithPropArg a: Account => Bool.\\n\\n---\\n\\n> UNSUPPORTED: validate(a).\\n"
+"module CallWithPropArg.\\n\\nAccount.\\nbalance a1: Account => Int.\\nowner a1: Account => String.\\ncallWithPropArg a: Account => Bool.\\n\\n---\\n\\n> UNSUPPORTED: validate(a.balance).\\n"
 `;
 
 exports[`expressions-calls.ts > freeCall 1`] = `

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -94,6 +94,38 @@ exports[`expressions-boolean.ts > or 1`] = `
 "module Or.\\n\\nor a: Bool, b: Bool => Bool.\\n\\n---\\n\\nor a b = (a or b).\\n"
 `;
 
+exports[`expressions-calls.ts > callInArithmetic 1`] = `
+"module CallInArithmetic.\\n\\ncallInArithmetic a: Int, b: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: max(a, b).\\n"
+`;
+
+exports[`expressions-calls.ts > callInComparison 1`] = `
+"module CallInComparison.\\n\\ncallInComparison a: Int, b: Int => Bool.\\n\\n---\\n\\n> UNSUPPORTED: max(a, b).\\n"
+`;
+
+exports[`expressions-calls.ts > callWithPropArg 1`] = `
+"module CallWithPropArg.\\n\\nAccount.\\nbalance a1: Account => Int.\\nowner a1: Account => String.\\ncallWithPropArg a: Account => Bool.\\n\\n---\\n\\n> UNSUPPORTED: validate(a).\\n"
+`;
+
+exports[`expressions-calls.ts > freeCall 1`] = `
+"module FreeCall.\\n\\nfreeCall a: Int, b: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: max(a, b).\\n"
+`;
+
+exports[`expressions-calls.ts > methodCall 1`] = `
+"module MethodCall.\\n\\nmethodCall s: String => String.\\n\\n---\\n\\n> UNSUPPORTED: s.toUpperCase().\\n"
+`;
+
+exports[`expressions-calls.ts > nestedCalls 1`] = `
+"module NestedCalls.\\n\\nnestedCalls x: Int, a: Int, b: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: clamp(x, 0, max(a, b)).\\n"
+`;
+
+exports[`expressions-calls.ts > spreadCall 1`] = `
+"module SpreadCall.\\n\\nspreadCall args: [Int] => Int.\\n\\n---\\n\\n> UNSUPPORTED: max(...args).\\n"
+`;
+
+exports[`expressions-calls.ts > zeroArityCall 1`] = `
+"module ZeroArityCall.\\n\\nzeroArityCall  => Int.\\n\\n---\\n\\n> UNSUPPORTED: now().\\n"
+`;
+
 exports[`expressions-comparison.ts > eq 1`] = `
 "module Eq.\\n\\neq a: Int, b: Int => Bool.\\n\\n---\\n\\neq a b = (a = b).\\n"
 `;

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-calls.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-calls.ts
@@ -9,7 +9,7 @@ interface Account {
   owner: string;
 }
 
-declare function validate(a: Account): boolean;
+declare function validate(balance: number): boolean;
 
 /** free function call with two args */
 export function freeCall(a: number, b: number): number {
@@ -33,7 +33,7 @@ export function callInArithmetic(a: number, b: number): number {
 
 /** call with property access argument */
 export function callWithPropArg(a: Account): boolean {
-  return validate(a);
+  return validate(a.balance);
 }
 
 /** method call: receiver.method(args) */

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-calls.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-calls.ts
@@ -1,0 +1,52 @@
+// General function calls: free calls, method calls, zero-arity, nested, spread
+
+declare function max(a: number, b: number): number;
+declare function now(): number;
+declare function clamp(x: number, lo: number, hi: number): number;
+
+interface Account {
+  balance: number;
+  owner: string;
+}
+
+declare function validate(a: Account): boolean;
+
+/** free function call with two args */
+export function freeCall(a: number, b: number): number {
+  return max(a, b);
+}
+
+/** zero-arity call (no arguments) */
+export function zeroArityCall(): number {
+  return now();
+}
+
+/** nested calls: clamp(x, 0, max(a, b)) */
+export function nestedCalls(x: number, a: number, b: number): number {
+  return clamp(x, 0, max(a, b));
+}
+
+/** call result used in arithmetic */
+export function callInArithmetic(a: number, b: number): number {
+  return max(a, b) + 1;
+}
+
+/** call with property access argument */
+export function callWithPropArg(a: Account): boolean {
+  return validate(a);
+}
+
+/** method call: receiver.method(args) */
+export function methodCall(s: string): string {
+  return s.toUpperCase();
+}
+
+/** call result used in comparison */
+export function callInComparison(a: number, b: number): boolean {
+  return max(a, b) > 0;
+}
+
+/** spread argument in call (should be rejected) */
+export function spreadCall(args: number[]): number {
+  return max(...args);
+}

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -177,3 +177,25 @@ describe("unsupported patterns", () => {
     assert.equal(props[0]?.kind, "unsupported");
   });
 });
+
+describe("translateCallExpr", () => {
+  it.skip("should translate free function call as uninterpreted application", () => {
+    // PENDING: Patch 2
+    // EUF encoding: max(a, b) → 'max a b'
+  });
+
+  it.skip("should translate method call with receiver as first argument", () => {
+    // PENDING: Patch 2
+    // Curried receiver: s.toUpperCase() → 'toUpperCase s'
+  });
+
+  it.skip("should translate zero-arity call as variable reference", () => {
+    // PENDING: Patch 2
+    // 0-arity EUF constant: now() → 'now'
+  });
+
+  it.skip("should reject spread arguments with UNSUPPORTED", () => {
+    // PENDING: Patch 2
+    // Pantagruel has no varargs; spread cannot be resolved to fixed arity
+  });
+});


### PR DESCRIPTION
## Patch 1: Add test fixtures and unit test stubs for general function calls

- Create expressions-calls.ts with 7+ exported functions covering general call patterns
- Each function uses declare'd callees with known signatures so type extraction produces correct declarations
- Run npm run test:update-snapshots to generate initial snapshot expectations (UNSUPPORTED for general calls)
- Add it.skip('translateCallExpr > should translate free function call as uninterpreted application') // PENDING: Patch 2
- Add it.skip('translateCallExpr > should translate method call with receiver as first argument') // PENDING: Patch 2
- Add it.skip('translateCallExpr > should translate zero-arity call as variable reference') // PENDING: Patch 2
- Add it.skip('translateCallExpr > should reject spread arguments with UNSUPPORTED') // PENDING: Patch 2

## Changes
- Create expressions-calls.ts with 7+ exported functions covering general call patterns
- Each function uses declare'd callees with known signatures so type extraction produces correct declarations
- Run npm run test:update-snapshots to generate initial snapshot expectations (UNSUPPORTED for general calls)
- Add it.skip('translateCallExpr > should translate free function call as uninterpreted application') // PENDING: Patch 2
- Add it.skip('translateCallExpr > should translate method call with receiver as first argument') // PENDING: Patch 2
- Add it.skip('translateCallExpr > should translate zero-arity call as variable reference') // PENDING: Patch 2
- Add it.skip('translateCallExpr > should reject spread arguments with UNSUPPORTED') // PENDING: Patch 2

## Gameplan Specification

```
module TS2PANT_GENERAL_CALLS.

> After milestone 2: general call translation + purity oracle.
> Ref: Kroening & Strichman, Decision Procedures, Ch. 4 (EUF).
> Ref: Cousot & Cousot, Abstract Interpretation, POPL 1977.
> Ref: Lucassen & Gifford, Polymorphic Effect Systems, POPL 1988.

CallExpression.
ConstBinding.
PurityTier.

builtin-allowlist => PurityTier.
effect-ts-aware => PurityTier.
conservative-default => PurityTier.

special-cased? c: CallExpression => Bool.
has-spread? c: CallExpression => Bool.
identifier-callee? c: CallExpression => Bool.
prop-access-callee? c: CallExpression => Bool.
translated? c: CallExpression => Bool.
rejected? c: CallExpression => Bool.
tier c: CallExpression => PurityTier.
pure? c: CallExpression => Bool.
initializer b: ConstBinding => CallExpression.
inlineable? b: ConstBinding => Bool.

---

> Every call expression has a definite translation outcome.
all c: CallExpression |
  translated? c or rejected? c.

> Special cases always translate.
all c: CallExpression, special-cased? c |
  translated? c.

> General calls with known callee shape and no spread translate.
all c: CallExpression, ~special-cased? c, ~has-spread? c |
  (identifier-callee? c or prop-access-callee? c)
  -> translated? c.

> Spread in non-special calls is rejected.
all c: CallExpression, has-spread? c, ~special-cased? c |
  rejected? c.

> Purity tiers: allowlist and effect-ts are pure.
all c: CallExpression, tier c = builtin-allowlist |
  pure? c.

all c: CallExpression, tier c = effect-ts-aware |
  pure? c.

> Conservative default is not pure.
all c: CallExpression, tier c = conservative-default |
  ~pure? c.

> Const bindings with pure call initializers are inlineable.
all b: ConstBinding, pure? (initializer b) |
  inlineable? b.

> Const bindings with impure initializers are not inlineable.
all b: ConstBinding, ~pure? (initializer b) |
  ~inlineable? b.

```

## Patch Specification

```
module TS2PANT_GENERAL_CALLS_PATCH_1.

> Test fixtures and stubs only. No behavioral invariants.

CallExpression.

---

```

## Files to Modify
- tools/ts2pant/tests/fixtures/constructs/expressions-calls.ts (create): Fixture file with exported functions exercising general call patterns: freeCall (2-arg), zeroArityCall (0-arg), nestedCalls, callInArithmetic, callWithPropArg, methodCall, callInComparison. Uses declare'd callees.
- tools/ts2pant/tests/translate-body.test.mts (modify): Add skipped unit tests for translateCallExpr edge cases


## Implementation Notes

- Added 8 fixture functions (one more than the spec's 7): included `spreadCall` to exercise the spread-rejection path, since Patch 2 needs a test target for the `has-spread? → rejected?` invariant.
- All `declare`d callees (`max`, `now`, `clamp`, `validate`) have explicit signatures so the snapshot pipeline extracts correct Pantagruel declarations even though the call bodies are currently UNSUPPORTED. This validates that type extraction works independently of body translation.
- `methodCall` uses `s.toUpperCase()` — a built-in `String` method with no `declare` needed. This covers the property-access callee shape distinctly from the identifier callee shape used by free functions.
- Snapshots confirm the existing catch-all at `translateCallExpr` line 938 (`return { unsupported: expr.getText() }`) fires for every non-special call. Patch 2 will replace these UNSUPPORTED baselines with EUF translations.
- The 4 skipped tests in `translate-body.test.mts` are intentionally empty bodies with comments — Patch 2 will fill in the `createSourceFileFromSource` + `translateBody` assertions following the existing test pattern in that file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for call-expression translation scenarios.
  * Added fixtures exporting functions exercising free, zero-arity, nested, arithmetic, comparison, property-arg, method, and spread-call patterns.
  * Added skipped unit tests asserting expected translation behaviors (including rejecting spread args).
  * Appended snapshot entries recording expected outputs (including UNSUPPORTED outcomes for unsupported call shapes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->