### PR TITLE
Constrain [Nat]/[Nat0] list elements in SMT preamble

### DIFF
--- a/lib/smt_preamble.ml
+++ b/lib/smt_preamble.ml
@@ -276,33 +276,54 @@ let generate_closure_axioms ?(include_primed = true) config env =
     [constrain_primed] is false, primed functions are unconstrained. *)
 let collect_type_constraint_exprs ?(constrain_primed = true) _config env =
   let constraints = ref [] in
+  let bound_of = function
+    | TyNat -> Some ("Nat", 1)
+    | TyNat0 -> Some ("Nat0", 0)
+    | TyBool | TyInt | TyReal | TyString | TyNothing | TyDomain _ | TyList _
+    | TyProduct _ | TySum _ | TyFunc _ ->
+        None
+  in
   let add_nat_constraint name sname params_sorts param_names ret_ty is_prime =
     let fname = if is_prime then sname ^ "_prime" else sname in
     let display_name = if is_prime then name ^ "'" else name in
-    let type_name, bound =
-      match ret_ty with
-      | TyNat -> ("Nat", 1)
-      | TyNat0 -> ("Nat0", 0)
-      | TyBool | TyInt | TyReal | TyString | TyNothing | TyDomain _ | TyList _
-      | TyProduct _ | TySum _ | TyFunc _ ->
-          ("", -1)
+    let applied =
+      if params_sorts = [] then fname
+      else Printf.sprintf "(%s %s)" fname (String.concat " " param_names)
     in
