### PR TITLE
check: split term namespace; alpha-rename capturing SMT binders

### DIFF
--- a/lib/check.ml
+++ b/lib/check.ml
@@ -27,6 +27,13 @@ type type_error =
   | PrimedExtracontextual of string * string list * loc
       (** function name, context names *)
   | BoolParam of string * string * loc  (** param name, declaration name *)
+  | NullaryRuleShadowedByVar of string * ty * ty * loc
+      (** name, rule's return type, variable's type, rule declaration loc.
+          Emitted by [Env.add_var] via the shadow_reporter when a variable is
+          introduced with the same name as an existing nullary rule — the one
+          case where var-versus-rule shadowing is semantically observable
+          (nullary rules auto-apply in bare-atom position, so a same-named
+          variable eclipses the rule). *)
   | ComprehensionNeedEach of ty * loc
   | AggregateRequiresNumeric of string * ty * loc
       (** combiner symbol, actual body type *)
@@ -38,6 +45,16 @@ type type_error =
 
 let type_warnings : type_error list ref = ref []
 let get_warnings () = List.rev !type_warnings
+
+(* Install the shadow-reporter callback so [Env.add_var]'s nullary-rule
+   collision detection funnels into the existing type-warnings pipeline.
+   Module-initialization statement; runs once when check.ml is loaded. *)
+let () =
+  Env.shadow_reporter :=
+    fun name rule_ret var_ty rule_loc _var_loc ->
+      type_warnings :=
+        NullaryRuleShadowedByVar (name, rule_ret, var_ty, rule_loc)
+        :: !type_warnings
 
 type context = {
   env : Env.t;
@@ -56,7 +73,13 @@ let rec infer_type ctx (expr : expr) : (ty, type_error) result =
   | ELitReal _ -> Ok TyReal
   | ELitString _ -> Ok TyString
   | EVar (Lower name) -> (
-      match[@warning "-4"] Env.lookup_term name ctx.env with
+      match(* Bare-atom reference: variables first, then nullary rules
+         (auto-applied) per Env.lookup_bare. The two namespaces are
+         separate at the env level; only this position and qualified-name
+         resolution consider both. *)
+           [@warning "-4"]
+        Env.lookup_bare name ctx.env
+      with
       | Some { kind = Env.KVar ty; _ } -> Ok ty
       | Some { kind = Env.KRule (TyFunc ([], Some ret)); _ } ->
           (* Nullary rule: auto-apply *)
@@ -143,7 +166,27 @@ let rec infer_type ctx (expr : expr) : (ty, type_error) result =
             Error (UnboundVariable (name, ctx.loc))
         | None -> Error (UnboundVariable (name, ctx.loc)))
   | EApp (func, args) ->
-      let* func_ty = infer_type ctx func in
+      (* Application heads are syntactically rule-only. If the head is a
+         bare lower identifier, probe [lookup_term] (rules and closures)
+         first — otherwise a parameter of the same name would mask the
+         rule and the application would fail with "not a function". Fall
+         back to [infer_type] (which uses [lookup_bare]) if the head isn't
+         a rule; that preserves list-indexing and list-search, whose
+         "function head" is actually a variable or a nullary rule
+         auto-applied to produce a list. *)
+      let* func_ty =
+        match[@warning "-4"] func with
+        | EVar (Lower name) -> (
+            match[@warning "-4"] Env.lookup_term name ctx.env with
+            | Some { kind = Env.KRule (TyFunc (_ :: _, _) as ty); _ } -> Ok ty
+            | Some { kind = Env.KClosure (ty, _); _ } -> Ok ty
+            | _ ->
+                (* Nullary rules, variables, and missing entries — let the
+                   general [infer_type] path handle auto-apply / list
+                   indexing / unbound diagnostics. *)
+                infer_type ctx func)
+        | _ -> infer_type ctx func
+      in
       check_application ctx func func_ty args
   | ETuple exprs ->
       let* tys = map_result (infer_type ctx) exprs in
@@ -343,18 +386,18 @@ and check_unop ctx op e =
 
 (** Check that binding doesn't shadow with a different type. Emits a warning
     (rather than an error) when it does, since propositions from different
-    chapters may legitimately reuse variable names at different types. *)
+    chapters may legitimately reuse variable names at different types. After the
+    env-namespace split, this probes [vars] rather than [terms] (which now holds
+    only rules / closures). Nullary-rule shadowing is detected separately inside
+    [Env.add_var] via the shadow_reporter. *)
 and check_no_type_shadow ctx name new_ty =
