### PR TITLE
ts2pant: refactor mutable plumbing toward self-translatability

### DIFF
--- a/tools/ts2pant/src/name-registry.ts
+++ b/tools/ts2pant/src/name-registry.ts
@@ -5,30 +5,43 @@
  * Each rule introduces its own bindings. No two rules should share
  * a parameter name, since they represent distinct variables that may
  * have different guards or invariants.
+ *
+ * Represented as an immutable record: each `registerName` call returns
+ * a fresh registry plus the chosen name. Threading the returned registry
+ * is the caller's responsibility.
  */
-export class NameRegistry {
-  private used = new Set<string>();
+export interface NameRegistry {
+  readonly used: ReadonlySet<string>;
+}
 
-  /**
-   * Register a name. If already used, appends numeric suffixes (1, 2, ...)
-   * until unique. Returns the actual name used.
-   */
-  register(name: string): string {
-    if (!this.used.has(name)) {
-      this.used.add(name);
-      return name;
-    }
-    let suffix = 1;
-    while (this.used.has(`${name}${suffix}`)) {
-      suffix++;
-    }
-    const actual = `${name}${suffix}`;
-    this.used.add(actual);
-    return actual;
-  }
+export function emptyNameRegistry(): NameRegistry {
+  return { used: new Set() };
+}
 
-  /** Check whether a name is already registered. */
-  isUsed(name: string): boolean {
-    return this.used.has(name);
+/** Check whether a name is already registered. */
+export function isUsed(registry: NameRegistry, name: string): boolean {
+  return registry.used.has(name);
+}
+
+/**
+ * Register a name. If already used, appends numeric suffixes (1, 2, ...)
+ * until unique. Returns the chosen name and the updated registry.
+ */
+export function registerName(
+  registry: NameRegistry,
+  name: string,
+): { name: string; registry: NameRegistry } {
+  if (!registry.used.has(name)) {
+    const used = new Set(registry.used);
+    used.add(name);
+    return { name, registry: { used } };
   }
+  let suffix = 1;
+  while (registry.used.has(`${name}${suffix}`)) {
+    suffix++;
+  }
+  const actual = `${name}${suffix}`;
+  const used = new Set(registry.used);
+  used.add(actual);
+  return { name: actual, registry: { used } };
 }

--- a/tools/ts2pant/src/pipeline.ts
+++ b/tools/ts2pant/src/pipeline.ts
@@ -1,11 +1,15 @@
 import type { SourceFile } from "ts-morph";
 import { extractFunctionAnnotationsAndOverrides } from "./annotations.js";
 import { extractReferencedTypes, getChecker } from "./extract.js";
-import { NameRegistry } from "./name-registry.js";
 import { loadAst, loadParser, rewriteAnnotation } from "./pant-wasm.js";
 import { translateBody } from "./translate-body.js";
 import { translateSignature } from "./translate-signature.js";
-import { type NumericStrategy, translateTypes } from "./translate-types.js";
+import {
+  cellEmitSynth,
+  type NumericStrategy,
+  newMapSynthCell,
+  translateTypes,
+} from "./translate-types.js";
 import type { PantDocument } from "./types.js";
 
 export interface PipelineOptions {
@@ -35,10 +39,13 @@ export async function buildPantDocument(
     : functionName;
 
   // Document-wide name registry ensures unique variable names across
-  // type-derived rules and the main function's parameters.
-  // Register the function's own param names first (they keep natural names);
-  // type-derived accessor rules adapt with suffixes if there's a collision.
-  const registry = new NameRegistry();
+  // type-derived rules and the main function's parameters. Held inside a
+  // `MapSynthCell` together with the Map synthesizer so deep body-level call
+  // sites can register on demand without threading state through every
+  // BodyResult. Register the function's own param names first (they keep
+  // natural names); type-derived accessor rules adapt with suffixes if
+  // there's a collision.
+  const synthCell = newMapSynthCell();
 
   // Extract @pant propositions and @pant-type overrides in one JSDoc pass.
   // Overrides influence parameter type mapping during signature translation;
@@ -47,32 +54,22 @@ export async function buildPantDocument(
     extractFunctionAnnotationsAndOverrides(sourceFile, functionName);
 
   // Translate signature first to claim the function's param names
-  const {
-    declaration: sigDecl,
-    paramNameMap,
-    mapSynth,
-  } = translateSignature(
+  const { declaration: sigDecl, paramNameMap } = translateSignature(
     sourceFile,
     functionName,
     strategy,
-    registry,
+    synthCell,
     overrides,
   );
 
   // Extract and translate types (type-derived param names adapt to registry).
   // Pass the synthesizer so nested Maps inside interface-field V register too.
   const extracted = extractReferencedTypes(sourceFile, functionName);
-  const typeDecls = translateTypes(
-    extracted,
-    checker,
-    strategy,
-    registry,
-    mapSynth,
-  );
+  const typeDecls = translateTypes(extracted, checker, strategy, synthCell);
   // After both sig and types have registered their Maps, emit the synth
   // decls (one domain + membership predicate + guarded value rule per
   // unique (K, V)). Splice before sigDecl so the sig's references resolve.
-  const synthDecls = mapSynth ? mapSynth.emit() : [];
+  const synthDecls = cellEmitSynth(synthCell);
   const declarations = [...typeDecls, ...synthDecls, sigDecl];
 
   const moduleName = baseName.charAt(0).toUpperCase() + baseName.slice(1);
@@ -90,22 +87,20 @@ export async function buildPantDocument(
       functionName,
       strategy,
       declarations,
-      mapSynth,
+      synthCell,
     });
     doc = { ...doc, propositions: [...doc.propositions, ...bodyProps] };
 
     // Drain any Map (K, V) pairs registered on demand during body translation
     // (e.g., `build().get(k)!` where `build`'s return type wasn't surfaced
-    // through the signature or referenced types). emit() is incremental, so
-    // this returns only entries new since the pre-body emit.
-    if (mapSynth) {
-      const extraSynthDecls = mapSynth.emit();
-      if (extraSynthDecls.length > 0) {
-        doc = {
-          ...doc,
-          declarations: [...doc.declarations, ...extraSynthDecls],
-        };
-      }
+    // through the signature or referenced types). cellEmitSynth is
+    // incremental, so this returns only entries new since the pre-body emit.
+    const extraSynthDecls = cellEmitSynth(synthCell);
+    if (extraSynthDecls.length > 0) {
+      doc = {
+        ...doc,
+        declarations: [...doc.declarations, ...extraSynthDecls],
+      };
     }
   }
 

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -19,9 +19,11 @@ import {
   translateOperator,
 } from "./translate-signature.js";
 import {
+  cellRegisterMap,
   isMapType,
   isSetType,
-  type MapSynthesizer,
+  lookupMapKV,
+  type MapSynthCell,
   mapTsType,
   type NumericStrategy,
 } from "./translate-types.js";
@@ -32,20 +34,30 @@ import type { PantDeclaration, PropResult } from "./types.js";
 /**
  * Per-body translation context threaded through every `translateBodyExpr`
  * call. Carries the hygienic-binder counter and (optionally) the
- * module-wide `MapSynthesizer` so `.get`/`.has` on non-field Map receivers
+ * module-wide `MapSynthCell` so `.get`/`.has` on non-field Map receivers
  * can resolve to the synthesized rule names.
+ *
+ * Mutable 2-field record: `n` is reassigned in place by `nextSupply`. This
+ * is within ts2pant's self-translation envelope (cell-field reassignment
+ * translates to primed rules on the cell), unlike the prior closure over a
+ * `let counter = 0`.
  */
 interface UniqueSupply {
-  next: () => number;
-  mapSynth?: MapSynthesizer | undefined;
+  n: number;
+  synthCell?: MapSynthCell | undefined;
 }
-function makeUniqueSupply(mapSynth?: MapSynthesizer): UniqueSupply {
-  let counter = 0;
-  return { next: () => counter++, mapSynth };
+function makeUniqueSupply(synthCell?: MapSynthCell): UniqueSupply {
+  return { n: 0, synthCell };
+}
+
+function nextSupply(supply: UniqueSupply): number {
+  const value = supply.n;
+  supply.n = value + 1;
+  return value;
 }
 
 function freshHygienicBinder(supply: UniqueSupply): string {
-  return `$${supply.next()}`;
+  return `$${nextSupply(supply)}`;
 }
 
 interface ConstBinding {
@@ -109,22 +121,33 @@ interface WriteEntry {
   value: OpaqueExpr;
 }
 
+/**
+ * Per-body symbolic-execution accumulator. Held as a cell of immutable
+ * records: `writes`, `writtenKeys`, `modifiedProps` are typed as read-only
+ * views, and updates replace the whole map/set via `putWrite`,
+ * `addWrittenKey`, `addModifiedProp`. Cell-field reassignment is within
+ * ts2pant's self-translation envelope (translatable as primed rules on the
+ * cell), whereas the prior `.set`/`.add` in-place mutation was not.
+ *
+ * `modifiedProps` is *shared* across cloned cells — it tracks which rules
+ * have been modified anywhere in this execution, including Shape A loop
+ * writes whose per-element equation is emitted directly (bypassing
+ * `writes`). Consumed by the frame-condition generator so loop-modified
+ * rules don't get a spurious identity frame.
+ *
+ * `canonicalize` applies the ambient const-binding substitution to an
+ * expression before it is used as a state key. Writes store keys under the
+ * post-substitution form so `const x = a; x.balance = 1` and a later
+ * `x.balance` read resolve to the same key. Updated by `symbolicExecute`
+ * whenever a new const binding is inlined so the in-flight `applyConst`
+ * stays in sync with the state.
+ */
 interface SymbolicState {
-  writes: Map<string, WriteEntry>;
+  writes: ReadonlyMap<string, WriteEntry>;
   // Keys *written during the current branch* (reset on clone). Used by the
   // if-merge algorithm to determine which locations are "touched."
-  writtenKeys: Set<string>;
-  // Names of rules that have been modified by *any* write in this execution,
-  // including Shape A loop writes whose per-element equation is emitted
-  // directly (bypassing `writes`). Consumed by the frame-condition generator
-  // so loop-modified rules don't get a spurious identity frame.
+  writtenKeys: ReadonlySet<string>;
   modifiedProps: Set<string>;
-  // Canonicalizer — applies the ambient const-binding substitution to an
-  // expression before it is used as a state key. Writes store keys under the
-  // post-substitution form so `const x = a; x.balance = 1` and a later
-  // `x.balance` read resolve to the same key. Updated by `symbolicExecute`
-  // whenever a new const binding is inlined so the in-flight `applyConst`
-  // stays in sync with the state.
   canonicalize: (e: OpaqueExpr) => OpaqueExpr;
 }
 
@@ -148,8 +171,42 @@ function cloneSymbolicState(s: SymbolicState): SymbolicState {
   };
 }
 
+function putWrite(state: SymbolicState, key: string, entry: WriteEntry): void {
+  const next = new Map(state.writes);
+  next.set(key, entry);
+  state.writes = next;
+}
+
+function addWrittenKey(state: SymbolicState, key: string): void {
+  const next = new Set(state.writtenKeys);
+  next.add(key);
+  state.writtenKeys = next;
+}
+
+function addModifiedProp(state: SymbolicState, prop: string): void {
+  state.modifiedProps.add(prop);
+}
+
+function setCanonicalize(
+  state: SymbolicState,
+  fn: (e: OpaqueExpr) => OpaqueExpr,
+): void {
+  state.canonicalize = fn;
+}
+
 function symbolicKey(prop: string, objExpr: OpaqueExpr): string {
   return `${prop}::${getAst().strExpr(objExpr)}`;
+}
+
+/**
+ * Return a fresh Map equal to `m` plus the binding `k -> v`. Used instead of
+ * `m.set(k, v)` so the immutable-record discipline holds: callers either
+ * thread the returned map or assign it into a cell field.
+ */
+function withParam<K, V>(m: ReadonlyMap<K, V>, k: K, v: V): ReadonlyMap<K, V> {
+  const next = new Map(m);
+  next.set(k, v);
+  return next;
 }
 
 function isBareReturn(stmt: ts.Statement): boolean {
@@ -404,12 +461,12 @@ export interface TranslateBodyOptions {
   /** Declarations in scope — used for frame condition generation. */
   declarations?: PantDeclaration[];
   /**
-   * Synthesizer populated during signature and type translation. Used by
-   * the body translator to (a) resolve Map-parameter types to their
+   * Synthesizer cell populated during signature and type translation. Used
+   * by the body translator to (a) resolve Map-parameter types to their
    * synthesized domain names when reconstructing the param list, and
    * (b) dispatch `.get`/`.has` on non-interface-field Map receivers.
    */
-  mapSynth?: MapSynthesizer | undefined;
+  synthCell?: MapSynthCell | undefined;
 }
 
 /**
@@ -420,7 +477,7 @@ export interface TranslateBodyOptions {
  * plus frame conditions for unmodified rules.
  */
 export function translateBody(opts: TranslateBodyOptions): PropResult[] {
-  const { sourceFile, functionName, strategy, declarations, mapSynth } = opts;
+  const { sourceFile, functionName, strategy, declarations, synthCell } = opts;
   const checker = sourceFile.getProject().getTypeChecker().compilerObject;
   const { node, className } = findFunction(sourceFile, functionName);
   // Strip class qualifier for use in Pantagruel identifiers
@@ -450,7 +507,7 @@ export function translateBody(opts: TranslateBodyOptions): PropResult[] {
       // Pass the synthesizer so Map parameters resolve to their synthesized
       // domain names (idempotent; the signature pass already registered
       // them, so this is a lookup rather than a fresh registration).
-      const typeName = mapTsType(paramType, checker, strategy, mapSynth);
+      const typeName = mapTsType(paramType, checker, strategy, synthCell);
       paramNames.set(param.name, param.name);
       paramList.push({ name: param.name, type: typeName });
     }
@@ -468,7 +525,7 @@ export function translateBody(opts: TranslateBodyOptions): PropResult[] {
       checker,
       strategy,
       paramNames,
-      mapSynth,
+      synthCell,
     );
   } else {
     return translateMutatingBody(
@@ -477,7 +534,7 @@ export function translateBody(opts: TranslateBodyOptions): PropResult[] {
       strategy,
       paramNames,
       declarations ?? [],
-      mapSynth,
+      synthCell,
     );
   }
 }
@@ -488,8 +545,8 @@ function translatePureBody(
   params: Array<{ name: string; type: string }>,
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
-  paramNames: Map<string, string>,
-  mapSynth?: MapSynthesizer,
+  paramNames: ReadonlyMap<string, string>,
+  synthCell?: MapSynthCell,
 ): PropResult[] {
   const ast = getAst();
 
@@ -503,7 +560,7 @@ function translatePureBody(
     return [{ kind: "unsupported", reason: `${functionName} — ${reason}` }];
   }
 
-  const supply = makeUniqueSupply(mapSynth);
+  const supply = makeUniqueSupply(synthCell);
   const inlined = inlineConstBindings(
     extracted.bindings.map((b) => ({
       tsName: b.name,
@@ -609,13 +666,13 @@ function extractReturnExpression(
   }
 
   const bindings: Array<{ name: string; initializer: ts.Expression }> = [];
-  let i = 0;
 
-  // Collect leading const bindings
-  for (; i < stmts.length - 1; i++) {
-    const stmt = stmts[i]!;
+  // Every statement before the last must be a const binding; any other shape
+  // rejects the whole body. The last statement is the return / if-else-return.
+  const last = stmts[stmts.length - 1]!;
+  for (const stmt of stmts.slice(0, -1)) {
     if (!ts.isVariableStatement(stmt)) {
-      break;
+      return null;
     }
 
     const declList = stmt.declarationList;
@@ -635,13 +692,6 @@ function extractReturnExpression(
       }
       bindings.push({ name: decl.name.text, initializer: decl.initializer });
     }
-  }
-
-  // The last statement must be a return or if/else-with-returns
-  const last = stmts[i]!;
-  // If we didn't consume all preceding statements as const bindings, reject
-  if (i < stmts.length - 1) {
-    return null;
   }
 
   if (ts.isReturnStatement(last) && last.expression) {
@@ -702,13 +752,13 @@ function inlineConstBindings(
   bindings: ConstBinding[],
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
-  baseParams: Map<string, string>,
+  baseParams: ReadonlyMap<string, string>,
   supply: UniqueSupply,
   state?: SymbolicState,
 ):
   | {
       applyTo: (expr: OpaqueExpr) => OpaqueExpr;
-      scopedParams: Map<string, string>;
+      scopedParams: ReadonlyMap<string, string>;
     }
   | { error: string } {
   const ast = getAst();
@@ -721,38 +771,64 @@ function inlineConstBindings(
     }
   }
 
-  // Phase 2: translate initializers, building scopedParams incrementally
-  const scopedParams = new Map(baseParams);
-  const translatedBindings: Array<{
-    hygienicName: string;
-    initExpr: OpaqueExpr;
-  }> = [];
+  // Phase 2: translate initializers as a left fold, threading scopedParams
+  // and translatedBindings through the accumulator. Errors short-circuit
+  // subsequent work via the `tag: "error"` discriminant; successful steps
+  // return a fresh map via `withParam` so no `.set`-style mutation remains.
+  type Acc =
+    | {
+        tag: "ok";
+        scopedParams: ReadonlyMap<string, string>;
+        translatedBindings: ReadonlyArray<{
+          hygienicName: string;
+          initExpr: OpaqueExpr;
+        }>;
+      }
+    | { tag: "error"; error: string };
 
-  for (const binding of bindings) {
-    const hygienicName = `$${supply.next()}`;
-    const initResult = translateBodyExpr(
-      binding.initializer,
-      checker,
-      strategy,
-      scopedParams,
-      state,
-      supply,
-    );
-    if (isBodyUnsupported(initResult)) {
-      return { error: initResult.unsupported };
-    }
-    translatedBindings.push({ hygienicName, initExpr: bodyExpr(initResult) });
-    scopedParams.set(binding.tsName, hygienicName);
+  const folded = bindings.reduce<Acc>(
+    (acc, binding) => {
+      if (acc.tag === "error") {
+        return acc;
+      }
+      const hygienicName = `$${nextSupply(supply)}`;
+      const initResult = translateBodyExpr(
+        binding.initializer,
+        checker,
+        strategy,
+        acc.scopedParams,
+        state,
+        supply,
+      );
+      if (isBodyUnsupported(initResult)) {
+        return { tag: "error", error: initResult.unsupported };
+      }
+      return {
+        tag: "ok",
+        scopedParams: withParam(acc.scopedParams, binding.tsName, hygienicName),
+        translatedBindings: [
+          ...acc.translatedBindings,
+          { hygienicName, initExpr: bodyExpr(initResult) },
+        ],
+      };
+    },
+    { tag: "ok", scopedParams: baseParams, translatedBindings: [] },
+  );
+
+  if (folded.tag === "error") {
+    return { error: folded.error };
   }
 
-  // Phase 3: right-fold substitution closure
-  const reversed = translatedBindings.slice().reverse();
-  const applyTo = (expr: OpaqueExpr): OpaqueExpr => {
-    for (const { hygienicName, initExpr } of reversed) {
-      expr = ast.substituteBinder(expr, hygienicName, initExpr);
-    }
-    return expr;
-  };
+  // Phase 3: right-fold substitution closure. `reduceRight` applies the last
+  // binding first so references to earlier bindings inside its init remain
+  // unresolved — they get substituted in subsequent iterations.
+  const { scopedParams, translatedBindings } = folded;
+  const applyTo = (expr: OpaqueExpr): OpaqueExpr =>
+    translatedBindings.reduceRight(
+      (acc, { hygienicName, initExpr }) =>
+        ast.substituteBinder(acc, hygienicName, initExpr),
+      expr,
+    );
 
   return { applyTo, scopedParams };
 }
@@ -959,7 +1035,7 @@ export function translateBodyExpr(
   expr: ts.Expression | ts.Statement,
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
-  paramNames: Map<string, string>,
+  paramNames: ReadonlyMap<string, string>,
   state: SymbolicState | undefined,
   supply: UniqueSupply,
 ): BodyResult {
@@ -1141,7 +1217,7 @@ function translateIfStatement(
   stmt: ts.IfStatement,
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
-  paramNames: Map<string, string>,
+  paramNames: ReadonlyMap<string, string>,
   state: SymbolicState | undefined,
   supply: UniqueSupply,
 ): BodyResult {
@@ -1253,7 +1329,7 @@ function translateArrayMethod(
   expr: ts.CallExpression,
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
-  paramNames: Map<string, string>,
+  paramNames: ReadonlyMap<string, string>,
   state: SymbolicState | undefined,
   supply: UniqueSupply,
 ): BodyResult | null {
@@ -1364,7 +1440,7 @@ function translateReduceCall(
   expr: ts.CallExpression,
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
-  paramNames: Map<string, string>,
+  paramNames: ReadonlyMap<string, string>,
   state: SymbolicState | undefined,
   supply: UniqueSupply,
 ): BodyResult | null {
@@ -1725,7 +1801,7 @@ function translateForOfLoopBody(
   bodyStmts: ts.Statement[],
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
-  paramNames: Map<string, string>,
+  paramNames: ReadonlyMap<string, string>,
   state: SymbolicState,
   propositions: PropResult[],
   applyConst: (e: OpaqueExpr) => OpaqueExpr,
@@ -1786,7 +1862,7 @@ function translateForOfLoopBody(
         lhs: ast.app(ast.primed(entry.prop), [entry.objExpr]),
         rhs: entry.value,
       });
-      state.modifiedProps.add(entry.prop);
+      addModifiedProp(state, entry.prop);
     }
   }
 
@@ -1853,8 +1929,8 @@ function translateForOfLoopBody(
       priorEntry?.value ?? ast.app(ast.var(leaf.prop), [accExpr]);
     const newVal = ast.binop(outerOp, priorVal, folded);
 
-    state.writes.set(key, { prop: leaf.prop, objExpr: accExpr, value: newVal });
-    state.writtenKeys.add(key);
+    putWrite(state, key, { prop: leaf.prop, objExpr: accExpr, value: newVal });
+    addWrittenKey(state, key);
   }
 
   return true;
@@ -1865,7 +1941,7 @@ function translateForOfLoop(
   stmt: ts.ForOfStatement,
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
-  paramNames: Map<string, string>,
+  paramNames: ReadonlyMap<string, string>,
   state: SymbolicState,
   propositions: PropResult[],
   applyConst: (e: OpaqueExpr) => OpaqueExpr,
@@ -1930,7 +2006,7 @@ function translateForEachStmt(
   call: ts.CallExpression,
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
-  paramNames: Map<string, string>,
+  paramNames: ReadonlyMap<string, string>,
   state: SymbolicState,
   propositions: PropResult[],
   applyConst: (e: OpaqueExpr) => OpaqueExpr,
@@ -2000,7 +2076,7 @@ function translateCallExpr(
   expr: ts.CallExpression,
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
-  paramNames: Map<string, string>,
+  paramNames: ReadonlyMap<string, string>,
   state: SymbolicState | undefined,
   supply: UniqueSupply,
 ): BodyResult {
@@ -2018,7 +2094,7 @@ function translateCallExpr(
     //     interface (translate-types.ts, interface-field branch).
     //   Stage B — receiver is anything else (parameter, call result, etc.).
     //     The rule was synthesized at signature/type translation time and
-    //     is looked up by (K, V) via the MapSynthesizer.
+    //     is looked up by (K, V) via the MapSynth cell.
     if (
       (methodName === "get" || methodName === "has") &&
       expr.arguments.length === 1 &&
@@ -2075,12 +2151,24 @@ function translateCallExpr(
       if (typeArgs.length !== 2) {
         return { unsupported: "Map with unexpected arity" };
       }
-      const kType = mapTsType(typeArgs[0]!, checker, strategy, supply.mapSynth);
-      const vType = mapTsType(typeArgs[1]!, checker, strategy, supply.mapSynth);
-      let info = supply.mapSynth?.lookup(kType, vType);
-      if (!info && supply.mapSynth) {
-        supply.mapSynth.register(kType, vType);
-        info = supply.mapSynth.lookup(kType, vType);
+      const kType = mapTsType(
+        typeArgs[0]!,
+        checker,
+        strategy,
+        supply.synthCell,
+      );
+      const vType = mapTsType(
+        typeArgs[1]!,
+        checker,
+        strategy,
+        supply.synthCell,
+      );
+      let info = supply.synthCell
+        ? lookupMapKV(supply.synthCell.synth, kType, vType)
+        : undefined;
+      if (!info && supply.synthCell) {
+        cellRegisterMap(supply.synthCell, kType, vType);
+        info = lookupMapKV(supply.synthCell.synth, kType, vType);
       }
       if (!info) {
         // register returns null only when K or V mangles to something that
@@ -2270,7 +2358,7 @@ function translateCallExpr(
 function extractArrowBody(
   expr: ts.Expression,
   binderName: string,
-  paramNames: Map<string, string>,
+  paramNames: ReadonlyMap<string, string>,
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
   supply: UniqueSupply,
@@ -2335,7 +2423,7 @@ function translateMutatingBody(
   strategy: NumericStrategy,
   paramNames: Map<string, string>,
   declarations: PantDeclaration[],
-  mapSynth?: MapSynthesizer,
+  synthCell?: MapSynthCell,
 ): PropResult[] {
   if (!node.body) {
     return [];
@@ -2344,7 +2432,7 @@ function translateMutatingBody(
   const ast = getAst();
   const propositions: PropResult[] = [];
   const state = makeSymbolicState();
-  const supply = makeUniqueSupply(mapSynth);
+  const supply = makeUniqueSupply(synthCell);
 
   const ok = symbolicExecute(
     node.body,
@@ -2370,7 +2458,7 @@ function translateMutatingBody(
       lhs: ast.app(ast.primed(entry.prop), [entry.objExpr]),
       rhs: entry.value,
     });
-    state.modifiedProps.add(entry.prop);
+    addModifiedProp(state, entry.prop);
   }
 
   const frames = generateFrameConditions(state.modifiedProps, declarations);
@@ -2402,11 +2490,10 @@ function symbolicExecute(
   let applyConst = outerApply;
   // Keep the state's canonicalize in sync with the frame's applyConst so
   // symbolic-state reads see the same normalization the write site uses.
-  state.canonicalize = applyConst;
+  setCanonicalize(state, applyConst);
   const stmts = ts.isBlock(body) ? Array.from(body.statements) : [body];
 
-  for (let i = 0; i < stmts.length; i++) {
-    const stmt = stmts[i]!;
+  for (const [i, stmt] of stmts.entries()) {
     // Skip guard statements (if-throw patterns and assertion calls)
     if (isGuardStatement(stmt, checker)) {
       continue;
@@ -2511,12 +2598,12 @@ function symbolicExecute(
               [gExpr, vContinuation],
               [ast.litBool(true), vEarlyReturn],
             ]);
-        state.writes.set(key, {
+        putWrite(state, key, {
           prop: entryR.prop,
           objExpr: entryR.objExpr,
           value: merged,
         });
-        state.writtenKeys.add(key);
+        addWrittenKey(state, key);
       }
       // Remaining stmts have been consumed by the continuation.
       break;
@@ -2563,7 +2650,7 @@ function symbolicExecute(
             }
             const prevApply = applyConst;
             applyConst = (e) => prevApply(inlined.applyTo(e));
-            state.canonicalize = applyConst;
+            setCanonicalize(state, applyConst);
           }
           continue;
         }
@@ -2627,8 +2714,8 @@ function symbolicExecute(
         const objExpr = applyConst(bodyExpr(obj));
         const valExpr = applyConst(bodyExpr(val));
         const key = symbolicKey(prop, objExpr);
-        state.writes.set(key, { prop, objExpr, value: valExpr });
-        state.writtenKeys.add(key);
+        putWrite(state, key, { prop, objExpr, value: valExpr });
+        addWrittenKey(state, key);
         continue;
       }
     }
@@ -2826,8 +2913,8 @@ function symbolicExecute(
           [gExpr, vT],
           [ast.litBool(true), vE],
         ]);
-        state.writes.set(key, { prop, objExpr, value: merged });
-        state.writtenKeys.add(key);
+        putWrite(state, key, { prop, objExpr, value: merged });
+        addWrittenKey(state, key);
       }
       continue;
     }

--- a/tools/ts2pant/src/translate-signature.ts
+++ b/tools/ts2pant/src/translate-signature.ts
@@ -1,10 +1,11 @@
 import type { SourceFile } from "ts-morph";
 import ts from "typescript";
-import type { NameRegistry } from "./name-registry.js";
 import type { OpaqueBinop, OpaqueExpr } from "./pant-ast.js";
 import { getAst } from "./pant-wasm.js";
 import {
-  MapSynthesizer,
+  cellIsUsed,
+  cellRegisterName,
+  type MapSynthCell,
   mapTsType,
   type NumericStrategy,
 } from "./translate-types.js";
@@ -18,12 +19,12 @@ export interface TranslatedSignature {
   /** Map from TS parameter names to Pantagruel parameter names. */
   paramNameMap: Map<string, string>;
   /**
-   * Synthesizer for `Map<K, V>` domains encountered during signature
+   * Synthesizer cell for `Map<K, V>` domains encountered during signature
    * translation (parameter and return types). Pass through to downstream
    * stages (`translateTypes`, `translateBody`) so they register and look up
-   * Maps in the same table. Present only when a `registry` was supplied.
+   * Maps in the same table. Present only when a `synthCell` was supplied.
    */
-  mapSynth?: MapSynthesizer | undefined;
+  synthCell?: MapSynthCell | undefined;
 }
 
 /**
@@ -186,7 +187,7 @@ export function extractAssertionGuard(
   checker: ts.TypeChecker,
   call: ts.CallExpression,
   strategy: NumericStrategy,
-  paramNames: Map<string, string>,
+  paramNames: ReadonlyMap<string, string>,
 ): OpaqueExpr | undefined {
   const paramIndex = isAssertionCall(checker, call);
   if (paramIndex === null) {
@@ -267,7 +268,7 @@ function buildSubstitutionMap(
   targetParams: ts.NodeArray<ts.ParameterDeclaration>,
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
-  callerParamNames: Map<string, string>,
+  callerParamNames: ReadonlyMap<string, string>,
 ): Map<string, string> | null {
   const ast = getAst();
 
@@ -307,7 +308,7 @@ function followGuards(
   call: ts.CallExpression,
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
-  callerParamNames: Map<string, string>,
+  callerParamNames: ReadonlyMap<string, string>,
   visited: Set<ts.Node>,
 ): OpaqueExpr[] {
   const target = resolveCallTarget(call, checker);
@@ -486,7 +487,7 @@ function scanBodyForGuards(
   body: ts.Block,
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
-  paramNames: Map<string, string>,
+  paramNames: ReadonlyMap<string, string>,
   visited: Set<ts.Node>,
 ): OpaqueExpr[] {
   const ast = getAst();
@@ -657,7 +658,7 @@ export function detectGuard(
   node: ts.FunctionDeclaration | ts.MethodDeclaration,
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
-  paramNames: Map<string, string>,
+  paramNames: ReadonlyMap<string, string>,
 ): OpaqueExpr | undefined {
   const ast = getAst();
 
@@ -715,7 +716,7 @@ export function translateExpr(
   expr: ts.Expression,
   _checker: ts.TypeChecker,
   _strategy: NumericStrategy,
-  paramNames: Map<string, string>,
+  paramNames: ReadonlyMap<string, string>,
 ): OpaqueExpr {
   const ast = getAst();
 
@@ -822,16 +823,19 @@ function capitalize(s: string): string {
 export function shortParamName(
   typeName: string,
   existingNames: Set<string>,
-  registry?: NameRegistry,
+  synthCell?: MapSynthCell,
 ): string {
   let name = typeName[0]!.toLowerCase();
   let suffix = 1;
-  while (existingNames.has(name) || registry?.isUsed(name)) {
+  while (
+    existingNames.has(name) ||
+    (synthCell ? cellIsUsed(synthCell, name) : false)
+  ) {
     name = typeName[0]!.toLowerCase() + suffix;
     suffix++;
   }
-  if (registry) {
-    registry.register(name);
+  if (synthCell) {
+    cellRegisterName(synthCell, name);
   }
   return name;
 }
@@ -843,7 +847,7 @@ export function translateSignature(
   sourceFile: SourceFile,
   functionName: string,
   strategy: NumericStrategy,
-  registry?: NameRegistry,
+  synthCell?: MapSynthCell,
   overrides?: Map<string, string>,
 ): TranslatedSignature {
   const checker = sourceFile.getProject().getTypeChecker().compilerObject;
@@ -862,13 +866,9 @@ export function translateSignature(
   const params: Array<{ name: string; type: string }> = [];
   const paramNameMap = new Map<string, string>();
 
-  // A synthesizer is only meaningful when a registry is present (it uses
-  // the registry to claim unique synthesized domain names).
-  const mapSynth = registry ? new MapSynthesizer(registry) : undefined;
-
   if (className) {
     const existingParamNames = new Set(sig.getParameters().map((p) => p.name));
-    const pName = shortParamName(className, existingParamNames, registry);
+    const pName = shortParamName(className, existingParamNames, synthCell);
     params.push({ name: pName, type: className });
     paramNameMap.set("this", pName);
   }
@@ -878,10 +878,12 @@ export function translateSignature(
       checker.getTypeOfSymbol(param),
       checker,
       strategy,
-      mapSynth,
+      synthCell,
     );
     const paramType = overrides?.get(param.name) ?? defaultType;
-    const pantName = registry ? registry.register(param.name) : param.name;
+    const pantName = synthCell
+      ? cellRegisterName(synthCell, param.name)
+      : param.name;
     params.push({ name: pantName, type: paramType });
     paramNameMap.set(param.name, pantName);
   }
@@ -893,7 +895,7 @@ export function translateSignature(
       sig.getReturnType(),
       checker,
       strategy,
-      mapSynth,
+      synthCell,
     );
     const decl: PantRule = {
       kind: "rule",
@@ -904,7 +906,7 @@ export function translateSignature(
     if (guard) {
       decl.guard = guard;
     }
-    return { declaration: decl, classification, paramNameMap, mapSynth };
+    return { declaration: decl, classification, paramNameMap, synthCell };
   } else {
     const decl: PantAction = {
       kind: "action",
@@ -914,6 +916,6 @@ export function translateSignature(
     if (guard) {
       decl.guard = guard;
     }
-    return { declaration: decl, classification, paramNameMap, mapSynth };
+    return { declaration: decl, classification, paramNameMap, synthCell };
   }
 }

--- a/tools/ts2pant/src/translate-types.ts
+++ b/tools/ts2pant/src/translate-types.ts
@@ -1,6 +1,10 @@
 import ts from "typescript";
 import type { ExtractedTypes } from "./extract.js";
-import type { NameRegistry } from "./name-registry.js";
+import {
+  emptyNameRegistry,
+  type NameRegistry,
+  registerName,
+} from "./name-registry.js";
 import { getAst } from "./pant-wasm.js";
 import type { PantDeclaration } from "./types.js";
 
@@ -45,83 +49,176 @@ export interface MapSynthEntry {
  * pair per unique `(K, V)`. McCarthy's theory of arrays applied via
  * Pantagruel rules: synthesized domain is the array sort, distinct elements
  * are distinct maps, `.get` is a partial function guarded by `.has`.
+ *
+ * Immutable record: pure `registerMapKV` / `lookupMapKV` / `emitSynthDecls`
+ * helpers operate on it, returning fresh records. Deep call sites that need
+ * to register on demand (e.g., `translateBody` via `.get(k)` on an
+ * expression-computed Map receiver) wrap synth + registry in a `MapSynthCell`
+ * to avoid threading updates through every `BodyResult`.
  */
-export class MapSynthesizer {
-  private byKV = new Map<string, MapSynthEntry>();
-  private emitted = new Set<string>();
+export interface MapSynth {
+  readonly byKV: ReadonlyMap<string, MapSynthEntry>;
+  readonly emitted: ReadonlySet<string>;
+}
 
-  constructor(private registry: NameRegistry) {}
+export function emptyMapSynth(): MapSynth {
+  return { byKV: new Map(), emitted: new Set() };
+}
 
-  register(kType: string, vType: string): string | null {
-    const key = `${kType}|${vType}`;
-    const cached = this.byKV.get(key);
-    if (cached) {
-      return cached.names.domain;
-    }
-    const kFrag = manglePantTypeToFragment(kType);
-    const vFrag = manglePantTypeToFragment(vType);
-    if (!kFrag || !vFrag) {
-      return null;
-    }
-    const baseDomain = `${kFrag}To${vFrag}Map`;
-    const domain = this.registry.register(baseDomain);
-    const rule = domain[0]!.toLowerCase() + domain.slice(1);
-    const entry: MapSynthEntry = {
-      names: { domain, rule, keyPred: `${rule}Key` },
-      kType,
-      vType,
-    };
-    this.byKV.set(key, entry);
-    return domain;
+/**
+ * Register a `Map<K, V>` occurrence. Idempotent: re-registering the same
+ * `(kType, vType)` returns the cached domain. Returns `{domain: null, ...}`
+ * when either fragment is unmangleable (unsupported upstream type); callers
+ * fall back to `checker.typeToString` in that case.
+ */
+export function registerMapKV(
+  synth: MapSynth,
+  registry: NameRegistry,
+  kType: string,
+  vType: string,
+): { domain: string | null; synth: MapSynth; registry: NameRegistry } {
+  const key = `${kType}|${vType}`;
+  const cached = synth.byKV.get(key);
+  if (cached) {
+    return { domain: cached.names.domain, synth, registry };
   }
-
-  lookup(kType: string, vType: string): MapSynthEntry | undefined {
-    return this.byKV.get(`${kType}|${vType}`);
+  const kFrag = manglePantTypeToFragment(kType);
+  const vFrag = manglePantTypeToFragment(vType);
+  if (!kFrag || !vFrag) {
+    return { domain: null, synth, registry };
   }
+  const baseDomain = `${kFrag}To${vFrag}Map`;
+  const reg1 = registerName(registry, baseDomain);
+  const domain = reg1.name;
+  const rule = domain[0]!.toLowerCase() + domain.slice(1);
+  const entry: MapSynthEntry = {
+    names: { domain, rule, keyPred: `${rule}Key` },
+    kType,
+    vType,
+  };
+  const newByKV = new Map(synth.byKV);
+  newByKV.set(key, entry);
+  return {
+    domain,
+    synth: { byKV: newByKV, emitted: synth.emitted },
+    registry: reg1.registry,
+  };
+}
 
-  /**
-   * Materialize accumulated decls (domain + membership predicate + guarded
-   * value rule) in registration order. Rule-internal binder names are
-   * registered *here*, after callers have claimed their own param names,
-   * so the synth decls get hygienic suffixes (e.g., `m1`, `k1`). Incremental:
-   * a second call only emits entries registered since the previous call, so
-   * the pipeline can drain new body-level registrations after signature/type
-   * translation has already run.
-   */
-  emit(): PantDeclaration[] {
-    const decls: PantDeclaration[] = [];
-    const ast = getAst();
-    for (const [key, entry] of this.byKV) {
-      if (this.emitted.has(key)) {
-        continue;
-      }
-      this.emitted.add(key);
-      const { domain, rule, keyPred } = entry.names;
-      const mName = this.registry.register("m");
-      const kName = this.registry.register("k");
-      decls.push({ kind: "domain", name: domain });
-      decls.push({
-        kind: "rule",
-        name: keyPred,
-        params: [
-          { name: mName, type: domain },
-          { name: kName, type: entry.kType },
-        ],
-        returnType: "Bool",
-      });
-      decls.push({
-        kind: "rule",
-        name: rule,
-        params: [
-          { name: mName, type: domain },
-          { name: kName, type: entry.kType },
-        ],
-        returnType: entry.vType,
-        guard: ast.app(ast.var(keyPred), [ast.var(mName), ast.var(kName)]),
-      });
+export function lookupMapKV(
+  synth: MapSynth,
+  kType: string,
+  vType: string,
+): MapSynthEntry | undefined {
+  return synth.byKV.get(`${kType}|${vType}`);
+}
+
+/**
+ * Materialize accumulated decls (domain + membership predicate + guarded
+ * value rule) in registration order. Rule-internal binder names are
+ * registered *here*, after callers have claimed their own param names,
+ * so the synth decls get hygienic suffixes (e.g., `m1`, `k1`). Incremental:
+ * only entries not in `synth.emitted` are emitted, so the pipeline can drain
+ * new body-level registrations after signature/type translation has already
+ * run. Callers must thread the returned `synth` back to preserve the
+ * emitted-set invariant.
+ */
+export function emitSynthDecls(
+  synth: MapSynth,
+  registry: NameRegistry,
+): { decls: PantDeclaration[]; synth: MapSynth; registry: NameRegistry } {
+  const decls: PantDeclaration[] = [];
+  const ast = getAst();
+  const newEmitted = new Set(synth.emitted);
+  let currentRegistry = registry;
+  for (const [key, entry] of synth.byKV) {
+    if (newEmitted.has(key)) {
+      continue;
     }
-    return decls;
+    newEmitted.add(key);
+    const { domain, rule, keyPred } = entry.names;
+    const mReg = registerName(currentRegistry, "m");
+    const mName = mReg.name;
+    currentRegistry = mReg.registry;
+    const kReg = registerName(currentRegistry, "k");
+    const kName = kReg.name;
+    currentRegistry = kReg.registry;
+    decls.push({ kind: "domain", name: domain });
+    decls.push({
+      kind: "rule",
+      name: keyPred,
+      params: [
+        { name: mName, type: domain },
+        { name: kName, type: entry.kType },
+      ],
+      returnType: "Bool",
+    });
+    decls.push({
+      kind: "rule",
+      name: rule,
+      params: [
+        { name: mName, type: domain },
+        { name: kName, type: entry.kType },
+      ],
+      returnType: entry.vType,
+      guard: ast.app(ast.var(keyPred), [ast.var(mName), ast.var(kName)]),
+    });
   }
+  return {
+    decls,
+    synth: { byKV: synth.byKV, emitted: newEmitted },
+    registry: currentRegistry,
+  };
+}
+
+/**
+ * Mutable 2-field cell bundling a `MapSynth` and `NameRegistry`. Used by
+ * deep call sites (mapTsType recursion, body translation) that would
+ * otherwise have to thread the pair through every return value. The fields
+ * are reassigned in place with freshly-computed immutable records; the
+ * inner `MapSynth` / `NameRegistry` remain pure values. Cell-field
+ * assignment is itself within ts2pant's self-translation envelope
+ * (translatable as primed rules on the cell).
+ */
+export interface MapSynthCell {
+  synth: MapSynth;
+  registry: NameRegistry;
+}
+
+export function newMapSynthCell(registry?: NameRegistry): MapSynthCell {
+  return { synth: emptyMapSynth(), registry: registry ?? emptyNameRegistry() };
+}
+
+/** Cell-mutating wrapper around `registerMapKV` for the legacy call shape. */
+export function cellRegisterMap(
+  cell: MapSynthCell,
+  kType: string,
+  vType: string,
+): string | null {
+  const r = registerMapKV(cell.synth, cell.registry, kType, vType);
+  cell.synth = r.synth;
+  cell.registry = r.registry;
+  return r.domain;
+}
+
+/** Cell-mutating wrapper around `registerName`. */
+export function cellRegisterName(cell: MapSynthCell, name: string): string {
+  const r = registerName(cell.registry, name);
+  cell.registry = r.registry;
+  return r.name;
+}
+
+/** Cell read-through for `isUsed`. */
+export function cellIsUsed(cell: MapSynthCell, name: string): boolean {
+  return cell.registry.used.has(name);
+}
+
+/** Cell-mutating wrapper around `emitSynthDecls`. */
+export function cellEmitSynth(cell: MapSynthCell): PantDeclaration[] {
+  const r = emitSynthDecls(cell.synth, cell.registry);
+  cell.synth = r.synth;
+  cell.registry = r.registry;
+  return r.decls;
 }
 
 /** Strategy for mapping TS `number` to a Pantagruel numeric type. */
@@ -144,19 +241,19 @@ export const RealStrategy: NumericStrategy = {
 /**
  * Map a TypeScript type to a Pantagruel type string.
  *
- * When `synth` is provided, `Map<K, V>` in any type position (parameter,
+ * When `synthCell` is provided, `Map<K, V>` in any type position (parameter,
  * return, nested in another Map's V, inside an array/tuple/union) is
  * registered with the synthesizer and replaced with the synthesized domain
- * name. Without `synth`, Map types fall through to the caller's fallback
+ * name. Without `synthCell`, Map types fall through to the caller's fallback
  * (typically `checker.typeToString()` which yields unparseable output).
- * The `synth`-less behavior is preserved for Stage A: interface-field Maps
+ * The cell-less behavior is preserved for Stage A: interface-field Maps
  * are handled specially in `translateTypes` and must not be synthesized.
  */
 export function mapTsType(
   type: ts.Type,
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
-  synth?: MapSynthesizer,
+  synthCell?: MapSynthCell,
 ): string {
   const flags = type.flags;
 
@@ -181,7 +278,7 @@ export function mapTsType(
   if (checker.isTupleType(type)) {
     const typeArgs = checker.getTypeArguments(type as ts.TypeReference);
     return typeArgs
-      .map((t) => mapTsType(t, checker, strategy, synth))
+      .map((t) => mapTsType(t, checker, strategy, synthCell))
       .join(" * ");
   }
 
@@ -189,7 +286,7 @@ export function mapTsType(
   if (checker.isArrayType(type)) {
     const typeArgs = checker.getTypeArguments(type as ts.TypeReference);
     if (typeArgs.length === 1) {
-      return `[${mapTsType(typeArgs[0]!, checker, strategy, synth)}]`;
+      return `[${mapTsType(typeArgs[0]!, checker, strategy, synthCell)}]`;
     }
     return checker.typeToString(type);
   }
@@ -200,21 +297,21 @@ export function mapTsType(
   if (isSetType(type)) {
     const typeArgs = checker.getTypeArguments(type as ts.TypeReference);
     if (typeArgs.length === 1) {
-      return `[${mapTsType(typeArgs[0]!, checker, strategy, synth)}]`;
+      return `[${mapTsType(typeArgs[0]!, checker, strategy, synthCell)}]`;
     }
     return checker.typeToString(type);
   }
 
-  // Map — synthesize a domain when a synthesizer is provided. If the K or V
-  // type is unmangleable (e.g., contains an unsupported TS type), register
-  // returns null and we fall through to checker.typeToString — the same
-  // unsupported-type fallback used by the array and set branches above.
-  if (isMapType(type) && synth) {
+  // Map — synthesize a domain when a synthesizer cell is provided. If the
+  // K or V type is unmangleable (e.g., contains an unsupported TS type),
+  // `cellRegisterMap` returns null and we fall through to checker.typeToString
+  // — the same unsupported-type fallback used by the array and set branches.
+  if (isMapType(type) && synthCell) {
     const typeArgs = checker.getTypeArguments(type as ts.TypeReference);
     if (typeArgs.length === 2) {
-      const kType = mapTsType(typeArgs[0]!, checker, strategy, synth);
-      const vType = mapTsType(typeArgs[1]!, checker, strategy, synth);
-      const domain = synth.register(kType, vType);
+      const kType = mapTsType(typeArgs[0]!, checker, strategy, synthCell);
+      const vType = mapTsType(typeArgs[1]!, checker, strategy, synthCell);
+      const domain = cellRegisterMap(synthCell, kType, vType);
       if (domain !== null) {
         return domain;
       }
@@ -227,7 +324,9 @@ export function mapTsType(
     if (type.types.every((t) => t.flags & ts.TypeFlags.BooleanLiteral)) {
       return "Bool";
     }
-    const parts = type.types.map((t) => mapTsType(t, checker, strategy, synth));
+    const parts = type.types.map((t) =>
+      mapTsType(t, checker, strategy, synthCell),
+    );
     // Deduplicate (e.g. boolean literal collapse)
     const unique = parts.filter((v, i, a) => a.indexOf(v) === i);
     // Sort Nothing to the end for consistent output
@@ -281,15 +380,16 @@ export function translateTypes(
   extracted: ExtractedTypes,
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
-  registry?: NameRegistry,
-  synth?: MapSynthesizer,
+  synthCell?: MapSynthCell,
 ): PantDeclaration[] {
   const decls: PantDeclaration[] = [];
 
   for (const iface of extracted.interfaces) {
     decls.push({ kind: "domain", name: iface.name });
     const candidate = paramName(iface.name);
-    const pName = registry ? registry.register(candidate) : candidate;
+    const pName = synthCell
+      ? cellRegisterName(synthCell, candidate)
+      : candidate;
     for (const prop of iface.properties) {
       if (isMapType(prop.type)) {
         const typeArgs = checker.getTypeArguments(
@@ -301,9 +401,9 @@ export function translateTypes(
           // via mapTsType with the synth passed through, so a nested Map
           // inside V (e.g., `inner: Map<K, Map<K', V'>>`) registers its
           // own synthesized domain and the Stage A rule's V references it.
-          const kType = mapTsType(typeArgs[0]!, checker, strategy, synth);
-          const vType = mapTsType(typeArgs[1]!, checker, strategy, synth);
-          const kName = registry ? registry.register("k") : "k";
+          const kType = mapTsType(typeArgs[0]!, checker, strategy, synthCell);
+          const vType = mapTsType(typeArgs[1]!, checker, strategy, synthCell);
+          const kName = synthCell ? cellRegisterName(synthCell, "k") : "k";
           const keyPredName = `${prop.name}Key`;
           decls.push({
             kind: "rule",
@@ -335,7 +435,7 @@ export function translateTypes(
         kind: "rule",
         name: prop.name,
         params: [{ name: pName, type: iface.name }],
-        returnType: mapTsType(prop.type, checker, strategy, synth),
+        returnType: mapTsType(prop.type, checker, strategy, synthCell),
       });
     }
   }
@@ -344,7 +444,7 @@ export function translateTypes(
     decls.push({
       kind: "alias",
       name: alias.name,
-      type: mapTsType(alias.type, checker, strategy, synth),
+      type: mapTsType(alias.type, checker, strategy, synthCell),
     });
   }
 


### PR DESCRIPTION
## Summary

Converts the shared-mutable containers in ts2pant's translation pipeline into immutable records + 2-field cell wrappers, bringing the translator's own source closer to something ts2pant can translate to Pantagruel.

This is the "immutable records only" scope of the plan — preserve the algorithm (forward symbolic execution, right-fold substitution for let-elimination, clone-and-merge for if-joins, deforestation for chain fusion) and keep every fixture snapshot byte-identical; just replace the plumbing.

### What changed

- **`NameRegistry`**: class with private `Set` → record + pure `registerName` / `isUsed`.
- **`MapSynthesizer`**: class with private `Map`s → `MapSynth` record + pure `registerMapKV` / `emitSynthDecls`. A `MapSynthCell` 2-field wrapper lets call sites that need on-demand registration (nested Map synthesis during body translation) thread the cell instead of the raw record.
- **`UniqueSupply`**: closure over `let counter` → `UniqueSupply` record with a `nextSupply` function.
- **`SymbolicState`**: mutable `writes` / `writtenKeys` → `ReadonlyMap` / `ReadonlySet` with `putWrite` / `addWrittenKey` helpers. `modifiedProps` intentionally kept as a shared mutable `Set` — if-branch merge semantics rely on shared-reference aliasing across cloned states.
- **`paramNames`**: `Map<string, string>` → `ReadonlyMap<string, string>` with a `withParam(m, k, v)` helper that returns a fresh map. Kept mutable only in `symbolicExecute` / `translateMutatingBody`, which extend the map in-place for algorithmic reasons (const-binding scope extension inside the forward walk).
- **`inlineConstBindings`**: Phase 2 indexed for-loop → `reduce` over a tagged-union accumulator (`{ tag: "ok" } | { tag: "error" }`). Phase 3 substitution → `reduceRight` over the translated bindings.
- **Indexed loops**: `symbolicExecute` outer loop → `for (const [i, stmt] of stmts.entries())` with early return instead of `break` on a `let` index. `extractReturnExpression`'s indexed walk → a `stmts.slice(0, -1)` traversal.

### Why

Every pattern removed here was outside ts2pant's self-translatability envelope: no `let`, no `Map.set`, no classes with mutable private fields, no indexed `for` with `break`, no closures over mutable counters. Making these pure is a prerequisite for dogfooding ts2pant on its own source.

Out of scope for this PR (flagged as follow-ups): the handful of remaining `paramNames.set` sites inside `symbolicExecute` (algorithm, not plumbing), the shared-by-design `modifiedProps.add`, and any catamorphism-style restructuring of the outer statement walk.

## Test plan

- [x] `cd tools/ts2pant && npm test` — 295/295 passing
- [x] `npx tsc --noEmit` — clean
- [x] Fixture snapshots are byte-identical vs. `master` (if they weren't, that's a refactor bug, not "semantically equivalent" churn)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)