### PR TITLE
ts2pant: translate Map.set / Map.delete via N-ary override

### DIFF
--- a/test/test_smt.ml
+++ b/test/test_smt.ml
@@ -994,8 +994,10 @@ let test_override_nary_tuple_key () =
     (contains result "(and ");
   check bool "arity-2 override fallback applies both args" true
     (contains result "(f h1 k1)");
-  check bool "arity-2 override guard mentions h" true (contains result "h1 h");
-  check bool "arity-2 override guard mentions k" true (contains result "k1 k")
+  check bool "arity-2 override guard mentions h equality" true
+    (contains result "(= h1 h)");
+  check bool "arity-2 override guard mentions k equality" true
+    (contains result "(= k1 k)")
 
 let test_initially () =
   let env = Env.empty "" in

--- a/tools/ts2pant/CLAUDE.md
+++ b/tools/ts2pant/CLAUDE.md
@@ -220,7 +220,9 @@ as distinct `(tuple |-> value)` pairs in a single override expression:
 `m.set(k1, v1); m.set(k2, v2)` emits `R[(m, k1) |-> v1, (m, k2) |-> v2]`.
 Conditional writes (`if (g) m.set(k, v)`) merge via `cond` over the
 per-key override values, with the else-branch fallback being the
-pre-state `R m k` at that specific key. Quantifier binders come from
+current symbolic value already accumulated for that `(m, k)` pair;
+this is the pre-state `R m k` only when no earlier write to the same
+key has occurred on the path. Quantifier binders come from
 the document-wide `NameRegistry` so they stay unique against the
 function's own params (which have already claimed `m`, `k`, etc.).
 

--- a/tools/ts2pant/CLAUDE.md
+++ b/tools/ts2pant/CLAUDE.md
@@ -178,11 +178,51 @@ are distinct maps (EUF keeps their lookups independent — `sumAt m1 m2 k` is
 sound because `m1 ≠ m2` does not imply `stringToIntMap m1 k = stringToIntMap m2 k`),
 and the guarded `select` lookup is Dafny-style partial-function discipline.
 
-**Scope:** read-only. Mutation (`.set`/`.delete`), construction
-(`new Map()`), and iteration (`.entries`/`.keys`/`.values`/`.forEach`) are
-unsupported. See `tests/fixtures/constructs/expressions-map.ts` (Stage A)
-and `tests/fixtures/constructs/expressions-map-params.ts` (Stage B) for
-supported shapes.
+**Scope:** reads and point-update mutation. Construction (`new Map()`)
+and iteration (`.entries`/`.keys`/`.values`/`.forEach`) are unsupported.
+See `tests/fixtures/constructs/expressions-map.ts` (Stage A reads),
+`tests/fixtures/constructs/expressions-map-params.ts` (Stage B reads),
+`tests/fixtures/constructs/expressions-map-mutation.ts` (Stage B
+mutation), and `tests/fixtures/constructs/expressions-map-mutation-field.ts`
+(Stage A mutation) for supported shapes.
+
+#### Mutation (.set / .delete)
+
+**Standard name:** Point update in McCarthy's theory of arrays (`store`);
+TLA+ `[f EXCEPT ![m][k] = v]` with implicit frame.
+**Reference:** Kroening & Strichman Ch. 7 (`select`/`store` axioms);
+Lamport, *Specifying Systems* Ch. 2–3 (EXCEPT expression and next-state
+relations).
+
+`m.set(k, v)` and `m.delete(k)` emit one point-update per call using
+Pantagruel's N-ary override `R[(m, k) |-> v]`. The override's ite
+expansion (`(= (R_prime m1 k1) (ite (and (= m1 m) (= k1 k)) v (R m1 k1)))`
+in SMT) carries the "everything-else unchanged" frame implicitly at
+the exact override key — exactly TLA+'s EXCEPT semantics.
+
+Each `.set` on a Map receiver modifies two rules: the value rule `R`
+and its membership predicate `Rkey`. One quantified equation is emitted
+per modified rule:
+
+```text
+all m1: T, k1: K
+  | R' m1 k1 = R[(m, k) |-> v] m1 k1.
+all m2: T, k2: K
+  | Rkey' m2 k2 = Rkey[(m, k) |-> true] m2 k2.
+```
+
+For `.delete`, only the membership equation is emitted (with `|-> false`);
+the value rule is not restated because Pantagruel's declaration guard
+makes the value-rule body vacuous under false membership.
+
+Multiple writes to the same rule inside one execution path accumulate
+as distinct `(tuple |-> value)` pairs in a single override expression:
+`m.set(k1, v1); m.set(k2, v2)` emits `R[(m, k1) |-> v1, (m, k2) |-> v2]`.
+Conditional writes (`if (g) m.set(k, v)`) merge via `cond` over the
+per-key override values, with the else-branch fallback being the
+pre-state `R m k` at that specific key. Quantifier binders come from
+the document-wide `NameRegistry` so they stay unique against the
+function's own params (which have already claimed `m`, `k`, etc.).
 
 ### Structured Iteration (for-of, forEach, reduce)
 

--- a/tools/ts2pant/README.md
+++ b/tools/ts2pant/README.md
@@ -124,8 +124,8 @@ This works with any function declared as `asserts condition` -- Node's `assert`,
 | `string` | `String` |
 | `T[]` | `[T]` |
 | `Set<T>` | `[T]` (membership via `.has(x)` → `x in`, cardinality via `.size` → `#`; uniqueness is not tracked) |
-| `Map<K, V>` field on `interface` | two rules: `<name>Key c: C, k: K => Bool` and `<name> c: C, k: K, <name>Key c k => V` (read via `.get(k)` → `<name> c k`, membership via `.has(k)` → `<name>Key c k`) |
-| `Map<K, V>` in any other type position (parameter, return, nested) | synthesizes a handle domain per `(K, V)` pair per module: `KToVMap.` plus the same rule pair as above, with the user's interface replaced by the synthesized domain. Non-identifier `K`/`V` are mangled — `[String]` → `ListString`, `A + B` → `AOrB`, `A * B` → `AAndB`. `.get(k)` → `kToVMap m k`, `.has(k)` → `kToVMapKey m k`. Nested Maps register bottom-up (e.g., `Map<string, Map<string, number>>` emits `StringToIntMap` then `StringToStringToIntMapMap`). |
+| `Map<K, V>` field on `interface` | two rules: `<name>Key c: C, k: K => Bool` and `<name> c: C, k: K, <name>Key c k => V` (read via `.get(k)` → `<name> c k`, membership via `.has(k)` → `<name>Key c k`; mutation via `.set(k, v)` / `.delete(k)` → Pantagruel N-ary override `<name>[(c, k) \|-> v]` on each modified rule) |
+| `Map<K, V>` in any other type position (parameter, return, nested) | synthesizes a handle domain per `(K, V)` pair per module: `KToVMap.` plus the same rule pair as above, with the user's interface replaced by the synthesized domain. Non-identifier `K`/`V` are mangled — `[String]` → `ListString`, `A + B` → `AOrB`, `A * B` → `AAndB`. `.get(k)` → `kToVMap m k`, `.has(k)` → `kToVMapKey m k`. `.set(k, v)` / `.delete(k)` emit the same override-based mutation encoding as the interface-field case. Nested Maps register bottom-up (e.g., `Map<string, Map<string, number>>` emits `StringToIntMap` then `StringToStringToIntMapMap`). |
 | `T \| null` / `T \| undefined` | `T + Nothing` |
 | `interface Foo { ... }` | `Foo.` (domain) + rules for each property |
 
@@ -178,7 +178,7 @@ FAIL: Not entailed: 'balance' account >= 0'
 - **No local variables.** Functions with `let`/`const` bindings before the return are rejected as unsupported.
 - **No loops.** `for`/`while` are not translated.
 - **Array operations** are partially supported: `.filter().map()` chains, `.includes()`, `.length`. Other array methods are unsupported.
-- **`Map<K, V>` support is read-only.** Interface-field Maps and Maps in any other type position (parameter, return, nested) both translate into a value rule guarded by a membership predicate — the only difference is whether the owner domain is the user's interface or a synthesized `KToVMap` handle. Mutation (`.set`, `.delete`), construction (`new Map()`), and iteration (`.entries`, `.keys`, `.values`, `.forEach`) are not yet supported.
+- **`Map<K, V>` support covers reads and point-update mutations.** Interface-field Maps and Maps in any other type position (parameter, return, nested) both translate into a value rule guarded by a membership predicate — the only difference is whether the owner domain is the user's interface or a synthesized `KToVMap` handle. `.get`, `.has`, `.set`, and `.delete` are supported; `.set`/`.delete` emit a point-update per call via Pantagruel's N-ary override (`R[(m, k) |-> v]`), with conditional writes path-merged via `cond`. Construction (`new Map()`) and iteration (`.entries`, `.keys`, `.values`, `.forEach`) are not yet supported.
 
 ## Development
 

--- a/tools/ts2pant/src/purity.ts
+++ b/tools/ts2pant/src/purity.ts
@@ -122,6 +122,9 @@ const PURE_METHODS_BY_TYPE: ReadonlyMap<string, ReadonlySet<string>> = new Map([
   ],
 ]);
 
