### PR TITLE
ts2pant: dogfood harness + first self-translation baseline

### DIFF
--- a/tools/ts2pant/src/translate-types.ts
+++ b/tools/ts2pant/src/translate-types.ts
@@ -344,13 +344,15 @@ export function mapTsType(
 }
 
 /**
- * Detect a TypeScript `Set<T>` by symbol name. Brittle against user-defined
- * classes named `Set`, but matches how `isArrayType` effectively works and is
- * the pragmatic choice — a user class named `Set` is vanishingly rare.
+ * Detect a TypeScript `Set<T>` or `ReadonlySet<T>` by symbol name. Both
+ * translate to `[T]` since Pantagruel lists encode membership. Brittle
+ * against user-defined classes by the same name, but matches how
+ * `isArrayType` effectively works and is the pragmatic choice.
  */
 export function isSetType(type: ts.Type): boolean {
   const symbol = type.getSymbol();
-  return symbol?.getName() === "Set";
+  const name = symbol?.getName();
+  return name === "Set" || name === "ReadonlySet";
 }
 
 /**

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -286,6 +286,14 @@ exports[`expressions-property.ts > getOwnerName 1`] = `
 "module GetOwnerName.\\n\\nUser.\\nname u: User => String.\\nAccount.\\nbalance a1: Account => Int.\\nowner a1: Account => User.\\nactive a1: Account => Bool.\\ngetOwnerName a: Account => String.\\n\\n---\\n\\ngetOwnerName a = name (owner a).\\n"
 `;
 
+exports[`expressions-readonly-set.ts > cardinalityReadonly 1`] = `
+"module CardinalityReadonly.\\n\\ncardinalityReadonly xs: [String] => Int.\\n\\n---\\n\\ncardinalityReadonly xs = #xs.\\n"
+`;
+
+exports[`expressions-readonly-set.ts > containsReadonly 1`] = `
+"module ContainsReadonly.\\n\\ncontainsReadonly xs: [String], x: String => Bool.\\n\\n---\\n\\ncontainsReadonly xs x = (x in xs).\\n"
+`;
+
 exports[`expressions-reduce.ts > allActive 1`] = `
 "module AllActive.\\n\\nItem.\\nvalue i: Item => Int.\\nactive i: Item => Bool.\\nallActive xs: [Item] => Bool.\\n\\n---\\n\\nallActive xs = (and over each $0 in xs | active $0).\\n"
 `;

--- a/tools/ts2pant/tests/dogfood.test.mts
+++ b/tools/ts2pant/tests/dogfood.test.mts
@@ -14,13 +14,16 @@ import {
 
 const SRC = resolve(import.meta.dirname, "../src");
 const PROJECT_ROOT = resolve(import.meta.dirname, "../../..");
+const PANT_TIMEOUT_MS = Number(
+  process.env.TS2PANT_DOGFOOD_TIMEOUT_MS ?? 30_000,
+);
 
 function assertPantTypeChecks(output: string): void {
   execFileSync("dune", ["exec", "pant", "--"], {
     cwd: PROJECT_ROOT,
     input: output,
     encoding: "utf-8",
-    timeout: 30_000,
+    timeout: PANT_TIMEOUT_MS,
     killSignal: "SIGKILL",
   });
 }

--- a/tools/ts2pant/tests/dogfood.test.mts
+++ b/tools/ts2pant/tests/dogfood.test.mts
@@ -1,0 +1,36 @@
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+import { describe, it } from "node:test";
+import {
+  buildDocument as buildDocumentFromPath,
+  emitDocument,
+} from "./helpers.mjs";
+
+// Dogfood: translate ts2pant's own source files with ts2pant itself.
+// Depth-first — one target module at a time, smallest function first.
+// See /Users/zax/.claude/plans/let-s-start-with-annotating-distributed-koala.md
+// for the roadmap. Each passing case here is a concrete self-translation
+// baseline; failing cases are documented separately in the plan file as
+// diagnostics driving the next feature to build.
+
+const SRC = resolve(import.meta.dirname, "../src");
+const PROJECT_ROOT = resolve(import.meta.dirname, "../../..");
+
+function assertPantTypeChecks(output: string): void {
+  execFileSync("dune", ["exec", "pant", "--"], {
+    cwd: PROJECT_ROOT,
+    input: output,
+    encoding: "utf-8",
+  });
+}
+
+describe("dogfood: src/name-registry.ts", () => {
+  const filePath = resolve(SRC, "name-registry.ts");
+
+  it("isUsed — translates and type-checks", async (t) => {
+    const doc = await buildDocumentFromPath(filePath, "isUsed");
+    const output = emitDocument(doc);
+    t.assert.snapshot(output);
+    assertPantTypeChecks(output);
+  });
+});

--- a/tools/ts2pant/tests/dogfood.test.mts
+++ b/tools/ts2pant/tests/dogfood.test.mts
@@ -8,10 +8,9 @@ import {
 
 // Dogfood: translate ts2pant's own source files with ts2pant itself.
 // Depth-first — one target module at a time, smallest function first.
-// See /Users/zax/.claude/plans/let-s-start-with-annotating-distributed-koala.md
-// for the roadmap. Each passing case here is a concrete self-translation
-// baseline; failing cases are documented separately in the plan file as
-// diagnostics driving the next feature to build.
+// Each passing case here is a concrete self-translation baseline; failing
+// cases are tracked in the project roadmap as diagnostics driving the next
+// feature to build.
 
 const SRC = resolve(import.meta.dirname, "../src");
 const PROJECT_ROOT = resolve(import.meta.dirname, "../../..");
@@ -21,6 +20,8 @@ function assertPantTypeChecks(output: string): void {
     cwd: PROJECT_ROOT,
     input: output,
     encoding: "utf-8",
+    timeout: 30_000,
+    killSignal: "SIGKILL",
   });
 }
 

--- a/tools/ts2pant/tests/dogfood.test.mts.snapshot
+++ b/tools/ts2pant/tests/dogfood.test.mts.snapshot
@@ -1,0 +1,3 @@
+exports[`dogfood: src/name-registry.ts > isUsed — translates and type-checks 1`] = `
+"module IsUsed.\\n\\nNameRegistry.\\nused n: NameRegistry => [String].\\nisUsed registry: NameRegistry, name: String => Bool.\\n\\n---\\n\\nisUsed registry name = (name in used registry).\\n"
+`;

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-readonly-set.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-readonly-set.ts
@@ -1,0 +1,14 @@
+// ReadonlySet<T> translates identically to Set<T> — both become [T] since
+// Pantagruel lists encode membership. Kept as a focused fixture so that any
+// regression in ReadonlySet handling surfaces here rather than only via
+// dogfood coverage.
+
+/** .has(x) on a ReadonlySet -> x in */
+export function containsReadonly(xs: ReadonlySet<string>, x: string): boolean {
+  return xs.has(x);
+}
+
+/** .size on a ReadonlySet -> # */
+export function cardinalityReadonly(xs: ReadonlySet<string>): number {
+  return xs.size;
+}


