### PR TITLE
override: accept N-ary rules with tuple-keyed overrides

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -369,10 +369,14 @@ Primed expressions denote the post-state value of a rule in a state transition.
 
 *f*`[`*k₁* `|->` *v₁*`,` ... `,` *kₙ* `|->` *vₙ*`]`:
 
-1. *f* must be a rule of arity 1 with a return type: *f* : (*T*) → *R*.
-2. Each key must be a **subtype** of the parameter type: *kᵢ* : *Sᵢ* with *Sᵢ* ≤ *T*.
+1. *f* must be a rule with a return type: *f* : (*T₁, …, Tₐ*) → *R*.
+2. Each key must match the rule's parameter arity *a*:
+    * When *a* = 1, *kᵢ* is a bare expression and *kᵢ* : *Sᵢ* must be a **subtype** of the parameter type: *Sᵢ* ≤ *T₁*.
+    * When *a* > 1, *kᵢ* must be a tuple `(kᵢ₁, …, kᵢₐ)` whose components type-check componentwise: *kᵢⱼ* : *Sᵢⱼ* with *Sᵢⱼ* ≤ *Tⱼ*.
 3. Each value must be a **subtype** of the return type: *vᵢ* : *Uᵢ* with *Uᵢ* ≤ *R*.
-4. Result type: (*T*) → *R*.
+4. Result type: (*T₁, …, Tₐ*) → *R*.
+
+An applied override `f[k |-> v] x₁ … xₐ` is semantically an everything-else-unchanged point update: it equals *v* when the key matches each *xⱼ* componentwise, and equals `f x₁ … xₐ` otherwise. This is McCarthy's `store` extended to multi-index arrays (Kroening & Strichman Ch. 7).
 
 ### Additional Constraints
 
@@ -681,6 +685,13 @@ f[x |-> 0, y |-> 1]     // Multiple overrides
 
 ```
 all k: Key, v: Value | mapping[k |-> v] k = v.
+```
+
+For an N-ary rule, the override key is a tuple whose arity matches the rule's parameter list:
+
+```
+store h: Handle, k: Key => Value.
+all h: Handle, k: Key, v: Value | store[(h, k) |-> v] h k = v.
 ```
 
 ### Qualified Names

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -689,7 +689,7 @@ all k: Key, v: Value | mapping[k |-> v] k = v.
 
 For an N-ary rule, the override key is a tuple whose arity matches the rule's parameter list:
 
