### PR TITLE
Apply @pant-type overrides to parameter types in ts2pant

### DIFF
--- a/tools/ts2pant/src/annotations.ts
+++ b/tools/ts2pant/src/annotations.ts
@@ -136,3 +136,16 @@ export function extractFunctionAnnotations(
   const result = extractAnnotations(node, sourceFile.compilerNode);
   return result.propositions.map((p) => p.text);
 }
+
+/**
+ * Convenience wrapper: find a function by name and extract its @pant-type
+ * overrides as a Map from TS parameter name to Pantagruel type string.
+ */
+export function extractFunctionTypeOverrides(
+  sourceFile: SourceFile,
+  functionName: string,
+): Map<string, string> {
+  const { node } = findFunction(sourceFile, functionName);
+  const result = extractAnnotations(node, sourceFile.compilerNode);
+  return new Map(result.typeOverrides.map((o) => [o.name, o.type]));
+}

--- a/tools/ts2pant/src/annotations.ts
+++ b/tools/ts2pant/src/annotations.ts
@@ -124,6 +124,28 @@ export function extractAnnotations(
   return result;
 }
 
+/** Combined proposition texts + type overrides from a function's JSDoc. */
+export interface FunctionAnnotations {
+  propositionTexts: string[];
+  typeOverrides: Map<string, string>;
+}
+
+/**
+ * Find a function by name and extract both @pant propositions and
+ * @pant-type overrides in a single JSDoc pass.
+ */
+export function extractFunctionAnnotationsAndOverrides(
+  sourceFile: SourceFile,
+  functionName: string,
+): FunctionAnnotations {
+  const { node } = findFunction(sourceFile, functionName);
+  const result = extractAnnotations(node, sourceFile.compilerNode);
+  return {
+    propositionTexts: result.propositions.map((p) => p.text),
+    typeOverrides: new Map(result.typeOverrides.map((o) => [o.name, o.type])),
+  };
+}
+
 /**
  * Convenience wrapper: find a function by name and extract its @pant
  * proposition texts as plain strings.
@@ -132,9 +154,8 @@ export function extractFunctionAnnotations(
   sourceFile: SourceFile,
   functionName: string,
 ): string[] {
-  const { node } = findFunction(sourceFile, functionName);
-  const result = extractAnnotations(node, sourceFile.compilerNode);
-  return result.propositions.map((p) => p.text);
+  return extractFunctionAnnotationsAndOverrides(sourceFile, functionName)
+    .propositionTexts;
 }
 
 /**
@@ -145,7 +166,6 @@ export function extractFunctionTypeOverrides(
   sourceFile: SourceFile,
   functionName: string,
 ): Map<string, string> {
-  const { node } = findFunction(sourceFile, functionName);
-  const result = extractAnnotations(node, sourceFile.compilerNode);
-  return new Map(result.typeOverrides.map((o) => [o.name, o.type]));
+  return extractFunctionAnnotationsAndOverrides(sourceFile, functionName)
+    .typeOverrides;
 }

--- a/tools/ts2pant/src/pipeline.ts
+++ b/tools/ts2pant/src/pipeline.ts
@@ -1,8 +1,5 @@
 import type { SourceFile } from "ts-morph";
-import {
-  extractFunctionAnnotations,
-  extractFunctionTypeOverrides,
-} from "./annotations.js";
+import { extractFunctionAnnotationsAndOverrides } from "./annotations.js";
 import { extractReferencedTypes, getChecker } from "./extract.js";
 import { NameRegistry } from "./name-registry.js";
 import { loadAst, loadParser, rewriteAnnotation } from "./pant-wasm.js";
@@ -43,9 +40,11 @@ export async function buildPantDocument(
   // type-derived accessor rules adapt with suffixes if there's a collision.
   const registry = new NameRegistry();
 
-  // @pant-type overrides are extracted up front so they can influence
-  // parameter type mapping during signature translation.
-  const overrides = extractFunctionTypeOverrides(sourceFile, functionName);
+  // Extract @pant propositions and @pant-type overrides in one JSDoc pass.
+  // Overrides influence parameter type mapping during signature translation;
+  // propositions become entailment checks once the body is translated.
+  const { propositionTexts: annotations, typeOverrides: overrides } =
+    extractFunctionAnnotationsAndOverrides(sourceFile, functionName);
 
   // Translate signature first to claim the function's param names
   const { declaration: sigDecl, paramNameMap } = translateSignature(
@@ -82,8 +81,6 @@ export async function buildPantDocument(
 
   // Annotations go to checks (entailment goals) — skip for skeleton docs
   if (!noBody && doc.propositions.length > 0) {
-    const annotations = extractFunctionAnnotations(sourceFile, functionName);
-
     // Rewrite annotation variable names using the embedded Pantagruel parser.
     // paramNameMap maps TS names → pant names; annotations use TS names.
     const hasRenames = [...paramNameMap.entries()].some(([k, v]) => k !== v);

--- a/tools/ts2pant/src/pipeline.ts
+++ b/tools/ts2pant/src/pipeline.ts
@@ -1,5 +1,8 @@
 import type { SourceFile } from "ts-morph";
-import { extractFunctionAnnotations } from "./annotations.js";
+import {
+  extractFunctionAnnotations,
+  extractFunctionTypeOverrides,
+} from "./annotations.js";
 import { extractReferencedTypes, getChecker } from "./extract.js";
 import { NameRegistry } from "./name-registry.js";
 import { loadAst, loadParser, rewriteAnnotation } from "./pant-wasm.js";
@@ -40,12 +43,17 @@ export async function buildPantDocument(
   // type-derived accessor rules adapt with suffixes if there's a collision.
   const registry = new NameRegistry();
 
+  // @pant-type overrides are extracted up front so they can influence
+  // parameter type mapping during signature translation.
+  const overrides = extractFunctionTypeOverrides(sourceFile, functionName);
+
   // Translate signature first to claim the function's param names
   const { declaration: sigDecl, paramNameMap } = translateSignature(
     sourceFile,
     functionName,
     strategy,
     registry,
+    overrides,
   );
 
   // Extract and translate types (type-derived param names adapt to registry)

--- a/tools/ts2pant/src/translate-signature.ts
+++ b/tools/ts2pant/src/translate-signature.ts
@@ -833,6 +833,7 @@ export function translateSignature(
   functionName: string,
   strategy: NumericStrategy,
   registry?: NameRegistry,
+  overrides?: Map<string, string>,
 ): TranslatedSignature {
   const checker = sourceFile.getProject().getTypeChecker().compilerObject;
   const { node, className } = findFunction(sourceFile, functionName);
@@ -858,11 +859,12 @@ export function translateSignature(
   }
 
   for (const param of sig.getParameters()) {
-    const paramType = mapTsType(
+    const defaultType = mapTsType(
       checker.getTypeOfSymbol(param),
       checker,
       strategy,
     );
+    const paramType = overrides?.get(param.name) ?? defaultType;
     const pantName = registry ? registry.register(param.name) : param.name;
     params.push({ name: pantName, type: paramType });
     paramNameMap.set(param.name, pantName);

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -2,6 +2,10 @@ exports[`annotations.ts > add 1`] = `
 "module Add.\\n\\nadd a: Int, b: Int => Int.\\n\\n---\\n\\nadd a b = a + b.\\n\\ncheck\\n\\nall a: Int, b: Int | add a b = a + b.\\n"
 `;
 
+exports[`annotations.ts > deposited 1`] = `
+"module Deposited.\\n\\ndeposited amount: Nat0 => Int.\\n\\n---\\n\\ndeposited amount = amount.\\n\\ncheck\\n\\nall a: Nat0 | deposited a >= 0.\\n"
+`;
+
 exports[`annotations.ts > noAnnot 1`] = `
 "module NoAnnot.\\n\\nnoAnnot x: Int => Int.\\n\\n---\\n\\nnoAnnot x = x.\\n"
 `;

--- a/tools/ts2pant/tests/fixtures/constructs/annotations.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/annotations.ts
@@ -32,3 +32,11 @@ export function rangeCheck(x: number): boolean {
 export function noAnnot(x: number): number {
   return x;
 }
+
+/**
+ * @pant-type amount: Nat0
+ * @pant all a: Nat0 | deposited a >= 0
+ */
+export function deposited(amount: number): number {
+  return amount;
+}