-  (match Env.lookup_term name ctx.env with
+  (match[@warning "-4"] Env.lookup_var name ctx.env with
   | Some { kind = Env.KVar existing_ty; _ } ->
       if not (is_subtype new_ty existing_ty) then
         type_warnings :=
           ShadowingTypeMismatch (name, existing_ty, new_ty, ctx.loc)
           :: !type_warnings
-  | Some { kind = Env.KDomain | Env.KAlias _ | Env.KRule _ | Env.KClosure _; _ }
-    ->
-      ()
-  | None -> ());
+  | _ -> ());
   Ok ()
 
 (** Resolve a parameter's type expression to an internal type *)

--- a/lib/check.ml
+++ b/lib/check.ml
@@ -28,12 +28,13 @@ type type_error =
       (** function name, context names *)
   | BoolParam of string * string * loc  (** param name, declaration name *)
   | NullaryRuleShadowedByVar of string * ty * ty * loc
-      (** name, rule's return type, variable's type, rule declaration loc.
+      (** name, declaration's return type, variable's type, declaration loc.
           Emitted by [Env.add_var] via the shadow_reporter when a variable is
-          introduced with the same name as an existing nullary rule — the one
-          case where var-versus-rule shadowing is semantically observable
-          (nullary rules auto-apply in bare-atom position, so a same-named
-          variable eclipses the rule). *)
+          introduced with the same name as an existing nullary declaration (rule
+          or closure) — the one case where var-versus-term shadowing is
+          semantically observable (both nullary rules and nullary closures
+          auto-apply in bare-atom position, so a same-named variable eclipses
+          them). *)
   | ComprehensionNeedEach of ty * loc
   | AggregateRequiresNumeric of string * ty * loc
       (** combiner symbol, actual body type *)

--- a/lib/check.mli
+++ b/lib/check.mli
@@ -20,6 +20,7 @@ type type_error =
   | UnboundQualified of string * string * Ast.loc
   | PrimedExtracontextual of string * string list * Ast.loc
   | BoolParam of string * string * Ast.loc
+  | NullaryRuleShadowedByVar of string * Types.ty * Types.ty * Ast.loc
   | ComprehensionNeedEach of Types.ty * Ast.loc
   | AggregateRequiresNumeric of string * Types.ty * Ast.loc
   | AggregateRequiresBool of string * Types.ty * Ast.loc

--- a/lib/env.ml
+++ b/lib/env.ml
@@ -24,11 +24,23 @@ module StringMap = Map.Make (String)
 
 type t = {
   types : entry StringMap.t;  (** Type namespace: domains and aliases *)
-  terms : entry StringMap.t;  (** Term namespace: rules and variables *)
+  terms : entry StringMap.t;
+      (** Term namespace: rules (KRule) and closures (KClosure) only. Variables
+          live in [vars]. Separating the two namespaces lets application heads /
+          primed / override positions resolve against [terms] without being
+          shadowed by same-named parameters — the six-of-seven syntactic
+          positions in which a lower identifier can appear are rule-only; only
+          bare-atom references are ambiguous, and those resolve through
+          [lookup_bare] with var-first-then-nullary-rule fallback. *)
+  vars : entry StringMap.t;
+      (** Variable namespace: KVar only. Parameters, quantifier binders, and
+          shorthand-bound values. Separated from [terms] so a param named the
+          same as a same-named rule no longer overwrites the rule in lookup. *)
   imported_types : (string * entry) list StringMap.t;
       (** Import index: name -> [(module, entry)] for types *)
   imported_terms : (string * entry) list StringMap.t;
-      (** Import index: name -> [(module, entry)] for terms *)
+      (** Import index: name -> [(module, entry)] for terms (rules). Imports
+          never include variables ([add_import] filters [KVar]). *)
   current_module : string;  (** Current module name *)
   contexts : string list StringMap.t;
       (** Context declarations: context name -> member function names *)
@@ -47,6 +59,7 @@ let empty module_name =
   {
     types = StringMap.empty;
     terms = StringMap.empty;
+    vars = StringMap.empty;
     imported_types = StringMap.empty;
     imported_terms = StringMap.empty;
     current_module = module_name;
@@ -56,6 +69,14 @@ let empty module_name =
     action_contexts = [];
     local_vars = [];
   }
+
+(** Callback for reporting that an [add_var] call shadowed a nullary rule of the
+    same name. Installed by [check.ml] so the existing warning pipeline picks up
+    the event without creating a circular dependency between [env.ml] and
+    [check.ml]. Default is no-op so tests that use the env directly don't
+    require setting it. *)
+let shadow_reporter : (string -> ty -> ty -> Ast.loc -> Ast.loc -> unit) ref =
+  ref (fun _ _ _ _ _ -> ())
 
 (** Add a raw entry to the type namespace *)
 let add_type_entry name entry env =
@@ -98,8 +119,17 @@ let add_closure name ty target loc ~chapter env =
   in
   { env with terms = StringMap.add name entry env.terms }
 
-(** Add a variable to the term namespace (also tracks as local var) *)
+(** Add a variable to the var namespace (also tracks as local var). If [name]
+    matches an existing nullary rule in [terms], fire the shadow reporter so the
+    check layer can emit a warning — the nullary-rule auto-apply case is the one
+    place where a var genuinely overrides a rule the user could otherwise reach
+    by bare reference. Non-nullary rule collisions are not shadowing (syntactic
+    position disambiguates) and don't warn. *)
 let add_var name ty env =
+  (match[@warning "-4"] StringMap.find_opt name env.terms with
+  | Some { kind = KRule (TyFunc ([], Some ret)); loc = rule_loc; _ } ->
+      !shadow_reporter name ret ty rule_loc Ast.dummy_loc
+  | _ -> ());
   let entry =
     {
       kind = KVar ty;
@@ -110,7 +140,7 @@ let add_var name ty env =
   in
   {
     env with
-    terms = StringMap.add name entry env.terms;
+    vars = StringMap.add name entry env.vars;
     local_vars = name :: env.local_vars;
   }
 
@@ -161,14 +191,40 @@ let in_action_context env = Option.is_some env.action
 (** Lookup a type by name *)
 let lookup_type name env = StringMap.find_opt name env.types
 
-(** Lookup a term by name *)
+(** Lookup a term (rule or closure) by name. Does not fall back to variables —
+    callers using this for application heads, primed references, override LHS,
+    or qualifier resolution get rule-only semantics. *)
 let lookup_term name env = StringMap.find_opt name env.terms
 
-(** Fold over the terms namespace *)
+(** Lookup a variable by name. *)
+let lookup_var name env = StringMap.find_opt name env.vars
+
+(** Lookup for bare-atom references in value position: try variables first, then
+    fall back to nullary rules (for auto-application). This is the one syntactic
+    position where rule and var names can refer to the same lexical token;
+    variables shadow nullary rules (their entries in [vars] were added later and
+    the user presumably meant the local binding).
+
+    Non-nullary rules in this position would indicate a first-class function
+    reference; Pantagruel has no first-class functions, so this is an error
+    upstream, but we still return the rule entry so the caller can produce a
+    meaningful error rather than an unbound-variable one. *)
+let lookup_bare name env =
+  match StringMap.find_opt name env.vars with
+  | Some _ as e -> e
+  | None -> StringMap.find_opt name env.terms
+
+(** Fold over the terms namespace (rules and closures). *)
 let fold_terms f env init = StringMap.fold f env.terms init
 
-(** Iterate over the terms namespace *)
+(** Iterate over the terms namespace (rules and closures). *)
 let iter_terms f env = StringMap.iter f env.terms
+
+(** Fold over every binding in both [terms] and [vars]. Used where callers need
+    the union (e.g., sort collection for SMT preamble). *)
+let fold_all_terms f env init =
+  let acc = StringMap.fold f env.terms init in
+  StringMap.fold f env.vars acc
 
 (** Fold over the types namespace *)
 let fold_types f env init = StringMap.fold f env.types init
@@ -176,7 +232,7 @@ let fold_types f env init = StringMap.fold f env.types init
 (** Iterate over the types namespace *)
 let iter_types f env = StringMap.iter f env.types
 
-(** Get bindings of the terms namespace *)
+(** Get bindings of the terms namespace (rules and closures only). *)
 let bindings_terms env = StringMap.bindings env.terms
 
 (** Get bindings of the types namespace *)
@@ -188,26 +244,28 @@ let action_contexts env = env.action_contexts
 (** Get the current module name *)
 let current_module env = env.current_module
 
-(** Initialize environment for a new module: set module name, clear action and
-    local_vars *)
+(** Initialize environment for a new module: set module name, clear action,
+    local_vars, and any scoped variables (which belong to a prior chapter body
+    and should not leak). *)
 let with_module_init mod_name env =
-  { env with current_module = mod_name; action = None; local_vars = [] }
+  {
+    env with
+    current_module = mod_name;
+    action = None;
+    local_vars = [];
+    vars = StringMap.empty;
+  }
 
 (** Create a child environment with additional variable bindings *)
 let with_vars vars env =
   List.fold_left (fun env (name, ty) -> add_var name ty env) env vars
 
-(** Get all exported names (for module system) *)
+(** Get all exported names (for module system). Variables are never exported —
+    only rules, closures, domains, and aliases cross module boundaries — so
+    [vars] is ignored here. *)
 let exports env =
   let type_names = StringMap.bindings env.types |> List.map fst in
-  let term_names =
-    StringMap.bindings env.terms
-    |> List.filter (fun (_, e) ->
-        match e.kind with
-        | KVar _ -> false
-        | KClosure _ | KDomain | KAlias _ | KRule _ -> true)
-    |> List.map fst
-  in
+  let term_names = StringMap.bindings env.terms |> List.map fst in
   (type_names, term_names)
 
 (** Add another environment's exports to the import index, then rebuild flat
@@ -303,7 +361,12 @@ let visible_in_head chapter_idx env =
   let filter_map m =
     StringMap.filter (fun _ entry -> entry.decl_chapter <= chapter_idx) m
   in
-  { env with types = filter_map env.types; terms = filter_map env.terms }
+  {
+    env with
+    types = filter_map env.types;
+    terms = filter_map env.terms;
+    vars = filter_map env.vars;
+  }
 
 (** Filter environment for visibility in a chapter body. Declaration in chapter
     N is visible in bodies of chapters M >= N-1. Imports (decl_chapter = -1) are
@@ -312,4 +375,9 @@ let visible_in_body chapter_idx env =
   let filter_map m =
     StringMap.filter (fun _ entry -> entry.decl_chapter <= chapter_idx + 1) m
   in
-  { env with types = filter_map env.types; terms = filter_map env.terms }
+  {
+    env with
+    types = filter_map env.types;
+    terms = filter_map env.terms;
+    vars = filter_map env.vars;
+  }

--- a/lib/env.ml
+++ b/lib/env.ml
@@ -120,14 +120,16 @@ let add_closure name ty target loc ~chapter env =
   { env with terms = StringMap.add name entry env.terms }
 
 (** Add a variable to the var namespace (also tracks as local var). If [name]
-    matches an existing nullary rule in [terms], fire the shadow reporter so the
-    check layer can emit a warning — the nullary-rule auto-apply case is the one
-    place where a var genuinely overrides a rule the user could otherwise reach
-    by bare reference. Non-nullary rule collisions are not shadowing (syntactic
-    position disambiguates) and don't warn. *)
+    matches an existing nullary declaration in [terms] (rule or closure), fire
+    the shadow reporter so the check layer can emit a warning — nullary
+    rules/closures auto-apply in bare-atom position, so a same-named variable
+    genuinely eclipses a binding the user could otherwise reach by bare
+    reference. Non-nullary collisions are not shadowing (syntactic position
+    disambiguates) and don't warn. *)
 let add_var name ty env =
   (match[@warning "-4"] StringMap.find_opt name env.terms with
-  | Some { kind = KRule (TyFunc ([], Some ret)); loc = rule_loc; _ } ->
+  | Some { kind = KRule (TyFunc ([], Some ret)); loc = rule_loc; _ }
+  | Some { kind = KClosure (TyFunc ([], Some ret), _); loc = rule_loc; _ } ->
       !shadow_reporter name ret ty rule_loc Ast.dummy_loc
   | _ -> ());
   let entry =
@@ -221,7 +223,11 @@ let fold_terms f env init = StringMap.fold f env.terms init
 let iter_terms f env = StringMap.iter f env.terms
 
 (** Fold over every binding in both [terms] and [vars]. Used where callers need
-    the union (e.g., sort collection for SMT preamble). *)
+    the union (e.g., sort collection for SMT preamble). Fold order: [terms]
+    first, then [vars]. The two namespaces are disjoint in well-formed programs,
+    but if a name appeared in both the [vars] entry would be visited second (and
+    so could override in a last-write-wins folder). Current callers are
+    order-insensitive. *)
 let fold_all_terms f env init =
   let acc = StringMap.fold f env.terms init in
   StringMap.fold f env.vars acc

--- a/lib/env.mli
+++ b/lib/env.mli
@@ -43,13 +43,36 @@ val with_action_contexts : string list -> t -> t
 val is_local_var : string -> t -> bool
 val in_action_context : t -> bool
 val lookup_type : string -> t -> entry option
+
 val lookup_term : string -> t -> entry option
+(** Lookup a rule or closure (no variable fallback). *)
+
+val lookup_var : string -> t -> entry option
+(** Lookup a variable only. *)
+
+val lookup_bare : string -> t -> entry option
+(** Bare-atom (value-position) lookup: variables first, then rules. The one site
+    where rule and variable namespaces may legitimately collide. *)
+
 val fold_terms : (string -> entry -> 'a -> 'a) -> t -> 'a -> 'a
 val iter_terms : (string -> entry -> unit) -> t -> unit
+
+val fold_all_terms : (string -> entry -> 'a -> 'a) -> t -> 'a -> 'a
+(** Fold over both rules/closures ([terms]) and variables ([vars]). *)
+
 val fold_types : (string -> entry -> 'a -> 'a) -> t -> 'a -> 'a
 val iter_types : (string -> entry -> unit) -> t -> unit
 val bindings_terms : t -> (string * entry) list
 val bindings_types : t -> (string * entry) list
+
+val shadow_reporter :
+  (string -> Types.ty -> Types.ty -> Ast.loc -> Ast.loc -> unit) ref
+(** Callback invoked by [add_var] when a variable is added with the same name as
+    an existing nullary rule. Args: name, rule's return type, var's type, rule's
+    declaration loc, var's add loc. The check layer installs a reporter that
+    pushes a warning into its type-warning accumulator; default is a no-op for
+    tests that use env in isolation. *)
+
 val action_contexts : t -> string list
 val current_module : t -> string
 val with_module_init : string -> t -> t

--- a/lib/env.mli
+++ b/lib/env.mli
@@ -68,10 +68,12 @@ val bindings_types : t -> (string * entry) list
 val shadow_reporter :
   (string -> Types.ty -> Types.ty -> Ast.loc -> Ast.loc -> unit) ref
 (** Callback invoked by [add_var] when a variable is added with the same name as
-    an existing nullary rule. Args: name, rule's return type, var's type, rule's
-    declaration loc, var's add loc. The check layer installs a reporter that
-    pushes a warning into its type-warning accumulator; default is a no-op for
-    tests that use env in isolation. *)
+    an existing nullary declaration (rule or closure). Both kinds auto-apply in
+    bare-atom position, so a same-named variable eclipses them identically.
+    Args: name, declaration's return type, var's type, declaration's loc, var's
+    add loc. The check layer installs a reporter that pushes a warning into its
+    type-warning accumulator; default is a no-op for tests that use env in
+    isolation. *)
 
 val action_contexts : t -> string list
 val current_module : t -> string

--- a/lib/error.ml
+++ b/lib/error.ml
@@ -77,6 +77,9 @@ let format_type_error err =
            (String.concat ", " ctx_names))
   | BoolParam (name, decl_name, loc) ->
       fmt loc (Printf.sprintf "Bool parameter '%s' in '%s'" name decl_name)
+  | NullaryRuleShadowedByVar (name, _rule_ret, _var_ty, loc) ->
+      (* Shadowing is a warning; this branch is kept for completeness *)
+      fmt loc (Printf.sprintf "Variable '%s' shadows nullary rule" name)
   | ComprehensionNeedEach (ty, loc) ->
       fmt loc
         (Printf.sprintf
@@ -144,6 +147,13 @@ let format_type_warning err =
             likely a mistake — use a predicate, a two-element domain, or split \
             into separate declarations"
            name decl_name)
+  | NullaryRuleShadowedByVar (name, rule_ret, var_ty, rule_loc) ->
+      fmt rule_loc
+        (Printf.sprintf
+           "Variable '%s' shadows nullary rule of return type %s (variable has \
+            type %s) — bare references to '%s' in body propositions will \
+            resolve to the variable"
+           name (Types.format_ty rule_ret) (Types.format_ty var_ty) name)
   | ( UnboundVariable _ | UnboundType _ | TypeMismatch _ | ArityMismatch _
     | NotAFunction _ | NotAList _ | NotAProduct _ | NotNumeric _
     | ExpectedBool _ | PrimedNonRule _ | PrimeOutsideActionContext _

--- a/lib/smt.ml
+++ b/lib/smt.ml
@@ -41,11 +41,23 @@ let alpha_rename_binders env (params : Ast.param list) (guards : Ast.guard list)
     in
     from_params @ from_guards
   in
-  (* Seed [occupied] with every binder in this quantifier, not just those
-     that shadow a rule. Non-rule binders must still be avoided when picking
-     fresh names — e.g., renaming rule-shadowing binder [foo] to [foo_q]
-     would collide with a sibling binder already named [foo_q]. *)
-  let occupied = ref (Smt_doc.StringSet.of_list binder_names) in
+  (* Seed [occupied] with every binder in this quantifier and every outer
+     quantifier binder already in scope via [env.vars]. Sibling binders must
+     be avoided (renaming [foo] to [foo_q] would collide with a sibling
+     [foo_q]); outer binders must be avoided too, because a fresh name that
+     matches an enclosing binder would capture outer references and change
+     the formula's meaning. Rules / closures are handled separately by
+     [is_rule_name] in [fresh_for]. *)
+  let occupied =
+    ref
+      (Env.fold_all_terms
+         (fun name entry acc ->
+           match entry.Env.kind with
+           | Env.KVar _ -> Smt_doc.StringSet.add name acc
+           | Env.KRule _ | Env.KClosure _ | Env.KDomain | Env.KAlias _ -> acc)
+         env
+         (Smt_doc.StringSet.of_list binder_names))
+  in
   let fresh_for orig =
     let rec try_n n =
       let cand =

--- a/lib/smt.ml
+++ b/lib/smt.ml
@@ -10,6 +10,87 @@ include Smt_preamble
 include Smt_doc
 include Smt_expr
 
+(** Compute alpha-renames for quantifier binders that would shadow a declared
+    rule / closure symbol at the SMT top level, then rewrite the params, guards,
+    and body accordingly. Returns the input unchanged when no renames are
+    needed. *)
+let alpha_rename_binders env (params : Ast.param list) (guards : Ast.guard list)
+    (body : Ast.expr) : Ast.param list * Ast.guard list * Ast.expr =
+  (* Names already declared as SMT top-level functions. We treat only
+     rule / closure kinds — variables in [Env.vars] aren't top-level SMT
+     decls (they're quantifier binders from enclosing scope, already
+     renamed if they needed to be). *)
+  let is_rule_name name =
+    match[@warning "-4"] Env.lookup_term name env with
+    | Some { kind = Env.KRule _ | Env.KClosure _; _ } -> true
+    | _ -> false
+  in
+  (* Every binder introduced in this quantifier, in lexical order. *)
+  let binder_names =
+    let from_params =
+      List.map (fun (p : Ast.param) -> Ast.lower_name p.param_name) params
+    in
+    let from_guards =
+      List.filter_map
+        (fun g ->
+          match g with
+          | GParam p -> Some (Ast.lower_name p.param_name)
+          | GIn (Lower n, _) -> Some n
+          | GExpr _ -> None)
+        guards
+    in
+    from_params @ from_guards
+  in
+  let occupied =
+    ref
+      (List.fold_left
+         (fun s n -> if is_rule_name n then Smt_doc.StringSet.add n s else s)
+         Smt_doc.StringSet.empty binder_names)
+  in
+  let fresh_for orig =
+    let rec try_n n =
+      let cand =
+        if n = 0 then Printf.sprintf "%s_q" orig
+        else Printf.sprintf "%s_q%d" orig n
+      in
+      if Smt_doc.StringSet.mem cand !occupied || is_rule_name cand then
+        try_n (n + 1)
+      else cand
+    in
+    let name = try_n 0 in
+    occupied := Smt_doc.StringSet.add name !occupied;
+    name
+  in
+  let renames =
+    List.filter_map
+      (fun orig ->
+        if is_rule_name orig then Some (orig, fresh_for orig) else None)
+      binder_names
+  in
+  if renames = [] then (params, guards, body)
+  else
+    let rename_param (p : Ast.param) =
+      match List.assoc_opt (Ast.lower_name p.param_name) renames with
+      | Some fresh -> { p with param_name = Lower fresh }
+      | None -> p
+    in
+    let params' = List.map rename_param params in
+    let guards' =
+      List.map
+        (fun g ->
+          match g with
+          | GParam p -> GParam (rename_param p)
+          | GIn (Lower n, e) ->
+              let n' =
+                match List.assoc_opt n renames with Some x -> x | None -> n
+              in
+              GIn (Lower n', Smt_expr.rename_var_refs env renames e)
+          | GExpr e -> GExpr (Smt_expr.rename_var_refs env renames e))
+        guards
+    in
+    let body' = Smt_expr.rename_var_refs env renames body in
+    (params', guards', body')
+
 (** Translate an expression to SMT-LIB2 term string *)
 let rec translate_expr config env (e : expr) =
   match e with
@@ -633,6 +714,22 @@ and translate_aggregate config env (comb : combiner) params guards body =
             dummy_acc lets)
 
 and translate_quantifier config env quant params guards body =
+  (* Alpha-rename any binder whose name collides with a declared rule /
+     closure symbol at the SMT top level. Without this, SMT's scope
+     rules shadow the function declaration within the quantifier body
+     and [(name (makePoint name))] — where [name] is both the binder
+     and an outer rule — is interpreted as applying the bound variable,
+     which z3 surfaces as "select requires 1 arguments". The
+     Pantagruel namespace split keeps rule and var references distinct
+     at the language level; this alpha-rename preserves the
+     distinction in the SMT emission.
+
+     The rename uses [Smt_expr.rename_var_refs] which walks the AST
+     and only rewrites variable-reference positions — application
+     heads, overrides, primed names, and qualified names stay under
+     the original name, so rule references to [name] inside the body
+     continue to resolve to the declared function. *)
+  let params, guards, body = alpha_rename_binders env params guards body in
   (* Enrich env with formal parameter bindings so that type inference
      on guard expressions (e.g., GIn list exprs) can resolve them. *)
   let param_bindings = resolve_param_bindings env params in

--- a/lib/smt.ml
+++ b/lib/smt.ml
@@ -41,12 +41,11 @@ let alpha_rename_binders env (params : Ast.param list) (guards : Ast.guard list)
     in
     from_params @ from_guards
   in
-  let occupied =
-    ref
-      (List.fold_left
-         (fun s n -> if is_rule_name n then Smt_doc.StringSet.add n s else s)
-         Smt_doc.StringSet.empty binder_names)
-  in
+  (* Seed [occupied] with every binder in this quantifier, not just those
+     that shadow a rule. Non-rule binders must still be avoided when picking
+     fresh names — e.g., renaming rule-shadowing binder [foo] to [foo_q]
+     would collide with a sibling binder already named [foo_q]. *)
+  let occupied = ref (Smt_doc.StringSet.of_list binder_names) in
   let fresh_for orig =
     let rec try_n n =
       let cand =

--- a/lib/smt_expr.ml
+++ b/lib/smt_expr.ml
@@ -168,17 +168,26 @@ and substitute_guards subst gs =
 (** Rename *variable references* only, leaving rule-reference positions alone.
     An [EVar name] appearing as the head of an [EApp] is treated as a
     rule-reference whenever [name] is declared as a [KRule] / [KClosure] in
-    [env] (post-namespace-split semantics). Similarly [EOverride] and [EPrimed]
-    carry rule names. Used by [translate_quantifier] to alpha-rename binders
-    that would otherwise shadow declared SMT function symbols; the rename
-    applies to variable references in the body/guards, not to the rule's own
-    name when it's applied. *)
+    [env] (post-namespace-split semantics) — *unless* [name] is a key in
+    [subst], which means the caller is explicitly alpha-renaming a binder that
+    shadows the rule. In that case the application head refers to the binder
+    (e.g. list-indexing on a nullary-rule-shadowing binder), and the explicit
+    substitution must win. Similarly [EOverride] and [EPrimed] carry rule names.
+    Used by [translate_quantifier] to alpha-rename binders that would otherwise
+    shadow declared SMT function symbols. *)
 let rec rename_var_refs env (subst : (string * string) list) (e : expr) : expr =
   let subst_name name =
     match List.assoc_opt name subst with Some r -> r | None -> name
   in
   match e with
   | EVar (Lower name) -> EVar (Lower (subst_name name))
+  | EApp (EVar (Lower name), args) when List.mem_assoc name subst ->
+      (* Explicit rename wins: the current-scope binder shadows any rule of
+         the same name, so a call to [name] in the body references the
+         (renamed) binder, not the rule. *)
+      EApp
+        ( EVar (Lower (subst_name name)),
+          List.map (rename_var_refs env subst) args )
   | EApp (EVar (Lower name), args) ->
       let head =
         match[@warning "-4"] Env.lookup_term name env with

--- a/lib/smt_expr.ml
+++ b/lib/smt_expr.ml
@@ -165,6 +165,93 @@ and substitute_guards subst gs =
       | GExpr e -> (subst, acc @ [ GExpr (substitute_vars subst e) ]))
     (subst, []) gs
 
+(** Rename *variable references* only, leaving rule-reference positions alone.
+    An [EVar name] appearing as the head of an [EApp] is treated as a
+    rule-reference whenever [name] is declared as a [KRule] / [KClosure] in
+    [env] (post-namespace-split semantics). Similarly [EOverride] and [EPrimed]
+    carry rule names. Used by [translate_quantifier] to alpha-rename binders
+    that would otherwise shadow declared SMT function symbols; the rename
+    applies to variable references in the body/guards, not to the rule's own
+    name when it's applied. *)
+let rec rename_var_refs env (subst : (string * string) list) (e : expr) : expr =
+  let subst_name name =
+    match List.assoc_opt name subst with Some r -> r | None -> name
+  in
+  match e with
+  | EVar (Lower name) -> EVar (Lower (subst_name name))
+  | EApp (EVar (Lower name), args) ->
+      let head =
+        match[@warning "-4"] Env.lookup_term name env with
+        | Some { kind = Env.KRule _ | Env.KClosure _; _ } ->
+            EVar (Lower name) (* rule ref — keep *)
+        | _ -> EVar (Lower (subst_name name))
+      in
+      EApp (head, List.map (rename_var_refs env subst) args)
+  | EApp (func, args) ->
+      EApp
+        ( rename_var_refs env subst func,
+          List.map (rename_var_refs env subst) args )
+  | EBinop (op, e1, e2) ->
+      EBinop (op, rename_var_refs env subst e1, rename_var_refs env subst e2)
+  | EUnop (op, e1) -> EUnop (op, rename_var_refs env subst e1)
+  | ETuple es -> ETuple (List.map (rename_var_refs env subst) es)
+  | EProj (e1, i) -> EProj (rename_var_refs env subst e1, i)
+  | EOverride (name, pairs) ->
+      EOverride
+        ( name,
+          List.map
+            (fun (k, v) ->
+              (rename_var_refs env subst k, rename_var_refs env subst v))
+            pairs )
+  | EForall (ps, gs, body) ->
+      let bound =
+        List.map (fun (p : param) -> Ast.lower_name p.param_name) ps
+      in
+      let subst' = List.filter (fun (n, _) -> not (List.mem n bound)) subst in
+      let gs' = rename_guards env subst' gs in
+      EForall (ps, gs', rename_var_refs env subst' body)
+  | EExists (ps, gs, body) ->
+      let bound =
+        List.map (fun (p : param) -> Ast.lower_name p.param_name) ps
+      in
+      let subst' = List.filter (fun (n, _) -> not (List.mem n bound)) subst in
+      let gs' = rename_guards env subst' gs in
+      EExists (ps, gs', rename_var_refs env subst' body)
+  | EEach (ps, gs, comb, body) ->
+      let bound =
+        List.map (fun (p : param) -> Ast.lower_name p.param_name) ps
+      in
+      let subst' = List.filter (fun (n, _) -> not (List.mem n bound)) subst in
+      let gs' = rename_guards env subst' gs in
+      EEach (ps, gs', comb, rename_var_refs env subst' body)
+  | ECond arms ->
+      ECond
+        (List.map
+           (fun (arm, cons) ->
+             (rename_var_refs env subst arm, rename_var_refs env subst cons))
+           arms)
+  | EInitially e1 -> EInitially (rename_var_refs env subst e1)
+  | EPrimed _ | ELitBool _ | ELitNat _ | ELitReal _ | ELitString _ | EDomain _
+  | EQualified _ ->
+      e
+
+and rename_guards env subst gs =
+  List.fold_left
+    (fun (subst, acc) g ->
+      match g with
+      | GParam p ->
+          let subst' =
+            List.filter (fun (n, _) -> n <> Ast.lower_name p.param_name) subst
+          in
+          (subst', acc @ [ GParam p ])
+      | GIn (Lower name, e) ->
+          let e' = rename_var_refs env subst e in
+          let subst' = List.filter (fun (n, _) -> n <> name) subst in
+          (subst', acc @ [ GIn (Lower name, e') ])
+      | GExpr e -> (subst, acc @ [ GExpr (rename_var_refs env subst e) ]))
+    (subst, []) gs
+  |> snd
+
 (** Substitute primed names in an expression (for invariant checking in next
     state). Tracks locally-bound names (from quantifiers) to avoid priming them.
 *)

--- a/test/regression/bug_nested_binder_collision.pant
+++ b/test/regression/bug_nested_binder_collision.pant
@@ -1,0 +1,20 @@
+module BUG_NESTED_BINDER_COLLISION.
+
+> Regression fixture for the alpha-rename capture bug in lib/smt.ml's
+> `alpha_rename_binders`. Before the fix, fresh_for only reserved the
+> current quantifier's own binders when picking a fresh name, ignoring
+> outer quantifier binders already in [env.vars]. A nested quantifier
+> whose binder [x] shadows a rule [x] would get renamed to [x_q] — even
+> when an enclosing quantifier already bound [x_q], capturing outer
+> references and silently changing the formula's meaning. The fix seeds
+> `occupied` with outer binders via [Env.fold_all_terms] filtered by
+> KVar, so the inner rename skips to [x_q1]. The companion unit test
+> asserts the emitted SMT contains [x_q1] (distinct from outer [x_q]).
+
+D.
+x => D.
+p a: D => Bool.
+
+---
+
+all x_q: D | p x_q and (all x: D | p x).

--- a/test/regression/bug_rename_app_head.pant
+++ b/test/regression/bug_rename_app_head.pant
@@ -1,0 +1,19 @@
+module BUG_RENAME_APP_HEAD.
+
+> Regression fixture for the rename_var_refs application-head bug in
+> lib/smt_expr.ml. Before the fix, `rename_var_refs` kept any EApp head
+> whose name resolved to a rule via [Env.lookup_term], even when the
+> rename map explicitly mapped that name. For a quantifier binder [xs]
+> shadowing a nullary rule [xs: [Nat0]] with body `xs 1` (list-indexing
+> at the AST level), alpha-rename would bind [xs_q] but leave the body's
+> `xs 1` calling the outer rule. The fix makes the explicit substitution
+> win in head position when the name is in the subst map. The companion
+> unit test asserts the emitted SMT contains [(xs_q 1)] rather than
+> [(xs 1)] inside the quantifier body.
+
+xs => [Nat0].
+p a: Nat0 => Bool.
+
+---
+
+all xs: [Nat0] | #xs > 0 and p (xs 1).

--- a/test/regression/bug_rule_param_collision.pant
+++ b/test/regression/bug_rule_param_collision.pant
@@ -1,0 +1,21 @@
+module BUG_RULE_PARAM_COLLISION.
+
+> Regression fixture for the accessor-rule / parameter-name collision
+> pre-term-namespace-split. Previously, a rule named `name` (an accessor
+> on the Point interface) and a function whose parameter is also named
+> `name` would collide: the body proposition
+> `name (makePoint name) = name.` failed to type-check with
+> "Cannot call String: not a function", because the flat `env.terms`
+> map let the parameter overwrite the rule entry and the LHS's `name`
+> resolved to a String. After the env split, `env.terms` holds rules
+> only, `env.vars` holds parameters, and application heads look up only
+> in the former. The LHS correctly resolves to the accessor rule and
+> the body type-checks.
+
+Point.
+name p: Point => String.
+makePoint name: String => Point.
+
+---
+
+name (makePoint name) = name.

--- a/test/test_check.ml
+++ b/test/test_check.ml
@@ -419,6 +419,20 @@ Item.
 ---
 |}
 
+let test_nullary_rule_shadowed_by_var () =
+  (* Introducing a variable whose name matches an existing nullary rule
+     emits the NullaryRuleShadowedByVar warning — the rule auto-applies in
+     bare-atom position, so a same-named variable eclipses it. *)
+  check_warns
+    {|module TEST.
+
+Item.
+pi => Nat.
+circleArea r: Nat, pi: Nat => Nat.
+---
+all r: Nat, pi: Nat | circleArea r pi = pi * r * r.
+|}
+
 let test_bool_return_type_ok () =
   (* Bool as return type is fine *)
   check_ok {|module TEST.
@@ -577,8 +591,9 @@ process.
     | OverrideKeyArityMismatch _ | ProjectionOutOfBounds _
     | PropositionNotBool _ | ShadowingTypeMismatch _ | AmbiguousName _
     | UnboundQualified _ | PrimedExtracontextual _ | BoolParam _
-    | ComprehensionNeedEach _ | AggregateRequiresNumeric _
-    | AggregateRequiresBool _ | CheckWithoutBody _ ->
+    | NullaryRuleShadowedByVar _ | ComprehensionNeedEach _
+    | AggregateRequiresNumeric _ | AggregateRequiresBool _ | CheckWithoutBody _
+      ->
         false)
 
 let test_qualified_type_resolves_ambiguity () =
@@ -659,8 +674,9 @@ WRONG::count >= 0.
     | OverrideKeyArityMismatch _ | ProjectionOutOfBounds _
     | PropositionNotBool _ | ShadowingTypeMismatch _ | AmbiguousName _
     | UnboundQualified _ | PrimedExtracontextual _ | BoolParam _
-    | ComprehensionNeedEach _ | AggregateRequiresNumeric _
-    | AggregateRequiresBool _ | CheckWithoutBody _ ->
+    | NullaryRuleShadowedByVar _ | ComprehensionNeedEach _
+    | AggregateRequiresNumeric _ | AggregateRequiresBool _ | CheckWithoutBody _
+      ->
         false)
 
 let test_local_domain_shadows_import () =
@@ -972,8 +988,8 @@ all u: User | role u.
     | OverrideKeyArityMismatch _ | ProjectionOutOfBounds _
     | PropositionNotBool _ | ShadowingTypeMismatch _ | AmbiguousName _
     | UnboundQualified _ | PrimedExtracontextual _ | BoolParam _
-    | AggregateRequiresNumeric _ | AggregateRequiresBool _ | CheckWithoutBody _
-      ->
+    | NullaryRuleShadowedByVar _ | AggregateRequiresNumeric _
+    | AggregateRequiresBool _ | CheckWithoutBody _ ->
         false)
 
 let test_all_non_bool_body_error () =
@@ -995,8 +1011,8 @@ some u: User | role u.
     | OverrideKeyArityMismatch _ | ProjectionOutOfBounds _
     | PropositionNotBool _ | ShadowingTypeMismatch _ | AmbiguousName _
     | UnboundQualified _ | PrimedExtracontextual _ | BoolParam _
-    | AggregateRequiresNumeric _ | AggregateRequiresBool _ | CheckWithoutBody _
-      ->
+    | NullaryRuleShadowedByVar _ | AggregateRequiresNumeric _
+    | AggregateRequiresBool _ | CheckWithoutBody _ ->
         false)
 
 let test_combiner_add_numeric () =
@@ -1039,7 +1055,8 @@ active u: User => Bool.
     | OverrideKeyArityMismatch _ | ProjectionOutOfBounds _
     | PropositionNotBool _ | ShadowingTypeMismatch _ | AmbiguousName _
     | UnboundQualified _ | PrimedExtracontextual _ | BoolParam _
-    | ComprehensionNeedEach _ | AggregateRequiresBool _ | CheckWithoutBody _ ->
+    | NullaryRuleShadowedByVar _ | ComprehensionNeedEach _
+    | AggregateRequiresBool _ | CheckWithoutBody _ ->
         false)
 
 let test_combiner_bool_on_numeric_fails () =
