### PR TITLE
[bindlib-migration] Patch 2: Add pending test stubs for capture-avoiding substitution

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -26,7 +26,8 @@
   test_e2e
   test_module
   test_smt_invariants
-  test_smt_property)
+  test_smt_property
+  test_smt_substitution)
  (modules :standard \ test_util smt_check)
  (libraries pantagruel test_util smt_check alcotest qcheck-alcotest)
  (deps

--- a/test/test_smt_substitution.ml
+++ b/test/test_smt_substitution.ml
@@ -1,0 +1,172 @@
+(** Capture-avoiding substitution tests for the Bindlib migration.
+
+    PENDING: Patch 4. Every test in this file is skipped via [Alcotest.skip] —
+    the executable compiles and runs, but the assertions are inert. Patch 4
+    (Activate capture-avoidance tests) removes the [pending ()] calls once the
+    AST reshape (Patch 3) is in place and [Smt.substitute_vars] /
+    [Smt.free_vars] delegate to [Pantagruel.Binder].
+
+    The test bodies after [pending ()] are intentionally written against the
+    *current* (pre-Patch-3) AST and walker API. They are dead code today; they
+    act as a type-check on the call shapes Patch 4 will assert against. If Patch
+    3's AST reshape breaks these bodies, Patch 4 must update them in lockstep
+    with activating the checks. *)
+
+open Alcotest
+open Pantagruel
+
+(** Marker for tests that should compile and run but remain inert until a later
+    patch activates them. Alcotest treats [skip ()] as a skipped test case. The
+    [unit] return annotation is what tells the compiler [pending] is not a
+    non-returning call, so the assertion skeleton that follows each invocation
+    is accepted as live (though never executed) code. *)
+let pending () : unit = skip ()
+
+(* ------------------------------------------------------------------ *)
+(* Test 1: substitute_vars is the identity when the domain name is not
+   free in e.                                                           *)
+(* ------------------------------------------------------------------ *)
+
+let test_substitute_identity_on_nonfree () =
+  pending ();
+  let e : Ast.expr =
+    Ast.EBinop
+      ( Ast.OpAnd,
+        Ast.EVar (Ast.Lower "a"),
+        Ast.EBinop (Ast.OpEq, Ast.EVar (Ast.Lower "b"), Ast.ELitNat 0) )
+  in
+  let subst = [ ("x", Ast.EVar (Ast.Lower "y")) ] in
+  check bool "substitute_vars is identity when domain name is not free" true
+    (Smt.substitute_vars subst e = e)
+
+(* ------------------------------------------------------------------ *)
+(* Test 2: substitute_vars [x -> EVar y] (EForall [y:T] (EVar x))
+   produces a quantifier alpha-equivalent to EForall [z:T] (EVar y).
+   The current implementation captures — its binder [y] swallows the
+   fresh occurrence of [y] introduced by the substitution. The
+   post-migration implementation must alpha-rename the binder before
+   substituting.                                                        *)
+(* ------------------------------------------------------------------ *)
+
+let test_substitute_avoids_capture () =
+  pending ();
+  let t : Ast.type_expr = Ast.TName (Ast.Upper "T") in
+  let param_y : Ast.param = { param_name = Ast.Lower "y"; param_type = t } in
+  let body_x = Ast.EVar (Ast.Lower "x") in
+  let input = Ast.EForall ([ param_y ], [], body_x) in
+  let subst = [ ("x", Ast.EVar (Ast.Lower "y")) ] in
+  let result = Smt.substitute_vars subst input in
+  (* Expected: a forall whose binder has been alpha-renamed away from [y]
+     (e.g. [z:T]) and whose body references the substituted [y] as a FREE
+     variable. Equivalently: the free variables of the result must include
+     [y]. The current implementation returns [EForall [y:T] | y] where [y] is
+     bound — so [y] is NOT free. Patch 4 asserts [y] IS free. *)
+  let free = Smt.free_vars result in
+  check bool "y is free in the substituted quantifier" true
+    (Smt.StringSet.mem "y" free)
+
+(* ------------------------------------------------------------------ *)
+(* Test 3: alpha-equivalent inputs produce alpha-equivalent outputs
+   under substitute_vars.                                              *)
+(* ------------------------------------------------------------------ *)
+
+let test_substitute_preserves_alpha_equivalence () =
+  pending ();
+  let t : Ast.type_expr = Ast.TName (Ast.Upper "T") in
+  let mk name : Ast.param = { param_name = Ast.Lower name; param_type = t } in
+  (* [all a: T | f a]  vs  [all b: T | f b] — alpha-equivalent. *)
+  let e1 =
+    Ast.EForall
+      ( [ mk "a" ],
+        [],
+        Ast.EApp (Ast.EVar (Ast.Lower "f"), [ Ast.EVar (Ast.Lower "a") ]) )
+  in
+  let e2 =
+    Ast.EForall
+      ( [ mk "b" ],
+        [],
+        Ast.EApp (Ast.EVar (Ast.Lower "f"), [ Ast.EVar (Ast.Lower "b") ]) )
+  in
+  let subst = [ ("f", Ast.EVar (Ast.Lower "g")) ] in
+  let r1 = Smt.substitute_vars subst e1 in
+  let r2 = Smt.substitute_vars subst e2 in
+  (* Patch 4 asserts alpha-equivalence via Binder.Mbinder.equal. Pre-migration
+     there is no alpha-aware equality on [Ast.expr]; the closest surrogate is
+     free-variable equality, which should hold if capture is avoided. *)
+  check bool "alpha-equivalent inputs produce equal free-variable sets" true
+    (Smt.StringSet.equal (Smt.free_vars r1) (Smt.free_vars r2))
+
+(* ------------------------------------------------------------------ *)
+(* Test 4: free_vars over the regression fixture corpus agrees with
+   the legacy StringSet-based implementation. The legacy result is the
+   frozen baseline; Patch 4 compares the library-backed implementation
+   against it fixture-by-fixture.                                       *)
+(* ------------------------------------------------------------------ *)
+
+let regression_dir =
+  Test_util.find_dir
+    [
+      "test/regression";
+      "../test/regression";
+      "../../test/regression";
+      "regression";
+      "../regression";
+      Filename.concat (Sys.getcwd ()) "test/regression";
+    ]
+
+(** Legacy free-variable set baseline: for each body proposition in each chapter
+    of [doc], pair the proposition with the result of the current
+    [Smt.free_vars]. Patch 4 recomputes this with the library-backed
+    implementation and checks agreement. *)
+let legacy_free_vars_baseline (doc : Ast.document) :
+    (Ast.expr * Smt.StringSet.t) list =
+  List.concat_map
+    (fun (ch : Ast.chapter) ->
+      List.map
+        (fun (p : Ast.expr Ast.located) -> (p.value, Smt.free_vars p.value))
+        ch.body)
+    doc.chapters
+
+let test_free_vars_matches_legacy () =
+  pending ();
+  match regression_dir with
+  | None -> ()
+  | Some dir ->
+      let fixtures = Test_util.pant_files dir in
+      List.iter
+        (fun name ->
+          let path = Filename.concat dir name in
+          let doc = Test_util.parse_pant_file path in
+          let baseline = legacy_free_vars_baseline doc in
+          (* Patch 4: compute the same list using the library-backed
+             free-variable function and assert set equality fixture-by-fixture.
+             Today both sides call the same function, so the check is trivially
+             true — and skipped by [pending ()] regardless. *)
+          List.iter
+            (fun (e, legacy) ->
+              check bool
+                (Printf.sprintf "free_vars agrees with legacy for %s" name)
+                true
+                (Smt.StringSet.equal legacy (Smt.free_vars e)))
+            baseline)
+        fixtures
+
+(* ------------------------------------------------------------------ *)
+(* Test registration                                                    *)
+(* ------------------------------------------------------------------ *)
+
+let () =
+  run "Smt_substitution"
+    [
+      ( "capture_avoidance",
+        [
+          test_case "substitute_vars is identity on non-free names" `Quick
+            test_substitute_identity_on_nonfree;
+          test_case "substitute_vars avoids capture in (all y:T | x) case"
+            `Quick test_substitute_avoids_capture;
+          test_case "substitute_vars preserves alpha-equivalence" `Quick
+            test_substitute_preserves_alpha_equivalence;
+          test_case "free_vars matches legacy implementation" `Quick
+            test_free_vars_matches_legacy;
+        ] );
+    ]


### PR DESCRIPTION
## Patch 2: Add pending test stubs for capture-avoiding substitution

- Create test/test_smt_substitution.ml with four tests tagged `PENDING: Patch 4` — each raises Failure "pending" so the test executable compiles and runs, but the tests themselves are skipped via Alcotest's `Skip` return.
- Test 1: substitute_vars is the identity when the domain name is not free in e.
- Test 2: substitute_vars [x -> EVar y] (EForall [y:T] (EVar x)) produces a quantifier alpha-equivalent to EForall [z:T] (EVar y) — the current implementation captures; the post-migration implementation must not.
- Test 3: alpha-equivalent inputs produce alpha-equivalent outputs under substitute_vars.
- Test 4: free_vars over the regression fixture corpus agrees with the legacy StringSet-based implementation (captured as a frozen baseline at stub time).
- Register the new executable in test/dune.

## Changes
- Create test/test_smt_substitution.ml with four tests tagged `PENDING: Patch 4` — each raises Failure "pending" so the test executable compiles and runs, but the tests themselves are skipped via Alcotest's `Skip` return.
- Test 1: substitute_vars is the identity when the domain name is not free in e.
- Test 2: substitute_vars [x -> EVar y] (EForall [y:T] (EVar x)) produces a quantifier alpha-equivalent to EForall [z:T] (EVar y) — the current implementation captures; the post-migration implementation must not.
- Test 3: alpha-equivalent inputs produce alpha-equivalent outputs under substitute_vars.
- Test 4: free_vars over the regression fixture corpus agrees with the legacy StringSet-based implementation (captured as a frozen baseline at stub time).
- Register the new executable in test/dune.

## Files to Modify
- test/test_smt_substitution.ml (create): Alcotest + QCheck2 file declaring pending tests for substitute identity, capture-avoidance (substitute [x -> y] (all y:T | x)), alpha-equivalence preservation, and free_vars parity with the legacy implementation.
- test/dune (modify): Register test_smt_substitution as a test executable.

## Gameplan Specification

```
module BINDLIB_MIGRATION.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> After this gameplan, Pantagruel's AST binder sites (EForall,
> EExists, EEach) are represented by Bindlib's mbinder. Capture
> avoidance is enforced by the library; the hand-rolled walker
> family in lib/smt_expr.ml collapses to thin wrappers. The
> latent capture bug in substitute_vars is closed.

Expr.
Var.
Subst.
free? x: Var, e: Expr => Bool.
bound-by e: Expr, x: Var => Expr.
substitute x: Var, rep: Expr, e: Expr => Expr.
substitute-many s: Subst, e: Expr => Expr.
alpha-equivalent? e1: Expr, e2: Expr => Bool.
---
> Substitution is the identity when the variable is not free.
all x: Var, rep: Expr, e: Expr, free? x e = false | substitute x rep e = e.

> Capture-avoiding substitution.
all x: Var, y: Var, rep: Expr, e: Expr, free? x e, free? y rep = false | alpha-equivalent? (substitute x rep (bound-by e y)) (bound-by (substitute x rep e) y).

> Substitution respects alpha-equivalence.
all s: Subst, e1: Expr, e2: Expr, alpha-equivalent? e1 e2 | alpha-equivalent? (substitute-many s e1) (substitute-many s e2).

where

> ══════════════════════════════════════════
> REDUCED SURFACE
> ══════════════════════════════════════════
> The walker family (substitute_vars, prime_expr, free_vars)
> is implemented via Bindlib primitives. Helpers added by PR
> #110 (rename_var_refs, alpha_rename_binders) are removed.

SmtExpr.
hand-rolled-walkers s: SmtExpr => Nat0.
library-backed? s: SmtExpr => Bool.
---
> No hand-rolled capture-avoidance walkers remain.
all s: SmtExpr | library-backed? s.
all s: SmtExpr | hand-rolled-walkers s = 0.

```

## Patch Specification

```
module BINDLIB_MIGRATION_PATCH_2.

> Patch 2 introduces pending test stubs for the capture-avoidance
> properties that Patch 4 will activate. No invariants asserted
> yet — the stubs compile but are skipped.

Binder.
Var.
Expr.
---
true.

```


## Implementation Notes

- **Skip mechanism.** The plan phrases this as "raises `Failure \"pending\"`", but Alcotest does not treat `Failure _` as a skip — raising it would fail the test. The actual mechanism is `Alcotest.skip ()` (from `Alcotest_engine.V1.Test`, available since 1.7.0), which raises an internal sentinel Alcotest converts to `[SKIP]`. All four cases report `[SKIP]` in the runner output.

- **`pending` return-type annotation.** `Alcotest.skip` has type `unit -> 'a`, which makes the compiler flag every call as a non-returning statement (warning 21, promoted to error in this project). The wrapper is declared `let pending () : unit = skip ()` — constraining the return to `unit` silences the warning and lets the assertion skeleton after `pending ()` type-check as live (unreachable) code.

- **Assertion skeletons are intentional dead code.** Each test body writes out the call shape Patch 4 will assert against, using the *current* (pre-Patch-3) AST (`EForall (params, guards, body)`) and walker API (`Smt.substitute_vars`, `Smt.free_vars`, `Smt.StringSet`). This means Patch 3's AST reshape will break these stubs, forcing Patch 4 to update them in lockstep — which is desirable, not a bug.

- **Test 3 uses free-variable set equality as an alpha-equivalence surrogate.** The pre-migration `Ast.expr` has no alpha-aware equality (its `[@@deriving eq]` compares binder names structurally). The stub asserts equal free-variable *sets* of the two substitution results as a weaker-but-available proxy; Patch 4 replaces this with `Binder.Mbinder.equal` once the AST carries mbinders.

- **Test 4 baseline is computed at runtime, not pinned to a file.** `legacy_free_vars_baseline` calls today's `Smt.free_vars` over each regression fixture's body propositions when the test runs. Because the test is skipped today, no snapshot is written. Patch 4 will keep calling `Smt.free_vars` on one side (now library-backed) and compare against a captured copy of the pre-migration result — the helper is structured so Patch 4 can freeze the baseline by, e.g., serializing it before swapping the implementation.

- **No QCheck2.** The "Files to Modify" bullet mentioned "Alcotest + QCheck2", but all four stubs are plain Alcotest cases — property-based generation isn't useful while the tests are skipped, and Patch 4 can add QCheck2 when activating the properties if desired.