--- a/tools/ts2pant/tests/translate-signature.test.mts
+++ b/tools/ts2pant/tests/translate-signature.test.mts
@@ -425,3 +425,76 @@ describe("class method declarations", () => {
     assert.equal(result.declaration.guard, undefined);
   });
 });
+
+describe("@pant-type override", () => {
+  it("overrides parameter type with the annotated Pantagruel type", () => {
+    const source = `
+      /**
+       * @pant-type amount: Nat
+       */
+      function withdraw(amount: number): number {
+        return amount;
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const overrides = new Map([["amount", "Nat"]]);
+    const result = translateSignature(
+      sourceFile,
+      "withdraw",
+      IntStrategy,
+      undefined,
+      overrides,
+    );
+    assert.equal(result.declaration.kind, "rule");
+    if (result.declaration.kind !== "rule") {
+      return;
+    }
+    assert.equal(result.declaration.params[0]?.name, "amount");
+    assert.equal(result.declaration.params[0]?.type, "Nat");
+  });
+
+  it("leaves non-overridden params at the default strategy type", () => {
+    const source = `
+      function pay(amount: number, memo: number): number {
+        return amount;
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const overrides = new Map([["amount", "Nat"]]);
+    const result = translateSignature(
+      sourceFile,
+      "pay",
+      IntStrategy,
+      undefined,
+      overrides,
+    );
+    assert.equal(result.declaration.kind, "rule");
+    if (result.declaration.kind !== "rule") {
+      return;
+    }
+    assert.equal(result.declaration.params[0]?.type, "Nat");
+    assert.equal(result.declaration.params[1]?.type, "Int");
+  });
+
+  it("ignores overrides for parameter names that don't exist", () => {
+    const source = `
+      function pay(amount: number): number {
+        return amount;
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const overrides = new Map([["nonexistent", "Nat"]]);
+    const result = translateSignature(
+      sourceFile,
+      "pay",
+      IntStrategy,
+      undefined,
+      overrides,
+    );
+    assert.equal(result.declaration.kind, "rule");
+    if (result.declaration.kind !== "rule") {
+      return;
+    }
+    assert.equal(result.declaration.params[0]?.type, "Int");
+  });
+});


### PR DESCRIPTION
## Summary

- ts2pant parsed `@pant-type amount: Nat` annotations but the pipeline discarded the `typeOverrides` field before translation — overrides were silently ignored in the emitted Pantagruel.
- Extract overrides up front, thread them into `translateSignature` as an optional `Map`, and consult the map at the parameter loop after `mapTsType`. `mapTsType` stays pure.
- Scope: function-parameter overrides only. Return-type and interface-property overrides deferred.

## Test plan

- [x] New unit tests in `translate-signature.test.mts`: override applies, non-overridden params unchanged, unknown names ignored
- [x] New snapshot in `fixtures/constructs/annotations.ts` (`deposited`) verifies end-to-end that `@pant-type amount: Nat0` emits `deposited amount: Nat0 => Int.` (override hits parameter, not return type)
- [x] Full ts2pant suite: 217/217 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)