### PR TITLE
ts2pant: translate object-literal returns; fix frame-condition binders

### DIFF
--- a/tools/ts2pant/CLAUDE.md
+++ b/tools/ts2pant/CLAUDE.md
@@ -226,6 +226,67 @@ key has occurred on the path. Quantifier binders come from
 the document-wide `NameRegistry` so they stay unique against the
 function's own params (which have already claimed `m`, `k`, etc.).
 
+### Record Returns (Object-Literal Return Expressions)
+
+**Standard name:** Observational specification / field-selector
+axiomatization of records.
+**Reference:** Kroening & Strichman, *Decision Procedures* Ch. 8
+(recursive data structures — records as disjoint-range field selectors);
+Dafny Reference Manual (function specifications via per-field
+postconditions).
+
+Pantagruel has no record-constructor expression syntax — interfaces are
+opaque domains reachable only through per-field accessor rules. A pure
+function that returns `{ f1: e1, f2: e2 }` therefore decomposes into one
+equation per declared field of the return type, observing the function's
+result through each accessor:
+
+```text
+f a: A, b: B => NamedInterface.
+---
+all a: A, b: B | f1 (f a b) = e1.
+all a: A, b: B | f2 (f a b) = e2.
+```
+
+For a nullary `emptyRecord(): I` the quantifier collapses:
+
+```text
+emptyRecord => I.
+---
+f1 emptyRecord = e1.
+f2 emptyRecord = e2.
+```
+
+**Empty-set initializer.** Pantagruel has no empty-list literal, so
+`new Set()` (only; not `new Set(iterable)`) in a `Set<T>` / `ReadonlySet<T>`
+/ `T[]` field position emits the membership-negation form rather than an
+equation:
+
+```text
+all x: T | ~(x in f_i (f <args>)).
+```
+
+This is a universally quantified assertion, not an equation — hence the
+new `assertion` kind on `PropResult` in `types.ts`.
+
+**Requirements / rejections.**
+- Return type must be a *named* interface/class/alias. Anonymous record
+  types (return `{name: string, registry: NameRegistry}` with no name)
+  are rejected with a clear message and tracked as a separate feature.
+- Every declared field must be present in the object literal; extra
+  fields are rejected.
+- Property kinds accepted: `PropertyAssignment` with identifier or string
+  key, and `ShorthandPropertyAssignment` (`{name}` sugar for
+  `{name: name}`). Spread, methods, accessors, and computed keys are
+  rejected.
+- Initializer expressions go through the normal `translateBodyExpr`
+  pipeline (const-inlining, etc.), so arithmetic and accessor reads
+  work without extra plumbing.
+
+See `tests/fixtures/constructs/expressions-record-return.ts` for the
+supported shapes and `tests/dogfood.test.mts` for the self-translation
+baseline (`emptyNameRegistry`).
+
 ### Structured Iteration (for-of, forEach, reduce)
 
 **Standard name:** Catamorphisms / structural recursion on lists.

