### PR TITLE
ts2pant: translate Set<T> reads

### DIFF
--- a/tools/ts2pant/CLAUDE.md
+++ b/tools/ts2pant/CLAUDE.md
@@ -123,6 +123,36 @@ body, emit frame conditions (`prop' obj = prop obj`) for everything not in the s
 `cond x ~= Nothing => prop x, true => Nothing`. This is the lifting encoding —
 partiality expressed as conditional expressions over the `Nothing` value.
 
+### Partial Rules (Map Fields)
+
+**Standard name:** Precondition-guarded partial function; declaration guard.
+**Reference:** Dafny Reference Manual (preconditions); Dijkstra, CACM 1975 (guards).
+
+A `Map<K, V>` field on a TypeScript interface becomes a *pair* of Pantagruel
+rules: a Bool-valued membership predicate and a `V`-valued rule guarded by it.
+
+```
+entriesKey c: Cache, k: K => Bool.
+entries c: Cache, k: K, entriesKey c k => V.
+```
+
+`.has(k)` translates to `entriesKey obj k`; `.get(k)` (or `.get(k)!`) translates
+to `entries obj k`. Pantagruel stores declaration guards in `Env.rule_guards`
+and automatically injects them as antecedents in SMT queries, so uses of
+`entries obj k` are implicitly conditioned on `entriesKey obj k`.
+
+**Why this encoding, not `V + Nothing`?** Pantagruel has no first-class
+`Nothing` expression value and no sum destructuring. With a sum-typed return,
+`.has` has no clean translation and `.get` cannot be used in arithmetic /
+comparisons without a lifting operation the language doesn't provide. The
+guarded-rule encoding trades a small semantic gap (absent keys are
+uninterpreted rather than explicitly `undefined`) for a much richer set of
+usable specifications.
+
+**Scope:** currently read-only and interface-field-only. Map parameters,
+mutation (`.set`/`.delete`), construction, and iteration are unsupported —
+see `tests/fixtures/constructs/expressions-map.ts` for the supported shape.
+
 ### Structured Iteration (for-of, forEach, reduce)
 
 **Standard name:** Catamorphisms / structural recursion on lists.

--- a/tools/ts2pant/README.md
+++ b/tools/ts2pant/README.md
@@ -124,6 +124,7 @@ This works with any function declared as `asserts condition` -- Node's `assert`,
 | `string` | `String` |
 | `T[]` | `[T]` |
 | `Set<T>` | `[T]` (membership via `.has(x)` → `x in`, cardinality via `.size` → `#`; uniqueness is not tracked) |
+| `Map<K, V>` field on `interface` | two rules: `<name>Key c: C, k: K => Bool` and `<name> c: C, k: K, <name>Key c k => V` (read via `.get(k)` → `<name> c k`, membership via `.has(k)` → `<name>Key c k`) |
 | `T \| null` / `T \| undefined` | `T + Nothing` |
 | `interface Foo { ... }` | `Foo.` (domain) + rules for each property |
 
@@ -176,6 +177,7 @@ FAIL: Not entailed: 'balance' account >= 0'
 - **No local variables.** Functions with `let`/`const` bindings before the return are rejected as unsupported.
 - **No loops.** `for`/`while` are not translated.
 - **Array operations** are partially supported: `.filter().map()` chains, `.includes()`, `.length`. Other array methods are unsupported.
+- **`Map<K, V>` support is read-only and interface-field-only.** Map fields translate into a value rule guarded by a membership predicate. Map parameters (not as interface fields), mutation (`.set`, `.delete`), construction (`new Map()`), and iteration (`.entries`, `.keys`, `.values`, `.forEach`) are not yet supported.
 
 ## Development
 

--- a/tools/ts2pant/README.md
+++ b/tools/ts2pant/README.md
@@ -123,6 +123,7 @@ This works with any function declared as `asserts condition` -- Node's `assert`,
 | `boolean` | `Bool` |
 | `string` | `String` |
 | `T[]` | `[T]` |