-```
+```pant
 store h: Handle, k: Key => Value.
 all h: Handle, k: Key, v: Value | store[(h, k) |-> v] h k = v.
 ```

--- a/lib/check.ml
+++ b/lib/check.ml
@@ -16,7 +16,8 @@ type type_error =
   | ExpectedBool of ty * loc
   | PrimedNonRule of string * loc
   | PrimeOutsideActionContext of string * loc
-  | OverrideRequiresArity1 of string * int * loc
+  | OverrideKeyArityMismatch of string * int * loc
+      (** rule name, expected arity (from the rule's param list) *)
   | ProjectionOutOfBounds of int * int * loc
   | PropositionNotBool of ty * loc
   | ShadowingTypeMismatch of
@@ -430,25 +431,46 @@ and check_quantifier ctx params guards body =
 
 and check_override ctx name pairs =
   match[@warning "-4"] Env.lookup_term name ctx.env with
-  | Some { kind = Env.KRule (TyFunc ([ param_ty ], Some ret_ty)); _ } ->
-      (* Override only for arity-1 rules *)
+  | Some { kind = Env.KRule (TyFunc (param_tys, Some ret_ty)); _ }
+    when param_tys <> [] ->
+      (* Override key must match the rule's parameter arity. For arity-1 rules
+         the key is a bare expression typed against the single parameter; for
+         arity-N rules the key must be an N-tuple whose components match the
+         parameter types componentwise. See Kroening & Strichman Ch. 7
+         (McCarthy's [store] applied to multi-index arrays). *)
+      let arity = List.length param_tys in
       let* _ =
         map_result
           (fun (k, v) ->
-            let* k_ty = infer_type ctx k in
             let* v_ty = infer_type ctx v in
             let* _ =
-              if is_subtype k_ty param_ty then Ok ()
-              else Error (TypeMismatch (param_ty, k_ty, ctx.loc))
+              if is_subtype v_ty ret_ty then Ok ()
+              else Error (TypeMismatch (ret_ty, v_ty, ctx.loc))
             in
-            if is_subtype v_ty ret_ty then Ok ()
-            else Error (TypeMismatch (ret_ty, v_ty, ctx.loc)))
+            check_override_key ctx name param_tys arity k)
           pairs
       in
-      Ok (TyFunc ([ param_ty ], Some ret_ty))
-  | Some { kind = Env.KRule (TyFunc (params, _)); _ } ->
-      Error (OverrideRequiresArity1 (name, List.length params, ctx.loc))
+      Ok (TyFunc (param_tys, Some ret_ty))
   | _ -> Error (UnboundVariable (name, ctx.loc))
+
+and check_override_key ctx name param_tys arity k =
+  match[@warning "-4"] (arity, k) with
+  | 1, _ ->
+      let param_ty = List.hd param_tys in
+      let* k_ty = infer_type ctx k in
+      if is_subtype k_ty param_ty then Ok ()
+      else Error (TypeMismatch (param_ty, k_ty, ctx.loc))
+  | _, ETuple parts when List.length parts = arity ->
+      let* _ =
+        map_result
+          (fun (part, pty) ->
+            let* pt = infer_type ctx part in
+            if is_subtype pt pty then Ok ()
+            else Error (TypeMismatch (pty, pt, ctx.loc)))
+          (List.combine parts param_tys)
+      in
+      Ok ()
+  | _ -> Error (OverrideKeyArityMismatch (name, arity, ctx.loc))
 
 (** Check a single proposition *)
 let check_proposition ctx (prop : expr located) =

--- a/lib/check.mli
+++ b/lib/check.mli
@@ -12,7 +12,7 @@ type type_error =
   | ExpectedBool of Types.ty * Ast.loc
   | PrimedNonRule of string * Ast.loc
   | PrimeOutsideActionContext of string * Ast.loc
-  | OverrideRequiresArity1 of string * int * Ast.loc
+  | OverrideKeyArityMismatch of string * int * Ast.loc
   | ProjectionOutOfBounds of int * int * Ast.loc
   | PropositionNotBool of Types.ty * Ast.loc
   | ShadowingTypeMismatch of string * Types.ty * Types.ty * Ast.loc

--- a/lib/error.ml
+++ b/lib/error.ml
@@ -38,10 +38,12 @@ let format_type_error err =
       fmt loc (Printf.sprintf "Cannot prime '%s': not a rule" name)
   | PrimeOutsideActionContext (name, loc) ->
       fmt loc (Printf.sprintf "Primed '%s' only valid in action context" name)
-  | OverrideRequiresArity1 (name, arity, loc) ->
+  | OverrideKeyArityMismatch (name, arity, loc) ->
       fmt loc
-        (Printf.sprintf "Override requires arity-1 rule, '%s' has arity %d" name
-           arity)
+        (Printf.sprintf
+           "Override key arity mismatch for rule '%s': expected %d-tuple key \
+            (or bare expression for arity-1)"
+           name arity)
   | ProjectionOutOfBounds (idx, len, loc) ->
       fmt loc
         (Printf.sprintf "Projection .%d out of bounds for %d-tuple" idx len)
@@ -140,8 +142,9 @@ let format_type_warning err =
   | ( UnboundVariable _ | UnboundType _ | TypeMismatch _ | ArityMismatch _
     | NotAFunction _ | NotAList _ | NotAProduct _ | NotNumeric _
     | ExpectedBool _ | PrimedNonRule _ | PrimeOutsideActionContext _
-    | OverrideRequiresArity1 _ | ProjectionOutOfBounds _ | PropositionNotBool _
-    | AmbiguousName _ | UnboundQualified _ | PrimedExtracontextual _
-    | ComprehensionNeedEach _ | AggregateRequiresNumeric _
-    | AggregateRequiresBool _ | CheckWithoutBody _ ) as other ->
+    | OverrideKeyArityMismatch _ | ProjectionOutOfBounds _
+    | PropositionNotBool _ | AmbiguousName _ | UnboundQualified _
+    | PrimedExtracontextual _ | ComprehensionNeedEach _
+    | AggregateRequiresNumeric _ | AggregateRequiresBool _ | CheckWithoutBody _
+      ) as other ->
       format_type_error other

--- a/lib/error.ml
+++ b/lib/error.ml
@@ -40,10 +40,15 @@ let format_type_error err =
       fmt loc (Printf.sprintf "Primed '%s' only valid in action context" name)
   | OverrideKeyArityMismatch (name, arity, loc) ->
       fmt loc
-        (Printf.sprintf
-           "Override key arity mismatch for rule '%s': expected %d-tuple key \
-            (or bare expression for arity-1)"
-           name arity)
+        (if arity = 1 then
+           Printf.sprintf
+             "Override key arity mismatch for rule '%s': expected bare \
+              expression key"
+             name
+         else
+           Printf.sprintf
+             "Override key arity mismatch for rule '%s': expected %d-tuple key"
+             name arity)
   | ProjectionOutOfBounds (idx, len, loc) ->
       fmt loc
         (Printf.sprintf "Projection .%d out of bounds for %d-tuple" idx len)

--- a/lib/smt.ml
+++ b/lib/smt.ml
@@ -121,29 +121,32 @@ and translate_app config env func args =
             | [] -> Printf.sprintf "(%s %s)" sname applied_args
             | (k, v) :: rest ->
                 let guard_str =
-                  match[@warning "-4"] (k, args_str) with
-                  | ETuple parts, _ -> (
-                      if List.length parts <> List.length args_str then
-                        failwith
-                          "SMT translation: override key arity does not match \
-                           application arity";
-                      let eqs =
-                        List.map2
-                          (fun part arg ->
-                            Printf.sprintf "(= %s %s)" arg
-                              (translate_expr config env part))
-                          parts args_str
-                      in
-                      match eqs with
-                      | [ one ] -> one
-                      | _ -> Printf.sprintf "(and %s)" (String.concat " " eqs))
-                  | _, [ arg ] ->
+                  match args_str with
+                  | [ arg ] ->
+                      (* Arity-1: bare-expression key, even when the key is
+                         itself a tuple literal (e.g. a rule whose single
+                         parameter has a product type). *)
                       Printf.sprintf "(= %s %s)" arg
                         (translate_expr config env k)
-                  | _ ->
-                      failwith
-                        "SMT translation: override key arity does not match \
-                         application arity"
+                  | _ -> (
+                      match[@warning "-4"] k with
+                      | ETuple parts ->
+                          if List.length parts <> List.length args_str then
+                            failwith
+                              "SMT translation: override key arity does not \
+                               match application arity";
+                          let eqs =
+                            List.map2
+                              (fun part arg ->
+                                Printf.sprintf "(= %s %s)" arg
+                                  (translate_expr config env part))
+                              parts args_str
+                          in
+                          Printf.sprintf "(and %s)" (String.concat " " eqs)
+                      | _ ->
+                          failwith
+                            "SMT translation: override key arity does not \
+                             match application arity")
                 in
                 Printf.sprintf "(ite %s %s %s)" guard_str
                   (translate_expr config env v)

--- a/lib/smt.ml
+++ b/lib/smt.ml
@@ -105,22 +105,44 @@ and translate_app config env func args =
   | None -> (
       match[@warning "-4"] func with
       | EOverride (Lower name, pairs) ->
-          (* f[k |-> v] applied to args: inline ite chain *)
+          (* f[k |-> v] applied to args: inline ite chain. For arity-1 rules
+             the key is a bare expression compared against the single arg;
+             for arity-N rules the key is an N-tuple whose components are
+             compared componentwise against the args, yielding a conjunctive
+             guard — McCarthy's [store] extended to multi-index arrays
+             (Kroening & Strichman Ch. 7). *)
           let sname = sanitize_ident name in
           let args_str = List.map (translate_expr config env) args in
           let applied_args = String.concat " " args_str in
-          (* For arity-1 overrides, the single arg is the dispatch key *)
-          let arg_str =
-            match args_str with
-            | [] ->
-                failwith "SMT translation: override applied with 0 arguments"
-            | hd :: _ -> hd
-          in
+          (match args_str with
+          | [] -> failwith "SMT translation: override applied with 0 arguments"
+          | _ -> ());
           let rec build_chain = function
             | [] -> Printf.sprintf "(%s %s)" sname applied_args
             | (k, v) :: rest ->
-                Printf.sprintf "(ite (= %s %s) %s %s)" arg_str
-                  (translate_expr config env k)
+                let guard_str =
+                  match[@warning "-4"] (k, args_str) with
+                  | ETuple parts, _
+                    when List.length parts = List.length args_str -> (
+                      let eqs =
+                        List.map2
+                          (fun part arg ->
+                            Printf.sprintf "(= %s %s)" arg
+                              (translate_expr config env part))
+                          parts args_str
+                      in
+                      match eqs with
+                      | [ one ] -> one
+                      | _ -> Printf.sprintf "(and %s)" (String.concat " " eqs))
+                  | _, [ arg ] ->
+                      Printf.sprintf "(= %s %s)" arg
+                        (translate_expr config env k)
+                  | _ ->
+                      failwith
+                        "SMT translation: override key arity does not match \
+                         application arity"
+                in
+                Printf.sprintf "(ite %s %s %s)" guard_str
                   (translate_expr config env v)
                   (build_chain rest)
           in

--- a/lib/smt.ml
+++ b/lib/smt.ml
@@ -122,8 +122,11 @@ and translate_app config env func args =
             | (k, v) :: rest ->
                 let guard_str =
                   match[@warning "-4"] (k, args_str) with
-                  | ETuple parts, _
-                    when List.length parts = List.length args_str -> (
+                  | ETuple parts, _ -> (
+                      if List.length parts <> List.length args_str then
+                        failwith
+                          "SMT translation: override key arity does not match \
+                           application arity";
                       let eqs =
                         List.map2
                           (fun part arg ->

--- a/samples/06-advanced.pant
+++ b/samples/06-advanced.pant
@@ -7,6 +7,11 @@ Value.
 mapping k: Key => Value.
 default-value => Value.
 
+> N-ary override: map-valued rule keyed by an owner handle and a key.
+> Override key is a tuple whose arity matches the rule's parameter list.
+Handle.
+store h: Handle, k: Key => Value.
+
 ---
 > Function override syntax: f[k |-> v]
 > Creates a function like f but with f(k) = v
@@ -21,6 +26,13 @@ all k1: Key, k2: Key, v: Value |
 > Override doesn't affect other keys
 all k1: Key, k2: Key, v: Value |
     k1 ~= k2 -> mapping[k1 |-> v] k2 = mapping k2.
+
+> N-ary override with a tuple key: the override binds the combined position
+> (h, k) and leaves every other (h', k') untouched.
+all h: Handle, k: Key, v: Value | store[(h, k) |-> v] h k = v.
+
+all h1: Handle, h2: Handle, k1: Key, k2: Key, v: Value |
+    (h1 ~= h2 or k1 ~= k2) -> store[(h1, k1) |-> v] h2 k2 = store h2 k2.
 
 where
 

--- a/test/snapshots/json/06-advanced.json
+++ b/test/snapshots/json/06-advanced.json
@@ -3,6 +3,7 @@
   "imports": [],
   "contexts": [],
   "types": {
+    "Handle": { "kind": "domain" },
     "Item": { "kind": "domain" },
     "Key": { "kind": "domain" },
     "Value": { "kind": "domain" }
@@ -10,7 +11,8 @@
   "rules": {
     "available": { "params": [ "Item" ], "return": "Bool" },
     "default-value": { "params": [], "return": "Value" },
-    "mapping": { "params": [ "Key" ], "return": "Value" }
+    "mapping": { "params": [ "Key" ], "return": "Value" },
+    "store": { "params": [ "Handle", "Key" ], "return": "Value" }
   },
   "chapters": [
     {
@@ -36,6 +38,28 @@
           "guards": [],
           "return": "Value",
           "resolved": { "func": { "params": [], "return": "Value" } }
+        },
+        {
+          "doc": [
+            [
+              "N-ary override: map-valued rule keyed by an owner handle and a key.",
+              "Override key is a tuple whose arity matches the rule's parameter list."
+            ]
+          ],
+          "kind": "domain",
+          "name": "Handle"
+        },
+        {
+          "kind": "rule",
+          "name": "store",
+          "params": [
+            { "name": "h", "type": "Handle" }, { "name": "k", "type": "Key" }
+          ],
+          "guards": [],
+          "return": "Value",
+          "resolved": {
+            "func": { "params": [ "Handle", "Key" ], "return": "Value" }
+          }
         }
       ],
       "body": [
@@ -175,6 +199,115 @@
                           "func": { "var": "mapping" },
                           "args": [ { "var": "k2" } ]
                         }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "doc": [
+            [
+              "N-ary override with a tuple key: the override binds the combined position",
+              "(h, k) and leaves every other (h', k') untouched."
+            ]
+          ],
+          "expr": {
+            "forall": {
+              "params": [
+                { "name": "h", "type": "Handle" },
+                { "name": "k", "type": "Key" },
+                { "name": "v", "type": "Value" }
+              ],
+              "guards": [],
+              "body": {
+                "binop": {
+                  "op": "eq",
+                  "left": {
+                    "app": {
+                      "func": {
+                        "override": {
+                          "func": "store",
+                          "mappings": [
+                            {
+                              "key": {
+                                "tuple": [ { "var": "h" }, { "var": "k" } ]
+                              },
+                              "value": { "var": "v" }
+                            }
+                          ]
+                        }
+                      },
+                      "args": [ { "var": "h" }, { "var": "k" } ]
+                    }
+                  },
+                  "right": { "var": "v" }
+                }
+              }
+            }
+          }
+        },
+        {
+          "forall": {
+            "params": [
+              { "name": "h1", "type": "Handle" },
+              { "name": "h2", "type": "Handle" },
+              { "name": "k1", "type": "Key" },
+              { "name": "k2", "type": "Key" },
+              { "name": "v", "type": "Value" }
+            ],
+            "guards": [],
+            "body": {
+              "binop": {
+                "op": "impl",
+                "left": {
+                  "binop": {
+                    "op": "or",
+                    "left": {
+                      "binop": {
+                        "op": "neq",
+                        "left": { "var": "h1" },
+                        "right": { "var": "h2" }
+                      }
+                    },
+                    "right": {
+                      "binop": {
+                        "op": "neq",
+                        "left": { "var": "k1" },
+                        "right": { "var": "k2" }
+                      }
+                    }
+                  }
+                },
+                "right": {
+                  "binop": {
+                    "op": "eq",
+                    "left": {
+                      "app": {
+                        "func": {
+                          "override": {
+                            "func": "store",
+                            "mappings": [
+                              {
+                                "key": {
+                                  "tuple": [
+                                    { "var": "h1" }, { "var": "k1" }
+                                  ]
+                                },
+                                "value": { "var": "v" }
+                              }
+                            ]
+                          }
+                        },
+                        "args": [ { "var": "h2" }, { "var": "k2" } ]
+                      }
+                    },
+                    "right": {
+                      "app": {
+                        "func": { "var": "store" },
+                        "args": [ { "var": "h2" }, { "var": "k2" } ]
                       }
                     }
                   }

--- a/test/snapshots/markdown/06-advanced.md
+++ b/test/snapshots/markdown/06-advanced.md
@@ -4,13 +4,21 @@ Advanced features: overrides, qualified names
 
 ### Domains
 
-`Key`, `Value`
+`Key`.
+
+`Value`.
+
+> N-ary override: map-valued rule keyed by an owner handle and a key. Override key is a tuple whose arity matches the rule's parameter list.
+
+`Handle`.
 
 ### Rules
 
 **mapping** *k*: `Key` ⇒ `Value`.
 
 **default-value** ⇒ `Value`.
+
+**store** *h*: `Handle`, *k*: `Key` ⇒ `Value`.
 
 ---
 
@@ -27,6 +35,13 @@ Advanced features: overrides, qualified names
 > Override doesn't affect other keys
 
 ∀ *k1*: `Key`, *k2*: `Key`, *v*: `Value` · *k1* ≠ *k2* → **mapping**[*k1* ↦ *v*] *k2* = **mapping** *k2*.
+
+> N-ary override with a tuple key: the override binds the combined position (h, k) and leaves every other (h', k') untouched.
+
+∀ *h*: `Handle`, *k*: `Key`, *v*: `Value` · **store**[(*h*, *k*) ↦ *v*] *h* *k* = *v*.
+
+∀ *h1*: `Handle`, *h2*: `Handle`, *k1*: `Key`, *k2*: `Key`, *v*: `Value` · *h1* ≠ *h2* ∨ *k1* ≠ *k2* → **store**[(*h1*, *k1*) ↦ *v*] *h2* *k2* = **store** *h2*
+*k2*.
 
 ## Chapter 2
 

--- a/test/snapshots/pretty/06-advanced.pant
+++ b/test/snapshots/pretty/06-advanced.pant
@@ -7,6 +7,12 @@ Value.
 mapping k: Key => Value.
 default-value => Value.
 
+> N-ary override: map-valued rule keyed by an owner handle and a key.
+> Override key is a tuple whose arity matches the rule's parameter list.
+
+Handle.
+store h: Handle, k: Key => Value.
+
 ---
 
 > Function override syntax: f[k |-> v]
@@ -23,6 +29,12 @@ all k1: Key, k2: Key, v: Value | k1 ~= k2 -> mapping[k1 |-> v] k2 = mapping k2.
 > Override doesn't affect other keys
 
 all k1: Key, k2: Key, v: Value | k1 ~= k2 -> mapping[k1 |-> v] k2 = mapping k2.
+
+> N-ary override with a tuple key: the override binds the combined position
+> (h, k) and leaves every other (h', k') untouched.
+
+all h: Handle, k: Key, v: Value | store[(h, k) |-> v] h k = v.
+all h1: Handle, h2: Handle, k1: Key, k2: Key, v: Value | h1 ~= h2 or k1 ~= k2 -> store[(h1, k1) |-> v] h2 k2 = store h2 k2.
 
 where
 

--- a/test/test_check.ml
+++ b/test/test_check.ml
@@ -574,11 +574,11 @@ process.
     | UnboundVariable _ | UnboundType _ | TypeMismatch _ | ArityMismatch _
     | NotAFunction _ | NotAList _ | NotAProduct _ | NotNumeric _
     | ExpectedBool _ | PrimedNonRule _ | PrimeOutsideActionContext _
-    | OverrideRequiresArity1 _ | ProjectionOutOfBounds _ | PropositionNotBool _
-    | ShadowingTypeMismatch _ | AmbiguousName _ | UnboundQualified _
-    | PrimedExtracontextual _ | BoolParam _ | ComprehensionNeedEach _
-    | AggregateRequiresNumeric _ | AggregateRequiresBool _ | CheckWithoutBody _
-      ->
+    | OverrideKeyArityMismatch _ | ProjectionOutOfBounds _
+    | PropositionNotBool _ | ShadowingTypeMismatch _ | AmbiguousName _
+    | UnboundQualified _ | PrimedExtracontextual _ | BoolParam _
+    | ComprehensionNeedEach _ | AggregateRequiresNumeric _
+    | AggregateRequiresBool _ | CheckWithoutBody _ ->
         false)
 
 let test_qualified_type_resolves_ambiguity () =
@@ -656,11 +656,11 @@ WRONG::count >= 0.
     | UnboundVariable _ | UnboundType _ | TypeMismatch _ | ArityMismatch _
     | NotAFunction _ | NotAList _ | NotAProduct _ | NotNumeric _
     | ExpectedBool _ | PrimedNonRule _ | PrimeOutsideActionContext _
-    | OverrideRequiresArity1 _ | ProjectionOutOfBounds _ | PropositionNotBool _
-    | ShadowingTypeMismatch _ | AmbiguousName _ | UnboundQualified _
-    | PrimedExtracontextual _ | BoolParam _ | ComprehensionNeedEach _
-    | AggregateRequiresNumeric _ | AggregateRequiresBool _ | CheckWithoutBody _
-      ->
+    | OverrideKeyArityMismatch _ | ProjectionOutOfBounds _
+    | PropositionNotBool _ | ShadowingTypeMismatch _ | AmbiguousName _
+    | UnboundQualified _ | PrimedExtracontextual _ | BoolParam _
+    | ComprehensionNeedEach _ | AggregateRequiresNumeric _
+    | AggregateRequiresBool _ | CheckWithoutBody _ ->
         false)
 
 let test_local_domain_shadows_import () =
@@ -969,10 +969,11 @@ all u: User | role u.
     | UnboundVariable _ | UnboundType _ | TypeMismatch _ | ArityMismatch _
     | NotAFunction _ | NotAList _ | NotAProduct _ | NotNumeric _
     | ExpectedBool _ | PrimedNonRule _ | PrimeOutsideActionContext _
-    | OverrideRequiresArity1 _ | ProjectionOutOfBounds _ | PropositionNotBool _
-    | ShadowingTypeMismatch _ | AmbiguousName _ | UnboundQualified _
-    | PrimedExtracontextual _ | BoolParam _ | AggregateRequiresNumeric _
-    | AggregateRequiresBool _ | CheckWithoutBody _ ->
+    | OverrideKeyArityMismatch _ | ProjectionOutOfBounds _
+    | PropositionNotBool _ | ShadowingTypeMismatch _ | AmbiguousName _
+    | UnboundQualified _ | PrimedExtracontextual _ | BoolParam _
+    | AggregateRequiresNumeric _ | AggregateRequiresBool _ | CheckWithoutBody _
+      ->
         false)
 
 let test_all_non_bool_body_error () =
@@ -991,10 +992,11 @@ some u: User | role u.
     | UnboundVariable _ | UnboundType _ | TypeMismatch _ | ArityMismatch _
     | NotAFunction _ | NotAList _ | NotAProduct _ | NotNumeric _
     | ExpectedBool _ | PrimedNonRule _ | PrimeOutsideActionContext _
-    | OverrideRequiresArity1 _ | ProjectionOutOfBounds _ | PropositionNotBool _
-    | ShadowingTypeMismatch _ | AmbiguousName _ | UnboundQualified _
-    | PrimedExtracontextual _ | BoolParam _ | AggregateRequiresNumeric _
-    | AggregateRequiresBool _ | CheckWithoutBody _ ->
+    | OverrideKeyArityMismatch _ | ProjectionOutOfBounds _
+    | PropositionNotBool _ | ShadowingTypeMismatch _ | AmbiguousName _
+    | UnboundQualified _ | PrimedExtracontextual _ | BoolParam _
+    | AggregateRequiresNumeric _ | AggregateRequiresBool _ | CheckWithoutBody _
+      ->
         false)
 
 let test_combiner_add_numeric () =
@@ -1034,10 +1036,10 @@ active u: User => Bool.
     | UnboundVariable _ | UnboundType _ | TypeMismatch _ | ArityMismatch _
     | NotAFunction _ | NotAList _ | NotAProduct _ | NotNumeric _
     | ExpectedBool _ | PrimedNonRule _ | PrimeOutsideActionContext _
-    | OverrideRequiresArity1 _ | ProjectionOutOfBounds _ | PropositionNotBool _
-    | ShadowingTypeMismatch _ | AmbiguousName _ | UnboundQualified _
-    | PrimedExtracontextual _ | BoolParam _ | ComprehensionNeedEach _
-    | AggregateRequiresBool _ | CheckWithoutBody _ ->
+    | OverrideKeyArityMismatch _ | ProjectionOutOfBounds _
+    | PropositionNotBool _ | ShadowingTypeMismatch _ | AmbiguousName _
+    | UnboundQualified _ | PrimedExtracontextual _ | BoolParam _
+    | ComprehensionNeedEach _ | AggregateRequiresBool _ | CheckWithoutBody _ ->
         false)
 
 let test_combiner_bool_on_numeric_fails () =
@@ -1055,10 +1057,11 @@ and over each u: User | score u.
     | UnboundVariable _ | UnboundType _ | TypeMismatch _ | ArityMismatch _
     | NotAFunction _ | NotAList _ | NotAProduct _ | NotNumeric _
     | ExpectedBool _ | PrimedNonRule _ | PrimeOutsideActionContext _
-    | OverrideRequiresArity1 _ | ProjectionOutOfBounds _ | PropositionNotBool _
-    | ShadowingTypeMismatch _ | AmbiguousName _ | UnboundQualified _
-    | PrimedExtracontextual _ | BoolParam _ | ComprehensionNeedEach _
-    | AggregateRequiresNumeric _ | CheckWithoutBody _ ->
+    | OverrideKeyArityMismatch _ | ProjectionOutOfBounds _
+    | PropositionNotBool _ | ShadowingTypeMismatch _ | AmbiguousName _
+    | UnboundQualified _ | PrimedExtracontextual _ | BoolParam _
+    | ComprehensionNeedEach _ | AggregateRequiresNumeric _ | CheckWithoutBody _
+      ->
         false)
 
 (* --- Closure tests --- *)
@@ -1266,7 +1269,7 @@ x.1 >= 0.
     | Check.NotAProduct _ -> true
     | UnboundVariable _ | UnboundType _ | TypeMismatch _ | ArityMismatch _
     | NotAFunction _ | NotAList _ | NotNumeric _ | ExpectedBool _
-    | PrimedNonRule _ | PrimeOutsideActionContext _ | OverrideRequiresArity1 _
+    | PrimedNonRule _ | PrimeOutsideActionContext _ | OverrideKeyArityMismatch _
     | ProjectionOutOfBounds _ | PropositionNotBool _ | ShadowingTypeMismatch _
     | AmbiguousName _ | UnboundQualified _ | PrimedExtracontextual _
     | BoolParam _ | ComprehensionNeedEach _ | AggregateRequiresNumeric _
@@ -1284,14 +1287,16 @@ f + 1 = 2.
     | Check.NotNumeric _ -> true
     | UnboundVariable _ | UnboundType _ | TypeMismatch _ | ArityMismatch _
     | NotAFunction _ | NotAList _ | NotAProduct _ | ExpectedBool _
-    | PrimedNonRule _ | PrimeOutsideActionContext _ | OverrideRequiresArity1 _
+    | PrimedNonRule _ | PrimeOutsideActionContext _ | OverrideKeyArityMismatch _
     | ProjectionOutOfBounds _ | PropositionNotBool _ | ShadowingTypeMismatch _
     | AmbiguousName _ | UnboundQualified _ | PrimedExtracontextual _
     | BoolParam _ | ComprehensionNeedEach _ | AggregateRequiresNumeric _
     | AggregateRequiresBool _ | CheckWithoutBody _ ->
         false)
 
-let test_override_requires_arity1 () =
+let test_override_key_bare_on_nary_rule () =
+  (* Bare expression key on an arity-2 rule is an arity mismatch: the key
+     must be a 2-tuple so each component can be bound against a parameter. *)
   check_error
     {|module TEST.
 
@@ -1299,10 +1304,10 @@ A.
 B.
 f a: A, b: B => A.
 ---
-all a: A, b: B | f[a |-> b] a = a.
+all a: A, b: B | f[a |-> a] a b = a.
 |}
     (function
-    | Check.OverrideRequiresArity1 _ -> true
+    | Check.OverrideKeyArityMismatch _ -> true
     | UnboundVariable _ | UnboundType _ | TypeMismatch _ | ArityMismatch _
     | NotAFunction _ | NotAList _ | NotAProduct _ | NotNumeric _
     | ExpectedBool _ | PrimedNonRule _ | PrimeOutsideActionContext _
@@ -1311,6 +1316,41 @@ all a: A, b: B | f[a |-> b] a = a.
     | BoolParam _ | ComprehensionNeedEach _ | AggregateRequiresNumeric _
     | AggregateRequiresBool _ | CheckWithoutBody _ ->
         false)
+
+let test_override_key_tuple_arity_mismatch () =
+  (* Tuple key with the wrong number of components on an arity-2 rule. *)
+  check_error
+    {|module TEST.
+
+A.
+B.
+f a: A, b: B => A.
+---
+all a: A, b: B | f[(a, b, a) |-> a] a b = a.
+|}
+    (function
+    | Check.OverrideKeyArityMismatch _ -> true
+    | UnboundVariable _ | UnboundType _ | TypeMismatch _ | ArityMismatch _
+    | NotAFunction _ | NotAList _ | NotAProduct _ | NotNumeric _
+    | ExpectedBool _ | PrimedNonRule _ | PrimeOutsideActionContext _
+    | ProjectionOutOfBounds _ | PropositionNotBool _ | ShadowingTypeMismatch _
+    | AmbiguousName _ | UnboundQualified _ | PrimedExtracontextual _
+    | BoolParam _ | ComprehensionNeedEach _ | AggregateRequiresNumeric _
+    | AggregateRequiresBool _ | CheckWithoutBody _ ->
+        false)
+
+let test_override_nary_tuple_key_ok () =
+  (* Arity-2 rule + 2-tuple key type-checks cleanly. *)
+  check_ok
+    {|module TEST.
+
+A.
+B.
+f a: A, b: B => A.
+g a1: A, b1: B => A.
+---
+all a: A, b: B | g a b = f[(a, b) |-> a] a b.
+|}
 
 let test_projection_out_of_bounds () =
   check_error {|module TEST.
@@ -1325,10 +1365,11 @@ p.5 >= 0.
     | UnboundVariable _ | UnboundType _ | TypeMismatch _ | ArityMismatch _
     | NotAFunction _ | NotAList _ | NotAProduct _ | NotNumeric _
     | ExpectedBool _ | PrimedNonRule _ | PrimeOutsideActionContext _
-    | OverrideRequiresArity1 _ | PropositionNotBool _ | ShadowingTypeMismatch _
-    | AmbiguousName _ | UnboundQualified _ | PrimedExtracontextual _
-    | BoolParam _ | ComprehensionNeedEach _ | AggregateRequiresNumeric _
-    | AggregateRequiresBool _ | CheckWithoutBody _ ->
+    | OverrideKeyArityMismatch _ | PropositionNotBool _
+    | ShadowingTypeMismatch _ | AmbiguousName _ | UnboundQualified _
+    | PrimedExtracontextual _ | BoolParam _ | ComprehensionNeedEach _
+    | AggregateRequiresNumeric _ | AggregateRequiresBool _ | CheckWithoutBody _
+      ->
         false)
 
 let test_unbound_type () =
@@ -1340,7 +1381,7 @@ f x: Nonexistent => Bool.
     | Check.UnboundType _ -> true
     | UnboundVariable _ | TypeMismatch _ | ArityMismatch _ | NotAFunction _
     | NotAList _ | NotAProduct _ | NotNumeric _ | ExpectedBool _
-    | PrimedNonRule _ | PrimeOutsideActionContext _ | OverrideRequiresArity1 _
+    | PrimedNonRule _ | PrimeOutsideActionContext _ | OverrideKeyArityMismatch _
     | ProjectionOutOfBounds _ | PropositionNotBool _ | ShadowingTypeMismatch _
     | AmbiguousName _ | UnboundQualified _ | PrimedExtracontextual _
     | BoolParam _ | ComprehensionNeedEach _ | AggregateRequiresNumeric _
@@ -1364,7 +1405,7 @@ x in x.
     | Check.NotAList _ -> true
     | UnboundVariable _ | UnboundType _ | TypeMismatch _ | ArityMismatch _
     | NotAFunction _ | NotAProduct _ | NotNumeric _ | ExpectedBool _
-    | PrimedNonRule _ | PrimeOutsideActionContext _ | OverrideRequiresArity1 _
+    | PrimedNonRule _ | PrimeOutsideActionContext _ | OverrideKeyArityMismatch _
     | ProjectionOutOfBounds _ | PropositionNotBool _ | ShadowingTypeMismatch _
     | AmbiguousName _ | UnboundQualified _ | PrimedExtracontextual _
     | BoolParam _ | ComprehensionNeedEach _ | AggregateRequiresNumeric _
@@ -1382,7 +1423,7 @@ f + 1 = 2.
     | Check.NotNumeric _ -> true
     | UnboundVariable _ | UnboundType _ | TypeMismatch _ | ArityMismatch _
     | NotAFunction _ | NotAList _ | NotAProduct _ | ExpectedBool _
-    | PrimedNonRule _ | PrimeOutsideActionContext _ | OverrideRequiresArity1 _
+    | PrimedNonRule _ | PrimeOutsideActionContext _ | OverrideKeyArityMismatch _
     | ProjectionOutOfBounds _ | PropositionNotBool _ | ShadowingTypeMismatch _
     | AmbiguousName _ | UnboundQualified _ | PrimedExtracontextual _
     | BoolParam _ | ComprehensionNeedEach _ | AggregateRequiresNumeric _
@@ -1496,11 +1537,11 @@ active? i: Item => Bool.
     | UnboundVariable _ | UnboundType _ | TypeMismatch _ | ArityMismatch _
     | NotAFunction _ | NotAList _ | NotAProduct _ | NotNumeric _
     | ExpectedBool _ | PrimedNonRule _ | PrimeOutsideActionContext _
-    | OverrideRequiresArity1 _ | ProjectionOutOfBounds _ | PropositionNotBool _
-    | ShadowingTypeMismatch _ | AmbiguousName _ | UnboundQualified _
-    | PrimedExtracontextual _ | BoolParam _ | ComprehensionNeedEach _
-    | AggregateRequiresNumeric _ | AggregateRequiresBool _ | CheckWithoutBody _
-      ->
+    | OverrideKeyArityMismatch _ | ProjectionOutOfBounds _
+    | PropositionNotBool _ | ShadowingTypeMismatch _ | AmbiguousName _
+    | UnboundQualified _ | PrimedExtracontextual _ | BoolParam _
+    | ComprehensionNeedEach _ | AggregateRequiresNumeric _
+    | AggregateRequiresBool _ | CheckWithoutBody _ ->
         false)
 
 let test_over_each_mul_nat () =
@@ -1527,11 +1568,11 @@ active? i: Item => Bool.
     | UnboundVariable _ | UnboundType _ | TypeMismatch _ | ArityMismatch _
     | NotAFunction _ | NotAList _ | NotAProduct _ | NotNumeric _
     | ExpectedBool _ | PrimedNonRule _ | PrimeOutsideActionContext _
-    | OverrideRequiresArity1 _ | ProjectionOutOfBounds _ | PropositionNotBool _
-    | ShadowingTypeMismatch _ | AmbiguousName _ | UnboundQualified _
-    | PrimedExtracontextual _ | BoolParam _ | ComprehensionNeedEach _
-    | AggregateRequiresNumeric _ | AggregateRequiresBool _ | CheckWithoutBody _
-      ->
+    | OverrideKeyArityMismatch _ | ProjectionOutOfBounds _
+    | PropositionNotBool _ | ShadowingTypeMismatch _ | AmbiguousName _
+    | UnboundQualified _ | PrimedExtracontextual _ | BoolParam _
+    | ComprehensionNeedEach _ | AggregateRequiresNumeric _
+    | AggregateRequiresBool _ | CheckWithoutBody _ ->
         false)
 
 let test_over_each_and_bool () =
@@ -1558,11 +1599,11 @@ and over each i: Item | weight i.
     | UnboundVariable _ | UnboundType _ | TypeMismatch _ | ArityMismatch _
     | NotAFunction _ | NotAList _ | NotAProduct _ | NotNumeric _
     | ExpectedBool _ | PrimedNonRule _ | PrimeOutsideActionContext _
-    | OverrideRequiresArity1 _ | ProjectionOutOfBounds _ | PropositionNotBool _
-    | ShadowingTypeMismatch _ | AmbiguousName _ | UnboundQualified _
-    | PrimedExtracontextual _ | BoolParam _ | ComprehensionNeedEach _
-    | AggregateRequiresNumeric _ | AggregateRequiresBool _ | CheckWithoutBody _
-      ->
+    | OverrideKeyArityMismatch _ | ProjectionOutOfBounds _
+    | PropositionNotBool _ | ShadowingTypeMismatch _ | AmbiguousName _
+    | UnboundQualified _ | PrimedExtracontextual _ | BoolParam _
+    | ComprehensionNeedEach _ | AggregateRequiresNumeric _
+    | AggregateRequiresBool _ | CheckWithoutBody _ ->
         false)
 
 let test_over_each_or_bool () =
@@ -1589,11 +1630,11 @@ or over each i: Item | weight i.
     | UnboundVariable _ | UnboundType _ | TypeMismatch _ | ArityMismatch _
     | NotAFunction _ | NotAList _ | NotAProduct _ | NotNumeric _
     | ExpectedBool _ | PrimedNonRule _ | PrimeOutsideActionContext _
-    | OverrideRequiresArity1 _ | ProjectionOutOfBounds _ | PropositionNotBool _
-    | ShadowingTypeMismatch _ | AmbiguousName _ | UnboundQualified _
-    | PrimedExtracontextual _ | BoolParam _ | ComprehensionNeedEach _
-    | AggregateRequiresNumeric _ | AggregateRequiresBool _ | CheckWithoutBody _
-      ->
+    | OverrideKeyArityMismatch _ | ProjectionOutOfBounds _
+    | PropositionNotBool _ | ShadowingTypeMismatch _ | AmbiguousName _
+    | UnboundQualified _ | PrimedExtracontextual _ | BoolParam _
+    | ComprehensionNeedEach _ | AggregateRequiresNumeric _
+    | AggregateRequiresBool _ | CheckWithoutBody _ ->
         false)
 
 let test_over_each_min_nat () =
@@ -1630,11 +1671,11 @@ active? i: Item => Bool.
     | UnboundVariable _ | UnboundType _ | TypeMismatch _ | ArityMismatch _
     | NotAFunction _ | NotAList _ | NotAProduct _ | NotNumeric _
     | ExpectedBool _ | PrimedNonRule _ | PrimeOutsideActionContext _
-    | OverrideRequiresArity1 _ | ProjectionOutOfBounds _ | PropositionNotBool _
-    | ShadowingTypeMismatch _ | AmbiguousName _ | UnboundQualified _
-    | PrimedExtracontextual _ | BoolParam _ | ComprehensionNeedEach _
-    | AggregateRequiresNumeric _ | AggregateRequiresBool _ | CheckWithoutBody _
-      ->
+    | OverrideKeyArityMismatch _ | ProjectionOutOfBounds _
+    | PropositionNotBool _ | ShadowingTypeMismatch _ | AmbiguousName _
+    | UnboundQualified _ | PrimedExtracontextual _ | BoolParam _
+    | ComprehensionNeedEach _ | AggregateRequiresNumeric _
+    | AggregateRequiresBool _ | CheckWithoutBody _ ->
         false)
 
 let test_over_each_min_bool_fails () =
@@ -1651,11 +1692,11 @@ active? i: Item => Bool.
     | UnboundVariable _ | UnboundType _ | TypeMismatch _ | ArityMismatch _
     | NotAFunction _ | NotAList _ | NotAProduct _ | NotNumeric _
     | ExpectedBool _ | PrimedNonRule _ | PrimeOutsideActionContext _
-    | OverrideRequiresArity1 _ | ProjectionOutOfBounds _ | PropositionNotBool _
-    | ShadowingTypeMismatch _ | AmbiguousName _ | UnboundQualified _
-    | PrimedExtracontextual _ | BoolParam _ | ComprehensionNeedEach _
-    | AggregateRequiresNumeric _ | AggregateRequiresBool _ | CheckWithoutBody _
-      ->
+    | OverrideKeyArityMismatch _ | ProjectionOutOfBounds _
+    | PropositionNotBool _ | ShadowingTypeMismatch _ | AmbiguousName _
+    | UnboundQualified _ | PrimedExtracontextual _ | BoolParam _
+    | ComprehensionNeedEach _ | AggregateRequiresNumeric _
+    | AggregateRequiresBool _ | CheckWithoutBody _ ->
         false)
 
 let test_over_each_bare_unchanged () =
@@ -1740,8 +1781,12 @@ let () =
           test_case "bool param action" `Quick test_bool_param_action;
           test_case "NotAProduct" `Quick test_not_a_product;
           test_case "NotNumeric" `Quick test_not_numeric;
