### PR TITLE
ts2pant: synthesize Map<K, V> domains for non-field positions

### DIFF
--- a/tools/ts2pant/CLAUDE.md
+++ b/tools/ts2pant/CLAUDE.md
@@ -123,23 +123,46 @@ body, emit frame conditions (`prop' obj = prop obj`) for everything not in the s
 `cond x ~= Nothing => prop x, true => Nothing`. This is the lifting encoding —
 partiality expressed as conditional expressions over the `Nothing` value.
 
-### Partial Rules (Map Fields)
+### Partial Rules (Map<K, V>)
 
-**Standard name:** Precondition-guarded partial function; declaration guard.
-**Reference:** Dafny Reference Manual (preconditions); Dijkstra, CACM 1975 (guards).
+**Standard name:** Precondition-guarded partial function; declaration guard;
+McCarthy's theory of arrays for the synthesized owner sort.
+**Reference:** Dafny Reference Manual (preconditions); Dijkstra, CACM 1975
+(guards); Kroening & Strichman, *Decision Procedures* Ch. 7 (arrays as
+`select`/`store` over a sort of map handles).
 
-A `Map<K, V>` field on a TypeScript interface becomes a *pair* of Pantagruel
+A `Map<K, V>` anywhere in the type language becomes a *pair* of Pantagruel
 rules: a Bool-valued membership predicate and a `V`-valued rule guarded by it.
+The owner domain depends on where the Map appears.
+
+**Stage A — Map is a declared interface field.** The owner is the user's
+interface; the rule name is the field name.
 
 ```
 entriesKey c: Cache, k: K => Bool.
 entries c: Cache, k: K, entriesKey c k => V.
 ```
 
-`.has(k)` translates to `entriesKey obj k`; `.get(k)` (or `.get(k)!`) translates
-to `entries obj k`. Pantagruel stores declaration guards in `Env.rule_guards`
-and automatically injects them as antecedents in SMT queries, so uses of
-`entries obj k` are implicitly conditioned on `entriesKey obj k`.
+**Stage B — Map is anywhere else** (parameter, return type, nested inside
+another Map's V, inside an array/tuple/union). The owner is a *synthesized*
+domain, one per unique `(K, V)` per module; naming is `KToVMap` with
+compound `K`/`V` mangled (`[String]` → `ListString`, `A + B` → `AOrB`,
+`A * B` → `AAndB`).
+
+```
+StringToIntMap.
+stringToIntMapKey m: StringToIntMap, k: String => Bool.
+stringToIntMap m: StringToIntMap, k: String, stringToIntMapKey m k => Int.
+```
+
+Both stages use the same encoding; only the owner differs. `.has(k)` →
+membership predicate; `.get(k)` (or `.get(k)!`) → value rule. Pantagruel
+stores declaration guards in `Env.rule_guards` and automatically injects
+them as antecedents in SMT queries, so uses of the value rule are implicitly
+conditioned on the membership predicate. Nested Maps register bottom-up via
+recursive `mapTsType` calls: `Map<string, Map<string, number>>` emits
+`StringToIntMap` first and then `StringToStringToIntMapMap` whose V
+references it.
 
 **Why this encoding, not `V + Nothing`?** Pantagruel has no first-class
 `Nothing` expression value and no sum destructuring. With a sum-typed return,
@@ -149,9 +172,17 @@ guarded-rule encoding trades a small semantic gap (absent keys are
 uninterpreted rather than explicitly `undefined`) for a much richer set of
 usable specifications.
 
-**Scope:** currently read-only and interface-field-only. Map parameters,
-mutation (`.set`/`.delete`), construction, and iteration are unsupported —
-see `tests/fixtures/constructs/expressions-map.ts` for the supported shape.
+**Why synthesize a sort per `(K, V)`?** Following McCarthy's theory of
+arrays: the synthesized sort is the array sort, distinct values of that sort
+are distinct maps (EUF keeps their lookups independent — `sumAt m1 m2 k` is
+sound because `m1 ≠ m2` does not imply `stringToIntMap m1 k = stringToIntMap m2 k`),
+and the guarded `select` lookup is Dafny-style partial-function discipline.
+
+**Scope:** read-only. Mutation (`.set`/`.delete`), construction
+(`new Map()`), and iteration (`.entries`/`.keys`/`.values`/`.forEach`) are
+unsupported. See `tests/fixtures/constructs/expressions-map.ts` (Stage A)
+and `tests/fixtures/constructs/expressions-map-params.ts` (Stage B) for
+supported shapes.
 
 ### Structured Iteration (for-of, forEach, reduce)
 

--- a/tools/ts2pant/CLAUDE.md
+++ b/tools/ts2pant/CLAUDE.md
@@ -138,7 +138,7 @@ The owner domain depends on where the Map appears.
 **Stage A — Map is a declared interface field.** The owner is the user's
 interface; the rule name is the field name.
 
-```
+```text
 entriesKey c: Cache, k: K => Bool.
 entries c: Cache, k: K, entriesKey c k => V.
 ```
@@ -149,7 +149,7 @@ domain, one per unique `(K, V)` per module; naming is `KToVMap` with
 compound `K`/`V` mangled (`[String]` → `ListString`, `A + B` → `AOrB`,
 `A * B` → `AAndB`).
 
-```
+```text
 StringToIntMap.
 stringToIntMapKey m: StringToIntMap, k: String => Bool.
 stringToIntMap m: StringToIntMap, k: String, stringToIntMapKey m k => Int.

--- a/tools/ts2pant/README.md
+++ b/tools/ts2pant/README.md
@@ -125,6 +125,7 @@ This works with any function declared as `asserts condition` -- Node's `assert`,
 | `T[]` | `[T]` |
 | `Set<T>` | `[T]` (membership via `.has(x)` → `x in`, cardinality via `.size` → `#`; uniqueness is not tracked) |
 | `Map<K, V>` field on `interface` | two rules: `<name>Key c: C, k: K => Bool` and `<name> c: C, k: K, <name>Key c k => V` (read via `.get(k)` → `<name> c k`, membership via `.has(k)` → `<name>Key c k`) |
+| `Map<K, V>` in any other type position (parameter, return, nested) | synthesizes a handle domain per `(K, V)` pair per module: `KToVMap.` plus the same rule pair as above, with the user's interface replaced by the synthesized domain. Non-identifier `K`/`V` are mangled — `[String]` → `ListString`, `A + B` → `AOrB`, `A * B` → `AAndB`. `.get(k)` → `kToVMap m k`, `.has(k)` → `kToVMapKey m k`. Nested Maps register bottom-up (e.g., `Map<string, Map<string, number>>` emits `StringToIntMap` then `StringToStringToIntMapMap`). |
 | `T \| null` / `T \| undefined` | `T + Nothing` |
 | `interface Foo { ... }` | `Foo.` (domain) + rules for each property |
 
@@ -177,7 +178,7 @@ FAIL: Not entailed: 'balance' account >= 0'
 - **No local variables.** Functions with `let`/`const` bindings before the return are rejected as unsupported.
 - **No loops.** `for`/`while` are not translated.
 - **Array operations** are partially supported: `.filter().map()` chains, `.includes()`, `.length`. Other array methods are unsupported.
-- **`Map<K, V>` support is read-only and interface-field-only.** Map fields translate into a value rule guarded by a membership predicate. Map parameters (not as interface fields), mutation (`.set`, `.delete`), construction (`new Map()`), and iteration (`.entries`, `.keys`, `.values`, `.forEach`) are not yet supported.
+- **`Map<K, V>` support is read-only.** Interface-field Maps and Maps in any other type position (parameter, return, nested) both translate into a value rule guarded by a membership predicate — the only difference is whether the owner domain is the user's interface or a synthesized `KToVMap` handle. Mutation (`.set`, `.delete`), construction (`new Map()`), and iteration (`.entries`, `.keys`, `.values`, `.forEach`) are not yet supported.
 
 ## Development
 

--- a/tools/ts2pant/src/pipeline.ts
+++ b/tools/ts2pant/src/pipeline.ts
@@ -93,6 +93,20 @@ export async function buildPantDocument(
       mapSynth,
     });
     doc = { ...doc, propositions: [...doc.propositions, ...bodyProps] };