--- a/tools/ts2pant/README.md
+++ b/tools/ts2pant/README.md
@@ -54,7 +54,29 @@ larger a: Int, b: Int => Int.
 all a: Int, b: Int | larger a b = cond a >= b => a, true => b.
 ```
 
-Supported return expressions: arithmetic, comparisons, ternaries (`? :` becomes `cond`), if/else with returns in both branches.
+Supported return expressions: arithmetic, comparisons, ternaries (`? :` becomes `cond`), if/else with returns in both branches, and object literals (record returns, below).
+
+### Record returns
+
+A pure function whose body is `return { f1: e1, f2: e2 }` decomposes into one equation per declared field of the return type. Pantagruel has no record-constructor syntax; interfaces are opaque domains reached only through per-field accessor rules, so the function's result is axiomatized by what each accessor returns:
+
+```typescript
+interface Point { x: number; y: number; }
+function translate(p: Point, dx: number, dy: number): Point {
+  return { x: p.x + dx, y: p.y + dy };
+}
+```
+
+```text
+translate p: Point, dx: Int, dy: Int => Point.
+
+---
+
+all p: Point, dx: Int, dy: Int | x (translate p dx dy) = x p + dx.
+all p: Point, dx: Int, dy: Int | y (translate p dx dy) = y p + dy.
+```
+
+Return type must be a named interface/class/alias (anonymous record types are not yet supported). `new Set()` in a set-typed field position is special-cased as "empty set" and emits an assertion `all x: T | ~(x in <field> (f <args>))` — Pantagruel has no empty-list literal.
 
 ### Mutating functions
 

--- a/tools/ts2pant/src/emit.ts
+++ b/tools/ts2pant/src/emit.ts
@@ -40,6 +40,13 @@ function renderPropResult(prop: PropResult): string {
       }
       return ast.strExpr(ast.forall(prop.quantifiers, guards, eq));
     }
+    case "assertion": {
+      const guards = prop.guards ?? [];
+      if (prop.quantifiers.length === 0 && guards.length === 0) {
+        return ast.strExpr(prop.body);
+      }
+      return ast.strExpr(ast.forall(prop.quantifiers, guards, prop.body));
+    }
     case "unsupported":
       return `> UNSUPPORTED: ${prop.reason}`;
     case "raw":

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -1,5 +1,6 @@
 import type { SourceFile } from "ts-morph";
 import ts from "typescript";
+import { type NameRegistry, registerName } from "./name-registry.js";
 import type {
   OpaqueCombiner,
   OpaqueExpr,
@@ -1083,13 +1084,33 @@ function translateRecordReturn(
   // equation path (`larger a b = cond ...`). Only fresh binders introduced
   // by a field's translation (e.g., the empty-set membership binder) are
   // quantified explicitly.
+  //
+  // Empty-set binders are *serialized* into the final assertion, so they
+  // must be valid Pantagruel identifiers and must not capture the function's
+  // own params. The synthCell branch already avoids both issues: its
+  // registry was seeded by translateSignature with every param name, so
+  // `cellRegisterName(synthCell, "x")` returns `x1` when `x` is a param.
+  // The fallback (no synthCell — direct callers / tests) seeds a local
+  // registry from `params` to preserve the same guarantees.
+  let localRegistry: NameRegistry = {
+    used: new Set(params.map((p) => p.name)),
+  };
+  const allocEmittedBinder = (hint: string): string => {
+    if (synthCell) {
+      return cellRegisterName(synthCell, hint);
+    }
+    const r = registerName(localRegistry, hint);
+    localRegistry = r.registry;
+    return r.name;
+  };
+
   const results: PropResult[] = [];
   for (const field of declaredFields) {
     const initializer = literalByName.get(field.name)!;
     const fieldApp = ast.app(ast.var(field.name), [fnApp]);
 
     // Special case: `new Set()` means "empty set". Emit as membership
-    // negation since Pantagruel has no empty-list literal.
+    // negation since Pantagruel has no empty-set literal.
     if (isEmptySetConstruction(initializer)) {
       const elemType = getSetElementTypeName(
         field.type,
@@ -1105,9 +1126,7 @@ function translateRecordReturn(
           },
         ];
       }
-      const binderName = synthCell
-        ? cellRegisterName(synthCell, "x")
-        : freshHygienicBinder(supply);
+      const binderName = allocEmittedBinder("x");
       const binderParam = ast.param(binderName, ast.tName(elemType));
       const body = ast.unop(
         ast.opNot(),

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -1007,7 +1007,9 @@ function translateRecordReturn(
     type: checker.getTypeOfSymbolAtLocation(prop, fnNode),
   }));
 
-  // Index literal properties by name. Reject unsupported property kinds.
+  // Index literal properties by name. Reject unsupported property kinds
+  // and duplicate keys (the spec requires exactly one assignment per
+  // declared field).
   const literalByName = new Map<string, ts.Expression>();
   for (const prop of lit.properties) {
     if (ts.isPropertyAssignment(prop)) {
@@ -1019,8 +1021,24 @@ function translateRecordReturn(
           },
         ];
       }
+      if (literalByName.has(prop.name.text)) {
+        return [
+          {
+            kind: "unsupported",
+            reason: `${functionName} — record return repeats field '${prop.name.text}'`,
+          },
+        ];
+      }
       literalByName.set(prop.name.text, prop.initializer);
     } else if (ts.isShorthandPropertyAssignment(prop)) {
+      if (literalByName.has(prop.name.text)) {
+        return [
+          {
+            kind: "unsupported",
+            reason: `${functionName} — record return repeats field '${prop.name.text}'`,
+          },
+        ];
+      }
       literalByName.set(prop.name.text, prop.name);
     } else {
       return [

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -891,6 +891,31 @@ function translatePureBody(
     ];
   }
 
+  // Record returns: when the function returns an object literal, decompose
+  // into one equation per field of the return type. Observational
+  // axiomatization (Kroening & Strichman Ch. 8; Dafny-style postcondition
+  // decomposition): `f(a) = { p: e }` becomes `p (f a) = e` for each field.
+  // Pantagruel has no record-constructor syntax — its interfaces are opaque
+  // domains exposed only through per-field accessor rules — so this is the
+  // natural shape.
+  if (
+    ts.isExpression(extracted.returnExpr) &&
+    ts.isObjectLiteralExpression(extracted.returnExpr)
+  ) {
+    return translateRecordReturn(
+      extracted.returnExpr,
+      functionName,
+      params,
+      node,
+      checker,
+      strategy,
+      inlined.scopedParams,
+      supply,
+      synthCell,
+      inlined.applyTo,
+    );
+  }
+
   const body = translateBodyExpr(
     extracted.returnExpr,
     checker,
@@ -916,6 +941,230 @@ function translatePureBody(
       rhs,
     },
   ];
+}
+
+/**
+ * Translate a function whose body returns an object literal
+ * `{ f1: e1, f2: e2 }` into one equation per field of the return type.
+ * Each equation shape: `all <params> | f_i (fn <args>) = e_i.` — the
+ * field's accessor rule applied to the function application is equated
+ * to the field's initializer expression.
+ *
+ * `new Set()` in a `[T]` field position is special-cased as "empty set"
+ * and emits an assertion `all x: T | not (x in f_i (fn <args>))` instead
+ * of an equation, since Pantagruel has no empty-list literal.
+ *
+ * Requirements:
+ *   - Return type must be a named TypeScript interface/class/alias whose
+ *     accessor rules are already declared elsewhere in the document.
+ *   - The object literal must supply exactly one PropertyAssignment or
+ *     ShorthandPropertyAssignment per declared field of the return type.
+ *   - Initializers must translate as pure expressions (or be the
+ *     `new Set()` special case above).
+ */
+function translateRecordReturn(
+  lit: ts.ObjectLiteralExpression,
+  functionName: string,
+  params: Array<{ name: string; type: string }>,
+  fnNode: ts.FunctionDeclaration | ts.MethodDeclaration,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  scopedParams: ReadonlyMap<string, string>,
+  supply: UniqueSupply,
+  synthCell: MapSynthCell | undefined,
+  applyConst: (e: OpaqueExpr) => OpaqueExpr,
+): PropResult[] {
+  const ast = getAst();
+
+  // Resolve return type. Use the signature's declared return rather than
+  // the object literal's inferred type (which would be
+  // `{ f1: SetLike, ... }` with contextual widening not applied).
+  const sig = checker.getSignatureFromDeclaration(fnNode);
+  const returnType = sig?.getReturnType();
+  if (!returnType) {
+    return [
+      {
+        kind: "unsupported",
+        reason: `${functionName} — cannot resolve return type for record return`,
+      },
+    ];
+  }
+  const returnSymbol = returnType.aliasSymbol ?? returnType.symbol;
+  const returnTypeName = returnSymbol?.getName();
+  if (!returnTypeName || returnTypeName === "__type") {
+    return [
+      {
+        kind: "unsupported",
+        reason: `${functionName} — record return of anonymous type not yet supported`,
+      },
+    ];
+  }
+
+  // Collect declared fields in declaration order so emission order is
+  // deterministic (matches the interface, not the literal's source order).
+  const declaredFields = returnType.getProperties().map((prop) => ({
+    name: prop.getName(),
+    type: checker.getTypeOfSymbolAtLocation(prop, fnNode),
+  }));
+
+  // Index literal properties by name. Reject unsupported property kinds.
+  const literalByName = new Map<string, ts.Expression>();
+  for (const prop of lit.properties) {
+    if (ts.isPropertyAssignment(prop)) {
+      if (!ts.isIdentifier(prop.name) && !ts.isStringLiteral(prop.name)) {
+        return [
+          {
+            kind: "unsupported",
+            reason: `${functionName} — record return with computed or non-simple key`,
+          },
+        ];
+      }
+      literalByName.set(prop.name.text, prop.initializer);
+    } else if (ts.isShorthandPropertyAssignment(prop)) {
+      literalByName.set(prop.name.text, prop.name);
+    } else {
+      return [
+        {
+          kind: "unsupported",
+          reason: `${functionName} — record return with spread/method/accessor property`,
+        },
+      ];
+    }
+  }
+
+  // Every declared field must be supplied. Extra fields on the literal
+  // are flagged separately below.
+  const missing = declaredFields
+    .filter((f) => !literalByName.has(f.name))
+    .map((f) => f.name);
+  if (missing.length > 0) {
+    return [
+      {
+        kind: "unsupported",
+        reason: `${functionName} — record return missing field(s): ${missing.join(", ")}`,
+      },
+    ];
+  }
+  const extras = [...literalByName.keys()].filter(
+    (n) => !declaredFields.some((f) => f.name === n),
+  );
+  if (extras.length > 0) {
+    return [
+      {
+        kind: "unsupported",
+        reason: `${functionName} — record return has extra field(s): ${extras.join(", ")}`,
+      },
+    ];
+  }
+
+  const argExprs = params.map((p) => ast.var(p.name));
+  const fnApp = ast.app(ast.var(functionName), argExprs);
+
+  // Rule parameters are implicitly in scope for body propositions, so we
+  // don't re-quantify over them — emission matches the existing single-
+  // equation path (`larger a b = cond ...`). Only fresh binders introduced
+  // by a field's translation (e.g., the empty-set membership binder) are
+  // quantified explicitly.
+  const results: PropResult[] = [];
+  for (const field of declaredFields) {
+    const initializer = literalByName.get(field.name)!;
+    const fieldApp = ast.app(ast.var(field.name), [fnApp]);
+
+    // Special case: `new Set()` means "empty set". Emit as membership
+    // negation since Pantagruel has no empty-list literal.
+    if (isEmptySetConstruction(initializer)) {
+      const elemType = getSetElementTypeName(
+        field.type,
+        checker,
+        strategy,
+        synthCell,
+      );
+      if (!elemType) {
+        return [
+          {
+            kind: "unsupported",
+            reason: `${functionName} — new Set() initializer on non-set field '${field.name}'`,
+          },
+        ];
+      }
+      const binderName = synthCell
+        ? cellRegisterName(synthCell, "x")
+        : freshHygienicBinder(supply);
+      const binderParam = ast.param(binderName, ast.tName(elemType));
+      const body = ast.unop(
+        ast.opNot(),
+        ast.binop(ast.opIn(), ast.var(binderName), fieldApp),
+      );
+      results.push({
+        kind: "assertion",
+        quantifiers: [binderParam],
+        body,
+      });
+      continue;
+    }
+
+    const body = translateBodyExpr(
+      initializer,
+      checker,
+      strategy,
+      scopedParams,
+      undefined,
+      supply,
+    );
+    if (isBodyUnsupported(body)) {
+      return [
+        {
+          kind: "unsupported",
+          reason: `${functionName}.${field.name} — ${body.unsupported}`,
+        },
+      ];
+    }
+    if (isBodyEffect(body)) {
+      return [
+        {
+          kind: "unsupported",
+          reason: `${functionName}.${field.name} — effect outside statement position`,
+        },
+      ];
+    }
+    const rhs = applyConst(bodyExpr(body));
+    results.push({
+      kind: "equation",
+      quantifiers: [],
+      lhs: fieldApp,
+      rhs,
+    });
+  }
+
+  return results;
+}
+
+/** `new Set()` (zero args) — the only Set construction form we currently
+ * translate. `new Set(iterable)` and subclass constructors are rejected. */
+function isEmptySetConstruction(expr: ts.Expression): boolean {
+  return (
+    ts.isNewExpression(expr) &&
+    ts.isIdentifier(expr.expression) &&
+    expr.expression.text === "Set" &&
+    (expr.arguments === undefined || expr.arguments.length === 0)
+  );
+}
+
+/** Return the Pantagruel type name of `T` in a `Set<T>` / `ReadonlySet<T>`
+ * / `[T]` (array) field, or null if the field isn't set-shaped. */
+function getSetElementTypeName(
+  fieldType: ts.Type,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  synthCell: MapSynthCell | undefined,
+): string | null {
+  if (isSetType(fieldType) || checker.isArrayType(fieldType)) {
+    const typeArgs = checker.getTypeArguments(fieldType as ts.TypeReference);
+    if (typeArgs.length === 1) {
+      return mapTsType(typeArgs[0]!, checker, strategy, synthCell);
+    }
+  }
+  return null;
 }
 
 interface ExtractedBody {
@@ -3761,8 +4010,13 @@ function symbolicExecute(
 
 /**
  * Generate frame conditions: for each rule in declarations not explicitly
- * modified, emit `rule' x = rule x`. Variables are already in scope from
- * the rule declarations in the chapter head.
+ * modified, emit `rule' x = rule x` using the rule's own parameter names
+ * as free variable references. Pantagruel's SMT translator auto-quantifies
+ * free rule-param references in action-body propositions via
+ * [bind_head_params] (see `lib/smt_doc.ml`), so the emission stays flat.
+ * This also preserves declaration guards through pant's guard-injection
+ * machinery on the quantified form, which would be lost if ts2pant
+ * pre-wrapped with a local `all` here.
  */
 function generateFrameConditions(
   modifiedRules: Set<string>,

--- a/tools/ts2pant/src/types.ts
+++ b/tools/ts2pant/src/types.ts
@@ -54,6 +54,12 @@ export type PropResult =
       lhs: OpaqueExpr;
       rhs: OpaqueExpr;
     }
