### PR TITLE
Add structural + property tests for the SMT translator; fix bind_head_params over-quantification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Install OCaml dependencies
         working-directory: .
         run: |
-          opam install . --deps-only --with-test
+          opam install . --deps-only
           opam install js_of_ocaml js_of_ocaml-ppx wasm_of_ocaml-compiler
 
       - name: Build pant

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
           opam exec -- dune exec fuzz/fuzz_lexer.exe
           opam exec -- dune exec fuzz/fuzz_parser.exe
           opam exec -- dune exec fuzz/fuzz_pipeline.exe
+          opam exec -- dune exec fuzz/fuzz_smt.exe
 
       - name: Check samples
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Build pant
         working-directory: .
-        run: opam exec -- dune build
+        run: opam exec -- dune build @install
 
       - name: Build wasm for ts2pant
         run: opam exec -- npm run build:wasm

--- a/fuzz/dune
+++ b/fuzz/dune
@@ -19,3 +19,7 @@
 (executable
  (name fuzz_pipeline)
  (libraries pantagruel crowbar))
+
+(executable
+ (name fuzz_smt)
+ (libraries pantagruel smt_check crowbar))

--- a/fuzz/fuzz_smt.ml
+++ b/fuzz/fuzz_smt.ml
@@ -13,10 +13,9 @@
 
 open Pantagruel
 
-(* Same allowlist as test_smt_property.ml. Keep these in sync; once a bug is
-   fixed, drop the corresponding kinds from BOTH lists. *)
-let kinds_pending_fix =
-  [ "duplicate_binder"; "vacuous_binder"; "fallback_emission" ]
+(* Same allowlist as test_smt_property.ml. Keep these in sync; re-add a kind
+   here only when a new known-pending translator bug appears. *)
+let kinds_pending_fix : string list = []
 
 let translate_and_check (doc : Ast.document) =
   let mod_name = Option.fold ~none:"" ~some:Ast.upper_name doc.module_name in

--- a/fuzz/fuzz_smt.ml
+++ b/fuzz/fuzz_smt.ml
@@ -1,0 +1,63 @@
+(** Fuzz the Pantagruel→SMT translator end-to-end. Catches:
+
+    - Crashes in the translator on type-checking input (via the bare
+      [try...with]).
+    - Malformed emitted SMT (via [Smt_check.parse_smt2]).
+    - Unbounded fallback emissions of new (unknown) kinds — the known set
+      mirrors the one in [test_smt_property.ml].
+
+    Mirrors [fuzz_pipeline.ml]: feed [Crowbar.bytes] through the parser, run
+    [Collect.collect_all] and [Check.check_document], and only assert invariants
+    if those succeeded. Parse/collect errors don't count as finds; only
+    translator-stage crashes or malformed SMT do. *)
+
+open Pantagruel
+
+(* Same allowlist as test_smt_property.ml. Keep these in sync; once a bug is
+   fixed, drop the corresponding kinds from BOTH lists. *)
+let kinds_pending_fix =
+  [ "duplicate_binder"; "vacuous_binder"; "fallback_emission" ]
+
+let translate_and_check (doc : Ast.document) =
+  let mod_name = Option.fold ~none:"" ~some:Ast.upper_name doc.module_name in
+  match Collect.collect_all ~base_env:(Env.empty mod_name) doc with
+  | Error _ -> ()
+  | Ok env -> (
+      match Check.check_document env doc with
+      | Error _ -> ()
+      | Ok _ ->
+          let domain_bounds = Smt.compute_domain_bounds 3 env in
+          let config =
+            Smt.make_config ~bound:3 ~steps:1 ~domain_bounds ~inject_guards:true
+          in
+          let queries = Smt.generate_queries config env doc in
+          List.iter
+            (fun (q : Smt.query) ->
+              (* Well-formedness: must parse as sexps. *)
+              (match Smt_check.parse_smt2 q.smt2 with
+              | Ok _ -> ()
+              | Error msg ->
+                  Crowbar.failf "malformed SMT in query %S: %s" q.name msg);
+              (* Structural failures: only the allowlisted kinds are
+                 tolerated. *)
+              List.iter
+                (fun (f : Smt_check.failure) ->
+                  let tag = Smt_check.failure_kind_tag f.kind in
+                  if not (List.mem tag kinds_pending_fix) then
+                    Crowbar.failf "unexpected SMT failure in %S: %s" q.name
+                      (Smt_check.format_failure f))
+                (Smt_check.check_query q.smt2))
+            queries)
+
+let () =
+  Crowbar.add_test ~name:"smt_no_crash_or_malformed" [ Crowbar.bytes ]
+    (fun input ->
+      try
+        let lexer = Lexer.create_from_string "<fuzz>" input in
+        let supplier = Lexer.menhir_token lexer in
+        let doc =
+          MenhirLib.Convert.Simplified.traditional2revised Parser.document
+            supplier
+        in
+        translate_and_check doc
+      with _ -> ())

--- a/lib/smt.ml
+++ b/lib/smt.ml
@@ -316,15 +316,19 @@ and translate_card config env e =
           Printf.sprintf "(+ %s)" (String.concat " " terms)
       | Ok (TyList _elem_ty) ->
           (* Non-domain list: element type is unbounded (e.g., Int) so
-             cardinality can't be computed in bounded model checking. Emit 0
-             as an approximation. We deliberately omit any inline ';'
-             comments — SMTLIB line comments run to end-of-line and would
-             swallow the surrounding context's closing parens / annotations. *)
+             cardinality can't be computed in bounded model checking. Emit a
+             fresh non-negative integer constant so the gap is visible to
+             downstream tooling rather than silently constrained to 0. *)
           let _ = set_str in
-          "0"
+          let name = fresh_fallback ~kind:"card" ~sort:"Int" in
+          add_fallback_assert (Printf.sprintf "(>= %s 0)" name);
+          name
       | _ ->
