### PR TITLE
[ts2pant-general-calls] Patch 2: Implement general function call translation via EUF encoding

### DIFF
--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -932,9 +932,57 @@ function translateCallExpr(
         return result;
       }
     }
+
+    // General method call: obj.method(args) → method obj args (EUF encoding)
+    // Ref: Kroening & Strichman, Decision Procedures, Ch. 4
+    if (expr.arguments.some(ts.isSpreadElement)) {
+      return { unsupported: expr.getText() };
+    }
+    const receiver = translateBodyExpr(
+      tsReceiver,
+      checker,
+      strategy,
+      paramNames,
+    );
+    if (isBodyUnsupported(receiver)) {
+      return receiver;
+    }
+    const methodArgs: OpaqueExpr[] = [bodyExpr(receiver)];
+    for (const arg of expr.arguments) {
+      const a = translateBodyExpr(arg, checker, strategy, paramNames);
+      if (isBodyUnsupported(a)) {
+        return a;
+      }
+      methodArgs.push(bodyExpr(a));
+    }
+    return { expr: ast.app(ast.var(methodName), methodArgs) };
   }
 
-  // Unsupported call
+  // Free function calls: fn(args) → fn args (EUF encoding)
+  if (ts.isIdentifier(expr.expression)) {
+    const fnName = expr.expression.text;
+
+    if (expr.arguments.some(ts.isSpreadElement)) {
+      return { unsupported: expr.getText() };
+    }
+
+    // Zero-arity call → variable reference (EUF constant)
+    if (expr.arguments.length === 0) {
+      return { expr: ast.var(paramNames.get(fnName) ?? fnName) };
+    }
+
+    const fnArgs: OpaqueExpr[] = [];
+    for (const arg of expr.arguments) {
+      const a = translateBodyExpr(arg, checker, strategy, paramNames);
+      if (isBodyUnsupported(a)) {
+        return a;
+      }
+      fnArgs.push(bodyExpr(a));
+    }
+    return { expr: ast.app(ast.var(paramNames.get(fnName) ?? fnName), fnArgs) };
+  }
+
+  // Unsupported call (computed calls, tagged templates, optional calls, etc.)
   return { unsupported: expr.getText() };
 }
 

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -95,27 +95,27 @@ exports[`expressions-boolean.ts > or 1`] = `
 `;
 
 exports[`expressions-calls.ts > callInArithmetic 1`] = `
-"module CallInArithmetic.\\n\\ncallInArithmetic a: Int, b: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: max(a, b).\\n"
+"module CallInArithmetic.\\n\\ncallInArithmetic a: Int, b: Int => Int.\\n\\n---\\n\\ncallInArithmetic a b = max a b + 1.\\n"
 `;
 
 exports[`expressions-calls.ts > callInComparison 1`] = `
-"module CallInComparison.\\n\\ncallInComparison a: Int, b: Int => Bool.\\n\\n---\\n\\n> UNSUPPORTED: max(a, b).\\n"
+"module CallInComparison.\\n\\ncallInComparison a: Int, b: Int => Bool.\\n\\n---\\n\\ncallInComparison a b = (max a b > 0).\\n"
 `;
 
 exports[`expressions-calls.ts > callWithPropArg 1`] = `
-"module CallWithPropArg.\\n\\nAccount.\\nbalance a1: Account => Int.\\nowner a1: Account => String.\\ncallWithPropArg a: Account => Bool.\\n\\n---\\n\\n> UNSUPPORTED: validate(a.balance).\\n"
+"module CallWithPropArg.\\n\\nAccount.\\nbalance a1: Account => Int.\\nowner a1: Account => String.\\ncallWithPropArg a: Account => Bool.\\n\\n---\\n\\ncallWithPropArg a = validate (balance a).\\n"
 `;
 
 exports[`expressions-calls.ts > freeCall 1`] = `
-"module FreeCall.\\n\\nfreeCall a: Int, b: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: max(a, b).\\n"
+"module FreeCall.\\n\\nfreeCall a: Int, b: Int => Int.\\n\\n---\\n\\nfreeCall a b = max a b.\\n"
 `;
 
 exports[`expressions-calls.ts > methodCall 1`] = `
-"module MethodCall.\\n\\nmethodCall s: String => String.\\n\\n---\\n\\n> UNSUPPORTED: s.toUpperCase().\\n"
+"module MethodCall.\\n\\nmethodCall s: String => String.\\n\\n---\\n\\nmethodCall s = toUpperCase s.\\n"
 `;
 
 exports[`expressions-calls.ts > nestedCalls 1`] = `
-"module NestedCalls.\\n\\nnestedCalls x: Int, a: Int, b: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: clamp(x, 0, max(a, b)).\\n"
+"module NestedCalls.\\n\\nnestedCalls x: Int, a: Int, b: Int => Int.\\n\\n---\\n\\nnestedCalls x a b = clamp x 0 (max a b).\\n"
 `;
 
 exports[`expressions-calls.ts > spreadCall 1`] = `
@@ -123,7 +123,7 @@ exports[`expressions-calls.ts > spreadCall 1`] = `
 `;
 
 exports[`expressions-calls.ts > zeroArityCall 1`] = `