@@ -1060,8 +1077,8 @@ and over each u: User | score u.
     | OverrideKeyArityMismatch _ | ProjectionOutOfBounds _
     | PropositionNotBool _ | ShadowingTypeMismatch _ | AmbiguousName _
     | UnboundQualified _ | PrimedExtracontextual _ | BoolParam _
-    | ComprehensionNeedEach _ | AggregateRequiresNumeric _ | CheckWithoutBody _
-      ->
+    | NullaryRuleShadowedByVar _ | ComprehensionNeedEach _
+    | AggregateRequiresNumeric _ | CheckWithoutBody _ ->
         false)
 
 (* --- Closure tests --- *)
@@ -1272,8 +1289,9 @@ x.1 >= 0.
     | PrimedNonRule _ | PrimeOutsideActionContext _ | OverrideKeyArityMismatch _
     | ProjectionOutOfBounds _ | PropositionNotBool _ | ShadowingTypeMismatch _
     | AmbiguousName _ | UnboundQualified _ | PrimedExtracontextual _
-    | BoolParam _ | ComprehensionNeedEach _ | AggregateRequiresNumeric _
-    | AggregateRequiresBool _ | CheckWithoutBody _ ->
+    | BoolParam _ | NullaryRuleShadowedByVar _ | ComprehensionNeedEach _
+    | AggregateRequiresNumeric _ | AggregateRequiresBool _ | CheckWithoutBody _
+      ->
         false)
 
 let test_not_numeric () =