+/** Non-mutating `Map<K, V>` methods — read-only lookups. */
+const PURE_MAP_METHODS: ReadonlySet<string> = new Set(["get", "has"]);
+
 /** Non-mutating array methods that take no callback. */
 const PURE_ARRAY_METHODS: ReadonlySet<string> = new Set([
   "at",
@@ -457,6 +460,15 @@ function isKnownPureCallInner(
       const pureMethods = PURE_METHODS_BY_TYPE.get("number");
       if (pureMethods?.has(methodName)) {
         return true;
+      }
+    }
+
+    // Map methods — .get(k) and .has(k) are pure lookups. Pantagruel's
+    // read encoding (guarded rule application) has no effects, so these
+    // are safe inside if-conditions and rhs expressions of mutating bodies.
+    if (receiverType.getSymbol()?.getName() === "Map") {
+      if (PURE_MAP_METHODS.has(methodName)) {
+        return expr.arguments.every((arg) => expressionIsPure(arg, checker));
       }
     }
 

--- a/tools/ts2pant/src/purity.ts
+++ b/tools/ts2pant/src/purity.ts
@@ -466,9 +466,14 @@ function isKnownPureCallInner(
     // Map methods — .get(k) and .has(k) are pure lookups. Pantagruel's
     // read encoding (guarded rule application) has no effects, so these
     // are safe inside if-conditions and rhs expressions of mutating bodies.
+    // The receiver expression itself is evaluated eagerly, so it must also
+    // be pure (e.g., `effectfulFactory().get(k)` is not pure).
     if (receiverType.getSymbol()?.getName() === "Map") {
       if (PURE_MAP_METHODS.has(methodName)) {
-        return expr.arguments.every((arg) => expressionIsPure(arg, checker));
+        return (
+          expressionIsPure(receiver, checker) &&
+          expr.arguments.every((arg) => expressionIsPure(arg, checker))
+        );
       }
     }
 

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -20,6 +20,7 @@ import {
 } from "./translate-signature.js";
 import {
   cellRegisterMap,
+  cellRegisterName,
   isMapType,
   isSetType,
   lookupMapKV,
@@ -85,13 +86,55 @@ interface PendingComprehension {
   guards: OpaqueGuard[];
 }
 
+/**
+ * A Map mutation effect produced by `.set(k, v)` or `.delete(k)` on a
+ * Map-typed receiver. The effect is not an expression — it can only appear
+ * as a statement (ExpressionStatement) and is consumed by `symbolicExecute`
+ * which installs a MapRuleWriteEntry in the symbolic state. Encountering an
+ * effect in expression position is a translation failure.
+ */
+interface MapMutation {
+  op: "set" | "delete";
+  ruleName: string;
+  keyPredName: string;
+  ownerType: string;
+  keyType: string;
+  objExpr: OpaqueExpr;
+  keyExpr: OpaqueExpr;
+  valueExpr: OpaqueExpr | null;
+}
+
 type BodyResult =
   | { unsupported: string }
-  | { expr: OpaqueExpr; pendingComprehension?: PendingComprehension };
+  | { expr: OpaqueExpr; pendingComprehension?: PendingComprehension }
+  | { effect: MapMutation };
 
 /** Type guard for unsupported BodyResult. */
 function isBodyUnsupported(r: BodyResult): r is { unsupported: string } {
   return "unsupported" in r;
+}
+
+/** Type guard for effect BodyResult. */
+function isBodyEffect(r: BodyResult): r is { effect: MapMutation } {
+  return "effect" in r;
+}
+
+/**
+ * Turn an `effect` result into an `unsupported` marker. Expression-position
+ * consumers of `translateBodyExpr` use this after the unsupported check so
+ * the remaining value narrows to the `{ expr, pendingComprehension? }` form.
+ * Only `symbolicExecute`'s ExpressionStatement handler consumes effects
+ * directly.
+ */
+function rejectEffect(
+  r: BodyResult,
+):
+  | { unsupported: string }
+  | { expr: OpaqueExpr; pendingComprehension?: PendingComprehension } {
+  if ("effect" in r) {
+    return { unsupported: "Map mutation outside statement position" };
+  }
+  return r;
 }
 
 /** Extract the OpaqueExpr from a successful BodyResult, materializing any
@@ -99,6 +142,9 @@ function isBodyUnsupported(r: BodyResult): r is { unsupported: string } {
 function bodyExpr(r: BodyResult): OpaqueExpr {
   if ("unsupported" in r) {
     throw new Error(`bodyExpr called on unsupported: ${r.unsupported}`);
+  }
+  if ("effect" in r) {
+    throw new Error("bodyExpr called on effect result");
   }
   if (r.pendingComprehension) {
     const ast = getAst();
@@ -115,11 +161,45 @@ function bodyExpr(r: BodyResult): OpaqueExpr {
 // for each branch and merge via `cond` at the join. Later reads of the same
 // property access see the accumulated value. See CLAUDE.md § Guarded Commands.
 
-interface WriteEntry {
+interface PropertyWriteEntry {
+  kind: "property";
   prop: string;
   objExpr: OpaqueExpr;
   value: OpaqueExpr;
 }
+
+// Accumulated point-updates to a Map-backed rule pair (value rule + membership
+// predicate). One entry per distinct rule name coalesces all `.set`/`.delete`
+// writes to the same receiver's underlying rule: a function writing
+// `m.set(k1, v1); m.set(k2, v2)` produces one MapRuleWriteEntry with two
+// valueOverrides and two membershipOverrides. Emission uses Pantagruel's
+// N-ary override `R[(m, k) |-> v]` (samples/06-advanced.pant).
+
+/**
+ * One point-update within a rule override. `keyTuple = (objExpr, keyExpr)`
+ * is the override LHS the emitter hands to `ast.override`; `objExpr` and
+ * `keyExpr` are kept around so the merge fallback can build the pre-state
+ * expression `R objExpr keyExpr` (pretty) instead of projecting off the
+ * tuple (ugly but equivalent).
+ */
+interface MapOverride {
+  keyTuple: OpaqueExpr;
+  objExpr: OpaqueExpr;
+  keyExpr: OpaqueExpr;
+  value: OpaqueExpr;
+}
+
+interface MapRuleWriteEntry {
+  kind: "map";
+  ruleName: string;
+  keyPredName: string;
+  ownerType: string;
+  keyType: string;
+  valueOverrides: MapOverride[];
+  membershipOverrides: MapOverride[];
+}
+
+type WriteEntry = PropertyWriteEntry | MapRuleWriteEntry;
 
 /**
  * Per-body symbolic-execution accumulator. Held as a cell of immutable
@@ -196,6 +276,115 @@ function setCanonicalize(
 
 function symbolicKey(prop: string, objExpr: OpaqueExpr): string {
   return `${prop}::${getAst().strExpr(objExpr)}`;
+}
+
+/**
+ * State-map key for Map writes. All writes to the same rule coalesce into
+ * one MapRuleWriteEntry so multiple `.set` calls on one receiver accumulate
+ * as distinct `(tuple |-> value)` override pairs rather than separate
+ * entries (the emission collapses them into one override expression).
+ */
+function mapWriteKey(ruleName: string): string {
+  return `map::${ruleName}`;
+}
+
+/**
+ * Collapse two arrays of overrides (from the two branches of an if, or
+ * a branch vs. identity fallback) into a single array, keyed by canonical
+ * tuple form. Per canonical key, the per-branch values are combined via
+ * `combine`. Overrides that only exist in one side use the caller-supplied
+ * `fallback` expression (pre-state `R m k` for value; pre-state `Rkey m k`
+ * for membership) for the missing side.
+ *
+ * Order is preserved from `aSide` first, then any `bSide` keys not already
+ * seen. The canonical form comes from `ast.strExpr(keyTuple)`.
+ */
+function mergeOverrides(
+  aSide: ReadonlyArray<MapOverride>,
+  bSide: ReadonlyArray<MapOverride>,
+  fallback: (o: MapOverride) => OpaqueExpr,
+  combine: (vA: OpaqueExpr, vB: OpaqueExpr) => OpaqueExpr,
+): MapOverride[] {
+  const ast = getAst();
+  const canonical = (t: OpaqueExpr) => ast.strExpr(t);
+  const bByKey = new Map<string, OpaqueExpr>();
+  for (const o of bSide) {
+    bByKey.set(canonical(o.keyTuple), o.value);
+  }
+  const seen = new Set<string>();
+  const out: MapOverride[] = [];
+  for (const o of aSide) {
+    const k = canonical(o.keyTuple);
+    seen.add(k);
+    const vB = bByKey.get(k) ?? fallback(o);
+    out.push({ ...o, value: combine(o.value, vB) });
+  }
+  for (const o of bSide) {
+    const k = canonical(o.keyTuple);
+    if (seen.has(k)) {
+      continue;
+    }
+    const vA = fallback(o);
+    out.push({ ...o, value: combine(vA, o.value) });
+  }
+  return out;
+}
+
+/**
+ * Install a `.set`/`.delete` effect into the symbolic state. Creates a new
+ * MapRuleWriteEntry on first use per rule; subsequent effects on the same
+ * rule append their (tuple |-> value) overrides. The key tuple is `(m, k)`
+ * — `m` is the receiver (so distinct receivers at the same key don't
+ * collide), `k` is the key argument.
+ */
+function installMapWrite(
+  state: SymbolicState,
+  effect: MapMutation,
+  applyConst: (e: OpaqueExpr) => OpaqueExpr,
+): void {
+  const ast = getAst();
+  const key = mapWriteKey(effect.ruleName);
+  const objExpr = applyConst(effect.objExpr);
+  const keyExpr = applyConst(effect.keyExpr);
+  const keyTuple = ast.tuple([objExpr, keyExpr]);
+
+  let entry = state.writes.get(key) as MapRuleWriteEntry | undefined;
+  if (entry === undefined || entry.kind !== "map") {
+    entry = {
+      kind: "map",
+      ruleName: effect.ruleName,
+      keyPredName: effect.keyPredName,
+      ownerType: effect.ownerType,
+      keyType: effect.keyType,
+      valueOverrides: [],
+      membershipOverrides: [],
+    };
+    putWrite(state, key, entry);
+  }
+
+  if (effect.op === "set") {
+    const valueExpr = applyConst(effect.valueExpr!);
+    entry.valueOverrides.push({ keyTuple, objExpr, keyExpr, value: valueExpr });
+    entry.membershipOverrides.push({
+      keyTuple,
+      objExpr,
+      keyExpr,
+      value: ast.litBool(true),
+    });
+  } else {
+    // delete: membership goes false; value rule need not be restated because
+    // the declaration guard makes the value-rule body vacuous under false
+    // membership.
+    entry.membershipOverrides.push({
+      keyTuple,
+      objExpr,
+      keyExpr,
+      value: ast.litBool(false),
+    });
+  }
+  addWrittenKey(state, key);
+  state.modifiedProps.add(effect.ruleName);
+  state.modifiedProps.add(effect.keyPredName);
 }
 
 /**
@@ -1131,7 +1320,7 @@ export function translateBodyExpr(
     if (state !== undefined) {
       const key = symbolicKey(prop, state.canonicalize(bodyExpr(obj)));
       const entry = state.writes.get(key);
-      if (entry !== undefined) {
+      if (entry !== undefined && entry.kind === "property") {
         return { expr: entry.value };
       }
     }
@@ -1339,7 +1528,7 @@ function translateArrayMethod(
     return null;
   }
 
-  const receiver = translateBodyExpr(
+  const receiverRaw = translateBodyExpr(
     tsReceiver,
     checker,
     strategy,
@@ -1347,6 +1536,7 @@ function translateArrayMethod(
     state,
     supply,
   );
+  const receiver = rejectEffect(receiverRaw);
   if (isBodyUnsupported(receiver)) {
     return receiver;
   }
@@ -1454,7 +1644,7 @@ function translateReduceCall(
     return null;
   }
 
-  const receiver = translateBodyExpr(
+  const receiverRaw = translateBodyExpr(
     tsReceiver,
     checker,
     strategy,
@@ -1462,6 +1652,7 @@ function translateReduceCall(
     state,
     supply,
   );
+  const receiver = rejectEffect(receiverRaw);
   if (isBodyUnsupported(receiver)) {
     return receiver;
   }
@@ -1855,6 +2046,13 @@ function translateForOfLoopBody(
       return false;
     }
     for (const [, entry] of subState.writes) {
+      if (entry.kind !== "property") {
+        propositions.push({
+          kind: "unsupported",
+          reason: "Map mutation inside Shape A loop",
+        });
+        return false;
+      }
       propositions.push({
         kind: "equation",
         quantifiers: [] as OpaqueParam[],
@@ -1925,11 +2123,23 @@ function translateForOfLoopBody(
     }
     const key = symbolicKey(leaf.prop, accExpr);
     const priorEntry = state.writes.get(key);
+    if (priorEntry !== undefined && priorEntry.kind !== "property") {
+      propositions.push({
+        kind: "unsupported",
+        reason: "loop-fold accumulator over a Map receiver",
+      });
+      return false;
+    }
     const priorVal =
       priorEntry?.value ?? ast.app(ast.var(leaf.prop), [accExpr]);
     const newVal = ast.binop(outerOp, priorVal, folded);
 
-    putWrite(state, key, { prop: leaf.prop, objExpr: accExpr, value: newVal });
+    putWrite(state, key, {
+      kind: "property",
+      prop: leaf.prop,
+      objExpr: accExpr,
+      value: newVal,
+    });
     addWrittenKey(state, key);
   }
 
@@ -2086,6 +2296,157 @@ function translateCallExpr(
   if (ts.isPropertyAccessExpression(expr.expression)) {
     const methodName = expr.expression.name.text;
     const tsReceiver = expr.expression.expression;
+
+    // .set(k, v) / .delete(k) on a Map<K,V> receiver -> emit a `{ effect: ... }`
+    // BodyResult that `symbolicExecute` consumes to install a MapRuleWriteEntry.
+    // Stage A / Stage B disambiguation mirrors the .get/.has branch below; the
+    // owner and key types are captured on the effect so `translateMutatingBody`
+    // can emit the quantifier binders when expanding the override equation.
+    if (
+      ((methodName === "set" && expr.arguments.length === 2) ||
+        (methodName === "delete" && expr.arguments.length === 1)) &&
+      isMapType(checker.getTypeAtLocation(tsReceiver))
+    ) {
+      const stageA =
+        ts.isPropertyAccessExpression(tsReceiver) &&
+        isInterfaceFieldAccess(tsReceiver, checker);
+
+      const keyArg = expr.arguments[0]!;
+      const kExprRaw = translateBodyExpr(
+        keyArg,
+        checker,
+        strategy,
+        paramNames,
+        state,
+        supply,
+      );
+      const kExpr = rejectEffect(kExprRaw);
+      if (isBodyUnsupported(kExpr)) {
+        return kExpr;
+      }
+
+      let valueExpr: OpaqueExpr | null = null;
+      if (methodName === "set") {
+        const vRaw = translateBodyExpr(
+          expr.arguments[1]!,
+          checker,
+          strategy,
+          paramNames,
+          state,
+          supply,
+        );
+        const vExpr = rejectEffect(vRaw);
+        if (isBodyUnsupported(vExpr)) {
+          return vExpr;
+        }
+        valueExpr = bodyExpr(vExpr);
+      }
+
+      if (stageA && ts.isPropertyAccessExpression(tsReceiver)) {
+        const fieldName = tsReceiver.name.text;
+        const innerObj = tsReceiver.expression;
+        const objRaw = translateBodyExpr(
+          innerObj,
+          checker,
+          strategy,
+          paramNames,
+          state,
+          supply,
+        );
+        const objExpr = rejectEffect(objRaw);
+        if (isBodyUnsupported(objExpr)) {
+          return objExpr;
+        }
+        const ownerType = mapTsType(
+          checker.getTypeAtLocation(innerObj),
+          checker,
+          strategy,
+          supply.synthCell,
+        );
+        const typeArgs = checker.getTypeArguments(
+          checker.getTypeAtLocation(tsReceiver) as ts.TypeReference,
+        );
+        if (typeArgs.length !== 2) {
+          return { unsupported: "Map with unexpected arity" };
+        }
+        const keyType = mapTsType(
+          typeArgs[0]!,
+          checker,
+          strategy,
+          supply.synthCell,
+        );
+        return {
+          effect: {
+            op: methodName as "set" | "delete",
+            ruleName: fieldName,
+            keyPredName: `${fieldName}Key`,
+            ownerType,
+            keyType,
+            objExpr: bodyExpr(objExpr),
+            keyExpr: bodyExpr(kExpr),
+            valueExpr,
+          },
+        };
+      }
+
+      // Stage B — synthesized rule lookup (same on-demand registration as
+      // the .get/.has branch).
+      const receiverType = checker.getTypeAtLocation(tsReceiver);
+      const typeArgs = checker.getTypeArguments(
+        receiverType as ts.TypeReference,
+      );
+      if (typeArgs.length !== 2) {
+        return { unsupported: "Map with unexpected arity" };
+      }
+      const kType = mapTsType(
+        typeArgs[0]!,
+        checker,
+        strategy,
+        supply.synthCell,
+      );
+      const vType = mapTsType(
+        typeArgs[1]!,
+        checker,
+        strategy,
+        supply.synthCell,
+      );
+      let info = supply.synthCell
+        ? lookupMapKV(supply.synthCell.synth, kType, vType)
+        : undefined;
+      if (!info && supply.synthCell) {
+        cellRegisterMap(supply.synthCell, kType, vType);
+        info = lookupMapKV(supply.synthCell.synth, kType, vType);
+      }
+      if (!info) {
+        return {
+          unsupported: `Map<${kType}, ${vType}>: key or value type cannot be mangled into a synthesized domain name`,
+        };
+      }
+      const objRaw = translateBodyExpr(
+        tsReceiver,
+        checker,
+        strategy,
+        paramNames,
+        state,
+        supply,
+      );
+      const objExpr = rejectEffect(objRaw);
+      if (isBodyUnsupported(objExpr)) {
+        return objExpr;
+      }
+      return {
+        effect: {
+          op: methodName as "set" | "delete",
+          ruleName: info.names.rule,
+          keyPredName: info.names.keyPred,
+          ownerType: info.names.domain,
+          keyType: kType,
+          objExpr: bodyExpr(objExpr),
+          keyExpr: bodyExpr(kExpr),
+          valueExpr,
+        },
+      };
+    }
 
     // .get(k) / .has(k) on a Map<K,V> receiver -> 2-arity rule application.
     // Two paths, same encoding shape:
@@ -2452,13 +2813,73 @@ function translateMutatingBody(
   }
 
   for (const [, entry] of state.writes) {
-    propositions.push({
-      kind: "equation",
-      quantifiers: [] as OpaqueParam[],
-      lhs: ast.app(ast.primed(entry.prop), [entry.objExpr]),
-      rhs: entry.value,
-    });
-    addModifiedProp(state, entry.prop);
+    if (entry.kind === "property") {
+      propositions.push({
+        kind: "equation",
+        quantifiers: [] as OpaqueParam[],
+        lhs: ast.app(ast.primed(entry.prop), [entry.objExpr]),
+        rhs: entry.value,
+      });
+      addModifiedProp(state, entry.prop);
+      continue;
+    }
+    // Map write: emit one quantified equation per modified rule using the
+    // override expression as the RHS applied to fresh quantifier binders.
+    // Binders are allocated through the document-wide name registry (inside
+    // synthCell) so they don't collide with the function's own params or
+    // with type-derived accessor rule binders — unlike the internal
+    // `freshHygienicBinder` which emits `$N` names that don't round-trip
+    // through the Pantagruel parser.
+    const allocBinder = (hint: string): string =>
+      synthCell
+        ? cellRegisterName(synthCell, hint)
+        : freshHygienicBinder(supply);
+    // `valueOverrides` empty (pure `.delete`) — skip the value rule; the
+    // membership going false makes the rule-guard vacuous.
+    if (entry.valueOverrides.length > 0) {
+      const m1 = allocBinder("m");
+      const k1 = allocBinder("k");
+      propositions.push({
+        kind: "equation",
+        quantifiers: [
+          ast.param(m1, ast.tName(entry.ownerType)),
+          ast.param(k1, ast.tName(entry.keyType)),
+        ] as OpaqueParam[],
+        lhs: ast.app(ast.primed(entry.ruleName), [ast.var(m1), ast.var(k1)]),
+        rhs: ast.app(
+          ast.override(
+            entry.ruleName,
+            entry.valueOverrides.map(
+              (o) => [o.keyTuple, o.value] as [OpaqueExpr, OpaqueExpr],
+            ),
+          ),
+          [ast.var(m1), ast.var(k1)],
+        ),
+      });
+      addModifiedProp(state, entry.ruleName);
+    }
+    if (entry.membershipOverrides.length > 0) {
+      const m1 = allocBinder("m");
+      const k1 = allocBinder("k");
+      propositions.push({
+        kind: "equation",
+        quantifiers: [
+          ast.param(m1, ast.tName(entry.ownerType)),
+          ast.param(k1, ast.tName(entry.keyType)),
+        ] as OpaqueParam[],
+        lhs: ast.app(ast.primed(entry.keyPredName), [ast.var(m1), ast.var(k1)]),
+        rhs: ast.app(
+          ast.override(
+            entry.keyPredName,
+            entry.membershipOverrides.map(
+              (o) => [o.keyTuple, o.value] as [OpaqueExpr, OpaqueExpr],
+            ),
+          ),
+          [ast.var(m1), ast.var(k1)],
+        ),
+      });
+      addModifiedProp(state, entry.keyPredName);
+    }
   }
 
   const frames = generateFrameConditions(state.modifiedProps, declarations);
@@ -2586,22 +3007,80 @@ function symbolicExecute(
       for (const key of sR.writtenKeys) {
         const entryR = sR.writes.get(key)!;
         const prior = state.writes.get(key);
-        const identity = ast.app(ast.var(entryR.prop), [entryR.objExpr]);
-        const vEarlyReturn = prior?.value ?? identity;
-        const vContinuation = entryR.value;
-        const merged = exit.earlyExitWhenTrue
-          ? ast.cond([
-              [gExpr, vEarlyReturn],
-              [ast.litBool(true), vContinuation],
-            ])
-          : ast.cond([
-              [gExpr, vContinuation],
-              [ast.litBool(true), vEarlyReturn],
-            ]);
+        if (prior !== undefined && prior.kind !== entryR.kind) {
+          ok = false;
+          propositions.push({
+            kind: "unsupported",
+            reason:
+              "branches wrote the same key with different kinds (property vs. map)",
+          });
+          break;
+        }
+        if (entryR.kind === "property") {
+          const priorP = prior as PropertyWriteEntry | undefined;
+          const identity = ast.app(ast.var(entryR.prop), [entryR.objExpr]);
+          const vEarlyReturn = priorP?.value ?? identity;
+          const vContinuation = entryR.value;
+          const merged = exit.earlyExitWhenTrue
+            ? ast.cond([
+                [gExpr, vEarlyReturn],
+                [ast.litBool(true), vContinuation],
+              ])
+            : ast.cond([
+                [gExpr, vContinuation],
+                [ast.litBool(true), vEarlyReturn],
+              ]);
+          putWrite(state, key, {
+            kind: "property",
+            prop: entryR.prop,
+            objExpr: entryR.objExpr,
+            value: merged,
+          });
+          addWrittenKey(state, key);
+          continue;
+        }
+        // Map: continuation-side overrides are taken only when NOT on the
+        // early-exit arm. The early-exit fallback for each override (m, k)
+        // is the pre-state lookup.
+        const ruleVar = ast.var(entryR.ruleName);
+        const keyVar = ast.var(entryR.keyPredName);
+        const valueFallback = (o: MapOverride): OpaqueExpr =>
+          ast.app(ruleVar, [o.objExpr, o.keyExpr]);
+        const memberFallback = (o: MapOverride): OpaqueExpr =>
+          ast.app(keyVar, [o.objExpr, o.keyExpr]);
+        const combineContCond = (
+          vCont: OpaqueExpr,
+          vExit: OpaqueExpr,
+        ): OpaqueExpr =>
+          exit.earlyExitWhenTrue
+            ? ast.cond([
+                [gExpr, vExit],
+                [ast.litBool(true), vCont],
+              ])
+            : ast.cond([
+                [gExpr, vCont],
+                [ast.litBool(true), vExit],
+              ]);
+        const mergedValue = mergeOverrides(
+          entryR.valueOverrides,
+          [],
+          valueFallback,
+          combineContCond,
+        );
+        const mergedMember = mergeOverrides(
+          entryR.membershipOverrides,
+          [],
+          memberFallback,
+          combineContCond,
+        );
         putWrite(state, key, {
-          prop: entryR.prop,
-          objExpr: entryR.objExpr,
-          value: merged,
+          kind: "map",
+          ruleName: entryR.ruleName,
+          keyPredName: entryR.keyPredName,
+          ownerType: entryR.ownerType,
+          keyType: entryR.keyType,
+          valueOverrides: mergedValue,
+          membershipOverrides: mergedMember,
         });
         addWrittenKey(state, key);
       }
@@ -2663,6 +3142,30 @@ function symbolicExecute(
       continue;
     }
 
+    // Map mutation: `m.set(k, v)` or `m.delete(k)` as a statement.
+    // translateCallExpr returns a `{ effect }` result for these calls; the
+    // write is installed via installMapWrite, which coalesces multiple
+    // writes to the same rule into one MapRuleWriteEntry.
+    if (
+      ts.isExpressionStatement(stmt) &&
+      ts.isCallExpression(unwrapExpression(stmt.expression))
+    ) {
+      const call = unwrapExpression(stmt.expression) as ts.CallExpression;
+      const callResult = translateCallExpr(
+        call,
+        checker,
+        strategy,
+        paramNames,
+        state,
+        supply,
+      );
+      if (isBodyEffect(callResult)) {
+        installMapWrite(state, callResult.effect, applyConst);
+        continue;
+      }
+      // Otherwise fall through to forEach / side-effect handling below.
+    }
+
     // Property assignment: obj.prop = rhs
     if (
       ts.isExpressionStatement(stmt) &&
@@ -2714,7 +3217,12 @@ function symbolicExecute(
         const objExpr = applyConst(bodyExpr(obj));
         const valExpr = applyConst(bodyExpr(val));
         const key = symbolicKey(prop, objExpr);
-        putWrite(state, key, { prop, objExpr, value: valExpr });
+        putWrite(state, key, {
+          kind: "property",
+          prop,
+          objExpr,
+          value: valExpr,
+        });
         addWrittenKey(state, key);
         continue;
       }
@@ -2900,21 +3408,84 @@ function symbolicExecute(
 
       // Merge touched keys via cond(g => vT, true => vE)
       const touched = new Set<string>([...sT.writtenKeys, ...sE.writtenKeys]);
+      let mergeOk = true;
       for (const key of touched) {
         const entryT = sT.writes.get(key);
         const entryE = sE.writes.get(key);
         // At least one branch wrote the key, so at least one entry exists.
-        const objExpr = (entryT ?? entryE)!.objExpr;
-        const prop = (entryT ?? entryE)!.prop;
-        const identity = ast.app(ast.var(prop), [objExpr]);
-        const vT = entryT?.value ?? identity;
-        const vE = entryE?.value ?? identity;
-        const merged = ast.cond([
-          [gExpr, vT],
-          [ast.litBool(true), vE],
-        ]);
-        putWrite(state, key, { prop, objExpr, value: merged });
+        const pick = (entryT ?? entryE)!;
+        if (entryT && entryE && entryT.kind !== entryE.kind) {
+          ok = false;
+          mergeOk = false;
+          propositions.push({
+            kind: "unsupported",
+            reason:
+              "branches wrote the same key with different kinds (property vs. map)",
+          });
+          break;
+        }
+        if (pick.kind === "property") {
+          const entryTP = entryT as PropertyWriteEntry | undefined;
+          const entryEP = entryE as PropertyWriteEntry | undefined;
+          const objExpr = pick.objExpr;
+          const prop = pick.prop;
+          const identity = ast.app(ast.var(prop), [objExpr]);
+          const vT = entryTP?.value ?? identity;
+          const vE = entryEP?.value ?? identity;
+          const merged = ast.cond([
+            [gExpr, vT],
+            [ast.litBool(true), vE],
+          ]);
+          putWrite(state, key, {
+            kind: "property",
+            prop,
+            objExpr,
+            value: merged,
+          });
+          addWrittenKey(state, key);
+          continue;
+        }
+        // Map: merge per-override-pair under gExpr. Identity fallbacks per
+        // side use the pre-state lookup at the override's (m, k) tuple.
+        const entryTM = entryT as MapRuleWriteEntry | undefined;
+        const entryEM = entryE as MapRuleWriteEntry | undefined;
+        const base = entryTM ?? entryEM!;
+        const ruleVar = ast.var(base.ruleName);
+        const keyVar = ast.var(base.keyPredName);
+        const valueFallback = (o: MapOverride): OpaqueExpr =>
+          ast.app(ruleVar, [o.objExpr, o.keyExpr]);
+        const memberFallback = (o: MapOverride): OpaqueExpr =>
+          ast.app(keyVar, [o.objExpr, o.keyExpr]);
+        const combineCond = (vA: OpaqueExpr, vB: OpaqueExpr): OpaqueExpr =>
+          ast.cond([
+            [gExpr, vA],
+            [ast.litBool(true), vB],
+          ]);
+        const mergedValue = mergeOverrides(
+          entryTM?.valueOverrides ?? [],
+          entryEM?.valueOverrides ?? [],
+          valueFallback,
+          combineCond,
+        );
+        const mergedMember = mergeOverrides(
+          entryTM?.membershipOverrides ?? [],
+          entryEM?.membershipOverrides ?? [],
+          memberFallback,
+          combineCond,
+        );
+        putWrite(state, key, {
+          kind: "map",
+          ruleName: base.ruleName,
+          keyPredName: base.keyPredName,
+          ownerType: base.ownerType,
+          keyType: base.keyType,
+          valueOverrides: mergedValue,
+          membershipOverrides: mergedMember,
+        });
         addWrittenKey(state, key);
+      }
+      if (!mergeOk) {
+        continue;
       }
       continue;
     }

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -348,40 +348,48 @@ function installMapWrite(
   const keyExpr = applyConst(effect.keyExpr);
   const keyTuple = ast.tuple([objExpr, keyExpr]);
 
-  let entry = state.writes.get(key) as MapRuleWriteEntry | undefined;
-  if (entry === undefined || entry.kind !== "map") {
-    entry = {
-      kind: "map",
-      ruleName: effect.ruleName,
-      keyPredName: effect.keyPredName,
-      ownerType: effect.ownerType,
-      keyType: effect.keyType,
-      valueOverrides: [],
-      membershipOverrides: [],
-    };
-    putWrite(state, key, entry);
-  }
+  // cloneSymbolicState only shallow-copies `writes`, so the MapRuleWriteEntry
+  // object is shared with sibling branches and the outer state. Copy the
+  // entry (including its arrays) before mutating so branch-local writes
+  // don't leak.
+  const prev = state.writes.get(key);
+  const entry: MapRuleWriteEntry =
+    prev !== undefined && prev.kind === "map"
+      ? {
+          ...prev,
+          valueOverrides: [...prev.valueOverrides],
+          membershipOverrides: [...prev.membershipOverrides],
+        }
+      : {
+          kind: "map",
+          ruleName: effect.ruleName,
+          keyPredName: effect.keyPredName,
+          ownerType: effect.ownerType,
+          keyType: effect.keyType,
+          valueOverrides: [],
+          membershipOverrides: [],
+        };
 
   if (effect.op === "set") {
     const valueExpr = applyConst(effect.valueExpr!);
-    entry.valueOverrides.push({ keyTuple, objExpr, keyExpr, value: valueExpr });
-    entry.membershipOverrides.push({
-      keyTuple,
-      objExpr,
-      keyExpr,
-      value: ast.litBool(true),
-    });
+    entry.valueOverrides = [
+      ...entry.valueOverrides,
+      { keyTuple, objExpr, keyExpr, value: valueExpr },
+    ];
+    entry.membershipOverrides = [
+      ...entry.membershipOverrides,
+      { keyTuple, objExpr, keyExpr, value: ast.litBool(true) },
+    ];
   } else {
     // delete: membership goes false; value rule need not be restated because
     // the declaration guard makes the value-rule body vacuous under false
     // membership.
-    entry.membershipOverrides.push({
-      keyTuple,
-      objExpr,
-      keyExpr,
-      value: ast.litBool(false),
-    });
+    entry.membershipOverrides = [
+      ...entry.membershipOverrides,
+      { keyTuple, objExpr, keyExpr, value: ast.litBool(false) },
+    ];
   }
+  putWrite(state, key, entry);
   addWrittenKey(state, key);
   state.modifiedProps.add(effect.ruleName);
   state.modifiedProps.add(effect.keyPredName);
@@ -1329,14 +1337,13 @@ export function translateBodyExpr(
   }
 
   // Call expression: handle .includes(), .filter().map(), etc.
+  // A Map.set/delete call returns a `{ effect }` BodyResult which only
+  // `symbolicExecute` consumes as a statement; in any expression context
+  // (ternary arm, binary operand, arg, etc.) turn it into `{ unsupported }`
+  // so downstream `bodyExpr()` calls see a narrow result and never throw.
   if (ts.isCallExpression(expr)) {
-    return translateCallExpr(
-      expr,
-      checker,
-      strategy,
-      paramNames,
-      state,
-      supply,
+    return rejectEffect(
+      translateCallExpr(expr, checker, strategy, paramNames, state, supply),
     );
   }
 
@@ -3041,7 +3048,13 @@ function symbolicExecute(
         }
         // Map: continuation-side overrides are taken only when NOT on the
         // early-exit arm. The early-exit fallback for each override (m, k)
-        // is the pre-state lookup.
+        // is the accumulated outer-state value if the outer state had a
+        // prior write there, else the pre-state lookup — so outer writes
+        // persist across the exit arm.
+        const priorMap =
+          prior !== undefined && prior.kind === "map"
+            ? (prior as MapRuleWriteEntry)
+            : undefined;
         const ruleVar = ast.var(entryR.ruleName);
         const keyVar = ast.var(entryR.keyPredName);
         const valueFallback = (o: MapOverride): OpaqueExpr =>
@@ -3063,13 +3076,13 @@ function symbolicExecute(
               ]);
         const mergedValue = mergeOverrides(
           entryR.valueOverrides,
-          [],
+          priorMap?.valueOverrides ?? [],
           valueFallback,
           combineContCond,
         );
         const mergedMember = mergeOverrides(
           entryR.membershipOverrides,
-          [],
+          priorMap?.membershipOverrides ?? [],
           memberFallback,
           combineContCond,
         );

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -2431,9 +2431,13 @@ function translateCallExpr(
         (methodName === "delete" && expr.arguments.length === 1)) &&
       isMapType(checker.getTypeAtLocation(tsReceiver))
     ) {
+      // Unwrap parens, non-null assertions, and type-only wrappers so
+      // `(cache.entries).set(...)` and `cache.entries!.set(...)` reach the
+      // same Stage A detection as the bare `cache.entries.set(...)` form.
+      const normalizedReceiver = unwrapExpression(tsReceiver);
       const stageA =
-        ts.isPropertyAccessExpression(tsReceiver) &&
-        isInterfaceFieldAccess(tsReceiver, checker);
+        ts.isPropertyAccessExpression(normalizedReceiver) &&
+        isInterfaceFieldAccess(normalizedReceiver, checker);
 
       const keyArg = expr.arguments[0]!;
       const kExprRaw = translateBodyExpr(
@@ -2466,9 +2470,9 @@ function translateCallExpr(
         valueExpr = bodyExpr(vExpr);
       }
 
-      if (stageA && ts.isPropertyAccessExpression(tsReceiver)) {
-        const fieldName = tsReceiver.name.text;
-        const innerObj = tsReceiver.expression;
+      if (stageA && ts.isPropertyAccessExpression(normalizedReceiver)) {
+        const fieldName = normalizedReceiver.name.text;
+        const innerObj = normalizedReceiver.expression;
         const objRaw = translateBodyExpr(
           innerObj,
           checker,
@@ -2488,7 +2492,7 @@ function translateCallExpr(
           supply.synthCell,
         );
         const typeArgs = checker.getTypeArguments(
-          checker.getTypeAtLocation(tsReceiver) as ts.TypeReference,
+          checker.getTypeAtLocation(normalizedReceiver) as ts.TypeReference,
         );
         if (typeArgs.length !== 2) {
           return { unsupported: "Map with unexpected arity" };
@@ -2585,13 +2589,16 @@ function translateCallExpr(
       expr.arguments.length === 1 &&
       isMapType(checker.getTypeAtLocation(tsReceiver))
     ) {
+      // Match the .set/.delete branch: unwrap so wrapped field receivers
+      // (`(cache.entries).get(k)`, `cache.entries!.has(k)`) stay on Stage A.
+      const normalizedReceiver = unwrapExpression(tsReceiver);
       const stageA =
-        ts.isPropertyAccessExpression(tsReceiver) &&
-        isInterfaceFieldAccess(tsReceiver, checker);
+        ts.isPropertyAccessExpression(normalizedReceiver) &&
+        isInterfaceFieldAccess(normalizedReceiver, checker);
 
-      if (stageA && ts.isPropertyAccessExpression(tsReceiver)) {
-        const fieldName = tsReceiver.name.text;
-        const innerObj = tsReceiver.expression;
+      if (stageA && ts.isPropertyAccessExpression(normalizedReceiver)) {
+        const fieldName = normalizedReceiver.name.text;
+        const innerObj = normalizedReceiver.expression;
         const kExpr = translateBodyExpr(
           expr.arguments[0]!,
           checker,
@@ -2615,7 +2622,7 @@ function translateCallExpr(
           return objExpr;
         }
         const typeArgs = checker.getTypeArguments(
-          checker.getTypeAtLocation(tsReceiver) as ts.TypeReference,
+          checker.getTypeAtLocation(normalizedReceiver) as ts.TypeReference,
         );
         if (typeArgs.length !== 2) {
           return { unsupported: "Map with unexpected arity" };

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -420,6 +420,14 @@ function installMapWrite(
  * at the override key the override fires, everywhere else it falls through
  * to the pre-state rule application. Without a staged entry, returns the
  * plain pre-state rule application.
+ *
+ * `.get` respects staged `.delete`s: a value override whose tuple has a
+ * literal `false` as its latest membership claim is dropped from the read,
+ * so `m.set(k, v); m.delete(k); m.get(k)` falls through to the pre-state
+ * rule rather than returning `v`. Pantagruel's declaration guard handles
+ * this at emission time (vacuous value under false membership — Dafny-style
+ * partial function), but an inline override application has no such guard,
+ * so the filter is explicit at the read site.
  */
 function readMapThroughWrites(
   state: SymbolicState | undefined,
@@ -452,8 +460,7 @@ function readMapThroughWrites(
   if (entry === undefined || entry.kind !== "map") {
     return baseRead;
   }
-  const overrides =
-    methodName === "has" ? entry.membershipOverrides : entry.valueOverrides;
+  const overrides = readOverridesFor(entry, methodName);
   if (overrides.length === 0) {
     return baseRead;
   }
@@ -463,6 +470,33 @@ function readMapThroughWrites(
       overrides.map((o) => [o.keyTuple, o.value] as [OpaqueExpr, OpaqueExpr]),
     ),
     [canonObj, canonKey],
+  );
+}
+
+/**
+ * Pick the override list to use for an inline `.get`/`.has` read. `.has`
+ * uses the raw membership list. `.get` drops value overrides whose tuple
+ * has a literal `false` latest membership — a staged `.delete` supersedes
+ * any earlier staged `.set` at that tuple. Conditional membership (e.g.
+ * `cond g => false, true => true` after a branch-merged `.delete`) is not
+ * filtered; only literal `false` is detected here.
+ */
+function readOverridesFor(
+  entry: MapRuleWriteEntry,
+  methodName: "get" | "has",
+): MapOverride[] {
+  if (methodName === "has") {
+    return [...entry.membershipOverrides];
+  }
+  const ast = getAst();
+  const canonical = (t: OpaqueExpr) => ast.strExpr(t);
+  const falseText = ast.strExpr(ast.litBool(false));
+  const latestMembership = new Map<string, string>();
+  for (const m of entry.membershipOverrides) {
+    latestMembership.set(canonical(m.keyTuple), ast.strExpr(m.value));
+  }
+  return entry.valueOverrides.filter(
+    (o) => latestMembership.get(canonical(o.keyTuple)) !== falseText,
   );
 }
 

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -279,13 +279,23 @@ function symbolicKey(prop: string, objExpr: OpaqueExpr): string {
 }
 
 /**
- * State-map key for Map writes. All writes to the same rule coalesce into
- * one MapRuleWriteEntry so multiple `.set` calls on one receiver accumulate
- * as distinct `(tuple |-> value)` override pairs rather than separate
- * entries (the emission collapses them into one override expression).
+ * State-map key for Map writes. Writes coalesce into one MapRuleWriteEntry
+ * so multiple `.set`/`.delete` calls to the same rule accumulate as distinct
+ * `(tuple |-> value)` override pairs (collapsed into one override expression
+ * at emission). Keying by just `ruleName` is too coarse for Stage A, where
+ * two different interfaces can share a field name (e.g., `A.cache` and
+ * `B.cache`) — emission quantifies one `ownerType`/`keyType` per entry, so
+ * crossed-field writes would be emitted against the first writer's types.
+ * Include the full rule identity (rule, key predicate, owner, key) so only
+ * writes that share a target rule coalesce.
  */
-function mapWriteKey(ruleName: string): string {
-  return `map::${ruleName}`;
+function mapWriteKey(
+  ruleName: string,
+  keyPredName: string,
+  ownerType: string,
+  keyType: string,
+): string {
+  return `map::${ruleName}::${keyPredName}::${ownerType}::${keyType}`;
 }
 
 /**
@@ -343,7 +353,12 @@ function installMapWrite(
   applyConst: (e: OpaqueExpr) => OpaqueExpr,
 ): void {
   const ast = getAst();
-  const key = mapWriteKey(effect.ruleName);
+  const key = mapWriteKey(
+    effect.ruleName,
+    effect.keyPredName,
+    effect.ownerType,
+    effect.keyType,
+  );
   const objExpr = applyConst(effect.objExpr);
   const keyExpr = applyConst(effect.keyExpr);
   const keyTuple = ast.tuple([objExpr, keyExpr]);
@@ -393,6 +408,62 @@ function installMapWrite(
   addWrittenKey(state, key);
   state.modifiedProps.add(effect.ruleName);
   state.modifiedProps.add(effect.keyPredName);
+}
+
+/**
+ * Build a `.get`/`.has` read expression that threads staged writes. When a
+ * prior `.set`/`.delete` on the same rule has been installed in the symbolic
+ * state, the returned read applies Pantagruel's N-ary override inline —
+ * `R[(m, k) |-> v](obj, key)` — so a `.set(k, v)` followed by `.get(k)` or
+ * `.has(k)` in the same body observes the just-written value. The ite
+ * expansion matches McCarthy's select/store (Kroening & Strichman Ch. 7):
+ * at the override key the override fires, everywhere else it falls through
+ * to the pre-state rule application. Without a staged entry, returns the
+ * plain pre-state rule application.
+ */
+function readMapThroughWrites(
+  state: SymbolicState | undefined,
+  methodName: "get" | "has",
+  ruleName: string,
+  keyPredName: string,
+  ownerType: string,
+  keyType: string,
+  objExpr: OpaqueExpr,
+  keyExpr: OpaqueExpr,
+): OpaqueExpr {
+  const ast = getAst();
+  const appliedRule = methodName === "has" ? keyPredName : ruleName;
+  if (state === undefined) {
+    return ast.app(ast.var(appliedRule), [objExpr, keyExpr]);
+  }
+  // Apply the ambient const-binding substitution so the read's receiver/key
+  // normalize to the same form the write site stored (installMapWrite passes
+  // its tuple components through applyConst). Otherwise a `const x = a;
+  // x.cache.set(k, v); x.cache.get(k)` would have `(a, k) |-> v` on the
+  // write and `(x, k)` on the read, and the ite in the override expansion
+  // wouldn't fire because the const alias has been inlined away and the SMT
+  // engine has no remaining equality to recover.
+  const canonObj = state.canonicalize(objExpr);
+  const canonKey = state.canonicalize(keyExpr);
+  const entry = state.writes.get(
+    mapWriteKey(ruleName, keyPredName, ownerType, keyType),
+  );
+  const baseRead = ast.app(ast.var(appliedRule), [canonObj, canonKey]);
+  if (entry === undefined || entry.kind !== "map") {
+    return baseRead;
+  }
+  const overrides =
+    methodName === "has" ? entry.membershipOverrides : entry.valueOverrides;
+  if (overrides.length === 0) {
+    return baseRead;
+  }
+  return ast.app(
+    ast.override(
+      appliedRule,
+      overrides.map((o) => [o.keyTuple, o.value] as [OpaqueExpr, OpaqueExpr]),
+    ),
+    [canonObj, canonKey],
+  );
 }
 
 /**
@@ -2497,12 +2568,35 @@ function translateCallExpr(
         if (isBodyUnsupported(objExpr)) {
           return objExpr;
         }
-        const ruleName = methodName === "has" ? `${fieldName}Key` : fieldName;
+        const typeArgs = checker.getTypeArguments(
+          checker.getTypeAtLocation(tsReceiver) as ts.TypeReference,
+        );
+        if (typeArgs.length !== 2) {
+          return { unsupported: "Map with unexpected arity" };
+        }
+        const ownerType = mapTsType(
+          checker.getTypeAtLocation(innerObj),
+          checker,
+          strategy,
+          supply.synthCell,
+        );
+        const keyType = mapTsType(
+          typeArgs[0]!,
+          checker,
+          strategy,
+          supply.synthCell,
+        );
         return {
-          expr: ast.app(ast.var(ruleName), [
+          expr: readMapThroughWrites(
+            state,
+            methodName as "get" | "has",
+            fieldName,
+            `${fieldName}Key`,
+            ownerType,
+            keyType,
             bodyExpr(objExpr),
             bodyExpr(kExpr),
-          ]),
+          ),
         };
       }
 
@@ -2568,10 +2662,17 @@ function translateCallExpr(
       if (isBodyUnsupported(kExpr)) {
         return kExpr;
       }
-      const ruleName =
-        methodName === "has" ? info.names.keyPred : info.names.rule;
       return {
-        expr: ast.app(ast.var(ruleName), [bodyExpr(objExpr), bodyExpr(kExpr)]),
+        expr: readMapThroughWrites(
+          state,
+          methodName as "get" | "has",
+          info.names.rule,
+          info.names.keyPred,
+          info.names.domain,
+          kType,
+          bodyExpr(objExpr),
+          bodyExpr(kExpr),
+        ),
       };
     }
 

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -362,6 +362,9 @@ function installMapWrite(
   const objExpr = applyConst(effect.objExpr);
   const keyExpr = applyConst(effect.keyExpr);
   const keyTuple = ast.tuple([objExpr, keyExpr]);
+  const tupleKeyText = ast.strExpr(keyTuple);
+  const isSameTuple = (o: MapOverride) =>
+    ast.strExpr(o.keyTuple) === tupleKeyText;
 
   // cloneSymbolicState only shallow-copies `writes`, so the MapRuleWriteEntry
   // object is shared with sibling branches and the outer state. Copy the
@@ -384,6 +387,15 @@ function installMapWrite(
           valueOverrides: [],
           membershipOverrides: [],
         };
+
+  // Pantagruel override semantics are first-pair-wins, but for a sequence
+  // `m.set(k, 1); m.set(k, 2)` inside one path the later write must win.
+  // Drop any prior override for the same (obj, key) tuple on both sides
+  // before appending the new one.
+  entry.valueOverrides = entry.valueOverrides.filter((o) => !isSameTuple(o));
+  entry.membershipOverrides = entry.membershipOverrides.filter(
+    (o) => !isSameTuple(o),
+  );
 
   if (effect.op === "set") {
     const valueExpr = applyConst(effect.valueExpr!);
@@ -3309,6 +3321,28 @@ function symbolicExecute(
       );
       if (isBodyEffect(callResult)) {
         installMapWrite(state, callResult.effect, applyConst);
+        continue;
+      }
+      // If the call *looks like* a Map.set/Map.delete (right method name,
+      // arity, and receiver type) but translateCallExpr returned an
+      // unsupported marker, propagate the specific reason rather than
+      // falling through to the generic "side-effectful expression" error.
+      // Other unsupported results (non-Map calls the EUF encoder rejected
+      // because of an arrow-function argument, etc.) still fall through so
+      // the forEach handler below gets its chance.
+      if (
+        isBodyUnsupported(callResult) &&
+        ts.isPropertyAccessExpression(call.expression) &&
+        ((call.expression.name.text === "set" && call.arguments.length === 2) ||
+          (call.expression.name.text === "delete" &&
+            call.arguments.length === 1)) &&
+        isMapType(checker.getTypeAtLocation(call.expression.expression))
+      ) {
+        ok = false;
+        propositions.push({
+          kind: "unsupported",
+          reason: callResult.unsupported,
+        });
         continue;
       }
       // Otherwise fall through to forEach / side-effect handling below.

--- a/tools/ts2pant/src/translate-signature.ts
+++ b/tools/ts2pant/src/translate-signature.ts
@@ -5,6 +5,7 @@ import { getAst } from "./pant-wasm.js";
 import {
   cellIsUsed,
   cellRegisterName,
+  isMapType,
   type MapSynthCell,
   mapTsType,
   type NumericStrategy,
@@ -77,7 +78,8 @@ export function findFunction(
 
 /**
  * Classify a function as pure or mutating.
- * Mutating: void return type or has property assignments in body.
+ * Mutating: void return type or has mutations in body (property assignments,
+ * or `.set`/`.delete` calls on a Map receiver).
  * Pure: everything else.
  */
 export function classifyFunction(
@@ -94,14 +96,14 @@ export function classifyFunction(
     return "mutating";
   }
 
-  if (node.body && hasPropertyAssignment(node.body)) {
+  if (node.body && hasMutation(node.body, checker)) {
     return "mutating";
   }
 
   return "pure";
 }
 
-function hasPropertyAssignment(node: ts.Node): boolean {
+function hasMutation(node: ts.Node, checker: ts.TypeChecker): boolean {
   let found = false;
   function visit(n: ts.Node) {
     if (found) {
@@ -118,6 +120,17 @@ function hasPropertyAssignment(node: ts.Node): boolean {
       ts.isBinaryExpression(n) &&
       n.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
       ts.isPropertyAccessExpression(n.left)
+    ) {
+      found = true;
+      return;
+    }
+    // `.set(k, v)` or `.delete(k)` on a Map-typed receiver is a mutation.
+    if (
+      ts.isCallExpression(n) &&
+      ts.isPropertyAccessExpression(n.expression) &&
+      (n.expression.name.text === "set" ||
+        n.expression.name.text === "delete") &&
+      isMapType(checker.getTypeAtLocation(n.expression.expression))
     ) {
       found = true;
       return;

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -230,6 +230,10 @@ exports[`expressions-map-mutation.ts > bump 1`] = `
 "module Bump.\\n\\nStringToIntMap.\\nstringToIntMapKey m: StringToIntMap, k1: String => Bool.\\nstringToIntMap m: StringToIntMap, k1: String, stringToIntMapKey m k1 => Int.\\n~> Bump @ counts: StringToIntMap, k: String.\\n\\n---\\n\\nall m1: StringToIntMap, k2: String | stringToIntMap' m1 k2 = stringToIntMap[(counts, k) |-> stringToIntMap counts k + 1] m1 k2.\\nall m2: StringToIntMap, k3: String | stringToIntMapKey' m2 k3 = stringToIntMapKey[(counts, k) |-> true] m2 k3.\\n"
 `;
 
+exports[`expressions-map-mutation.ts > deleteThenCopy 1`] = `
+"module DeleteThenCopy.\\n\\nStringToIntMap.\\nstringToIntMapKey m1: StringToIntMap, k: String => Bool.\\nstringToIntMap m1: StringToIntMap, k: String, stringToIntMapKey m1 k => Int.\\n~> DeleteThenCopy @ m: StringToIntMap, kA: String, kB: String, v: Int.\\n\\n---\\n\\nall m2: StringToIntMap, k1: String | stringToIntMap' m2 k1 = stringToIntMap[(m, kA) |-> v, (m, kB) |-> stringToIntMap m kA] m2 k1.\\nall m3: StringToIntMap, k2: String | stringToIntMapKey' m3 k2 = stringToIntMapKey[(m, kA) |-> true, (m, kA) |-> false, (m, kB) |-> true] m3 k2.\\n"
+`;
+
 exports[`expressions-map-mutation.ts > put 1`] = `
 "module Put.\\n\\nStringToIntMap.\\nstringToIntMapKey m1: StringToIntMap, k1: String => Bool.\\nstringToIntMap m1: StringToIntMap, k1: String, stringToIntMapKey m1 k1 => Int.\\n~> Put @ m: StringToIntMap, k: String, v: Int.\\n\\n---\\n\\nall m2: StringToIntMap, k2: String | stringToIntMap' m2 k2 = stringToIntMap[(m, k) |-> v] m2 k2.\\nall m3: StringToIntMap, k3: String | stringToIntMapKey' m3 k3 = stringToIntMapKey[(m, k) |-> true] m3 k3.\\n"
 `;

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -222,8 +222,16 @@ exports[`expressions-map-mutation-field.ts > cacheEvict 1`] = `
 "module CacheEvict.\\n\\nCache.\\nentriesKey c1: Cache, k1: String => Bool.\\nentries c1: Cache, k1: String, entriesKey c1 k1 => Int.\\n~> CacheEvict @ c: Cache, k: String.\\n\\n---\\n\\nall m: Cache, k2: String | entriesKey' m k2 = entriesKey[(c, k) |-> false] m k2.\\n"
 `;
 
+exports[`expressions-map-mutation-field.ts > cacheEvictParen 1`] = `
+"module CacheEvictParen.\\n\\nCache.\\nentriesKey c1: Cache, k1: String => Bool.\\nentries c1: Cache, k1: String, entriesKey c1 k1 => Int.\\n~> CacheEvictParen @ c: Cache, k: String.\\n\\n---\\n\\nall m: Cache, k2: String | entriesKey' m k2 = entriesKey[(c, k) |-> false] m k2.\\n"
+`;
+
 exports[`expressions-map-mutation-field.ts > cachePut 1`] = `
 "module CachePut.\\n\\nCache.\\nentriesKey c1: Cache, k1: String => Bool.\\nentries c1: Cache, k1: String, entriesKey c1 k1 => Int.\\n~> CachePut @ c: Cache, k: String, v: Int.\\n\\n---\\n\\nall m: Cache, k2: String | entries' m k2 = entries[(c, k) |-> v] m k2.\\nall m1: Cache, k3: String | entriesKey' m1 k3 = entriesKey[(c, k) |-> true] m1 k3.\\n"
+`;
+
+exports[`expressions-map-mutation-field.ts > cachePutNonNull 1`] = `
+"module CachePutNonNull.\\n\\nCache.\\nentriesKey c1: Cache, k1: String => Bool.\\nentries c1: Cache, k1: String, entriesKey c1 k1 => Int.\\n~> CachePutNonNull @ c: Cache, k: String, v: Int.\\n\\n---\\n\\nall m: Cache, k2: String | entries' m k2 = entries[(c, k) |-> v] m k2.\\nall m1: Cache, k3: String | entriesKey' m1 k3 = entriesKey[(c, k) |-> true] m1 k3.\\n"
 `;
 
 exports[`expressions-map-mutation.ts > bump 1`] = `
@@ -300,6 +308,10 @@ exports[`expressions-map.ts > contains 1`] = `
 
 exports[`expressions-map.ts > lookup 1`] = `
 "module Lookup.\\n\\nCache.\\nentriesKey c1: Cache, k1: String => Bool.\\nentries c1: Cache, k1: String, entriesKey c1 k1 => Int.\\nlookup c: Cache, k: String => Int.\\n\\n---\\n\\nlookup c k = entries c k.\\n"
+`;
+
+exports[`expressions-map.ts > lookupNonNull 1`] = `
+"module LookupNonNull.\\n\\nCache.\\nentriesKey c1: Cache, k1: String => Bool.\\nentries c1: Cache, k1: String, entriesKey c1 k1 => Int.\\nlookupNonNull c: Cache, k: String => Int.\\n\\n---\\n\\nlookupNonNull c k = entries c k.\\n"
 `;
 
 exports[`expressions-misc.ts > asNumber 1`] = `

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -218,6 +218,34 @@ exports[`expressions-literals.ts > yes 1`] = `
 "module Yes.\\n\\nyes  => Bool.\\n\\n---\\n\\nyes = true.\\n"
 `;
 
+exports[`expressions-map-mutation-field.ts > cacheEvict 1`] = `
+"module CacheEvict.\\n\\nCache.\\nentriesKey c1: Cache, k1: String => Bool.\\nentries c1: Cache, k1: String, entriesKey c1 k1 => Int.\\n~> CacheEvict @ c: Cache, k: String.\\n\\n---\\n\\nall m: Cache, k2: String | entriesKey' m k2 = entriesKey[(c, k) |-> false] m k2.\\n"
+`;
+
+exports[`expressions-map-mutation-field.ts > cachePut 1`] = `
+"module CachePut.\\n\\nCache.\\nentriesKey c1: Cache, k1: String => Bool.\\nentries c1: Cache, k1: String, entriesKey c1 k1 => Int.\\n~> CachePut @ c: Cache, k: String, v: Int.\\n\\n---\\n\\nall m: Cache, k2: String | entries' m k2 = entries[(c, k) |-> v] m k2.\\nall m1: Cache, k3: String | entriesKey' m1 k3 = entriesKey[(c, k) |-> true] m1 k3.\\n"
+`;
+
+exports[`expressions-map-mutation.ts > bump 1`] = `
+"module Bump.\\n\\nStringToIntMap.\\nstringToIntMapKey m: StringToIntMap, k1: String => Bool.\\nstringToIntMap m: StringToIntMap, k1: String, stringToIntMapKey m k1 => Int.\\n~> Bump @ counts: StringToIntMap, k: String.\\n\\n---\\n\\nall m1: StringToIntMap, k2: String | stringToIntMap' m1 k2 = stringToIntMap[(counts, k) |-> stringToIntMap counts k + 1] m1 k2.\\nall m2: StringToIntMap, k3: String | stringToIntMapKey' m2 k3 = stringToIntMapKey[(counts, k) |-> true] m2 k3.\\n"
+`;
+
+exports[`expressions-map-mutation.ts > put 1`] = `
+"module Put.\\n\\nStringToIntMap.\\nstringToIntMapKey m1: StringToIntMap, k1: String => Bool.\\nstringToIntMap m1: StringToIntMap, k1: String, stringToIntMapKey m1 k1 => Int.\\n~> Put @ m: StringToIntMap, k: String, v: Int.\\n\\n---\\n\\nall m2: StringToIntMap, k2: String | stringToIntMap' m2 k2 = stringToIntMap[(m, k) |-> v] m2 k2.\\nall m3: StringToIntMap, k3: String | stringToIntMapKey' m3 k3 = stringToIntMapKey[(m, k) |-> true] m3 k3.\\n"
+`;
+
+exports[`expressions-map-mutation.ts > putIfAbsent 1`] = `
+"module PutIfAbsent.\\n\\nStringToIntMap.\\nstringToIntMapKey m1: StringToIntMap, k1: String => Bool.\\nstringToIntMap m1: StringToIntMap, k1: String, stringToIntMapKey m1 k1 => Int.\\n~> PutIfAbsent @ m: StringToIntMap, k: String, v: Int.\\n\\n---\\n\\nall m2: StringToIntMap, k2: String | stringToIntMap' m2 k2 = stringToIntMap[(m, k) |-> cond ~(stringToIntMapKey m k) => v, true => stringToIntMap m k] m2 k2.\\nall m3: StringToIntMap, k3: String | stringToIntMapKey' m3 k3 = stringToIntMapKey[(m, k) |-> cond ~(stringToIntMapKey m k) => true, true => stringToIntMapKey m k] m3 k3.\\n"
+`;
+
+exports[`expressions-map-mutation.ts > putPair 1`] = `
+"module PutPair.\\n\\nStringToIntMap.\\nstringToIntMapKey m1: StringToIntMap, k: String => Bool.\\nstringToIntMap m1: StringToIntMap, k: String, stringToIntMapKey m1 k => Int.\\n~> PutPair @ m: StringToIntMap, k1: String, v1: Int, k2: String, v2: Int.\\n\\n---\\n\\nall m2: StringToIntMap, k3: String | stringToIntMap' m2 k3 = stringToIntMap[(m, k1) |-> v1, (m, k2) |-> v2] m2 k3.\\nall m3: StringToIntMap, k4: String | stringToIntMapKey' m3 k4 = stringToIntMapKey[(m, k1) |-> true, (m, k2) |-> true] m3 k4.\\n"
+`;
+
+exports[`expressions-map-mutation.ts > remove 1`] = `
+"module Remove.\\n\\nStringToIntMap.\\nstringToIntMapKey m1: StringToIntMap, k1: String => Bool.\\nstringToIntMap m1: StringToIntMap, k1: String, stringToIntMapKey m1 k1 => Int.\\n~> Remove @ m: StringToIntMap, k: String.\\n\\n---\\n\\nall m2: StringToIntMap, k2: String | stringToIntMapKey' m2 k2 = stringToIntMapKey[(m, k) |-> false] m2 k2.\\n"
+`;
+
 exports[`expressions-map-params.ts > contains 1`] = `
 "module Contains.\\n\\nStringToIntMap.\\nstringToIntMapKey m1: StringToIntMap, k1: String => Bool.\\nstringToIntMap m1: StringToIntMap, k1: String, stringToIntMapKey m1 k1 => Int.\\ncontains m: StringToIntMap, k: String => Bool.\\n\\n---\\n\\ncontains m k = stringToIntMapKey m k.\\n"
 `;

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -231,7 +231,7 @@ exports[`expressions-map-mutation.ts > bump 1`] = `
 `;
 
 exports[`expressions-map-mutation.ts > deleteThenCopy 1`] = `
-"module DeleteThenCopy.\\n\\nStringToIntMap.\\nstringToIntMapKey m1: StringToIntMap, k: String => Bool.\\nstringToIntMap m1: StringToIntMap, k: String, stringToIntMapKey m1 k => Int.\\n~> DeleteThenCopy @ m: StringToIntMap, kA: String, kB: String, v: Int.\\n\\n---\\n\\nall m2: StringToIntMap, k1: String | stringToIntMap' m2 k1 = stringToIntMap[(m, kA) |-> v, (m, kB) |-> stringToIntMap m kA] m2 k1.\\nall m3: StringToIntMap, k2: String | stringToIntMapKey' m3 k2 = stringToIntMapKey[(m, kA) |-> true, (m, kA) |-> false, (m, kB) |-> true] m3 k2.\\n"
+"module DeleteThenCopy.\\n\\nStringToIntMap.\\nstringToIntMapKey m1: StringToIntMap, k: String => Bool.\\nstringToIntMap m1: StringToIntMap, k: String, stringToIntMapKey m1 k => Int.\\n~> DeleteThenCopy @ m: StringToIntMap, kA: String, kB: String, v: Int.\\n\\n---\\n\\nall m2: StringToIntMap, k1: String | stringToIntMap' m2 k1 = stringToIntMap[(m, kB) |-> stringToIntMap m kA] m2 k1.\\nall m3: StringToIntMap, k2: String | stringToIntMapKey' m3 k2 = stringToIntMapKey[(m, kA) |-> false, (m, kB) |-> true] m3 k2.\\n"
 `;
 
 exports[`expressions-map-mutation.ts > put 1`] = `
@@ -252,6 +252,14 @@ exports[`expressions-map-mutation.ts > remove 1`] = `
 
 exports[`expressions-map-mutation.ts > setAndCopy 1`] = `
 "module SetAndCopy.\\n\\nStringToIntMap.\\nstringToIntMapKey m1: StringToIntMap, k: String => Bool.\\nstringToIntMap m1: StringToIntMap, k: String, stringToIntMapKey m1 k => Int.\\n~> SetAndCopy @ m: StringToIntMap, kSrc: String, kDst: String, v: Int.\\n\\n---\\n\\nall m2: StringToIntMap, k1: String | stringToIntMap' m2 k1 = stringToIntMap[(m, kSrc) |-> v, (m, kDst) |-> stringToIntMap[(m, kSrc) |-> v] m kSrc] m2 k1.\\nall m3: StringToIntMap, k2: String | stringToIntMapKey' m3 k2 = stringToIntMapKey[(m, kSrc) |-> true, (m, kDst) |-> true] m3 k2.\\n"
+`;
+
+exports[`expressions-map-mutation.ts > setThenDelete 1`] = `
+"module SetThenDelete.\\n\\nStringToIntMap.\\nstringToIntMapKey m1: StringToIntMap, k1: String => Bool.\\nstringToIntMap m1: StringToIntMap, k1: String, stringToIntMapKey m1 k1 => Int.\\n~> SetThenDelete @ m: StringToIntMap, k: String, v: Int.\\n\\n---\\n\\nall m2: StringToIntMap, k2: String | stringToIntMapKey' m2 k2 = stringToIntMapKey[(m, k) |-> false] m2 k2.\\n"
+`;
+
+exports[`expressions-map-mutation.ts > setTwice 1`] = `
+"module SetTwice.\\n\\nStringToIntMap.\\nstringToIntMapKey m1: StringToIntMap, k1: String => Bool.\\nstringToIntMap m1: StringToIntMap, k1: String, stringToIntMapKey m1 k1 => Int.\\n~> SetTwice @ m: StringToIntMap, k: String, v1: Int, v2: Int.\\n\\n---\\n\\nall m2: StringToIntMap, k2: String | stringToIntMap' m2 k2 = stringToIntMap[(m, k) |-> v2] m2 k2.\\nall m3: StringToIntMap, k3: String | stringToIntMapKey' m3 k3 = stringToIntMapKey[(m, k) |-> true] m3 k3.\\n"
 `;
 
 exports[`expressions-map-params.ts > contains 1`] = `

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -246,6 +246,10 @@ exports[`expressions-map-mutation.ts > remove 1`] = `
 "module Remove.\\n\\nStringToIntMap.\\nstringToIntMapKey m1: StringToIntMap, k1: String => Bool.\\nstringToIntMap m1: StringToIntMap, k1: String, stringToIntMapKey m1 k1 => Int.\\n~> Remove @ m: StringToIntMap, k: String.\\n\\n---\\n\\nall m2: StringToIntMap, k2: String | stringToIntMapKey' m2 k2 = stringToIntMapKey[(m, k) |-> false] m2 k2.\\n"
 `;
 
+exports[`expressions-map-mutation.ts > setAndCopy 1`] = `
+"module SetAndCopy.\\n\\nStringToIntMap.\\nstringToIntMapKey m1: StringToIntMap, k: String => Bool.\\nstringToIntMap m1: StringToIntMap, k: String, stringToIntMapKey m1 k => Int.\\n~> SetAndCopy @ m: StringToIntMap, kSrc: String, kDst: String, v: Int.\\n\\n---\\n\\nall m2: StringToIntMap, k1: String | stringToIntMap' m2 k1 = stringToIntMap[(m, kSrc) |-> v, (m, kDst) |-> stringToIntMap[(m, kSrc) |-> v] m kSrc] m2 k1.\\nall m3: StringToIntMap, k2: String | stringToIntMapKey' m3 k2 = stringToIntMapKey[(m, kSrc) |-> true, (m, kDst) |-> true] m3 k2.\\n"
+`;
+
 exports[`expressions-map-params.ts > contains 1`] = `
 "module Contains.\\n\\nStringToIntMap.\\nstringToIntMapKey m1: StringToIntMap, k1: String => Bool.\\nstringToIntMap m1: StringToIntMap, k1: String, stringToIntMapKey m1 k1 => Int.\\ncontains m: StringToIntMap, k: String => Bool.\\n\\n---\\n\\ncontains m k = stringToIntMapKey m k.\\n"
 `;

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-map-mutation-field.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-map-mutation-field.ts
@@ -1,0 +1,16 @@
+// Stage A: .set / .delete on an interface-field Map. Owner is the
+// user's interface, rule name is the field name (and `${field}Key`
+// for the membership predicate). Same override-based encoding as
+// Stage B. See CLAUDE.md § Partial Rules / Mutation.
+
+interface Cache {
+  entries: Map<string, number>;
+}
+
+export function cachePut(c: Cache, k: string, v: number): void {
+  c.entries.set(k, v);
+}
+
+export function cacheEvict(c: Cache, k: string): void {
+  c.entries.delete(k);
+}

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-map-mutation-field.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-map-mutation-field.ts
@@ -14,3 +14,23 @@ export function cachePut(c: Cache, k: string, v: number): void {
 export function cacheEvict(c: Cache, k: string): void {
   c.entries.delete(k);
 }
+
+/**
+ * Non-null-asserted field receiver — `c.entries!` is a NonNullExpression
+ * wrapping the PropertyAccessExpression. Stage A detection must unwrap
+ * before checking `isPropertyAccessExpression` / `isInterfaceFieldAccess`,
+ * otherwise the write falls into Stage B and synthesizes a separate
+ * StringToIntMap sort instead of using the declared `entries` rule.
+ */
+export function cachePutNonNull(c: Cache, k: string, v: number): void {
+  c.entries!.set(k, v);
+}
+
+/**
+ * Parenthesized field receiver — `(c.entries)` is a ParenthesizedExpression
+ * wrapping the PropertyAccessExpression. Same unwrapping requirement as the
+ * non-null case.
+ */
+export function cacheEvictParen(c: Cache, k: string): void {
+  (c.entries).delete(k);
+}

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-map-mutation.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-map-mutation.ts
@@ -1,0 +1,55 @@
+// Stage C: Map<K, V> mutation via Pantagruel's N-ary override.
+// .set(k, v) and .delete(k) on a Map parameter emit one override pair
+// per modified rule (value rule + membership predicate), quantified
+// over (m, k) with frame semantics implicit in the override's ite
+// expansion. See CLAUDE.md § Partial Rules / Mutation.
+
+/** Single .set, unconditional. */
+export function put(m: Map<string, number>, k: string, v: number): void {
+  m.set(k, v);
+}
+
+/** Single .delete, unconditional. */
+export function remove(m: Map<string, number>, k: string): void {
+  m.delete(k);
+}
+
+/**
+ * Counter bump — .set reading the prior value through the guarded rule.
+ * `.get(k)!` asserts membership; Pantagruel's declaration guard on
+ * `stringToIntMap` means uses of the value are implicitly conditioned on
+ * `stringToIntMapKey counts k`.
+ */
+export function bump(counts: Map<string, number>, k: string): void {
+  counts.set(k, counts.get(k)! + 1);
+}
+
+/**
+ * Conditional .set — exercises if-merge over map writes. The else-branch
+ * has no mutation, so per-key fallback for value is `stringToIntMap m k`
+ * and for membership is `stringToIntMapKey m k`.
+ */
+export function putIfAbsent(
+  m: Map<string, number>,
+  k: string,
+  v: number,
+): void {
+  if (!m.has(k)) {
+    m.set(k, v);
+  }
+}
+
+/**
+ * Two writes to the same map — overrides accumulate as two pairs in one
+ * override expression per modified rule.
+ */
+export function putPair(
+  m: Map<string, number>,
+  k1: string,
+  v1: number,
+  k2: string,
+  v2: number,
+): void {
+  m.set(k1, v1);
+  m.set(k2, v2);
+}

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-map-mutation.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-map-mutation.ts
@@ -90,3 +90,34 @@ export function deleteThenCopy(
   m.delete(kA);
   m.set(kB, m.get(kA)!);
 }
+
+/**
+ * Repeated writes to the same key — the later write must win. Pantagruel
+ * override expansion is first-pair-wins, so `installMapWrite` must drop
+ * the prior `(m, k) |-> v1` pair when `(m, k) |-> v2` is appended; the
+ * emitted override contains only the last write at `(m, k)`.
+ */
+export function setTwice(
+  m: Map<string, number>,
+  k: string,
+  v1: number,
+  v2: number,
+): void {
+  m.set(k, v1);
+  m.set(k, v2);
+}
+
+/**
+ * Set then delete on the same key — membership must end up `false` after
+ * the delete (the later write), not `true` from the stale `.set`. Without
+ * per-tuple dedupe in `installMapWrite`, first-pair-wins would keep the
+ * `.set`'s membership `|-> true` ahead of the `.delete`'s `|-> false`.
+ */
+export function setThenDelete(
+  m: Map<string, number>,
+  k: string,
+  v: number,
+): void {
+  m.set(k, v);
+  m.delete(k);
+}

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-map-mutation.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-map-mutation.ts
@@ -70,3 +70,23 @@ export function setAndCopy(
   m.set(kSrc, v);
   m.set(kDst, m.get(kSrc)!);
 }
+
+/**
+ * Read-after-delete — `.get(kA)` after `.set(kA, v); .delete(kA)` must not
+ * pick up the staged `v`. Pantagruel's declaration guard makes the value
+ * rule vacuous under false membership at emission time, but an inline
+ * override read has no such guard — so the filter in readMapThroughWrites
+ * drops the stale value override at `(m, kA)` once its latest membership
+ * is false. The inner `m.get(kA)!` therefore lowers to the pre-state
+ * `stringToIntMap m kA`.
+ */
+export function deleteThenCopy(
+  m: Map<string, number>,
+  kA: string,
+  kB: string,
+  v: number,
+): void {
+  m.set(kA, v);
+  m.delete(kA);
+  m.set(kB, m.get(kA)!);
+}

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-map-mutation.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-map-mutation.ts
@@ -53,3 +53,20 @@ export function putPair(
   m.set(k1, v1);
   m.set(k2, v2);
 }
+
+/**
+ * Read-after-write — `.get(kSrc)` after `.set(kSrc, v)` must observe the
+ * staged write. The second `.set`'s value threads the prior override
+ * inline as `stringToIntMap[(m, kSrc) |-> v] m kSrc`, so the emitted
+ * equation correctly reflects "copy the just-written value at kSrc into
+ * kDst" rather than reading the pre-state rule.
+ */
+export function setAndCopy(
+  m: Map<string, number>,
+  kSrc: string,
+  kDst: string,
+  v: number,
+): void {
+  m.set(kSrc, v);
+  m.set(kDst, m.get(kSrc)!);
+}

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-map.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-map.ts
@@ -22,6 +22,17 @@ export function contains(c: Cache, k: string): boolean {
 }
 
 /**
+ * Non-null-asserted field receiver on a read: `c.entries!` is a
+ * NonNullExpression wrapping a PropertyAccessExpression. Stage A read
+ * detection must unwrap before the PropertyAccessExpression / interface-field
+ * checks, otherwise the read synthesizes a separate StringToIntMap instead
+ * of using the declared `entries` rule.
+ */
+export function lookupNonNull(c: Cache, k: string): number {
+  return c.entries!.get(k)!;
+}
+
+/**
  * Real entailment exercising both rules in the same module: when the
  * predicate holds (via `.has`), the guarded value rule has a meaning and is
  * equal to itself (EUF congruence). The body sets `congruence c k` to


### PR DESCRIPTION
## Summary

Stage C of Wave 2 `Map<K, V>` support for ts2pant: translate `.set(k, v)` and `.delete(k)` on any Map receiver into Pantagruel's N-ary override (`R[(m, k) |-> v]`). Closes the mutation gap in the Map translation — stages A (interface-field) and B (synthesized `KToVMap` handle) both supported, reads (`.get`, `.has`) already landed.

- **`.set(k, v)`** emits one quantified equation per modified rule — the value rule `R` and membership predicate `Rkey` — each with `R[(objExpr, keyExpr) |-> v]` on the RHS. `.delete(k)` emits only the membership equation (value rule is vacuous under false membership via Pantagruel's declaration guard).
- **Conditional writes** (`if (g) m.set(k, v)`) merge per-(m, k) override pair under `cond`, with the else-branch fallback being the pre-state `R m k` at that specific key.
- **Multiple writes to the same rule** accumulate as distinct `(tuple |-> value)` pairs in one override expression rather than separate equations.
- **Binders** `m`, `k` for the emitted `all` quantifiers come from the document-wide `NameRegistry` inside `synthCell` so they stay unique against the function's own params and type-derived accessor-rule binders.

Frame semantics come implicitly from the override's ite expansion (McCarthy's `store`, Kroening & Strichman Ch. 7; matches TLA+'s `[f EXCEPT ![m][k] = v]`, Lamport Ch. 2–3). New `MapRuleWriteEntry` in the symbolic state coalesces all `.set`/`.delete` calls to the same rule per branch; `WriteEntry` becomes a tagged union (`kind: "property" | "map"`) so every merge/emission site dispatches explicitly.

**Depends on #103** (override: accept N-ary rules with tuple-keyed overrides) — the Pantagruel core needs to accept `R[(m, k) |-> v]` syntax for arity-2 rules. The first commit on this branch is the #103 change, rebased onto current master; it will be a no-op once #103 merges.

## Test plan

- [x] `npm test` — all 302 tests pass, 7 new snapshots for `expressions-map-mutation{,-field}.ts` fixtures (put, remove, bump, putIfAbsent, putPair; cachePut, cacheEvict)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `pant --check` on `putIfAbsent`, `bump`, `putPair`, `cachePut`, `cacheEvict` — OK: Entailed, cond-arms exhaustive
- [x] Regression: Stage A + B read snapshots unchanged
- [x] Regression: existing property-only mutation fixtures unchanged
- [x] Classifier: functions with `Map.set` and void return are classified mutating (`hasMutation` replaces `hasPropertyAssignment`)
- [x] Two-write coalescing: `putPair` emits one override with two `|->` pairs per rule
- [x] Conditional merge: `putIfAbsent`'s membership-predicate RHS contains `cond ~(stringToIntMapKey m k) => true, true => stringToIntMapKey m k`

🤖 Generated with [Claude Code](https://claude.com/claude-code)