-          test_case "OverrideRequiresArity1" `Quick
-            test_override_requires_arity1;
+          test_case "OverrideKeyArityMismatch bare key on N-ary rule" `Quick
+            test_override_key_bare_on_nary_rule;
+          test_case "OverrideKeyArityMismatch wrong tuple arity" `Quick
+            test_override_key_tuple_arity_mismatch;
+          test_case "Override N-ary tuple key OK" `Quick
+            test_override_nary_tuple_key_ok;
           test_case "ProjectionOutOfBounds" `Quick test_projection_out_of_bounds;
           test_case "UnboundType" `Quick test_unbound_type;
           test_case "BuiltinRedefined" `Quick test_builtin_redefined;
@@ -1913,7 +1958,7 @@ all a: Int | f a > a.
                     | ArityMismatch _ | NotAFunction _ | NotAList _
                     | NotAProduct _ | NotNumeric _ | ExpectedBool _
                     | PrimedNonRule _ | PrimeOutsideActionContext _
-                    | OverrideRequiresArity1 _ | ProjectionOutOfBounds _
+                    | OverrideKeyArityMismatch _ | ProjectionOutOfBounds _
                     | PropositionNotBool _ | ShadowingTypeMismatch _
                     | AmbiguousName _ | UnboundQualified _
                     | PrimedExtracontextual _ | BoolParam _

--- a/test/test_check.ml
+++ b/test/test_check.ml
@@ -1753,6 +1753,8 @@ let () =
           test_case "list search vs indexing" `Quick
             test_list_search_vs_indexing_types;
           test_case "declaration guards" `Quick test_declaration_guards_in_rules;
+          test_case "Override N-ary tuple key OK" `Quick
+            test_override_nary_tuple_key_ok;
         ] );
       ( "invalid",
         [
@@ -1785,8 +1787,6 @@ let () =
             test_override_key_bare_on_nary_rule;
           test_case "OverrideKeyArityMismatch wrong tuple arity" `Quick
             test_override_key_tuple_arity_mismatch;
-          test_case "Override N-ary tuple key OK" `Quick
-            test_override_nary_tuple_key_ok;
           test_case "ProjectionOutOfBounds" `Quick test_projection_out_of_bounds;
           test_case "UnboundType" `Quick test_unbound_type;
           test_case "BuiltinRedefined" `Quick test_builtin_redefined;

--- a/test/test_error.ml
+++ b/test/test_error.ml
@@ -21,7 +21,7 @@ let test_format_type_error_coverage () =
       ("ExpectedBool", ExpectedBool (TyNat, loc));
       ("PrimedNonRule", PrimedNonRule ("x", loc));
       ("PrimeOutsideActionContext", PrimeOutsideActionContext ("f", loc));
-      ("OverrideRequiresArity1", OverrideRequiresArity1 ("f", 2, loc));
+      ("OverrideKeyArityMismatch", OverrideKeyArityMismatch ("f", 2, loc));
       ("ProjectionOutOfBounds", ProjectionOutOfBounds (5, 2, loc));
       ("PropositionNotBool", PropositionNotBool (TyNat, loc));
       ("ShadowingTypeMismatch", ShadowingTypeMismatch ("x", TyBool, TyNat, loc));

--- a/test/test_smt.ml
+++ b/test/test_smt.ml
@@ -931,6 +931,39 @@ let test_override () =
   check bool "standalone override placeholder" true
     (contains result2 "override")
 
+let test_override_unary_tuple_key () =
+  (* Arity-1 rule whose single parameter is a product type: the override key
+     (a, b) is a tuple literal but must still follow the bare-expression
+     (arity-1) path, not be misclassified as a 2-ary key. *)
+  let env =
+    Env.empty ""
+    |> Env.add_domain "A" Ast.dummy_loc ~chapter:0
+    |> Env.add_domain "B" Ast.dummy_loc ~chapter:0
+    |> Env.add_rule "g"
+         (Types.TyFunc
+            ( [ Types.TyProduct [ Types.TyDomain "A"; Types.TyDomain "B" ] ],
+              Some Types.TyNat ))
+         Ast.dummy_loc ~chapter:0
+    |> Env.add_var "a" (Types.TyDomain "A")
+    |> Env.add_var "b" (Types.TyDomain "B")
+    |> Env.add_var "p"
+         (Types.TyProduct [ Types.TyDomain "A"; Types.TyDomain "B" ])
+  in
+  let result =
+    Smt.translate_expr config env
+      (Ast.EApp
+         ( EOverride
+             ( Lower "g",
+               [ (ETuple [ EVar (Lower "a"); EVar (Lower "b") ], ELitNat 42) ]
+             ),
+           [ EVar (Lower "p") ] ))
+  in
+  check bool "unary tuple-key override has ite" true (contains result "ite");
+  check bool "unary tuple-key override has no conjunctive guard" false
+    (contains result "(and ");
+  check bool "unary tuple-key override fallback applies single arg" true
+    (contains result "(g p)")
+
 let test_override_nary_tuple_key () =
   (* Arity-2 rule with a tuple-keyed override: the ite guard conjoins equality
      on each arg. McCarthy's [store] extended to multi-index arrays. *)
@@ -1086,6 +1119,7 @@ let expression_tests =
     test_case "projection" `Quick test_proj;
     test_case "tuple" `Quick test_tuple;
     test_case "override" `Quick test_override;
+    test_case "override unary tuple key" `Quick test_override_unary_tuple_key;
     test_case "override N-ary tuple key" `Quick test_override_nary_tuple_key;
     test_case "initially" `Quick test_initially;
     test_case "cardinality domain" `Quick test_card_domain;

--- a/test/test_smt.ml
+++ b/test/test_smt.ml
@@ -931,6 +931,39 @@ let test_override () =
   check bool "standalone override placeholder" true
     (contains result2 "override")
 
+let test_override_nary_tuple_key () =
+  (* Arity-2 rule with a tuple-keyed override: the ite guard conjoins equality
+     on each arg. McCarthy's [store] extended to multi-index arrays. *)
+  let env =
+    Env.empty ""
+    |> Env.add_domain "H" Ast.dummy_loc ~chapter:0
+    |> Env.add_domain "K" Ast.dummy_loc ~chapter:0
+    |> Env.add_rule "f"
+         (Types.TyFunc
+            ([ Types.TyDomain "H"; Types.TyDomain "K" ], Some Types.TyNat))
+         Ast.dummy_loc ~chapter:0
+    |> Env.add_var "h" (Types.TyDomain "H")
+    |> Env.add_var "k" (Types.TyDomain "K")
+    |> Env.add_var "h1" (Types.TyDomain "H")
+    |> Env.add_var "k1" (Types.TyDomain "K")
+  in
+  let result =
+    Smt.translate_expr config env
+      (Ast.EApp
+         ( EOverride
+             ( Lower "f",
+               [ (ETuple [ EVar (Lower "h"); EVar (Lower "k") ], ELitNat 42) ]
+             ),
+           [ EVar (Lower "h1"); EVar (Lower "k1") ] ))
+  in
+  check bool "arity-2 override has ite" true (contains result "ite");
+  check bool "arity-2 override has conjunctive guard" true
+    (contains result "(and ");
+  check bool "arity-2 override fallback applies both args" true
+    (contains result "(f h1 k1)");
+  check bool "arity-2 override guard mentions h" true (contains result "h1 h");
+  check bool "arity-2 override guard mentions k" true (contains result "k1 k")
+
 let test_initially () =
   let env = Env.empty "" in
   let result = Smt.translate_expr config env (Ast.EInitially (ELitBool true)) in
@@ -1053,6 +1086,7 @@ let expression_tests =
     test_case "projection" `Quick test_proj;
     test_case "tuple" `Quick test_tuple;
     test_case "override" `Quick test_override;
+    test_case "override N-ary tuple key" `Quick test_override_nary_tuple_key;
     test_case "initially" `Quick test_initially;
     test_case "cardinality domain" `Quick test_card_domain;
     test_case "cardinality list" `Quick test_card_list;


### PR DESCRIPTION
## Summary

- Extend `f[k |-> v]` from arity-1 rules to rules of any arity. For an arity-N rule, the override key must be an N-tuple whose components type-check componentwise; arity-1 rules continue to accept a bare-expression key.
- The applied form `f[(x1, ..., xN) |-> v] a1 ... aN` expands to an `ite` guarded by a conjunction of componentwise equalities — McCarthy's `store` extended to multi-index arrays (Kroening & Strichman, *Decision Procedures* Ch. 7), matching TLA+'s `[f EXCEPT ![m][k] = v]` point-update semantics. Everything-else stays unchanged via the `ite` fallback to the unprimed application.
- Rename `OverrideRequiresArity1` to `OverrideKeyArityMismatch`.

Motivation: Stage C of ts2pant Map-mutation support needs to emit point updates on arity-2 guarded rules (`R m k`, `K m k`). Using Pantagruel's existing override expression is the idiomatic encoding, but the checker currently rejects overrides on anything other than arity-1 rules. This PR closes that gap; Phase 2 (ts2pant) will use it in a follow-up.

## Test plan

- [x] `dune build` clean
- [x] `dune test` green — existing override tests still pass, new tests in `test/test_check.ml` cover bare-key on N-ary (error), wrong-arity tuple (error), and correct-arity tuple (OK); new test in `test/test_smt.ml` covers the conjunctive-guard `ite` expansion
- [x] `samples/06-advanced.pant` updated with an arity-2 tuple-keyed override example; pretty/json/markdown snapshots regenerated
- [x] End-to-end `pant --check` verification on an arity-2 override sample: `OK: Entailed`
- [x] `REFERENCE.md` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)