@@ -1290,8 +1308,9 @@ f + 1 = 2.
     | PrimedNonRule _ | PrimeOutsideActionContext _ | OverrideKeyArityMismatch _
     | ProjectionOutOfBounds _ | PropositionNotBool _ | ShadowingTypeMismatch _
     | AmbiguousName _ | UnboundQualified _ | PrimedExtracontextual _
-    | BoolParam _ | ComprehensionNeedEach _ | AggregateRequiresNumeric _
-    | AggregateRequiresBool _ | CheckWithoutBody _ ->
+    | BoolParam _ | NullaryRuleShadowedByVar _ | ComprehensionNeedEach _
+    | AggregateRequiresNumeric _ | AggregateRequiresBool _ | CheckWithoutBody _
+      ->
         false)
 
 let test_override_key_bare_on_nary_rule () =
@@ -1313,8 +1332,9 @@ all a: A, b: B | f[a |-> a] a b = a.
     | ExpectedBool _ | PrimedNonRule _ | PrimeOutsideActionContext _
     | ProjectionOutOfBounds _ | PropositionNotBool _ | ShadowingTypeMismatch _
     | AmbiguousName _ | UnboundQualified _ | PrimedExtracontextual _
-    | BoolParam _ | ComprehensionNeedEach _ | AggregateRequiresNumeric _
-    | AggregateRequiresBool _ | CheckWithoutBody _ ->
+    | BoolParam _ | NullaryRuleShadowedByVar _ | ComprehensionNeedEach _
+    | AggregateRequiresNumeric _ | AggregateRequiresBool _ | CheckWithoutBody _
+      ->
         false)
 
 let test_override_key_tuple_arity_mismatch () =