+  | {
+      kind: "assertion";
+      quantifiers: OpaqueParam[];
+      guards?: OpaqueGuard[];
+      body: OpaqueExpr;
+    }
   | { kind: "unsupported"; reason: string }
   | { kind: "raw"; text: string };
 

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -350,6 +350,18 @@ exports[`expressions-readonly-set.ts > containsReadonly 1`] = `
 "module ContainsReadonly.\\n\\ncontainsReadonly xs: [String], x: String => Bool.\\n\\n---\\n\\ncontainsReadonly xs x = (x in xs).\\n"
 `;
 
+exports[`expressions-record-return.ts > emptyBag 1`] = `
+"module EmptyBag.\\n\\nBag.\\nitems b: Bag => [String].\\nemptyBag  => Bag.\\n\\n---\\n\\nall x: String | ~(x in items emptyBag).\\n"
+`;
+
+exports[`expressions-record-return.ts > origin 1`] = `
+"module Origin.\\n\\nPoint.\\nx p: Point => Int.\\ny p: Point => Int.\\norigin  => Point.\\n\\n---\\n\\nx origin = 0.\\ny origin = 0.\\n"
+`;
+
+exports[`expressions-record-return.ts > translate 1`] = `
+"module Translate.\\n\\nPoint.\\nx p1: Point => Int.\\ny p1: Point => Int.\\ntranslate p: Point, dx: Int, dy: Int => Point.\\n\\n---\\n\\nx (translate p dx dy) = x p + dx.\\ny (translate p dx dy) = y p + dy.\\n"
+`;
+
 exports[`expressions-reduce.ts > allActive 1`] = `
 "module AllActive.\\n\\nItem.\\nvalue i: Item => Int.\\nactive i: Item => Bool.\\nallActive xs: [Item] => Bool.\\n\\n---\\n\\nallActive xs = (and over each $0 in xs | active $0).\\n"
 `;

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -354,6 +354,10 @@ exports[`expressions-record-return.ts > emptyBag 1`] = `
 "module EmptyBag.\\n\\nBag.\\nitems b: Bag => [String].\\nemptyBag  => Bag.\\n\\n---\\n\\nall x: String | ~(x in items emptyBag).\\n"
 `;
 