-"module ZeroArityCall.\\n\\nzeroArityCall  => Int.\\n\\n---\\n\\n> UNSUPPORTED: now().\\n"
+"module ZeroArityCall.\\n\\nzeroArityCall  => Int.\\n\\n---\\n\\nzeroArityCall = now.\\n"
 `;
 
 exports[`expressions-comparison.ts > eq 1`] = `
@@ -359,15 +359,15 @@ exports[`unsupported.ts > arrowWithLocals 1`] = `
 `;
 
 exports[`unsupported.ts > bubbleCondition 1`] = `
-"module BubbleCondition.\\n\\nbubbleCondition  => Int.\\n\\n---\\n\\n> UNSUPPORTED: bar().\\n"
+"module BubbleCondition.\\n\\nbubbleCondition  => Int.\\n\\n---\\n\\nbubbleCondition = (cond bar => 1, true => 2).\\n"
 `;
 
 exports[`unsupported.ts > bubbleNegation 1`] = `
-"module BubbleNegation.\\n\\nbubbleNegation  => Bool.\\n\\n---\\n\\n> UNSUPPORTED: bar().\\n"
+"module BubbleNegation.\\n\\nbubbleNegation  => Bool.\\n\\n---\\n\\nbubbleNegation = (~bar).\\n"
 `;
 
 exports[`unsupported.ts > callInReturn 1`] = `
-"module CallInReturn.\\n\\ncallInReturn  => Int.\\n\\n---\\n\\n> UNSUPPORTED: foo().\\n"
+"module CallInReturn.\\n\\ncallInReturn  => Int.\\n\\n---\\n\\ncallInReturn = #foo.\\n"
 `;
 
 exports[`unsupported.ts > conditionalAssign 1`] = `

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -179,23 +179,89 @@ describe("unsupported patterns", () => {
 });
 
 describe("translateCallExpr", () => {
-  it.skip("should translate free function call as uninterpreted application", () => {
-    // PENDING: Patch 2
-    // EUF encoding: max(a, b) → 'max a b'
+  it("should translate free function call as uninterpreted application", () => {
+    const source = `
+      declare function max(a: number, b: number): number;
+      function f(a: number, b: number): number {
+        return max(a, b);
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "f",
+      strategy: IntStrategy,
+    });
+
+    assert.equal(props.length, 1);
+    const prop = props[0]!;
+    assert.equal(prop.kind, "equation");
+    if (prop.kind === "equation") {
+      const ast = getAst();
+      assert.equal(ast.strExpr(prop.rhs), "max a b");
+    }
   });
 