-    if bound >= 0 then begin
-      let smt_expr =
-        if params_sorts = [] then Printf.sprintf "(>= %s %d)" fname bound
-        else
-          Printf.sprintf "(forall (%s) (>= (%s %s) %d))"
-            (String.concat " "
-               (List.map2
-                  (fun n s -> Printf.sprintf "(%s %s)" n s)
-                  param_names params_sorts))
-            fname
-            (String.concat " " param_names)
-            bound
-      in
-      let human = Printf.sprintf "%s : %s" display_name type_name in
-      constraints := (human, smt_expr) :: !constraints
-    end
+    let param_binders =
+      List.map2
+        (fun n s -> Printf.sprintf "(%s %s)" n s)
+        param_names params_sorts
+    in
+    let wrap_forall binders body =
+      if binders = [] then body
+      else Printf.sprintf "(forall (%s) %s)" (String.concat " " binders) body
+    in
+    (match bound_of ret_ty with
+    | Some (type_name, bound) ->
+        let smt_expr =
+          wrap_forall param_binders (Printf.sprintf "(>= %s %d)" applied bound)
+        in
+        let human = Printf.sprintf "%s : %s" display_name type_name in
+        constraints := (human, smt_expr) :: !constraints
+    | None -> ());
+    match[@warning "-4"] ret_ty with
+    | TyList elem_ty -> (
+        match bound_of elem_ty with
+        | Some (type_name, bound) ->
+            let elem_binder = "k_elem" in
+            let inner_binders =
+              param_binders @ [ Printf.sprintf "(%s Int)" elem_binder ]
+            in
+            let smt_expr =
+              wrap_forall inner_binders
+                (Printf.sprintf "(=> (select %s %s) (>= %s %d))" applied
+                   elem_binder elem_binder bound)
+            in
+            let human = Printf.sprintf "%s : [%s]" display_name type_name in
+            constraints := (human, smt_expr) :: !constraints
+        | None -> ())
+    | _ -> ()
   in
   Env.iter_terms
     (fun name entry ->

--- a/test/test_smt.ml
+++ b/test/test_smt.ml
@@ -1112,7 +1112,8 @@ let test_list_nat0_element_constraint () =
          Ast.dummy_loc ~chapter:0
   in
   let constraints = Smt.declare_type_constraints config env in
-  check bool "has >= k_elem 0" true (contains constraints "(>= k_elem 0)")
+  check bool "has implication shape" true
+    (contains constraints "(=> (select ys k_elem) (>= k_elem 0))")
 
 let test_list_with_params_element_constraint () =
   (* Parameterized rule: constraint applies under both the param and the elem quantifier *)
@@ -1127,7 +1128,8 @@ let test_list_with_params_element_constraint () =
   let constraints = Smt.declare_type_constraints config env in
   check bool "param binder present" true (contains constraints "(x_0 User)");
   check bool "element select applied" true
-    (contains constraints "(select (following x_0) k_elem)")
+    (contains constraints "(select (following x_0) k_elem)");
+  check bool "has >= k_elem 1" true (contains constraints "(>= k_elem 1)")
 
 let test_list_domain_element_no_constraint () =
   (* [Domain] elements aren't numeric -> no element bound *)

--- a/test/test_smt.ml
+++ b/test/test_smt.ml
@@ -1092,6 +1092,56 @@ let test_nat_type_constraints () =
   check bool "has >= 1 for Nat" true (contains constraints ">= (balance");
   check bool "has assert" true (contains constraints "(assert")
 
+let test_list_nat_element_constraint () =
+  (* [Nat] nullary: element bound asserted over the array membership *)
+  let env =
+    Env.empty ""
+    |> Env.add_rule "xs"
+         (Types.TyFunc ([], Some (Types.TyList Types.TyNat)))
+         Ast.dummy_loc ~chapter:0
+  in
+  let constraints = Smt.declare_type_constraints config env in
+  check bool "has select xs" true (contains constraints "(select xs k_elem)");
+  check bool "has >= k_elem 1" true (contains constraints "(>= k_elem 1)")
+
+let test_list_nat0_element_constraint () =
+  let env =
+    Env.empty ""
+    |> Env.add_rule "ys"
+         (Types.TyFunc ([], Some (Types.TyList Types.TyNat0)))
+         Ast.dummy_loc ~chapter:0
+  in
+  let constraints = Smt.declare_type_constraints config env in
+  check bool "has >= k_elem 0" true (contains constraints "(>= k_elem 0)")
+
+let test_list_with_params_element_constraint () =
+  (* Parameterized rule: constraint applies under both the param and the elem quantifier *)
+  let env =
+    Env.empty ""
+    |> Env.add_domain "User" Ast.dummy_loc ~chapter:0
+    |> Env.add_rule "following"
+         (Types.TyFunc
+            ([ Types.TyDomain "User" ], Some (Types.TyList Types.TyNat)))
+         Ast.dummy_loc ~chapter:0
+  in
+  let constraints = Smt.declare_type_constraints config env in
+  check bool "param binder present" true (contains constraints "(x_0 User)");
+  check bool "element select applied" true
+    (contains constraints "(select (following x_0) k_elem)")
+
+let test_list_domain_element_no_constraint () =
+  (* [Domain] elements aren't numeric -> no element bound *)
+  let env =
+    Env.empty ""
+    |> Env.add_domain "Color" Ast.dummy_loc ~chapter:0
+    |> Env.add_rule "palette"
+         (Types.TyFunc ([], Some (Types.TyList (Types.TyDomain "Color"))))
+         Ast.dummy_loc ~chapter:0
+  in
+  let constraints = Smt.declare_type_constraints config env in
+  check bool "no k_elem for non-numeric elem" false
+    (contains constraints "k_elem")
+
 let test_invariant_query_content () =
   let env, doc =
     parse_and_collect
@@ -1153,6 +1203,14 @@ let integration_tests =
     test_case "prime expr" `Quick test_prime_expr;
     test_case "sanitize ident" `Quick test_sanitize_ident;
     test_case "nat type constraints" `Quick test_nat_type_constraints;
+    test_case "list<Nat> element constraint" `Quick
+      test_list_nat_element_constraint;
+    test_case "list<Nat0> element constraint" `Quick
+      test_list_nat0_element_constraint;
+    test_case "list<Nat> with params element constraint" `Quick
+      test_list_with_params_element_constraint;
+    test_case "list<Domain> no element constraint" `Quick
+      test_list_domain_element_no_constraint;
     test_case "invariant query content" `Quick test_invariant_query_content;
     test_case "init query content" `Quick test_init_query_content;
   ]


### PR DESCRIPTION
## Summary
- `[Nat]` and `[Nat0]` were encoded as `(Array Int Bool)` with no bound on the underlying `Int` domain, so the SMT model could "contain" negative integers — a soundness gap against the intended semantics.
- Extend `collect_type_constraint_exprs` to emit, for any rule returning `TyList TyNat` or `TyList TyNat0`, a universally quantified element-range assertion over `(select (f ...) k_elem)`. Covers both nullary and parameterized rules.

## Test plan
- [x] `dune test` — 139 tests pass, including 4 new unit tests (`[Nat]`, `[Nat0]`, parameterized list rule, `[Domain]` negative case)
- [x] Smoke: `xs => [Nat].` with `1 in xs.` now emits `(forall ((k_elem Int)) (=> (select xs k_elem) (>= k_elem 1)))` in the preamble

🤖 Generated with [Claude Code](https://claude.com/claude-code)