### PR TITLE
[ts2pant-general-calls] Patch 4: Wire purity oracle into expressionHasSideEffects for const inlining

### DIFF
--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -2,6 +2,7 @@ import type { SourceFile } from "ts-morph";
 import ts from "typescript";
 import type { OpaqueExpr, OpaqueParam } from "./pant-ast.js";
 import { getAst } from "./pant-wasm.js";
+import { isKnownPureCall } from "./purity.js";
 import {
   classifyFunction,
   findFunction,
@@ -247,7 +248,7 @@ function extractReturnExpression(
         return null;
       }
       // Reject effectful initializers
-      if (expressionHasSideEffects(decl.initializer)) {
+      if (expressionHasSideEffects(decl.initializer, checker)) {
         return null;
       }
       bindings.push({ name: decl.name.text, initializer: decl.initializer });
@@ -285,7 +286,10 @@ function describeRejectedBody(body: ts.Block, checker: ts.TypeChecker): string {
           return "let/var bindings not supported";
         }
         for (const decl of declList.declarations) {
-          if (decl.initializer && expressionHasSideEffects(decl.initializer)) {
+          if (
+            decl.initializer &&
+            expressionHasSideEffects(decl.initializer, checker)
+          ) {
             return "const binding with side-effectful initializer";
           }
         }
@@ -398,16 +402,16 @@ function isGuardStatement(
     return false;
   }
   // if (...) { throw } without else
-  if (!stmt.elseStatement && blockThrows(stmt.thenStatement)) {
+  if (!stmt.elseStatement && blockThrows(stmt.thenStatement, checker)) {
     return true;
   }
   // if (...) { ... } else { throw }
-  if (stmt.elseStatement && blockThrows(stmt.elseStatement)) {
+  if (stmt.elseStatement && blockThrows(stmt.elseStatement, checker)) {
     // Only a guard if the then-block has no side effects and doesn't return.
     // A mutating then-branch like `if (ok) { a.balance = 1; } else { throw e; }`
     // must NOT be classified as a guard — collectAssignments() needs to see it.
     return (
-      blockHasNoSideEffects(stmt.thenStatement) &&
+      blockHasNoSideEffects(stmt.thenStatement, checker) &&
       !blockReturns(stmt.thenStatement)
     );
   }
@@ -416,13 +420,15 @@ function isGuardStatement(
 
 function variableStatementHasNoSideEffects(
   stmt: ts.VariableStatement,
+  checker: ts.TypeChecker,
 ): boolean {
   return stmt.declarationList.declarations.every(
-    (decl) => !decl.initializer || !expressionHasSideEffects(decl.initializer),
+    (decl) =>
+      !decl.initializer || !expressionHasSideEffects(decl.initializer, checker),
   );
 }
 
-function blockThrows(node: ts.Statement): boolean {
+function blockThrows(node: ts.Statement, checker: ts.TypeChecker): boolean {
   if (ts.isThrowStatement(node)) {
     return true;
   }
@@ -440,7 +446,8 @@ function blockThrows(node: ts.Statement): boolean {
       .slice(0, -1)
       .every(
         (s) =>
-          ts.isVariableStatement(s) && variableStatementHasNoSideEffects(s),
+          ts.isVariableStatement(s) &&
+          variableStatementHasNoSideEffects(s, checker),
       );
   }
   return false;
@@ -454,16 +461,19 @@ function blockReturns(node: ts.Statement): boolean {
 }
 
 /** Check that a statement/block contains no assignments or property writes. */
-function blockHasNoSideEffects(node: ts.Statement): boolean {
+function blockHasNoSideEffects(
+  node: ts.Statement,
+  checker: ts.TypeChecker,
+): boolean {
   if (ts.isBlock(node)) {
-    return node.statements.every((s) => blockHasNoSideEffects(s));
+    return node.statements.every((s) => blockHasNoSideEffects(s, checker));
   }
   if (ts.isExpressionStatement(node)) {
-    return !expressionHasSideEffects(node.expression);
+    return !expressionHasSideEffects(node.expression, checker);
   }
   // Variable declarations are fine only if initializers have no side effects
   if (ts.isVariableStatement(node)) {
-    return variableStatementHasNoSideEffects(node);
+    return variableStatementHasNoSideEffects(node, checker);
   }
   // Return statements, throw statements are fine
   if (ts.isReturnStatement(node) || ts.isThrowStatement(node)) {
@@ -509,7 +519,10 @@ function unwrapExpression(expr: ts.Expression): ts.Expression {
   return expr;
 }
 
-function expressionHasSideEffects(expr: ts.Expression): boolean {
+function expressionHasSideEffects(
+  expr: ts.Expression,
+  checker: ts.TypeChecker,
+): boolean {
   expr = unwrapExpression(expr);
 
   if (ts.isDeleteExpression(expr)) {
@@ -521,11 +534,14 @@ function expressionHasSideEffects(expr: ts.Expression): boolean {
     return (
       (expr.operatorToken.kind >= ts.SyntaxKind.EqualsToken &&
         expr.operatorToken.kind <= ts.SyntaxKind.CaretEqualsToken) ||
-      expressionHasSideEffects(expr.left) ||
-      expressionHasSideEffects(expr.right)
+      expressionHasSideEffects(expr.left, checker) ||
+      expressionHasSideEffects(expr.right, checker)
     );
   }
   if (ts.isCallExpression(expr)) {
+    if (isKnownPureCall(expr, checker)) {
+      return expr.arguments.some((a) => expressionHasSideEffects(a, checker));
+    }
     return true;
   }
   if (ts.isNewExpression(expr) || ts.isAwaitExpression(expr)) {
@@ -536,12 +552,12 @@ function expressionHasSideEffects(expr: ts.Expression): boolean {
     return (
       op === ts.SyntaxKind.PlusPlusToken ||
       op === ts.SyntaxKind.MinusMinusToken ||
-      expressionHasSideEffects(expr.operand)
+      expressionHasSideEffects(expr.operand, checker)
     );
   }
   return (
     ts.forEachChild(expr, (child) =>
-      ts.isExpression(child) ? expressionHasSideEffects(child) : false,
+      ts.isExpression(child) ? expressionHasSideEffects(child, checker) : false,
     ) ?? false
   );
 }
@@ -1104,7 +1120,7 @@ function collectAssignments(
           if (
             !ts.isIdentifier(decl.name) ||
             !decl.initializer ||
-            expressionHasSideEffects(decl.initializer)
+            expressionHasSideEffects(decl.initializer, checker)
           ) {
             allPure = false;
             break;
@@ -1192,7 +1208,7 @@ function collectAssignments(
 
     if (
       ts.isExpressionStatement(stmt) &&
-      expressionHasSideEffects(stmt.expression)
+      expressionHasSideEffects(stmt.expression, checker)
     ) {
       propositions.push({
         kind: "unsupported",
@@ -1205,7 +1221,8 @@ function collectAssignments(
     if (
       ts.isVariableStatement(stmt) &&
       stmt.declarationList.declarations.some(
-        (d) => d.initializer && expressionHasSideEffects(d.initializer),
+        (d) =>
+          d.initializer && expressionHasSideEffects(d.initializer, checker),
       )
     ) {
       propositions.push({
@@ -1219,7 +1236,7 @@ function collectAssignments(
     if (
       (ts.isReturnStatement(stmt) || ts.isThrowStatement(stmt)) &&
       stmt.expression &&
-      expressionHasSideEffects(stmt.expression)
+      expressionHasSideEffects(stmt.expression, checker)
     ) {
       propositions.push({
         kind: "unsupported",

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -175,7 +175,7 @@ exports[`expressions-const-bindings.ts > simpleConst 1`] = `
 `;
 
 exports[`expressions-const-pure-calls.ts > constChainedPure 1`] = `
-"module ConstChainedPure.\\n\\nconstChainedPure x: Int, y: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: constChainedPure — const binding with side-effectful initializer.\\n"
+"module ConstChainedPure.\\n\\nconstChainedPure x: Int, y: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: constChainedPure — Math.abs(x).\\n"
 `;
 
 exports[`expressions-const-pure-calls.ts > constImpureCall 1`] = `
@@ -183,11 +183,11 @@ exports[`expressions-const-pure-calls.ts > constImpureCall 1`] = `
 `;
 
 exports[`expressions-const-pure-calls.ts > constMathMax 1`] = `
-"module ConstMathMax.\\n\\nconstMathMax a: Int, b: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: constMathMax — const binding with side-effectful initializer.\\n"
+"module ConstMathMax.\\n\\nconstMathMax a: Int, b: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: constMathMax — Math.max(a, b).\\n"
 `;
 
 exports[`expressions-const-pure-calls.ts > constStringMethod 1`] = `
-"module ConstStringMethod.\\n\\nconstStringMethod s: String => Int.\\n\\n---\\n\\n> UNSUPPORTED: constStringMethod — const binding with side-effectful initializer.\\n"
+"module ConstStringMethod.\\n\\nconstStringMethod s: String => Int.\\n\\n---\\n\\n> UNSUPPORTED: constStringMethod — s.indexOf(\\"x\\").\\n"
 `;
 
 exports[`expressions-literals.ts > fortyTwo 1`] = `


### PR DESCRIPTION
## Patch 4: Wire purity oracle into expressionHasSideEffects for const inlining

- Import isKnownPureCall from ./purity.js in translate-body.ts
- Change expressionHasSideEffects signature to (expr: ts.Expression, checker: ts.TypeChecker): boolean — checker is REQUIRED, not optional
- In the ts.isCallExpression branch (line 528): delegate to isKnownPureCall. If known pure, check argument purity recursively: return expr.arguments.some(a => expressionHasSideEffects(a, checker)). If not known pure, return true
- Thread checker through ALL recursive expressionHasSideEffects calls: binary expressions, prefix/postfix, and the forEachChild fallback
- Update ALL call sites to pass checker: extractReturnExpression (thread from translateBody), collectAssignments (already has checker), isGuardStatement (already has checker), variableStatementHasNoSideEffects (add checker param), blockHasNoSideEffects (add checker param), isPureExpression in translate-signature.ts (add checker param if it calls expressionHasSideEffects, or inline the check)
- Run npm run test:update-snapshots — expressions-const-pure-calls.ts expectations now show inlined-and-translated output for pure calls; impure call fixture still shows rejected
- Verify existing const-binding tests in expressions-const-bindings.ts are unchanged (no calls in those fixtures)

## Changes
- Import isKnownPureCall from ./purity.js in translate-body.ts
- Change expressionHasSideEffects signature to (expr: ts.Expression, checker: ts.TypeChecker): boolean — checker is REQUIRED, not optional
- In the ts.isCallExpression branch (line 528): delegate to isKnownPureCall. If known pure, check argument purity recursively: return expr.arguments.some(a => expressionHasSideEffects(a, checker)). If not known pure, return true
- Thread checker through ALL recursive expressionHasSideEffects calls: binary expressions, prefix/postfix, and the forEachChild fallback
- Update ALL call sites to pass checker: extractReturnExpression (thread from translateBody), collectAssignments (already has checker), isGuardStatement (already has checker), variableStatementHasNoSideEffects (add checker param), blockHasNoSideEffects (add checker param), isPureExpression in translate-signature.ts (add checker param if it calls expressionHasSideEffects, or inline the check)
- Run npm run test:update-snapshots — expressions-const-pure-calls.ts expectations now show inlined-and-translated output for pure calls; impure call fixture still shows rejected
- Verify existing const-binding tests in expressions-const-bindings.ts are unchanged (no calls in those fixtures)

## Gameplan Specification

```
module TS2PANT_GENERAL_CALLS.

> After milestone 2: general call translation + purity oracle.
> Ref: Kroening & Strichman, Decision Procedures, Ch. 4 (EUF).
> Ref: Cousot & Cousot, Abstract Interpretation, POPL 1977.
> Ref: Lucassen & Gifford, Polymorphic Effect Systems, POPL 1988.

CallExpression.
ConstBinding.
PurityTier.

builtin-allowlist => PurityTier.
effect-ts-aware => PurityTier.
conservative-default => PurityTier.

special-cased? c: CallExpression => Bool.
has-spread? c: CallExpression => Bool.
identifier-callee? c: CallExpression => Bool.
prop-access-callee? c: CallExpression => Bool.
translated? c: CallExpression => Bool.
rejected? c: CallExpression => Bool.
tier c: CallExpression => PurityTier.
pure? c: CallExpression => Bool.
initializer b: ConstBinding => CallExpression.
inlineable? b: ConstBinding => Bool.

---

> Every call expression has a definite translation outcome.
all c: CallExpression |
  translated? c or rejected? c.

> Special cases always translate.
all c: CallExpression, special-cased? c |
  translated? c.

> General calls with known callee shape and no spread translate.
all c: CallExpression, ~special-cased? c, ~has-spread? c |
  (identifier-callee? c or prop-access-callee? c)
  -> translated? c.

> Spread in non-special calls is rejected.
all c: CallExpression, has-spread? c, ~special-cased? c |
  rejected? c.

> Purity tiers: allowlist and effect-ts are pure.
all c: CallExpression, tier c = builtin-allowlist |
  pure? c.

all c: CallExpression, tier c = effect-ts-aware |
  pure? c.

> Conservative default is not pure.
all c: CallExpression, tier c = conservative-default |
  ~pure? c.

> Const bindings with pure call initializers are inlineable.
all b: ConstBinding, pure? (initializer b) |
  inlineable? b.

> Const bindings with impure initializers are not inlineable.
all b: ConstBinding, ~pure? (initializer b) |
  ~inlineable? b.

```

## Patch Specification

```
module TS2PANT_GENERAL_CALLS_PATCH_4.

> Purity oracle wired into const-binding inlining.
> Pure calls in const initializers are now inlineable.

ConstBinding.
CallExpression.

pure? c: CallExpression => Bool.
initializer b: ConstBinding => CallExpression.
inlineable? b: ConstBinding => Bool.

---

> Const bindings with pure call initializers are inlineable.
all b: ConstBinding, pure? (initializer b) |
  inlineable? b.

> Const bindings with impure initializers are not inlineable.
all b: ConstBinding, ~pure? (initializer b) |
  ~inlineable? b.

```

## Files to Modify
- tools/ts2pant/src/translate-body.ts (modify): Make checker a required parameter on expressionHasSideEffects. For CallExpression nodes, delegate to isKnownPureCall. Thread checker through all call sites — every caller must provide it.
- tools/ts2pant/tests/constructs.test.mts.snapshot (modify): Snapshot expectations for expressions-const-pure-calls.ts change from rejected to translated output

## Implementation Notes

- **`isPureExpression` in translate-signature.ts was not modified.** The plan mentioned it as a potential call site, but it has its own independent purity notion (strictly no calls allowed) and does not call `expressionHasSideEffects`. No changes needed there.
- **`blockThrows` also required `checker` threading** — not called out in the plan, but it calls `variableStatementHasNoSideEffects` which now requires `checker`. The cascade was: `isGuardStatement` → `blockThrows` → `variableStatementHasNoSideEffects` → `expressionHasSideEffects`.
- **Snapshot changes show partial progress, not full translation.** Pure calls now pass the side-effect gate (const inlining succeeds), but since Patch 2 (general call translation via EUF encoding) is not yet merged into this branch, the inlined call expressions hit the catch-all `return { unsupported: expr.getText() }` in `translateCallExpr`. So the UNSUPPORTED reason shifts from "const binding with side-effectful initializer" to the call text itself (e.g., `Math.max(a, b)`). Once Patches 2–4 are stacked, these will translate fully.
- **Pre-existing e2e test failures** in this worktree (missing OCaml `parsexp` library) are unrelated to this patch — confirmed by verifying the same 2 failures exist on the base branch.
