### PR TITLE
ts2pant: synthesize domain per anonymous record return shape

### DIFF
--- a/tools/ts2pant/CLAUDE.md
+++ b/tools/ts2pant/CLAUDE.md
@@ -269,10 +269,45 @@ all x: T | ~(x in f_i (f <args>)).
 This is a universally quantified assertion, not an equation — hence the
 new `assertion` kind on `PropResult` in `types.ts`.
 
+**Anonymous record returns — synthesized domain per shape.** A function
+whose return type is an inline object literal — `{name: string, reg: NameRegistry}`
+— has no interface to decompose against. Mirroring the `Map<K, V>` synth
+pattern, ts2pant synthesizes one Pantagruel domain per unique shape,
+plus one accessor rule per field:
+
+```text
+NameRegRec.
+name r: NameRegRec => String.
+reg r: NameRegRec => NameRegistry.
+registerShape r: NameRegistry, s: String => NameRegRec.
+---
+name (registerShape r s) = s.
+reg (registerShape r s) = r.
+```
+
+- **Dedup key** = canonical shape string: fields sorted alphabetically
+  by name, paired with their Pantagruel types, joined with `|`. Field-
+  order permutations hash to the same key, so `{a, b}` and `{b, a}`
+  share a domain.
+- **Domain name** = sorted capitalized field names concatenated +
+  `Rec` suffix. Empty shape (`{}`) → `EmptyRec`. Collisions resolve
+  via `NameRegistry`'s numeric suffixing.
+- **Nested shapes compose bottom-up.** `{outer: {inner: string}}`
+  registers `InnerRec` first, then `OuterRec` whose `outer` accessor
+  returns `InnerRec`. Nested object-literal initializers in body
+  position recursively decompose into per-accessor equations
+  (`inner (outer f) = "hi".`) since Pantagruel has no record-
+  constructor expression.
+- **Cross-module composition** uses Pantagruel's module namespacing
+  (`ModA::NameRegRec` ≠ `ModB::NameRegRec`). Per-module synth is fine
+  — lexical collision is handled by the import machinery at
+  `lib/env.ml:213-265`; structural identification across modules is a
+  checker concern, not ts2pant's.
+
 **Requirements / rejections.**
-- Return type must be a *named* interface/class/alias. Anonymous record
-  types (return `{name: string, registry: NameRegistry}` with no name)
-  are rejected with a clear message and tracked as a separate feature.
+- Return type must be an object type — a named interface/class/alias
+  or an anonymous `__type`. Unions, function types, and other exotic
+  shapes are rejected.
 - Every declared field must be present in the object literal; extra
   fields are rejected.
 - Property kinds accepted: `PropertyAssignment` with identifier or string
@@ -281,7 +316,13 @@ new `assertion` kind on `PropResult` in `types.ts`.
   rejected.
 - Initializer expressions go through the normal `translateBodyExpr`
   pipeline (const-inlining, etc.), so arithmetic and accessor reads
-  work without extra plumbing.
+  work without extra plumbing. Nested object-literal initializers
+  decompose recursively.
+- **Known limitation**: accessor rule names are the field names
+  directly, and the user's function parameters share that namespace.
+  A field named `name` with a parameter also named `name` produces a
+  Pantagruel error (parameter shadows accessor rule). Workaround:
+  rename params, or use a named interface with distinct field names.
 
 See `tests/fixtures/constructs/expressions-record-return.ts` for the
 supported shapes and `tests/dogfood.test.mts` for the self-translation

