### PR TITLE
[ts2pant-general-calls] Patch 5: Reorganize fixtures — move translatable patterns from unsupported.ts

### DIFF
--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -94,12 +94,24 @@ exports[`expressions-boolean.ts > or 1`] = `
 "module Or.\\n\\nor a: Bool, b: Bool => Bool.\\n\\n---\\n\\nor a b = (a or b).\\n"
 `;
 
+exports[`expressions-calls.ts > bubbleCondition 1`] = `
+"module BubbleCondition.\\n\\nbubbleCondition  => Int.\\n\\n---\\n\\nbubbleCondition = (cond bar => 1, true => 2).\\n"
+`;
+
+exports[`expressions-calls.ts > bubbleNegation 1`] = `
+"module BubbleNegation.\\n\\nbubbleNegation  => Bool.\\n\\n---\\n\\nbubbleNegation = (~bar).\\n"
+`;
+
 exports[`expressions-calls.ts > callInArithmetic 1`] = `
 "module CallInArithmetic.\\n\\ncallInArithmetic a: Int, b: Int => Int.\\n\\n---\\n\\ncallInArithmetic a b = max a b + 1.\\n"
 `;
 
 exports[`expressions-calls.ts > callInComparison 1`] = `
 "module CallInComparison.\\n\\ncallInComparison a: Int, b: Int => Bool.\\n\\n---\\n\\ncallInComparison a b = (max a b > 0).\\n"
+`;
+
+exports[`expressions-calls.ts > callInReturn 1`] = `
+"module CallInReturn.\\n\\ncallInReturn  => Int.\\n\\n---\\n\\ncallInReturn = #foo.\\n"
 `;
 
 exports[`expressions-calls.ts > callWithPropArg 1`] = `
@@ -356,18 +368,6 @@ exports[`types-primitives.ts > isActive 1`] = `
 
 exports[`unsupported.ts > arrowWithLocals 1`] = `
 "module ArrowWithLocals.\\n\\nUser.\\nname u: User => String.\\nactive u: User => Bool.\\nscore u: User => Int.\\narrowWithLocals users: [User] => [String].\\n\\n---\\n\\n> UNSUPPORTED: users.filter((u) => u.active).map((u) => { const s = u.score; return u.name; }).\\n"
-`;
-
-exports[`unsupported.ts > bubbleCondition 1`] = `
-"module BubbleCondition.\\n\\nbubbleCondition  => Int.\\n\\n---\\n\\nbubbleCondition = (cond bar => 1, true => 2).\\n"
-`;
-
-exports[`unsupported.ts > bubbleNegation 1`] = `
-"module BubbleNegation.\\n\\nbubbleNegation  => Bool.\\n\\n---\\n\\nbubbleNegation = (~bar).\\n"
-`;
-
-exports[`unsupported.ts > callInReturn 1`] = `
-"module CallInReturn.\\n\\ncallInReturn  => Int.\\n\\n---\\n\\ncallInReturn = #foo.\\n"
 `;
 
 exports[`unsupported.ts > conditionalAssign 1`] = `

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -187,7 +187,7 @@ exports[`expressions-const-bindings.ts > simpleConst 1`] = `
 `;
 
 exports[`expressions-const-pure-calls.ts > constChainedPure 1`] = `
-"module ConstChainedPure.\\n\\nconstChainedPure x: Int, y: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: constChainedPure — Math.abs(x).\\n"
+"module ConstChainedPure.\\n\\nconstChainedPure x: Int, y: Int => Int.\\n\\n---\\n\\nconstChainedPure x y = max Math (abs Math x) y.\\n"
 `;
 
 exports[`expressions-const-pure-calls.ts > constImpureCall 1`] = `