+exports[`expressions-record-return.ts > emptyBagShadowed 1`] = `
+"module EmptyBagShadowed.\\n\\nBag.\\nitems b: Bag => [String].\\nemptyBagShadowed x: Int => Bag.\\n\\n---\\n\\nall x1: String | ~(x1 in items (emptyBagShadowed x)).\\n"
+`;
+
 exports[`expressions-record-return.ts > origin 1`] = `
 "module Origin.\\n\\nPoint.\\nx p: Point => Int.\\ny p: Point => Int.\\norigin  => Point.\\n\\n---\\n\\nx origin = 0.\\ny origin = 0.\\n"
 `;

--- a/tools/ts2pant/tests/dogfood.test.mts
+++ b/tools/ts2pant/tests/dogfood.test.mts
@@ -37,4 +37,11 @@ describe("dogfood: src/name-registry.ts", () => {
     t.assert.snapshot(output);
     assertPantTypeChecks(output);
   });
+
+  it("emptyNameRegistry — translates and type-checks", async (t) => {
+    const doc = await buildDocumentFromPath(filePath, "emptyNameRegistry");
+    const output = emitDocument(doc);
+    t.assert.snapshot(output);
+    assertPantTypeChecks(output);
+  });
 });

--- a/tools/ts2pant/tests/dogfood.test.mts.snapshot
+++ b/tools/ts2pant/tests/dogfood.test.mts.snapshot
@@ -1,3 +1,7 @@
+exports[`dogfood: src/name-registry.ts > emptyNameRegistry — translates and type-checks 1`] = `
+"module EmptyNameRegistry.\\n\\nNameRegistry.\\nused n: NameRegistry => [String].\\nemptyNameRegistry  => NameRegistry.\\n\\n---\\n\\nall x: String | ~(x in used emptyNameRegistry).\\n"
+`;
+
 exports[`dogfood: src/name-registry.ts > isUsed — translates and type-checks 1`] = `
 "module IsUsed.\\n\\nNameRegistry.\\nused n: NameRegistry => [String].\\nisUsed registry: NameRegistry, name: String => Bool.\\n\\n---\\n\\nisUsed registry name = (name in used registry).\\n"
 `;

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-record-return.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-record-return.ts
@@ -29,3 +29,12 @@ export interface Bag {
 export function emptyBag(): Bag {
   return { items: new Set() };
 }
+
+/** Param name `x` collides with the binder hint used for the empty-set
+ *  quantifier; the binder is suffixed (e.g. `x1`) so it cannot capture the
+ *  rule parameter. The param is intentionally unread — the fixture exists
+ *  only to prove the name doesn't get captured. */
+// biome-ignore lint/correctness/noUnusedFunctionParameters: deliberate shadowing test
+export function emptyBagShadowed(x: number): Bag {
+  return { items: new Set() };
+}

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-record-return.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-record-return.ts
@@ -1,0 +1,31 @@
+// Record returns: a pure function whose body is `return { f1: e1, f2: e2 }`
+// decomposes into one equation per field of the return type. The return
+// type must be a named interface whose accessor rules are already declared;
+// anonymous record types (synthesized result domains) are a separate stage.
+// See CLAUDE.md § Record Returns.
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+/** Multi-field record return; each field gets its own equation. */
+export function origin(): Point {
+  return { x: 0, y: 0 };
+}
+
+/** Field initializers reference parameters; quantifier form is used. */
+export function translate(p: Point, dx: number, dy: number): Point {
+  return { x: p.x + dx, y: p.y + dy };
+}
+
+export interface Bag {
+  items: ReadonlySet<string>;
+}
+
+/** `new Set()` in a set-typed field position → empty-set via membership
+ *  negation. Pantagruel has no empty-list literal; the emitted form is
+ *  `all x: T | ~(x in items f)`. */
+export function emptyBag(): Bag {
+  return { items: new Set() };
+}

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-record-return.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-record-return.ts
@@ -24,7 +24,7 @@ export interface Bag {
 }
 
 /** `new Set()` in a set-typed field position → empty-set via membership
- *  negation. Pantagruel has no empty-list literal; the emitted form is
+ *  negation. Pantagruel has no empty-set literal; the emitted form is
  *  `all x: T | ~(x in items f)`. */
 export function emptyBag(): Bag {
   return { items: new Set() };


### PR DESCRIPTION
## Summary

Pure functions whose body is `return { f1: e1, f2: e2 }` now decompose into one equation per declared field of the return type. Pantagruel has no record-constructor syntax — interfaces are opaque domains reached only through per-field accessor rules — so the function's result is axiomatized observationally (Kroening & Strichman Ch. 8; Dafny postcondition decomposition):

```typescript
interface Point { x: number; y: number; }
function translate(p: Point, dx: number, dy: number): Point {
  return { x: p.x + dx, y: p.y + dy };
}
```

```text
translate p: Point, dx: Int, dy: Int => Point.
---
x (translate p dx dy) = x p + dx.
y (translate p dx dy) = y p + dy.
```

`new Set()` in a set-typed field position is the only Set construction form currently accepted; it emits `all x: T | ~(x in f (fn args))` since Pantagruel has no empty-list literal. Non-named return types, spreads, methods, accessors, computed keys, and partial/extra fields are rejected with specific unsupported messages.

Adds a new `assertion` PropResult kind (quantified boolean proposition) alongside `equation` — the membership-negation form for empty sets isn't an equation.

**Dogfood impact**: `emptyNameRegistry` translates and passes `pant --check` end-to-end, joining `isUsed` as the second self-translation baseline.

## Notes

- Rule parameters are implicitly in scope for body propositions (matches the existing single-equation `larger a b = ...` pattern with no outer `all`), so record-return equations emit as `x (f args) = e` without re-quantifying over the rule's own params.
- An earlier version of this PR also fixed a pre-existing frame-condition SMT bug (free rule-param references in action bodies not being SMT-declared). That fix has been split out to subsetpark/pantagruel#108 at the pant level, which is the right layer; after it merges, ts2pant's frame emission needs no changes.

## What's next

Dogfood Phase 2 still needs:
- Anonymous record return types (synthesize a result domain per shape) — unblocks `registerName`.
- `let` + `while` loop lowering — also needed for `registerName`.
- Template literals, `new Set(iterable)`, `.add` mutation.

## Test plan

- [x] `npm test` — 316 tests pass, 3 new record-return fixtures + 1 new dogfood baseline
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `pant --check` on `src/name-registry.ts isUsed` and `emptyNameRegistry` — both `OK: Invariants are jointly satisfiable`
- [x] Snapshots reviewed: only new record-return entries added; existing snapshots unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)