--- a/tools/ts2pant/README.md
+++ b/tools/ts2pant/README.md
@@ -76,7 +76,9 @@ all p: Point, dx: Int, dy: Int | x (translate p dx dy) = x p + dx.
 all p: Point, dx: Int, dy: Int | y (translate p dx dy) = y p + dy.
 ```
 
-Return type must be a named interface/class/alias (anonymous record types are not yet supported). `new Set()` in a set-typed field position is special-cased as "empty set" and emits an assertion `all x: T | ~(x in <field> (f <args>))` — Pantagruel has no empty-list literal.
+Anonymous return types — `function f(): { name: string; reg: NameRegistry } { ... }` — synthesize a domain per shape (mirroring the `Map<K, V>` handle pattern). The domain name is derived from sorted field names; `{name, reg}` → `NameRegRec`, empty `{}` → `EmptyRec`. Accessor rules are declared alongside the synthesized domain. Nested object literals in body position decompose recursively (`{outer: {inner: "hi"}}` → `inner (outer f) = "hi".`).
+
+`new Set()` in a set-typed field position is special-cased as "empty set" and emits an assertion `all x: T | ~(x in <field> (f <args>))` — Pantagruel has no empty-list literal.
 
 ### Mutating functions
 

--- a/tools/ts2pant/src/pipeline.ts
+++ b/tools/ts2pant/src/pipeline.ts
@@ -7,7 +7,7 @@ import { translateSignature } from "./translate-signature.js";
 import {
   cellEmitSynth,
   type NumericStrategy,
-  newMapSynthCell,
+  newSynthCell,
   translateTypes,
 } from "./translate-types.js";
 import type { PantDocument } from "./types.js";
@@ -40,12 +40,12 @@ export async function buildPantDocument(
 
   // Document-wide name registry ensures unique variable names across
   // type-derived rules and the main function's parameters. Held inside a
-  // `MapSynthCell` together with the Map synthesizer so deep body-level call
+  // `SynthCell` together with the Map synthesizer so deep body-level call
   // sites can register on demand without threading state through every
   // BodyResult. Register the function's own param names first (they keep
   // natural names); type-derived accessor rules adapt with suffixes if
   // there's a collision.
-  const synthCell = newMapSynthCell();
+  const synthCell = newSynthCell();
 
   // Extract @pant propositions and @pant-type overrides in one JSDoc pass.
   // Overrides influence parameter type mapping during signature translation;

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -25,9 +25,9 @@ import {
   isMapType,
   isSetType,
   lookupMapKV,
-  type MapSynthCell,
   mapTsType,
   type NumericStrategy,
+  type SynthCell,
 } from "./translate-types.js";
 import type { PantDeclaration, PropResult } from "./types.js";
 
@@ -36,7 +36,7 @@ import type { PantDeclaration, PropResult } from "./types.js";
 /**
  * Per-body translation context threaded through every `translateBodyExpr`
  * call. Carries the hygienic-binder counter and (optionally) the
- * module-wide `MapSynthCell` so `.get`/`.has` on non-field Map receivers
+ * module-wide `SynthCell` so `.get`/`.has` on non-field Map receivers
  * can resolve to the synthesized rule names.
  *
  * Mutable 2-field record: `n` is reassigned in place by `nextSupply`. This
@@ -46,9 +46,9 @@ import type { PantDeclaration, PropResult } from "./types.js";
  */
 interface UniqueSupply {
   n: number;
-  synthCell?: MapSynthCell | undefined;
+  synthCell?: SynthCell | undefined;
 }
-function makeUniqueSupply(synthCell?: MapSynthCell): UniqueSupply {
+function makeUniqueSupply(synthCell?: SynthCell): UniqueSupply {
   return { n: 0, synthCell };
 }
 
@@ -781,7 +781,7 @@ export interface TranslateBodyOptions {
    * synthesized domain names when reconstructing the param list, and
    * (b) dispatch `.get`/`.has` on non-interface-field Map receivers.
    */
-  synthCell?: MapSynthCell | undefined;
+  synthCell?: SynthCell | undefined;
 }
 
 /**
@@ -861,7 +861,7 @@ function translatePureBody(
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
   paramNames: ReadonlyMap<string, string>,
-  synthCell?: MapSynthCell,
+  synthCell?: SynthCell,
 ): PropResult[] {
   const ast = getAst();
 
@@ -972,7 +972,7 @@ function translateRecordReturn(
   strategy: NumericStrategy,
   scopedParams: ReadonlyMap<string, string>,
   supply: UniqueSupply,
-  synthCell: MapSynthCell | undefined,
+  synthCell: SynthCell | undefined,
   applyConst: (e: OpaqueExpr) => OpaqueExpr,
 ): PropResult[] {
   const ast = getAst();
@@ -992,21 +992,54 @@ function translateRecordReturn(
   }
   const returnSymbol = returnType.aliasSymbol ?? returnType.symbol;
   const returnTypeName = returnSymbol?.getName();
-  if (!returnTypeName || returnTypeName === "__type") {
+  if (!returnTypeName) {
     return [
       {
         kind: "unsupported",
-        reason: `${functionName} — record return of anonymous type not yet supported`,
+        reason: `${functionName} — cannot resolve return type name for record return`,
       },
     ];
   }
+  // Anonymous record return (`returnTypeName === "__type"`): the
+  // `mapTsType` branch during signature translation has already
+  // registered the shape with the synth cell, so the synthesized
+  // domain and its accessor rules are declared by the time the body
+  // is translated. The field-emission loop below works unchanged — it
+  // iterates `returnType.getProperties()` (which enumerates the
+  // anonymous shape's declared fields just as well as an interface's)
+  // and emits one equation per field, applying each accessor rule to
+  // the function application. Reject only when the cell is missing or
+  // when upstream synth registration failed (field types unmangleable).
+  if (returnTypeName === "__type") {
+    if (!synthCell) {
+      return [
+        {
+          kind: "unsupported",
+          reason: `${functionName} — anonymous record return requires a synth cell`,
+        },
+      ];
+    }
+    if (returnType.getCallSignatures().length > 0) {
+      return [
+        {
+          kind: "unsupported",
+          reason: `${functionName} — callable anonymous return type`,
+        },
+      ];
+    }
+  }
 
-  // Collect declared fields in declaration order so emission order is
-  // deterministic (matches the interface, not the literal's source order).
-  const declaredFields = returnType.getProperties().map((prop) => ({
-    name: prop.getName(),
-    type: checker.getTypeOfSymbolAtLocation(prop, fnNode),
-  }));
+  // Collect declared fields. For named interfaces this is the declared
+  // property list; for anonymous records it's the same shape seen through
+  // the structural type's properties. Canonical order matches the synth's
+  // sorted order (by field name) so the emission stays deterministic.
+  const declaredFields = returnType
+    .getProperties()
+    .map((prop) => ({
+      name: prop.getName(),
+      type: checker.getTypeOfSymbolAtLocation(prop, fnNode),
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
 
   // Index literal properties by name. Reject unsupported property kinds
   // and duplicate keys (the spec requires exactly one assignment per
@@ -1104,13 +1137,86 @@ function translateRecordReturn(
     return r.name;
   };
 
+  return emitRecordEquations(
+    lit,
+    fnApp,
+    declaredFields,
+    functionName,
+    checker,
+    strategy,
+    scopedParams,
+    supply,
+    synthCell,
+    applyConst,
+    allocEmittedBinder,
+  );
+}
+
+/**
+ * Emit one equation per field of a record-typed receiver. Shared between
+ * the top-level function return (receiver = function application) and
+ * nested object-literal initializers (receiver = accessor application on
+ * the outer record). Recurses when a field's initializer is itself an
+ * object literal — translating a literal value under Pantagruel's
+ * observational discipline requires decomposing it into per-accessor
+ * equations, since there's no record-constructor expression to fall back
+ * on.
+ */
+function emitRecordEquations(
+  lit: ts.ObjectLiteralExpression,
+  receiverExpr: OpaqueExpr,
+  declaredFields: Array<{ name: string; type: ts.Type }>,
+  functionName: string,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  scopedParams: ReadonlyMap<string, string>,
+  supply: UniqueSupply,
+  synthCell: SynthCell | undefined,
+  applyConst: (e: OpaqueExpr) => OpaqueExpr,
+  allocEmittedBinder: (hint: string) => string,
+): PropResult[] {
+  const ast = getAst();
+
+  // Re-index the literal's properties by name for this level. Nested
+  // calls each index their own literal.
+  const literalByName = new Map<string, ts.Expression>();
+  for (const prop of lit.properties) {
+    if (ts.isPropertyAssignment(prop)) {
+      if (!ts.isIdentifier(prop.name) && !ts.isStringLiteral(prop.name)) {
+        return [
+          {
+            kind: "unsupported",
+            reason: `${functionName} — nested record literal with computed or non-simple key`,
+          },
+        ];
+      }
+      literalByName.set(prop.name.text, prop.initializer);
+    } else if (ts.isShorthandPropertyAssignment(prop)) {
+      literalByName.set(prop.name.text, prop.name);
+    } else {
+      return [
+        {
+          kind: "unsupported",
+          reason: `${functionName} — nested record literal with spread/method/accessor property`,
+        },
+      ];
+    }
+  }
+
   const results: PropResult[] = [];
   for (const field of declaredFields) {
-    const initializer = literalByName.get(field.name)!;
-    const fieldApp = ast.app(ast.var(field.name), [fnApp]);
+    const initializer = literalByName.get(field.name);
+    if (!initializer) {
+      return [
+        {
+          kind: "unsupported",
+          reason: `${functionName} — nested record literal missing field '${field.name}'`,
+        },
+      ];
+    }
+    const fieldApp = ast.app(ast.var(field.name), [receiverExpr]);
 
-    // Special case: `new Set()` means "empty set". Emit as membership
-    // negation since Pantagruel has no empty-set literal.
+    // `new Set()` → empty-set membership negation.
     if (isEmptySetConstruction(initializer)) {
       const elemType = getSetElementTypeName(
         field.type,
@@ -1137,6 +1243,35 @@ function translateRecordReturn(
         quantifiers: [binderParam],
         body,
       });
+      continue;
+    }
+
+    // Nested object literal → recursively decompose into per-subfield
+    // equations with `fieldApp` as the new receiver. Pantagruel has no
+    // record-constructor expression; the only way to specify a record
+    // value is observationally (equations on its accessors).
+    if (ts.isObjectLiteralExpression(initializer)) {
+      const subFields = field.type
+        .getProperties()
+        .map((prop) => ({
+          name: prop.getName(),
+          type: checker.getTypeOfSymbol(prop),
+        }))
+        .sort((a, b) => a.name.localeCompare(b.name));
+      const subResults = emitRecordEquations(
+        initializer,
+        fieldApp,
+        subFields,
+        `${functionName}.${field.name}`,
+        checker,
+        strategy,
+        scopedParams,
+        supply,
+        synthCell,
+        applyConst,
+        allocEmittedBinder,
+      );
+      results.push(...subResults);
       continue;
     }
 
@@ -1193,7 +1328,7 @@ function getSetElementTypeName(
   fieldType: ts.Type,
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
-  synthCell: MapSynthCell | undefined,
+  synthCell: SynthCell | undefined,
 ): string | null {
   if (isSetType(fieldType) || checker.isArrayType(fieldType)) {
     const typeArgs = checker.getTypeArguments(fieldType as ts.TypeReference);
@@ -3231,7 +3366,7 @@ function translateMutatingBody(
   strategy: NumericStrategy,
   paramNames: Map<string, string>,
   declarations: PantDeclaration[],
-  synthCell?: MapSynthCell,
+  synthCell?: SynthCell,
 ): PropResult[] {
   if (!node.body) {
     return [];

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -28,6 +28,7 @@ import {
   mapTsType,
   type NumericStrategy,
   type SynthCell,
+  UNSUPPORTED_ANONYMOUS_RECORD,
 } from "./translate-types.js";
 import type { PantDeclaration, PropResult } from "./types.js";
 
@@ -1027,6 +1028,20 @@ function translateRecordReturn(
         },
       ];
     }
+    // Re-run the (idempotent) synth-mapping to confirm registration
+    // actually succeeded for this shape. If a field type is unmangleable
+    // the synth returns the failure sentinel rather than a domain name,
+    // and the body emission below would otherwise reference accessor
+    // rules that were never declared.
+    const mapped = mapTsType(returnType, checker, strategy, synthCell);
+    if (mapped === UNSUPPORTED_ANONYMOUS_RECORD) {
+      return [
+        {
+          kind: "unsupported",
+          reason: `${functionName} — anonymous record return shape could not be synthesized`,
+        },
+      ];
+    }
   }
 
   // Collect declared fields. For named interfaces this is the declared
@@ -1178,7 +1193,9 @@ function emitRecordEquations(
   const ast = getAst();
 
   // Re-index the literal's properties by name for this level. Nested
-  // calls each index their own literal.
+  // calls each index their own literal. Apply the same exact-field
+  // contract as the top-level record return: reject unsupported property
+  // kinds, duplicate keys, missing fields, and extra fields.
   const literalByName = new Map<string, ts.Expression>();
   for (const prop of lit.properties) {
     if (ts.isPropertyAssignment(prop)) {
@@ -1190,8 +1207,24 @@ function emitRecordEquations(
           },
         ];
       }
+      if (literalByName.has(prop.name.text)) {
+        return [
+          {
+            kind: "unsupported",
+            reason: `${functionName} — nested record literal repeats field '${prop.name.text}'`,
+          },
+        ];
+      }
       literalByName.set(prop.name.text, prop.initializer);
     } else if (ts.isShorthandPropertyAssignment(prop)) {
+      if (literalByName.has(prop.name.text)) {
+        return [
+          {
+            kind: "unsupported",
+            reason: `${functionName} — nested record literal repeats field '${prop.name.text}'`,
+          },
+        ];
+      }
       literalByName.set(prop.name.text, prop.name);
     } else {
       return [
@@ -1201,6 +1234,18 @@ function emitRecordEquations(
         },
       ];
     }
+  }
+
+  const extras = [...literalByName.keys()].filter(
+    (n) => !declaredFields.some((f) => f.name === n),
+  );
+  if (extras.length > 0) {
+    return [
+      {
+        kind: "unsupported",
+        reason: `${functionName} — nested record literal has extra field(s): ${extras.join(", ")}`,
+      },
+    ];
   }
 
   const results: PropResult[] = [];
@@ -1271,6 +1316,10 @@ function emitRecordEquations(
         applyConst,
         allocEmittedBinder,
       );
+      const subUnsupported = subResults.find((p) => p.kind === "unsupported");
+      if (subUnsupported) {
+        return [subUnsupported];
+      }
       results.push(...subResults);
       continue;
     }

--- a/tools/ts2pant/src/translate-signature.ts
+++ b/tools/ts2pant/src/translate-signature.ts
@@ -6,9 +6,9 @@ import {
   cellIsUsed,
   cellRegisterName,
   isMapType,
-  type MapSynthCell,
   mapTsType,
   type NumericStrategy,
+  type SynthCell,
 } from "./translate-types.js";
 import type { PantAction, PantDeclaration, PantRule } from "./types.js";
 
@@ -25,7 +25,7 @@ export interface TranslatedSignature {
    * stages (`translateTypes`, `translateBody`) so they register and look up
    * Maps in the same table. Present only when a `synthCell` was supplied.
    */
-  synthCell?: MapSynthCell | undefined;
+  synthCell?: SynthCell | undefined;
 }
 
 /**
@@ -836,7 +836,7 @@ function capitalize(s: string): string {
 export function shortParamName(
   typeName: string,
   existingNames: Set<string>,
-  synthCell?: MapSynthCell,
+  synthCell?: SynthCell,
 ): string {
   let name = typeName[0]!.toLowerCase();
   let suffix = 1;
@@ -860,7 +860,7 @@ export function translateSignature(
   sourceFile: SourceFile,
   functionName: string,
   strategy: NumericStrategy,
-  synthCell?: MapSynthCell,
+  synthCell?: SynthCell,
   overrides?: Map<string, string>,
 ): TranslatedSignature {
   const checker = sourceFile.getProject().getTypeChecker().compilerObject;

--- a/tools/ts2pant/src/translate-types.ts
+++ b/tools/ts2pant/src/translate-types.ts
@@ -234,6 +234,18 @@ function capitalize(s: string): string {
 }
 
 /**
+ * Conservative gate against `mapTsType` fallback strings reaching synth
+ * registration. Pantagruel type expressions are built from identifiers,
+ * the list bracket `[T]`, sum `T + U`, product `T * U`, parens, the
+ * module qualifier `::`, and whitespace. Compiler-text fallbacks
+ * (`Map<string, number>`, `{ x: number }`, `() => void`) contain
+ * characters outside that set and must be rejected at synth time.
+ */
+function isValidPantFieldType(s: string): boolean {
+  return s.length > 0 && /^[A-Za-z0-9_:\s[\]+*()]+$/u.test(s);
+}
+
+/**
  * Register an anonymous record shape. Idempotent: re-registering the same
  * sorted-field set returns the cached domain. Returns `{domain: null, ...}`
  * when any field name or type fragment is unmangleable.
@@ -252,18 +264,21 @@ export function registerRecordShape(
   if (cached) {
     return { domain: cached.domain, synth, registry };
   }
-  // Validate field names (must be valid identifiers) and base name
-  // mangleability.
+  // Validate field names (must be valid identifiers) and field types
+  // (must be parseable Pantagruel type expressions). `mapTsType` falls
+  // back to `checker.typeToString` for unsupported types, yielding
+  // strings like `Map<string, number>` or `{ x: number }` that contain
+  // TS-compiler artifacts (`<`, `>`, `{`, `}`, `,`, etc.) — never legal
+  // Pantagruel. Reject any field whose type isn't drawn from the
+  // Pantagruel type-expression character set so the broken text can't
+  // reach `emitRecordSynthDecls`.
   for (const f of fields) {
     if (!/^[A-Za-z_][A-Za-z0-9_]*$/u.test(f.name)) {
       return { domain: null, synth, registry };
     }
-    // Field types need not mangle to a single identifier (e.g. `[String]`
-    // is a valid accessor-rule return type); we just need them to be
-    // legal Pantagruel type strings. `mapTsType` already produces those
-    // or falls through to `checker.typeToString` which yields unparseable
-    // output — that latter case is the only real failure mode. Accept
-    // anything for now and let upstream mangleability checks gate.
+    if (!isValidPantFieldType(f.type)) {
+      return { domain: null, synth, registry };
+    }
   }
   const baseDomain =
     fields.length === 0
@@ -617,12 +632,18 @@ export function isSetType(type: ts.Type): boolean {
 /**
  * Detect an anonymous object/record type — a TS inline shape with no
  * declared interface / alias. These surface with the compiler-assigned
- * symbol name `__type`. Callable types (`{ (): void }`) and constructor
- * types (`{ new(): T }`) would also match on the name alone; we guard
- * against those by rejecting shapes with call or construct signatures —
- * record synthesis is only for finite field-based shapes. Zero-property
- * records (`{}`) are intentionally supported and synthesize as
- * `EmptyRec` via `registerRecordShape`.
+ * symbol name `__type`. Several other shapes match on the name alone
+ * and must be rejected because record synthesis is only for finite
+ * field-based shapes:
+ *   - Callable / constructor types (`{ (): T }`, `{ new(): T }`) —
+ *     detected via call/construct signatures.
+ *   - Index-signature dictionaries (`{ [k: string]: T }`,
+ *     `{ [k: number]: T }`) — `getProperties()` returns empty for
+ *     these, so without an explicit guard they would synthesize as
+ *     `EmptyRec`, misclassifying an unbounded dictionary as a finite
+ *     empty record.
+ * Zero-property records (`{}`) are intentionally supported and
+ * synthesize as `EmptyRec` via `registerRecordShape`.
  */
 export function isAnonymousRecord(type: ts.Type): boolean {
   const symbol = type.getSymbol();
@@ -632,6 +653,12 @@ export function isAnonymousRecord(type: ts.Type): boolean {
   if (
     type.getCallSignatures().length > 0 ||
     type.getConstructSignatures().length > 0
+  ) {
+    return false;
+  }
+  if (
+    type.getStringIndexType() !== undefined ||
+    type.getNumberIndexType() !== undefined
   ) {
     return false;
   }

--- a/tools/ts2pant/src/translate-types.ts
+++ b/tools/ts2pant/src/translate-types.ts
@@ -587,6 +587,12 @@ function registerAnonymousRecord(
       return null;
     }
     const mapped = mapTsType(propType, checker, strategy, synthCell);
+    // Propagate failure from a nested anonymous-record synthesis.
+    // Without this, the parent shape would register with the sentinel
+    // string as a field type and emit invalid output.
+    if (mapped === UNSUPPORTED_ANONYMOUS_RECORD) {
+      return null;
+    }
     fields.push({ name: prop.getName(), type: mapped });
   }
   // Canonical order: sort alphabetically by field name.

--- a/tools/ts2pant/src/translate-types.ts
+++ b/tools/ts2pant/src/translate-types.ts
@@ -53,7 +53,7 @@ export interface MapSynthEntry {
  * Immutable record: pure `registerMapKV` / `lookupMapKV` / `emitSynthDecls`
  * helpers operate on it, returning fresh records. Deep call sites that need
  * to register on demand (e.g., `translateBody` via `.get(k)` on an
- * expression-computed Map receiver) wrap synth + registry in a `MapSynthCell`
+ * expression-computed Map receiver) wrap synth + registry in a `SynthCell`
  * to avoid threading updates through every `BodyResult`.
  */
 export interface MapSynth {
@@ -171,27 +171,180 @@ export function emitSynthDecls(
   };
 }
 
+/** Fields of a synthesized record, in canonical (alphabetically sorted) order. */
+export interface RecordSynthField {
+  name: string;
+  type: string;
+}
+
+export interface RecordSynthEntry {
+  domain: string;
+  /** Binder name for accessor-rule parameters on this domain
+   *  (e.g., `r` in `name r: NameRegRec => String.`). Registry-allocated so
+   *  binders across multiple synthesized record domains don't collide. */
+  binder: string;
+  fields: RecordSynthField[];
+}
+
 /**
- * Mutable 2-field cell bundling a `MapSynth` and `NameRegistry`. Used by
- * deep call sites (mapTsType recursion, body translation) that would
- * otherwise have to thread the pair through every return value. The fields
- * are reassigned in place with freshly-computed immutable records; the
- * inner `MapSynth` / `NameRegistry` remain pure values. Cell-field
- * assignment is itself within ts2pant's self-translation envelope
- * (translatable as primed rules on the cell).
+ * Accumulates anonymous object-literal type occurrences encountered anywhere
+ * in the module's type positions (parameters, return types, nested fields)
+ * and synthesizes one domain + one accessor rule per field per unique
+ * shape. Records are specified *observationally* — Pantagruel has no
+ * record-constructor expression syntax, so a function returning a record
+ * literal is axiomatized by what each accessor returns when applied.
+ *
+ * Dedup by canonical shape string: fields sorted alphabetically by name,
+ * each paired with its Pantagruel type, joined with `|`. Field-order
+ * permutations in source (`{a, b}` vs `{b, a}`) hash to the same key.
+ *
+ * Immutable record (same discipline as `MapSynth`): pure register / lookup /
+ * emit helpers return fresh records. Deep call sites wrap synth + registry
+ * in a `SynthCell` to avoid threading updates through every return value.
  */
-export interface MapSynthCell {
+export interface RecordSynth {
+  readonly byShape: ReadonlyMap<string, RecordSynthEntry>;
+  readonly emitted: ReadonlySet<string>;
+}
+
+export function emptyRecordSynth(): RecordSynth {
+  return { byShape: new Map(), emitted: new Set() };
+}
+
+/** Canonical shape string: sorted `<name>:<type>|<name>:<type>|...`. */
+function recordShapeKey(fields: ReadonlyArray<RecordSynthField>): string {
+  return fields.map((f) => `${f.name}:${f.type}`).join("|");
+}
+
+/** Capitalize first letter. `"name"` → `"Name"`. */
+function capitalize(s: string): string {
+  return s.length === 0 ? s : s[0]!.toUpperCase() + s.slice(1);
+}
+
+/**
+ * Register an anonymous record shape. Idempotent: re-registering the same
+ * sorted-field set returns the cached domain. Returns `{domain: null, ...}`
+ * when any field name or type fragment is unmangleable.
+ *
+ * `fields` must already be in canonical (alphabetically sorted) order with
+ * Pantagruel type strings; the caller (`cellRegisterRecord`) is responsible
+ * for that normalization.
+ */
+export function registerRecordShape(
+  synth: RecordSynth,
+  registry: NameRegistry,
+  fields: ReadonlyArray<RecordSynthField>,
+): { domain: string | null; synth: RecordSynth; registry: NameRegistry } {
+  const key = recordShapeKey(fields);
+  const cached = synth.byShape.get(key);
+  if (cached) {
+    return { domain: cached.domain, synth, registry };
+  }
+  // Validate field names (must be valid identifiers) and base name
+  // mangleability.
+  for (const f of fields) {
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/u.test(f.name)) {
+      return { domain: null, synth, registry };
+    }
+    // Field types need not mangle to a single identifier (e.g. `[String]`
+    // is a valid accessor-rule return type); we just need them to be
+    // legal Pantagruel type strings. `mapTsType` already produces those
+    // or falls through to `checker.typeToString` which yields unparseable
+    // output — that latter case is the only real failure mode. Accept
+    // anything for now and let upstream mangleability checks gate.
+  }
+  const baseDomain =
+    fields.length === 0
+      ? "EmptyRec"
+      : `${fields.map((f) => capitalize(f.name)).join("")}Rec`;
+  const reg1 = registerName(registry, baseDomain);
+  const domain = reg1.name;
+  // Allocate a shared binder name for this domain's accessor rules.
+  // Using "r" as the mnemonic (matching Map synth's "m"/"k" convention).
+  const bReg = registerName(reg1.registry, "r");
+  const binder = bReg.name;
+  const entry: RecordSynthEntry = {
+    domain,
+    binder,
+    fields: fields.map((f) => ({ ...f })),
+  };
+  const newByShape = new Map(synth.byShape);
+  newByShape.set(key, entry);
+  return {
+    domain,
+    synth: { byShape: newByShape, emitted: synth.emitted },
+    registry: bReg.registry,
+  };
+}
+
+export function lookupRecordShape(
+  synth: RecordSynth,
+  fields: ReadonlyArray<RecordSynthField>,
+): RecordSynthEntry | undefined {
+  return synth.byShape.get(recordShapeKey(fields));
+}
+
+/**
+ * Materialize accumulated record decls (domain + one accessor rule per
+ * field) in registration order. Incremental like `emitSynthDecls`: only
+ * entries not in `synth.emitted` are emitted, so the pipeline can drain
+ * new body-level registrations after signature/type translation has
+ * already run.
+ */
+export function emitRecordSynthDecls(
+  synth: RecordSynth,
+  registry: NameRegistry,
+): { decls: PantDeclaration[]; synth: RecordSynth; registry: NameRegistry } {
+  const decls: PantDeclaration[] = [];
+  const newEmitted = new Set(synth.emitted);
+  for (const [key, entry] of synth.byShape) {
+    if (newEmitted.has(key)) {
+      continue;
+    }
+    newEmitted.add(key);
+    decls.push({ kind: "domain", name: entry.domain });
+    for (const field of entry.fields) {
+      decls.push({
+        kind: "rule",
+        name: field.name,
+        params: [{ name: entry.binder, type: entry.domain }],
+        returnType: field.type,
+      });
+    }
+  }
+  return {
+    decls,
+    synth: { byShape: synth.byShape, emitted: newEmitted },
+    registry,
+  };
+}
+
+/**
+ * Mutable 3-field cell bundling a `MapSynth`, `RecordSynth` and
+ * `NameRegistry`. Used by deep call sites (mapTsType recursion, body
+ * translation) that would otherwise have to thread state through every
+ * return value. The fields are reassigned in place with freshly-computed
+ * immutable records; the inner values remain pure. Cell-field assignment
+ * is itself within ts2pant's self-translation envelope (translatable as
+ * primed rules on the cell).
+ */
+export interface SynthCell {
   synth: MapSynth;
+  recordSynth: RecordSynth;
   registry: NameRegistry;
 }
 
-export function newMapSynthCell(registry?: NameRegistry): MapSynthCell {
-  return { synth: emptyMapSynth(), registry: registry ?? emptyNameRegistry() };
+export function newSynthCell(registry?: NameRegistry): SynthCell {
+  return {
+    synth: emptyMapSynth(),
+    recordSynth: emptyRecordSynth(),
+    registry: registry ?? emptyNameRegistry(),
+  };
 }
 
 /** Cell-mutating wrapper around `registerMapKV` for the legacy call shape. */
 export function cellRegisterMap(
-  cell: MapSynthCell,
+  cell: SynthCell,
   kType: string,
   vType: string,
 ): string | null {
@@ -201,24 +354,50 @@ export function cellRegisterMap(
   return r.domain;
 }
 
+/** Cell-mutating wrapper around `registerRecordShape`. `fields` must be in
+ *  canonical (alphabetically sorted) order. */
+export function cellRegisterRecord(
+  cell: SynthCell,
+  fields: ReadonlyArray<RecordSynthField>,
+): string | null {
+  const r = registerRecordShape(cell.recordSynth, cell.registry, fields);
+  cell.recordSynth = r.synth;
+  cell.registry = r.registry;
+  return r.domain;
+}
+
+/** Cell read-through for `lookupRecordShape`. `fields` must be canonical. */
+export function cellLookupRecord(
+  cell: SynthCell,
+  fields: ReadonlyArray<RecordSynthField>,
+): RecordSynthEntry | undefined {
+  return lookupRecordShape(cell.recordSynth, fields);
+}
+
 /** Cell-mutating wrapper around `registerName`. */
-export function cellRegisterName(cell: MapSynthCell, name: string): string {
+export function cellRegisterName(cell: SynthCell, name: string): string {
   const r = registerName(cell.registry, name);
   cell.registry = r.registry;
   return r.name;
 }
 
 /** Cell read-through for `isUsed`. */
-export function cellIsUsed(cell: MapSynthCell, name: string): boolean {
+export function cellIsUsed(cell: SynthCell, name: string): boolean {
   return cell.registry.used.has(name);
 }
 
-/** Cell-mutating wrapper around `emitSynthDecls`. */
-export function cellEmitSynth(cell: MapSynthCell): PantDeclaration[] {
-  const r = emitSynthDecls(cell.synth, cell.registry);
-  cell.synth = r.synth;
-  cell.registry = r.registry;
-  return r.decls;
+/** Cell-mutating wrapper that drains both Map and Record synth decls.
+ *  Emits Maps first so Record accessor-rule return types can reference
+ *  any Map domain registered bottom-up. Incremental: each call returns
+ *  only the entries added since the previous drain. */
+export function cellEmitSynth(cell: SynthCell): PantDeclaration[] {
+  const mapR = emitSynthDecls(cell.synth, cell.registry);
+  cell.synth = mapR.synth;
+  cell.registry = mapR.registry;
+  const recR = emitRecordSynthDecls(cell.recordSynth, cell.registry);
+  cell.recordSynth = recR.synth;
+  cell.registry = recR.registry;
+  return [...mapR.decls, ...recR.decls];
 }
 
 /** Strategy for mapping TS `number` to a Pantagruel numeric type. */
@@ -253,7 +432,7 @@ export function mapTsType(
   type: ts.Type,
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
-  synthCell?: MapSynthCell,
+  synthCell?: SynthCell,
 ): string {
   const flags = type.flags;
 
@@ -334,6 +513,17 @@ export function mapTsType(
     return unique.join(" + ");
   }
 
+  // Anonymous record type — synthesize a domain + accessor rules per
+  // unique shape. Mirrors the `Map<K, V>` synth pattern: registration is
+  // idempotent on canonical (sorted-field) shape, one domain per shape,
+  // nested anonymous records compose bottom-up via recursive mapTsType.
+  if (isAnonymousRecord(type) && synthCell) {
+    const domain = registerAnonymousRecord(type, checker, strategy, synthCell);
+    if (domain !== null) {
+      return domain;
+    }
+  }
+
   // Named type (interface, class, enum, type alias)
   const symbol = type.aliasSymbol ?? type.symbol;
   if (symbol) {
@@ -341,6 +531,42 @@ export function mapTsType(
   }
 
   return checker.typeToString(type);
+}
+
+/**
+ * Collect declared fields from an anonymous object type, map each field's
+ * type via `mapTsType`, sort fields alphabetically by name, and register
+ * with the synth cell. Returns the synthesized domain name, or null if
+ * any field's type is unmangleable or a field name is a non-identifier.
+ *
+ * Callers must have already checked `isAnonymousRecord(type)`.
+ */
+function registerAnonymousRecord(
+  type: ts.Type,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  synthCell: SynthCell,
+): string | null {
+  const properties = type.getProperties();
+  const fields: RecordSynthField[] = [];
+  for (const prop of properties) {
+    // Resolve the property's declared type. For anonymous object types,
+    // `PropertySignature` is the usual declaration kind; fall back to the
+    // checker when the property has no source declaration (structural
+    // shapes from mapped / indexed-access types).
+    const decl = prop.getDeclarations()?.[0];
+    const propType = decl
+      ? checker.getTypeOfSymbolAtLocation(prop, decl)
+      : (prop as unknown as { type?: ts.Type }).type;
+    if (!propType) {
+      return null;
+    }
+    const mapped = mapTsType(propType, checker, strategy, synthCell);
+    fields.push({ name: prop.getName(), type: mapped });
+  }
+  // Canonical order: sort alphabetically by field name.
+  fields.sort((a, b) => a.name.localeCompare(b.name));
+  return cellRegisterRecord(synthCell, fields);
 }
 
 /**
@@ -353,6 +579,24 @@ export function isSetType(type: ts.Type): boolean {
   const symbol = type.getSymbol();
   const name = symbol?.getName();
   return name === "Set" || name === "ReadonlySet";
+}
+
+/**
+ * Detect an anonymous object/record type — a TS inline shape with no
+ * declared interface / alias. These surface with the compiler-assigned
+ * symbol name `__type`. Callable types (`{ (): void }`) and indexed
+ * access shapes would also match on the name alone; we guard against
+ * those by requiring at least one property and no call signatures.
+ */
+export function isAnonymousRecord(type: ts.Type): boolean {
+  const symbol = type.getSymbol();
+  if (symbol?.getName() !== "__type") {
+    return false;
+  }
+  if (type.getCallSignatures().length > 0) {
+    return false;
+  }
+  return true;
 }
 
 /**
@@ -382,7 +626,7 @@ export function translateTypes(
   extracted: ExtractedTypes,
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
-  synthCell?: MapSynthCell,
+  synthCell?: SynthCell,
 ): PantDeclaration[] {
   const decls: PantDeclaration[] = [];
 

--- a/tools/ts2pant/src/translate-types.ts
+++ b/tools/ts2pant/src/translate-types.ts
@@ -9,6 +9,18 @@ import { getAst } from "./pant-wasm.js";
 import type { PantDeclaration } from "./types.js";
 
 /**
+ * Sentinel returned by `mapTsType` when an anonymous-record type is
+ * encountered but synthesis is unavailable or fails. Distinct from the
+ * compiler's `__type` symbol name so that downstream code (notably
+ * `translateRecordReturn`) can detect synthesis failure rather than
+ * silently treat the unmangleable shape as a supported anonymous record.
+ * The value is not a valid Pantagruel identifier — emission of a signature
+ * containing it will be visibly broken rather than referring to an
+ * undeclared domain.
+ */
+export const UNSUPPORTED_ANONYMOUS_RECORD = "__unsupported_anon_record__";
+
+/**
  * Mangle a Pantagruel type string into an identifier-safe fragment suitable
  * for embedding inside a synthesized Map domain name.
  *   "String"           → "String"
@@ -517,11 +529,24 @@ export function mapTsType(
   // unique shape. Mirrors the `Map<K, V>` synth pattern: registration is
   // idempotent on canonical (sorted-field) shape, one domain per shape,
   // nested anonymous records compose bottom-up via recursive mapTsType.
-  if (isAnonymousRecord(type) && synthCell) {
-    const domain = registerAnonymousRecord(type, checker, strategy, synthCell);
-    if (domain !== null) {
-      return domain;
+  // Never fall through to the generic symbol branch on failure — that
+  // branch returns `__type`, which is the same sentinel
+  // `translateRecordReturn` uses to detect anonymous returns and would
+  // silently mark the function as a supported record return whose
+  // synthesized domain has not actually been registered.
+  if (isAnonymousRecord(type)) {
+    if (synthCell) {
+      const domain = registerAnonymousRecord(
+        type,
+        checker,
+        strategy,
+        synthCell,
+      );
+      if (domain !== null) {
+        return domain;
+      }
     }
+    return UNSUPPORTED_ANONYMOUS_RECORD;
   }
 
   // Named type (interface, class, enum, type alias)

--- a/tools/ts2pant/src/translate-types.ts
+++ b/tools/ts2pant/src/translate-types.ts
@@ -578,7 +578,9 @@ function registerAnonymousRecord(
     // Resolve the property's declared type. For anonymous object types,
     // `PropertySignature` is the usual declaration kind; fall back to the
     // checker when the property has no source declaration (structural
-    // shapes from mapped / indexed-access types).
+    // shapes from mapped / indexed-access types). The fallback cast
+    // reaches an internal TypeScript compiler property and should be
+    // revisited if the compiler internals change.
     const decl = prop.getDeclarations()?.[0];
     const propType = decl
       ? checker.getTypeOfSymbolAtLocation(prop, decl)
@@ -615,9 +617,10 @@ export function isSetType(type: ts.Type): boolean {
 /**
  * Detect an anonymous object/record type — a TS inline shape with no
  * declared interface / alias. These surface with the compiler-assigned
- * symbol name `__type`. Callable types (`{ (): void }`) and indexed
- * access shapes would also match on the name alone; we guard against
- * those by requiring at least one property and no call signatures.
+ * symbol name `__type`. Callable types (`{ (): void }`) would also
+ * match on the name alone; we guard against those by rejecting shapes
+ * with call signatures. Zero-property records (`{}`) are intentionally
+ * supported and synthesize as `EmptyRec` via `registerRecordShape`.
  */
 export function isAnonymousRecord(type: ts.Type): boolean {
   const symbol = type.getSymbol();

--- a/tools/ts2pant/src/translate-types.ts
+++ b/tools/ts2pant/src/translate-types.ts
@@ -617,17 +617,22 @@ export function isSetType(type: ts.Type): boolean {
 /**
  * Detect an anonymous object/record type — a TS inline shape with no
  * declared interface / alias. These surface with the compiler-assigned
- * symbol name `__type`. Callable types (`{ (): void }`) would also
- * match on the name alone; we guard against those by rejecting shapes
- * with call signatures. Zero-property records (`{}`) are intentionally
- * supported and synthesize as `EmptyRec` via `registerRecordShape`.
+ * symbol name `__type`. Callable types (`{ (): void }`) and constructor
+ * types (`{ new(): T }`) would also match on the name alone; we guard
+ * against those by rejecting shapes with call or construct signatures —
+ * record synthesis is only for finite field-based shapes. Zero-property
+ * records (`{}`) are intentionally supported and synthesize as
+ * `EmptyRec` via `registerRecordShape`.
  */
 export function isAnonymousRecord(type: ts.Type): boolean {
   const symbol = type.getSymbol();
   if (symbol?.getName() !== "__type") {
     return false;
   }
-  if (type.getCallSignatures().length > 0) {
+  if (
+    type.getCallSignatures().length > 0 ||
+    type.getConstructSignatures().length > 0
+  ) {
     return false;
   }
   return true;

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -350,6 +350,10 @@ exports[`expressions-readonly-set.ts > containsReadonly 1`] = `
 "module ContainsReadonly.\\n\\ncontainsReadonly xs: [String], x: String => Bool.\\n\\n---\\n\\ncontainsReadonly xs x = (x in xs).\\n"
 `;
 
+exports[`expressions-record-return.ts > emptyAnonBag 1`] = `
+"module EmptyAnonBag.\\n\\nItemsRec.\\nitems r: ItemsRec => [String].\\nemptyAnonBag  => ItemsRec.\\n\\n---\\n\\nall x: String | ~(x in items emptyAnonBag).\\n"
+`;
+
 exports[`expressions-record-return.ts > emptyBag 1`] = `
 "module EmptyBag.\\n\\nBag.\\nitems b: Bag => [String].\\nemptyBag  => Bag.\\n\\n---\\n\\nall x: String | ~(x in items emptyBag).\\n"
 `;
@@ -358,8 +362,24 @@ exports[`expressions-record-return.ts > emptyBagShadowed 1`] = `
 "module EmptyBagShadowed.\\n\\nBag.\\nitems b: Bag => [String].\\nemptyBagShadowed x: Int => Bag.\\n\\n---\\n\\nall x1: String | ~(x1 in items (emptyBagShadowed x)).\\n"
 `;
 
+exports[`expressions-record-return.ts > nestPair 1`] = `
+"module NestPair.\\n\\nInnerRec.\\ninner r: InnerRec => String.\\nOuterRec.\\nouter r1: OuterRec => InnerRec.\\nnestPair  => OuterRec.\\n\\n---\\n\\ninner (outer nestPair) = \\"hi\\".\\n"
+`;
+
+exports[`expressions-record-return.ts > nothing 1`] = `
+"module Nothing.\\n\\nEmptyRec.\\nnothing  => EmptyRec.\\n\\n---\\n\\ntrue.\\n"
+`;
+
 exports[`expressions-record-return.ts > origin 1`] = `
 "module Origin.\\n\\nPoint.\\nx p: Point => Int.\\ny p: Point => Int.\\norigin  => Point.\\n\\n---\\n\\nx origin = 0.\\ny origin = 0.\\n"