+
+    // Drain any Map (K, V) pairs registered on demand during body translation
+    // (e.g., `build().get(k)!` where `build`'s return type wasn't surfaced
+    // through the signature or referenced types). emit() is incremental, so
+    // this returns only entries new since the pre-body emit.
+    if (mapSynth) {
+      const extraSynthDecls = mapSynth.emit();
+      if (extraSynthDecls.length > 0) {
+        doc = {
+          ...doc,
+          declarations: [...doc.declarations, ...extraSynthDecls],
+        };
+      }
+    }
   }
 
   // Annotations go to checks (entailment goals) — skip for skeleton docs

--- a/tools/ts2pant/src/pipeline.ts
+++ b/tools/ts2pant/src/pipeline.ts
@@ -47,7 +47,11 @@ export async function buildPantDocument(
     extractFunctionAnnotationsAndOverrides(sourceFile, functionName);
 
   // Translate signature first to claim the function's param names
-  const { declaration: sigDecl, paramNameMap } = translateSignature(
+  const {
+    declaration: sigDecl,
+    paramNameMap,
+    mapSynth,
+  } = translateSignature(
     sourceFile,
     functionName,
     strategy,
@@ -55,10 +59,21 @@ export async function buildPantDocument(
     overrides,
   );
 
-  // Extract and translate types (type-derived param names adapt to registry)
+  // Extract and translate types (type-derived param names adapt to registry).
+  // Pass the synthesizer so nested Maps inside interface-field V register too.
   const extracted = extractReferencedTypes(sourceFile, functionName);
-  const typeDecls = translateTypes(extracted, checker, strategy, registry);
-  const declarations = [...typeDecls, sigDecl];
+  const typeDecls = translateTypes(
+    extracted,
+    checker,
+    strategy,
+    registry,
+    mapSynth,
+  );
+  // After both sig and types have registered their Maps, emit the synth
+  // decls (one domain + membership predicate + guarded value rule per
+  // unique (K, V)). Splice before sigDecl so the sig's references resolve.
+  const synthDecls = mapSynth ? mapSynth.emit() : [];
+  const declarations = [...typeDecls, ...synthDecls, sigDecl];
 
   const moduleName = baseName.charAt(0).toUpperCase() + baseName.slice(1);
   let doc: PantDocument = {
@@ -75,6 +90,7 @@ export async function buildPantDocument(
       functionName,
       strategy,
       declarations,
+      mapSynth,
     });
     doc = { ...doc, propositions: [...doc.propositions, ...bodyProps] };
   }

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -2083,8 +2083,11 @@ function translateCallExpr(
         info = supply.mapSynth.lookup(kType, vType);
       }
       if (!info) {
+        // register returns null only when K or V mangles to something that
+        // isn't a valid Pantagruel identifier — typically because mapTsType
+        // fell back to checker.typeToString for an unsupported TS construct.
         return {
-          unsupported: `Map<${kType}, ${vType}> not synthesized`,
+          unsupported: `Map<${kType}, ${vType}>: key or value type cannot be mangled into a synthesized domain name`,
         };
       }
       const objExpr = translateBodyExpr(

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -21,6 +21,7 @@ import {
 import {
   isMapType,
   isSetType,
+  type MapSynthesizer,
   mapTsType,
   type NumericStrategy,
 } from "./translate-types.js";
@@ -28,12 +29,19 @@ import type { PantDeclaration, PropResult } from "./types.js";
 
 // --- Const-binding inlining infrastructure (let-elimination) ---
 
+/**
+ * Per-body translation context threaded through every `translateBodyExpr`
+ * call. Carries the hygienic-binder counter and (optionally) the
+ * module-wide `MapSynthesizer` so `.get`/`.has` on non-field Map receivers
+ * can resolve to the synthesized rule names.
+ */
 interface UniqueSupply {
   next: () => number;
+  mapSynth?: MapSynthesizer | undefined;
 }
-function makeUniqueSupply(): UniqueSupply {
+function makeUniqueSupply(mapSynth?: MapSynthesizer): UniqueSupply {
   let counter = 0;
-  return { next: () => counter++ };
+  return { next: () => counter++, mapSynth };
 }
 
 function freshHygienicBinder(supply: UniqueSupply): string {
@@ -395,6 +403,13 @@ export interface TranslateBodyOptions {
   strategy: NumericStrategy;
   /** Declarations in scope — used for frame condition generation. */
   declarations?: PantDeclaration[];
+  /**
+   * Synthesizer populated during signature and type translation. Used by
+   * the body translator to (a) resolve Map-parameter types to their
+   * synthesized domain names when reconstructing the param list, and
+   * (b) dispatch `.get`/`.has` on non-interface-field Map receivers.
+   */
+  mapSynth?: MapSynthesizer | undefined;
 }
 
 /**
@@ -405,7 +420,7 @@ export interface TranslateBodyOptions {
  * plus frame conditions for unmodified rules.
  */
 export function translateBody(opts: TranslateBodyOptions): PropResult[] {
-  const { sourceFile, functionName, strategy, declarations } = opts;
+  const { sourceFile, functionName, strategy, declarations, mapSynth } = opts;
   const checker = sourceFile.getProject().getTypeChecker().compilerObject;
   const { node, className } = findFunction(sourceFile, functionName);
   // Strip class qualifier for use in Pantagruel identifiers
@@ -432,7 +447,10 @@ export function translateBody(opts: TranslateBodyOptions): PropResult[] {
   if (sig) {
     for (const param of sig.getParameters()) {
       const paramType = checker.getTypeOfSymbol(param);
-      const typeName = mapTsType(paramType, checker, strategy);
+      // Pass the synthesizer so Map parameters resolve to their synthesized
+      // domain names (idempotent; the signature pass already registered
+      // them, so this is a lookup rather than a fresh registration).
+      const typeName = mapTsType(paramType, checker, strategy, mapSynth);
       paramNames.set(param.name, param.name);
       paramList.push({ name: param.name, type: typeName });
     }
@@ -450,6 +468,7 @@ export function translateBody(opts: TranslateBodyOptions): PropResult[] {
       checker,
       strategy,
       paramNames,
+      mapSynth,
     );
   } else {
     return translateMutatingBody(
@@ -458,6 +477,7 @@ export function translateBody(opts: TranslateBodyOptions): PropResult[] {
       strategy,
       paramNames,
       declarations ?? [],
+      mapSynth,
     );
   }
 }
@@ -469,6 +489,7 @@ function translatePureBody(
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
   paramNames: Map<string, string>,
+  mapSynth?: MapSynthesizer,
 ): PropResult[] {
   const ast = getAst();
 
@@ -482,7 +503,7 @@ function translatePureBody(
     return [{ kind: "unsupported", reason: `${functionName} — ${reason}` }];
   }
 
-  const supply = makeUniqueSupply();
+  const supply = makeUniqueSupply(mapSynth);
   const inlined = inlineConstBindings(
     extracted.bindings.map((b) => ({
       tsName: b.name,
@@ -529,6 +550,33 @@ function translatePureBody(
 interface ExtractedBody {
   bindings: Array<{ name: string; initializer: ts.Expression }>;
   returnExpr: ts.Expression | ts.IfStatement;
+}
+
+/**
+ * True when the property access names a field declared on a user-defined
+ * interface (e.g., `cache.entries` where `entries` is declared in
+ * `interface Cache`). Disambiguates Stage A (interface-field Map encoding)
+ * from Stage B (synthesized-domain Map encoding) for `.get`/`.has` on a
+ * Map-typed receiver.
+ */
+function isInterfaceFieldAccess(
+  node: ts.PropertyAccessExpression,
+  checker: ts.TypeChecker,
+): boolean {
+  const symbol = checker.getSymbolAtLocation(node.name);
+  if (!symbol) {
+    return false;
+  }
+  for (const decl of symbol.getDeclarations() ?? []) {
+    if (
+      ts.isPropertySignature(decl) &&
+      decl.parent &&
+      ts.isInterfaceDeclaration(decl.parent)
+    ) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /**
@@ -1954,17 +2002,84 @@ function translateCallExpr(
     const methodName = expr.expression.name.text;
     const tsReceiver = expr.expression.expression;
 
-    // .get(k) / .has(k) on a Map<K,V> field -> 2-arity rule application.
-    // Map fields translate to a pair of rules: `<name>Key c k => Bool` and
-    // `<name> c k, <name>Key c k => V`. See translate-types.ts.
+    // .get(k) / .has(k) on a Map<K,V> receiver -> 2-arity rule application.
+    // Two paths, same encoding shape:
+    //   Stage A — receiver is a property access to a declared interface
+    //     field. The field's own name is the rule; the owner is the user's
+    //     interface (translate-types.ts, interface-field branch).
+    //   Stage B — receiver is anything else (parameter, call result, etc.).
+    //     The rule was synthesized at signature/type translation time and
+    //     is looked up by (K, V) via the MapSynthesizer.
     if (
       (methodName === "get" || methodName === "has") &&
       expr.arguments.length === 1 &&
-      ts.isPropertyAccessExpression(tsReceiver) &&
       isMapType(checker.getTypeAtLocation(tsReceiver))
     ) {
-      const fieldName = tsReceiver.name.text;
-      const innerObj = tsReceiver.expression;
+      const stageA =
+        ts.isPropertyAccessExpression(tsReceiver) &&
+        isInterfaceFieldAccess(tsReceiver, checker);
+
+      if (stageA && ts.isPropertyAccessExpression(tsReceiver)) {
+        const fieldName = tsReceiver.name.text;
+        const innerObj = tsReceiver.expression;
+        const kExpr = translateBodyExpr(
+          expr.arguments[0]!,
+          checker,
+          strategy,
+          paramNames,
+          state,
+          supply,
+        );
+        if (isBodyUnsupported(kExpr)) {
+          return kExpr;
+        }
+        const objExpr = translateBodyExpr(
+          innerObj,
+          checker,
+          strategy,
+          paramNames,
+          state,
+          supply,
+        );
+        if (isBodyUnsupported(objExpr)) {
+          return objExpr;
+        }
+        const ruleName = methodName === "has" ? `${fieldName}Key` : fieldName;
+        return {
+          expr: ast.app(ast.var(ruleName), [
+            bodyExpr(objExpr),
+            bodyExpr(kExpr),
+          ]),
+        };
+      }
+
+      // Stage B: synthesized rule lookup.
+      const receiverType = checker.getTypeAtLocation(tsReceiver);
+      const typeArgs = checker.getTypeArguments(
+        receiverType as ts.TypeReference,
+      );
+      if (typeArgs.length !== 2) {
+        return { unsupported: "Map with unexpected arity" };
+      }
+      const kType = mapTsType(typeArgs[0]!, checker, strategy, supply.mapSynth);
+      const vType = mapTsType(typeArgs[1]!, checker, strategy, supply.mapSynth);
+      const info = supply.mapSynth?.lookup(kType, vType);
+      if (!info) {
+        return {
+          unsupported: `Map<${kType}, ${vType}> not synthesized`,
+        };
+      }
+      const objExpr = translateBodyExpr(
+        tsReceiver,
+        checker,
+        strategy,
+        paramNames,
+        state,
+        supply,
+      );
+      if (isBodyUnsupported(objExpr)) {
+        return objExpr;
+      }
       const kExpr = translateBodyExpr(
         expr.arguments[0]!,
         checker,
@@ -1976,18 +2091,8 @@ function translateCallExpr(
       if (isBodyUnsupported(kExpr)) {
         return kExpr;
       }
-      const objExpr = translateBodyExpr(
-        innerObj,
-        checker,
-        strategy,
-        paramNames,
-        state,
-        supply,
-      );
-      if (isBodyUnsupported(objExpr)) {
-        return objExpr;
-      }
-      const ruleName = methodName === "has" ? `${fieldName}Key` : fieldName;
+      const ruleName =
+        methodName === "has" ? info.names.keyPred : info.names.rule;
       return {
         expr: ast.app(ast.var(ruleName), [bodyExpr(objExpr), bodyExpr(kExpr)]),
       };
@@ -2209,6 +2314,7 @@ function translateMutatingBody(
   strategy: NumericStrategy,
   paramNames: Map<string, string>,
   declarations: PantDeclaration[],
+  mapSynth?: MapSynthesizer,
 ): PropResult[] {
   if (!node.body) {
     return [];
@@ -2217,6 +2323,7 @@ function translateMutatingBody(
   const ast = getAst();
   const propositions: PropResult[] = [];
   const state = makeSymbolicState();
+  const supply = makeUniqueSupply(mapSynth);
 
   const ok = symbolicExecute(
     node.body,
@@ -2225,6 +2332,8 @@ function translateMutatingBody(
     paramNames,
     state,
     propositions,
+    (e) => e,
+    supply,
   );
 
   // Only emit state equations + frames when the whole body was translatable;

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -554,10 +554,12 @@ interface ExtractedBody {
 
 /**
  * True when the property access names a field declared on a user-defined
- * interface (e.g., `cache.entries` where `entries` is declared in
- * `interface Cache`). Disambiguates Stage A (interface-field Map encoding)
- * from Stage B (synthesized-domain Map encoding) for `.get`/`.has` on a
- * Map-typed receiver.
+ * interface or class (e.g., `cache.entries` where `entries` is declared in
+ * `interface Cache`, or `this.entries` inside a class method). Disambiguates
+ * Stage A (interface/class-field Map encoding) from Stage B (synthesized-
+ * domain Map encoding) for `.get`/`.has` on a Map-typed receiver. Class
+ * methods reuse the surrounding module's field declarations rather than
+ * synthesized handles.
  */
 function isInterfaceFieldAccess(
   node: ts.PropertyAccessExpression,
@@ -572,6 +574,13 @@ function isInterfaceFieldAccess(
       ts.isPropertySignature(decl) &&
       decl.parent &&
       ts.isInterfaceDeclaration(decl.parent)
+    ) {
+      return true;
+    }
+    if (
+      ts.isPropertyDeclaration(decl) &&
+      decl.parent &&
+      ts.isClassDeclaration(decl.parent)
     ) {
       return true;
     }
@@ -2053,7 +2062,12 @@ function translateCallExpr(
         };
       }
 
-      // Stage B: synthesized rule lookup.
+      // Stage B: synthesized rule lookup. Register on demand — a body-only
+      // receiver (e.g., `build().get(k)!` where `build`'s return type wasn't
+      // surfaced through the current function's signature or referenced
+      // types) wouldn't be pre-registered by the signature/type passes.
+      // The pipeline drains any new registrations with a second emit() call
+      // after body translation completes.
       const receiverType = checker.getTypeAtLocation(tsReceiver);
       const typeArgs = checker.getTypeArguments(
         receiverType as ts.TypeReference,
@@ -2063,7 +2077,11 @@ function translateCallExpr(
       }
       const kType = mapTsType(typeArgs[0]!, checker, strategy, supply.mapSynth);
       const vType = mapTsType(typeArgs[1]!, checker, strategy, supply.mapSynth);
-      const info = supply.mapSynth?.lookup(kType, vType);
+      let info = supply.mapSynth?.lookup(kType, vType);
+      if (!info && supply.mapSynth) {
+        supply.mapSynth.register(kType, vType);
+        info = supply.mapSynth.lookup(kType, vType);
+      }
       if (!info) {
         return {
           unsupported: `Map<${kType}, ${vType}> not synthesized`,

--- a/tools/ts2pant/src/translate-signature.ts
+++ b/tools/ts2pant/src/translate-signature.ts
@@ -3,7 +3,11 @@ import ts from "typescript";
 import type { NameRegistry } from "./name-registry.js";
 import type { OpaqueBinop, OpaqueExpr } from "./pant-ast.js";
 import { getAst } from "./pant-wasm.js";
-import { mapTsType, type NumericStrategy } from "./translate-types.js";
+import {
+  MapSynthesizer,
+  mapTsType,
+  type NumericStrategy,
+} from "./translate-types.js";
 import type { PantAction, PantDeclaration, PantRule } from "./types.js";
 
 export type Classification = "pure" | "mutating";
@@ -13,6 +17,13 @@ export interface TranslatedSignature {
   classification: Classification;
   /** Map from TS parameter names to Pantagruel parameter names. */
   paramNameMap: Map<string, string>;
+  /**
+   * Synthesizer for `Map<K, V>` domains encountered during signature
+   * translation (parameter and return types). Pass through to downstream
+   * stages (`translateTypes`, `translateBody`) so they register and look up
+   * Maps in the same table. Present only when a `registry` was supplied.
+   */
+  mapSynth?: MapSynthesizer | undefined;
 }
 
 /**
@@ -851,6 +862,10 @@ export function translateSignature(
   const params: Array<{ name: string; type: string }> = [];
   const paramNameMap = new Map<string, string>();
 
+  // A synthesizer is only meaningful when a registry is present (it uses
+  // the registry to claim unique synthesized domain names).
+  const mapSynth = registry ? new MapSynthesizer(registry) : undefined;
+
   if (className) {
     const existingParamNames = new Set(sig.getParameters().map((p) => p.name));
     const pName = shortParamName(className, existingParamNames, registry);
@@ -863,6 +878,7 @@ export function translateSignature(
       checker.getTypeOfSymbol(param),
       checker,
       strategy,
+      mapSynth,
     );
     const paramType = overrides?.get(param.name) ?? defaultType;
     const pantName = registry ? registry.register(param.name) : param.name;
@@ -873,7 +889,12 @@ export function translateSignature(
   const guard = detectGuard(node, checker, strategy, paramNameMap);
 
   if (classification === "pure") {
-    const returnType = mapTsType(sig.getReturnType(), checker, strategy);
+    const returnType = mapTsType(
+      sig.getReturnType(),
+      checker,
+      strategy,
+      mapSynth,
+    );
     const decl: PantRule = {
       kind: "rule",
       name: baseName,
@@ -883,7 +904,7 @@ export function translateSignature(
     if (guard) {
       decl.guard = guard;
     }
-    return { declaration: decl, classification, paramNameMap };
+    return { declaration: decl, classification, paramNameMap, mapSynth };
   } else {
     const decl: PantAction = {
       kind: "action",
@@ -893,6 +914,6 @@ export function translateSignature(
     if (guard) {
       decl.guard = guard;
     }
-    return { declaration: decl, classification, paramNameMap };
+    return { declaration: decl, classification, paramNameMap, mapSynth };
   }
 }

--- a/tools/ts2pant/src/translate-types.ts
+++ b/tools/ts2pant/src/translate-types.ts
@@ -4,6 +4,120 @@ import type { NameRegistry } from "./name-registry.js";
 import { getAst } from "./pant-wasm.js";
 import type { PantDeclaration } from "./types.js";
 
+/**
+ * Mangle a Pantagruel type string into an identifier-safe fragment suitable
+ * for embedding inside a synthesized Map domain name.
+ *   "String"           → "String"
+ *   "[String]"         → "ListString"
+ *   "String + Nothing" → "StringOrNothing"
+ *   "A * B"            → "AAndB"
+ * Returns null if the mangled result still contains non-identifier chars
+ * (e.g., a bare `Map<...>` literal from a Map in value position with no
+ * synthesizer upstream). Distinct Pantagruel types produce distinct
+ * fragments.
+ */
+export function manglePantTypeToFragment(pantType: string): string | null {
+  const mangled = pantType
+    .replace(/\s+/gu, "")
+    .replace(/\+/gu, "Or")
+    .replace(/\*/gu, "And")
+    .replace(/\[/gu, "List")
+    .replace(/\]/gu, "");
+  return /^[A-Za-z_][A-Za-z0-9_]*$/u.test(mangled) ? mangled : null;
+}
+
+export interface MapSynthNames {
+  domain: string;
+  rule: string;
+  keyPred: string;
+}
+
+export interface MapSynthEntry {
+  names: MapSynthNames;
+  kType: string;
+  vType: string;
+}
+
+/**
+ * Accumulates `Map<K, V>` occurrences encountered anywhere in the module's
+ * type positions (parameters, return types, nested inside another Map's V,
+ * inside arrays / tuples / unions) and synthesizes one domain + guarded-rule
+ * pair per unique `(K, V)`. McCarthy's theory of arrays applied via
+ * Pantagruel rules: synthesized domain is the array sort, distinct elements
+ * are distinct maps, `.get` is a partial function guarded by `.has`.
+ */
+export class MapSynthesizer {
+  private byKV = new Map<string, MapSynthEntry>();
+
+  constructor(private registry: NameRegistry) {}
+
+  register(kType: string, vType: string): string {
+    const key = `${kType}|${vType}`;
+    const cached = this.byKV.get(key);
+    if (cached) {
+      return cached.names.domain;
+    }
+    const kFrag = manglePantTypeToFragment(kType);
+    const vFrag = manglePantTypeToFragment(vType);
+    if (!kFrag || !vFrag) {
+      throw new Error(
+        `Cannot synthesize Map domain for K=${kType}, V=${vType}`,
+      );
+    }
+    const baseDomain = `${kFrag}To${vFrag}Map`;
+    const domain = this.registry.register(baseDomain);
+    const rule = domain[0]!.toLowerCase() + domain.slice(1);
+    const entry: MapSynthEntry = {
+      names: { domain, rule, keyPred: `${rule}Key` },
+      kType,
+      vType,
+    };
+    this.byKV.set(key, entry);
+    return domain;
+  }
+
+  lookup(kType: string, vType: string): MapSynthEntry | undefined {
+    return this.byKV.get(`${kType}|${vType}`);
+  }
+
+  /**
+   * Materialize accumulated decls (domain + membership predicate + guarded
+   * value rule) in registration order. Rule-internal binder names are
+   * registered *here*, after callers have claimed their own param names,
+   * so the synth decls get hygienic suffixes (e.g., `m1`, `k1`).
+   */
+  emit(): PantDeclaration[] {
+    const decls: PantDeclaration[] = [];
+    const ast = getAst();
+    for (const entry of this.byKV.values()) {
+      const { domain, rule, keyPred } = entry.names;
+      const mName = this.registry.register("m");
+      const kName = this.registry.register("k");
+      decls.push({ kind: "domain", name: domain });
+      decls.push({
+        kind: "rule",
+        name: keyPred,
+        params: [
+          { name: mName, type: domain },
+          { name: kName, type: entry.kType },
+        ],
+        returnType: "Bool",
+      });
+      decls.push({
+        kind: "rule",
+        name: rule,
+        params: [
+          { name: mName, type: domain },
+          { name: kName, type: entry.kType },
+        ],
+        returnType: entry.vType,
+        guard: ast.app(ast.var(keyPred), [ast.var(mName), ast.var(kName)]),
+      });
+    }
+    return decls;
+  }
+}
+
 /** Strategy for mapping TS `number` to a Pantagruel numeric type. */
 export interface NumericStrategy {
   mapNumber: (context?: string) => string;
@@ -21,11 +135,22 @@ export const RealStrategy: NumericStrategy = {
   },
 };
 
-/** Map a TypeScript type to a Pantagruel type string. */
+/**
+ * Map a TypeScript type to a Pantagruel type string.
+ *
+ * When `synth` is provided, `Map<K, V>` in any type position (parameter,
+ * return, nested in another Map's V, inside an array/tuple/union) is
+ * registered with the synthesizer and replaced with the synthesized domain
+ * name. Without `synth`, Map types fall through to the caller's fallback
+ * (typically `checker.typeToString()` which yields unparseable output).
+ * The `synth`-less behavior is preserved for Stage A: interface-field Maps
+ * are handled specially in `translateTypes` and must not be synthesized.
+ */
 export function mapTsType(
   type: ts.Type,
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
+  synth?: MapSynthesizer,
 ): string {
   const flags = type.flags;
 
@@ -49,14 +174,16 @@ export function mapTsType(
   // Tuple (check before array since tuples are also type references)
   if (checker.isTupleType(type)) {
     const typeArgs = checker.getTypeArguments(type as ts.TypeReference);
-    return typeArgs.map((t) => mapTsType(t, checker, strategy)).join(" * ");
+    return typeArgs
+      .map((t) => mapTsType(t, checker, strategy, synth))
+      .join(" * ");
   }
 
   // Array
   if (checker.isArrayType(type)) {
     const typeArgs = checker.getTypeArguments(type as ts.TypeReference);
     if (typeArgs.length === 1) {
-      return `[${mapTsType(typeArgs[0]!, checker, strategy)}]`;
+      return `[${mapTsType(typeArgs[0]!, checker, strategy, synth)}]`;
     }
     return checker.typeToString(type);
   }
@@ -67,9 +194,19 @@ export function mapTsType(
   if (isSetType(type)) {
     const typeArgs = checker.getTypeArguments(type as ts.TypeReference);
     if (typeArgs.length === 1) {
-      return `[${mapTsType(typeArgs[0]!, checker, strategy)}]`;
+      return `[${mapTsType(typeArgs[0]!, checker, strategy, synth)}]`;
     }
     return checker.typeToString(type);
+  }
+
+  // Map — synthesize a domain when a synthesizer is provided.
+  if (isMapType(type) && synth) {
+    const typeArgs = checker.getTypeArguments(type as ts.TypeReference);
+    if (typeArgs.length === 2) {
+      const kType = mapTsType(typeArgs[0]!, checker, strategy, synth);
+      const vType = mapTsType(typeArgs[1]!, checker, strategy, synth);
+      return synth.register(kType, vType);
+    }
   }
 
   // Union
@@ -78,7 +215,7 @@ export function mapTsType(
     if (type.types.every((t) => t.flags & ts.TypeFlags.BooleanLiteral)) {
       return "Bool";
     }
-    const parts = type.types.map((t) => mapTsType(t, checker, strategy));
+    const parts = type.types.map((t) => mapTsType(t, checker, strategy, synth));
     // Deduplicate (e.g. boolean literal collapse)
     const unique = parts.filter((v, i, a) => a.indexOf(v) === i);
     // Sort Nothing to the end for consistent output
@@ -133,6 +270,7 @@ export function translateTypes(
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
   registry?: NameRegistry,
+  synth?: MapSynthesizer,
 ): PantDeclaration[] {
   const decls: PantDeclaration[] = [];
 
@@ -146,8 +284,13 @@ export function translateTypes(
           prop.type as ts.TypeReference,
         );
         if (typeArgs.length === 2) {
-          const kType = mapTsType(typeArgs[0]!, checker, strategy);
-          const vType = mapTsType(typeArgs[1]!, checker, strategy);
+          // Stage A field-Map encoding: rule name is the field name; the
+          // domain is the user's interface. K and V are still translated
+          // via mapTsType with the synth passed through, so a nested Map
+          // inside V (e.g., `inner: Map<K, Map<K', V'>>`) registers its
+          // own synthesized domain and the Stage A rule's V references it.
+          const kType = mapTsType(typeArgs[0]!, checker, strategy, synth);
+          const vType = mapTsType(typeArgs[1]!, checker, strategy, synth);
           const kName = registry ? registry.register("k") : "k";
           const keyPredName = `${prop.name}Key`;
           decls.push({
@@ -180,7 +323,7 @@ export function translateTypes(
         kind: "rule",
         name: prop.name,
         params: [{ name: pName, type: iface.name }],
-        returnType: mapTsType(prop.type, checker, strategy),
+        returnType: mapTsType(prop.type, checker, strategy, synth),
       });
     }
   }
@@ -189,7 +332,7 @@ export function translateTypes(
     decls.push({
       kind: "alias",
       name: alias.name,
-      type: mapTsType(alias.type, checker, strategy),
+      type: mapTsType(alias.type, checker, strategy, synth),
     });
   }
 

--- a/tools/ts2pant/src/translate-types.ts
+++ b/tools/ts2pant/src/translate-types.ts
@@ -48,10 +48,11 @@ export interface MapSynthEntry {
  */
 export class MapSynthesizer {
   private byKV = new Map<string, MapSynthEntry>();
+  private emitted = new Set<string>();
 
   constructor(private registry: NameRegistry) {}
 
-  register(kType: string, vType: string): string {
+  register(kType: string, vType: string): string | null {
     const key = `${kType}|${vType}`;
     const cached = this.byKV.get(key);
     if (cached) {
@@ -60,9 +61,7 @@ export class MapSynthesizer {
     const kFrag = manglePantTypeToFragment(kType);
     const vFrag = manglePantTypeToFragment(vType);
     if (!kFrag || !vFrag) {
-      throw new Error(
-        `Cannot synthesize Map domain for K=${kType}, V=${vType}`,
-      );
+      return null;
     }
     const baseDomain = `${kFrag}To${vFrag}Map`;
     const domain = this.registry.register(baseDomain);
@@ -84,12 +83,19 @@ export class MapSynthesizer {
    * Materialize accumulated decls (domain + membership predicate + guarded
    * value rule) in registration order. Rule-internal binder names are
    * registered *here*, after callers have claimed their own param names,
-   * so the synth decls get hygienic suffixes (e.g., `m1`, `k1`).
+   * so the synth decls get hygienic suffixes (e.g., `m1`, `k1`). Incremental:
+   * a second call only emits entries registered since the previous call, so
+   * the pipeline can drain new body-level registrations after signature/type
+   * translation has already run.
    */
   emit(): PantDeclaration[] {
     const decls: PantDeclaration[] = [];
     const ast = getAst();
-    for (const entry of this.byKV.values()) {
+    for (const [key, entry] of this.byKV) {
+      if (this.emitted.has(key)) {
+        continue;
+      }
+      this.emitted.add(key);
       const { domain, rule, keyPred } = entry.names;
       const mName = this.registry.register("m");
       const kName = this.registry.register("k");
@@ -199,13 +205,19 @@ export function mapTsType(
     return checker.typeToString(type);
   }
 
-  // Map — synthesize a domain when a synthesizer is provided.
+  // Map — synthesize a domain when a synthesizer is provided. If the K or V
+  // type is unmangleable (e.g., contains an unsupported TS type), register
+  // returns null and we fall through to checker.typeToString — the same
+  // unsupported-type fallback used by the array and set branches above.
   if (isMapType(type) && synth) {
     const typeArgs = checker.getTypeArguments(type as ts.TypeReference);
     if (typeArgs.length === 2) {
       const kType = mapTsType(typeArgs[0]!, checker, strategy, synth);
       const vType = mapTsType(typeArgs[1]!, checker, strategy, synth);
-      return synth.register(kType, vType);
+      const domain = synth.register(kType, vType);
+      if (domain !== null) {
+        return domain;
+      }
     }
   }
 

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -218,6 +218,34 @@ exports[`expressions-literals.ts > yes 1`] = `
 "module Yes.\\n\\nyes  => Bool.\\n\\n---\\n\\nyes = true.\\n"
 `;
 
+exports[`expressions-map-params.ts > contains 1`] = `
+"module Contains.\\n\\nStringToIntMap.\\nstringToIntMapKey m1: StringToIntMap, k1: String => Bool.\\nstringToIntMap m1: StringToIntMap, k1: String, stringToIntMapKey m1 k1 => Int.\\ncontains m: StringToIntMap, k: String => Bool.\\n\\n---\\n\\ncontains m k = stringToIntMapKey m k.\\n"
+`;
+
+exports[`expressions-map-params.ts > lookup 1`] = `
+"module Lookup.\\n\\nStringToIntMap.\\nstringToIntMapKey m1: StringToIntMap, k1: String => Bool.\\nstringToIntMap m1: StringToIntMap, k1: String, stringToIntMapKey m1 k1 => Int.\\nlookup m: StringToIntMap, k: String => Int.\\n\\n---\\n\\nlookup m k = stringToIntMap m k.\\n"
+`;
+
+exports[`expressions-map-params.ts > nestedLookup 1`] = `
+"module NestedLookup.\\n\\nStringToIntMap.\\nstringToIntMapKey m1: StringToIntMap, k: String => Bool.\\nstringToIntMap m1: StringToIntMap, k: String, stringToIntMapKey m1 k => Int.\\nStringToStringToIntMapMap.\\nstringToStringToIntMapMapKey m2: StringToStringToIntMapMap, k3: String => Bool.\\nstringToStringToIntMapMap m2: StringToStringToIntMapMap, k3: String, stringToStringToIntMapMapKey m2 k3 => StringToIntMap.\\nnestedLookup m: StringToStringToIntMapMap, k1: String, k2: String => Int.\\n\\n---\\n\\nnestedLookup m k1 k2 = stringToIntMap (stringToStringToIntMapMap m k1) k2.\\n"
+`;
+
+exports[`expressions-map-params.ts > passThrough 1`] = `
+"module PassThrough.\\n\\nStringToIntMap.\\nstringToIntMapKey m1: StringToIntMap, k: String => Bool.\\nstringToIntMap m1: StringToIntMap, k: String, stringToIntMapKey m1 k => Int.\\npassThrough m: StringToIntMap => StringToIntMap.\\n\\n---\\n\\npassThrough m = m.\\n"
+`;
+
+exports[`expressions-map-params.ts > pickByFlag 1`] = `
+"module PickByFlag.\\n\\nStringToBoolMap.\\nstringToBoolMapKey m: StringToBoolMap, k1: String => Bool.\\nstringToBoolMap m: StringToBoolMap, k1: String, stringToBoolMapKey m k1 => Bool.\\nStringToIntMap.\\nstringToIntMapKey m1: StringToIntMap, k2: String => Bool.\\nstringToIntMap m1: StringToIntMap, k2: String, stringToIntMapKey m1 k2 => Int.\\npickByFlag flags: StringToBoolMap, values: StringToIntMap, k: String => Int.\\n\\n---\\n\\npickByFlag flags values k = (cond stringToBoolMapKey flags k => stringToIntMap values k, true => 0).\\n"
+`;
+
+exports[`expressions-map-params.ts > sumAt 1`] = `
+"module SumAt.\\n\\nStringToIntMap.\\nstringToIntMapKey m: StringToIntMap, k1: String => Bool.\\nstringToIntMap m: StringToIntMap, k1: String, stringToIntMapKey m k1 => Int.\\nsumAt m1: StringToIntMap, m2: StringToIntMap, k: String => Int.\\n\\n---\\n\\nsumAt m1 m2 k = stringToIntMap m1 k + stringToIntMap m2 k.\\n\\ncheck\\n\\nall m1: StringToIntMap, m2: StringToIntMap, k: String | stringToIntMapKey m1 k and stringToIntMapKey m2 k -> sumAt m1 m2 k = stringToIntMap m1 k + stringToIntMap m2 k.\\n"
+`;
+
+exports[`expressions-map-params.ts > tagsFor 1`] = `
+"module TagsFor.\\n\\nStringToListStringMap.\\nstringToListStringMapKey m: StringToListStringMap, k1: String => Bool.\\nstringToListStringMap m: StringToListStringMap, k1: String, stringToListStringMapKey m k1 => [String].\\ntagsFor tags: StringToListStringMap, k: String => [String].\\n\\n---\\n\\ntagsFor tags k = stringToListStringMap tags k.\\n"
+`;
+
 exports[`expressions-map.ts > congruence 1`] = `
 "module Congruence.\\n\\nCache.\\nentriesKey c1: Cache, k1: String => Bool.\\nentries c1: Cache, k1: String, entriesKey c1 k1 => Int.\\ncongruence c: Cache, k: String => Bool.\\n\\n---\\n\\ncongruence c k = entriesKey c k.\\n\\ncheck\\n\\nall c: Cache, k: String | congruence c k -> entries c k = entries c k.\\n"
 `;

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-map-params.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-map-params.ts
@@ -1,0 +1,62 @@
+// Map<K, V> in non-field type positions synthesizes a domain handle per
+// (K, V) pair per module. McCarthy's theory of arrays (Kroening & Strichman
+// Ch. 7): synthesized sort is the handle domain; distinct parameter values
+// are distinct elements; .get is a partial function guarded by .has
+// membership (Dafny-style precondition discipline).
+
+/** Single Map parameter. */
+export function lookup(m: Map<string, number>, k: string): number {
+  return m.get(k)!;
+}
+
+/** .has on a Map parameter -> synthesized key predicate. */
+export function contains(m: Map<string, number>, k: string): boolean {
+  return m.has(k);
+}
+
+/**
+ * Two parameters of the *same* Map type: one shared synthesized domain.
+ * Two distinct elements; EUF keeps their lookups independent. The
+ * annotation exercises both guards together.
+ * @pant all m1: StringToIntMap, m2: StringToIntMap, k: String | stringToIntMapKey m1 k and stringToIntMapKey m2 k -> sumAt m1 m2 k = stringToIntMap m1 k + stringToIntMap m2 k
+ */
+export function sumAt(
+  m1: Map<string, number>,
+  m2: Map<string, number>,
+  k: string,
+): number {
+  return m1.get(k)! + m2.get(k)!;
+}
+
+/** Two different Map types -> two independent synthesized domains. */
+export function pickByFlag(
+  flags: Map<string, boolean>,
+  values: Map<string, number>,
+  k: string,
+): number {
+  return flags.has(k) ? values.get(k)! : 0;
+}
+
+/** Compound V: domain name StringToListStringMap; return type [String]. */
+export function tagsFor(tags: Map<string, string[]>, k: string): string[] {
+  return tags.get(k)!;
+}
+
+/** Map in return position (identity): domain flows through signature. */
+export function passThrough(m: Map<string, number>): Map<string, number> {
+  return m;
+}
+
+/**
+ * Nested Map parameter: outer K=String, V=Map<string, number>. Synthesis
+ * is bottom-up: inner StringToIntMap registers first, then the outer
+ * StringToStringToIntMapMap whose V references it. The body does a
+ * double .get(k)!, composing two synthesized guarded rules.
+ */
+export function nestedLookup(
+  m: Map<string, Map<string, number>>,
+  k1: string,
+  k2: string,
+): number {
+  return m.get(k1)!.get(k2)!;
+}


### PR DESCRIPTION
## Summary

- Extends the `Map<K, V>` encoding from interface fields (Stage A, #99) to any other type position: parameters, return types, nested Maps, and Maps inside arrays/tuples/unions.
- For each unique `(K, V)` per module, synthesizes a handle domain (`KToVMap`) plus the same guarded rule pair used for fields, with compound K/V mangled (`[String]` → `ListString`, `A + B` → `AOrB`, `A * B` → `AAndB`). Nested Maps register bottom-up.
- Stage A output is unchanged; both paths use the same encoding and differ only in whether the owner domain is a user interface or a synthesized handle.

Principle: McCarthy's theory of arrays (Kroening & Strichman, *Decision Procedures* Ch. 7). The synthesized domain is the array sort, distinct values are distinct maps (EUF keeps their lookups independent), and the guarded `select` lookup is Dafny-style partial-function discipline.

## Example

```ts
function lookup(m: Map<string, number>, k: string): number { return m.get(k)!; }
```

translates to:

```
module Lookup.

StringToIntMap.
stringToIntMapKey m1: StringToIntMap, k1: String => Bool.
stringToIntMap m1: StringToIntMap, k1: String, stringToIntMapKey m1 k1 => Int.
lookup m: StringToIntMap, k: String => Int.

---

lookup m k = stringToIntMap m k.
```

Fixture (`tests/fixtures/constructs/expressions-map-params.ts`) covers: single Map param, `.has` on a Map param, two params sharing a synthesized domain (`sumAt`), two distinct Map types producing distinct domains (`pickByFlag`), compound V (`tagsFor`), Map in return position (`passThrough`), and nested Maps (`nestedLookup`, which emits `StringToIntMap` and `StringToStringToIntMapMap` bottom-up).

## Test plan
- [x] `npm test` — 295 tests pass, Stage A snapshots unchanged
- [x] `npm run lint` — clean
- [x] `npx tsx src/index.ts tests/fixtures/constructs/expressions-map-params.ts sumAt --check` → `OK: Entailed`
- [x] Dedup verified: `sumAt` emits one `StringToIntMap`, `pickByFlag` emits two distinct synthesized domains
- [x] Nested Maps register bottom-up with correct V reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)