@@ -1335,8 +1355,9 @@ all a: A, b: B | f[(a, b, a) |-> a] a b = a.
     | ExpectedBool _ | PrimedNonRule _ | PrimeOutsideActionContext _
     | ProjectionOutOfBounds _ | PropositionNotBool _ | ShadowingTypeMismatch _
     | AmbiguousName _ | UnboundQualified _ | PrimedExtracontextual _
-    | BoolParam _ | ComprehensionNeedEach _ | AggregateRequiresNumeric _
-    | AggregateRequiresBool _ | CheckWithoutBody _ ->
+    | BoolParam _ | NullaryRuleShadowedByVar _ | ComprehensionNeedEach _
+    | AggregateRequiresNumeric _ | AggregateRequiresBool _ | CheckWithoutBody _
+      ->
         false)
 
 let test_override_nary_tuple_key_ok () =
@@ -1367,9 +1388,9 @@ p.5 >= 0.
     | ExpectedBool _ | PrimedNonRule _ | PrimeOutsideActionContext _
     | OverrideKeyArityMismatch _ | PropositionNotBool _
     | ShadowingTypeMismatch _ | AmbiguousName _ | UnboundQualified _
-    | PrimedExtracontextual _ | BoolParam _ | ComprehensionNeedEach _
-    | AggregateRequiresNumeric _ | AggregateRequiresBool _ | CheckWithoutBody _
-      ->
+    | PrimedExtracontextual _ | BoolParam _ | NullaryRuleShadowedByVar _
+    | ComprehensionNeedEach _ | AggregateRequiresNumeric _
+    | AggregateRequiresBool _ | CheckWithoutBody _ ->
         false)
 
 let test_unbound_type () =