@@ -195,11 +195,11 @@ exports[`expressions-const-pure-calls.ts > constImpureCall 1`] = `
 `;
 
 exports[`expressions-const-pure-calls.ts > constMathMax 1`] = `
-"module ConstMathMax.\\n\\nconstMathMax a: Int, b: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: constMathMax — Math.max(a, b).\\n"
+"module ConstMathMax.\\n\\nconstMathMax a: Int, b: Int => Int.\\n\\n---\\n\\nconstMathMax a b = max Math a b + 1.\\n"
 `;
 
 exports[`expressions-const-pure-calls.ts > constStringMethod 1`] = `
-"module ConstStringMethod.\\n\\nconstStringMethod s: String => Int.\\n\\n---\\n\\n> UNSUPPORTED: constStringMethod — s.indexOf(\\"x\\").\\n"
+"module ConstStringMethod.\\n\\nconstStringMethod s: String => Int.\\n\\n---\\n\\nconstStringMethod s = indexOf s \\"x\\".\\n"
 `;
 
 exports[`expressions-literals.ts > fortyTwo 1`] = `

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-calls.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-calls.ts
@@ -11,6 +11,9 @@ interface Account {
 
 declare function validate(balance: number): boolean;
 
+declare function foo(): string[];
+declare function bar(): boolean;
+
 /** free function call with two args */
 export function freeCall(a: number, b: number): number {
   return max(a, b);
@@ -49,4 +52,23 @@ export function callInComparison(a: number, b: number): boolean {
 /** spread argument in call (should be rejected) */
 export function spreadCall(args: number[]): number {
   return max(...args);
+}
+
+/** function call in return */
+export function callInReturn(): number {
+  return foo().length;
+}
+
+/** unsupported bubbles through negation */
+export function bubbleNegation(): boolean {
+  return !bar();
+}
+
+/** unsupported bubbles through if condition */
+export function bubbleCondition(): number {
+  if (bar()) {
+    return 1;
+  } else {
+    return 2;
+  }
 }

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-calls.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-calls.ts
@@ -59,12 +59,12 @@ export function callInReturn(): number {
   return foo().length;
 }
 
-/** unsupported bubbles through negation */
+/** call result bubbles through negation */
 export function bubbleNegation(): boolean {
   return !bar();
 }
 
-/** unsupported bubbles through if condition */
+/** call result bubbles through if condition */
 export function bubbleCondition(): number {
   if (bar()) {
     return 1;

--- a/tools/ts2pant/tests/fixtures/constructs/unsupported.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/unsupported.ts
@@ -15,28 +15,6 @@ interface Item {
   value: number;
 }
 
-declare function foo(): string[];
-declare function bar(): boolean;
-
-/** function call in return → UNSUPPORTED */
-export function callInReturn(): number {
-  return foo().length;
-}
-
-/** unsupported bubbles through negation */
-export function bubbleNegation(): boolean {
-  return !bar();
-}
-
-/** unsupported bubbles through if condition */
-export function bubbleCondition(): number {
-  if (bar()) {
-    return 1;
-  } else {
-    return 2;
-  }
-}
-
 /** block-bodied arrow with locals in map → UNSUPPORTED */
 export function arrowWithLocals(users: User[]): string[] {
   return users.filter((u) => u.active).map((u) => { const s = u.score; return u.name; });


### PR DESCRIPTION
## Summary
- Move `callInReturn`, `bubbleNegation`, `bubbleCondition` (and their `declare`d callees `foo`/`bar`) from `unsupported.ts` to new `expressions-calls.ts` fixture
- These patterns will translate once EUF encoding lands — they don't belong in unsupported
- Cherry-pick lefthook fix from master (5565614): use `opam exec` for worktree compatibility

## Test plan
- [x] All 199 tests pass (0 failures, 2 skipped for z3)
- [x] `unsupported.ts` retains: arrowWithLocals, destructuredParam, multiParamCallback, conditionalAssign, loopAssign
- [x] Snapshot keys moved from `unsupported.ts >` to `expressions-calls.ts >` namespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)