+`;
+
+exports[`expressions-record-return.ts > registerShape 1`] = `
+"module RegisterShape.\\n\\nNameRegistry.\\nused n: NameRegistry => [String].\\nNameRegRec.\\nname r1: NameRegRec => String.\\nreg r1: NameRegRec => NameRegistry.\\nregisterShape r: NameRegistry, s: String => NameRegRec.\\n\\n---\\n\\nname (registerShape r s) = s.\\nreg (registerShape r s) = r.\\n"
+`;
+
+exports[`expressions-record-return.ts > registerShapeFlipped 1`] = `
+"module RegisterShapeFlipped.\\n\\nNameRegistry.\\nused n: NameRegistry => [String].\\nNameRegRec.\\nname r1: NameRegRec => String.\\nreg r1: NameRegRec => NameRegistry.\\nregisterShapeFlipped r: NameRegistry, s: String => NameRegRec.\\n\\n---\\n\\nname (registerShapeFlipped r s) = s.\\nreg (registerShapeFlipped r s) = r.\\n"
 `;
 
 exports[`expressions-record-return.ts > translate 1`] = `

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-record-return.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-record-return.ts
@@ -71,8 +71,10 @@ export function nestPair(): { outer: { inner: string } } {
 }
 
 /** Empty anonymous return — default synthesized name `EmptyRec`, no
- *  accessor rules. */
-export function nothing(): Record<string, never> {
+ *  accessor rules. The return type is the empty object literal `{}`,
+ *  not `Record<string, never>` (which carries a string index signature
+ *  and is rejected as an unbounded dictionary, not a finite record). */
+export function nothing(): {} {
   return {};
 }
 

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-record-return.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-record-return.ts
@@ -1,8 +1,8 @@
 // Record returns: a pure function whose body is `return { f1: e1, f2: e2 }`
-// decomposes into one equation per field of the return type. The return
-// type must be a named interface whose accessor rules are already declared;
-// anonymous record types (synthesized result domains) are a separate stage.
-// See CLAUDE.md § Record Returns.
+// decomposes into one equation per field of the return type. Return types
+// may be named interfaces (accessor rules are already declared) or
+// anonymous object shapes (a domain is synthesized per shape). See
+// CLAUDE.md § Record Returns.
 
 export interface Point {
   x: number;
@@ -36,5 +36,49 @@ export function emptyBag(): Bag {
  *  only to prove the name doesn't get captured. */
 // biome-ignore lint/correctness/noUnusedFunctionParameters: deliberate shadowing test
 export function emptyBagShadowed(x: number): Bag {
+  return { items: new Set() };
+}
+
+// --- Anonymous record returns ---
+
+export interface NameRegistry {
+  readonly used: ReadonlySet<string>;
+}
+
+/** Anonymous return type → synthesized domain `NameRegRec`. Parameter
+ *  names are intentionally distinct from field names to avoid collision
+ *  with accessor rules (same rule applies for named interfaces). */
+export function registerShape(
+  r: NameRegistry,
+  s: string,
+): { name: string; reg: NameRegistry } {
+  return { name: s, reg: r };
+}
+
+/** Field-order permutation — should reuse the same synthesized domain
+ *  as `registerShape` via canonical (sorted) dedup key. */
+export function registerShapeFlipped(
+  r: NameRegistry,
+  s: string,
+): { reg: NameRegistry; name: string } {
+  return { reg: r, name: s };
+}
+
+/** Nested anonymous record — the inner shape registers its own domain
+ *  bottom-up, and the outer domain's accessor references it. */
+export function nestPair(): { outer: { inner: string } } {
+  return { outer: { inner: "hi" } };
+}
+
+/** Empty anonymous return — default synthesized name `EmptyRec`, no
+ *  accessor rules. */
+export function nothing(): Record<string, never> {
+  return {};
+}
+
+/** Anonymous return whose field type is itself a set — empty-set
+ *  initializer still works via membership negation on the synthesized
+ *  accessor. */
+export function emptyAnonBag(): { items: ReadonlySet<string> } {
   return { items: new Set() };
 }


### PR DESCRIPTION
## Summary

Extends record-return translation (#107) to handle **anonymous** object return types — `function f(): { name: string; reg: NameRegistry } { ... }` where TypeScript assigns symbol name `__type` and the old code bailed with an `unsupported` marker.

Mirrors the existing `MapSynth` pattern (Kroening & Strichman Ch. 8 record axiomatization): synthesize one Pantagruel domain per unique shape, plus one accessor rule per field, then translate the return value observationally via per-accessor equations:

```typescript
function registerShape(
  r: NameRegistry, s: string,
): { name: string; reg: NameRegistry } {
  return { name: s, reg: r };
}
```

```text
NameRegistry.
used n: NameRegistry => [String].
NameRegRec.
name r1: NameRegRec => String.
reg r1: NameRegRec => NameRegistry.
registerShape r: NameRegistry, s: String => NameRegRec.
---
name (registerShape r s) = s.
reg (registerShape r s) = r.
```

## Design

- **Dedup key** = canonical shape string: fields sorted alphabetically by name, paired with Pantagruel types, joined with `|`. `{a, b}` and `{b, a}` share a domain.
- **Domain name** = sorted capitalized field names + `Rec` suffix. Empty shape (`{}`) → `EmptyRec`. Collisions resolve via `NameRegistry`'s numeric suffixing.
- **Nested composition** bottom-up via recursive `mapTsType`: `{outer: {inner: string}}` registers `InnerRec` first, then `OuterRec` with `outer` accessor returning `InnerRec`. Nested object-literal initializers in body position also decompose recursively (`inner (outer f) = "hi".`), since Pantagruel has no record-constructor expression.
- **Cross-module composition** uses Pantagruel's module namespacing (`ModA::NameRegRec` ≠ `ModB::NameRegRec` — `lib/env.ml:213-265`'s unambiguous-import flat map handles lexical collision); structural identification across modules is a checker concern, not ts2pant's.

## Changes

- Rename `MapSynthCell` → `SynthCell` (mechanical; via sed).
- New `RecordSynth` / `RecordSynthEntry` / `RecordSynthField` types and `registerRecordShape` / `lookupRecordShape` / `emitRecordSynthDecls` helpers in `translate-types.ts`.
- `SynthCell` gets a `recordSynth` field; `cellEmitSynth` drains Maps before Records (records can reference Map-typed fields).
- `isAnonymousRecord` + anonymous-record branch in `mapTsType` before the named-type fallback.
- In `translate-body.ts`: drop the `__type` rejection in `translateRecordReturn`; factor the field-emission loop into `emitRecordEquations` so nested literals can recurse with a new receiver expression.
- Five new fixtures: `registerShape`, `registerShapeFlipped` (same domain via canonical key), `nestPair` (bottom-up nested), `nothing` (empty → `EmptyRec`), `emptyAnonBag` (anonymous shape with set-typed field).

## Known pre-existing limitation (not fixed here)

Accessor rule names are the field names directly, so a function parameter that shares a name with a field shadows the accessor rule (Pantagruel error: "Cannot call String: not a function"). The named-interface path in #107 has the same issue. Fixture params are named to avoid collision; documented in CLAUDE.md.

## Test plan

- [x] `npm test` — 322 tests pass, 5 new fixture snapshots
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `pant --check` on `registerShape`, `nestPair`, `nothing`, `emptyAnonBag`, `emptyNameRegistry` — OK (the `--check` FAILs on `registerShape`/`Flipped`/`translate` are the pre-existing bounded-model-check limitation over uninterpreted domains + unbounded inputs, same behavior as PR #107's `translate(Point)`).
- [x] Existing snapshots unchanged — only additions for the new fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)