@@ -1384,8 +1405,9 @@ f x: Nonexistent => Bool.
     | PrimedNonRule _ | PrimeOutsideActionContext _ | OverrideKeyArityMismatch _
     | ProjectionOutOfBounds _ | PropositionNotBool _ | ShadowingTypeMismatch _
     | AmbiguousName _ | UnboundQualified _ | PrimedExtracontextual _
-    | BoolParam _ | ComprehensionNeedEach _ | AggregateRequiresNumeric _
-    | AggregateRequiresBool _ | CheckWithoutBody _ ->
+    | BoolParam _ | NullaryRuleShadowedByVar _ | ComprehensionNeedEach _
+    | AggregateRequiresNumeric _ | AggregateRequiresBool _ | CheckWithoutBody _
+      ->
         false)
 
 let test_builtin_redefined () = check_fails {|module TEST.
@@ -1408,8 +1430,9 @@ x in x.
     | PrimedNonRule _ | PrimeOutsideActionContext _ | OverrideKeyArityMismatch _
     | ProjectionOutOfBounds _ | PropositionNotBool _ | ShadowingTypeMismatch _
     | AmbiguousName _ | UnboundQualified _ | PrimedExtracontextual _
-    | BoolParam _ | ComprehensionNeedEach _ | AggregateRequiresNumeric _
-    | AggregateRequiresBool _ | CheckWithoutBody _ ->
+    | BoolParam _ | NullaryRuleShadowedByVar _ | ComprehensionNeedEach _
+    | AggregateRequiresNumeric _ | AggregateRequiresBool _ | CheckWithoutBody _
+      ->
         false)
 
 let test_arithmetic_type_mismatch () =