### PR DESCRIPTION
## Summary

Start dogfooding ts2pant on its own source. This PR is infrastructure: a new `tests/dogfood.test.mts` suite that runs the full pipeline against `src/name-registry.ts` and snapshots the output, plus one incidental fix that the first dogfood run surfaced.

- **`isSetType` now matches `ReadonlySet`** alongside `Set`. Both translate to `[T]` since Pantagruel lists already encode membership, and TypeScript enforces at compile time that `.add`/`.delete` are only called on the mutable variant. No existing fixture covered this; the first real TS file we tried tripped it immediately.
- **`tests/dogfood.test.mts`** translates `isUsed` from `src/name-registry.ts`, snapshots the emission, and runs it through the `pant` type-checker. Uses the existing `buildDocument` / `emitDocument` helpers (path-agnostic, no changes needed).

Only `isUsed` translates cleanly today. `emptyNameRegistry` and `registerName` both fail — diagnostics recorded in the planning doc, not this PR.

## Dogfood output

```text
module IsUsed.

NameRegistry.
used n: NameRegistry => [String].
isUsed registry: NameRegistry, name: String => Bool.

---

isUsed registry name = (name in used registry).
```

Passes `pant --check` with `OK: Invariants are jointly satisfiable`.

## What's next (separate PR)

Both `emptyNameRegistry` (object-literal return) and `registerName` (first blocker: `let` mutation, plus anonymous record return type) collapse onto one underlying gap: records aren't modeled as types or values in the current translator. The follow-up will add record-return translation — design choice between synthesized product domain (mirrors `MapSynth`) and tuple desugaring (reuses existing `.1`/`.2` projection).

## Test plan

- [x] `npm test` — 296 tests pass, new dogfood suite included
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npx tsx src/index.ts src/name-registry.ts isUsed --check` — `OK: ...`
- [x] Existing snapshots (constructs, e2e) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)