-  it.skip("should translate method call with receiver as first argument", () => {
-    // PENDING: Patch 2
-    // Curried receiver: s.toUpperCase() → 'toUpperCase s'
+  it("should translate method call with receiver as first argument", () => {
+    const source = `
+      function f(s: string): string {
+        return s.toUpperCase();
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "f",
+      strategy: IntStrategy,
+    });
+
+    assert.equal(props.length, 1);
+    const prop = props[0]!;
+    assert.equal(prop.kind, "equation");
+    if (prop.kind === "equation") {
+      const ast = getAst();
+      assert.equal(ast.strExpr(prop.rhs), "toUpperCase s");
+    }
   });
 
-  it.skip("should translate zero-arity call as variable reference", () => {
-    // PENDING: Patch 2
-    // 0-arity EUF constant: now() → 'now'
+  it("should translate zero-arity call as variable reference", () => {
+    const source = `
+      declare function now(): number;
+      function f(): number {
+        return now();
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "f",
+      strategy: IntStrategy,
+    });
+
+    assert.equal(props.length, 1);
+    const prop = props[0]!;
+    assert.equal(prop.kind, "equation");
+    if (prop.kind === "equation") {
+      const ast = getAst();
+      assert.equal(ast.strExpr(prop.rhs), "now");
+    }
   });
 
-  it.skip("should reject spread arguments with UNSUPPORTED", () => {
-    // PENDING: Patch 2
-    // Pantagruel has no varargs; spread cannot be resolved to fixed arity
+  it("should reject spread arguments with UNSUPPORTED", () => {
+    const source = `
+      declare function max(...args: number[]): number;
+      function f(args: number[]): number {
+        return max(...args);
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "f",
+      strategy: IntStrategy,
+    });
+
+    assert.equal(props.length, 1);
+    assert.equal(props[0]?.kind, "unsupported");
   });
 });


### PR DESCRIPTION
## Patch 2: Implement general function call translation via EUF encoding

- In translateCallExpr, INSIDE the ts.isPropertyAccessExpression block (after .includes/.filter/.map), add general method call handler: reject spread args, translate receiver and args via translateBodyExpr, return ast.app(ast.var(methodName), [receiver, ...translatedArgs])
- In translateCallExpr, AFTER the property access block, add general free function call handler for ts.isIdentifier callees: reject spread args, if 0 args return ast.var(fnName) (using paramNames mapping), else translate args and return ast.app(ast.var(fnName), translatedArgs)
- Keep final return { unsupported: expr.getText() } for non-identifier, non-property-access callees (computed calls, tagged templates, etc.)
- Unskip and implement 4 unit tests: free call → ast.app, method call → receiver as first arg, zero-arity → ast.var, spread → unsupported
- Run npm run test:update-snapshots — expressions-calls.ts expectations change from UNSUPPORTED to Pantagruel; unsupported.ts expectations for callInReturn/bubbleNegation/bubbleCondition also change

## Changes
- In translateCallExpr, INSIDE the ts.isPropertyAccessExpression block (after .includes/.filter/.map), add general method call handler: reject spread args, translate receiver and args via translateBodyExpr, return ast.app(ast.var(methodName), [receiver, ...translatedArgs])
- In translateCallExpr, AFTER the property access block, add general free function call handler for ts.isIdentifier callees: reject spread args, if 0 args return ast.var(fnName) (using paramNames mapping), else translate args and return ast.app(ast.var(fnName), translatedArgs)
- Keep final return { unsupported: expr.getText() } for non-identifier, non-property-access callees (computed calls, tagged templates, etc.)
- Unskip and implement 4 unit tests: free call → ast.app, method call → receiver as first arg, zero-arity → ast.var, spread → unsupported
- Run npm run test:update-snapshots — expressions-calls.ts expectations change from UNSUPPORTED to Pantagruel; unsupported.ts expectations for callInReturn/bubbleNegation/bubbleCondition also change

## Gameplan Specification

```
module TS2PANT_GENERAL_CALLS.

> After milestone 2: general call translation + purity oracle.
> Ref: Kroening & Strichman, Decision Procedures, Ch. 4 (EUF).
> Ref: Cousot & Cousot, Abstract Interpretation, POPL 1977.
> Ref: Lucassen & Gifford, Polymorphic Effect Systems, POPL 1988.

CallExpression.
ConstBinding.
PurityTier.

builtin-allowlist => PurityTier.
effect-ts-aware => PurityTier.
conservative-default => PurityTier.

special-cased? c: CallExpression => Bool.
has-spread? c: CallExpression => Bool.
identifier-callee? c: CallExpression => Bool.
prop-access-callee? c: CallExpression => Bool.
translated? c: CallExpression => Bool.
rejected? c: CallExpression => Bool.
tier c: CallExpression => PurityTier.
pure? c: CallExpression => Bool.
initializer b: ConstBinding => CallExpression.
inlineable? b: ConstBinding => Bool.

---

> Every call expression has a definite translation outcome.
all c: CallExpression |
  translated? c or rejected? c.

> Special cases always translate.
all c: CallExpression, special-cased? c |
  translated? c.

> General calls with known callee shape and no spread translate.
all c: CallExpression, ~special-cased? c, ~has-spread? c |
  (identifier-callee? c or prop-access-callee? c)
  -> translated? c.

> Spread in non-special calls is rejected.
all c: CallExpression, has-spread? c, ~special-cased? c |
  rejected? c.

> Purity tiers: allowlist and effect-ts are pure.
all c: CallExpression, tier c = builtin-allowlist |
  pure? c.

all c: CallExpression, tier c = effect-ts-aware |
  pure? c.

> Conservative default is not pure.
all c: CallExpression, tier c = conservative-default |
  ~pure? c.

> Const bindings with pure call initializers are inlineable.
all b: ConstBinding, pure? (initializer b) |
  inlineable? b.

> Const bindings with impure initializers are not inlineable.
all b: ConstBinding, ~pure? (initializer b) |
  ~inlineable? b.

```

## Patch Specification

```
module TS2PANT_GENERAL_CALLS_PATCH_2.

> General function calls translate as uninterpreted
> function applications (EUF theory).
> Ref: Kroening & Strichman, Decision Procedures, Ch. 4.

CallExpression.

special-cased? c: CallExpression => Bool.
has-spread? c: CallExpression => Bool.
translated? c: CallExpression => Bool.

---

all c: CallExpression, special-cased? c |
  translated? c.

all c: CallExpression, ~special-cased? c, ~has-spread? c |
  translated? c.

```

## Files to Modify
- tools/ts2pant/src/translate-body.ts (modify): Extend translateCallExpr with general call handlers after special cases
- tools/ts2pant/tests/translate-body.test.mts (modify): Unskip and implement unit tests for general call translation
- tools/ts2pant/tests/constructs.test.mts.snapshot (modify): Snapshot expectations update — general calls now produce translated output

## Implementation Notes
- Both general handlers (method calls and free function calls) iterate arguments with an early-return-on-unsupported loop rather than `map`, matching the existing pattern in the `.includes` handler — this keeps unsupported errors from nested sub-expressions bubbling up correctly (e.g. if a call argument itself contains an untranslatable construct).
- Method call handler builds the args array as `[receiver, ...args]` imperatively (`methodArgs` starts with receiver, then pushes each translated arg) to avoid a second pass or intermediate array allocation.
- The `paramNames` mapping is consulted for free function names (`paramNames.get(fnName) ?? fnName`) to handle the edge case where a function parameter shadows a free function name — consistent with how `translateExpr` resolves identifiers.
- No deviations from the plan. The spec's second clause (`~special-cased? c, ~has-spread? c → translated? c`) is satisfied because both the identifier-callee and prop-access-callee paths produce `ast.app`/`ast.var` results, and anything else falls through to the unchanged `{ unsupported: ... }` return (which only fires for computed callees like `obj[key]()` — not covered by the spec's `identifier-callee? or prop-access-callee?` precondition in the gameplan spec, but correctly rejected here).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Function and method calls are now properly translated to executable code instead of generating unsupported placeholders.
  * Zero-arity function calls are now correctly handled.

* **Tests**
  * Enhanced test coverage for call expression translation scenarios, activating previously pending test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->