+| `Set<T>` | `[T]` (membership via `.has(x)` → `x in`, cardinality via `.size` → `#`; uniqueness is not tracked) |
 | `T \| null` / `T \| undefined` | `T + Nothing` |
 | `interface Foo { ... }` | `Foo.` (domain) + rules for each property |
 

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -19,6 +19,7 @@ import {
   translateOperator,
 } from "./translate-signature.js";
 import {
+  isMapType,
   isSetType,
   mapTsType,
   type NumericStrategy,
@@ -1952,6 +1953,45 @@ function translateCallExpr(
   if (ts.isPropertyAccessExpression(expr.expression)) {
     const methodName = expr.expression.name.text;
     const tsReceiver = expr.expression.expression;
+
+    // .get(k) / .has(k) on a Map<K,V> field -> 2-arity rule application.
+    // Map fields translate to a pair of rules: `<name>Key c k => Bool` and
+    // `<name> c k, <name>Key c k => V`. See translate-types.ts.
+    if (
+      (methodName === "get" || methodName === "has") &&
+      expr.arguments.length === 1 &&
+      ts.isPropertyAccessExpression(tsReceiver) &&
+      isMapType(checker.getTypeAtLocation(tsReceiver))
+    ) {
+      const fieldName = tsReceiver.name.text;
+      const innerObj = tsReceiver.expression;
+      const kExpr = translateBodyExpr(
+        expr.arguments[0]!,
+        checker,
+        strategy,
+        paramNames,
+        state,
+        supply,
+      );
+      if (isBodyUnsupported(kExpr)) {
+        return kExpr;
+      }
+      const objExpr = translateBodyExpr(
+        innerObj,
+        checker,
+        strategy,
+        paramNames,
+        state,
+        supply,
+      );
+      if (isBodyUnsupported(objExpr)) {
+        return objExpr;
+      }
+      const ruleName = methodName === "has" ? `${fieldName}Key` : fieldName;
+      return {
+        expr: ast.app(ast.var(ruleName), [bodyExpr(objExpr), bodyExpr(kExpr)]),
+      };
+    }
 
     // .includes(x) on Array / .has(x) on Set -> x in obj
     if (

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -18,7 +18,11 @@ import {
   translateExpr,
   translateOperator,
 } from "./translate-signature.js";
-import { mapTsType, type NumericStrategy } from "./translate-types.js";
+import {
+  isSetType,
+  mapTsType,
+  type NumericStrategy,
+} from "./translate-types.js";
 import type { PantDeclaration, PropResult } from "./types.js";
 
 // --- Const-binding inlining infrastructure (let-elimination) ---
@@ -976,10 +980,12 @@ export function translateBodyExpr(
     if (isBodyUnsupported(obj)) {
       return obj;
     }
-    // .length -> #obj (array only)
-    if (prop === "length") {
+    // .length (array) / .size (Set) -> #obj
+    if (prop === "length" || prop === "size") {
       const receiverType = checker.getTypeAtLocation(expr.expression);
-      if (checker.isArrayType(receiverType)) {
+      const isArray = prop === "length" && checker.isArrayType(receiverType);
+      const isSet = prop === "size" && isSetType(receiverType);
+      if (isArray || isSet) {
         return { expr: ast.unop(ast.opCard(), bodyExpr(obj)) };
       }
     }
@@ -1947,11 +1953,22 @@ function translateCallExpr(
     const methodName = expr.expression.name.text;
     const tsReceiver = expr.expression.expression;
 
-    // .includes(x) -> x in obj (array only)
-    if (methodName === "includes" && expr.arguments.length === 1) {
+    // .includes(x) on Array / .has(x) on Set -> x in obj
+    if (
+      (methodName === "includes" || methodName === "has") &&
+      expr.arguments.length === 1
+    ) {
       const receiverType = checker.getTypeAtLocation(tsReceiver);
-      if (!checker.isArrayType(receiverType)) {
-        return { unsupported: "non-array .includes()" };
+      const isArray =
+        methodName === "includes" && checker.isArrayType(receiverType);
+      const isSet = methodName === "has" && isSetType(receiverType);
+      if (!isArray && !isSet) {
+        return {
+          unsupported:
+            methodName === "includes"
+              ? "non-array .includes()"
+              : "non-Set .has()",
+        };
       }
       const arg = translateBodyExpr(
         expr.arguments[0]!,

--- a/tools/ts2pant/src/translate-types.ts
+++ b/tools/ts2pant/src/translate-types.ts
@@ -60,6 +60,17 @@ export function mapTsType(
     return checker.typeToString(type);
   }
 
+  // Set — modeled as a list. Pantagruel lists already encode membership
+  // (smt_types.ml: Array elem_sort Bool), so `s.has(x)` can become `x in s`
+  // with list semantics. Uniqueness is not tracked as a logical invariant.
+  if (isSetType(type)) {
+    const typeArgs = checker.getTypeArguments(type as ts.TypeReference);
+    if (typeArgs.length === 1) {
+      return `[${mapTsType(typeArgs[0]!, checker, strategy)}]`;
+    }
+    return checker.typeToString(type);
+  }
+
   // Union
   if (type.isUnion()) {
     // Boolean is represented as true | false union
@@ -81,6 +92,16 @@ export function mapTsType(
   }
 
   return checker.typeToString(type);
+}
+
+/**
+ * Detect a TypeScript `Set<T>` by symbol name. Brittle against user-defined
+ * classes named `Set`, but matches how `isArrayType` effectively works and is
+ * the pragmatic choice — a user class named `Set` is vanishingly rare.
+ */
+export function isSetType(type: ts.Type): boolean {
+  const symbol = type.getSymbol();
+  return symbol?.getName() === "Set";
 }
 
 /** Derive a short parameter name from a type name (first letter, lowercased). */

--- a/tools/ts2pant/src/translate-types.ts
+++ b/tools/ts2pant/src/translate-types.ts
@@ -1,6 +1,7 @@
 import ts from "typescript";
 import type { ExtractedTypes } from "./extract.js";
 import type { NameRegistry } from "./name-registry.js";
+import { getAst } from "./pant-wasm.js";
 import type { PantDeclaration } from "./types.js";
 
 /** Strategy for mapping TS `number` to a Pantagruel numeric type. */
@@ -104,6 +105,14 @@ export function isSetType(type: ts.Type): boolean {
   return symbol?.getName() === "Set";
 }
 
+/**
+ * Detect a TypeScript `Map<K, V>` by symbol name. Same caveat as `isSetType`.
+ */
+export function isMapType(type: ts.Type): boolean {
+  const symbol = type.getSymbol();
+  return symbol?.getName() === "Map";
+}
+
 /** Derive a short parameter name from a type name (first letter, lowercased). */
 function paramName(typeName: string): string {
   if (!typeName) {
@@ -132,6 +141,41 @@ export function translateTypes(
     const candidate = paramName(iface.name);
     const pName = registry ? registry.register(candidate) : candidate;
     for (const prop of iface.properties) {
+      if (isMapType(prop.type)) {
+        const typeArgs = checker.getTypeArguments(
+          prop.type as ts.TypeReference,
+        );
+        if (typeArgs.length === 2) {
+          const kType = mapTsType(typeArgs[0]!, checker, strategy);
+          const vType = mapTsType(typeArgs[1]!, checker, strategy);
+          const kName = registry ? registry.register("k") : "k";
+          const keyPredName = `${prop.name}Key`;
+          decls.push({
+            kind: "rule",
+            name: keyPredName,
+            params: [
+              { name: pName, type: iface.name },
+              { name: kName, type: kType },
+            ],
+            returnType: "Bool",
+          });
+          const ast = getAst();
+          decls.push({
+            kind: "rule",
+            name: prop.name,
+            params: [
+              { name: pName, type: iface.name },
+              { name: kName, type: kType },
+            ],
+            returnType: vType,
+            guard: ast.app(ast.var(keyPredName), [
+              ast.var(pName),
+              ast.var(kName),
+            ]),
+          });
+          continue;
+        }
+      }
       decls.push({
         kind: "rule",
         name: prop.name,

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -274,6 +274,18 @@ exports[`expressions-reduce.ts > sumFromBase 1`] = `
 "module SumFromBase.\\n\\nItem.\\nvalue i: Item => Int.\\nactive i: Item => Bool.\\nsumFromBase xs: [Item] => Int.\\n\\n---\\n\\nsumFromBase xs = 100 + (+ over each $0 in xs | value $0).\\n"
 `;
 
+exports[`expressions-set.ts > both 1`] = `
+"module Both.\\n\\nboth xs: [String], x: String, y: String => Bool.\\n\\n---\\n\\nboth xs x y = (x in xs and y in xs).\\n\\ncheck\\n\\nall xs: [String], x: String, y: String | both xs x y -> x in xs.\\n"
+`;
+
+exports[`expressions-set.ts > cardinality 1`] = `
+"module Cardinality.\\n\\ncardinality xs: [String] => Int.\\n\\n---\\n\\ncardinality xs = #xs.\\n"
+`;
+
+exports[`expressions-set.ts > contains 1`] = `
+"module Contains.\\n\\ncontains xs: [String], x: String => Bool.\\n\\n---\\n\\ncontains xs x = (x in xs).\\n"
+`;
+
 exports[`functions-class.ts > Account.deposit 1`] = `
 "module Deposit.\\n\\n~> Deposit @ a: Account, amount: Int.\\n\\n---\\n\\nbalance' a = balance a + amount.\\n"
 `;

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -218,6 +218,18 @@ exports[`expressions-literals.ts > yes 1`] = `
 "module Yes.\\n\\nyes  => Bool.\\n\\n---\\n\\nyes = true.\\n"
 `;
 
+exports[`expressions-map.ts > congruence 1`] = `
+"module Congruence.\\n\\nCache.\\nentriesKey c1: Cache, k1: String => Bool.\\nentries c1: Cache, k1: String, entriesKey c1 k1 => Int.\\ncongruence c: Cache, k: String => Bool.\\n\\n---\\n\\ncongruence c k = entriesKey c k.\\n\\ncheck\\n\\nall c: Cache, k: String | congruence c k -> entries c k = entries c k.\\n"
+`;
+
+exports[`expressions-map.ts > contains 1`] = `
+"module Contains.\\n\\nCache.\\nentriesKey c1: Cache, k1: String => Bool.\\nentries c1: Cache, k1: String, entriesKey c1 k1 => Int.\\ncontains c: Cache, k: String => Bool.\\n\\n---\\n\\ncontains c k = entriesKey c k.\\n"
+`;
+
+exports[`expressions-map.ts > lookup 1`] = `
+"module Lookup.\\n\\nCache.\\nentriesKey c1: Cache, k1: String => Bool.\\nentries c1: Cache, k1: String, entriesKey c1 k1 => Int.\\nlookup c: Cache, k: String => Int.\\n\\n---\\n\\nlookup c k = entries c k.\\n"
+`;
+
 exports[`expressions-misc.ts > asNumber 1`] = `
 "module AsNumber.\\n\\nasNumber x: unknown => Int.\\n\\n---\\n\\nasNumber x = x.\\n"
 `;

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-map.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-map.ts
@@ -1,0 +1,34 @@
+// Map<K, V> on an interface field expands into two Pantagruel rules:
+//   entriesKey c: Cache, k: String => Bool.
+//   entries c: Cache, k: String, entriesKey c k => Int.
+//
+// The value rule is guarded by the membership predicate. Declaration guards
+// are automatically injected as antecedents in SMT queries, so absent keys
+// say nothing about the value — a cleaner specification semantics than
+// modeling partiality as `V + Nothing`.
+
+interface Cache {
+  entries: Map<string, number>;
+}
+
+/** .get(k)! on a Map field -> guarded rule application */
+export function lookup(c: Cache, k: string): number {
+  return c.entries.get(k)!;
+}
+
+/** .has(k) on a Map field -> membership predicate */
+export function contains(c: Cache, k: string): boolean {
+  return c.entries.has(k);
+}
+
+/**
+ * Real entailment exercising both rules in the same module: when the
+ * predicate holds (via `.has`), the guarded value rule has a meaning and is
+ * equal to itself (EUF congruence). The body sets `congruence c k` to
+ * `entriesKey c k`, so under `congruence c k`, the guard on `entries` is
+ * discharged and the proposition is tautologically true.
+ * @pant all c: Cache, k: String | congruence c k -> entries c k = entries c k
+ */
+export function congruence(c: Cache, k: string): boolean {
+  return c.entries.has(k);
+}

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-set.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-set.ts
@@ -1,0 +1,22 @@
+// Set<T> operations: .has, .size
+// Pantagruel models Set<T> as [T] (the list type already encodes membership
+// via `x in xs` in the SMT backend). Uniqueness is not a tracked invariant.
+
+/** .has(x) on a Set -> x in */
+export function contains(xs: Set<string>, x: string): boolean {
+  return xs.has(x);
+}
+
+/** .size on a Set -> # */
+export function cardinality(xs: Set<string>): number {
+  return xs.size;
+}
+
+/**
+ * Both membership and cardinality in one body. The annotation is a genuine
+ * (non-tautological) entailment: if two names are in the set, the first is in.
+ * @pant all xs: [String], x: String, y: String | both xs x y -> x in xs
+ */
+export function both(xs: Set<string>, x: string, y: string): boolean {
+  return xs.has(x) && xs.has(y);
+}


### PR DESCRIPTION
## Summary

- Map `Set<T>` to `[T]` in `mapTsType` — Pantagruel lists already encode membership at the SMT layer (`smt_types.ml`: `Array elem_sort Bool`), so a set with only read operations is just a list.
- `.has(x)` on a Set becomes `x in xs` (same emission as `Array.includes`); `.size` becomes `#xs` (same as `Array.length`).
- Add `tests/fixtures/constructs/expressions-set.ts` with `contains`, `cardinality`, and `both` — `both` carries a `@pant` assertion that `pant --check` reports `OK: Entailed`.
- Uniqueness is deliberately not tracked as a logical invariant.

Scope: read-only. Set mutation (`.add`, `.delete`), iteration, and Maps-as-rules are deferred.

## Test plan

- [x] `npm test` — 285/285 pass
- [x] `npm run lint`
- [x] `npx tsx src/index.ts tests/fixtures/constructs/expressions-set.ts both --check` → `OK: Entailed: all xs: [String], x: String, y: String | both xs x y -> x in xs`
- [x] Snapshot updated for the new fixture
- [x] README type-translation table updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)