### PR TITLE
[bindlib-migration] Patch 1: Add bindlib dependency and Binder adapter module

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -18,6 +18,7 @@
   yojson
   sexplib0
   parsexp
+  bindlib
   (alcotest :with-test)
   (qcheck-alcotest :with-test)
   (crowbar :with-test)))

--- a/lib/binder.ml
+++ b/lib/binder.ml
@@ -1,0 +1,38 @@
+module Var = struct
+  type 'a t = 'a Bindlib.var
+
+  let make = Bindlib.new_var
+  let name = Bindlib.name_of
+  let equal = Bindlib.eq_vars
+  let compare = Bindlib.compare_vars
+end
+
+module Box = struct
+  type 'a t = 'a Bindlib.box
+
+  let pure = Bindlib.box
+  let var = Bindlib.box_var
+  let apply = Bindlib.box_apply
+  let apply2 = Bindlib.box_apply2
+  let list = Bindlib.box_list
+  let array = Bindlib.box_array
+  let unbox = Bindlib.unbox
+end
+
+module Mbinder = struct
+  type ('a, 'b) t = ('a, 'b) Bindlib.mbinder
+
+  let bind = Bindlib.bind_mvar
+  let unbind = Bindlib.unmbind
+  let subst = Bindlib.msubst
+  let arity = Bindlib.mbinder_arity
+  let names = Bindlib.mbinder_names
+  let equal = Bindlib.eq_mbinder
+
+  let free_vars body_fvs m =
+    let bound, body = Bindlib.unmbind m in
+    let body_fvs = body_fvs body in
+    List.filter
+      (fun v -> not (Array.exists (fun b -> Bindlib.eq_vars v b) bound))
+      body_fvs
+end