@@ -1426,8 +1449,9 @@ f + 1 = 2.
     | PrimedNonRule _ | PrimeOutsideActionContext _ | OverrideKeyArityMismatch _
     | ProjectionOutOfBounds _ | PropositionNotBool _ | ShadowingTypeMismatch _
     | AmbiguousName _ | UnboundQualified _ | PrimedExtracontextual _
-    | BoolParam _ | ComprehensionNeedEach _ | AggregateRequiresNumeric _
-    | AggregateRequiresBool _ | CheckWithoutBody _ ->
+    | BoolParam _ | NullaryRuleShadowedByVar _ | ComprehensionNeedEach _
+    | AggregateRequiresNumeric _ | AggregateRequiresBool _ | CheckWithoutBody _
+      ->
         false)
 
 (* --- Bug-finding tests --- *)
@@ -1540,8 +1564,9 @@ active? i: Item => Bool.
     | OverrideKeyArityMismatch _ | ProjectionOutOfBounds _
     | PropositionNotBool _ | ShadowingTypeMismatch _ | AmbiguousName _
     | UnboundQualified _ | PrimedExtracontextual _ | BoolParam _
-    | ComprehensionNeedEach _ | AggregateRequiresNumeric _
-    | AggregateRequiresBool _ | CheckWithoutBody _ ->
+    | NullaryRuleShadowedByVar _ | ComprehensionNeedEach _
+    | AggregateRequiresNumeric _ | AggregateRequiresBool _ | CheckWithoutBody _
+      ->
         false)
 
 let test_over_each_mul_nat () =
@@ -1571,8 +1596,9 @@ active? i: Item => Bool.
     | OverrideKeyArityMismatch _ | ProjectionOutOfBounds _
     | PropositionNotBool _ | ShadowingTypeMismatch _ | AmbiguousName _
     | UnboundQualified _ | PrimedExtracontextual _ | BoolParam _
-    | ComprehensionNeedEach _ | AggregateRequiresNumeric _
-    | AggregateRequiresBool _ | CheckWithoutBody _ ->
+    | NullaryRuleShadowedByVar _ | ComprehensionNeedEach _
+    | AggregateRequiresNumeric _ | AggregateRequiresBool _ | CheckWithoutBody _
+      ->
         false)
 
 let test_over_each_and_bool () =
@@ -1602,8 +1628,9 @@ and over each i: Item | weight i.
     | OverrideKeyArityMismatch _ | ProjectionOutOfBounds _
     | PropositionNotBool _ | ShadowingTypeMismatch _ | AmbiguousName _
     | UnboundQualified _ | PrimedExtracontextual _ | BoolParam _
-    | ComprehensionNeedEach _ | AggregateRequiresNumeric _
-    | AggregateRequiresBool _ | CheckWithoutBody _ ->
+    | NullaryRuleShadowedByVar _ | ComprehensionNeedEach _
+    | AggregateRequiresNumeric _ | AggregateRequiresBool _ | CheckWithoutBody _
+      ->
         false)
 
 let test_over_each_or_bool () =
@@ -1633,8 +1660,9 @@ or over each i: Item | weight i.
     | OverrideKeyArityMismatch _ | ProjectionOutOfBounds _
     | PropositionNotBool _ | ShadowingTypeMismatch _ | AmbiguousName _
     | UnboundQualified _ | PrimedExtracontextual _ | BoolParam _
-    | ComprehensionNeedEach _ | AggregateRequiresNumeric _
-    | AggregateRequiresBool _ | CheckWithoutBody _ ->
+    | NullaryRuleShadowedByVar _ | ComprehensionNeedEach _
+    | AggregateRequiresNumeric _ | AggregateRequiresBool _ | CheckWithoutBody _
+      ->
         false)
 
 let test_over_each_min_nat () =
@@ -1674,8 +1702,9 @@ active? i: Item => Bool.
     | OverrideKeyArityMismatch _ | ProjectionOutOfBounds _
     | PropositionNotBool _ | ShadowingTypeMismatch _ | AmbiguousName _
     | UnboundQualified _ | PrimedExtracontextual _ | BoolParam _
-    | ComprehensionNeedEach _ | AggregateRequiresNumeric _
-    | AggregateRequiresBool _ | CheckWithoutBody _ ->
+    | NullaryRuleShadowedByVar _ | ComprehensionNeedEach _
+    | AggregateRequiresNumeric _ | AggregateRequiresBool _ | CheckWithoutBody _
+      ->
         false)
 
 let test_over_each_min_bool_fails () =
@@ -1695,8 +1724,9 @@ active? i: Item => Bool.
     | OverrideKeyArityMismatch _ | ProjectionOutOfBounds _
     | PropositionNotBool _ | ShadowingTypeMismatch _ | AmbiguousName _
     | UnboundQualified _ | PrimedExtracontextual _ | BoolParam _
-    | ComprehensionNeedEach _ | AggregateRequiresNumeric _
-    | AggregateRequiresBool _ | CheckWithoutBody _ ->
+    | NullaryRuleShadowedByVar _ | ComprehensionNeedEach _
+    | AggregateRequiresNumeric _ | AggregateRequiresBool _ | CheckWithoutBody _
+      ->
         false)
 
 let test_over_each_bare_unchanged () =
@@ -1781,6 +1811,8 @@ let () =
             test_local_duplicate_proc_still_errors;
           test_case "bool param rule" `Quick test_bool_param_rule;
           test_case "bool param action" `Quick test_bool_param_action;
+          test_case "nullary rule shadowed by var" `Quick
+            test_nullary_rule_shadowed_by_var;
           test_case "NotAProduct" `Quick test_not_a_product;
           test_case "NotNumeric" `Quick test_not_numeric;
           test_case "OverrideKeyArityMismatch bare key on N-ary rule" `Quick
@@ -1962,8 +1994,8 @@ all a: Int | f a > a.
                     | PropositionNotBool _ | ShadowingTypeMismatch _
                     | AmbiguousName _ | UnboundQualified _
                     | PrimedExtracontextual _ | BoolParam _
-                    | ComprehensionNeedEach _ | AggregateRequiresNumeric _
-                    | AggregateRequiresBool _ ) ->
+                    | NullaryRuleShadowedByVar _ | ComprehensionNeedEach _
+                    | AggregateRequiresNumeric _ | AggregateRequiresBool _ ) ->
                     false
               in
               if not is_expected then fail "Expected CheckWithoutBody error");

