### PR TITLE
ts2pant: translate for-of, forEach, and reduce as catamorphisms

### DIFF
--- a/tools/ts2pant/CLAUDE.md
+++ b/tools/ts2pant/CLAUDE.md
@@ -123,6 +123,42 @@ body, emit frame conditions (`prop' obj = prop obj`) for everything not in the s
 `cond x ~= Nothing => prop x, true => Nothing`. This is the lifting encoding —
 partiality expressed as conditional expressions over the `Nothing` value.
 
+### Structured Iteration (for-of, forEach, reduce)
+
+**Standard name:** Catamorphisms / structural recursion on lists.
+**Reference:** Meijer, Fokkinga, Paterson, ["Functional Programming with Bananas, Lenses,
+Envelopes and Barbed Wire"](https://maartenfokkinga.github.io/utwente/mmf91m.pdf), FPCA 1991;
+Lamport, *Specifying Systems* (TLA+ `\A x \in arr` idiom for per-element next-state).
+
+ts2pant accepts three shapes that are all instances of the catamorphism `foldr : (a -> b -> b) -> b -> [a] -> b`:
+
+**Shape A — uniform iterator write (mutating).**
+`for (const x of arr) { x.p = e(x) }` and `arr.forEach(x => { x.p = e(x) })` become
+`all x in arr | p' x = e(x).` (universal-quantifier proposition form; binding is Pantagruel's
+bare `x in arr` via `ast.gIn`, with empty `params`). The body runs through a fresh
+sub-`symbolicExecute` with `x` bound, so conditional writes inside the loop pass through
+the standard if-conversion machinery.
+
+**Shape B — accumulator fold (mutating).**
+`for (const x of arr) { a.p OP= f(x) }` becomes `p' a = p a OP (combOP over each x in arr | f(x)).`
+Single-branch `if (g(x)) { a.p OP= f(x) }` folds `g(x)` into the comprehension as an extra
+guard. Supported ops: `+=`, `-=`, `*=`, `/=`. Non-commutative outer ops (`-`, `/`) only appear
+outside the comprehension — never as combiners.
+
+**Shape C — pure reduce (expression).**
+`arr.reduce((a, x) => a OP f(x), init)` becomes `init OP (combOP over each x: T | f(x))`,
+with `init` elided when it equals the combiner identity (0 for `+`, 1 for `*`, `true` for `&&`,
+`false` for `||`). `reduceRight` is accepted only for commutative combiners; non-commutative
+ops require acc on the left.
+
+**Invariants:**
+- Sub-execution uses a *fresh* `SymbolicState` — the iterator's writes must not leak.
+- Shape B writes merge into the outer `state.writes` via `binop(outerOp, priorVal, eachComb)`
+  so frame conditions for untouched properties still fire.
+- `state.modifiedProps` (shared across state clones) tracks which primed rules were emitted,
+  including Shape A equations that bypass `state.writes`; used to compute frame conditions
+  correctly when Shape A and Shape B appear in the same body.
+
 ## PR #84 Post-Mortem: Why Standard Algorithms Matter
 
 The initial const-inlining implementation used ad-hoc string-name substitution rather

--- a/tools/ts2pant/CLAUDE.md
+++ b/tools/ts2pant/CLAUDE.md
@@ -146,7 +146,7 @@ guard. Supported ops: `+=`, `-=`, `*=`, `/=`. Non-commutative outer ops (`-`, `/
 outside the comprehension — never as combiners.
 
 **Shape C — pure reduce (expression).**
-`arr.reduce((a, x) => a OP f(x), init)` becomes `init OP (combOP over each x: T | f(x))`,
+`arr.reduce((a, x) => a OP f(x), init)` becomes `init OP (combOP over each x in arr | f(x))`,
 with `init` elided when it equals the combiner identity (0 for `+`, 1 for `*`, `true` for `&&`,
 `false` for `||`). `reduceRight` is accepted only for commutative combiners; non-commutative
 ops require acc on the left.
@@ -158,6 +158,20 @@ ops require acc on the left.
 - `state.modifiedProps` (shared across state clones) tracks which primed rules were emitted,
   including Shape A equations that bypass `state.writes`; used to compute frame conditions
   correctly when Shape A and Shape B appear in the same body.
+
+### Chain Fusion (.filter / .map / .reduce)
+
+**Standard name:** Deforestation.
+**Reference:** Wadler, ["Deforestation: Transforming Programs to Eliminate Trees"](https://homepages.inf.ed.ac.uk/wadler/papers/deforest/deforest.ps), TCS 1990.
+
+`xs.filter(p).map(f).reduce((a, x) => a OP g(x), init)` fuses into a single traversal:
+`init OP (combOP over each x in xs, p(x) | g(f(x)))`. Each `.filter`/`.map` returns a
+`BodyResult` with `pendingComprehension = { binder, arrExpr, guards }` carrying the chain
+state in deferred form; `r.expr` holds the current projection. `bodyExpr(r)` materializes
+into `ast.each([], [gIn(binder, arrExpr), ...guards], projection)` at the chain boundary
+(return statement, binop operand, const initializer, etc.). `.filter` extends `guards`;
+`.map` rewrites the projection via `ast.substituteBinder(callbackBody, callbackBinder, receiver.expr)`;
+`.reduce` fuses the pending chain into an `eachComb` instead of triggering materialization.
 
 ## PR #84 Post-Mortem: Why Standard Algorithms Matter
 

--- a/tools/ts2pant/src/emit.ts
+++ b/tools/ts2pant/src/emit.ts
@@ -34,10 +34,11 @@ function renderPropResult(prop: PropResult): string {
   switch (prop.kind) {
     case "equation": {
       const eq = ast.binop(ast.opEq(), prop.lhs, prop.rhs);
-      if (prop.quantifiers.length === 0) {
+      const guards = prop.guards ?? [];
+      if (prop.quantifiers.length === 0 && guards.length === 0) {
         return ast.strExpr(eq);
       }
-      return ast.strExpr(ast.forall(prop.quantifiers, [], eq));
+      return ast.strExpr(ast.forall(prop.quantifiers, guards, eq));
     }
     case "unsupported":
       return `> UNSUPPORTED: ${prop.reason}`;

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -1,6 +1,11 @@
 import type { SourceFile } from "ts-morph";
 import ts from "typescript";
-import type { OpaqueExpr, OpaqueParam } from "./pant-ast.js";
+import type {
+  OpaqueCombiner,
+  OpaqueExpr,
+  OpaqueGuard,
+  OpaqueParam,
+} from "./pant-ast.js";
 import { getAst } from "./pant-wasm.js";
 import { isKnownPureCall } from "./purity.js";
 import {
@@ -85,6 +90,11 @@ interface SymbolicState {
   // Keys *written during the current branch* (reset on clone). Used by the
   // if-merge algorithm to determine which locations are "touched."
   writtenKeys: Set<string>;
+  // Names of rules that have been modified by *any* write in this execution,
+  // including Shape A loop writes whose per-element equation is emitted
+  // directly (bypassing `writes`). Consumed by the frame-condition generator
+  // so loop-modified rules don't get a spurious identity frame.
+  modifiedProps: Set<string>;
   // Canonicalizer — applies the ambient const-binding substitution to an
   // expression before it is used as a state key. Writes store keys under the
   // post-substitution form so `const x = a; x.balance = 1` and a later
@@ -97,13 +107,19 @@ interface SymbolicState {
 function makeSymbolicState(
   canonicalize: (e: OpaqueExpr) => OpaqueExpr = (e) => e,
 ): SymbolicState {
-  return { writes: new Map(), writtenKeys: new Set(), canonicalize };
+  return {
+    writes: new Map(),
+    writtenKeys: new Set(),
+    modifiedProps: new Set(),
+    canonicalize,
+  };
 }
 
 function cloneSymbolicState(s: SymbolicState): SymbolicState {
   return {
     writes: new Map(s.writes),
     writtenKeys: new Set(),
+    modifiedProps: s.modifiedProps,
     canonicalize: s.canonicalize,
   };
 }
@@ -197,6 +213,122 @@ const COMPOUND_ASSIGN_TO_BINOP: Map<ts.SyntaxKind, ts.BinaryOperator> = new Map(
     [ts.SyntaxKind.SlashEqualsToken, ts.SyntaxKind.SlashToken],
   ],
 );
+
+/**
+ * Map each compound assignment operator to the pair it induces for
+ * loop-fold translation: the *inside* combiner (for the comprehension)
+ * and the *outside* binary operator (joining prior state to the aggregate).
+ *
+ *   a.p += f(x)  iterated  =>  p' a = p a + (+ over each x in arr | f x)
+ *   a.p -= f(x)  iterated  =>  p' a = p a - (+ over each x in arr | f x)
+ *   a.p *= f(x)  iterated  =>  p' a = p a * (* over each x in arr | f x)
+ *   a.p /= f(x)  iterated  =>  p' a = p a / (* over each x in arr | f x)
+ *
+ * Non-commutative outer ops (`-`, `/`) pair with the commutative combiner
+ * of their identity group (`+`/`*`), since e.g. `p - f(x1) - f(x2)`
+ * equals `p - (f(x1) + f(x2))`.
+ */
+type CombinerKind = "add" | "mul" | "and" | "or";
+
+interface FoldOps {
+  combiner: CombinerKind;
+  outer: ts.BinaryOperator;
+}
+const COMPOUND_ASSIGN_TO_FOLD: Map<ts.SyntaxKind, FoldOps> = new Map([
+  [
+    ts.SyntaxKind.PlusEqualsToken,
+    { combiner: "add", outer: ts.SyntaxKind.PlusToken },
+  ],
+  [
+    ts.SyntaxKind.MinusEqualsToken,
+    { combiner: "add", outer: ts.SyntaxKind.MinusToken },
+  ],
+  [
+    ts.SyntaxKind.AsteriskEqualsToken,
+    { combiner: "mul", outer: ts.SyntaxKind.AsteriskToken },
+  ],
+  [
+    ts.SyntaxKind.SlashEqualsToken,
+    { combiner: "mul", outer: ts.SyntaxKind.SlashToken },
+  ],
+]);
+
+interface ReduceOpInfo {
+  combiner: CombinerKind;
+  outer: ts.BinaryOperator;
+  /** Source text of the init value that permits eliding init (combiner identity). */
+  identityText: string | null;
+  /** Whether `acc` can appear on either side — true iff the outer op is commutative. */
+  commutative: boolean;
+}
+
+/** Map a TypeScript binary operator (as used in `.reduce` callback body) to fold info. */
+function binopToReduceInfo(kind: ts.SyntaxKind): ReduceOpInfo | null {
+  switch (kind) {
+    case ts.SyntaxKind.PlusToken:
+      return {
+        combiner: "add",
+        outer: kind,
+        identityText: "0",
+        commutative: true,
+      };
+    case ts.SyntaxKind.MinusToken:
+      return {
+        combiner: "add",
+        outer: kind,
+        identityText: null,
+        commutative: false,
+      };
+    case ts.SyntaxKind.AsteriskToken:
+      return {
+        combiner: "mul",
+        outer: kind,
+        identityText: "1",
+        commutative: true,
+      };
+    case ts.SyntaxKind.SlashToken:
+      return {
+        combiner: "mul",
+        outer: kind,
+        identityText: null,
+        commutative: false,
+      };
+    case ts.SyntaxKind.AmpersandAmpersandToken:
+      return {
+        combiner: "and",
+        outer: kind,
+        identityText: "true",
+        commutative: true,
+      };
+    case ts.SyntaxKind.BarBarToken:
+      return {
+        combiner: "or",
+        outer: kind,
+        identityText: "false",
+        commutative: true,
+      };
+    default:
+      return null;
+  }
+}
+
+function makeCombiner(kind: CombinerKind): OpaqueCombiner {
+  const ast = getAst();
+  switch (kind) {
+    case "add":
+      return ast.combAdd();
+    case "mul":
+      return ast.combMul();
+    case "and":
+      return ast.combAnd();
+    case "or":
+      return ast.combOr();
+    default: {
+      const _exhaustive: never = kind;
+      throw new Error(`unknown combiner kind: ${_exhaustive as string}`);
+    }
+  }
+}
 
 export interface TranslateBodyOptions {
   sourceFile: SourceFile;
@@ -1079,6 +1211,618 @@ function translateArrayMethod(
   }
 }
 
+/**
+ * Translate `arr.reduce((acc, x) => acc OP f(x), init)` to a comprehension fold.
+ * Emits `init OP (combOP over each x: T | f(x))`, eliding `init` when it
+ * equals the combiner's identity element.
+ *
+ * Rejects composition with upstream `.filter` / `.map` for now (the opaque-AST
+ * constraint means we can't pull the filter predicate back out as a guard);
+ * a future change could track the predicate alongside `comprehensionBinder`.
+ */
+function translateReduceCall(
+  methodName: "reduce" | "reduceRight",
+  tsReceiver: ts.Expression,
+  expr: ts.CallExpression,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  paramNames: Map<string, string>,
+  state?: SymbolicState,
+): BodyResult | null {
+  const ast = getAst();
+
+  if (expr.arguments.length !== 2) {
+    return { unsupported: `.${methodName} requires an explicit initial value` };
+  }
+
+  const elemType = getArrayElementType(tsReceiver, checker, strategy);
+  if (!elemType) {
+    return null;
+  }
+
+  const receiver = translateBodyExpr(
+    tsReceiver,
+    checker,
+    strategy,
+    paramNames,
+    state,
+  );
+  if (isBodyUnsupported(receiver)) {
+    return receiver;
+  }
+  if (receiver.comprehensionBinder !== undefined) {
+    return {
+      unsupported: `.${methodName} after .filter/.map composition is not yet supported`,
+    };
+  }
+
+  const cb = expr.arguments[0]!;
+  if (!ts.isArrowFunction(cb)) {
+    return { unsupported: `.${methodName} callback must be an arrow function` };
+  }
+  if (cb.parameters.length !== 2) {
+    return {
+      unsupported: `.${methodName} callback must take exactly (acc, x)`,
+    };
+  }
+  const accParamNode = cb.parameters[0]!;
+  const xParamNode = cb.parameters[1]!;
+  if (
+    !ts.isIdentifier(accParamNode.name) ||
+    !ts.isIdentifier(xParamNode.name)
+  ) {
+    return {
+      unsupported: `.${methodName} callback parameters must be identifiers`,
+    };
+  }
+  const accName = (accParamNode.name as ts.Identifier).text;
+  const xName = (xParamNode.name as ts.Identifier).text;
+
+  let body: ts.Expression;
+  if (ts.isBlock(cb.body)) {
+    const stmts = cb.body.statements;
+    if (
+      stmts.length !== 1 ||
+      !ts.isReturnStatement(stmts[0]!) ||
+      !stmts[0]!.expression
+    ) {
+      return {
+        unsupported: `.${methodName} callback block body must be a single return`,
+      };
+    }
+    body = stmts[0]!.expression;
+  } else {
+    body = cb.body;
+  }
+  body = unwrapExpression(body);
+
+  if (!ts.isBinaryExpression(body)) {
+    return {
+      unsupported: `.${methodName} callback body must be 'acc OP f(x)'`,
+    };
+  }
+  const info = binopToReduceInfo(body.operatorToken.kind);
+  if (info === null) {
+    return {
+      unsupported: `.${methodName} operator ${ts.SyntaxKind[body.operatorToken.kind]} has no combiner`,
+    };
+  }
+
+  // `reduceRight` visits elements right-to-left; safe only for commutative combiners.
+  if (methodName === "reduceRight" && !info.commutative) {
+    return {
+      unsupported: `.reduceRight with non-commutative operator`,
+    };
+  }
+
+  const leftRoot = getRootIdentifier(body.left);
+  const rightRoot = getRootIdentifier(body.right);
+  let innerExpr: ts.Expression;
+  if (leftRoot === accName && rightRoot !== accName) {
+    innerExpr = body.right;
+  } else if (rightRoot === accName && leftRoot !== accName) {
+    if (!info.commutative) {
+      return {
+        unsupported: `.${methodName} with acc on the right of a non-commutative operator`,
+      };
+    }
+    innerExpr = body.left;
+  } else {
+    return {
+      unsupported: `.${methodName} callback must reference acc exactly once`,
+    };
+  }
+
+  if (expressionReferencesNames(innerExpr, new Set([accName]))) {
+    return {
+      unsupported: `.${methodName} inner expression must not reference acc`,
+    };
+  }
+
+  const sourceBinder = freshBinder(paramNames);
+  const extendedParams = new Map(paramNames);
+  extendedParams.set(xName, sourceBinder);
+
+  const innerResult = translateBodyExpr(
+    innerExpr,
+    checker,
+    strategy,
+    extendedParams,
+    state,
+  );
+  if (isBodyUnsupported(innerResult)) {
+    return innerResult;
+  }
+
+  const comb = makeCombiner(info.combiner);
+  const folded = ast.eachComb(
+    [ast.param(sourceBinder, ast.tName(elemType))],
+    [],
+    comb,
+    bodyExpr(innerResult),
+  );
+
+  const initNode = expr.arguments[1]!;
+  const initText = initNode.getText().trim();
+  if (info.identityText !== null && initText === info.identityText) {
+    return { expr: folded };
+  }
+
+  const initResult = translateBodyExpr(
+    initNode,
+    checker,
+    strategy,
+    paramNames,
+    state,
+  );
+  if (isBodyUnsupported(initResult)) {
+    return initResult;
+  }
+
+  const outerOp = translateOperator(info.outer);
+  if (outerOp === null) {
+    return { unsupported: `.${methodName} outer operator translation` };
+  }
+  return {
+    expr: ast.binop(outerOp, bodyExpr(initResult), folded),
+  };
+}
+
+// --- Structured iteration (for-of / forEach / reduce) ---
+//
+// Catamorphisms over arrays (Meijer et al., "Functional Programming with
+// Bananas, Lenses, Envelopes and Barbed Wire", FPCA 1991). Three shapes:
+//
+//   A. `for (const x of arr) { x.p = e }`   → `all x in arr | p' x = e`
+//   B. `for (const x of arr) { a.p OP= f }` → `p' a = p a OP (combOP over each x in arr | f)`
+//   C. `arr.reduce((acc, x) => acc OP f, i)`→ `i OP (combOP over each x in arr | f)`
+//
+// See CLAUDE.md § Structured Iteration.
+
+interface ShapeBLeaf {
+  /** `a` in `a.total += x.v` — the accumulator base expression (must not depend on iterator). */
+  target: ts.Expression;
+  /** `total` in `a.total += x.v`. */
+  prop: string;
+  /** Fold op pair (inner combiner + outer binary operator). */
+  ops: FoldOps;
+  /** RHS expression `f(x)` — may reference the iterator. */
+  rhs: ts.Expression;
+  /** Optional guard from a wrapping `if (g(x)) { a.p OP= f(x) }`. */
+  guard?: ts.Expression;
+}
+
+type LoopStmtClass =
+  | { kind: "shapeA" }
+  | { kind: "shapeB"; leaves: ShapeBLeaf[] }
+  | { unsupported: string };
+
+/** Extract the root identifier of a chained property access (`a.b.c` → `a`). */
+function getRootIdentifier(expr: ts.Expression): string | null {
+  expr = unwrapExpression(expr);
+  if (ts.isIdentifier(expr)) {
+    return expr.text;
+  }
+  if (ts.isPropertyAccessExpression(expr)) {
+    return getRootIdentifier(expr.expression);
+  }
+  return null;
+}
+
+/**
+ * Classify one loop-body statement as Shape A (iterator-targeted write),
+ * Shape B (accumulator fold), or unsupported. Handles nested if-stmts:
+ *   - if all branches are Shape A, the whole is Shape A
+ *   - if the stmt is `if (g(x)) { a.p OP= f }` with no else, it becomes a
+ *     single Shape B leaf with `guard = g(x)`.
+ */
+function classifyLoopStmt(
+  stmt: ts.Statement,
+  iterName: string,
+  checker: ts.TypeChecker,
+  parentGuard?: ts.Expression,
+): LoopStmtClass {
+  if (
+    ts.isExpressionStatement(stmt) &&
+    ts.isBinaryExpression(unwrapExpression(stmt.expression))
+  ) {
+    const bin = unwrapExpression(stmt.expression) as ts.BinaryExpression;
+    if (!ts.isPropertyAccessExpression(bin.left)) {
+      return {
+        unsupported: "loop body assignment target must be a property access",
+      };
+    }
+    const rootName = getRootIdentifier(bin.left.expression);
+    const isSimpleAssign = bin.operatorToken.kind === ts.SyntaxKind.EqualsToken;
+    const compoundFold = COMPOUND_ASSIGN_TO_FOLD.get(bin.operatorToken.kind);
+
+    if (rootName === iterName) {
+      if (!isSimpleAssign) {
+        return {
+          unsupported: "compound assignment on loop iterator property",
+        };
+      }
+      return { kind: "shapeA" };
+    }
+    if (compoundFold === undefined) {
+      return {
+        unsupported:
+          "loop accumulator write must use a compound assignment (+=, -=, *=, /=)",
+      };
+    }
+    if (expressionReferencesNames(bin.left.expression, new Set([iterName]))) {
+      return { unsupported: "loop accumulator target depends on iterator" };
+    }
+    const leaf: ShapeBLeaf = {
+      target: bin.left.expression,
+      prop: bin.left.name.text,
+      ops: compoundFold,
+      rhs: bin.right,
+    };
+    if (parentGuard) {
+      leaf.guard = parentGuard;
+    }
+    return { kind: "shapeB", leaves: [leaf] };
+  }
+
+  if (ts.isIfStatement(stmt)) {
+    if (expressionHasSideEffects(stmt.expression, checker)) {
+      return { unsupported: "impure if-condition in loop body" };
+    }
+    const thenStmts = flattenStmt(stmt.thenStatement);
+    const elseStmts = stmt.elseStatement ? flattenStmt(stmt.elseStatement) : [];
+
+    // Shape A: every branch-leaf is an iterator-write
+    const allA = [...thenStmts, ...elseStmts].every((s) => {
+      const c = classifyLoopStmt(s, iterName, checker);
+      return "kind" in c && c.kind === "shapeA";
+    });
+    if (allA) {
+      return { kind: "shapeA" };
+    }
+
+    // Shape B: `if (g) { a.p OP= f }` — single leaf, no else, no parent guard
+    if (
+      elseStmts.length === 0 &&
+      thenStmts.length === 1 &&
+      parentGuard === undefined
+    ) {
+      const inner = classifyLoopStmt(
+        thenStmts[0]!,
+        iterName,
+        checker,
+        stmt.expression,
+      );
+      if ("kind" in inner && inner.kind === "shapeB") {
+        return inner;
+      }
+    }
+    return {
+      unsupported:
+        "loop body if-statement mixes shapes or has an unsupported structure",
+    };
+  }
+
+  if (ts.isBlock(stmt)) {
+    const stmts = Array.from(stmt.statements);
+    const classes = stmts.map((s) =>
+      classifyLoopStmt(s, iterName, checker, parentGuard),
+    );
+    const firstBad = classes.find((c) => "unsupported" in c);
+    if (firstBad) {
+      return firstBad;
+    }
+    const allA = classes.every((c) => "kind" in c && c.kind === "shapeA");
+    if (allA) {
+      return { kind: "shapeA" };
+    }
+    const allB = classes.every((c) => "kind" in c && c.kind === "shapeB");
+    if (allB) {
+      const leaves = classes.flatMap(
+        (c) => (c as { kind: "shapeB"; leaves: ShapeBLeaf[] }).leaves,
+      );
+      return { kind: "shapeB", leaves };
+    }
+    return {
+      unsupported: "loop body block mixes iterator and accumulator writes",
+    };
+  }
+
+  return { unsupported: `loop body statement: ${ts.SyntaxKind[stmt.kind]}` };
+}
+
+/**
+ * Emit Shape A / Shape B propositions for a loop body.
+ *
+ * Shape A uses a sub-`symbolicExecute` to reuse the full symbolic-state
+ * machinery (path merging via `cond` for conditional writes). Each emitted
+ * write is wrapped in `all x in arr | p' x = v`.
+ *
+ * Shape B writes are merged into the caller's `state`: the outer state's
+ * prior value (or the pre-state identity) is combined with the comprehension
+ * `(combOP over each x in arr[, g(x)] | f(x))` via the outer binary operator.
+ */
+function translateForOfLoopBody(
+  iterName: string,
+  arrExpr: OpaqueExpr,
+  bodyStmts: ts.Statement[],
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  paramNames: Map<string, string>,
+  state: SymbolicState,
+  propositions: PropResult[],
+  applyConst: (e: OpaqueExpr) => OpaqueExpr,
+  supply: UniqueSupply,
+): boolean {
+  const ast = getAst();
+
+  const shapeAStmts: ts.Statement[] = [];
+  const shapeBLeaves: ShapeBLeaf[] = [];
+  for (const stmt of bodyStmts) {
+    const cls = classifyLoopStmt(stmt, iterName, checker);
+    if ("unsupported" in cls) {
+      propositions.push({ kind: "unsupported", reason: cls.unsupported });
+      return false;
+    }
+    if (cls.kind === "shapeA") {
+      shapeAStmts.push(stmt);
+    } else {
+      shapeBLeaves.push(...cls.leaves);
+    }
+  }
+
+  if (shapeAStmts.length > 0) {
+    const subParams = new Map(paramNames);
+    subParams.set(iterName, iterName);
+    const subState = makeSymbolicState(applyConst);
+    const subProps: PropResult[] = [];
+    const subBlock = ts.factory.createBlock(shapeAStmts, true);
+    const okA = symbolicExecute(
+      subBlock,
+      checker,
+      strategy,
+      subParams,
+      subState,
+      subProps,
+      applyConst,
+      supply,
+      false,
+    );
+    if (!okA) {
+      for (const p of subProps) {
+        propositions.push(p);
+      }
+      return false;
+    }
+    for (const [, entry] of subState.writes) {
+      propositions.push({
+        kind: "equation",
+        quantifiers: [] as OpaqueParam[],
+        guards: [ast.gIn(iterName, arrExpr)],
+        lhs: ast.app(ast.primed(entry.prop), [entry.objExpr]),
+        rhs: entry.value,
+      });
+      state.modifiedProps.add(entry.prop);
+    }
+  }
+
+  for (const leaf of shapeBLeaves) {
+    const subParams = new Map(paramNames);
+    subParams.set(iterName, iterName);
+
+    const accResult = translateBodyExpr(
+      leaf.target,
+      checker,
+      strategy,
+      paramNames,
+      state,
+    );
+    if (isBodyUnsupported(accResult)) {
+      propositions.push({ kind: "unsupported", reason: accResult.unsupported });
+      return false;
+    }
+    const accExpr = applyConst(bodyExpr(accResult));
+
+    const rhsResult = translateBodyExpr(leaf.rhs, checker, strategy, subParams);
+    if (isBodyUnsupported(rhsResult)) {
+      propositions.push({ kind: "unsupported", reason: rhsResult.unsupported });
+      return false;
+    }
+    const rhsExpr = applyConst(bodyExpr(rhsResult));
+
+    const guards: OpaqueGuard[] = [ast.gIn(iterName, arrExpr)];
+    if (leaf.guard) {
+      const gResult = translateBodyExpr(
+        leaf.guard,
+        checker,
+        strategy,
+        subParams,
+      );
+      if (isBodyUnsupported(gResult)) {
+        propositions.push({ kind: "unsupported", reason: gResult.unsupported });
+        return false;
+      }
+      guards.push(ast.gExpr(applyConst(bodyExpr(gResult))));
+    }
+
+    const comb = makeCombiner(leaf.ops.combiner);
+    const folded = ast.eachComb([], guards, comb, rhsExpr);
+
+    const outerOp = translateOperator(leaf.ops.outer);
+    if (outerOp === null) {
+      propositions.push({
+        kind: "unsupported",
+        reason: "loop-fold outer operator",
+      });
+      return false;
+    }
+    const key = symbolicKey(leaf.prop, accExpr);
+    const priorEntry = state.writes.get(key);
+    const priorVal =
+      priorEntry?.value ?? ast.app(ast.var(leaf.prop), [accExpr]);
+    const newVal = ast.binop(outerOp, priorVal, folded);
+
+    state.writes.set(key, { prop: leaf.prop, objExpr: accExpr, value: newVal });
+    state.writtenKeys.add(key);
+  }
+
+  return true;
+}
+
+/** Translate a `for (const x of arr) { ... }` statement. */
+function translateForOfLoop(
+  stmt: ts.ForOfStatement,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  paramNames: Map<string, string>,
+  state: SymbolicState,
+  propositions: PropResult[],
+  applyConst: (e: OpaqueExpr) => OpaqueExpr,
+  supply: UniqueSupply,
+): boolean {
+  const initList = stmt.initializer;
+  if (
+    !ts.isVariableDeclarationList(initList) ||
+    !(initList.flags & ts.NodeFlags.Const) ||
+    initList.declarations.length !== 1
+  ) {
+    propositions.push({
+      kind: "unsupported",
+      reason: "for-of initializer must be a single const binding",
+    });
+    return false;
+  }
+  const decl = initList.declarations[0]!;
+  if (!ts.isIdentifier(decl.name)) {
+    propositions.push({
+      kind: "unsupported",
+      reason: "for-of destructuring pattern is not supported",
+    });
+    return false;
+  }
+  const iterName = decl.name.text;
+
+  const arrResult = translateBodyExpr(
+    stmt.expression,
+    checker,
+    strategy,
+    paramNames,
+    state,
+  );
+  if (isBodyUnsupported(arrResult)) {
+    propositions.push({ kind: "unsupported", reason: arrResult.unsupported });
+    return false;
+  }
+  const arrExpr = applyConst(bodyExpr(arrResult));
+  const bodyStmts = flattenStmt(stmt.statement);
+
+  return translateForOfLoopBody(
+    iterName,
+    arrExpr,
+    bodyStmts,
+    checker,
+    strategy,
+    paramNames,
+    state,
+    propositions,
+    applyConst,
+    supply,
+  );
+}
+
+/**
+ * Translate a `arr.forEach(x => { ... })` call-statement. Returns null if
+ * the call is not a forEach (caller falls back to normal handling).
+ */
+function translateForEachStmt(
+  call: ts.CallExpression,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  paramNames: Map<string, string>,
+  state: SymbolicState,
+  propositions: PropResult[],
+  applyConst: (e: OpaqueExpr) => OpaqueExpr,
+  supply: UniqueSupply,
+): boolean | null {
+  if (
+    !ts.isPropertyAccessExpression(call.expression) ||
+    call.expression.name.text !== "forEach" ||
+    call.arguments.length !== 1
+  ) {
+    return null;
+  }
+  const receiver = call.expression.expression;
+  const arg = call.arguments[0]!;
+  if (!ts.isArrowFunction(arg)) {
+    propositions.push({
+      kind: "unsupported",
+      reason: "forEach callback must be an arrow function",
+    });
+    return false;
+  }
+  if (
+    arg.parameters.length !== 1 ||
+    !ts.isIdentifier(arg.parameters[0]!.name)
+  ) {
+    propositions.push({
+      kind: "unsupported",
+      reason: "forEach callback must take a single identifier parameter",
+    });
+    return false;
+  }
+  const iterName = (arg.parameters[0]!.name as ts.Identifier).text;
+
+  const arrResult = translateBodyExpr(
+    receiver,
+    checker,
+    strategy,
+    paramNames,
+    state,
+  );
+  if (isBodyUnsupported(arrResult)) {
+    propositions.push({ kind: "unsupported", reason: arrResult.unsupported });
+    return false;
+  }
+  const arrExpr = applyConst(bodyExpr(arrResult));
+
+  const bodyStmts = ts.isBlock(arg.body)
+    ? Array.from(arg.body.statements)
+    : [ts.factory.createExpressionStatement(arg.body)];
+
+  return translateForOfLoopBody(
+    iterName,
+    arrExpr,
+    bodyStmts,
+    checker,
+    strategy,
+    paramNames,
+    state,
+    propositions,
+    applyConst,
+    supply,
+  );
+}
+
 function translateCallExpr(
   expr: ts.CallExpression,
   checker: ts.TypeChecker,
@@ -1128,6 +1872,22 @@ function translateCallExpr(
       expr.arguments.length === 1
     ) {
       const result = translateArrayMethod(
+        methodName,
+        tsReceiver,
+        expr,
+        checker,
+        strategy,
+        paramNames,
+        state,
+      );
+      if (result) {
+        return result;
+      }
+    }
+
+    // .reduce(cb, init) / .reduceRight(cb, init) — fold into `over each` aggregate
+    if (methodName === "reduce" || methodName === "reduceRight") {
+      const result = translateReduceCall(
         methodName,
         tsReceiver,
         expr,
@@ -1272,7 +2032,6 @@ function translateMutatingBody(
     return propositions;
   }
 
-  const modifiedRules = new Set<string>();
   for (const [, entry] of state.writes) {
     propositions.push({
       kind: "equation",
@@ -1280,10 +2039,10 @@ function translateMutatingBody(
       lhs: ast.app(ast.primed(entry.prop), [entry.objExpr]),
       rhs: entry.value,
     });
-    modifiedRules.add(entry.prop);
+    state.modifiedProps.add(entry.prop);
   }
 
-  const frames = generateFrameConditions(modifiedRules, declarations);
+  const frames = generateFrameConditions(state.modifiedProps, declarations);
   propositions.push(...frames);
 
   return propositions;
@@ -1521,6 +2280,32 @@ function symbolicExecute(
       }
     }
 
+    // `arr.forEach(x => { ... })` — structurally equivalent to `for-of` when
+    // used as a statement. Dispatch to the same loop-body translator.
+    if (
+      ts.isExpressionStatement(stmt) &&
+      ts.isCallExpression(unwrapExpression(stmt.expression)) &&
+      !insideBranch
+    ) {
+      const call = unwrapExpression(stmt.expression) as ts.CallExpression;
+      const okF = translateForEachStmt(
+        call,
+        checker,
+        strategy,
+        paramNames,
+        state,
+        propositions,
+        applyConst,
+        supply,
+      );
+      if (okF !== null) {
+        if (!okF) {
+          ok = false;
+        }
+        continue;
+      }
+    }
+
     if (
       ts.isExpressionStatement(stmt) &&
       expressionHasSideEffects(stmt.expression, checker)
@@ -1689,6 +2474,23 @@ function symbolicExecute(
         ]);
         state.writes.set(key, { prop, objExpr, value: merged });
         state.writtenKeys.add(key);
+      }
+      continue;
+    }
+
+    if (ts.isForOfStatement(stmt) && !insideBranch) {
+      const okL = translateForOfLoop(
+        stmt,
+        checker,
+        strategy,
+        paramNames,
+        state,
+        propositions,
+        applyConst,
+        supply,
+      );
+      if (!okL) {
+        ok = false;
       }
       continue;
     }

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -334,6 +334,49 @@ function binopToReduceInfo(kind: ts.SyntaxKind): ReduceOpInfo | null {
   }
 }
 
+/**
+ * Decide whether an init expression evaluates to the combiner's identity element.
+ * Normalizes parenthesized/cast wrappers and numeric-literal variants so that
+ * `0`, `(0)`, `0.0`, `+0`, `-0` all match identity 0 for `+`, etc. Avoids
+ * relying on raw source text, which fails on whitespace or syntactically
+ * distinct but semantically equivalent forms.
+ */
+function isIdentityInit(node: ts.Expression, identityText: string): boolean {
+  const inner = unwrapExpression(node);
+  if (identityText === "true") {
+    return inner.kind === ts.SyntaxKind.TrueKeyword;
+  }
+  if (identityText === "false") {
+    return inner.kind === ts.SyntaxKind.FalseKeyword;
+  }
+  const n = evaluateNumericLiteral(inner);
+  if (n === null) {
+    return false;
+  }
+  const target = Number(identityText);
+  return Number.isFinite(target) && n === target;
+}
+
+function evaluateNumericLiteral(node: ts.Expression): number | null {
+  if (ts.isNumericLiteral(node)) {
+    const n = Number(node.text);
+    return Number.isFinite(n) ? n : null;
+  }
+  if (
+    ts.isPrefixUnaryExpression(node) &&
+    (node.operator === ts.SyntaxKind.PlusToken ||
+      node.operator === ts.SyntaxKind.MinusToken) &&
+    ts.isNumericLiteral(node.operand)
+  ) {
+    const n = Number(node.operand.text);
+    if (!Number.isFinite(n)) {
+      return null;
+    }
+    return node.operator === ts.SyntaxKind.MinusToken ? -n : n;
+  }
+  return null;
+}
+
 function makeCombiner(kind: CombinerKind): OpaqueCombiner {
   const ast = getAst();
   switch (kind) {
@@ -1383,8 +1426,10 @@ function translateReduceCall(
   }
 
   const initNode = expr.arguments[1]!;
-  const initText = initNode.getText().trim();
-  if (info.identityText !== null && initText === info.identityText) {
+  if (
+    info.identityText !== null &&
+    isIdentityInit(initNode, info.identityText)
+  ) {
     return { expr: folded };
   }
 

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -31,24 +31,13 @@ function makeUniqueSupply(): UniqueSupply {
   return { next: () => counter++ };
 }
 
+function freshHygienicBinder(supply: UniqueSupply): string {
+  return `$${supply.next()}`;
+}
+
 interface ConstBinding {
   tsName: string;
   initializer: ts.Expression;
-}
-
-/** Generate a binder name not already used by params. */
-function freshBinder(paramNames: Map<string, string>): string {
-  const used = new Set(paramNames.values());
-  for (const candidate of ["x", "y", "z", "w", "v", "u", "t"]) {
-    if (!used.has(candidate)) {
-      return candidate;
-    }
-  }
-  let i = 0;
-  while (used.has(`x${i}`)) {
-    i++;
-  }
-  return `x${i}`;
 }
 
 /**
@@ -488,6 +477,7 @@ function translatePureBody(
     return [{ kind: "unsupported", reason: `${functionName} — ${reason}` }];
   }
 
+  const supply = makeUniqueSupply();
   const inlined = inlineConstBindings(
     extracted.bindings.map((b) => ({
       tsName: b.name,
@@ -496,7 +486,7 @@ function translatePureBody(
     checker,
     strategy,
     paramNames,
-    makeUniqueSupply(),
+    supply,
   );
   if ("error" in inlined) {
     return [
@@ -509,6 +499,8 @@ function translatePureBody(
     checker,
     strategy,
     inlined.scopedParams,
+    undefined,
+    supply,
   );
 
   if (isBodyUnsupported(body)) {
@@ -682,6 +674,7 @@ function inlineConstBindings(
       strategy,
       scopedParams,
       state,
+      supply,
     );
     if (isBodyUnsupported(initResult)) {
       return { error: initResult.unsupported };
@@ -905,7 +898,8 @@ export function translateBodyExpr(
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
   paramNames: Map<string, string>,
-  state?: SymbolicState,
+  state: SymbolicState | undefined,
+  supply: UniqueSupply,
 ): BodyResult {
   const ast = getAst();
 
@@ -915,7 +909,14 @@ export function translateBodyExpr(
 
   // if/else statement -> cond
   if (ts.isIfStatement(expr)) {
-    return translateIfStatement(expr, checker, strategy, paramNames, state);
+    return translateIfStatement(
+      expr,
+      checker,
+      strategy,
+      paramNames,
+      state,
+      supply,
+    );
   }
 
   // Ternary: a ? b : c -> cond([[a, b], [true, c]])
@@ -926,6 +927,7 @@ export function translateBodyExpr(
       strategy,
       paramNames,
       state,
+      supply,
     );
     if (isBodyUnsupported(cond)) {
       return cond;
@@ -936,6 +938,7 @@ export function translateBodyExpr(
       strategy,
       paramNames,
       state,
+      supply,
     );
     if (isBodyUnsupported(whenTrue)) {
       return whenTrue;
@@ -946,6 +949,7 @@ export function translateBodyExpr(
       strategy,
       paramNames,
       state,
+      supply,
     );
     if (isBodyUnsupported(whenFalse)) {
       return whenFalse;
@@ -967,6 +971,7 @@ export function translateBodyExpr(
       strategy,
       paramNames,
       state,
+      supply,
     );
     if (isBodyUnsupported(obj)) {
       return obj;
@@ -996,7 +1001,14 @@ export function translateBodyExpr(
 
   // Call expression: handle .includes(), .filter().map(), etc.
   if (ts.isCallExpression(expr)) {
-    return translateCallExpr(expr, checker, strategy, paramNames, state);
+    return translateCallExpr(
+      expr,
+      checker,
+      strategy,
+      paramNames,
+      state,
+      supply,
+    );
   }
 
   // Prefix unary: !x -> unop(opNot(), x), -x -> unop(opNeg(), x)
@@ -1007,6 +1019,7 @@ export function translateBodyExpr(
       strategy,
       paramNames,
       state,
+      supply,
     );
     if (isBodyUnsupported(operand)) {
       return operand;
@@ -1033,6 +1046,7 @@ export function translateBodyExpr(
       strategy,
       paramNames,
       state,
+      supply,
     );
     if (isBodyUnsupported(left)) {
       return left;
@@ -1043,6 +1057,7 @@ export function translateBodyExpr(
       strategy,
       paramNames,
       state,
+      supply,
     );
     if (isBodyUnsupported(right)) {
       return right;
@@ -1063,7 +1078,8 @@ function translateIfStatement(
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
   paramNames: Map<string, string>,
-  state?: SymbolicState,
+  state: SymbolicState | undefined,
+  supply: UniqueSupply,
 ): BodyResult {
   const ast = getAst();
 
@@ -1073,6 +1089,7 @@ function translateIfStatement(
     strategy,
     paramNames,
     state,
+    supply,
   );
   if (isBodyUnsupported(cond)) {
     return cond;
@@ -1089,6 +1106,7 @@ function translateIfStatement(
       strategy,
       paramNames,
       state,
+      supply,
     );
     if (isBodyUnsupported(thenVal)) {
       return thenVal;
@@ -1099,6 +1117,7 @@ function translateIfStatement(
       strategy,
       paramNames,
       state,
+      supply,
     );
     if (isBodyUnsupported(elseVal)) {
       return elseVal;
@@ -1171,7 +1190,8 @@ function translateArrayMethod(
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
   paramNames: Map<string, string>,
-  state?: SymbolicState,
+  state: SymbolicState | undefined,
+  supply: UniqueSupply,
 ): BodyResult | null {
   const ast = getAst();
 
@@ -1185,6 +1205,7 @@ function translateArrayMethod(
     strategy,
     paramNames,
     state,
+    supply,
   );
   if (isBodyUnsupported(receiver)) {
     return receiver;
@@ -1192,9 +1213,14 @@ function translateArrayMethod(
 
   const pending = receiver.pendingComprehension;
   const isComposing = pending !== undefined;
-  const sourceBinder = isComposing ? pending.binder : freshBinder(paramNames);
+  // Hygienic `$N` binders (Barendregt convention): they cannot clash with
+  // user-visible identifiers or with other fresh binders from the same
+  // translation session.
+  const sourceBinder = isComposing
+    ? pending.binder
+    : freshHygienicBinder(supply);
   const callbackBinder = isComposing
-    ? freshBinder(new Map([...paramNames, [sourceBinder, sourceBinder]]))
+    ? freshHygienicBinder(supply)
     : sourceBinder;
   const extendedParams = new Map(paramNames);
   extendedParams.set(callbackBinder, callbackBinder);
@@ -1205,6 +1231,7 @@ function translateArrayMethod(
     extendedParams,
     checker,
     strategy,
+    supply,
   );
   if (!rawBody) {
     return { unsupported: expr.getText() };
@@ -1274,7 +1301,8 @@ function translateReduceCall(
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
   paramNames: Map<string, string>,
-  state?: SymbolicState,
+  state: SymbolicState | undefined,
+  supply: UniqueSupply,
 ): BodyResult | null {
   const ast = getAst();
 
@@ -1292,6 +1320,7 @@ function translateReduceCall(
     strategy,
     paramNames,
     state,
+    supply,
   );
   if (isBodyUnsupported(receiver)) {
     return receiver;
@@ -1381,13 +1410,10 @@ function translateReduceCall(
   }
 
   const pending = receiver.pendingComprehension;
-  // Fresh binder for the callback's `x`; in the composing case we'll substitute
-  // it away with the prior projection so the outer guard binds `pending.binder`.
-  const reservedForCallback = new Map(paramNames);
-  if (pending) {
-    reservedForCallback.set(pending.binder, pending.binder);
-  }
-  const xBinder = freshBinder(reservedForCallback);
+  // Hygienic `$N` binder for the callback's `x`; in the composing case we'll
+  // substitute it away with the prior projection so the outer guard binds
+  // `pending.binder`.
+  const xBinder = freshHygienicBinder(supply);
   const extendedParams = new Map(paramNames);
   extendedParams.set(xName, xBinder);
 
@@ -1397,6 +1423,7 @@ function translateReduceCall(
     strategy,
     extendedParams,
     state,
+    supply,
   );
   if (isBodyUnsupported(innerResult)) {
     return innerResult;
@@ -1439,6 +1466,7 @@ function translateReduceCall(
     strategy,
     paramNames,
     state,
+    supply,
   );
   if (isBodyUnsupported(initResult)) {
     return initResult;
@@ -1656,10 +1684,17 @@ function translateForOfLoopBody(
     }
   }
 
+  // `subState` captures Shape A's per-iteration writes so that Shape B reads
+  // of the iterator's properties resolve to the updated expression. E.g.
+  // `x.value = x.value + 1; a.total += x.value` must fold as
+  // `total a + (+ over each x in xs | value x + 1)`, not `value x`. Property
+  // reads against non-iterator objects pass through unchanged (they don't
+  // appear as keys in `subState.writes`).
+  const subState = makeSymbolicState(applyConst);
+  const subParams = new Map(paramNames);
+  subParams.set(iterName, iterName);
+
   if (shapeAStmts.length > 0) {
-    const subParams = new Map(paramNames);
-    subParams.set(iterName, iterName);
-    const subState = makeSymbolicState(applyConst);
     const subProps: PropResult[] = [];
     const subBlock = ts.factory.createBlock(shapeAStmts, true);
     const okA = symbolicExecute(
@@ -1692,15 +1727,13 @@ function translateForOfLoopBody(
   }
 
   for (const leaf of shapeBLeaves) {
-    const subParams = new Map(paramNames);
-    subParams.set(iterName, iterName);
-
     const accResult = translateBodyExpr(
       leaf.target,
       checker,
       strategy,
       paramNames,
       state,
+      supply,
     );
     if (isBodyUnsupported(accResult)) {
       propositions.push({ kind: "unsupported", reason: accResult.unsupported });
@@ -1708,7 +1741,14 @@ function translateForOfLoopBody(
     }
     const accExpr = applyConst(bodyExpr(accResult));
 
-    const rhsResult = translateBodyExpr(leaf.rhs, checker, strategy, subParams);
+    const rhsResult = translateBodyExpr(
+      leaf.rhs,
+      checker,
+      strategy,
+      subParams,
+      subState,
+      supply,
+    );
     if (isBodyUnsupported(rhsResult)) {
       propositions.push({ kind: "unsupported", reason: rhsResult.unsupported });
       return false;
@@ -1722,6 +1762,8 @@ function translateForOfLoopBody(
         checker,
         strategy,
         subParams,
+        subState,
+        supply,
       );
       if (isBodyUnsupported(gResult)) {
         propositions.push({ kind: "unsupported", reason: gResult.unsupported });
@@ -1793,6 +1835,7 @@ function translateForOfLoop(
     strategy,
     paramNames,
     state,
+    supply,
   );
   if (isBodyUnsupported(arrResult)) {
     propositions.push({ kind: "unsupported", reason: arrResult.unsupported });
@@ -1863,6 +1906,7 @@ function translateForEachStmt(
     strategy,
     paramNames,
     state,
+    supply,
   );
   if (isBodyUnsupported(arrResult)) {
     propositions.push({ kind: "unsupported", reason: arrResult.unsupported });
@@ -1893,7 +1937,8 @@ function translateCallExpr(
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
   paramNames: Map<string, string>,
-  state?: SymbolicState,
+  state: SymbolicState | undefined,
+  supply: UniqueSupply,
 ): BodyResult {
   const ast = getAst();
 
@@ -1914,6 +1959,7 @@ function translateCallExpr(
         strategy,
         paramNames,
         state,
+        supply,
       );
       if (isBodyUnsupported(arg)) {
         return arg;
@@ -1924,6 +1970,7 @@ function translateCallExpr(
         strategy,
         paramNames,
         state,
+        supply,
       );
       if (isBodyUnsupported(objExpr)) {
         return objExpr;
@@ -1944,6 +1991,7 @@ function translateCallExpr(
         strategy,
         paramNames,
         state,
+        supply,
       );
       if (result) {
         return result;
@@ -1960,6 +2008,7 @@ function translateCallExpr(
         strategy,
         paramNames,
         state,
+        supply,
       );
       if (result) {
         return result;
@@ -1977,13 +2026,21 @@ function translateCallExpr(
       strategy,
       paramNames,
       state,
+      supply,
     );
     if (isBodyUnsupported(receiver)) {
       return receiver;
     }
     const methodArgs: OpaqueExpr[] = [bodyExpr(receiver)];
     for (const arg of expr.arguments) {
-      const a = translateBodyExpr(arg, checker, strategy, paramNames, state);
+      const a = translateBodyExpr(
+        arg,
+        checker,
+        strategy,
+        paramNames,
+        state,
+        supply,
+      );
       if (isBodyUnsupported(a)) {
         return a;
       }
@@ -2007,7 +2064,14 @@ function translateCallExpr(
 
     const fnArgs: OpaqueExpr[] = [];
     for (const arg of expr.arguments) {
-      const a = translateBodyExpr(arg, checker, strategy, paramNames, state);
+      const a = translateBodyExpr(
+        arg,
+        checker,
+        strategy,
+        paramNames,
+        state,
+        supply,
+      );
       if (isBodyUnsupported(a)) {
         return a;
       }
@@ -2026,6 +2090,7 @@ function extractArrowBody(
   paramNames: Map<string, string>,
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
+  supply: UniqueSupply,
 ): BodyResult | null {
   if (!ts.isArrowFunction(expr)) {
     return null;
@@ -2055,14 +2120,28 @@ function extractArrowBody(
     if (nonGuard.length === 1) {
       const s = nonGuard[0]!;
       if (ts.isReturnStatement(s) && s.expression) {
-        return translateBodyExpr(s.expression, checker, strategy, arrowParams);
+        return translateBodyExpr(
+          s.expression,
+          checker,
+          strategy,
+          arrowParams,
+          undefined,
+          supply,
+        );
       }
     }
     return null;
   }
 
   // Expression body
-  return translateBodyExpr(expr.body, checker, strategy, arrowParams);
+  return translateBodyExpr(
+    expr.body,
+    checker,
+    strategy,
+    arrowParams,
+    undefined,
+    supply,
+  );
 }
 
 // --- Mutating function body translation ---
@@ -2166,6 +2245,7 @@ function symbolicExecute(
         strategy,
         paramNames,
         state,
+        supply,
       );
       if (isBodyUnsupported(gResult)) {
         ok = false;
@@ -2203,6 +2283,25 @@ function symbolicExecute(
       if (!okR) {
         ok = false;
         propositions.push(...remainingProps);
+        break;
+      }
+
+      // Shape A loop equations emit directly into `propositions` rather than
+      // flowing through `state.writes`, so they'd be silently dropped by the
+      // merge-only path below. Reject when the continuation produced such
+      // equations — we'd need to thread `gExpr` into each rhs (and reconcile
+      // `state.modifiedProps`) to preserve the early-exit semantics, which
+      // isn't yet implemented.
+      const directEquations = remainingProps.filter(
+        (p) => p.kind === "equation",
+      );
+      if (directEquations.length > 0) {
+        ok = false;
+        propositions.push({
+          kind: "unsupported",
+          reason:
+            "loop with per-iteration writes cannot appear after an early-exit guard",
+        });
         break;
       }
 
@@ -2310,6 +2409,7 @@ function symbolicExecute(
           strategy,
           paramNames,
           state,
+          supply,
         );
         if (isBodyUnsupported(obj)) {
           ok = false;
@@ -2330,6 +2430,7 @@ function symbolicExecute(
           strategy,
           paramNames,
           state,
+          supply,
         );
         if (isBodyUnsupported(val)) {
           ok = false;
@@ -2471,6 +2572,7 @@ function symbolicExecute(
         strategy,
         paramNames,
         state,
+        supply,
       );
       if (isBodyUnsupported(gResult)) {
         ok = false;

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -53,21 +53,43 @@ function freshBinder(paramNames: Map<string, string>): string {
 
 /**
  * Result of translating a body expression. Either an opaque expression
- * (possibly tagged as a comprehension for chaining), or a failure.
+ * (possibly with a deferred list-comprehension structure for chain fusion),
+ * or a failure.
+ *
+ * When `pendingComprehension` is set, `expr` holds the *projection body*
+ * (e.g., `name u`) and the field carries the binder, root array, and
+ * accumulated filter predicates. Materialization (calling `bodyExpr`) emits
+ * the flat `each([], [gIn(binder, arrExpr), ...guards], expr)`.
+ *
+ * Deforestation (Wadler, TCS 1990) — chained `.filter`/`.map`/`.reduce` fuse
+ * into a single traversal by deferring materialization until a consumer
+ * outside the chain demands an opaque expression.
  */
+interface PendingComprehension {
+  binder: string;
+  arrExpr: OpaqueExpr;
+  guards: OpaqueGuard[];
+}
+
 type BodyResult =
   | { unsupported: string }
-  | { expr: OpaqueExpr; comprehensionBinder?: string };
+  | { expr: OpaqueExpr; pendingComprehension?: PendingComprehension };
 
 /** Type guard for unsupported BodyResult. */
 function isBodyUnsupported(r: BodyResult): r is { unsupported: string } {
   return "unsupported" in r;
 }
 
-/** Extract the OpaqueExpr from a successful BodyResult. */
+/** Extract the OpaqueExpr from a successful BodyResult, materializing any
+ * deferred comprehension chain into a flat `each` at the boundary. */
 function bodyExpr(r: BodyResult): OpaqueExpr {
   if ("unsupported" in r) {
     throw new Error(`bodyExpr called on unsupported: ${r.unsupported}`);
+  }
+  if (r.pendingComprehension) {
+    const ast = getAst();
+    const { binder, arrExpr, guards } = r.pendingComprehension;
+    return ast.each([], [ast.gIn(binder, arrExpr), ...guards], r.expr);
   }
   return r.expr;
 }
@@ -1091,8 +1113,13 @@ function getArrayElementType(
 }
 
 /**
- * Translate a .filter() or .map() call on an array to a comprehension,
- * composing with any existing comprehension from a prior chain step.
+ * Translate `.filter()` / `.map()` on an array. Returns a BodyResult whose
+ * `pendingComprehension` encodes the deferred chain (Wadler, TCS 1990).
+ * Materialization into `each([], [gIn(binder, arrExpr), ...guards], body)`
+ * happens at the chain boundary via `bodyExpr`.
+ *
+ * `.filter(p)` extends the guard list; `.map(f)` rewrites the projection.
+ * Composition preserves the original root array in `arrExpr`.
  */
 function translateArrayMethod(
   methodName: "filter" | "map",
@@ -1105,8 +1132,7 @@ function translateArrayMethod(
 ): BodyResult | null {
   const ast = getAst();
 
-  const elemType = getArrayElementType(tsReceiver, checker, strategy);
-  if (!elemType) {
+  if (!getArrayElementType(tsReceiver, checker, strategy)) {
     return null;
   }
 
@@ -1121,18 +1147,13 @@ function translateArrayMethod(
     return receiver;
   }
 
-  const isComposing = receiver.comprehensionBinder !== undefined;
-  const sourceBinder = isComposing
-    ? receiver.comprehensionBinder!
-    : freshBinder(paramNames);
-  // Use a fresh binder for the callback so it doesn't collide with sourceBinder
+  const pending = receiver.pendingComprehension;
+  const isComposing = pending !== undefined;
+  const sourceBinder = isComposing ? pending.binder : freshBinder(paramNames);
   const callbackBinder = isComposing
     ? freshBinder(new Map([...paramNames, [sourceBinder, sourceBinder]]))
     : sourceBinder;
   const extendedParams = new Map(paramNames);
-  if (isComposing) {
-    extendedParams.set(sourceBinder, sourceBinder);
-  }
   extendedParams.set(callbackBinder, callbackBinder);
 
   const rawBody = extractArrowBody(
@@ -1149,76 +1170,59 @@ function translateArrayMethod(
     return rawBody;
   }
 
-  // When composing, substitute the callback's binder with the prior step's body
-  // so that e.g. xs.map(f).map(g) becomes (each x: T | g(f(x))) not (each x: T | g(x))
-  //
-  // For composition, we need the inner comprehension's body expression. Since
-  // we can't inspect opaque values, we use ast.substituteBinder on the raw
-  // callback body, replacing the callback binder with a variable named after
-  // the source binder. The outer comprehension will bind that variable.
+  // Substitute the callback binder with the prior chain's *projection* (not
+  // `var(sourceBinder)` — for a prior `.map(u => score u)`, the element in
+  // scope is `score u`, not `u`). Initial step has no prior projection, so
+  // `callbackBinder === sourceBinder` and this is a no-op.
   const bodyE = isComposing
-    ? ast.substituteBinder(
-        bodyExpr(rawBody),
-        callbackBinder,
-        ast.var(sourceBinder),
-      )
+    ? ast.substituteBinder(bodyExpr(rawBody), callbackBinder, receiver.expr)
     : bodyExpr(rawBody);
 
   if (methodName === "filter") {
     if (isComposing) {
-      // Composing filter onto an existing comprehension: add a guard predicate.
-      // We build a new comprehension with both the existing body and the new
-      // filter predicate as a guard.
-      // The existing comprehension's body becomes the new body, and the filter
-      // predicate is added as an additional guard.
-      //
-      // We reconstruct the comprehension: each sourceBinder: elemType, guards + new guard | existingBody
-      // Since we can't inspect the opaque comprehension, we track enough to rebuild.
-      // For now, produce a standalone comprehension with the filter as a guard on the source binder variable.
       return {
-        expr: ast.each(
-          [ast.param(sourceBinder, ast.tName(elemType))],
-          [ast.gExpr(bodyE)],
-          ast.var(sourceBinder),
-        ),
-        comprehensionBinder: sourceBinder,
+        expr: receiver.expr,
+        pendingComprehension: {
+          binder: pending.binder,
+          arrExpr: pending.arrExpr,
+          guards: [...pending.guards, ast.gExpr(bodyE)],
+        },
       };
     }
     return {
-      expr: ast.each(
-        [ast.param(sourceBinder, ast.tName(elemType))],
-        [ast.gExpr(bodyE)],
-        ast.var(sourceBinder),
-      ),
-      comprehensionBinder: sourceBinder,
-    };
-  } else {
-    // map
-    if (isComposing) {
-      return {
-        expr: ast.each(
-          [ast.param(sourceBinder, ast.tName(elemType))],
-          [],
-          bodyE,
-        ),
-        comprehensionBinder: sourceBinder,
-      };
-    }
-    return {
-      expr: ast.each([ast.param(sourceBinder, ast.tName(elemType))], [], bodyE),
-      comprehensionBinder: sourceBinder,
+      expr: ast.var(sourceBinder),
+      pendingComprehension: {
+        binder: sourceBinder,
+        arrExpr: receiver.expr,
+        guards: [ast.gExpr(bodyE)],
+      },
     };
   }
+  // map
+  if (isComposing) {
+    return {
+      expr: bodyE,
+      pendingComprehension: pending,
+    };
+  }
+  return {
+    expr: bodyE,
+    pendingComprehension: {
+      binder: sourceBinder,
+      arrExpr: receiver.expr,
+      guards: [],
+    },
+  };
 }
 
 /**
  * Translate `arr.reduce((acc, x) => acc OP f(x), init)` to a comprehension fold.
- * Emits `init OP (combOP over each x: T | f(x))`, eliding `init` when it
+ * Emits `init OP (combOP over each x in arr | f(x))`, eliding `init` when it
  * equals the combiner's identity element.
  *
- * Rejects composition with upstream `.filter` / `.map` for now (the opaque-AST
- * constraint means we can't pull the filter predicate back out as a guard);
- * a future change could track the predicate alongside `comprehensionBinder`.
+ * Fuses with an upstream `.filter`/`.map` pending comprehension (Wadler,
+ * TCS 1990) into a single `eachComb` with accumulated guards and the
+ * composed projection.
  */
 function translateReduceCall(
   methodName: "reduce" | "reduceRight",
@@ -1235,8 +1239,7 @@ function translateReduceCall(
     return { unsupported: `.${methodName} requires an explicit initial value` };
   }
 
-  const elemType = getArrayElementType(tsReceiver, checker, strategy);
-  if (!elemType) {
+  if (!getArrayElementType(tsReceiver, checker, strategy)) {
     return null;
   }
 
@@ -1249,11 +1252,6 @@ function translateReduceCall(
   );
   if (isBodyUnsupported(receiver)) {
     return receiver;
-  }
-  if (receiver.comprehensionBinder !== undefined) {
-    return {
-      unsupported: `.${methodName} after .filter/.map composition is not yet supported`,
-    };
   }
 
   const cb = expr.arguments[0]!;
@@ -1339,9 +1337,16 @@ function translateReduceCall(
     };
   }
 
-  const sourceBinder = freshBinder(paramNames);
+  const pending = receiver.pendingComprehension;
+  // Fresh binder for the callback's `x`; in the composing case we'll substitute
+  // it away with the prior projection so the outer guard binds `pending.binder`.
+  const reservedForCallback = new Map(paramNames);
+  if (pending) {
+    reservedForCallback.set(pending.binder, pending.binder);
+  }
+  const xBinder = freshBinder(reservedForCallback);
   const extendedParams = new Map(paramNames);
-  extendedParams.set(xName, sourceBinder);
+  extendedParams.set(xName, xBinder);
 
   const innerResult = translateBodyExpr(
     innerExpr,
@@ -1355,12 +1360,27 @@ function translateReduceCall(
   }
 
   const comb = makeCombiner(info.combiner);
-  const folded = ast.eachComb(
-    [ast.param(sourceBinder, ast.tName(elemType))],
-    [],
-    comb,
-    bodyExpr(innerResult),
-  );
+  let folded: OpaqueExpr;
+  if (pending) {
+    const projectedInner = ast.substituteBinder(
+      bodyExpr(innerResult),
+      xBinder,
+      receiver.expr,
+    );
+    folded = ast.eachComb(
+      [],
+      [ast.gIn(pending.binder, pending.arrExpr), ...pending.guards],
+      comb,
+      projectedInner,
+    );
+  } else {
+    folded = ast.eachComb(
+      [],
+      [ast.gIn(xBinder, receiver.expr)],
+      comb,
+      bodyExpr(innerResult),
+    );
+  }
 
   const initNode = expr.arguments[1]!;
   const initText = initNode.getText().trim();

--- a/tools/ts2pant/src/types.ts
+++ b/tools/ts2pant/src/types.ts
@@ -1,4 +1,4 @@
-import type { OpaqueExpr, OpaqueParam } from "./pant-ast.js";
+import type { OpaqueExpr, OpaqueGuard, OpaqueParam } from "./pant-ast.js";
 
 /** Pantagruel numeric type strategy. */
 export type NumericType = "Int" | "Real" | "Nat0";
@@ -50,6 +50,7 @@ export type PropResult =
   | {
       kind: "equation";
       quantifiers: OpaqueParam[];
+      guards?: OpaqueGuard[];
       lhs: OpaqueExpr;
       rhs: OpaqueExpr;
     }

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -63,7 +63,7 @@ exports[`expressions-arithmetic.ts > remainder 1`] = `
 `;
 
 exports[`expressions-array.ts > activeNames 1`] = `
-"module ActiveNames.\\n\\nUser.\\nname u: User => String.\\nactive u: User => Bool.\\nscore u: User => Int.\\nactiveNames users: [User] => [String].\\n\\n---\\n\\nactiveNames users = (each x: User | name x).\\n"
+"module ActiveNames.\\n\\nUser.\\nname u: User => String.\\nactive u: User => Bool.\\nscore u: User => Int.\\nactiveNames users: [User] => [String].\\n\\n---\\n\\nactiveNames users = (each x in users, active x | name x).\\n"
 `;
 
 exports[`expressions-array.ts > contains 1`] = `
@@ -75,11 +75,11 @@ exports[`expressions-array.ts > count 1`] = `
 `;
 
 exports[`expressions-array.ts > highScores 1`] = `
-"module HighScores.\\n\\nUser.\\nname u: User => String.\\nactive u: User => Bool.\\nscore u: User => Int.\\nhighScores users: [User] => [Int].\\n\\n---\\n\\nhighScores users = (each x: Int, x > 0 | x).\\n"
+"module HighScores.\\n\\nUser.\\nname u: User => String.\\nactive u: User => Bool.\\nscore u: User => Int.\\nhighScores users: [User] => [Int].\\n\\n---\\n\\nhighScores users = (each x in users, score x > 0 | score x).\\n"
 `;
 
 exports[`expressions-array.ts > nameLengths 1`] = `
-"module NameLengths.\\n\\nUser.\\nname u: User => String.\\nactive u: User => Bool.\\nscore u: User => Int.\\nnameLengths users: [User] => [Int].\\n\\n---\\n\\nnameLengths users = (each x: String | length x).\\n"
+"module NameLengths.\\n\\nUser.\\nname u: User => String.\\nactive u: User => Bool.\\nscore u: User => Int.\\nnameLengths users: [User] => [Int].\\n\\n---\\n\\nnameLengths users = (each x in users | length (name x)).\\n"
 `;
 
 exports[`expressions-boolean.ts > and 1`] = `
@@ -247,31 +247,31 @@ exports[`expressions-property.ts > getOwnerName 1`] = `
 `;
 
 exports[`expressions-reduce.ts > allActive 1`] = `
-"module AllActive.\\n\\nItem.\\nvalue i: Item => Int.\\nactive i: Item => Bool.\\nallActive xs: [Item] => Bool.\\n\\n---\\n\\nallActive xs = (and over each x: Item | active x).\\n"
+"module AllActive.\\n\\nItem.\\nvalue i: Item => Int.\\nactive i: Item => Bool.\\nallActive xs: [Item] => Bool.\\n\\n---\\n\\nallActive xs = (and over each x in xs | active x).\\n"
 `;
 
 exports[`expressions-reduce.ts > anyActive 1`] = `
-"module AnyActive.\\n\\nItem.\\nvalue i: Item => Int.\\nactive i: Item => Bool.\\nanyActive xs: [Item] => Bool.\\n\\n---\\n\\nanyActive xs = (or over each x: Item | active x).\\n"
+"module AnyActive.\\n\\nItem.\\nvalue i: Item => Int.\\nactive i: Item => Bool.\\nanyActive xs: [Item] => Bool.\\n\\n---\\n\\nanyActive xs = (or over each x in xs | active x).\\n"
 `;
 
 exports[`expressions-reduce.ts > productValues 1`] = `
-"module ProductValues.\\n\\nItem.\\nvalue i: Item => Int.\\nactive i: Item => Bool.\\nproductValues xs: [Item] => Int.\\n\\n---\\n\\nproductValues xs = (* over each x: Item | value x).\\n"
+"module ProductValues.\\n\\nItem.\\nvalue i: Item => Int.\\nactive i: Item => Bool.\\nproductValues xs: [Item] => Int.\\n\\n---\\n\\nproductValues xs = (* over each x in xs | value x).\\n"
 `;
 
 exports[`expressions-reduce.ts > subtractAll 1`] = `
-"module SubtractAll.\\n\\nItem.\\nvalue i: Item => Int.\\nactive i: Item => Bool.\\nsubtractAll xs: [Item] => Int.\\n\\n---\\n\\nsubtractAll xs = 1000 - (+ over each x: Item | value x).\\n"
+"module SubtractAll.\\n\\nItem.\\nvalue i: Item => Int.\\nactive i: Item => Bool.\\nsubtractAll xs: [Item] => Int.\\n\\n---\\n\\nsubtractAll xs = 1000 - (+ over each x in xs | value x).\\n"
 `;
 
 exports[`expressions-reduce.ts > sumAmounts 1`] = `
-"module SumAmounts.\\n\\nItem.\\nvalue i: Item => Int.\\nactive i: Item => Bool.\\nsumAmounts xs: [Item] => Int.\\n\\n---\\n\\nsumAmounts xs = (+ over each x: Item | value x).\\n"
+"module SumAmounts.\\n\\nItem.\\nvalue i: Item => Int.\\nactive i: Item => Bool.\\nsumAmounts xs: [Item] => Int.\\n\\n---\\n\\nsumAmounts xs = (+ over each x in xs | value x).\\n"
 `;
 
 exports[`expressions-reduce.ts > sumAmountsRight 1`] = `
-"module SumAmountsRight.\\n\\nItem.\\nvalue i: Item => Int.\\nactive i: Item => Bool.\\nsumAmountsRight xs: [Item] => Int.\\n\\n---\\n\\nsumAmountsRight xs = (+ over each x: Item | value x).\\n"
+"module SumAmountsRight.\\n\\nItem.\\nvalue i: Item => Int.\\nactive i: Item => Bool.\\nsumAmountsRight xs: [Item] => Int.\\n\\n---\\n\\nsumAmountsRight xs = (+ over each x in xs | value x).\\n"
 `;
 
 exports[`expressions-reduce.ts > sumFromBase 1`] = `
-"module SumFromBase.\\n\\nItem.\\nvalue i: Item => Int.\\nactive i: Item => Bool.\\nsumFromBase xs: [Item] => Int.\\n\\n---\\n\\nsumFromBase xs = 100 + (+ over each x: Item | value x).\\n"
+"module SumFromBase.\\n\\nItem.\\nvalue i: Item => Int.\\nactive i: Item => Bool.\\nsumFromBase xs: [Item] => Int.\\n\\n---\\n\\nsumFromBase xs = 100 + (+ over each x in xs | value x).\\n"
 `;
 
 exports[`functions-class.ts > Account.deposit 1`] = `

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -63,7 +63,7 @@ exports[`expressions-arithmetic.ts > remainder 1`] = `
 `;
 
 exports[`expressions-array.ts > activeNames 1`] = `
-"module ActiveNames.\\n\\nUser.\\nname u: User => String.\\nactive u: User => Bool.\\nscore u: User => Int.\\nactiveNames users: [User] => [String].\\n\\n---\\n\\nactiveNames users = (each x in users, active x | name x).\\n"
+"module ActiveNames.\\n\\nUser.\\nname u: User => String.\\nactive u: User => Bool.\\nscore u: User => Int.\\nactiveNames users: [User] => [String].\\n\\n---\\n\\nactiveNames users = (each $0 in users, active $0 | name $0).\\n"
 `;
 
 exports[`expressions-array.ts > contains 1`] = `
@@ -75,11 +75,11 @@ exports[`expressions-array.ts > count 1`] = `
 `;
 
 exports[`expressions-array.ts > highScores 1`] = `
-"module HighScores.\\n\\nUser.\\nname u: User => String.\\nactive u: User => Bool.\\nscore u: User => Int.\\nhighScores users: [User] => [Int].\\n\\n---\\n\\nhighScores users = (each x in users, score x > 0 | score x).\\n"
+"module HighScores.\\n\\nUser.\\nname u: User => String.\\nactive u: User => Bool.\\nscore u: User => Int.\\nhighScores users: [User] => [Int].\\n\\n---\\n\\nhighScores users = (each $0 in users, score $0 > 0 | score $0).\\n"
 `;
 
 exports[`expressions-array.ts > nameLengths 1`] = `
-"module NameLengths.\\n\\nUser.\\nname u: User => String.\\nactive u: User => Bool.\\nscore u: User => Int.\\nnameLengths users: [User] => [Int].\\n\\n---\\n\\nnameLengths users = (each x in users | length (name x)).\\n"
+"module NameLengths.\\n\\nUser.\\nname u: User => String.\\nactive u: User => Bool.\\nscore u: User => Int.\\nnameLengths users: [User] => [Int].\\n\\n---\\n\\nnameLengths users = (each $0 in users | length (name $0)).\\n"
 `;
 
 exports[`expressions-boolean.ts > and 1`] = `
@@ -247,31 +247,31 @@ exports[`expressions-property.ts > getOwnerName 1`] = `
 `;
 
 exports[`expressions-reduce.ts > allActive 1`] = `
-"module AllActive.\\n\\nItem.\\nvalue i: Item => Int.\\nactive i: Item => Bool.\\nallActive xs: [Item] => Bool.\\n\\n---\\n\\nallActive xs = (and over each x in xs | active x).\\n"
+"module AllActive.\\n\\nItem.\\nvalue i: Item => Int.\\nactive i: Item => Bool.\\nallActive xs: [Item] => Bool.\\n\\n---\\n\\nallActive xs = (and over each $0 in xs | active $0).\\n"
 `;
 
 exports[`expressions-reduce.ts > anyActive 1`] = `
-"module AnyActive.\\n\\nItem.\\nvalue i: Item => Int.\\nactive i: Item => Bool.\\nanyActive xs: [Item] => Bool.\\n\\n---\\n\\nanyActive xs = (or over each x in xs | active x).\\n"
+"module AnyActive.\\n\\nItem.\\nvalue i: Item => Int.\\nactive i: Item => Bool.\\nanyActive xs: [Item] => Bool.\\n\\n---\\n\\nanyActive xs = (or over each $0 in xs | active $0).\\n"
 `;
 
 exports[`expressions-reduce.ts > productValues 1`] = `
-"module ProductValues.\\n\\nItem.\\nvalue i: Item => Int.\\nactive i: Item => Bool.\\nproductValues xs: [Item] => Int.\\n\\n---\\n\\nproductValues xs = (* over each x in xs | value x).\\n"
+"module ProductValues.\\n\\nItem.\\nvalue i: Item => Int.\\nactive i: Item => Bool.\\nproductValues xs: [Item] => Int.\\n\\n---\\n\\nproductValues xs = (* over each $0 in xs | value $0).\\n"
 `;
 
 exports[`expressions-reduce.ts > subtractAll 1`] = `
-"module SubtractAll.\\n\\nItem.\\nvalue i: Item => Int.\\nactive i: Item => Bool.\\nsubtractAll xs: [Item] => Int.\\n\\n---\\n\\nsubtractAll xs = 1000 - (+ over each x in xs | value x).\\n"
+"module SubtractAll.\\n\\nItem.\\nvalue i: Item => Int.\\nactive i: Item => Bool.\\nsubtractAll xs: [Item] => Int.\\n\\n---\\n\\nsubtractAll xs = 1000 - (+ over each $0 in xs | value $0).\\n"
 `;
 
 exports[`expressions-reduce.ts > sumAmounts 1`] = `
-"module SumAmounts.\\n\\nItem.\\nvalue i: Item => Int.\\nactive i: Item => Bool.\\nsumAmounts xs: [Item] => Int.\\n\\n---\\n\\nsumAmounts xs = (+ over each x in xs | value x).\\n"
+"module SumAmounts.\\n\\nItem.\\nvalue i: Item => Int.\\nactive i: Item => Bool.\\nsumAmounts xs: [Item] => Int.\\n\\n---\\n\\nsumAmounts xs = (+ over each $0 in xs | value $0).\\n"
 `;
 
 exports[`expressions-reduce.ts > sumAmountsRight 1`] = `
-"module SumAmountsRight.\\n\\nItem.\\nvalue i: Item => Int.\\nactive i: Item => Bool.\\nsumAmountsRight xs: [Item] => Int.\\n\\n---\\n\\nsumAmountsRight xs = (+ over each x in xs | value x).\\n"
+"module SumAmountsRight.\\n\\nItem.\\nvalue i: Item => Int.\\nactive i: Item => Bool.\\nsumAmountsRight xs: [Item] => Int.\\n\\n---\\n\\nsumAmountsRight xs = (+ over each $0 in xs | value $0).\\n"
 `;
 
 exports[`expressions-reduce.ts > sumFromBase 1`] = `
-"module SumFromBase.\\n\\nItem.\\nvalue i: Item => Int.\\nactive i: Item => Bool.\\nsumFromBase xs: [Item] => Int.\\n\\n---\\n\\nsumFromBase xs = 100 + (+ over each x in xs | value x).\\n"
+"module SumFromBase.\\n\\nItem.\\nvalue i: Item => Int.\\nactive i: Item => Bool.\\nsumFromBase xs: [Item] => Int.\\n\\n---\\n\\nsumFromBase xs = 100 + (+ over each $0 in xs | value $0).\\n"
 `;
 
 exports[`functions-class.ts > Account.deposit 1`] = `

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -246,6 +246,34 @@ exports[`expressions-property.ts > getOwnerName 1`] = `
 "module GetOwnerName.\\n\\nUser.\\nname u: User => String.\\nAccount.\\nbalance a1: Account => Int.\\nowner a1: Account => User.\\nactive a1: Account => Bool.\\ngetOwnerName a: Account => String.\\n\\n---\\n\\ngetOwnerName a = name (owner a).\\n"
 `;
 
+exports[`expressions-reduce.ts > allActive 1`] = `
+"module AllActive.\\n\\nItem.\\nvalue i: Item => Int.\\nactive i: Item => Bool.\\nallActive xs: [Item] => Bool.\\n\\n---\\n\\nallActive xs = (and over each x: Item | active x).\\n"
+`;
+
+exports[`expressions-reduce.ts > anyActive 1`] = `
+"module AnyActive.\\n\\nItem.\\nvalue i: Item => Int.\\nactive i: Item => Bool.\\nanyActive xs: [Item] => Bool.\\n\\n---\\n\\nanyActive xs = (or over each x: Item | active x).\\n"
+`;
+
+exports[`expressions-reduce.ts > productValues 1`] = `
+"module ProductValues.\\n\\nItem.\\nvalue i: Item => Int.\\nactive i: Item => Bool.\\nproductValues xs: [Item] => Int.\\n\\n---\\n\\nproductValues xs = (* over each x: Item | value x).\\n"
+`;
+
+exports[`expressions-reduce.ts > subtractAll 1`] = `
+"module SubtractAll.\\n\\nItem.\\nvalue i: Item => Int.\\nactive i: Item => Bool.\\nsubtractAll xs: [Item] => Int.\\n\\n---\\n\\nsubtractAll xs = 1000 - (+ over each x: Item | value x).\\n"
+`;
+
+exports[`expressions-reduce.ts > sumAmounts 1`] = `
+"module SumAmounts.\\n\\nItem.\\nvalue i: Item => Int.\\nactive i: Item => Bool.\\nsumAmounts xs: [Item] => Int.\\n\\n---\\n\\nsumAmounts xs = (+ over each x: Item | value x).\\n"
+`;
+
+exports[`expressions-reduce.ts > sumAmountsRight 1`] = `
+"module SumAmountsRight.\\n\\nItem.\\nvalue i: Item => Int.\\nactive i: Item => Bool.\\nsumAmountsRight xs: [Item] => Int.\\n\\n---\\n\\nsumAmountsRight xs = (+ over each x: Item | value x).\\n"
+`;
+
+exports[`expressions-reduce.ts > sumFromBase 1`] = `
+"module SumFromBase.\\n\\nItem.\\nvalue i: Item => Int.\\nactive i: Item => Bool.\\nsumFromBase xs: [Item] => Int.\\n\\n---\\n\\nsumFromBase xs = 100 + (+ over each x: Item | value x).\\n"
+`;
+
 exports[`functions-class.ts > Account.deposit 1`] = `
 "module Deposit.\\n\\n~> Deposit @ a: Account, amount: Int.\\n\\n---\\n\\nbalance' a = balance a + amount.\\n"
 `;
@@ -360,6 +388,38 @@ exports[`functions-mutating-early-exit.ts > elseReturnThenMore 1`] = `
 
 exports[`functions-mutating-early-exit.ts > writeThenEarlyReturn 1`] = `
 "module WriteThenEarlyReturn.\\n\\nAccount.\\nbalance a1: Account => Int.\\nowner a1: Account => String.\\n~> WriteThenEarlyReturn @ a: Account, g: Bool.\\n\\n---\\n\\nbalance' a = (cond g => 10, true => 10 + 5).\\nowner' a1 = owner a1.\\n"
+`;
+
+exports[`functions-mutating-loop.ts > activateActive 1`] = `
+"module ActivateActive.\\n\\nUser.\\nactive u: User => Bool.\\nscore u: User => Int.\\n~> ActivateActive @ users: [User].\\n\\n---\\n\\nall u in users | active' u = (cond score u > 0 => true, true => active u).\\nscore' u = score u.\\n"
+`;
+
+exports[`functions-mutating-loop.ts > activateAll 1`] = `
+"module ActivateAll.\\n\\nUser.\\nactive u: User => Bool.\\nscore u: User => Int.\\n~> ActivateAll @ users: [User].\\n\\n---\\n\\nall u in users | active' u = true.\\nscore' u = score u.\\n"
+`;
+
+exports[`functions-mutating-loop.ts > deductFees 1`] = `
+"module DeductFees.\\n\\nAccount.\\ntotal a1: Account => Int.\\nbalance a1: Account => Int.\\nFee.\\namount f: Fee => Int.\\n~> DeductFees @ a: Account, fees: [Fee].\\n\\n---\\n\\nbalance' a = balance a - (+ over each f in fees | amount f).\\ntotal' a1 = total a1.\\namount' f = amount f.\\n"
+`;
+
+exports[`functions-mutating-loop.ts > forEachActivate 1`] = `
+"module ForEachActivate.\\n\\nUser.\\nactive u: User => Bool.\\nscore u: User => Int.\\n~> ForEachActivate @ users: [User].\\n\\n---\\n\\nall u in users | active' u = true.\\nscore' u = score u.\\n"
+`;
+
+exports[`functions-mutating-loop.ts > forEachSum 1`] = `
+"module ForEachSum.\\n\\nAccount.\\ntotal a1: Account => Int.\\nbalance a1: Account => Int.\\nItem.\\nvalue i: Item => Int.\\ntagged i: Item => Bool.\\n~> ForEachSum @ a: Account, items: [Item].\\n\\n---\\n\\ntotal' a = total a + (+ over each x in items | value x).\\nbalance' a1 = balance a1.\\nvalue' i = value i.\\ntagged' i = tagged i.\\n"
+`;
+
+exports[`functions-mutating-loop.ts > mixedUpdates 1`] = `
+"module MixedUpdates.\\n\\nAccount.\\ntotal a1: Account => Int.\\nbalance a1: Account => Int.\\nItem.\\nvalue i: Item => Int.\\ntagged i: Item => Bool.\\n~> MixedUpdates @ a: Account, items: [Item].\\n\\n---\\n\\nall x in items | tagged' x = true.\\ntotal' a = total a + (+ over each x in items | value x).\\nbalance' a1 = balance a1.\\nvalue' i = value i.\\n"
+`;
+
+exports[`functions-mutating-loop.ts > sumAmounts 1`] = `
+"module SumAmounts.\\n\\nAccount.\\ntotal a1: Account => Int.\\nbalance a1: Account => Int.\\nItem.\\nvalue i: Item => Int.\\ntagged i: Item => Bool.\\n~> SumAmounts @ a: Account, items: [Item].\\n\\n---\\n\\ntotal' a = total a + (+ over each x in items | value x).\\nbalance' a1 = balance a1.\\nvalue' i = value i.\\ntagged' i = tagged i.\\n"
+`;
+
+exports[`functions-mutating-loop.ts > sumPositive 1`] = `
+"module SumPositive.\\n\\nAccount.\\ntotal a1: Account => Int.\\nbalance a1: Account => Int.\\nItem.\\nvalue i: Item => Int.\\ntagged i: Item => Bool.\\n~> SumPositive @ a: Account, items: [Item].\\n\\n---\\n\\ntotal' a = total a + (+ over each x in items, value x > 0 | value x).\\nbalance' a1 = balance a1.\\nvalue' i = value i.\\ntagged' i = tagged i.\\n"
 `;
 
 exports[`functions-mutating.ts > deposit 1`] = `

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-reduce.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-reduce.ts
@@ -1,0 +1,45 @@
+// Shape C: pure `.reduce` / `.reduceRight` → aggregate comprehension
+//   `arr.reduce((a, x) => a OP f(x), init)`
+//   → `init OP (combOP over each x: T | f(x))`
+// `init` is elided when it equals the combiner's identity (0 for +, 1 for *,
+// true for &&, false for ||). See CLAUDE.md § Structured Iteration.
+
+interface Item {
+  value: number;
+  active: boolean;
+}
+
+/** explicit init = 0 (add identity) → init is elided */
+export function sumAmounts(xs: Item[]): number {
+  return xs.reduce((a, x) => a + x.value, 0);
+}
+
+/** explicit init = 1 (mul identity) → init is elided */
+export function productValues(xs: Item[]): number {
+  return xs.reduce((a, x) => a * x.value, 1);
+}
+
+/** explicit init = true (and identity) → init is elided */
+export function allActive(xs: Item[]): boolean {
+  return xs.reduce((a, x) => a && x.active, true);
+}
+
+/** init = false (or identity) → init is elided */
+export function anyActive(xs: Item[]): boolean {
+  return xs.reduce((a, x) => a || x.active, false);
+}
+
+/** init differs from identity → preserved on the outside */
+export function sumFromBase(xs: Item[]): number {
+  return xs.reduce((a, x) => a + x.value, 100);
+}
+
+/** non-commutative outer op (`-`) → init preserved; acc must be on the left */
+export function subtractAll(xs: Item[]): number {
+  return xs.reduce((a, x) => a - x.value, 1000);
+}
+
+/** reduceRight with commutative op is accepted */
+export function sumAmountsRight(xs: Item[]): number {
+  return xs.reduceRight((a, x) => a + x.value, 0);
+}

--- a/tools/ts2pant/tests/fixtures/constructs/functions-mutating-loop.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/functions-mutating-loop.ts
@@ -1,0 +1,87 @@
+// Structured loop translation (Meijer et al., FPCA 1991). `for-of` and
+// `.forEach` over an array become catamorphisms:
+//   - Iterator-writes (Shape A): `all x in arr | p' x = v`
+//   - Accumulator folds (Shape B): `p' a = p a OP (comb over each x in arr | f)`
+// See CLAUDE.md § Structured Iteration.
+
+interface User {
+  active: boolean;
+  score: number;
+}
+
+interface Account {
+  total: number;
+  balance: number;
+}
+
+interface Fee {
+  amount: number;
+}
+
+interface Item {
+  value: number;
+  tagged: boolean;
+}
+
+/** Shape A: uniform iterator write */
+export function activateAll(users: User[]): void {
+  for (const u of users) {
+    u.active = true;
+  }
+}
+
+/** Shape A: conditional iterator write — path-merged via cond per element */
+export function activateActive(users: User[]): void {
+  for (const u of users) {
+    if (u.score > 0) {
+      u.active = true;
+    }
+  }
+}
+
+/** Shape B: accumulator sum via += */
+export function sumAmounts(a: Account, items: Item[]): void {
+  for (const x of items) {
+    a.total += x.value;
+  }
+}
+
+/** Shape B: accumulator deduction via -= */
+export function deductFees(a: Account, fees: Fee[]): void {
+  for (const f of fees) {
+    a.balance -= f.amount;
+  }
+}
+
+/** Shape B with guard — predicate folds into the comprehension */
+export function sumPositive(a: Account, items: Item[]): void {
+  for (const x of items) {
+    if (x.value > 0) {
+      a.total += x.value;
+    }
+  }
+}
+
+/** Shape A + Shape B in the same body — *independent*: the iterator write
+ * and the fold read touch disjoint properties, so per-step order is
+ * semantically irrelevant. */
+export function mixedUpdates(a: Account, items: Item[]): void {
+  for (const x of items) {
+    x.tagged = true;
+    a.total += x.value;
+  }
+}
+
+/** forEach variant of Shape A */
+export function forEachActivate(users: User[]): void {
+  users.forEach((u) => {
+    u.active = true;
+  });
+}
+
+/** forEach variant of Shape B */
+export function forEachSum(a: Account, items: Item[]): void {
+  items.forEach((x) => {
+    a.total += x.value;
+  });
+}

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -501,3 +501,258 @@ describe("conditional mutations (symbolic last-write)", () => {
     }
   });
 });
+
+describe("structured iteration (for-of, forEach, reduce)", () => {
+  it("Shape A: uniform iterator write emits `all x in arr | p' x = v`", () => {
+    const source = `
+      interface User { active: boolean; }
+      function f(us: User[]): void {
+        for (const u of us) { u.active = true; }
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "f",
+      strategy: IntStrategy,
+    });
+    const eqs = props.filter((p) => p.kind === "equation");
+    const loopEq = eqs.find(
+      (e) => e.kind === "equation" && (e.guards?.length ?? 0) > 0,
+    );
+    assert.ok(loopEq, "expected one loop equation with a guard");
+    if (loopEq?.kind === "equation") {
+      const ast = getAst();
+      const rendered = ast.strExpr(
+        ast.forall([], loopEq.guards ?? [], ast.var("__body__")),
+      );
+      assert.match(rendered, /all u in us \| /);
+      assert.equal(ast.strExpr(loopEq.lhs), "active' u");
+      assert.equal(ast.strExpr(loopEq.rhs), "true");
+    }
+  });
+
+  it("Shape A: conditional iterator write delegates to symbolic-execute", () => {
+    const source = `
+      interface User { active: boolean; score: number; }
+      function f(us: User[]): void {
+        for (const u of us) {
+          if (u.score > 0) { u.active = true; }
+        }
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "f",
+      strategy: IntStrategy,
+    });
+    const eqs = props.filter((p) => p.kind === "equation");
+    const loopEq = eqs.find(
+      (e) => e.kind === "equation" && (e.guards?.length ?? 0) > 0,
+    );
+    assert.ok(loopEq);
+    if (loopEq?.kind === "equation") {
+      const ast = getAst();
+      assert.equal(
+        ast.strExpr(loopEq.rhs),
+        "cond score u > 0 => true, true => active u",
+      );
+    }
+  });
+
+  it("Shape B: += emits `p a + (+ over each x in arr | rhs)`", () => {
+    const source = `
+      interface Account { total: number; }
+      interface Item { value: number; }
+      function f(a: Account, xs: Item[]): void {
+        for (const x of xs) { a.total += x.value; }
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "f",
+      strategy: IntStrategy,
+    });
+    const eqs = props.filter((p) => p.kind === "equation");
+    const totalEq = eqs.find(
+      (e) =>
+        e.kind === "equation" && getAst().strExpr(e.lhs) === "total' a",
+    );
+    assert.ok(totalEq);
+    if (totalEq?.kind === "equation") {
+      const ast = getAst();
+      assert.equal(
+        ast.strExpr(totalEq.rhs),
+        "total a + (+ over each x in xs | value x)",
+      );
+    }
+  });
+
+  it("Shape B: guard folds into the comprehension", () => {
+    const source = `
+      interface Account { total: number; }
+      interface Item { value: number; }
+      function f(a: Account, xs: Item[]): void {
+        for (const x of xs) {
+          if (x.value > 0) { a.total += x.value; }
+        }
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "f",
+      strategy: IntStrategy,
+    });
+    const eqs = props.filter((p) => p.kind === "equation");
+    const totalEq = eqs.find(
+      (e) =>
+        e.kind === "equation" && getAst().strExpr(e.lhs) === "total' a",
+    );
+    assert.ok(totalEq);
+    if (totalEq?.kind === "equation") {
+      const ast = getAst();
+      assert.equal(
+        ast.strExpr(totalEq.rhs),
+        "total a + (+ over each x in xs, value x > 0 | value x)",
+      );
+    }
+  });
+
+  it("Mixed body emits one Shape A equation and one Shape B equation", () => {
+    const source = `
+      interface Account { total: number; }
+      interface Item { value: number; tagged: boolean; }
+      function f(a: Account, xs: Item[]): void {
+        for (const x of xs) {
+          x.tagged = true;
+          a.total += x.value;
+        }
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "f",
+      strategy: IntStrategy,
+    });
+    const eqs = props.filter((p) => p.kind === "equation");
+    const ast = getAst();
+    const lhsStrings = eqs.map((e) =>
+      e.kind === "equation" ? ast.strExpr(e.lhs) : "",
+    );
+    assert.ok(lhsStrings.includes("tagged' x"));
+    assert.ok(lhsStrings.includes("total' a"));
+  });
+
+  it("rejects simple-assign fold (requires compound assignment)", () => {
+    const source = `
+      interface Account { total: number; }
+      interface Item { value: number; }
+      function f(a: Account, xs: Item[]): void {
+        for (const x of xs) { a.total = a.total + x.value; }
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "f",
+      strategy: IntStrategy,
+    });
+    assert.ok(props.some((p) => p.kind === "unsupported"));
+  });
+
+  it("forEach dispatches to the same loop-body translator", () => {
+    const source = `
+      interface Account { total: number; }
+      interface Item { value: number; }
+      function f(a: Account, xs: Item[]): void {
+        xs.forEach((x) => { a.total += x.value; });
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "f",
+      strategy: IntStrategy,
+    });
+    const eqs = props.filter((p) => p.kind === "equation");
+    const totalEq = eqs.find(
+      (e) =>
+        e.kind === "equation" && getAst().strExpr(e.lhs) === "total' a",
+    );
+    assert.ok(totalEq);
+    if (totalEq?.kind === "equation") {
+      const ast = getAst();
+      assert.equal(
+        ast.strExpr(totalEq.rhs),
+        "total a + (+ over each x in xs | value x)",
+      );
+    }
+  });
+
+  it("Shape C: reduce elides init when it equals combiner identity", () => {
+    const source = `
+      interface Item { value: number; }
+      function f(xs: Item[]): number {
+        return xs.reduce((a, x) => a + x.value, 0);
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "f",
+      strategy: IntStrategy,
+    });
+    const eqs = props.filter((p) => p.kind === "equation");
+    assert.equal(eqs.length, 1);
+    const ast = getAst();
+    if (eqs[0]?.kind === "equation") {
+      assert.equal(
+        ast.strExpr(eqs[0].rhs),
+        "+ over each x: Item | value x",
+      );
+    }
+  });
+
+  it("Shape C: reduce preserves non-identity init", () => {
+    const source = `
+      interface Item { value: number; }
+      function f(xs: Item[]): number {
+        return xs.reduce((a, x) => a + x.value, 100);
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "f",
+      strategy: IntStrategy,
+    });
+    const eqs = props.filter((p) => p.kind === "equation");
+    const ast = getAst();
+    if (eqs[0]?.kind === "equation") {
+      assert.equal(
+        ast.strExpr(eqs[0].rhs),
+        "100 + (+ over each x: Item | value x)",
+      );
+    }
+  });
+
+  it("Shape C: reduce rejects implicit-init form", () => {
+    const source = `
+      interface Item { value: number; }
+      function f(xs: Item[]): number {
+        return xs.reduce((a, x) => a + x.value);
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "f",
+      strategy: IntStrategy,
+    });
+    assert.ok(props.some((p) => p.kind === "unsupported"));
+  });
+});

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -712,7 +712,7 @@ describe("structured iteration (for-of, forEach, reduce)", () => {
     if (eqs[0]?.kind === "equation") {
       assert.equal(
         ast.strExpr(eqs[0].rhs),
-        "+ over each x in xs | value x",
+        "+ over each $0 in xs | value $0",
       );
     }
   });
@@ -735,7 +735,7 @@ describe("structured iteration (for-of, forEach, reduce)", () => {
     if (eqs[0]?.kind === "equation") {
       assert.equal(
         ast.strExpr(eqs[0].rhs),
-        "100 + (+ over each x in xs | value x)",
+        "100 + (+ over each $0 in xs | value $0)",
       );
     }
   });
@@ -772,6 +772,63 @@ describe("structured iteration (for-of, forEach, reduce)", () => {
     assert.ok(props.some((p) => p.kind === "unsupported"));
   });
 
+  it("rejects Shape A loop in an early-exit continuation", () => {
+    // Shape A equations emit directly into `propositions`, not `state.writes`.
+    // The early-exit merge path only threads guards through `state.writes`,
+    // so accepting this would silently drop the loop equation while leaving
+    // `state.modifiedProps` populated (suppressing the frame). Reject instead.
+    const source = `
+      interface User { active: boolean; }
+      function f(g: boolean, us: User[]): void {
+        if (g) return;
+        for (const u of us) { u.active = true; }
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "f",
+      strategy: IntStrategy,
+    });
+    assert.ok(
+      props.some((p) => p.kind === "unsupported"),
+      "expected an unsupported marker",
+    );
+  });
+
+  it("Shape B reads observe Shape A writes in the same iteration", () => {
+    const source = `
+      interface Account { total: number; }
+      interface Item { value: number; }
+      function f(a: Account, xs: Item[]): void {
+        for (const x of xs) {
+          x.value = x.value + 1;
+          a.total += x.value;
+        }
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "f",
+      strategy: IntStrategy,
+    });
+    const ast = getAst();
+    const eqs = props.filter((p) => p.kind === "equation");
+    const totalEq = eqs.find(
+      (e) => e.kind === "equation" && ast.strExpr(e.lhs) === "total' a",
+    );
+    assert.ok(totalEq, "expected a Shape B equation for total");
+    if (totalEq?.kind === "equation") {
+      // Shape B's `x.value` read must resolve through the in-iteration
+      // Shape A write `value' x = value x + 1`, not the pre-state `value x`.
+      assert.equal(
+        ast.strExpr(totalEq.rhs),
+        "total a + (+ over each x in xs | value x + 1)",
+      );
+    }
+  });
+
   it("Shape C: reduce elides parenthesized/signed-zero init variants", () => {
     const variants = ["(0)", "0.0", "+0", "-0", " 0 "];
     for (const initText of variants) {
@@ -793,7 +850,7 @@ describe("structured iteration (for-of, forEach, reduce)", () => {
       if (eqs[0]?.kind === "equation") {
         assert.equal(
           ast.strExpr(eqs[0].rhs),
-          "+ over each x in xs | value x",
+          "+ over each $0 in xs | value $0",
           `variant ${initText}: init should have been elided`,
         );
       }

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -755,4 +755,48 @@ describe("structured iteration (for-of, forEach, reduce)", () => {
     });
     assert.ok(props.some((p) => p.kind === "unsupported"));
   });
+
+  it("Shape C: reduceRight rejects non-commutative operators", () => {
+    const source = `
+      interface Item { value: number; }
+      function f(xs: Item[]): number {
+        return xs.reduceRight((a, x) => a - x.value, 0);
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "f",
+      strategy: IntStrategy,
+    });
+    assert.ok(props.some((p) => p.kind === "unsupported"));
+  });
+
+  it("Shape C: reduce elides parenthesized/signed-zero init variants", () => {
+    const variants = ["(0)", "0.0", "+0", "-0", " 0 "];
+    for (const initText of variants) {
+      const source = `
+        interface Item { value: number; }
+        function f(xs: Item[]): number {
+          return xs.reduce((a, x) => a + x.value, ${initText});
+        }
+      `;
+      const sourceFile = createSourceFileFromSource(source);
+      const props = translateBody({
+        sourceFile,
+        functionName: "f",
+        strategy: IntStrategy,
+      });
+      const eqs = props.filter((p) => p.kind === "equation");
+      assert.equal(eqs.length, 1, `variant ${initText}: expected 1 equation`);
+      const ast = getAst();
+      if (eqs[0]?.kind === "equation") {
+        assert.equal(
+          ast.strExpr(eqs[0].rhs),
+          "+ over each x in xs | value x",
+          `variant ${initText}: init should have been elided`,
+        );
+      }
+    }
+  });
 });

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -712,7 +712,7 @@ describe("structured iteration (for-of, forEach, reduce)", () => {
     if (eqs[0]?.kind === "equation") {
       assert.equal(
         ast.strExpr(eqs[0].rhs),
-        "+ over each x: Item | value x",
+        "+ over each x in xs | value x",
       );
     }
   });
@@ -735,7 +735,7 @@ describe("structured iteration (for-of, forEach, reduce)", () => {
     if (eqs[0]?.kind === "equation") {
       assert.equal(
         ast.strExpr(eqs[0].rhs),
-        "100 + (+ over each x: Item | value x)",
+        "100 + (+ over each x in xs | value x)",
       );
     }
   });


### PR DESCRIPTION
## Summary

Teach ts2pant to translate three list-traversal shapes, all instances of the catamorphism pattern (Meijer et al., *Bananas, Lenses, Envelopes and Barbed Wire*, FPCA 1991):

- **Shape A** — mutating iterator writes (`for (const x of arr) { x.p = e(x) }`, `arr.forEach(...)`) → `all x in arr | p' x = e(x).`
- **Shape B** — accumulator folds with compound assignment (`for (const x of arr) { a.p OP= f(x) }`) → `p' a = p a OP (combOP over each x in arr | f(x)).` Supports `+=`, `-=`, `*=`, `/=`. Single-branch guards fold into the comprehension.
- **Shape C** — pure `.reduce` / `.reduceRight` → `init OP (combOP over each x: T | f(x))`, with `init` elided at combiner identity. `reduceRight` accepted only for commutative combiners.

Adds `SymbolicState.modifiedProps` (shared across state clones) so frame conditions fire correctly when Shape A equations — which emit quantified propositions directly rather than writing through `state.writes` — appear alongside ordinary scalar writes.

## Test plan

- [x] `npm test` — 278 tests pass (up from 268)
- [x] Snapshots for `functions-mutating-loop.ts` and `expressions-reduce.ts` cover all three shapes plus mixed bodies
- [x] Unit tests in `translate-body.test.mts` cover identity elision, guard folding, simple-assign rejection, and implicit-init rejection
- [ ] Manual `pant --check` spot-check on a generated Shape B fixture

🤖 Generated with [Claude Code](https://claude.com/claude-code)