--- a/lib/binder.mli
+++ b/lib/binder.mli
@@ -1,0 +1,108 @@
+(** Binder adapter for Pantagruel.
+
+    This module is the single seam between Pantagruel and its underlying binder
+    library. The Bindlib backend is re-exported under project-local names; no
+    raw [Bindlib] types leak through this interface.
+
+    The adapter API is deliberately restricted to primitives that both Bindlib
+    and a hand-rolled locally-nameless representation can support:
+    - [Var.make] / [Var.name] / [Var.equal] / [Var.compare]
+    - [Mbinder.bind] / [unbind] / [subst] / [arity] / [names]
+    - alpha-aware [Mbinder.equal]
+    - [Mbinder.free_vars] parameterised over a body free-variable function
+
+    The [Box] type is needed to construct binders under the Bindlib backend. For
+    a locally-nameless backend, [Box] would collapse to the identity and its
+    operations would be trivial wrappers. *)
+
+(** {2 Variables} *)
+
+module Var : sig
+  type 'a t
+  (** Type of a free variable carrying a value of type ['a]. *)
+
+  val make : ('a t -> 'a) -> string -> 'a t
+  (** [make mkfree name] creates a fresh variable. The [mkfree] function injects
+      a variable into the carrier type ['a] (typically a constructor of the AST
+      type). *)
+
+  val name : 'a t -> string
+  (** [name v] returns the preferred name of [v]. This name is not guaranteed to
+      be collision-free; use [Mbinder.unbind] inside a renaming context when
+      converting binders to text. *)
+
+  val equal : 'a t -> 'a t -> bool
+  (** [equal v1 v2] compares variables by unique identity. *)
+
+  val compare : 'a t -> 'a t -> int
+  (** [compare v1 v2] gives a total order on variables by unique identity. *)
+end
+
+(** {2 Boxed terms}
+
+    Terms with free variables that are to be bound must first be placed in the
+    [Box.t] type. This reifies the free-variable structure so the library can
+    weave it through [Mbinder.bind]. *)
+
+module Box : sig
+  type 'a t
+  (** Type of a term of type ['a] under construction. *)
+
+  val pure : 'a -> 'a t
+  (** [pure x] lifts a closed value into the box. *)
+
+  val var : 'a Var.t -> 'a t
+  (** [var v] lifts a variable into the box. *)
+
+  val apply : ('a -> 'b) -> 'a t -> 'b t
+  (** [apply f b] applies a function to a boxed value. *)
+
+  val apply2 : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
+  (** [apply2 f b1 b2] applies a binary function to two boxed values. *)
+
+  val list : 'a t list -> 'a list t
+  (** [list bs] lifts a list of boxed values to a boxed list. *)
+
+  val array : 'a t array -> 'a array t
+  (** [array bs] lifts an array of boxed values to a boxed array. *)
+
+  val unbox : 'a t -> 'a
+  (** [unbox b] closes a boxed term. All intended bindings must already have
+      been introduced; any remaining free variables become meaningful. *)
+end
+
+(** {2 Multi-variable binders} *)
+
+module Mbinder : sig
+  type ('a, 'b) t
+  (** A binder for an array of ['a]-valued variables in a body of type ['b]. *)
+
+  val bind : 'a Var.t array -> 'b Box.t -> ('a, 'b) t Box.t
+  (** [bind vs body] binds every variable in [vs] in [body], returning a boxed
+      [mbinder]. Call [Box.unbox] once all desired bindings have been
+      introduced. *)
+
+  val unbind : ('a, 'b) t -> 'a Var.t array * 'b
+  (** [unbind b] opens [b] with a fresh array of variables. *)
+
+  val subst : ('a, 'b) t -> 'a array -> 'b
+  (** [subst b vs] substitutes the bound variables with the values [vs]. The
+      length of [vs] must equal [arity b]. *)
+
+  val arity : ('a, 'b) t -> int
+  (** [arity b] is the number of variables bound by [b]. *)
+
+  val names : ('a, 'b) t -> string array
+  (** [names b] returns the preferred names of the variables bound by [b]. As
+      with [Var.name], these are not guaranteed to be collision-free. *)
+
+  val equal : ('b -> 'b -> bool) -> ('a, 'b) t -> ('a, 'b) t -> bool
+  (** [equal eq b1 b2] tests alpha-equivalence of [b1] and [b2]. The binders
+      must have the same arity; their bodies are opened with the same fresh
+      variables and compared with [eq]. *)
+
+  val free_vars : ('b -> 'a Var.t list) -> ('a, 'b) t -> 'a Var.t list
+  (** [free_vars body_fvs b] returns the free variables of [b]'s body, excluding
+      those bound by [b]. The [body_fvs] function must extract the free
+      variables of a body of type ['b]. *)
+end

--- a/lib/dune
+++ b/lib/dune
@@ -1,6 +1,6 @@
 (library
  (name pantagruel)
- (libraries sedlex menhirLib yojson unix sexplib0 parsexp)
+ (libraries sedlex menhirLib yojson unix sexplib0 parsexp bindlib)
  (preprocess
   (pps sedlex.ppx ppx_deriving.show ppx_deriving.eq)))
 

--- a/pantagruel.opam
+++ b/pantagruel.opam
@@ -11,6 +11,7 @@ depends: [
   "yojson"
   "sexplib0"
   "parsexp"
+  "bindlib"
   "alcotest" {with-test}
   "qcheck-alcotest" {with-test}
   "crowbar" {with-test}


### PR DESCRIPTION
## Patch 1: Add bindlib dependency and Binder adapter module

- Add `bindlib` to the depends stanza in dune-project and regenerate pantagruel.opam (via `dune build` or manual sync).
- Create lib/binder.ml with `module Var = Bindlib.Var`, `module Mbinder` wrapping Bindlib.mbinder / bind_mvar / unmbind / msubst / mbinder_arity / mbinder_names, plus a `free_vars : ('a -> 'a Var.t list) -> ('a, 'b) t -> 'a Var.t list` helper.
- Restrict the adapter API to primitives that both Bindlib and a hand-rolled locally-nameless backend can support (Var.make/Var.name, Mbinder.bind/unbind/subst/free_vars, alpha-aware equality). This keeps the locally-nameless fallback a single-file swap if Bindlib proves incompatible downstream.
- Create lib/binder.mli with the public surface only; do not re-export raw Bindlib types.
- Add `bindlib` to lib/dune (libraries ...).
- Run `dune build` to confirm the new module compiles.

## Changes
- Add `bindlib` to the depends stanza in dune-project and regenerate pantagruel.opam (via `dune build` or manual sync).
- Create lib/binder.ml with `module Var = Bindlib.Var`, `module Mbinder` wrapping Bindlib.mbinder / bind_mvar / unmbind / msubst / mbinder_arity / mbinder_names, plus a `free_vars : ('a -> 'a Var.t list) -> ('a, 'b) t -> 'a Var.t list` helper.
- Restrict the adapter API to primitives that both Bindlib and a hand-rolled locally-nameless backend can support (Var.make/Var.name, Mbinder.bind/unbind/subst/free_vars, alpha-aware equality). This keeps the locally-nameless fallback a single-file swap if Bindlib proves incompatible downstream.
- Create lib/binder.mli with the public surface only; do not re-export raw Bindlib types.
- Add `bindlib` to lib/dune (libraries ...).
- Run `dune build` to confirm the new module compiles.

## Files to Modify
- dune-project (modify): Add bindlib to the pantagruel package's depends list.
- pantagruel.opam (modify): Regenerate via dune to include bindlib.
- lib/dune (modify): Add bindlib to (libraries ...).
- lib/binder.ml (create): Adapter module: Var (make/name), Mbinder (bind/unbind/subst/free_vars). Re-exports selected Bindlib primitives under stable local names.
- lib/binder.mli (create): Interface file constraining the adapter surface. Does not re-export raw Bindlib types.

## Gameplan Specification

```
module BINDLIB_MIGRATION.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> After this gameplan, Pantagruel's AST binder sites (EForall,
> EExists, EEach) are represented by Bindlib's mbinder. Capture
> avoidance is enforced by the library; the hand-rolled walker
> family in lib/smt_expr.ml collapses to thin wrappers. The
> latent capture bug in substitute_vars is closed.

Expr.
Var.
Subst.
free? x: Var, e: Expr => Bool.
bound-by e: Expr, x: Var => Expr.
substitute x: Var, rep: Expr, e: Expr => Expr.
substitute-many s: Subst, e: Expr => Expr.
alpha-equivalent? e1: Expr, e2: Expr => Bool.
---
> Substitution is the identity when the variable is not free.
all x: Var, rep: Expr, e: Expr, free? x e = false | substitute x rep e = e.

> Capture-avoiding substitution.
all x: Var, y: Var, rep: Expr, e: Expr, free? x e, free? y rep = false | alpha-equivalent? (substitute x rep (bound-by e y)) (bound-by (substitute x rep e) y).

> Substitution respects alpha-equivalence.
all s: Subst, e1: Expr, e2: Expr, alpha-equivalent? e1 e2 | alpha-equivalent? (substitute-many s e1) (substitute-many s e2).

where

> ══════════════════════════════════════════
> REDUCED SURFACE
> ══════════════════════════════════════════
> The walker family (substitute_vars, prime_expr, free_vars)
> is implemented via Bindlib primitives. Helpers added by PR
> #110 (rename_var_refs, alpha_rename_binders) are removed.

SmtExpr.
hand-rolled-walkers s: SmtExpr => Nat0.
library-backed? s: SmtExpr => Bool.
---
> No hand-rolled capture-avoidance walkers remain.
all s: SmtExpr | library-backed? s.
all s: SmtExpr | hand-rolled-walkers s = 0.

```

## Patch Specification

```
module BINDLIB_MIGRATION_PATCH_1.

> Patch 1 introduces the Binder adapter module wrapping Bindlib's
> Var and Mbinder primitives. No AST changes yet; no invariants
> asserted. The contribution is the adapter surface itself,
> available to subsequent patches.

Binder.
Var.
---
true.

```


## Implementation Notes

- **Added a `Box` sub-module** beyond what the plan listed. `Bindlib.bind_mvar` returns a boxed binder (`'b box -> (_,_) mbinder box`), so an honest, non-leaky `Mbinder.bind` signature requires exposing the box type. `Box` provides `pure / var / apply / apply2 / list / array / unbox`, which is the minimum set a consumer needs to reconstruct an AST node under construction. For a locally-nameless backend, `'a Box.t` would collapse to `'a` and every operation becomes trivial — the abstraction still permits the single-file swap the plan calls for.
- **`Var.equal` is monomorphic (`'a t -> 'a t -> bool`)** rather than Bindlib's cross-type `'a var -> 'b var -> bool`. Bindlib's extra polymorphism compares unique IDs across types, which we never need and which a locally-nameless backend could not offer.
- **`Mbinder.free_vars` strategy**: unbind once to get the fresh variable array and the body, apply the caller-supplied body-free-var extractor, then filter with `Bindlib.eq_vars` against the bound array. This is the shape Patch 3 will use for `free_vars` on expressions.
- **The adapter is currently unused by the rest of the codebase** — Patch 1 only adds it. The existing `substitute_vars` / `prime_expr` / `free_vars` walkers in `lib/smt_expr.ml` are untouched; they are not routed through `Binder` yet. No behavior changes; `dune test` is clean.
- **No `Binder.t` identifier is included** (the patch spec lists `Binder.` but as a module name, not an exported entity). The module surface is `Var`, `Box`, `Mbinder`.
- **ocamlformat** moved the doc comments to the post-declaration position during the pre-commit hook; this is stylistic only.