--- a/test/test_smt_invariants.ml
+++ b/test/test_smt_invariants.ml
@@ -236,6 +236,39 @@ let test_no_shadowing_forall fixture shadowed_name () =
             scan 0)
         queries
 
+(** Assert that at least one emitted SMT query for [fixture] contains [needle]
+    as a substring. Used to lock in structural post-fix shapes — e.g., the
+    alpha-rename of colliding quantifier binders produces a specific suffixed
+    name that [test_regression_fixture] (which only checks structural
+    invariants) would miss. *)
+let test_smt_contains fixture needle () =
+  match regression_dir with
+  | None -> failf "regression directory not found"
+  | Some dir ->
+      let path = Filename.concat dir fixture in
+      if not (Sys.file_exists path) then failf "missing fixture: %s" path;
+      let queries =
+        match translate_path path with
+        | Ok qs -> qs
+        | Error msg -> failf "%s — translation failed: %s" fixture msg
+      in
+      let needle_len = String.length needle in
+      let contains (s : string) =
+        let sl = String.length s in
+        if needle_len > sl then false
+        else
+          let rec scan i =
+            if i + needle_len > sl then false
+            else if String.sub s i needle_len = needle then true
+            else scan (i + 1)
+          in
+          scan 0
+      in
+      let found =
+        List.exists (fun (q : Pantagruel.Smt.query) -> contains q.smt2) queries
+      in
+      if not found then failf "%s: no query contains %S" fixture needle
+
 (* ------------------------------------------------------------------ *)
 (* Test suite assembly.                                                 *)
 (* ------------------------------------------------------------------ *)
@@ -265,6 +298,8 @@ let regression_cases () =
       (test_no_shadowing_forall "bug_action_param_shadows_rule.pant" "a1");
     test_case "bug_rule_param_collision.pant — clean post-fix" `Quick
       (test_regression_fixture "bug_rule_param_collision.pant" []);
+    test_case "bug_rule_param_collision.pant — quantifier binder renamed" `Quick
+      (test_smt_contains "bug_rule_param_collision.pant" "name_q");
   ]
 
 let () =

--- a/test/test_smt_invariants.ml
+++ b/test/test_smt_invariants.ml
@@ -263,6 +263,8 @@ let regression_cases () =
       (test_regression_fixture "bug_action_param_shadows_rule.pant" []);
     test_case "bug_action_param_shadows_rule.pant — no shadow forall" `Quick
       (test_no_shadowing_forall "bug_action_param_shadows_rule.pant" "a1");
+    test_case "bug_rule_param_collision.pant — clean post-fix" `Quick
+      (test_regression_fixture "bug_rule_param_collision.pant" []);
   ]
 
 let () =

--- a/test/test_smt_invariants.ml
+++ b/test/test_smt_invariants.ml
@@ -300,6 +300,15 @@ let regression_cases () =
       (test_regression_fixture "bug_rule_param_collision.pant" []);
     test_case "bug_rule_param_collision.pant — quantifier binder renamed" `Quick
       (test_smt_contains "bug_rule_param_collision.pant" "name_q");
+    test_case "bug_nested_binder_collision.pant — clean post-fix" `Quick
+      (test_regression_fixture "bug_nested_binder_collision.pant" []);
+    test_case
+      "bug_nested_binder_collision.pant — inner rename skips outer binder"
+      `Quick
+      (test_smt_contains "bug_nested_binder_collision.pant" "x_q1");
+    test_case "bug_rename_app_head.pant — renamed binder used in head position"
+      `Quick
+      (test_smt_contains "bug_rename_app_head.pant" "(xs_q 1)");
   ]
 
 let () =


### PR DESCRIPTION
## Summary

Two commits, cleanly separated:

### 1. `check: split term namespace into rules and variables`

Pantagruel stored rule names and variables in a shared `env.terms: StringMap<string, entry>`. `add_rule` and `add_var` both wrote to it; later `add_var` overwrote any same-named rule via `StringMap.add`. This shadowing was correct for **nullary** rules (bare references could reasonably mean either "auto-apply a nullary rule" or "refer to a variable") but wrong for **application / primed / override** positions, where the syntactic form alone makes clear a rule is intended. The canonical failure was `name (makePoint name) = name.` — with `name` as both an accessor rule and a function parameter, the param shadowed the rule and the LHS failed with "Cannot call String: not a function".

Grammar survey: lower identifiers appear in seven syntactic positions. Six are unambiguously rule-or-var by parse alone; only **bare atom in value position** is ambiguous (and only because nullary rules auto-apply). The split-namespace model matches the grammar's disambiguation.

**Changes:**
- Split `env.t` by adding `vars: entry StringMap.t`. `add_rule` / `add_closure` keep writing to `terms`; `add_var` now writes to `vars`.
- New lookups: `lookup_var` (vars-only), `lookup_bare` (vars then nullary rules). `lookup_term` stays but is now rules-only.
- `check.ml:EApp` probes `lookup_term` for bare heads; `EVar` uses `lookup_bare`; override/primed sites unchanged since `lookup_term` is now rules-only. `check_no_type_shadow` probes `lookup_var`.
- New `Env.shadow_reporter` callback fires when `add_var` introduces a name matching an existing nullary rule — the one case where var-vs-rule shadowing is semantically observable. `check.ml` installs a reporter that pushes a new `NullaryRuleShadowedByVar` variant onto the existing `type_warnings` pipeline (same mechanism as `ShadowingTypeMismatch` / `BoolParam`).
- Visibility filters, `with_module_init`, and `exports` updated for the new field.

Regression fixture `test/regression/bug_rule_param_collision.pant` locks in the type-check of the pattern. New test `test_nullary_rule_shadowed_by_var` asserts the warning fires.

### 2. `smt: alpha-rename quantifier binders that shadow declared rules`

Follow-up to commit 1. The namespace split accepts body propositions where a rule and a parameter share a name — but the SMT encoding doesn't have the split. A `(forall ((name String)) ...)` binder shadows the top-level `(declare-fun name ...)` inside the quantifier body, and z3's "innermost-wins" rule treats the inner rule reference as the bound String:

```
(forall ((name String)) (= (name (makePoint name)) name))
                                ^
                                z3 binds this to the String, not the fn
```

Z3 surfaces the capture as `select requires 1 arguments, but was provided with 2 arguments`.

**Fix:** at `translate_quantifier` entry, collect each binder name (param / GParam / GIn), check whether any collide with a declared rule/closure, and if so pick a fresh name (default `_q`, then `_q1`, `_q2`, …). Rewrite params, guards, and body to use the fresh names in *variable-reference positions only* — application heads, overrides, primed names, and qualified names keep the original names so rule references still resolve.

Primitive: `Smt_expr.rename_var_refs` — capture-avoiding substitution that only rewrites `EVar` in variable position, using `env` to detect rule references at application heads. Parallel to `substitute_vars` but position-sensitive.

Post-fix SMT for the regression fixture:

```
(forall ((name_q String)) (= (name (makePoint name_q)) name_q))
```

Rule `name` unshadowed; binder renamed.

New `test_smt_contains` helper and test assert the rename fired.

## Test plan

- [x] `dune test` — all tests green; two new regression cases and one new unit test
- [x] `pant test/regression/bug_rule_param_collision.pant` — type-checks cleanly (commit 1)
- [x] `pant --check test/regression/bug_rule_param_collision.pant` — proceeds to BMC layer (commit 2); remaining "Invariants are contradictory" is the pre-existing bounded-model limitation on uninterpreted domains, not an emission bug
- [x] `pant --check` on every `samples/*.pant` — unchanged behavior, no new warnings, no SMT errors
- [x] Existing snapshots + regression fixtures untouched

## What this unblocks

ts2pant's record-return translation (#107, #109) currently renames fixture parameters to avoid colliding with accessor rule names. After this lands, ts2pant can emit the natural form with matching field and param names, and `pant --check` proceeds past the type-check layer cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)