-          (* Can't determine element type at all *)
-          "0")
+          (* Can't determine element type at all — same fallback. *)
+          let _ = set_str in
+          let name = fresh_fallback ~kind:"card" ~sort:"Int" in
+          add_fallback_assert (Printf.sprintf "(>= %s 0)" name);
+          name)
 
 and translate_forall_comprehension config env params guards body =
   (* Standalone comprehension: (all x: D | f x) → array where exactly
@@ -735,8 +739,11 @@ and translate_cond config env = function[@warning "-4"]
 and translate_override _config _env name _pairs =
   (* Standalone override (not applied) — can't be directly represented in
      SMT-LIB2 without higher-order functions. Applied overrides are handled
-     in translate_app. *)
-  Printf.sprintf "<<override:%s>>" (sanitize_ident name)
+     in translate_app. Emit a fresh constant so the gap is visible to
+     downstream tooling rather than emitting a malformed token. The base
+     function name is recorded only for debug context. *)
+  let _ = name in
+  fresh_fallback ~kind:"override" ~sort:"Int"
 
 (** Translate a proposition expression to SMT, injecting guards from guarded
     function applications. For quantified expressions, delegates to

--- a/lib/smt_doc.ml
+++ b/lib/smt_doc.ml
@@ -57,13 +57,89 @@ let classify_chapter (chapter : chapter) =
 
 let classify_chapters (doc : document) = List.map classify_chapter doc.chapters
 
-(** Wrap a proposition in a universal quantifier over the given head bindings.
-    Always wraps, even if the proposition is already quantified, because inner
-    quantifiers may still reference head-level variables. *)
+module StringSet = Set.Make (String)
+(** [free_vars e] is the set of [lower_ident] names that appear free in [e].
+    Used by [bind_head_params] to decide which head-level rule parameters
+    actually need to be universally quantified for a given proposition. *)
+
+let free_vars (e : expr) : StringSet.t =
+  let bound_of_params (params : param list) =
+    List.fold_left
+      (fun s (p : param) -> StringSet.add (Ast.lower_name p.param_name) s)
+      StringSet.empty params
+  in
+  let rec go acc = function
+    | EVar (Lower n) | EPrimed (Lower n) -> StringSet.add n acc
+    | ELitNat _ | ELitReal _ | ELitString _ | ELitBool _ | EDomain _
+    | EQualified _ ->
+        acc
+    | EApp (f, args) -> List.fold_left go (go acc f) args
+    | ETuple exprs -> List.fold_left go acc exprs
+    | EProj (e, _) -> go acc e
+    | EBinop (_, e1, e2) -> go (go acc e1) e2
+    | EUnop (_, e) -> go acc e
+    | EOverride (Lower n, pairs) ->
+        let acc = StringSet.add n acc in
+        List.fold_left (fun acc (k, v) -> go (go acc k) v) acc pairs
+    | EForall (params, guards, body) | EExists (params, guards, body) ->
+        scope_quantifier acc params guards body
+    | EEach (params, guards, _comb, body) ->
+        scope_quantifier acc params guards body
+    | ECond arms -> List.fold_left (fun acc (g, c) -> go (go acc g) c) acc arms
+    | EInitially e -> go acc e
+  and scope_quantifier acc params guards body =
+    let initial_bound = bound_of_params params in
+    let final_bound, guard_free = scan_guards initial_bound guards in
+    let body_free = go StringSet.empty body in
+    let local_free =
+      StringSet.union guard_free (StringSet.diff body_free final_bound)
+    in
+    StringSet.union acc local_free
+  and scan_guards initial_bound guards =
+    List.fold_left
+      (fun (bound, acc) g ->
+        match g with
+        | GParam p -> (StringSet.add (Ast.lower_name p.param_name) bound, acc)
+        | GIn (Lower n, list_expr) ->
+            (* List expression is evaluated in the OUTER scope: its free
+               vars are filtered only by names bound BEFORE this guard. *)
+            let list_free =
+              StringSet.diff (go StringSet.empty list_expr) bound
+            in
+            (StringSet.add n bound, StringSet.union acc list_free)
+        | GExpr e ->
+            let e_free = StringSet.diff (go StringSet.empty e) bound in
+            (bound, StringSet.union acc e_free))
+      (initial_bound, StringSet.empty)
+      guards
+  in
+  go StringSet.empty e
+
+(** Wrap a proposition in a universal quantifier over the head bindings that
+    actually appear free in the proposition. Deduplicates by parameter name
+    (first declaration wins) so that chapters declaring multiple rules with a
+    shared parameter name don't introduce duplicate quantifier binders. Always
+    wraps when at least one binding survives the filter, even if the proposition
+    is itself quantified — inner quantifiers may still reference head-level
+    variables. *)
 let bind_head_params (bindings : param list) (p : expr located) =
   match bindings with
   | [] -> p
-  | _ -> { p with value = EForall (bindings, [], p.value) }
+  | _ -> (
+      let free = free_vars p.value in
+      let _, kept_rev =
+        List.fold_left
+          (fun (seen, acc) (param : param) ->
+            let name = Ast.lower_name param.param_name in
+            if StringSet.mem name seen then (seen, acc)
+            else if not (StringSet.mem name free) then (seen, acc)
+            else (StringSet.add name seen, param :: acc))
+          (StringSet.empty, []) bindings
+      in
+      let kept = List.rev kept_rev in
+      match kept with
+      | [] -> p
+      | _ -> { p with value = EForall (kept, [], p.value) })
 
 (** Collect all invariants from the document (non-initially propositions) *)
 let collect_invariants chapters =

--- a/lib/smt_types.ml
+++ b/lib/smt_types.ml
@@ -46,23 +46,27 @@ let drain_cond_aux_decls () =
   if decls = [] then ""
   else "\n; --- Cond default constants ---\n" ^ String.concat "\n" decls ^ "\n"
 
-(** Insert accumulated cond-default declarations into a finished SMT-LIB2
-    string, right before the first [(assert ...)]. Must be called after all
-    [translate_*] calls for this query are done. *)
-let insert_cond_aux_decls smt2 =
-  let decls = drain_cond_aux_decls () in
+(** Splice [decls] into [smt2] right before the first [(assert ...)] line. Used
+    to inject accumulated auxiliary declarations after the per-query translator
+    has already produced the body text. *)
+let splice_before_first_assert smt2 decls =
   if decls = "" then smt2
   else
     let lines = String.split_on_char '\n' smt2 in
-    let rec split_at_assert acc = function
+    let rec split acc = function
       | [] -> (List.rev acc, [])
       | line :: rest
         when String.length line >= 7 && String.sub line 0 7 = "(assert" ->
           (List.rev acc, line :: rest)
-      | line :: rest -> split_at_assert (line :: acc) rest
+      | line :: rest -> split (line :: acc) rest
     in
-    let before, after = split_at_assert [] lines in
+    let before, after = split [] lines in
     String.concat "\n" before ^ decls ^ String.concat "\n" after
+
+(** Insert accumulated cond-default declarations into a finished SMT-LIB2
+    string. Must be called after all [translate_*] calls for the query. *)
+let insert_cond_aux_decls smt2 =
+  splice_before_first_assert smt2 (drain_cond_aux_decls ())
 
 (** Fresh uninterpreted constants for translation fallbacks. When a translation
     site cannot produce a faithful SMT term (e.g. cardinality of a list over an
@@ -99,22 +103,9 @@ let drain_fallback_decls () =
   if decls = [] then ""
   else "\n; --- Fallback constants ---\n" ^ String.concat "\n" decls ^ "\n"
 
-(** Insert accumulated fallback declarations into a finished SMT-LIB2 string,
-    right before the first [(assert ...)]. Mirrors [insert_cond_aux_decls]. *)
+(** Insert accumulated fallback declarations into a finished SMT-LIB2 string. *)
 let insert_fallback_decls smt2 =
-  let decls = drain_fallback_decls () in
-  if decls = "" then smt2
-  else
-    let lines = String.split_on_char '\n' smt2 in
-    let rec split_at_assert acc = function
-      | [] -> (List.rev acc, [])
-      | line :: rest
-        when String.length line >= 7 && String.sub line 0 7 = "(assert" ->
-          (List.rev acc, line :: rest)
-      | line :: rest -> split_at_assert (line :: acc) rest
-    in
-    let before, after = split_at_assert [] lines in
-    String.concat "\n" before ^ decls ^ String.concat "\n" after
+  splice_before_first_assert smt2 (drain_fallback_decls ())
 
 (** Compute per-domain minimum bounds by counting nullary constants. For each
     domain, the bound is max(default_bound, number_of_nullary_constants). *)

--- a/lib/smt_types.ml
+++ b/lib/smt_types.ml
@@ -64,6 +64,58 @@ let insert_cond_aux_decls smt2 =
     let before, after = split_at_assert [] lines in
     String.concat "\n" before ^ decls ^ String.concat "\n" after
 
+(** Fresh uninterpreted constants for translation fallbacks. When a translation
+    site cannot produce a faithful SMT term (e.g. cardinality of a list over an
+    unbounded element type, or a standalone first-class override that has no
+    direct SMT-LIB encoding), it emits a fresh constant of the appropriate sort
+    and uses its name in place of the silent literal it would otherwise emit.
+    The named constants make the approximation visible to downstream tooling (in
+    particular, the structural checks in [test/smt_check.ml]). *)
+let fallback_counter = ref 0
+
+let fallback_decls : string list ref = ref []
+
+let reset_fallbacks () =
+  fallback_counter := 0;
+  fallback_decls := []
+
+let fresh_fallback ~kind ~sort =
+  let n = !fallback_counter in
+  incr fallback_counter;
+  let name = Printf.sprintf "_%s_fallback_%d" kind n in
+  fallback_decls :=
+    Printf.sprintf "(declare-const %s %s)" name sort :: !fallback_decls;
+  name
+
+(** Queue an additional [(assert ...)] alongside the most recently declared
+    fallback constant — useful for soft constraints like non-negativity. *)
+let add_fallback_assert assertion_body =
+  fallback_decls :=
+    Printf.sprintf "(assert %s)" assertion_body :: !fallback_decls
+
+let drain_fallback_decls () =
+  let decls = List.rev !fallback_decls in
+  fallback_decls := [];
+  if decls = [] then ""
+  else "\n; --- Fallback constants ---\n" ^ String.concat "\n" decls ^ "\n"
+
+(** Insert accumulated fallback declarations into a finished SMT-LIB2 string,
+    right before the first [(assert ...)]. Mirrors [insert_cond_aux_decls]. *)
+let insert_fallback_decls smt2 =
+  let decls = drain_fallback_decls () in
+  if decls = "" then smt2
+  else
+    let lines = String.split_on_char '\n' smt2 in
+    let rec split_at_assert acc = function
+      | [] -> (List.rev acc, [])
+      | line :: rest
+        when String.length line >= 7 && String.sub line 0 7 = "(assert" ->
+          (List.rev acc, line :: rest)
+      | line :: rest -> split_at_assert (line :: acc) rest
+    in
+    let before, after = split_at_assert [] lines in
+    String.concat "\n" before ^ decls ^ String.concat "\n" after
+
 (** Compute per-domain minimum bounds by counting nullary constants. For each
     domain, the bound is max(default_bound, number_of_nullary_constants). *)
 let compute_domain_bounds default_bound env =
@@ -176,9 +228,11 @@ let sanitize_ident name =
       match c with '-' -> '_' | '?' -> 'p' | '!' -> 'b' | _ -> c)
   |> String.of_seq
 
-(** Wrap a query generator: reset cond-aux state, run the generator, and insert
-    any accumulated cond-default declarations into the output. *)
+(** Wrap a query generator: reset per-query auxiliary state (cond defaults and
+    fallback constants), run the generator, and insert any accumulated
+    declarations into the output. *)
 let with_cond_aux f =
   reset_cond_aux ();
+  reset_fallbacks ();
   let q = f () in
-  { q with smt2 = insert_cond_aux_decls q.smt2 }
+  { q with smt2 = q.smt2 |> insert_cond_aux_decls |> insert_fallback_decls }

--- a/test/dune
+++ b/test/dune
@@ -5,6 +5,11 @@
  (preprocess
   (pps sedlex.ppx)))
 
+(library
+ (name smt_check)
+ (libraries pantagruel sexplib0 parsexp)
+ (modules smt_check))
+
 (tests
  (names
   test_lexer
@@ -19,13 +24,18 @@
   test_solver
   test_error
   test_e2e
-  test_module)
- (modules :standard \ test_util)
- (libraries pantagruel test_util alcotest qcheck-alcotest)
+  test_module
+  test_smt_invariants
+  test_smt_property)
+ (modules :standard \ test_util smt_check)
+ (libraries pantagruel test_util smt_check alcotest qcheck-alcotest)
  (deps
   (glob_files ../samples/*.pant)
+  (glob_files ../samples/smt-examples/*.pant)
   (glob_files snapshots/json/*.json)
   (glob_files snapshots/pretty/*.pant)
-  (glob_files snapshots/markdown/*.md))
+  (glob_files snapshots/markdown/*.md)
+  (glob_files regression/*.pant)
+  regression/expected_failures.txt)
  (preprocess
   (pps sedlex.ppx)))

--- a/test/regression/bug_card_zero.pant
+++ b/test/regression/bug_card_zero.pant
@@ -1,0 +1,16 @@
+module BUG_CARD_ZERO.
+
+> Regression fixture for the translate_card silent-zero bug
+> (lib/smt.ml:317-324). Cardinality of a non-domain element list (here
+> [Real]) used to translate to literal `0`, producing a false UNSAT for
+> `#v = dim` combined with the `dim: Nat` constraint. After the fallback
+> instrumentation (lib/smt_types.ml `fresh_fallback`) the translator now
+> emits a fresh `_card_fallback_N` constant; Layer 1 reports a
+> Fallback_emission failure so the approximation is visible.
+
+dim => Nat.
+v => [Real].
+---
+
+> True invariant; should be jointly satisfiable, not contradictory.
+#v = dim.

--- a/test/regression/bug_overquantify.pant
+++ b/test/regression/bug_overquantify.pant
@@ -1,0 +1,20 @@
+module BUG_OVERQUANTIFY.
+
+> Regression fixture for the bind_head_params over-quantification bug
+> (lib/smt_doc.ml:46-66). Two rules in one chapter head share parameter
+> name `n`, and the body has its own quantifier referencing `x` only.
+> Expected: SMT translation wraps the body in `(forall ((n A) (n A) (k A))
+> ...)` — duplicate binders and unused vars. Layer 1 must report
+> Duplicate_binder and Vacuous_binder failures on this fixture.
+> When the bug is fixed, this fixture must produce a clean translation
+> with no structural failures.
+
+A.
+B.
+
+f n: A => B.
+g n: A, k: A => B.
+---
+
+> Body has its own quantifier; should NOT pull in n/k from rules.
+all x: A | x = x.

--- a/test/regression/bug_overquantify.pant
+++ b/test/regression/bug_overquantify.pant
@@ -1,13 +1,14 @@
 module BUG_OVERQUANTIFY.
 
 > Regression fixture for the bind_head_params over-quantification bug
-> (lib/smt_doc.ml:46-66). Two rules in one chapter head share parameter
-> name `n`, and the body has its own quantifier referencing `x` only.
-> Expected: SMT translation wraps the body in `(forall ((n A) (n A) (k A))
-> ...)` — duplicate binders and unused vars. Layer 1 must report
-> Duplicate_binder and Vacuous_binder failures on this fixture.
-> When the bug is fixed, this fixture must produce a clean translation
-> with no structural failures.
+> (previously lib/smt_doc.ml:46-66). Two rules in one chapter head share
+> parameter name `n`, and the body has its own quantifier referencing `x`
+> only. Before the fix, SMT translation wrapped the body in
+> `(forall ((n A) (n A) (k A)) ...)` — duplicate binders and unused vars.
+> The fix in lib/smt_doc.ml filters head bindings to those that appear
+> free in the proposition and dedupes by name; this fixture must now
+> translate cleanly with no structural failures. The corresponding
+> regression test asserts an empty failure list.
 
 A.
 B.

--- a/test/regression/expected_failures.txt
+++ b/test/regression/expected_failures.txt
@@ -1,0 +1,42 @@
+# Layer 1 (test_smt_invariants) allowlist of known-pending structural failures
+# in the sample corpus. Format:
+#
+#   <fixture_basename>:<failure_kind>[,<failure_kind>...]
+#
+# Failure kinds (must match the kind tag emitted by Smt_check.failure_kind_tag):
+#   parse_error
+#   duplicate_binder
+#   vacuous_binder
+#   fallback_emission
+#
+# When a tracked bug is fixed, remove the corresponding entries. The harness
+# fails if an allowlist entry does not correspond to an actual failure
+# (so stale entries are caught immediately).
+#
+# Bugs currently tracked:
+#   1. bind_head_params over-quantifies invariants (lib/smt_doc.ml:46-66) —
+#      causes duplicate_binder and/or vacuous_binder on chapters that declare
+#      multiple rules sharing parameter names.
+#   2. translate_card non-domain fallback (lib/smt.ml:317-327) — emits a
+#      named fallback constant for cardinality of [Real] / [Int] / etc;
+#      flagged as fallback_emission until callers stop relying on the
+#      approximation.
+
+# Bug 1: bind_head_params over-quantifies invariants in chapters that
+# declare multiple rules whose parameters share names — every body
+# proposition gets wrapped in a (forall (... duplicate binders ...) ...).
+# Removing these entries is the acceptance test for the bug fix.
+01-basics.pant:duplicate_binder,vacuous_binder
+03-types.pant:vacuous_binder
+04-operators.pant:duplicate_binder,vacuous_binder
+05-state.pant:vacuous_binder
+06-advanced.pant:vacuous_binder
+07-pantagruel.pant:duplicate_binder,vacuous_binder
+08-contexts.pant:duplicate_binder
+10-cond.pant:duplicate_binder
+11-over-each.pant:duplicate_binder,vacuous_binder
+game.pant:vacuous_binder
+guarded-frame.pant:duplicate_binder
+non-exhaustive-cond.pant:duplicate_binder
+over-each-ok.pant:vacuous_binder
+underspecified.pant:duplicate_binder

--- a/test/regression/expected_failures.txt
+++ b/test/regression/expected_failures.txt
@@ -22,21 +22,5 @@
 #      flagged as fallback_emission until callers stop relying on the
 #      approximation.
 
-# Bug 1: bind_head_params over-quantifies invariants in chapters that
-# declare multiple rules whose parameters share names — every body
-# proposition gets wrapped in a (forall (... duplicate binders ...) ...).
-# Removing these entries is the acceptance test for the bug fix.
-01-basics.pant:duplicate_binder,vacuous_binder
-03-types.pant:vacuous_binder
-04-operators.pant:duplicate_binder,vacuous_binder
-05-state.pant:vacuous_binder
-06-advanced.pant:vacuous_binder
-07-pantagruel.pant:duplicate_binder,vacuous_binder
-08-contexts.pant:duplicate_binder
-10-cond.pant:duplicate_binder
-11-over-each.pant:duplicate_binder,vacuous_binder
-game.pant:vacuous_binder
-guarded-frame.pant:duplicate_binder
-non-exhaustive-cond.pant:duplicate_binder
-over-each-ok.pant:vacuous_binder
-underspecified.pant:duplicate_binder
+# (No entries currently. Bug 1 — bind_head_params over-quantification —
+# was fixed; sample fixtures pass cleanly.)

--- a/test/smt_check.ml
+++ b/test/smt_check.ml
@@ -163,9 +163,19 @@ let free_atoms (sexp : Sexp.t) : StringSet.t =
             let bound' =
               List.fold_left (fun s n -> StringSet.add n s) bound names
             in
-            (* Descend into the binding sorts too — those are atoms but
-               typically refer to declared sorts (like a Domain name). *)
-            let acc = go bound acc bindings in
+            (* Descend only into binding sort terms, not binder names. *)
+            let acc =
+              match[@warning "-4"] bindings with
+              | Sexp.List binders ->
+                  List.fold_left
+                    (fun acc b ->
+                      match[@warning "-4"] b with
+                      | Sexp.List (_name :: sort_terms) ->
+                          List.fold_left (go bound) acc sort_terms
+                      | _ -> acc)
+                    acc binders
+              | _ -> acc
+            in
             go bound' acc body
         | [ Sexp.Atom "let"; bindings; body ] ->
             (* (let ((x e1) (y e2)) body) — bindings are scoped only in body *)
@@ -221,7 +231,16 @@ let fallback_kind_of_atom s =
       if
         String.length rest > String.length suffix
         && String.sub rest 0 (String.length suffix) = suffix
-      then Some kind
+      then
+        let counter =
+          String.sub rest (String.length suffix)
+            (String.length rest - String.length suffix)
+        in
+        let is_all_digits t =
+          String.length t > 0
+          && String.to_seq t |> Seq.for_all (fun c -> c >= '0' && c <= '9')
+        in
+        if is_all_digits counter then Some kind else None
       else None
     with Not_found -> None
 

--- a/test/smt_check.ml
+++ b/test/smt_check.ml
@@ -255,6 +255,9 @@ let collect_failures (sexps : Sexp.t list) : failure list =
     if not (body_is_trivial body) then
       let body_free = free_atoms body in
       let any_used = List.exists (fun n -> StringSet.mem n body_free) names in
+      (* Flag partial vacuity (some binders used, some not) but not total
+         vacuity (no binders used) — the latter is caught by body_is_trivial
+         for literal bodies and is otherwise a tolerated edge case. *)
       if any_used then
         List.iter
           (fun name ->

--- a/test/smt_check.ml
+++ b/test/smt_check.ml
@@ -14,13 +14,6 @@ let failure_kind_tag = function
   | Vacuous_binder -> "vacuous_binder"
   | Fallback_emission -> "fallback_emission"
 
-let failure_kind_of_tag = function
-  | "parse_error" -> Some Parse_error
-  | "duplicate_binder" -> Some Duplicate_binder
-  | "vacuous_binder" -> Some Vacuous_binder
-  | "fallback_emission" -> Some Fallback_emission
-  | _ -> None
-
 type failure = { kind : failure_kind; message : string }
 
 let format_failure { kind; message } =
@@ -197,58 +190,16 @@ let free_atoms (sexp : Sexp.t) : StringSet.t =
   in
   go StringSet.empty StringSet.empty sexp
 
-(** Iterate over every [(forall ...)] / [(exists ...)] form, calling [visit]
-    with [(quant_kind, bindings_sexp, body_sexp)]. Recurses through the entire
-    sexp tree including inside the body. *)
-let iter_quantifiers (sexp : Sexp.t)
-    (visit : string -> Sexp.t -> Sexp.t -> unit) =
-  let rec go = function
-    | Sexp.Atom _ -> ()
-    | Sexp.List items ->
-        (match[@warning "-4"] items with
-        | [ Sexp.Atom (("forall" | "exists") as q); bindings; body ] ->
-            visit q bindings body
-        | _ -> ());
-        List.iter go items
-  in
-  go sexp
-
 (* ------------------------------------------------------------------ *)
-(* Individual checks.                                                   *)
+(* Per-quantifier and per-atom checks, fused into one tree walk.        *)
 (* ------------------------------------------------------------------ *)
 
-(** Quantifier binders must be unique within their introducing form. *)
-let check_no_duplicate_binders (sexps : Sexp.t list) : failure list =
-  let failures = ref [] in
-  List.iter
-    (fun sexp ->
-      iter_quantifiers sexp (fun q bindings _body ->
-          let names = binder_names bindings in
-          let seen = Hashtbl.create 8 in
-          List.iter
-            (fun name ->
-              if Hashtbl.mem seen name then
-                failures :=
-                  {
-                    kind = Duplicate_binder;
-                    message =
-                      Printf.sprintf
-                        "%s introduces duplicate binder %S in (%s (%s) ...)" q
-                        name q (Sexp.to_string bindings);
-                  }
-                  :: !failures
-              else Hashtbl.add seen name ())
-            names))
-    sexps;
-  List.rev !failures
-
-(** A body that consists entirely of a single literal/constant atom is
-    "trivially vacuous": the user explicitly wrote [all x: T | true] or similar.
-    Faithful translation preserves the no-op binders, but they are not a
-    translator bug. We also peel one layer of [(=> antecedent consequent)] —
-    quantifiers over [Nat]/[Nat0] are translated to
-    [(forall ((n Int)) (=> (>= n 1) <user-body>))], so the literal sits inside
-    an implication that's not user-authored. *)
+(** A body that consists of a single literal/constant atom is "trivially
+    vacuous": the user explicitly wrote [all x: T | true]. Faithful translation
+    preserves the no-op binders, which is not a translator bug. We peel one
+    layer of [(=> antecedent consequent)] because quantifiers over [Nat]/[Nat0]
+    are translated to [(forall ((n Int)) (=> (>= n 1) <user-body>))], putting
+    any literal inside an implication the translator inserted, not the user. *)
 let rec body_is_trivial = function
   | Sexp.Atom a ->
       a = "true" || a = "false" || is_numeric_literal a || is_string_literal a
@@ -256,88 +207,91 @@ let rec body_is_trivial = function
       body_is_trivial consequent
   | Sexp.List _ -> false
 
-(** Every quantifier binder must appear free somewhere in its body. The check is
-    designed to catch translator-introduced spurious binders, not user-authored
-    deliberate tautologies. We skip:
+(** Atoms emitted by [Smt_types.fresh_fallback] have the shape
+    [_<kind>_fallback_<N>]. *)
+let fallback_kind_of_atom s =
+  let suffix = "_fallback_" in
+  let len = String.length s in
+  if len < 1 + String.length suffix + 1 || s.[0] <> '_' then None
+  else
+    try
+      let i = String.index_from s 1 '_' in
+      let kind = String.sub s 1 (i - 1) in
+      let rest = String.sub s i (len - i) in
+      if
+        String.length rest > String.length suffix
+        && String.sub rest 0 (String.length suffix) = suffix
+      then Some kind
+      else None
+    with Not_found -> None
 
-    - bodies that are a trivial literal (peeling one [(=>)] layer to handle
-      Nat/Nat0 type-constraint antecedents the translator inserts);
-    - quantifiers where NO binder is used. Total vacuity is intentional
-      ([all c: Color | true] is a non-emptiness tautology); partial vacuity
-      ([all x: T, y: U | g x] with [y] unused) is what the check is for and
-      remains flagged. *)
-let check_no_vacuous_binders (sexps : Sexp.t list) : failure list =
+(** Visit every quantifier and every atom in [sexps] in a single pass and
+    accumulate failures from all structural checks:
+    - duplicate binders within one [(forall ...)] / [(exists ...)] form
+    - vacuous binders (with the [body_is_trivial] / total-vacuity carve-outs)
+    - fallback-constant emissions (deduplicated). *)
+let collect_failures (sexps : Sexp.t list) : failure list =
   let failures = ref [] in
-  List.iter
-    (fun sexp ->
-      iter_quantifiers sexp (fun q bindings body ->
-          if body_is_trivial body then ()
-          else
-            let names = binder_names bindings in
-            let body_free = free_atoms body in
-            let any_used =
-              List.exists (fun n -> StringSet.mem n body_free) names
-            in
-            if any_used then
-              List.iter
-                (fun name ->
-                  if not (StringSet.mem name body_free) then
-                    failures :=
-                      {
-                        kind = Vacuous_binder;
-                        message =
-                          Printf.sprintf
-                            "%s binds %S but it does not appear free in body" q
-                            name;
-                      }
-                      :: !failures)
-                names))
-    sexps;
-  List.rev !failures
-
-(** Detect uses of the translator's named-fallback constants. The naming
-    convention is [_<kind>_fallback_N]. We scan all atoms in all sexps. *)
-let check_no_fallback_emissions (sexps : Sexp.t list) : failure list =
-  (* Atoms emitted by [Smt_types.fresh_fallback] have the shape
-     [_<kind>_fallback_<N>]. Extract the kind by splitting on `_`. *)
-  let suffix_marker = "_fallback_" in
-  let fallback_kind_of_atom s =
-    let len = String.length s in
-    if len < 1 + String.length suffix_marker + 1 then None
-    else if s.[0] <> '_' then None
-    else
-      try
-        let i = String.index_from s 1 '_' in
-        let kind = String.sub s 1 (i - 1) in
-        let rest = String.sub s i (len - i) in
-        if
-          String.length rest > String.length suffix_marker
-          && String.sub rest 0 (String.length suffix_marker) = suffix_marker
-        then Some kind
-        else None
-      with Not_found -> None
+  let push f = failures := f :: !failures in
+  let seen_fallbacks : (string * string, unit) Hashtbl.t = Hashtbl.create 4 in
+  let check_quantifier q bindings body =
+    let names = binder_names bindings in
+    (* duplicate binders *)
+    let seen = Hashtbl.create 8 in
+    List.iter
+      (fun name ->
+        if Hashtbl.mem seen name then
+          push
+            {
+              kind = Duplicate_binder;
+              message =
+                Printf.sprintf
+                  "%s introduces duplicate binder %S in (%s (%s) ...)" q name q
+                  (Sexp.to_string bindings);
+            }
+        else Hashtbl.add seen name ())
+      names;
+    (* vacuous binders *)
+    if not (body_is_trivial body) then
+      let body_free = free_atoms body in
+      let any_used = List.exists (fun n -> StringSet.mem n body_free) names in
+      if any_used then
+        List.iter
+          (fun name ->
+            if not (StringSet.mem name body_free) then
+              push
+                {
+                  kind = Vacuous_binder;
+                  message =
+                    Printf.sprintf
+                      "%s binds %S but it does not appear free in body" q name;
+                })
+          names
   in
-  let seen : (string * string, unit) Hashtbl.t = Hashtbl.create 4 in
   let rec walk = function
     | Sexp.Atom a -> (
         match fallback_kind_of_atom a with
+        | None -> ()
         | Some kind ->
-            if not (Hashtbl.mem seen (kind, a)) then
-              Hashtbl.add seen (kind, a) ()
-        | None -> ())
-    | Sexp.List items -> List.iter walk items
+            if not (Hashtbl.mem seen_fallbacks (kind, a)) then begin
+              Hashtbl.add seen_fallbacks (kind, a) ();
+              push
+                {
+                  kind = Fallback_emission;
+                  message =
+                    Printf.sprintf
+                      "kind=%s constant=%s (translator approximation)" kind a;
+                }
+            end)
+    | Sexp.List items ->
+        (match[@warning "-4"] items with
+        | [ Sexp.Atom (("forall" | "exists") as q); bindings; body ] ->
+            check_quantifier q bindings body
+        | _ -> ());
+        List.iter walk items
   in
   List.iter walk sexps;
-  Hashtbl.fold
-    (fun (kind, atom) () acc ->
-      {
-        kind = Fallback_emission;
-        message =
-          Printf.sprintf "kind=%s constant=%s (translator approximation)" kind
-            atom;
-      }
-      :: acc)
-    seen []
+  List.rev !failures
 
 (* ------------------------------------------------------------------ *)
 (* Public entry point.                                                  *)
@@ -347,10 +301,4 @@ let check_query (smt2 : string) : failure list =
   match parse_smt2 smt2 with
   | Error msg ->
       [ { kind = Parse_error; message = Printf.sprintf "parsexp: %s" msg } ]
-  | Ok sexps ->
-      check_no_duplicate_binders sexps
-      @ check_no_vacuous_binders sexps
-      @ check_no_fallback_emissions sexps
-
-let check_queries (smt2s : string list) : failure list =
-  List.concat_map check_query smt2s
+  | Ok sexps -> collect_failures sexps

--- a/test/smt_check.ml
+++ b/test/smt_check.ml
@@ -1,0 +1,329 @@
+(** Structural sanity checks on emitted SMT-LIB2. See [smt_check.mli]. *)
+
+module Sexp = Sexplib0.Sexp
+
+type failure_kind =
+  | Parse_error
+  | Duplicate_binder
+  | Vacuous_binder
+  | Fallback_emission
+
+let failure_kind_tag = function
+  | Parse_error -> "parse_error"
+  | Duplicate_binder -> "duplicate_binder"
+  | Vacuous_binder -> "vacuous_binder"
+  | Fallback_emission -> "fallback_emission"
+
+let failure_kind_of_tag = function
+  | "parse_error" -> Some Parse_error
+  | "duplicate_binder" -> Some Duplicate_binder
+  | "vacuous_binder" -> Some Vacuous_binder
+  | "fallback_emission" -> Some Fallback_emission
+  | _ -> None
+
+type failure = { kind : failure_kind; message : string }
+
+let format_failure { kind; message } =
+  Printf.sprintf "[%s] %s" (failure_kind_tag kind) message
+
+(* ------------------------------------------------------------------ *)
+(* Sexp parsing — wraps Parsexp with a uniform error shape.            *)
+(* ------------------------------------------------------------------ *)
+
+let parse_smt2 (smt2 : string) : (Sexp.t list, string) result =
+  match Parsexp.Many.parse_string smt2 with
+  | Ok sexps -> Ok sexps
+  | Error err -> Error (Parsexp.Parse_error.message err)
+
+(* ------------------------------------------------------------------ *)
+(* SMT-LIB2 keyword set — atoms in this set are not free variables.    *)
+(* The set is conservative: anything the translator emits as a fixed   *)
+(* operator/keyword goes here. Identifiers from the user's spec or     *)
+(* declared functions are NOT in this set, so they show up as free.    *)
+(* ------------------------------------------------------------------ *)
+
+module StringSet = Set.Make (String)
+
+let smt_keywords =
+  StringSet.of_list
+    [
+      (* logical *)
+      "and";
+      "or";
+      "not";
+      "=>";
+      "xor";
+      "ite";
+      "true";
+      "false";
+      "=";
+      (* arithmetic *)
+      "+";
+      "-";
+      "*";
+      "/";
+      "div";
+      "mod";
+      "abs";
+      (* comparisons *)
+      "<";
+      ">";
+      "<=";
+      ">=";
+      (* arrays *)
+      "select";
+      "store";
+      "as";
+      "const";
+      (* binders *)
+      "forall";
+      "exists";
+      "let";
+      "match";
+      (* commands (don't appear inside terms but harmless to include) *)
+      "assert";
+      "check-sat";
+      "declare-const";
+      "declare-fun";
+      "declare-sort";
+      "define-fun";
+      "set-option";
+      "set-info";
+      "set-logic";
+      "get-value";
+      "get-unsat-core";
+      "get-model";
+      "push";
+      "pop";
+      "echo";
+      "exit";
+      (* annotations *)
+      "!";
+      ":named";
+      (* sorts that may appear as atoms *)
+      "Bool";
+      "Int";
+      "Real";
+      "String";
+      "Array";
+      (* datatypes *)
+      "declare-datatype";
+      "declare-datatypes";
+    ]
+
+let is_numeric_literal s =
+  let len = String.length s in
+  if len = 0 then false
+  else
+    let i = if s.[0] = '-' && len > 1 then 1 else 0 in
+    let rec loop saw_dot j =
+      if j >= len then j > i
+      else
+        match s.[j] with
+        | '0' .. '9' -> loop saw_dot (j + 1)
+        | '.' when not saw_dot -> loop true (j + 1)
+        | _ -> false
+    in
+    loop false i
+
+let is_string_literal s =
+  String.length s >= 2 && s.[0] = '"' && s.[String.length s - 1] = '"'
+
+let is_keyword_like s = String.length s >= 1 && s.[0] = ':'
+(* SMT keyword form like :named *)
+
+(* ------------------------------------------------------------------ *)
+(* Sexp walking — extract free atoms while respecting binders.          *)
+(* ------------------------------------------------------------------ *)
+
+(** Extract binder names from an SMT-LIB binding list of the shape
+    [((x T) (y U) ...)]. Returns names in declaration order (with duplicates if
+    present, so the caller can detect them). *)
+let binder_names (bindings : Sexp.t) : string list =
+  match bindings with
+  | Sexp.List binders ->
+      List.filter_map
+        (fun b ->
+          match[@warning "-4"] b with
+          | Sexp.List (Sexp.Atom name :: _) -> Some name
+          | _ -> None)
+        binders
+  | Sexp.Atom _ -> []
+
+(** [free_atoms sexp] returns the set of atoms in [sexp] that are not bound by
+    enclosing [forall] / [exists] / [let] forms, and that look like user
+    identifiers (not keywords, not numeric literals, not string literals, not
+    :keywords). *)
+let free_atoms (sexp : Sexp.t) : StringSet.t =
+  let rec go bound acc = function
+    | Sexp.Atom a ->
+        if
+          StringSet.mem a smt_keywords
+          || is_numeric_literal a || is_string_literal a || is_keyword_like a
+          || StringSet.mem a bound
+        then acc
+        else StringSet.add a acc
+    | Sexp.List items -> (
+        match[@warning "-4"] items with
+        | [ Sexp.Atom ("forall" | "exists"); bindings; body ] ->
+            let names = binder_names bindings in
+            let bound' =
+              List.fold_left (fun s n -> StringSet.add n s) bound names
+            in
+            (* Descend into the binding sorts too — those are atoms but
+               typically refer to declared sorts (like a Domain name). *)
+            let acc = go bound acc bindings in
+            go bound' acc body
+        | [ Sexp.Atom "let"; bindings; body ] ->
+            (* (let ((x e1) (y e2)) body) — bindings are scoped only in body *)
+            let names = binder_names bindings in
+            let bound' =
+              List.fold_left (fun s n -> StringSet.add n s) bound names
+            in
+            (* Visit each let-bound expression with the *outer* scope. *)
+            let acc =
+              match[@warning "-4"] bindings with
+              | Sexp.List binders ->
+                  List.fold_left
+                    (fun acc b ->
+                      match[@warning "-4"] b with
+                      | Sexp.List [ Sexp.Atom _; expr ] -> go bound acc expr
+                      | _ -> acc)
+                    acc binders
+              | _ -> acc
+            in
+            go bound' acc body
+        | _ -> List.fold_left (go bound) acc items)
+  in
+  go StringSet.empty StringSet.empty sexp
+
+(** Iterate over every [(forall ...)] / [(exists ...)] form, calling [visit]
+    with [(quant_kind, bindings_sexp, body_sexp)]. Recurses through the entire
+    sexp tree including inside the body. *)
+let iter_quantifiers (sexp : Sexp.t)
+    (visit : string -> Sexp.t -> Sexp.t -> unit) =
+  let rec go = function
+    | Sexp.Atom _ -> ()
+    | Sexp.List items ->
+        (match[@warning "-4"] items with
+        | [ Sexp.Atom (("forall" | "exists") as q); bindings; body ] ->
+            visit q bindings body
+        | _ -> ());
+        List.iter go items
+  in
+  go sexp
+
+(* ------------------------------------------------------------------ *)
+(* Individual checks.                                                   *)
+(* ------------------------------------------------------------------ *)
+
+(** Quantifier binders must be unique within their introducing form. *)
+let check_no_duplicate_binders (sexps : Sexp.t list) : failure list =
+  let failures = ref [] in
+  List.iter
+    (fun sexp ->
+      iter_quantifiers sexp (fun q bindings _body ->
+          let names = binder_names bindings in
+          let seen = Hashtbl.create 8 in
+          List.iter
+            (fun name ->
+              if Hashtbl.mem seen name then
+                failures :=
+                  {
+                    kind = Duplicate_binder;
+                    message =
+                      Printf.sprintf
+                        "%s introduces duplicate binder %S in (%s (%s) ...)" q
+                        name q (Sexp.to_string bindings);
+                  }
+                  :: !failures
+              else Hashtbl.add seen name ())
+            names))
+    sexps;
+  List.rev !failures
+
+(** Every quantifier binder must appear free somewhere in its body. Body here
+    includes any guard antecedent emitted as [(=> (and guards...) inner)] —
+    guards live structurally inside the body, so [free_atoms body] picks them up
+    automatically. *)
+let check_no_vacuous_binders (sexps : Sexp.t list) : failure list =
+  let failures = ref [] in
+  List.iter
+    (fun sexp ->
+      iter_quantifiers sexp (fun q bindings body ->
+          let names = binder_names bindings in
+          let body_free = free_atoms body in
+          List.iter
+            (fun name ->
+              if not (StringSet.mem name body_free) then
+                failures :=
+                  {
+                    kind = Vacuous_binder;
+                    message =
+                      Printf.sprintf
+                        "%s binds %S but it does not appear free in body" q name;
+                  }
+                  :: !failures)
+            names))
+    sexps;
+  List.rev !failures
+
+(** Detect uses of the translator's named-fallback constants. The naming
+    convention is [_<kind>_fallback_N]. We scan all atoms in all sexps. *)
+let check_no_fallback_emissions (sexps : Sexp.t list) : failure list =
+  (* Atoms emitted by [Smt_types.fresh_fallback] have the shape
+     [_<kind>_fallback_<N>]. Extract the kind by splitting on `_`. *)
+  let suffix_marker = "_fallback_" in
+  let fallback_kind_of_atom s =
+    let len = String.length s in
+    if len < 1 + String.length suffix_marker + 1 then None
+    else if s.[0] <> '_' then None
+    else
+      try
+        let i = String.index_from s 1 '_' in
+        let kind = String.sub s 1 (i - 1) in
+        let rest = String.sub s i (len - i) in
+        if
+          String.length rest > String.length suffix_marker
+          && String.sub rest 0 (String.length suffix_marker) = suffix_marker
+        then Some kind
+        else None
+      with Not_found -> None
+  in
+  let seen : (string * string, unit) Hashtbl.t = Hashtbl.create 4 in
+  let rec walk = function
+    | Sexp.Atom a -> (
+        match fallback_kind_of_atom a with
+        | Some kind ->
+            if not (Hashtbl.mem seen (kind, a)) then
+              Hashtbl.add seen (kind, a) ()
+        | None -> ())
+    | Sexp.List items -> List.iter walk items
+  in
+  List.iter walk sexps;
+  Hashtbl.fold
+    (fun (kind, atom) () acc ->
+      {
+        kind = Fallback_emission;
+        message =
+          Printf.sprintf "kind=%s constant=%s (translator approximation)" kind
+            atom;
+      }
+      :: acc)
+    seen []
+
+(* ------------------------------------------------------------------ *)
+(* Public entry point.                                                  *)
+(* ------------------------------------------------------------------ *)
+
+let check_query (smt2 : string) : failure list =
+  match parse_smt2 smt2 with
+  | Error msg ->
+      [ { kind = Parse_error; message = Printf.sprintf "parsexp: %s" msg } ]
+  | Ok sexps ->
+      check_no_duplicate_binders sexps
+      @ check_no_vacuous_binders sexps
+      @ check_no_fallback_emissions sexps
+
+let check_queries (smt2s : string list) : failure list =
+  List.concat_map check_query smt2s

--- a/test/smt_check.ml
+++ b/test/smt_check.ml
@@ -242,29 +242,56 @@ let check_no_duplicate_binders (sexps : Sexp.t list) : failure list =
     sexps;
   List.rev !failures
 
-(** Every quantifier binder must appear free somewhere in its body. Body here
-    includes any guard antecedent emitted as [(=> (and guards...) inner)] —
-    guards live structurally inside the body, so [free_atoms body] picks them up
-    automatically. *)
+(** A body that consists entirely of a single literal/constant atom is
+    "trivially vacuous": the user explicitly wrote [all x: T | true] or similar.
+    Faithful translation preserves the no-op binders, but they are not a
+    translator bug. We also peel one layer of [(=> antecedent consequent)] —
+    quantifiers over [Nat]/[Nat0] are translated to
+    [(forall ((n Int)) (=> (>= n 1) <user-body>))], so the literal sits inside
+    an implication that's not user-authored. *)
+let rec body_is_trivial = function
+  | Sexp.Atom a ->
+      a = "true" || a = "false" || is_numeric_literal a || is_string_literal a
+  | Sexp.List [ Sexp.Atom "=>"; _antecedent; consequent ] ->
+      body_is_trivial consequent
+  | Sexp.List _ -> false
+
+(** Every quantifier binder must appear free somewhere in its body. The check is
+    designed to catch translator-introduced spurious binders, not user-authored
+    deliberate tautologies. We skip:
+
+    - bodies that are a trivial literal (peeling one [(=>)] layer to handle
+      Nat/Nat0 type-constraint antecedents the translator inserts);
+    - quantifiers where NO binder is used. Total vacuity is intentional
+      ([all c: Color | true] is a non-emptiness tautology); partial vacuity
+      ([all x: T, y: U | g x] with [y] unused) is what the check is for and
+      remains flagged. *)
 let check_no_vacuous_binders (sexps : Sexp.t list) : failure list =
   let failures = ref [] in
   List.iter
     (fun sexp ->
       iter_quantifiers sexp (fun q bindings body ->
-          let names = binder_names bindings in
-          let body_free = free_atoms body in
-          List.iter
-            (fun name ->
-              if not (StringSet.mem name body_free) then
-                failures :=
-                  {
-                    kind = Vacuous_binder;
-                    message =
-                      Printf.sprintf
-                        "%s binds %S but it does not appear free in body" q name;
-                  }
-                  :: !failures)
-            names))
+          if body_is_trivial body then ()
+          else
+            let names = binder_names bindings in
+            let body_free = free_atoms body in
+            let any_used =
+              List.exists (fun n -> StringSet.mem n body_free) names
+            in
+            if any_used then
+              List.iter
+                (fun name ->
+                  if not (StringSet.mem name body_free) then
+                    failures :=
+                      {
+                        kind = Vacuous_binder;
+                        message =
+                          Printf.sprintf
+                            "%s binds %S but it does not appear free in body" q
+                            name;
+                      }
+                      :: !failures)
+                names))
     sexps;
   List.rev !failures
 

--- a/test/smt_check.mli
+++ b/test/smt_check.mli
@@ -15,9 +15,6 @@ type failure_kind =
 val failure_kind_tag : failure_kind -> string
 (** Stable string tag matching the allowlist file format. *)
 
-val failure_kind_of_tag : string -> failure_kind option
-(** Inverse of [failure_kind_tag]; returns [None] for unknown tags. *)
-
 type failure = { kind : failure_kind; message : string }
 (** A concrete failure with enough context to debug. *)
 
@@ -29,7 +26,3 @@ val parse_smt2 : string -> (Sexplib0.Sexp.t list, string) result
 val check_query : string -> failure list
 (** Run all structural checks on a single SMT-LIB2 string. Failures are
     accumulated; the function does not short-circuit on the first error. *)
-
-val check_queries : string list -> failure list
-(** Run [check_query] on a list of query SMT-LIB2 strings, accumulating all
-    failures. *)

--- a/test/smt_check.mli
+++ b/test/smt_check.mli
@@ -1,0 +1,35 @@
+(** Structural sanity checks on emitted SMT-LIB2.
+
+    Layer 1 of the SMT-translator test strategy: walks the sexp form of a
+    generated query and reports failures of the structural invariants the
+    translator is supposed to maintain. Pure OCaml, no solver required. *)
+
+(** A failure-kind tag, used in the per-fixture allowlist
+    ([test/regression/expected_failures.txt]). *)
+type failure_kind =
+  | Parse_error
+  | Duplicate_binder
+  | Vacuous_binder
+  | Fallback_emission
+
+val failure_kind_tag : failure_kind -> string
+(** Stable string tag matching the allowlist file format. *)
+
+val failure_kind_of_tag : string -> failure_kind option
+(** Inverse of [failure_kind_tag]; returns [None] for unknown tags. *)
+
+type failure = { kind : failure_kind; message : string }
+(** A concrete failure with enough context to debug. *)
+
+val format_failure : failure -> string
+
+val parse_smt2 : string -> (Sexplib0.Sexp.t list, string) result
+(** Parse an SMT-LIB2 string into its sexp form. Wraps [Parsexp.Many]. *)
+
+val check_query : string -> failure list
+(** Run all structural checks on a single SMT-LIB2 string. Failures are
+    accumulated; the function does not short-circuit on the first error. *)
+
+val check_queries : string list -> failure list
+(** Run [check_query] on a list of query SMT-LIB2 strings, accumulating all
+    failures. *)

--- a/test/test_smt.ml
+++ b/test/test_smt.ml
@@ -409,13 +409,12 @@ let test_card_non_domain_list () =
      visible to downstream tooling (see lib/smt_types.ml `fresh_fallback`).
      Must NOT emit ';' line comments — they would swallow the wrapping
      context's closing parens / annotations and corrupt the SMT assertion. *)
-  check bool "is fallback constant"
-    (String.length result >= 15 && String.sub result 0 15 = "_card_fallback_")
-    true;
+  check bool "is fallback constant" true
+    (String.length result >= 15 && String.sub result 0 15 = "_card_fallback_");
   check bool "no line comment" false (contains result ";");
   (* The corresponding declaration is queued in fallback_decls. *)
   let drained = Smt.drain_fallback_decls () in
-  check bool "declaration queued" (contains drained "_card_fallback_") true
+  check bool "declaration queued" true (contains drained "_card_fallback_")
 
 let test_subset_domain_rhs () =
   (* Ensure OpSubset with EDomain on RHS doesn't trigger standalone failwith *)

--- a/test/test_smt.ml
+++ b/test/test_smt.ml
@@ -401,14 +401,21 @@ let test_card_non_domain_list () =
          (Types.TyFunc ([], Some (Types.TyList Types.TyInt)))
          Ast.dummy_loc ~chapter:0
   in
+  Smt.reset_fallbacks ();
   let result =
     Smt.translate_expr config env (Ast.EUnop (OpCard, EVar (Lower "nums")))
   in
-  (* Non-domain list card falls back to 0. Must NOT emit ';' line comments:
-     they would swallow the wrapping context's closing parens / annotations
-     and corrupt the surrounding SMT assertion. *)
-  check string "is bare 0" "0" result;
-  check bool "no line comment" false (contains result ";")
+  (* Non-domain list card emits a fresh fallback constant name so the gap is
+     visible to downstream tooling (see lib/smt_types.ml `fresh_fallback`).
+     Must NOT emit ';' line comments — they would swallow the wrapping
+     context's closing parens / annotations and corrupt the SMT assertion. *)
+  check bool "is fallback constant"
+    (String.length result >= 15 && String.sub result 0 15 = "_card_fallback_")
+    true;
+  check bool "no line comment" false (contains result ";");
+  (* The corresponding declaration is queued in fallback_decls. *)
+  let drained = Smt.drain_fallback_decls () in
+  check bool "declaration queued" (contains drained "_card_fallback_") true
 
 let test_subset_domain_rhs () =
   (* Ensure OpSubset with EDomain on RHS doesn't trigger standalone failwith *)

--- a/test/test_smt_invariants.ml
+++ b/test/test_smt_invariants.ml
@@ -1,0 +1,257 @@
+(** Layer 1 SMT translation tests: structural invariants on emitted SMT-LIB2.
+
+    For each [.pant] fixture in [samples/], [samples/smt-examples/], and
+    [test/regression/], runs the full translation pipeline and checks the
+    emitted SMT against the structural invariants defined in [Smt_check].
+
+    Sample failures may be allow-listed in
+    [test/regression/expected_failures.txt] while known-pending bugs are being
+    fixed. The harness fails if an allowlist entry does not correspond to an
+    actual failure (so stale entries are caught). *)
+
+open Alcotest
+open Pantagruel
+
+(* ------------------------------------------------------------------ *)
+(* Filesystem helpers — mirror test_e2e.ml.                             *)
+(* ------------------------------------------------------------------ *)
+
+let find_dir candidates = List.find_opt Sys.file_exists candidates
+
+let sample_dir =
+  find_dir
+    [
+      "samples";
+      "../samples";
+      "../../samples";
+      Filename.concat (Sys.getcwd ()) "samples";
+    ]
+
+let smt_examples_dir =
+  find_dir
+    [
+      "samples/smt-examples";
+      "../samples/smt-examples";
+      "../../samples/smt-examples";
+      Filename.concat (Sys.getcwd ()) "samples/smt-examples";
+    ]
+
+let regression_dir =
+  find_dir
+    [
+      "test/regression";
+      "../test/regression";
+      "../../test/regression";
+      "regression";
+      "../regression";
+      Filename.concat (Sys.getcwd ()) "test/regression";
+    ]
+
+let pant_files dir =
+  Sys.readdir dir |> Array.to_list
+  |> List.filter (fun f -> Filename.check_suffix f ".pant")
+  |> List.sort String.compare
+
+let parse_file path =
+  let channel = open_in path in
+  let lexer = Lexer.create_from_channel path channel in
+  let supplier = Lexer.menhir_token lexer in
+  let doc =
+    MenhirLib.Convert.Simplified.traditional2revised Parser.document supplier
+  in
+  close_in channel;
+  doc
+
+(* ------------------------------------------------------------------ *)
+(* Pipeline.                                                            *)
+(* ------------------------------------------------------------------ *)
+
+(** Parse, collect, type-check and translate a [.pant] file to SMT queries.
+    Returns [None] when the upstream pipeline rejects the fixture (no SMT is
+    generated, so structural checks have nothing to inspect). *)
+let queries_of_path path : Smt.query list option =
+  let doc = parse_file path in
+  let mod_name = Option.fold ~none:"" ~some:Ast.upper_name doc.module_name in
+  match Collect.collect_all ~base_env:(Env.empty mod_name) doc with
+  | Error _ -> None
+  | Ok env -> (
+      match Check.check_document env doc with
+      | Error _ -> None
+      | Ok _ ->
+          let domain_bounds = Smt.compute_domain_bounds 3 env in
+          let config =
+            Smt.make_config ~bound:3 ~steps:1 ~domain_bounds ~inject_guards:true
+          in
+          Some (Smt.generate_queries config env doc))
+
+(* ------------------------------------------------------------------ *)
+(* Allowlist.                                                           *)
+(* ------------------------------------------------------------------ *)
+
+module StringMap = Map.Make (String)
+(** Per-fixture set of failure kinds that are tolerated. *)
+
+module KindSet = Set.Make (String)
+
+let parse_allowlist (lines : string list) : KindSet.t StringMap.t =
+  List.fold_left
+    (fun acc raw ->
+      let trimmed = String.trim raw in
+      if trimmed = "" || trimmed.[0] = '#' then acc
+      else
+        match String.index_opt trimmed ':' with
+        | None -> acc
+        | Some i ->
+            let fixture = String.trim (String.sub trimmed 0 i) in
+            let kinds_str =
+              String.sub trimmed (i + 1) (String.length trimmed - i - 1)
+            in
+            let kinds =
+              String.split_on_char ',' kinds_str
+              |> List.map String.trim
+              |> List.filter (fun s -> s <> "")
+              |> KindSet.of_list
+            in
+            let prev =
+              StringMap.find_opt fixture acc
+              |> Option.value ~default:KindSet.empty
+            in
+            StringMap.add fixture (KindSet.union prev kinds) acc)
+    StringMap.empty lines
+
+let load_allowlist () : KindSet.t StringMap.t =
+  match regression_dir with
+  | None -> StringMap.empty
+  | Some dir ->
+      let path = Filename.concat dir "expected_failures.txt" in
+      if not (Sys.file_exists path) then StringMap.empty
+      else
+        let ic = open_in path in
+        let rec read acc =
+          match input_line ic with
+          | line -> read (line :: acc)
+          | exception End_of_file -> List.rev acc
+        in
+        let lines = read [] in
+        close_in ic;
+        parse_allowlist lines
+
+(* ------------------------------------------------------------------ *)
+(* Per-fixture check.                                                   *)
+(* ------------------------------------------------------------------ *)
+
+(** Run [Smt_check] over every emitted query for one fixture. Returns the set of
+    failure kinds observed (deduplicated). *)
+let observed_kinds_for path : KindSet.t =
+  match queries_of_path path with
+  | None -> KindSet.empty
+  | Some queries ->
+      List.fold_left
+        (fun acc (q : Smt.query) ->
+          List.fold_left
+            (fun acc (f : Smt_check.failure) ->
+              KindSet.add (Smt_check.failure_kind_tag f.kind) acc)
+            acc
+            (Smt_check.check_query q.smt2))
+        KindSet.empty queries
+
+(** Diff observed vs allowed kinds, returning (unexpected, missing). Each is a
+    list of failure-kind tags. [unexpected] = observed but not allowed.
+    [missing] = allowed but not observed (stale allowlist entries). *)
+let diff_kinds ~observed ~allowed =
+  let unexpected = KindSet.diff observed allowed |> KindSet.elements in
+  let missing = KindSet.diff allowed observed |> KindSet.elements in
+  (unexpected, missing)
+
+(** Format a per-fixture failure report for alcotest. *)
+let format_report fixture path ~unexpected ~missing =
+  let detail =
+    match queries_of_path path with
+    | None -> "  (no queries generated; upstream pipeline rejected)\n"
+    | Some queries ->
+        let buf = Buffer.create 256 in
+        List.iter
+          (fun (q : Smt.query) ->
+            List.iter
+              (fun f ->
+                Buffer.add_string buf "  - ";
+                Buffer.add_string buf q.name;
+                Buffer.add_string buf ": ";
+                Buffer.add_string buf (Smt_check.format_failure f);
+                Buffer.add_char buf '\n')
+              (Smt_check.check_query q.smt2))
+          queries;
+        Buffer.contents buf
+  in
+  let parts = ref [] in
+  if unexpected <> [] then
+    parts :=
+      Printf.sprintf "unexpected failures: [%s]" (String.concat ", " unexpected)
+      :: !parts;
+  if missing <> [] then
+    parts :=
+      Printf.sprintf "stale allowlist entries: [%s]"
+        (String.concat ", " missing)
+      :: !parts;
+  Printf.sprintf "%s — %s\n%s" fixture (String.concat "; " !parts) detail
+
+(** Sample / smt-examples fixture test. Allowlist-aware. *)
+let test_sample_fixture allowlist dir name () =
+  let path = Filename.concat dir name in
+  let observed = observed_kinds_for path in
+  let allowed =
+    StringMap.find_opt name allowlist |> Option.value ~default:KindSet.empty
+  in
+  let unexpected, missing = diff_kinds ~observed ~allowed in
+  if unexpected <> [] || missing <> [] then
+    failf "%s" (format_report name path ~unexpected ~missing)
+
+(* ------------------------------------------------------------------ *)
+(* Regression cases — explicit assertions on the two known bugs.        *)
+(* ------------------------------------------------------------------ *)
+
+(** Assert that [fixture] in the regression dir produces every kind in
+    [expect_kinds]. Used to lock in behavior pending bug fixes; once a bug is
+    fixed, flip [expect_kinds] to [[]] so the test asserts cleanliness. *)
+let test_regression_fixture fixture expect_kinds () =
+  match regression_dir with
+  | None -> failf "regression directory not found"
+  | Some dir ->
+      let path = Filename.concat dir fixture in
+      if not (Sys.file_exists path) then failf "missing fixture: %s" path;
+      let observed = observed_kinds_for path in
+      let expected = KindSet.of_list expect_kinds in
+      let missing = KindSet.diff expected observed |> KindSet.elements in
+      let extra = KindSet.diff observed expected |> KindSet.elements in
+      if missing <> [] || extra <> [] then
+        failf "%s — missing expected: [%s]; extra unexpected: [%s]" fixture
+          (String.concat ", " missing)
+          (String.concat ", " extra)
+
+(* ------------------------------------------------------------------ *)
+(* Test suite assembly.                                                 *)
+(* ------------------------------------------------------------------ *)
+
+let sample_cases () =
+  let allowlist = load_allowlist () in
+  let from dir =
+    pant_files dir
+    |> List.map (fun n ->
+        test_case n `Quick (test_sample_fixture allowlist dir n))
+  in
+  let main = match sample_dir with None -> [] | Some d -> from d in
+  let smt = match smt_examples_dir with None -> [] | Some d -> from d in
+  main @ smt
+
+let regression_cases () =
+  [
+    test_case "bug_overquantify.pant — duplicate + vacuous binders" `Quick
+      (test_regression_fixture "bug_overquantify.pant"
+         [ "duplicate_binder"; "vacuous_binder" ]);
+    test_case "bug_card_zero.pant — fallback emission" `Quick
+      (test_regression_fixture "bug_card_zero.pant" [ "fallback_emission" ]);
+  ]
+
+let () =
+  run "SmtInvariants"
+    [ ("samples", sample_cases ()); ("regression", regression_cases ()) ]

--- a/test/test_smt_invariants.ml
+++ b/test/test_smt_invariants.ml
@@ -10,16 +10,9 @@
     actual failure (so stale entries are caught). *)
 
 open Alcotest
-open Pantagruel
-
-(* ------------------------------------------------------------------ *)
-(* Filesystem helpers — mirror test_e2e.ml.                             *)
-(* ------------------------------------------------------------------ *)
-
-let find_dir candidates = List.find_opt Sys.file_exists candidates
 
 let sample_dir =
-  find_dir
+  Test_util.find_dir
     [
       "samples";
       "../samples";
@@ -28,7 +21,7 @@ let sample_dir =
     ]
 
 let smt_examples_dir =
-  find_dir
+  Test_util.find_dir
     [
       "samples/smt-examples";
       "../samples/smt-examples";
@@ -37,7 +30,7 @@ let smt_examples_dir =
     ]
 
 let regression_dir =
-  find_dir
+  Test_util.find_dir
     [
       "test/regression";
       "../test/regression";
@@ -47,42 +40,13 @@ let regression_dir =
       Filename.concat (Sys.getcwd ()) "test/regression";
     ]
 
-let pant_files dir =
-  Sys.readdir dir |> Array.to_list
-  |> List.filter (fun f -> Filename.check_suffix f ".pant")
-  |> List.sort String.compare
-
-let parse_file path =
-  let channel = open_in path in
-  let lexer = Lexer.create_from_channel path channel in
-  let supplier = Lexer.menhir_token lexer in
-  let doc =
-    MenhirLib.Convert.Simplified.traditional2revised Parser.document supplier
-  in
-  close_in channel;
-  doc
-
-(* ------------------------------------------------------------------ *)
-(* Pipeline.                                                            *)
-(* ------------------------------------------------------------------ *)
-
-(** Parse, collect, type-check and translate a [.pant] file to SMT queries.
-    Returns [None] when the upstream pipeline rejects the fixture (no SMT is
-    generated, so structural checks have nothing to inspect). *)
-let queries_of_path path : Smt.query list option =
-  let doc = parse_file path in
-  let mod_name = Option.fold ~none:"" ~some:Ast.upper_name doc.module_name in
-  match Collect.collect_all ~base_env:(Env.empty mod_name) doc with
+(** Parse + translate a [.pant] file to SMT queries; [None] if the upstream
+    pipeline rejects the fixture (no SMT is generated, so structural checks have
+    nothing to inspect). *)
+let queries_of_path path : Pantagruel.Smt.query list option =
+  match Test_util.translate_to_queries (Test_util.parse_pant_file path) with
+  | Ok qs -> Some qs
   | Error _ -> None
-  | Ok env -> (
-      match Check.check_document env doc with
-      | Error _ -> None
-      | Ok _ ->
-          let domain_bounds = Smt.compute_domain_bounds 3 env in
-          let config =
-            Smt.make_config ~bound:3 ~steps:1 ~domain_bounds ~inject_guards:true
-          in
-          Some (Smt.generate_queries config env doc))
 
 (* ------------------------------------------------------------------ *)
 (* Allowlist.                                                           *)
@@ -140,71 +104,60 @@ let load_allowlist () : KindSet.t StringMap.t =
 (* Per-fixture check.                                                   *)
 (* ------------------------------------------------------------------ *)
 
-(** Run [Smt_check] over every emitted query for one fixture. Returns the set of
-    failure kinds observed (deduplicated). *)
-let observed_kinds_for path : KindSet.t =
+(** Run [Smt_check] over every emitted query for one fixture, returning the flat
+    list of (query_name, failure) pairs. The translation pipeline runs exactly
+    once per fixture; [observed_kinds] and [format_failures] both derive from
+    this list. *)
+let collect_failures path : (string * Smt_check.failure) list =
   match queries_of_path path with
-  | None -> KindSet.empty
+  | None -> []
   | Some queries ->
-      List.fold_left
-        (fun acc (q : Smt.query) ->
-          List.fold_left
-            (fun acc (f : Smt_check.failure) ->
-              KindSet.add (Smt_check.failure_kind_tag f.kind) acc)
-            acc
-            (Smt_check.check_query q.smt2))
-        KindSet.empty queries
+      List.concat_map
+        (fun (q : Pantagruel.Smt.query) ->
+          List.map (fun f -> (q.name, f)) (Smt_check.check_query q.smt2))
+        queries
 
-(** Diff observed vs allowed kinds, returning (unexpected, missing). Each is a
-    list of failure-kind tags. [unexpected] = observed but not allowed.
-    [missing] = allowed but not observed (stale allowlist entries). *)
-let diff_kinds ~observed ~allowed =
-  let unexpected = KindSet.diff observed allowed |> KindSet.elements in
-  let missing = KindSet.diff allowed observed |> KindSet.elements in
-  (unexpected, missing)
+let observed_kinds (failures : (string * Smt_check.failure) list) : KindSet.t =
+  List.fold_left
+    (fun acc (_, (f : Smt_check.failure)) ->
+      KindSet.add (Smt_check.failure_kind_tag f.kind) acc)
+    KindSet.empty failures
 
-(** Format a per-fixture failure report for alcotest. *)
-let format_report fixture path ~unexpected ~missing =
-  let detail =
-    match queries_of_path path with
-    | None -> "  (no queries generated; upstream pipeline rejected)\n"
-    | Some queries ->
-        let buf = Buffer.create 256 in
-        List.iter
-          (fun (q : Smt.query) ->
-            List.iter
-              (fun f ->
-                Buffer.add_string buf "  - ";
-                Buffer.add_string buf q.name;
-                Buffer.add_string buf ": ";
-                Buffer.add_string buf (Smt_check.format_failure f);
-                Buffer.add_char buf '\n')
-              (Smt_check.check_query q.smt2))
-          queries;
-        Buffer.contents buf
-  in
-  let parts = ref [] in
-  if unexpected <> [] then
-    parts :=
-      Printf.sprintf "unexpected failures: [%s]" (String.concat ", " unexpected)
-      :: !parts;
-  if missing <> [] then
-    parts :=
-      Printf.sprintf "stale allowlist entries: [%s]"
-        (String.concat ", " missing)
-      :: !parts;
-  Printf.sprintf "%s — %s\n%s" fixture (String.concat "; " !parts) detail
+let format_failures failures =
+  let buf = Buffer.create 256 in
+  List.iter
+    (fun (qname, f) ->
+      Buffer.add_string buf "  - ";
+      Buffer.add_string buf qname;
+      Buffer.add_string buf ": ";
+      Buffer.add_string buf (Smt_check.format_failure f);
+      Buffer.add_char buf '\n')
+    failures;
+  Buffer.contents buf
 
 (** Sample / smt-examples fixture test. Allowlist-aware. *)
 let test_sample_fixture allowlist dir name () =
   let path = Filename.concat dir name in
-  let observed = observed_kinds_for path in
+  let failures = collect_failures path in
+  let observed = observed_kinds failures in
   let allowed =
     StringMap.find_opt name allowlist |> Option.value ~default:KindSet.empty
   in
-  let unexpected, missing = diff_kinds ~observed ~allowed in
+  let unexpected = KindSet.diff observed allowed |> KindSet.elements in
+  let missing = KindSet.diff allowed observed |> KindSet.elements in
   if unexpected <> [] || missing <> [] then
-    failf "%s" (format_report name path ~unexpected ~missing)
+    let parts =
+      List.filter_map
+        (fun (label, items) ->
+          if items = [] then None
+          else Some (Printf.sprintf "%s: [%s]" label (String.concat ", " items)))
+        [
+          ("unexpected failures", unexpected);
+          ("stale allowlist entries", missing);
+        ]
+    in
+    failf "%s — %s\n%s" name (String.concat "; " parts)
+      (format_failures failures)
 
 (* ------------------------------------------------------------------ *)
 (* Regression cases — explicit assertions on the two known bugs.        *)
@@ -219,7 +172,7 @@ let test_regression_fixture fixture expect_kinds () =
   | Some dir ->
       let path = Filename.concat dir fixture in
       if not (Sys.file_exists path) then failf "missing fixture: %s" path;
-      let observed = observed_kinds_for path in
+      let observed = observed_kinds (collect_failures path) in
       let expected = KindSet.of_list expect_kinds in
       let missing = KindSet.diff expected observed |> KindSet.elements in
       let extra = KindSet.diff observed expected |> KindSet.elements in
@@ -235,7 +188,7 @@ let test_regression_fixture fixture expect_kinds () =
 let sample_cases () =
   let allowlist = load_allowlist () in
   let from dir =
-    pant_files dir
+    Test_util.pant_files dir
     |> List.map (fun n ->
         test_case n `Quick (test_sample_fixture allowlist dir n))
   in

--- a/test/test_smt_invariants.ml
+++ b/test/test_smt_invariants.ml
@@ -245,9 +245,8 @@ let sample_cases () =
 
 let regression_cases () =
   [
-    test_case "bug_overquantify.pant — duplicate + vacuous binders" `Quick
-      (test_regression_fixture "bug_overquantify.pant"
-         [ "duplicate_binder"; "vacuous_binder" ]);
+    test_case "bug_overquantify.pant — clean post-fix" `Quick
+      (test_regression_fixture "bug_overquantify.pant" []);
     test_case "bug_card_zero.pant — fallback emission" `Quick
       (test_regression_fixture "bug_card_zero.pant" [ "fallback_emission" ]);
   ]

--- a/test/test_smt_property.ml
+++ b/test/test_smt_property.ml
@@ -22,25 +22,12 @@ let kinds_pending_fix : string list = []
 
 let pp_doc = Test_util.print_document
 
-(** Run the canonical translation pipeline for one generated document. *)
-let translate (doc : Ast.document) : (Smt.query list, string) result =
-  let mod_name = Option.fold ~none:"" ~some:Ast.upper_name doc.module_name in
-  match Collect.collect_all ~base_env:(Env.empty mod_name) doc with
-  | Error e -> Error (Collect.show_collect_error e)
-  | Ok env -> (
-      match Check.check_document env doc with
-      | Error e -> Error (Check.show_type_error e)
-      | Ok _ ->
-          let domain_bounds = Smt.compute_domain_bounds 3 env in
-          let config =
-            Smt.make_config ~bound:3 ~steps:1 ~domain_bounds ~inject_guards:true
-          in
-          Ok (Smt.generate_queries config env doc))
-
 (** [accepted doc] returns the queries iff [doc] type-checks. Discards via
     [QCheck.assume_fail] otherwise. *)
 let accepted doc : Smt.query list =
-  match translate doc with Error _ -> QCheck.assume_fail () | Ok qs -> qs
+  match Test_util.translate_to_queries doc with
+  | Error _ -> QCheck.assume_fail ()
+  | Ok qs -> qs
 
 (* ------------------------------------------------------------------ *)
 (* Properties                                                           *)

--- a/test/test_smt_property.ml
+++ b/test/test_smt_property.ml
@@ -1,0 +1,101 @@
+(** Layer 2 SMT translation tests: property-based checks on randomly generated
+    Pantagruel documents.
+
+    Strategy: generate small documents via [Test_util.gen_document], filter via
+    [QCheck.assume] to those that type-check, then run the same structural
+    invariants as Layer 1 ([Smt_check]) on the emitted SMT. Properties:
+    - translation totality (no exception)
+    - well-formed SMT (parses as sexps)
+    - no structural failures except those in the kind-level allowlist below
+      (mirroring the per-fixture allowlist used in Layer 1)
+
+    The allowlist is a set of failure kinds that are tolerated globally until
+    the corresponding translator bug is fixed. When a tracked bug is fixed,
+    remove its kind(s) here. *)
+
+open Pantagruel
+
+(** Failure kinds Layer 2 currently tolerates. Once a corresponding translator
+    bug is fixed, remove its tag here so the property tightens.
+
+    - [duplicate_binder], [vacuous_binder]: Bug 1 — bind_head_params
+      over-quantifies (lib/smt_doc.ml:46-66).
+    - [fallback_emission]: an acceptable approximation by design today; tightens
+      once translator can encode all source constructs faithfully. *)
+let kinds_pending_fix =
+  [ "duplicate_binder"; "vacuous_binder"; "fallback_emission" ]
+
+let pp_doc = Test_util.print_document
+
+(** Run the canonical translation pipeline for one generated document. *)
+let translate (doc : Ast.document) : (Smt.query list, string) result =
+  let mod_name = Option.fold ~none:"" ~some:Ast.upper_name doc.module_name in
+  match Collect.collect_all ~base_env:(Env.empty mod_name) doc with
+  | Error e -> Error (Collect.show_collect_error e)
+  | Ok env -> (
+      match Check.check_document env doc with
+      | Error e -> Error (Check.show_type_error e)
+      | Ok _ ->
+          let domain_bounds = Smt.compute_domain_bounds 3 env in
+          let config =
+            Smt.make_config ~bound:3 ~steps:1 ~domain_bounds ~inject_guards:true
+          in
+          Ok (Smt.generate_queries config env doc))
+
+(** [accepted doc] returns the queries iff [doc] type-checks. Discards via
+    [QCheck.assume_fail] otherwise. *)
+let accepted doc : Smt.query list =
+  match translate doc with Error _ -> QCheck.assume_fail () | Ok qs -> qs
+
+(* ------------------------------------------------------------------ *)
+(* Properties                                                           *)
+(* ------------------------------------------------------------------ *)
+
+(** [Smt.generate_queries] doesn't raise on any type-checking input. *)
+let prop_translation_totality doc =
+  let _ = accepted doc in
+  true
+
+(** Every emitted query is well-formed SMT-LIB2 (parses as sexps). *)
+let prop_well_formed doc =
+  let qs = accepted doc in
+  List.for_all
+    (fun (q : Smt.query) ->
+      match Smt_check.parse_smt2 q.smt2 with Ok _ -> true | Error _ -> false)
+    qs
+
+(** No emitted query has a structural failure outside [kinds_pending_fix]. When
+    the pending list is empty, this is the strict "no failures at all" property.
+*)
+let prop_no_unexpected_failures doc =
+  let qs = accepted doc in
+  List.for_all
+    (fun (q : Smt.query) ->
+      Smt_check.check_query q.smt2
+      |> List.for_all (fun (f : Smt_check.failure) ->
+          List.mem (Smt_check.failure_kind_tag f.kind) kinds_pending_fix))
+    qs
+
+(* ------------------------------------------------------------------ *)
+(* Suite assembly                                                       *)
+(* ------------------------------------------------------------------ *)
+
+let count = 200
+
+let mk_property ~name ~prop =
+  QCheck_alcotest.to_alcotest
+    (QCheck.Test.make ~name ~count
+       (QCheck.set_print pp_doc Test_util.arb_document)
+       prop)
+
+let () =
+  Alcotest.run "SmtProperty"
+    [
+      ( "translation",
+        [
+          mk_property ~name:"totality" ~prop:prop_translation_totality;
+          mk_property ~name:"well-formed SMT" ~prop:prop_well_formed;
+          mk_property ~name:"no unexpected structural failures"
+            ~prop:prop_no_unexpected_failures;
+        ] );
+    ]

--- a/test/test_smt_property.ml
+++ b/test/test_smt_property.ml
@@ -15,15 +15,10 @@
 
 open Pantagruel
 
-(** Failure kinds Layer 2 currently tolerates. Once a corresponding translator
-    bug is fixed, remove its tag here so the property tightens.
-
-    - [duplicate_binder], [vacuous_binder]: Bug 1 — bind_head_params
-      over-quantifies (lib/smt_doc.ml:46-66).
-    - [fallback_emission]: an acceptable approximation by design today; tightens
-      once translator can encode all source constructs faithfully. *)
-let kinds_pending_fix =
-  [ "duplicate_binder"; "vacuous_binder"; "fallback_emission" ]
+(** Failure kinds Layer 2 currently tolerates. Empty: all generated documents
+    must satisfy every structural invariant. Re-add a tag here only when a new
+    known-pending translator bug appears, with a comment linking to it. *)
+let kinds_pending_fix : string list = []
 
 let pp_doc = Test_util.print_document
 

--- a/test/test_util.ml
+++ b/test/test_util.ml
@@ -91,3 +91,212 @@ let[@warning "-44"] gen_type_expr_at_depth =
 
 let gen_type_expr = gen_type_expr_at_depth 2
 let arb_type_expr = QCheck.make ~print:Pretty.str_type_expr gen_type_expr
+
+(** ============================================================ AST document
+    generators (Layer 2 of the SMT-translator tests).
+
+    Strategy: build a small "world" of declared symbols (1–2 domains, a few
+    rules with explicit parameters) first, then generate boolean body
+    propositions that refer only to those declared symbols. The aim is to
+    exercise the patterns that hit the known SMT translation bugs (multiple
+    rules sharing parameter names, quantified bodies that may or may not
+    reference rule parameters), while staying simple enough for
+    [Check.check_document] to accept most of what we produce.
+    ============================================================ *)
+
+type gen_world = {
+  domains : string list;  (** Declared domain names *)
+  base_types : Ast.type_expr list;  (** Domain TName plus a few primitives *)
+  rules : (string * Ast.param list * Ast.type_expr) list;
+      (** name, formal params, return type *)
+  vars : (string * Ast.type_expr) list;  (** In-scope variables *)
+}
+(** A minimal symbol world generated before any expression construction. *)
+
+(** Generate a list of exactly [n] elements from [g]. (The deprecated
+    [QCheck.Gen.list_repeat] does the same; this wrapper documents intent.) *)
+let list_of_size n g = QCheck.Gen.list_size (QCheck.Gen.return n) g
+
+(** Lower-case identifiers we cycle through. Some collisions are intentional —
+    sharing names like [x]/[n] across rules is exactly what triggers the
+    over-quantification bug we want Layer 2 to keep an eye on. *)
+let lower_pool = [ "x"; "y"; "n"; "k"; "u"; "v"; "a"; "b" ]
+
+let gen_lower : string QCheck.Gen.t =
+  let open QCheck.Gen in
+  oneof_list lower_pool
+
+let gen_domain_name : string QCheck.Gen.t = QCheck.Gen.oneof_list [ "X"; "Y" ]
+
+let mk_param name ty : Ast.param =
+  { Ast.param_name = Ast.Lower name; param_type = ty }
+
+let mk_located v : 'a Ast.located =
+  { Ast.loc = Ast.dummy_loc; value = v; doc = []; doc_adjacent = false }
+
+let gen_param_with world : Ast.param QCheck.Gen.t =
+  let open QCheck.Gen in
+  let* name = gen_lower in
+  let* ty = oneof_list world.base_types in
+  return (mk_param name ty)
+
+(** Generate a small world: 1–2 domains, 0–4 rules, 0–2 vars. *)
+let gen_world : gen_world QCheck.Gen.t =
+  let open QCheck.Gen in
+  let* n_domains = int_range 1 2 in
+  let domains = List.filteri (fun i _ -> i < n_domains) [ "X"; "Y" ] in
+  let base_types =
+    List.map (fun d -> Ast.TName (Ast.Upper d)) domains
+    @ [ Ast.TName (Ast.Upper "Bool"); Ast.TName (Ast.Upper "Nat") ]
+  in
+  let world0 = { domains; base_types; rules = []; vars = [] } in
+  let rule_names = [ "f"; "g"; "h"; "p"; "q" ] in
+  let* n_rules = int_range 0 (List.length rule_names) in
+  let rule_names = List.filteri (fun i _ -> i < n_rules) rule_names in
+  let* rules =
+    list_of_size n_rules
+      (let* n_params = int_range 0 2 in
+       let* params = list_of_size n_params (gen_param_with world0) in
+       let* ret = oneof_list base_types in
+       return (params, ret))
+  in
+  let rules =
+    List.map2 (fun name (params, ret) -> (name, params, ret)) rule_names rules
+  in
+  let* n_vars = int_range 0 2 in
+  let* vars =
+    list_of_size n_vars
+      (let* name = gen_lower in
+       let* ty = oneof_list base_types in
+       return (name, ty))
+  in
+  return { world0 with rules; vars }
+
+(** Boolean expression generator. Bias toward leaves; allow [forall]/[exists]
+    that introduce fresh params (the patterns that exercise the
+    over-quantification bug). *)
+let[@warning "-44"] gen_bool_expr_at_depth =
+  let open QCheck.Gen in
+  let lit = oneof_list [ Ast.ELitBool true; Ast.ELitBool false ] in
+  let var_of world =
+    match world.vars with
+    | [] -> lit
+    | _ ->
+        let* name, _ty = oneof_list world.vars in
+        return (Ast.EVar (Ast.Lower name))
+  in
+  let app_of world =
+    let bool_rules =
+      List.filter
+        (fun (_, _, ret) -> ret = Ast.TName (Ast.Upper "Bool"))
+        world.rules
+    in
+    match bool_rules with
+    | [] -> lit
+    | _ ->
+        let* name, params, _ret = oneof_list bool_rules in
+        let* args =
+          flatten_list
+            (List.map
+               (fun (p : Ast.param) ->
+                 let v_opt =
+                   List.find_opt (fun (_, ty) -> ty = p.param_type) world.vars
+                 in
+                 match v_opt with
+                 | Some (vname, _) -> return (Ast.EVar (Ast.Lower vname))
+                 | None -> (
+                     match(* Fall back to a literal of the right shape — Bool/Nat
+                        only, otherwise emit a free var (may fail check). *)
+                          [@warning "-4"]
+                       p.param_type
+                     with
+                     | Ast.TName (Ast.Upper "Bool") ->
+                         return (Ast.ELitBool true)
+                     | Ast.TName (Ast.Upper "Nat") -> return (Ast.ELitNat 0)
+                     | _ -> return (Ast.EVar (Ast.Lower "x"))))
+               params)
+        in
+        return (Ast.EApp (Ast.EVar (Ast.Lower name), args))
+  in
+  fix (fun self (depth, world) ->
+      if depth <= 0 then oneof [ lit; var_of world; app_of world ]
+      else
+        oneof_weighted
+          [
+            (4, lit);
+            (3, var_of world);
+            (2, app_of world);
+            ( 1,
+              let* p = gen_param_with world in
+              let* body =
+                self
+                  ( depth - 1,
+                    {
+                      world with
+                      vars =
+                        (Ast.lower_name p.param_name, p.param_type)
+                        :: world.vars;
+                    } )
+              in
+              return (Ast.EForall ([ p ], [], body)) );
+            ( 1,
+              let* p = gen_param_with world in
+              let* body =
+                self
+                  ( depth - 1,
+                    {
+                      world with
+                      vars =
+                        (Ast.lower_name p.param_name, p.param_type)
+                        :: world.vars;
+                    } )
+              in
+              return (Ast.EExists ([ p ], [], body)) );
+          ])
+
+let gen_bool_expr world = gen_bool_expr_at_depth (2, world)
+
+(** Build a chapter from a world: the rules become declarations in the head; the
+    body is 1–3 generated boolean propositions. *)
+let gen_chapter (world : gen_world) : Ast.chapter QCheck.Gen.t =
+  let open QCheck.Gen in
+  let head =
+    List.map (fun d -> mk_located (Ast.DeclDomain (Ast.Upper d))) world.domains
+    @ List.map
+        (fun (name, params, ret) ->
+          mk_located
+            (Ast.DeclRule
+               {
+                 name = Ast.Lower name;
+                 params;
+                 guards = [];
+                 return_type = ret;
+                 contexts = [];
+               }))
+        world.rules
+  in
+  let* n_props = int_range 1 3 in
+  let* props = list_of_size n_props (gen_bool_expr world) in
+  let body = List.map mk_located props in
+  return { Ast.head; body; checks = []; trailing_docs = [] }
+
+(** Top-level document generator. *)
+let gen_document : Ast.document QCheck.Gen.t =
+  let open QCheck.Gen in
+  let* world = gen_world in
+  let* chapter = gen_chapter world in
+  return
+    {
+      Ast.module_name = Some (Ast.Upper "GEN");
+      imports = [];
+      contexts = [];
+      chapters = [ chapter ];
+    }
+
+(** Pretty-print a generated document for QCheck shrinking output. There is no
+    top-level pretty-printer for full documents, so fall back to the derived
+    [show_document]. *)
+let print_document doc = Ast.show_document doc
+
+let arb_document : Ast.document QCheck.arbitrary =
+  QCheck.make ~print:print_document gen_document

--- a/test/test_util.ml
+++ b/test/test_util.ml
@@ -214,6 +214,17 @@ let gen_world : gen_world QCheck.Gen.t =
   in
   return { world0 with rules; vars }
 
+(** Keep only the most-recent (nearest) binding per name, so that generators
+    respect shadowing and don't pick hidden outer bindings. *)
+let visible_vars vars =
+  let rec go seen acc = function
+    | [] -> List.rev acc
+    | ((name, _) as v) :: tl ->
+        if List.mem name seen then go seen acc tl
+        else go (name :: seen) (v :: acc) tl
+  in
+  go [] [] vars
+
 (** Boolean expression generator. Bias toward leaves; allow [forall]/[exists]
     that introduce fresh params (the patterns that exercise the
     over-quantification bug). *)
@@ -221,8 +232,9 @@ let[@warning "-44"] gen_bool_expr_at_depth =
   let open QCheck.Gen in
   let lit = oneof_list [ Ast.ELitBool true; Ast.ELitBool false ] in
   let var_of world =
+    let vars = visible_vars world.vars in
     let bool_vars =
-      List.filter (fun (_, ty) -> ty = Ast.TName (Ast.Upper "Bool")) world.vars
+      List.filter (fun (_, ty) -> ty = Ast.TName (Ast.Upper "Bool")) vars
     in
     match bool_vars with
     | [] -> lit
@@ -231,6 +243,7 @@ let[@warning "-44"] gen_bool_expr_at_depth =
         return (Ast.EVar (Ast.Lower name))
   in
   let app_of world =
+    let vars = visible_vars world.vars in
     let bool_rules =
       List.filter
         (fun (_, _, ret) -> ret = Ast.TName (Ast.Upper "Bool"))
@@ -245,7 +258,7 @@ let[@warning "-44"] gen_bool_expr_at_depth =
             (List.map
                (fun (p : Ast.param) ->
                  let v_opt =
-                   List.find_opt (fun (_, ty) -> ty = p.param_type) world.vars
+                   List.find_opt (fun (_, ty) -> ty = p.param_type) vars
                  in
                  match v_opt with
                  | Some (vname, _) -> return (Ast.EVar (Ast.Lower vname))
@@ -273,28 +286,20 @@ let[@warning "-44"] gen_bool_expr_at_depth =
             (2, app_of world);
             ( 1,
               let* p = gen_param_with world in
+              let pname = Ast.lower_name p.param_name in
               let* body =
                 self
                   ( depth - 1,
-                    {
-                      world with
-                      vars =
-                        (Ast.lower_name p.param_name, p.param_type)
-                        :: world.vars;
-                    } )
+                    { world with vars = (pname, p.param_type) :: world.vars } )
               in
               return (Ast.EForall ([ p ], [], body)) );
             ( 1,
               let* p = gen_param_with world in
+              let pname = Ast.lower_name p.param_name in
               let* body =
                 self
                   ( depth - 1,
-                    {
-                      world with
-                      vars =
-                        (Ast.lower_name p.param_name, p.param_type)
-                        :: world.vars;
-                    } )
+                    { world with vars = (pname, p.param_type) :: world.vars } )
               in
               return (Ast.EExists ([ p ], [], body)) );
           ])

--- a/test/test_util.ml
+++ b/test/test_util.ml
@@ -254,7 +254,7 @@ let[@warning "-44"] gen_bool_expr_at_depth =
                      with
                      | Ast.TName (Ast.Upper "Bool") ->
                          return (Ast.ELitBool true)
-                     | Ast.TName (Ast.Upper "Nat") -> return (Ast.ELitNat 0)
+                     | Ast.TName (Ast.Upper "Nat") -> return (Ast.ELitNat 1)
                      | _ -> return (Ast.EVar (Ast.Lower "x"))))
                params)
         in

--- a/test/test_util.ml
+++ b/test/test_util.ml
@@ -28,6 +28,48 @@ let parse_and_collect str =
       | Error e -> failf "Type error: %s" (Check.show_type_error e)
       | Ok _warnings -> (env, doc))
 
+(** Locate a directory by trying each candidate path in order; returns the first
+    that exists. Used to make tests robust against the working directory that
+    dune sets up (samples can live under [samples/], [../samples/], etc). *)
+let find_dir candidates = List.find_opt Sys.file_exists candidates
+
+(** All [.pant] basenames in [dir], sorted lexicographically. *)
+let pant_files dir =
+  Sys.readdir dir |> Array.to_list
+  |> List.filter (fun f -> Filename.check_suffix f ".pant")
+  |> List.sort String.compare
+
+(** Parse a [.pant] file from disk into an [Ast.document]. *)
+let parse_pant_file path =
+  let channel = open_in path in
+  let lexer = Lexer.create_from_channel path channel in
+  let supplier = Lexer.menhir_token lexer in
+  let doc =
+    MenhirLib.Convert.Simplified.traditional2revised Parser.document supplier
+  in
+  close_in channel;
+  doc
+
+(** Run the canonical translator pipeline on a parsed document and return the
+    generated SMT queries, or an error message if collection or type-checking
+    fails. The config matches [bin/main.ml --check] defaults: bound 3, steps 1,
+    guards injected. Used by every Layer-1, Layer-2, and fuzz test that needs
+    the full translator output. *)
+let translate_to_queries (doc : Ast.document) : (Smt.query list, string) result
+    =
+  let mod_name = Option.fold ~none:"" ~some:Ast.upper_name doc.module_name in
+  match Collect.collect_all ~base_env:(Env.empty mod_name) doc with
+  | Error e -> Error (Collect.show_collect_error e)
+  | Ok env -> (
+      match Check.check_document env doc with
+      | Error e -> Error (Check.show_type_error e)
+      | Ok _ ->
+          let domain_bounds = Smt.compute_domain_bounds 3 env in
+          let config =
+            Smt.make_config ~bound:3 ~steps:1 ~domain_bounds ~inject_guards:true
+          in
+          Ok (Smt.generate_queries config env doc))
+
 (** QCheck generator for Types.ty, depth-limited *)
 let[@warning "-44"] gen_ty_at_depth =
   let open QCheck.Gen in

--- a/test/test_util.ml
+++ b/test/test_util.ml
@@ -31,7 +31,8 @@ let parse_and_collect str =
 (** Locate a directory by trying each candidate path in order; returns the first
     that exists. Used to make tests robust against the working directory that
     dune sets up (samples can live under [samples/], [../samples/], etc). *)
-let find_dir candidates = List.find_opt Sys.file_exists candidates
+let find_dir candidates =
+  List.find_opt (fun p -> Sys.file_exists p && Sys.is_directory p) candidates
 
 (** All [.pant] basenames in [dir], sorted lexicographically. *)
 let pant_files dir =
@@ -42,17 +43,16 @@ let pant_files dir =
 (** Parse a [.pant] file from disk into an [Ast.document]. *)
 let parse_pant_file path =
   let channel = open_in path in
-  let lexer = Lexer.create_from_channel path channel in
-  let supplier = Lexer.menhir_token lexer in
-  let doc =
-    MenhirLib.Convert.Simplified.traditional2revised Parser.document supplier
-  in
-  close_in channel;
-  doc
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr channel)
+    (fun () ->
+      let lexer = Lexer.create_from_channel path channel in
+      let supplier = Lexer.menhir_token lexer in
+      MenhirLib.Convert.Simplified.traditional2revised Parser.document supplier)
 
 (** Run the canonical translator pipeline on a parsed document and return the
     generated SMT queries, or an error message if collection or type-checking
-    fails. The config matches [bin/main.ml --check] defaults: bound 3, steps 1,
+    fails. Test-specific baseline: bound 3, steps 1 (CLI default is steps 5),
     guards injected. Used by every Layer-1, Layer-2, and fuzz test that needs
     the full translator output. *)
 let translate_to_queries (doc : Ast.document) : (Smt.query list, string) result
@@ -221,10 +221,13 @@ let[@warning "-44"] gen_bool_expr_at_depth =
   let open QCheck.Gen in
   let lit = oneof_list [ Ast.ELitBool true; Ast.ELitBool false ] in
   let var_of world =
-    match world.vars with
+    let bool_vars =
+      List.filter (fun (_, ty) -> ty = Ast.TName (Ast.Upper "Bool")) world.vars
+    in
+    match bool_vars with
     | [] -> lit
     | _ ->
-        let* name, _ty = oneof_list world.vars in
+        let* name, _ty = oneof_list bool_vars in
         return (Ast.EVar (Ast.Lower name))
   in
   let app_of world =


### PR DESCRIPTION
## Summary

Two SMT translation bugs surfaced while checking a real spec:

1. **`bind_head_params` over-quantified invariants** (`lib/smt_doc.ml:46-66`): every body proposition was wrapped in a `forall` over the union of *all* parameters of every rule in the chapter head — duplicate binders, vacuous binders, and spurious type antecedents. Caused Z3 parse errors and bogus contradictory-invariant verdicts.
2. **`translate_card` silent zero** (`lib/smt.ml:317-324`): `#v` for a non-domain element list (e.g. `[Real]`) emitted the literal string `"0"`, turning satisfiable specs into spurious contradictions.

Neither would have been caught by any existing test. This PR adds two layers of structural defence and fixes Bug 1.

## What's in the PR

**Layer 1 — corpus invariants + regression tests** (commit 1)
- `lib/smt_types.ml`: `fresh_fallback` / `add_fallback_assert` helpers (mirror `fresh_cond_default`). Each fallback site now declares a fresh `_<kind>_fallback_N` constant rather than emitting a silent literal.
- `lib/smt.ml`: `translate_card` non-domain branch and `translate_override` standalone branch use `fresh_fallback` so the approximation is visible.
- `test/smt_check.ml{,.mli}`: pure-OCaml sexp walker (`parsexp`) reporting `Parse_error` / `Duplicate_binder` / `Vacuous_binder` / `Fallback_emission`.
- `test/test_smt_invariants.ml`: per-fixture sweep over `samples/`, `samples/smt-examples/`, and `test/regression/`. Per-fixture allowlist in `test/regression/expected_failures.txt`; stale entries fail the test.
- `test/regression/bug_overquantify.pant` + `bug_card_zero.pant`: minimal repros locking in expected failure kinds.

**Layer 2 — qcheck-alcotest property tests + crowbar fuzz** (commit 1)
- `test/test_util.ml`: `gen_world`, `gen_document`, `arb_document`. Builds a small declared-symbol world (1-2 domains, 0-5 rules, 0-2 vars) with intentional name collisions to stress the over-quantification site.
- `test/test_smt_property.ml`: 200-iteration properties for translation totality, SMT well-formedness, and a kind-level allowlist mirroring Layer 1.
- `fuzz/fuzz_smt.ml` + `fuzz/dune` + `.github/workflows/ci.yml`: crowbar target wired into CI's existing fuzz step. No new system deps.

**Bug 1 fix + allowlist collapse** (commit 2)
- `lib/smt_doc.ml`: added `free_vars : Ast.expr -> StringSet.t` (respects forall/exists/each binders and staged GIn/GParam guard scoping); `bind_head_params` keeps only those head bindings that appear free in the proposition, dedup'd by name.
- `test/smt_check.ml`: `check_no_vacuous_binders` refined so user-authored `all i: Item | true.` and Nat-constraint-wrapped trivial bodies aren't flagged. Partial vacuity (`all x, y | g x` with `y` unused) is still caught.
- All 14 sample-fixture allowlist entries removed; `bug_overquantify.pant` regression flipped to expect `[]`; `kinds_pending_fix` is `[]` in both `test_smt_property.ml` and `fuzz_smt.ml`.

**Simplification pass** (commit 3, net −86 lines)
- Added `Test_util.{find_dir, pant_files, parse_pant_file, translate_to_queries}` so Layer 1 and Layer 2 stop reimplementing the canonical pipeline.
- `test_smt_invariants.ml`: cache the pipeline result via a single `collect_failures` call per fixture; the failure path no longer re-runs the entire translator just to format the report.
- `lib/smt_types.ml`: extracted `splice_before_first_assert` so `insert_cond_aux_decls` and `insert_fallback_decls` no longer duplicate the line-splitting logic.
- `test/smt_check.ml`: fused the three independent sexp walks into one `collect_failures` traversal (~3× → 1× walks per query).
- Removed unused exports `Smt_check.failure_kind_of_tag` and `Smt_check.check_queries`.

## Out of scope (deliberate)

- Differential z3-vs-cvc5 testing (no solvers in CI).
- Unifying the `cond_aux` + `fallback` ref-state into one buffer (touches stable pre-existing code).
- Relocating `free_vars` to `lib/ast.ml` (single consumer today).
- Pulling `fuzz/fuzz_smt.ml` onto `test_util` (would taint the fuzz binary with `alcotest` dep).

## Test plan

- [x] `dune build` clean
- [x] `dune build @fmt` clean
- [x] `dune test` green across all 15 test executables (Layer 1: 27/27, Layer 2: 3/3 at 200 iterations, plus the existing 12 suites)
- [x] `dune exec fuzz/fuzz_smt.exe` PASS in QuickCheck mode
- [x] Original failing spec from bug report now reports `OK: Invariants are jointly satisfiable`
- [x] Manually reverting just `lib/smt_doc.ml` immediately surfaces Layer 1 + Layer 2 failures, confirming the harness has teeth
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)