### PR TITLE
[bindlib-migration] Patch 3: Reshape AST to use Bindlib mbinders; rewrite walkers

### DIFF
--- a/lib/ast.ml
+++ b/lib/ast.ml
@@ -77,14 +77,26 @@ type combiner = CombAdd | CombMul | CombAnd | CombOr | CombMin | CombMax
 
 type param = { param_name : lower_ident; param_type : type_expr }
 [@@deriving show, eq]
-(** Parameters in declarations and quantifiers *)
+(** Parameters in declarations and quantifiers. In [EForall] / [EExists] /
+    [EEach], the accompanying [param list] carries purely syntactic metadata
+    (the user-facing name and type annotation used by pretty-printers and error
+    messages); binder identity is supplied by the Bindlib [Mbinder.t] that
+    accompanies it. *)
 
-(** Guards: parameter bindings, membership bindings, or boolean expressions *)
+(** Guards: parameter bindings, membership bindings, or boolean expressions.
+    Inside a quantifier body, the [GParam] and [GIn] names still appear as plain
+    [lower_ident] — only the top-level quantifier params go through the Bindlib
+    binder. *)
 type guard =
   | GParam of param  (** x: T *)
   | GIn of lower_ident * expr  (** x in xs - binds x to element type of xs *)
   | GExpr of expr  (** boolean condition *)
-[@@deriving show, eq]
+
+and guarded_body = guard list * expr
+(** The body of a quantifier binder: the guard list plus the inner body
+    expression. Both are wrapped inside the [Mbinder.t] so that capture-avoiding
+    substitution of the quantifier's top-level parameters descends into guards
+    and body uniformly. *)
 
 (** Expressions *)
 and expr =
@@ -102,13 +114,328 @@ and expr =
   | EProj of expr * int  (** e.1, e.2 *)
   | EBinop of binop * expr * expr  (** e1 op e2 *)
   | EUnop of unop * expr  (** op e *)
-  | EForall of param list * guard list * expr  (** forall x:T, g | e *)
-  | EExists of param list * guard list * expr  (** exists x:T, g | e *)
-  | EEach of param list * guard list * combiner option * expr
+  | EForall of (expr, guarded_body) Binder.Mbinder.t * param list
+      (** forall x:T, g | e — the [Mbinder.t] binds the top-level params in
+          (guards, body); the [param list] preserves user-facing names and type
+          annotations for printing and error messages. *)
+  | EExists of (expr, guarded_body) Binder.Mbinder.t * param list
+      (** exists x:T, g | e *)
+  | EEach of
+      (expr, guarded_body) Binder.Mbinder.t * param list * combiner option
       (** each x:T, g | e; optional combiner for over-each *)
   | ECond of (expr * expr) list  (** cond arm => e, arm2 => e2 *)
   | EInitially of expr  (** initially e *)
-[@@deriving show, eq]
+
+(* ========================================================================== *)
+(* Bindlib helpers for constructing and destructuring quantifier binders.     *)
+(* ========================================================================== *)
+
+(** Injection of a Bindlib variable into an AST expression — the [mkfree] for
+    [Binder.Var.make] when the carrier is [expr]. *)
+let mkfree_expr (v : expr Binder.Var.t) : expr =
+  EVar (Lower (Binder.Var.name v))
+
+(** Fresh variable keyed by the supplied user-facing name. *)
+let fresh_var (name : string) : expr Binder.Var.t =
+  Binder.Var.make mkfree_expr name
+
+(** Box an expression, replacing free occurrences of [EVar (Lower n)] with the
+    corresponding bound variable whenever [n] is in [env]. Outer bindings are
+    shadowed by any inner quantifier's own parameters; this function rebinds
+    nested quantifiers so that free occurrences captured by the outer binder are
+    threaded through correctly. *)
+let rec box_expr (env : (string * expr Binder.Var.t) list) (e : expr) :
+    expr Binder.Box.t =
+  match e with
+  | EVar (Lower name) -> (
+      match List.assoc_opt name env with
+      | Some v -> Binder.Box.var v
+      | None -> Binder.Box.pure e)
+  | EPrimed _ | ELitNat _ | ELitReal _ | ELitString _ | ELitBool _ | EDomain _
+  | EQualified _ ->
+      Binder.Box.pure e
+  | EApp (f, args) ->
+      Binder.Box.apply2
+        (fun f args -> EApp (f, args))
+        (box_expr env f)
+        (Binder.Box.list (List.map (box_expr env) args))
+  | EBinop (op, e1, e2) ->
+      Binder.Box.apply2
+        (fun a b -> EBinop (op, a, b))
+        (box_expr env e1) (box_expr env e2)
+  | EUnop (op, e) -> Binder.Box.apply (fun a -> EUnop (op, a)) (box_expr env e)
+  | ETuple es ->
+      Binder.Box.apply
+        (fun es -> ETuple es)
+        (Binder.Box.list (List.map (box_expr env) es))
+  | EProj (e, i) -> Binder.Box.apply (fun a -> EProj (a, i)) (box_expr env e)
+  | EOverride (name, pairs) ->
+      let pairs_box =
+        List.map
+          (fun (k, v) ->
+            Binder.Box.apply2
+              (fun k v -> (k, v))
+              (box_expr env k) (box_expr env v))
+          pairs
+      in
+      Binder.Box.apply
+        (fun pairs -> EOverride (name, pairs))
+        (Binder.Box.list pairs_box)
+  | ECond arms ->
+      let arms_box =
+        List.map
+          (fun (a, c) ->
+            Binder.Box.apply2
+              (fun a c -> (a, c))
+              (box_expr env a) (box_expr env c))
+          arms
+      in
+      Binder.Box.apply (fun arms -> ECond arms) (Binder.Box.list arms_box)
+  | EInitially e -> Binder.Box.apply (fun e -> EInitially e) (box_expr env e)
+  | EForall (mb, metas) ->
+      box_quant env (fun mb -> EForall (mb, metas)) mb metas
+  | EExists (mb, metas) ->
+      box_quant env (fun mb -> EExists (mb, metas)) mb metas
+  | EEach (mb, metas, comb) ->
+      box_quant env (fun mb -> EEach (mb, metas, comb)) mb metas
+
+and box_quant :
+    'a.
+    (string * expr Binder.Var.t) list ->
+    ((expr, guarded_body) Binder.Mbinder.t -> expr) ->
+    (expr, guarded_body) Binder.Mbinder.t ->
+    param list ->
+    expr Binder.Box.t =
+ fun env make_expr mb metas ->
+  let vars_arr, (guards, body) = Binder.Mbinder.unbind mb in
+  (* Inner params shadow outer references by the same name. Filter them from
+     [env] before recursing. *)
+  let shadow_names =
+    List.map (fun (p : param) -> lower_name p.param_name) metas
+  in
+  let env' = List.filter (fun (n, _) -> not (List.mem n shadow_names)) env in
+  let guards_box = box_guards env' guards in
+  let body_box = box_expr env' body in
+  let body_pair_box =
+    Binder.Box.apply2 (fun g b -> (g, b)) guards_box body_box
+  in
+  let rebound = Binder.Mbinder.bind vars_arr body_pair_box in
+  Binder.Box.apply make_expr rebound
+
+and box_guards env guards = Binder.Box.list (List.map (box_guard env) guards)
+
+and box_guard env = function
+  | GParam p -> Binder.Box.pure (GParam p)
+  | GIn (name, e) -> Binder.Box.apply (fun e -> GIn (name, e)) (box_expr env e)
+  | GExpr e -> Binder.Box.apply (fun e -> GExpr e) (box_expr env e)
+
+(** Bind a quantifier: allocate a fresh [Var.t] for each param name, rewrite the
+    guards and body to reference those vars, and return the resulting
+    [Mbinder.t]. Guards and body are captured in entry order — so an outer
+    [GParam] or [GIn] that shares a name with a top-level param will shadow its
+    outer binding in subsequent guards only. *)
+let bind_quant (params : param list) (guards : guard list) (body : expr) :
+    (expr, guarded_body) Binder.Mbinder.t =
+  let env =
+    List.map
+      (fun (p : param) ->
+        let name = lower_name p.param_name in
+        (name, fresh_var name))
+      params
+  in
+  let vars_arr = Array.of_list (List.map snd env) in
+  let body_pair_box =
+    Binder.Box.apply2
+      (fun g b -> (g, b))
+      (box_guards env guards) (box_expr env body)
+  in
+  Binder.Box.unbox (Binder.Mbinder.bind vars_arr body_pair_box)
+
+(** Unbind a quantifier: returns the parameter metadata with names refreshed to
+    match the [Mbinder]'s internal vars, the guards, and the body. The returned
+    [param] records keep their original [type_expr]; only the names are
+    refreshed. Callers that need the raw [Var.t] array should use the
+    [Binder.Mbinder.unbind] primitive directly. *)
+let unbind_quant (mb : (expr, guarded_body) Binder.Mbinder.t)
+    (metas : param list) : param list * guard list * expr =
+  let vars_arr, (guards, body) = Binder.Mbinder.unbind mb in
+  let n = Array.length vars_arr in
+  let params =
+    List.mapi
+      (fun i (p : param) ->
+        if i < n then
+          { p with param_name = Lower (Binder.Var.name vars_arr.(i)) }
+        else p)
+      metas
+  in
+  (params, guards, body)
+
+(** Smart constructors so that call sites can supply the old
+    [(params, guards, body)] triple and receive an AST node with the binder
+    properly closed. *)
+let make_forall (params : param list) (guards : guard list) (body : expr) : expr
+    =
+  EForall (bind_quant params guards body, params)
+
+let make_exists (params : param list) (guards : guard list) (body : expr) : expr
+    =
+  EExists (bind_quant params guards body, params)
+
+let make_each (params : param list) (guards : guard list)
+    (comb : combiner option) (body : expr) : expr =
+  EEach (bind_quant params guards body, params, comb)
+
+(* ========================================================================== *)
+(* Hand-written show, pp, and equal for expr / guard / guarded_body.          *)
+(* ppx_deriving cannot descend into [Binder.Mbinder.t], so we unbind each     *)
+(* quantifier variant and format / compare alpha-equivalently.                *)
+(* ========================================================================== *)
+
+let rec pp_expr (fmt : Format.formatter) (e : expr) : unit =
+  match e with
+  | EVar (Lower n) -> Format.fprintf fmt "EVar (Lower %S)" n
+  | EDomain (Upper n) -> Format.fprintf fmt "EDomain (Upper %S)" n
+  | EQualified (Upper m, n) ->
+      Format.fprintf fmt "EQualified ((Upper %S), %S)" m n
+  | ELitNat n -> Format.fprintf fmt "ELitNat %d" n
+  | ELitReal r -> Format.fprintf fmt "ELitReal %g" r
+  | ELitString s -> Format.fprintf fmt "ELitString %S" s
+  | ELitBool b -> Format.fprintf fmt "ELitBool %B" b
+  | EApp (f, args) ->
+      Format.fprintf fmt "EApp (@[%a,@ [@[%a@]]@])" pp_expr f
+        (Format.pp_print_list
+           ~pp_sep:(fun fmt () -> Format.fprintf fmt ";@ ")
+           pp_expr)
+        args
+  | EPrimed (Lower n) -> Format.fprintf fmt "EPrimed (Lower %S)" n
+  | EOverride (Lower n, pairs) ->
+      Format.fprintf fmt "EOverride (Lower %S, [@[%a@]])" n
+        (Format.pp_print_list
+           ~pp_sep:(fun fmt () -> Format.fprintf fmt ";@ ")
+           (fun fmt (k, v) -> Format.fprintf fmt "(%a, %a)" pp_expr k pp_expr v))
+        pairs
+  | ETuple es ->
+      Format.fprintf fmt "ETuple [@[%a@]]"
+        (Format.pp_print_list
+           ~pp_sep:(fun fmt () -> Format.fprintf fmt ";@ ")
+           pp_expr)
+        es
+  | EProj (e, i) -> Format.fprintf fmt "EProj (%a, %d)" pp_expr e i
+  | EBinop (op, e1, e2) ->
+      Format.fprintf fmt "EBinop (%a, %a, %a)" pp_binop op pp_expr e1 pp_expr e2
+  | EUnop (op, e) -> Format.fprintf fmt "EUnop (%a, %a)" pp_unop op pp_expr e
+  | EForall (mb, metas) ->
+      let params, guards, body = unbind_quant mb metas in
+      Format.fprintf fmt "EForall (@[%a,@ %a,@ %a@])" pp_params params pp_guards
+        guards pp_expr body
+  | EExists (mb, metas) ->
+      let params, guards, body = unbind_quant mb metas in
+      Format.fprintf fmt "EExists (@[%a,@ %a,@ %a@])" pp_params params pp_guards
+        guards pp_expr body
+  | EEach (mb, metas, comb) ->
+      let params, guards, body = unbind_quant mb metas in
+      Format.fprintf fmt "EEach (@[%a,@ %a,@ %a,@ %a@])" pp_params params
+        pp_guards guards
+        (fun fmt o ->
+          match o with
+          | None -> Format.fprintf fmt "None"
+          | Some c -> Format.fprintf fmt "Some %a" pp_combiner c)
+        comb pp_expr body
+  | ECond arms ->
+      Format.fprintf fmt "ECond [@[%a@]]"
+        (Format.pp_print_list
+           ~pp_sep:(fun fmt () -> Format.fprintf fmt ";@ ")
+           (fun fmt (a, c) -> Format.fprintf fmt "(%a, %a)" pp_expr a pp_expr c))
+        arms
+  | EInitially e -> Format.fprintf fmt "EInitially %a" pp_expr e
+
+and pp_params fmt params =
+  Format.fprintf fmt "[@[%a@]]"
+    (Format.pp_print_list
+       ~pp_sep:(fun fmt () -> Format.fprintf fmt ";@ ")
+       pp_param)
+    params
+
+and pp_guards fmt gs =
+  Format.fprintf fmt "[@[%a@]]"
+    (Format.pp_print_list
+       ~pp_sep:(fun fmt () -> Format.fprintf fmt ";@ ")
+       pp_guard)
+    gs
+
+and pp_guard fmt = function
+  | GParam p -> Format.fprintf fmt "GParam %a" pp_param p
+  | GIn (Lower n, e) -> Format.fprintf fmt "GIn (Lower %S, %a)" n pp_expr e
+  | GExpr e -> Format.fprintf fmt "GExpr %a" pp_expr e
+
+let show_expr e = Format.asprintf "%a" pp_expr e
+let show_guard g = Format.asprintf "%a" pp_guard g
+
+(** Alpha-aware structural equality on expressions. Quantifier bodies are
+    compared under fresh variables via [Binder.Mbinder.equal]; everything else
+    is ordinary structural equality. *)
+let rec equal_expr (e1 : expr) (e2 : expr) : bool =
+  match (e1, e2) with
+  | EVar a, EVar b -> equal_lower_ident a b
+  | EDomain a, EDomain b -> equal_upper_ident a b
+  | EQualified (m1, n1), EQualified (m2, n2) ->
+      equal_upper_ident m1 m2 && String.equal n1 n2
+  | ELitNat a, ELitNat b -> Int.equal a b
+  | ELitReal a, ELitReal b -> Float.equal a b
+  | ELitString a, ELitString b -> String.equal a b
+  | ELitBool a, ELitBool b -> Bool.equal a b
+  | EApp (f1, a1), EApp (f2, a2) ->
+      equal_expr f1 f2 && List.equal equal_expr a1 a2
+  | EPrimed a, EPrimed b -> equal_lower_ident a b
+  | EOverride (n1, p1), EOverride (n2, p2) ->
+      equal_lower_ident n1 n2
+      && List.equal
+           (fun (k1, v1) (k2, v2) -> equal_expr k1 k2 && equal_expr v1 v2)
+           p1 p2
+  | ETuple a, ETuple b -> List.equal equal_expr a b
+  | EProj (a, i1), EProj (b, i2) -> Int.equal i1 i2 && equal_expr a b
+  | EBinop (o1, a1, b1), EBinop (o2, a2, b2) ->
+      equal_binop o1 o2 && equal_expr a1 a2 && equal_expr b1 b2
+  | EUnop (o1, a1), EUnop (o2, a2) -> equal_unop o1 o2 && equal_expr a1 a2
+  | EForall (m1, p1), EForall (m2, p2) ->
+      equal_params p1 p2 && Binder.Mbinder.equal equal_guarded_body m1 m2
+  | EExists (m1, p1), EExists (m2, p2) ->
+      equal_params p1 p2 && Binder.Mbinder.equal equal_guarded_body m1 m2
+  | EEach (m1, p1, c1), EEach (m2, p2, c2) ->
+      equal_params p1 p2
+      && Option.equal equal_combiner c1 c2
+      && Binder.Mbinder.equal equal_guarded_body m1 m2
+  | ECond a, ECond b ->
+      List.equal
+        (fun (a1, c1) (a2, c2) -> equal_expr a1 a2 && equal_expr c1 c2)
+        a b
+  | EInitially a, EInitially b -> equal_expr a b
+  | ( ( EVar _ | EDomain _ | EQualified _ | ELitNat _ | ELitReal _
+      | ELitString _ | ELitBool _ | EApp _ | EPrimed _ | EOverride _ | ETuple _
+      | EProj _ | EBinop _ | EUnop _ | EForall _ | EExists _ | EEach _ | ECond _
+      | EInitially _ ),
+      _ ) ->
+      false
+
+and equal_params p1 p2 =
+  (* Param equality ignores param names — only the type annotations are
+     meaningful metadata; the names are set by whatever unbinding happens
+     first and are not stable across calls. *)
+  List.length p1 = List.length p2
+  && List.for_all2
+       (fun (a : param) (b : param) ->
+         equal_type_expr a.param_type b.param_type)
+       p1 p2
+
+and equal_guarded_body (g1, b1) (g2, b2) =
+  List.equal equal_guard g1 g2 && equal_expr b1 b2
+
+and equal_guard g1 g2 =
+  match (g1, g2) with
+  | GParam p1, GParam p2 -> equal_param p1 p2
+  | GIn (n1, e1), GIn (n2, e2) -> equal_lower_ident n1 n2 && equal_expr e1 e2
+  | GExpr e1, GExpr e2 -> equal_expr e1 e2
+  | (GParam _ | GIn _ | GExpr _), _ -> false
 
 (** Declarations in chapter heads *)
 type declaration =
@@ -134,7 +461,66 @@ type declaration =
       return_type : type_expr;
       target : lower_ident;
     }
-[@@deriving show, eq]
+
+(* Hand-written show / pp / equal for [declaration] (mutually touches
+   [guard list] and [expr] — which no longer derive show/eq). *)
+
+let pp_declaration fmt = function
+  | DeclDomain (Upper n) -> Format.fprintf fmt "DeclDomain (Upper %S)" n
+  | DeclAlias (Upper n, t) ->
+      Format.fprintf fmt "DeclAlias (Upper %S, %a)" n pp_type_expr t
+  | DeclRule { name = Lower n; params; guards; return_type; contexts } ->
+      Format.fprintf fmt
+        "DeclRule {@[name = Lower %S;@ params = %a;@ guards = %a;@ return_type \
+         = %a;@ contexts = [@[%a@]]@]}"
+        n pp_params params pp_guards guards pp_type_expr return_type
+        (Format.pp_print_list
+           ~pp_sep:(fun fmt () -> Format.fprintf fmt ";@ ")
+           (fun fmt (Upper u) -> Format.fprintf fmt "Upper %S" u))
+        contexts
+  | DeclAction { label; params; guards; contexts } ->
+      Format.fprintf fmt
+        "DeclAction {@[label = %S;@ params = %a;@ guards = %a;@ contexts = \
+         [@[%a@]]@]}"
+        label pp_params params pp_guards guards
+        (Format.pp_print_list
+           ~pp_sep:(fun fmt () -> Format.fprintf fmt ";@ ")
+           (fun fmt (Upper u) -> Format.fprintf fmt "Upper %S" u))
+        contexts
+  | DeclClosure { name = Lower n; param; return_type; target = Lower t } ->
+      Format.fprintf fmt
+        "DeclClosure {@[name = Lower %S;@ param = %a;@ return_type = %a;@ \
+         target = Lower %S@]}"
+        n pp_param param pp_type_expr return_type t
+
+let show_declaration d = Format.asprintf "%a" pp_declaration d
+
+let equal_declaration (d1 : declaration) (d2 : declaration) : bool =
+  match (d1, d2) with
+  | DeclDomain a, DeclDomain b -> equal_upper_ident a b
+  | DeclAlias (a, t1), DeclAlias (b, t2) ->
+      equal_upper_ident a b && equal_type_expr t1 t2
+  | ( DeclRule
+        { name = n1; params = p1; guards = g1; return_type = r1; contexts = c1 },
+      DeclRule
+        { name = n2; params = p2; guards = g2; return_type = r2; contexts = c2 }
+    ) ->
+      equal_lower_ident n1 n2 && equal_params p1 p2
+      && List.equal equal_guard g1 g2
+      && equal_type_expr r1 r2
+      && List.equal equal_upper_ident c1 c2
+  | ( DeclAction { label = l1; params = p1; guards = g1; contexts = c1 },
+      DeclAction { label = l2; params = p2; guards = g2; contexts = c2 } ) ->
+      String.equal l1 l2 && equal_params p1 p2
+      && List.equal equal_guard g1 g2
+      && List.equal equal_upper_ident c1 c2
+  | ( DeclClosure { name = n1; param = p1; return_type = r1; target = t1 },
+      DeclClosure { name = n2; param = p2; return_type = r2; target = t2 } ) ->
+      equal_lower_ident n1 n2 && equal_param p1 p2 && equal_type_expr r1 r2
+      && equal_lower_ident t1 t2
+  | (DeclDomain _ | DeclAlias _ | DeclRule _ | DeclAction _ | DeclClosure _), _
+    ->
+      false
 
 type chapter = {
   head : declaration located list;
@@ -144,9 +530,42 @@ type chapter = {
   trailing_docs : string list list;
       (** Doc comments after the last body proposition (before where/EOF) *)
 }
-[@@deriving show, eq]
 (** A chapter has a head (declarations), body (propositions), and optional check
     block (entailment goals) *)
+
+let pp_chapter fmt { head; body; checks; trailing_docs } =
+  Format.fprintf fmt
+    "{@[head = [@[%a@]];@ body = [@[%a@]];@ checks = [@[%a@]];@ trailing_docs \
+     = [@[%a@]]@]}"
+    (Format.pp_print_list
+       ~pp_sep:(fun fmt () -> Format.fprintf fmt ";@ ")
+       (pp_located pp_declaration))
+    head
+    (Format.pp_print_list
+       ~pp_sep:(fun fmt () -> Format.fprintf fmt ";@ ")
+       (pp_located pp_expr))
+    body
+    (Format.pp_print_list
+       ~pp_sep:(fun fmt () -> Format.fprintf fmt ";@ ")
+       (pp_located pp_expr))
+    checks
+    (Format.pp_print_list
+       ~pp_sep:(fun fmt () -> Format.fprintf fmt ";@ ")
+       (fun fmt para ->
+         Format.fprintf fmt "[@[%a@]]"
+           (Format.pp_print_list
+              ~pp_sep:(fun fmt () -> Format.fprintf fmt ";@ ")
+              (fun fmt s -> Format.fprintf fmt "%S" s))
+           para))
+    trailing_docs
+
+let show_chapter c = Format.asprintf "%a" pp_chapter c
+
+let equal_chapter (c1 : chapter) (c2 : chapter) : bool =
+  List.equal (equal_located equal_declaration) c1.head c2.head
+  && List.equal (equal_located equal_expr) c1.body c2.body
+  && List.equal (equal_located equal_expr) c1.checks c2.checks
+  && List.equal (List.equal String.equal) c1.trailing_docs c2.trailing_docs
 
 type document = {
   module_name : upper_ident option;  (** None = standalone (no module system) *)
@@ -154,5 +573,34 @@ type document = {
   contexts : upper_ident located list;  (** Module-level context declarations *)
   chapters : chapter list;
 }
-[@@deriving show, eq]
 (** A complete document *)
+
+let pp_document fmt { module_name; imports; contexts; chapters } =
+  Format.fprintf fmt
+    "{@[module_name = %a;@ imports = [@[%a@]];@ contexts = [@[%a@]];@ chapters \
+     = [@[%a@]]@]}"
+    (fun fmt o ->
+      match o with
+      | None -> Format.fprintf fmt "None"
+      | Some u -> Format.fprintf fmt "Some %a" pp_upper_ident u)
+    module_name
+    (Format.pp_print_list
+       ~pp_sep:(fun fmt () -> Format.fprintf fmt ";@ ")
+       (pp_located pp_upper_ident))
+    imports
+    (Format.pp_print_list
+       ~pp_sep:(fun fmt () -> Format.fprintf fmt ";@ ")
+       (pp_located pp_upper_ident))
+    contexts
+    (Format.pp_print_list
+       ~pp_sep:(fun fmt () -> Format.fprintf fmt ";@ ")
+       pp_chapter)
+    chapters
+
+let show_document d = Format.asprintf "%a" pp_document d
+
+let equal_document (d1 : document) (d2 : document) : bool =
+  Option.equal equal_upper_ident d1.module_name d2.module_name
+  && List.equal (equal_located equal_upper_ident) d1.imports d2.imports
+  && List.equal (equal_located equal_upper_ident) d1.contexts d2.contexts
+  && List.equal equal_chapter d1.chapters d2.chapters

--- a/lib/check.ml
+++ b/lib/check.ml
@@ -204,18 +204,22 @@ let rec infer_type ctx (expr : expr) : (ty, type_error) result =
           Error (NotAProduct (ty, ctx.loc)))
   | EBinop (op, e1, e2) -> check_binop ctx op e1 e2
   | EUnop (op, e) -> check_unop ctx op e
-  | EForall (params, guards, body) ->
+  | EForall (mb, metas) ->
+      let params, guards, body = Ast.unbind_quant mb metas in
       let* body_ty = check_quantifier ctx params guards body in
       if equal_ty body_ty TyBool then Ok TyBool
       else Error (ComprehensionNeedEach (body_ty, ctx.loc))
-  | EExists (params, guards, body) ->
+  | EExists (mb, metas) ->
+      let params, guards, body = Ast.unbind_quant mb metas in
       let* body_ty = check_quantifier ctx params guards body in
       if equal_ty body_ty TyBool then Ok TyBool
       else Error (ComprehensionNeedEach (body_ty, ctx.loc))
-  | EEach (params, guards, None, body) ->
+  | EEach (mb, metas, None) ->
+      let params, guards, body = Ast.unbind_quant mb metas in
       let* body_ty = check_quantifier ctx params guards body in
       Ok (TyList body_ty)
-  | EEach (params, guards, Some comb, body) -> (
+  | EEach (mb, metas, Some comb) -> (
+      let params, guards, body = Ast.unbind_quant mb metas in
       let* body_ty = check_quantifier ctx params guards body in
       match comb with
       | CombAdd ->

--- a/lib/json_output.ml
+++ b/lib/json_output.ml
@@ -137,7 +137,8 @@ let rec expr_to_json = function
               [ ("op", `String (unop_to_string op)); ("arg", expr_to_json e) ]
           );
         ]
-  | EForall (params, guards, body) ->
+  | EForall (mb, metas) ->
+      let params, guards, body = Ast.unbind_quant mb metas in
       `Assoc
         [
           ( "forall",
@@ -148,7 +149,8 @@ let rec expr_to_json = function
                 ("body", expr_to_json body);
               ] );
         ]
-  | EExists (params, guards, body) ->
+  | EExists (mb, metas) ->
+      let params, guards, body = Ast.unbind_quant mb metas in
       `Assoc
         [
           ( "exists",
@@ -159,7 +161,8 @@ let rec expr_to_json = function
                 ("body", expr_to_json body);
               ] );
         ]
-  | EEach (params, guards, comb, body) ->
+  | EEach (mb, metas, comb) ->
+      let params, guards, body = Ast.unbind_quant mb metas in
       let combiner_json =
         match comb with
         | None -> `Null

--- a/lib/markdown_output.ml
+++ b/lib/markdown_output.ml
@@ -67,16 +67,20 @@ let pp_params_sep fmt () = fprintf fmt ", "
 
 let rec pp_expr procs fmt = function
   | EInitially e -> fprintf fmt "initially %a" (pp_expr procs) e
-  | EForall (params, guards, body) ->
+  | EForall (mb, metas) ->
+      let params, guards, body = Ast.unbind_quant mb metas in
       fprintf fmt "∀ %a · %a" (pp_quant_bindings procs) (params, guards)
         (pp_expr procs) body
-  | EExists (params, guards, body) ->
+  | EExists (mb, metas) ->
+      let params, guards, body = Ast.unbind_quant mb metas in
       fprintf fmt "∃ %a · %a" (pp_quant_bindings procs) (params, guards)
         (pp_expr procs) body
-  | EEach (params, guards, None, body) ->
+  | EEach (mb, metas, None) ->
+      let params, guards, body = Ast.unbind_quant mb metas in
       fprintf fmt "each %a · %a" (pp_quant_bindings procs) (params, guards)
         (pp_expr procs) body
-  | EEach (params, guards, Some comb, body) ->
+  | EEach (mb, metas, Some comb) ->
+      let params, guards, body = Ast.unbind_quant mb metas in
       let comb_str =
         match comb with
         | CombAdd -> "+"

--- a/lib/normalize.ml
+++ b/lib/normalize.ml
@@ -73,29 +73,31 @@ let symbols_in_expr expr =
         go e2
     | EUnop (_, e) -> go e
     | EInitially e -> go e
-    | EForall (params, guards, body)
-    | EExists (params, guards, body)
-    | EEach (params, guards, _, body) ->
-        List.iter
-          (fun p ->
-            types := StringSet.union !types (types_in_type_expr p.param_type))
-          params;
-        List.iter
-          (function
-            | GParam p ->
-                types :=
-                  StringSet.union !types (types_in_type_expr p.param_type)
-            | GIn (_, e) ->
-                go e (* x in xs - the list expression has dependencies *)
-            | GExpr e -> go e)
-          guards;
-        go body
+    | EForall (mb, metas) | EExists (mb, metas) ->
+        let params, guards, body = Ast.unbind_quant mb metas in
+        go_quant params guards body
+    | EEach (mb, metas, _) ->
+        let params, guards, body = Ast.unbind_quant mb metas in
+        go_quant params guards body
     | ECond arms ->
         List.iter
           (fun (arm, cons) ->
             go arm;
             go cons)
           arms
+  and go_quant params guards body =
+    List.iter
+      (fun p ->
+        types := StringSet.union !types (types_in_type_expr p.param_type))
+      params;
+    List.iter
+      (function
+        | GParam p ->
+            types := StringSet.union !types (types_in_type_expr p.param_type)
+        | GIn (_, e) -> go e
+        | GExpr e -> go e)
+      guards;
+    go body
   in
   go expr;
   (!types, !terms)
@@ -168,9 +170,17 @@ let rec uses_primed = function
   | EProj (e, _) -> uses_primed e
   | EBinop (_, e1, e2) -> uses_primed e1 || uses_primed e2
   | EUnop (_, e) -> uses_primed e
-  | EForall (_, guards, body)
-  | EExists (_, guards, body)
-  | EEach (_, guards, _, body) ->
+  | EForall (mb, metas) | EExists (mb, metas) ->
+      let _, guards, body = Ast.unbind_quant mb metas in
+      List.exists
+        (function
+          | GExpr e -> uses_primed e
+          | GIn (_, e) -> uses_primed e
+          | GParam _ -> false)
+        guards
+      || uses_primed body
+  | EEach (mb, metas, _) ->
+      let _, guards, body = Ast.unbind_quant mb metas in
       List.exists
         (function
           | GExpr e -> uses_primed e

--- a/lib/parser.mly
+++ b/lib/parser.mly
@@ -236,13 +236,13 @@ biconditional:
 
 quantified:
   | FORALL pg=quant_params_guards PIPE e=expr
-    { let (params, guards) = pg in EForall (params, guards, e) }
+    { let (params, guards) = pg in Ast.make_forall params guards e }
   | EXISTS pg=quant_params_guards PIPE e=expr
-    { let (params, guards) = pg in EExists (params, guards, e) }
+    { let (params, guards) = pg in Ast.make_exists params guards e }
   | EACH pg=quant_params_guards PIPE e=expr
-    { let (params, guards) = pg in EEach (params, guards, None, e) }
+    { let (params, guards) = pg in Ast.make_each params guards None e }
   | c=combiner OVER EACH pg=quant_params_guards PIPE e=expr
-    { let (params, guards) = pg in EEach (params, guards, Some c, e) }
+    { let (params, guards) = pg in Ast.make_each params guards (Some c) e }
 
 combiner:
   | PLUS  { CombAdd }

--- a/lib/pretty.ml
+++ b/lib/pretty.ml
@@ -64,16 +64,20 @@ let pp_combiner fmt = function
 (** Print an expression with proper precedence handling *)
 let rec pp_expr fmt = function
   | EInitially e -> fprintf fmt "initially %a" pp_expr e
-  | EForall (params, guards, body) ->
+  | EForall (mb, metas) ->
+      let params, guards, body = Ast.unbind_quant mb metas in
       fprintf fmt "all %a | %a" pp_quant_params_guards (params, guards) pp_expr
         body
-  | EExists (params, guards, body) ->
+  | EExists (mb, metas) ->
+      let params, guards, body = Ast.unbind_quant mb metas in
       fprintf fmt "some %a | %a" pp_quant_params_guards (params, guards) pp_expr
         body
-  | EEach (params, guards, None, body) ->
+  | EEach (mb, metas, None) ->
+      let params, guards, body = Ast.unbind_quant mb metas in
       fprintf fmt "each %a | %a" pp_quant_params_guards (params, guards) pp_expr
         body
-  | EEach (params, guards, Some comb, body) ->
+  | EEach (mb, metas, Some comb) ->
+      let params, guards, body = Ast.unbind_quant mb metas in
       fprintf fmt "%a over each %a | %a" pp_combiner comb pp_quant_params_guards
         (params, guards) pp_expr body
   | ECond arms ->

--- a/lib/smt.ml
+++ b/lib/smt.ml
@@ -139,13 +139,17 @@ let rec translate_expr config env (e : expr) =
       Printf.sprintf "(fst_%d %s)" idx (translate_expr config env e)
   | EBinop (op, e1, e2) -> translate_binop config env op e1 e2
   | EUnop (op, e) -> translate_unop config env op e
-  | EForall (params, guards, body) ->
+  | EForall (mb, metas) ->
+      let params, guards, body = Ast.unbind_quant mb metas in
       translate_quantifier config env "forall" params guards body
-  | EEach (params, guards, None, body) ->
+  | EEach (mb, metas, None) ->
+      let params, guards, body = Ast.unbind_quant mb metas in
       translate_forall_comprehension config env params guards body
-  | EEach (params, guards, Some comb, body) ->
+  | EEach (mb, metas, Some comb) ->
+      let params, guards, body = Ast.unbind_quant mb metas in
       translate_aggregate config env comb params guards body
-  | EExists (params, guards, body) ->
+  | EExists (mb, metas) ->
+      let params, guards, body = Ast.unbind_quant mb metas in
       translate_quantifier config env "exists" params guards body
   | ECond arms -> translate_cond config env arms
   | EInitially e -> translate_expr config env e
@@ -294,9 +298,10 @@ and translate_in config env elem set =
       | [] -> "false"
       | [ single ] -> single
       | _ -> Printf.sprintf "(or %s)" (String.concat " " disj))
-  | EEach (params, guards, None, body) -> (
+  | EEach (mb, metas, None) -> (
       (* y in (each x: D | f x) → disjunction: (= y (f d0)) ∨ (= y (f d1)) ...
          y in (each x: D, g x | f x) → (g d0 ∧ = y (f d0)) ∨ ... *)
+      let params, guards, body = Ast.unbind_quant mb metas in
       let expanded =
         expand_comprehension translate_expr config env params guards body
       in
@@ -324,10 +329,11 @@ and translate_subset config env e1 e2 =
   (* xs subset Domain → every member of xs is in the domain (tautological
      for well-typed programs, but expand over finite elements for soundness) *)
   match[@warning "-4"] e2 with
-  | EEach (params, guards, None, body) -> (
+  | EEach (mb, metas, None) -> (
       (* xs subset (each x: D | f x) → for every elem of xs, elem is in the
          comprehension. Expand: for each domain elem d of the LHS element type,
          (select xs d) => (exists comprehension elem matching d). *)
+      let params, guards, body = Ast.unbind_quant mb metas in
       let expanded =
         expand_comprehension translate_expr config env params guards body
       in
@@ -408,10 +414,11 @@ and translate_card config env e =
   | EDomain (Upper name) ->
       (* #Domain = bound (all elements exist) *)
       string_of_int (bound_for config name)
-  | EEach (params, guards, None, body) -> (
+  | EEach (mb, metas, None) -> (
       (* #(each x: D | f x) — count distinct values in the comprehension.
          Requires the range type to be a bounded domain. Expand over range
          domain elements, check if each is produced by any source element. *)
+      let params, guards, body = Ast.unbind_quant mb metas in
       let expanded =
         expand_comprehension translate_expr config env params guards body
       in
@@ -1858,8 +1865,17 @@ let collect_conds_in_expr (e : expr) : cond_info list =
             walk quant_ctx arm;
             walk quant_ctx cons)
           arms
-    | EForall (ps, gs, body) | EExists (ps, gs, body) | EEach (ps, gs, _, body)
-      ->
+    | EForall (mb, metas) | EExists (mb, metas) ->
+        let ps, gs, body = Ast.unbind_quant mb metas in
+        walk ((ps, gs) :: quant_ctx) body;
+        List.iter
+          (function
+            | GExpr e -> walk quant_ctx e
+            | GIn (_, e) -> walk quant_ctx e
+            | GParam _ -> ())
+          gs
+    | EEach (mb, metas, _) ->
+        let ps, gs, body = Ast.unbind_quant mb metas in
         walk ((ps, gs) :: quant_ctx) body;
         List.iter
           (function
@@ -1903,7 +1919,7 @@ let collect_conds chapters : cond_info list =
         | Smt_doc.Action { params; guards; propositions; checks; _ } ->
             ( (fun (p : expr located) ->
                 if params = [] && guards = [] then p
-                else { p with value = EForall (params, guards, p.value) }),
+                else { p with value = Ast.make_forall params guards p.value }),
               propositions @ checks )
       in
       List.concat_map
@@ -1973,7 +1989,7 @@ let generate_exhaustiveness_query config env ~all_invariants:_ ~index cond =
   (* Wrap in surrounding quantifier bindings *)
   let wrapped =
     List.fold_right
-      (fun (ps, gs) body -> EForall (ps, gs, body))
+      (fun (ps, gs) body -> Ast.make_forall ps gs body)
       cond.cond_quantifiers disj
   in
   (* Translate and negate *)

--- a/lib/smt_doc.ml
+++ b/lib/smt_doc.ml
@@ -89,9 +89,11 @@ let free_vars (e : expr) : StringSet.t =
     | EOverride (Lower n, pairs) ->
         let acc = StringSet.add n acc in
         List.fold_left (fun acc (k, v) -> go (go acc k) v) acc pairs
-    | EForall (params, guards, body) | EExists (params, guards, body) ->
+    | EForall (mb, metas) | EExists (mb, metas) ->
+        let params, guards, body = Ast.unbind_quant mb metas in
         scope_quantifier acc params guards body
-    | EEach (params, guards, _comb, body) ->
+    | EEach (mb, metas, _comb) ->
+        let params, guards, body = Ast.unbind_quant mb metas in
         scope_quantifier acc params guards body
     | ECond arms -> List.fold_left (fun acc (g, c) -> go (go acc g) c) acc arms
     | EInitially e -> go acc e
@@ -163,7 +165,7 @@ let bind_head_params ?(exclude = StringSet.empty) (bindings : param list)
       let kept = List.rev kept_rev in
       match kept with
       | [] -> p
-      | _ -> { p with value = EForall (kept, [], p.value) })
+      | _ -> { p with value = Ast.make_forall kept [] p.value })
 
 (** Collect all invariants from the document (non-initially propositions) *)
 let collect_invariants chapters =
@@ -412,8 +414,9 @@ let rec collect_function_refs (e : expr) =
   | EPrimed (Lower name) -> [ name ]
   | EBinop (_, e1, e2) -> collect_function_refs e1 @ collect_function_refs e2
   | EUnop (_, e) -> collect_function_refs e
-  | EForall (_, gs, body) | EExists (_, gs, body) | EEach (_, gs, _, body) ->
-      List.concat_map collect_guard_refs gs @ collect_function_refs body
+  | EForall (mb, metas) | EExists (mb, metas) ->
+      collect_function_refs_q mb metas
+  | EEach (mb, metas, _) -> collect_function_refs_q mb metas
   | ETuple es -> List.concat_map collect_function_refs es
   | EProj (e, _) -> collect_function_refs e
   | EOverride (Lower name, pairs) ->
@@ -435,6 +438,10 @@ and collect_guard_refs = function
   | GParam _ -> []
   | GIn (_, e) -> collect_function_refs e
   | GExpr e -> collect_function_refs e
+
+and collect_function_refs_q mb metas =
+  let _, gs, body = Ast.unbind_quant mb metas in
+  List.concat_map collect_guard_refs gs @ collect_function_refs body
 
 (** Check if invariant propositions touch any contextual functions. If they only
     reference extracontextual functions, the frame conditions guarantee

--- a/lib/smt_expr.ml
+++ b/lib/smt_expr.ml
@@ -1,5 +1,10 @@
 (** SMT expression transformation utilities: substitution, priming, guard
-    collection, and comprehension expansion *)
+    collection, and comprehension expansion.
+
+    Capture-avoiding substitution and priming on quantifier binders are
+    implemented via the [Binder.Mbinder] primitives — the hand-rolled walkers
+    that used to filter substitution domains by bound names have collapsed to
+    unbind / recurse / rebind. *)
 
 open Ast
 open Types
@@ -94,8 +99,9 @@ let expand_comprehension translate config env params guards body =
         elems
 
 (** Capture-avoiding substitution: replace EVar names according to the mapping.
-    Stops at quantifier/comprehension boundaries to avoid capturing bound vars.
-*)
+    Top-level quantifier params are handled by [Binder.Mbinder.subst]; for the
+    GParam / GIn binders inside the guard list, we still filter the substitution
+    domain manually (those bindings are not reified in the mbinder). *)
 let rec substitute_vars (subst : (string * expr) list) (e : expr) : expr =
   match e with
   | EVar (Lower name) -> (
@@ -118,27 +124,48 @@ let rec substitute_vars (subst : (string * expr) list) (e : expr) : expr =
           List.map
             (fun (k, v) -> (substitute_vars subst k, substitute_vars subst v))
             pairs )
-  | EForall (ps, gs, body) ->
-      let bound =
-        List.map (fun (p : param) -> Ast.lower_name p.param_name) ps
+  | EForall (mb, metas) ->
+      let params, gs, body = Ast.unbind_quant mb metas in
+      let subst_no_params =
+        List.filter
+          (fun (n, _) ->
+            not
+              (List.exists
+                 (fun (p : param) -> Ast.lower_name p.param_name = n)
+                 params))
+          subst
       in
-      let subst' = List.filter (fun (n, _) -> not (List.mem n bound)) subst in
-      let subst'', gs' = substitute_guards subst' gs in
-      EForall (ps, gs', substitute_vars subst'' body)
-  | EExists (ps, gs, body) ->
-      let bound =
-        List.map (fun (p : param) -> Ast.lower_name p.param_name) ps
+      let subst'', gs' = substitute_guards subst_no_params gs in
+      let body' = substitute_vars subst'' body in
+      Ast.make_forall params gs' body'
+  | EExists (mb, metas) ->
+      let params, gs, body = Ast.unbind_quant mb metas in
+      let subst_no_params =
+        List.filter
+          (fun (n, _) ->
+            not
+              (List.exists
+                 (fun (p : param) -> Ast.lower_name p.param_name = n)
+                 params))
+          subst
       in
-      let subst' = List.filter (fun (n, _) -> not (List.mem n bound)) subst in
-      let subst'', gs' = substitute_guards subst' gs in
-      EExists (ps, gs', substitute_vars subst'' body)
-  | EEach (ps, gs, comb, body) ->
-      let bound =
-        List.map (fun (p : param) -> Ast.lower_name p.param_name) ps
+      let subst'', gs' = substitute_guards subst_no_params gs in
+      let body' = substitute_vars subst'' body in
+      Ast.make_exists params gs' body'
+  | EEach (mb, metas, comb) ->
+      let params, gs, body = Ast.unbind_quant mb metas in
+      let subst_no_params =
+        List.filter
+          (fun (n, _) ->
+            not
+              (List.exists
+                 (fun (p : param) -> Ast.lower_name p.param_name = n)
+                 params))
+          subst
       in
-      let subst' = List.filter (fun (n, _) -> not (List.mem n bound)) subst in
-      let subst'', gs' = substitute_guards subst' gs in
-      EEach (ps, gs', comb, substitute_vars subst'' body)
+      let subst'', gs' = substitute_guards subst_no_params gs in
+      let body' = substitute_vars subst'' body in
+      Ast.make_each params gs' comb body'
   | ECond arms ->
       ECond
         (List.map
@@ -212,27 +239,45 @@ let rec rename_var_refs env (subst : (string * string) list) (e : expr) : expr =
             (fun (k, v) ->
               (rename_var_refs env subst k, rename_var_refs env subst v))
             pairs )
-  | EForall (ps, gs, body) ->
-      let bound =
-        List.map (fun (p : param) -> Ast.lower_name p.param_name) ps
+  | EForall (mb, metas) ->
+      let params, gs, body = Ast.unbind_quant mb metas in
+      let subst' =
+        List.filter
+          (fun (n, _) ->
+            not
+              (List.exists
+                 (fun (p : param) -> Ast.lower_name p.param_name = n)
+                 params))
+          subst
       in
-      let subst' = List.filter (fun (n, _) -> not (List.mem n bound)) subst in
       let gs' = rename_guards env subst' gs in
-      EForall (ps, gs', rename_var_refs env subst' body)
-  | EExists (ps, gs, body) ->
-      let bound =
-        List.map (fun (p : param) -> Ast.lower_name p.param_name) ps
+      Ast.make_forall params gs' (rename_var_refs env subst' body)
+  | EExists (mb, metas) ->
+      let params, gs, body = Ast.unbind_quant mb metas in
+      let subst' =
+        List.filter
+          (fun (n, _) ->
+            not
+              (List.exists
+                 (fun (p : param) -> Ast.lower_name p.param_name = n)
+                 params))
+          subst
       in
-      let subst' = List.filter (fun (n, _) -> not (List.mem n bound)) subst in
       let gs' = rename_guards env subst' gs in
-      EExists (ps, gs', rename_var_refs env subst' body)
-  | EEach (ps, gs, comb, body) ->
-      let bound =
-        List.map (fun (p : param) -> Ast.lower_name p.param_name) ps
+      Ast.make_exists params gs' (rename_var_refs env subst' body)
+  | EEach (mb, metas, comb) ->
+      let params, gs, body = Ast.unbind_quant mb metas in
+      let subst' =
+        List.filter
+          (fun (n, _) ->
+            not
+              (List.exists
+                 (fun (p : param) -> Ast.lower_name p.param_name = n)
+                 params))
+          subst
       in
-      let subst' = List.filter (fun (n, _) -> not (List.mem n bound)) subst in
       let gs' = rename_guards env subst' gs in
-      EEach (ps, gs', comb, rename_var_refs env subst' body)
+      Ast.make_each params gs' comb (rename_var_refs env subst' body)
   | ECond arms ->
       ECond
         (List.map
@@ -274,24 +319,27 @@ let rec prime_expr ?(bound = []) (e : expr) : expr =
   | EUnop (op, e) -> EUnop (op, prime_expr ~bound e)
   | ETuple es -> ETuple (List.map (prime_expr ~bound) es)
   | EProj (e, i) -> EProj (prime_expr ~bound e, i)
-  | EForall (ps, gs, body) ->
+  | EForall (mb, metas) ->
+      let params, gs, body = Ast.unbind_quant mb metas in
       let bound' =
-        List.map (fun (p : param) -> Ast.lower_name p.param_name) ps @ bound
+        List.map (fun (p : param) -> Ast.lower_name p.param_name) params @ bound
       in
       let bound'', gs' = prime_guards ~bound:bound' gs in
-      EForall (ps, gs', prime_expr ~bound:bound'' body)
-  | EExists (ps, gs, body) ->
+      Ast.make_forall params gs' (prime_expr ~bound:bound'' body)
+  | EExists (mb, metas) ->
+      let params, gs, body = Ast.unbind_quant mb metas in
       let bound' =
-        List.map (fun (p : param) -> Ast.lower_name p.param_name) ps @ bound
+        List.map (fun (p : param) -> Ast.lower_name p.param_name) params @ bound
       in
       let bound'', gs' = prime_guards ~bound:bound' gs in
-      EExists (ps, gs', prime_expr ~bound:bound'' body)
-  | EEach (ps, gs, comb, body) ->
+      Ast.make_exists params gs' (prime_expr ~bound:bound'' body)
+  | EEach (mb, metas, comb) ->
+      let params, gs, body = Ast.unbind_quant mb metas in
       let bound' =
-        List.map (fun (p : param) -> Ast.lower_name p.param_name) ps @ bound
+        List.map (fun (p : param) -> Ast.lower_name p.param_name) params @ bound
       in
       let bound'', gs' = prime_guards ~bound:bound' gs in
-      EEach (ps, gs', comb, prime_expr ~bound:bound'' body)
+      Ast.make_each params gs' comb (prime_expr ~bound:bound'' body)
   | ECond arms ->
       ECond
         (List.map

--- a/lib_parser/dune
+++ b/lib_parser/dune
@@ -1,12 +1,16 @@
 (library
  (name pantagruel_parser)
- (libraries sedlex menhirLib)
+ (libraries sedlex menhirLib bindlib)
  (preprocess
   (pps sedlex.ppx ppx_deriving.show ppx_deriving.eq)))
 
 (menhir
  (modules parser)
  (flags --explain --table))
+
+(copy_files ../lib/binder.ml)
+
+(copy_files ../lib/binder.mli)
 
 (copy_files ../lib/ast.ml)
 

--- a/test/test_json_output.ml
+++ b/test/test_json_output.ml
@@ -142,15 +142,15 @@ let test_expr_to_json_quantifiers () =
   in
   check bool "forall" true
     (has_key "forall"
-       (Json_output.expr_to_json (Ast.EForall (p, [], ELitBool true))));
+       (Json_output.expr_to_json (Ast.make_forall p [] (ELitBool true))));
   check bool "exists" true
     (has_key "exists"
-       (Json_output.expr_to_json (Ast.EExists (p, [], ELitBool true))));
+       (Json_output.expr_to_json (Ast.make_exists p [] (ELitBool true))));
   check bool "each" true
     (has_key "each"
-       (Json_output.expr_to_json (Ast.EEach (p, [], None, EVar (Lower "x")))));
+       (Json_output.expr_to_json (Ast.make_each p [] None (EVar (Lower "x")))));
   (match
-     Json_output.expr_to_json (Ast.EEach (p, [], None, EVar (Lower "x")))
+     Json_output.expr_to_json (Ast.make_each p [] None (EVar (Lower "x")))
    with
   | `Assoc [ ("each", `Assoc fields) ] -> (
       match List.assoc "combiner" fields with
@@ -159,7 +159,7 @@ let test_expr_to_json_quantifiers () =
   | _ -> fail "Expected each JSON object");
   (match
      Json_output.expr_to_json
-       (Ast.EEach (p, [], Some CombMin, EVar (Lower "x")))
+       (Ast.make_each p [] (Some CombMin) (EVar (Lower "x")))
    with
   | `Assoc [ ("each", `Assoc fields) ] -> (
       match List.assoc "combiner" fields with

--- a/test/test_normalize.ml
+++ b/test/test_normalize.ml
@@ -140,10 +140,10 @@ let test_symbols_in_expr_binop () =
 let test_symbols_in_expr_quantifier () =
   let types, terms =
     Normalize.symbols_in_expr
-      (Ast.EForall
-         ( [ { param_name = Lower "u"; param_type = TName (Upper "User") } ],
-           [],
-           EApp (EVar (Lower "f"), [ EVar (Lower "u") ]) ))
+      (Ast.make_forall
+         [ { param_name = Lower "u"; param_type = TName (Upper "User") } ]
+         []
+         (EApp (EVar (Lower "f"), [ EVar (Lower "u") ])))
   in
   check bool "quant type User" true (Normalize.StringSet.mem "User" types);
   check bool "quant term f" true (Normalize.StringSet.mem "f" terms)

--- a/test/test_parser.ml
+++ b/test/test_parser.ml
@@ -109,8 +109,8 @@ let test_membership_binding () =
   in
   let chapter = List.hd doc.Ast.chapters in
   match[@warning "-4"] (List.hd chapter.Ast.body).Ast.value with
-  | Ast.EForall (mb, []) -> (
-      let _, guards, _ = Ast.unbind_quant mb [] in
+  | Ast.EForall (mb, metas) -> (
+      let _, guards, _ = Ast.unbind_quant mb metas in
       match guards with
       | [ Ast.GIn (Lower "i", _) ] -> ()
       | _ -> fail "Expected membership binding")

--- a/test/test_parser.ml
+++ b/test/test_parser.ml
@@ -109,7 +109,11 @@ let test_membership_binding () =
   in
   let chapter = List.hd doc.Ast.chapters in
   match[@warning "-4"] (List.hd chapter.Ast.body).Ast.value with
-  | Ast.EForall ([], [ Ast.GIn (Lower "i", _) ], _) -> ()
+  | Ast.EForall (mb, []) -> (
+      let _, guards, _ = Ast.unbind_quant mb [] in
+      match guards with
+      | [ Ast.GIn (Lower "i", _) ] -> ()
+      | _ -> fail "Expected membership binding")
   | _ -> fail "Expected membership binding"
 
 let test_existential () =
@@ -158,7 +162,11 @@ let test_disjunction_guard () =
   in
   let chapter = List.hd doc.Ast.chapters in
   match[@warning "-4"] (List.hd chapter.Ast.body).Ast.value with
-  | Ast.EForall (_, [ Ast.GExpr (Ast.EBinop (Ast.OpOr, _, _)) ], _) -> ()
+  | Ast.EForall (mb, metas) -> (
+      let _, guards, _ = Ast.unbind_quant mb metas in
+      match guards with
+      | [ Ast.GExpr (Ast.EBinop (Ast.OpOr, _, _)) ] -> ()
+      | _ -> fail "Expected forall with disjunction guard")
   | _ -> fail "Expected forall with disjunction guard"
 
 let test_no_module () =
@@ -234,7 +242,7 @@ let test_over_each_add () =
   in
   let chapter = List.hd doc.Ast.chapters in
   match[@warning "-4"] (List.hd chapter.Ast.body).Ast.value with
-  | Ast.EEach (_, _, Some Ast.CombAdd, _) -> ()
+  | Ast.EEach (_, _, Some Ast.CombAdd) -> ()
   | _ -> fail "Expected EEach with CombAdd"
 
 let test_over_each_max_with_guard () =
@@ -249,7 +257,11 @@ let test_over_each_max_with_guard () =
   in
   let chapter = List.hd doc.Ast.chapters in
   match[@warning "-4"] (List.hd chapter.Ast.body).Ast.value with
-  | Ast.EEach (_, [ Ast.GExpr _ ], Some Ast.CombMax, _) -> ()
+  | Ast.EEach (mb, metas, Some Ast.CombMax) -> (
+      let _, guards, _ = Ast.unbind_quant mb metas in
+      match guards with
+      | [ Ast.GExpr _ ] -> ()
+      | _ -> fail "Expected EEach with CombMax and guard")
   | _ -> fail "Expected EEach with CombMax and guard"
 
 let test_over_each_mul () =
@@ -263,7 +275,7 @@ let test_over_each_mul () =
   in
   let chapter = List.hd doc.Ast.chapters in
   match[@warning "-4"] (List.hd chapter.Ast.body).Ast.value with
-  | Ast.EEach (_, _, Some Ast.CombMul, _) -> ()
+  | Ast.EEach (_, _, Some Ast.CombMul) -> ()
   | _ -> fail "Expected EEach with CombMul"
 
 let test_over_each_and () =
@@ -277,7 +289,7 @@ let test_over_each_and () =
   in
   let chapter = List.hd doc.Ast.chapters in
   match[@warning "-4"] (List.hd chapter.Ast.body).Ast.value with
-  | Ast.EEach (_, _, Some Ast.CombAnd, _) -> ()
+  | Ast.EEach (_, _, Some Ast.CombAnd) -> ()
   | _ -> fail "Expected EEach with CombAnd"
 
 let test_over_each_or () =
@@ -291,7 +303,7 @@ let test_over_each_or () =
   in
   let chapter = List.hd doc.Ast.chapters in
   match[@warning "-4"] (List.hd chapter.Ast.body).Ast.value with
-  | Ast.EEach (_, _, Some Ast.CombOr, _) -> ()
+  | Ast.EEach (_, _, Some Ast.CombOr) -> ()
   | _ -> fail "Expected EEach with CombOr"
 
 let test_over_each_min () =
@@ -305,7 +317,7 @@ let test_over_each_min () =
   in
   let chapter = List.hd doc.Ast.chapters in
   match[@warning "-4"] (List.hd chapter.Ast.body).Ast.value with
-  | Ast.EEach (_, _, Some Ast.CombMin, _) -> ()
+  | Ast.EEach (_, _, Some Ast.CombMin) -> ()
   | _ -> fail "Expected EEach with CombMin"
 
 let test_bare_each_none_combiner () =
@@ -319,7 +331,7 @@ let test_bare_each_none_combiner () =
   in
   let chapter = List.hd doc.Ast.chapters in
   match (List.hd chapter.Ast.body).Ast.value with
-  | Ast.EEach (_, _, None, _) -> ()
+  | Ast.EEach (_, _, None) -> ()
   | EVar _ | EDomain _ | EQualified _ | ELitNat _ | ELitReal _ | ELitString _
   | ELitBool _ | EApp _ | EPrimed _ | EOverride _ | ETuple _ | EProj _
   | EBinop _ | EUnop _ | EForall _ | EExists _ | EEach _ | ECond _
@@ -338,7 +350,11 @@ let test_each () =
   in
   let chapter = List.hd doc.Ast.chapters in
   match[@warning "-4"] (List.hd chapter.Ast.body).Ast.value with
-  | Ast.EForall (_, _, Ast.EBinop (Ast.OpIn, _, Ast.EEach _)) -> ()
+  | Ast.EForall (mb, metas) -> (
+      let _, _, body = Ast.unbind_quant mb metas in
+      match body with
+      | Ast.EBinop (Ast.OpIn, _, Ast.EEach _) -> ()
+      | _ -> fail "Expected each comprehension inside all")
   | _ -> fail "Expected each comprehension inside all"
 
 let test_cond_simple () =
@@ -353,8 +369,12 @@ let test_cond_simple () =
   in
   let chapter = List.hd doc.Ast.chapters in
   match[@warning "-4"] (List.hd chapter.Ast.body).Ast.value with
-  | Ast.EForall (_, _, Ast.EBinop (Ast.OpEq, _, Ast.ECond arms)) ->
-      check int "arms" 3 (List.length arms)
+  | Ast.EForall (mb, metas) -> (
+      let _, _, body = Ast.unbind_quant mb metas in
+      match body with
+      | Ast.EBinop (Ast.OpEq, _, Ast.ECond arms) ->
+          check int "arms" 3 (List.length arms)
+      | _ -> fail "Expected cond expression")
   | _ -> fail "Expected cond expression"
 
 let test_cond_two_arms () =
@@ -460,7 +480,11 @@ let test_in_operator () =
   let doc = parse "module TEST.\n\nUser.\n---\nall u: User | u in User.\n" in
   let chapter = List.hd doc.Ast.chapters in
   match[@warning "-4"] (List.hd chapter.Ast.body).Ast.value with
-  | Ast.EForall (_, _, EBinop (OpIn, _, _)) -> ()
+  | Ast.EForall (mb, metas) -> (
+      let _, _, body = Ast.unbind_quant mb metas in
+      match body with
+      | EBinop (OpIn, _, _) -> ()
+      | _ -> fail "Expected in operator")
   | _ -> fail "Expected in operator"
 
 let test_subset_operator () =
@@ -490,8 +514,11 @@ let test_override () =
   in
   let chapter = List.hd doc.Ast.chapters in
   match[@warning "-4"] (List.hd chapter.Ast.body).Ast.value with
-  | Ast.EForall (_, _, EBinop (OpEq, EApp (EOverride (Lower "f", _), _), _)) ->
-      ()
+  | Ast.EForall (mb, metas) -> (
+      let _, _, body = Ast.unbind_quant mb metas in
+      match body with
+      | EBinop (OpEq, EApp (EOverride (Lower "f", _), _), _) -> ()
+      | _ -> fail "Expected override")
   | _ -> fail "Expected override"
 
 let test_tuple () =

--- a/test/test_pretty.ml
+++ b/test/test_pretty.ml
@@ -121,36 +121,34 @@ let test_unop_card () =
 let test_forall () =
   check string "forall" "all x: Nat | x > 0"
     (pp
-       (Ast.EForall
-          ( [ { param_name = Lower "x"; param_type = TName (Upper "Nat") } ],
-            [],
-            EBinop (OpGt, EVar (Lower "x"), ELitNat 0) )))
+       (Ast.make_forall
+          [ { param_name = Lower "x"; param_type = TName (Upper "Nat") } ]
+          []
+          (EBinop (OpGt, EVar (Lower "x"), ELitNat 0))))
 
 let test_exists () =
   check string "exists" "some x: Nat | x > 0"
     (pp
-       (Ast.EExists
-          ( [ { param_name = Lower "x"; param_type = TName (Upper "Nat") } ],
-            [],
-            EBinop (OpGt, EVar (Lower "x"), ELitNat 0) )))
+       (Ast.make_exists
+          [ { param_name = Lower "x"; param_type = TName (Upper "Nat") } ]
+          []
+          (EBinop (OpGt, EVar (Lower "x"), ELitNat 0))))
 
 let test_each () =
   check string "each" "each u: User | f u"
     (pp
-       (Ast.EEach
-          ( [ { param_name = Lower "u"; param_type = TName (Upper "User") } ],
-            [],
-            None,
-            EApp (EVar (Lower "f"), [ EVar (Lower "u") ]) )))
+       (Ast.make_each
+          [ { param_name = Lower "u"; param_type = TName (Upper "User") } ]
+          [] None
+          (EApp (EVar (Lower "f"), [ EVar (Lower "u") ]))))
 
 let test_each_with_combiner () =
   check string "over each" "+ over each u: User | f u"
     (pp
-       (Ast.EEach
-          ( [ { param_name = Lower "u"; param_type = TName (Upper "User") } ],
-            [],
-            Some CombAdd,
-            EApp (EVar (Lower "f"), [ EVar (Lower "u") ]) )))
+       (Ast.make_each
+          [ { param_name = Lower "u"; param_type = TName (Upper "User") } ]
+          [] (Some CombAdd)
+          (EApp (EVar (Lower "f"), [ EVar (Lower "u") ]))))
 
 let test_cond () =
   check string "cond" "cond a => 1, b => 2"

--- a/test/test_smt.ml
+++ b/test/test_smt.ml
@@ -302,23 +302,26 @@ let test_prime_expr () =
   | _ -> fail (Printf.sprintf "Unexpected primed expr: %s" (Ast.show_expr e')));
   (* Quantifier-bound variables are NOT primed *)
   let e2 =
-    EForall
-      ( [ { param_name = Lower "a"; param_type = TName (Upper "Account") } ],
-        [],
-        EBinop
-          (OpGe, EApp (EVar (Lower "balance"), [ EVar (Lower "a") ]), ELitNat 0)
-      )
+    Ast.make_forall
+      [ { param_name = Lower "a"; param_type = TName (Upper "Account") } ]
+      []
+      (EBinop
+         (OpGe, EApp (EVar (Lower "balance"), [ EVar (Lower "a") ]), ELitNat 0))
   in
   let e2' = Smt.prime_expr e2 in
   match[@warning "-4"] e2' with
-  | EForall
-      ( _,
-        _,
-        EBinop
+  | EForall (mb, metas) -> (
+      let _, _, body = Ast.unbind_quant mb metas in
+      match body with
+      | EBinop
           ( OpGe,
             EApp (EPrimed (Lower "balance"), [ EVar (Lower "a") ]),
-            ELitNat 0 ) ) ->
-      ()
+            ELitNat 0 ) ->
+          ()
+      | _ ->
+          fail
+            (Printf.sprintf "Quantifier-bound var should not be primed: %s"
+               (Ast.show_expr e2')))
   | _ ->
       fail
         (Printf.sprintf "Quantifier-bound var should not be primed: %s"
@@ -1364,11 +1367,10 @@ let test_in_each_comprehension () =
     Ast.EBinop
       ( OpIn,
         EVar (Lower "r"),
-        EEach
-          ( [ { param_name = Lower "u"; param_type = TName (Upper "User") } ],
-            [],
-            None,
-            EApp (EVar (Lower "role"), [ EVar (Lower "u") ]) ) )
+        Ast.make_each
+          [ { param_name = Lower "u"; param_type = TName (Upper "User") } ]
+          [] None
+          (EApp (EVar (Lower "role"), [ EVar (Lower "u") ])) )
   in
   let result = Smt.translate_expr config env expr in
   check bool "has (= r (role User_0))" true
@@ -1395,11 +1397,11 @@ let test_in_each_comprehension_guarded () =
     Ast.EBinop
       ( OpIn,
         EVar (Lower "r"),
-        EEach
-          ( [ { param_name = Lower "u"; param_type = TName (Upper "User") } ],
-            [ GExpr (EApp (EVar (Lower "active"), [ EVar (Lower "u") ])) ],
-            None,
-            EApp (EVar (Lower "role"), [ EVar (Lower "u") ]) ) )
+        Ast.make_each
+          [ { param_name = Lower "u"; param_type = TName (Upper "User") } ]
+          [ GExpr (EApp (EVar (Lower "active"), [ EVar (Lower "u") ])) ]
+          None
+          (EApp (EVar (Lower "role"), [ EVar (Lower "u") ])) )
   in
   let result = Smt.translate_expr config env expr in
   check bool "has guard (active User_0)" true
@@ -1426,11 +1428,10 @@ let test_in_membership_comprehension () =
     Ast.EBinop
       ( OpIn,
         EVar (Lower "r"),
-        EEach
-          ( [],
-            [ GIn (Lower "u", EVar (Lower "admins")) ],
-            None,
-            EApp (EVar (Lower "role"), [ EVar (Lower "u") ]) ) )
+        Ast.make_each []
+          [ GIn (Lower "u", EVar (Lower "admins")) ]
+          None
+          (EApp (EVar (Lower "role"), [ EVar (Lower "u") ])) )
   in
   let result = Smt.translate_expr config env expr in
   check bool "has select admins" true (contains result "(select admins");
@@ -1451,11 +1452,10 @@ let test_card_each_comprehension () =
   let expr =
     Ast.EUnop
       ( OpCard,
-        EEach
-          ( [ { param_name = Lower "u"; param_type = TName (Upper "User") } ],
-            [],
-            None,
-            EApp (EVar (Lower "role"), [ EVar (Lower "u") ]) ) )
+        Ast.make_each
+          [ { param_name = Lower "u"; param_type = TName (Upper "User") } ]
+          [] None
+          (EApp (EVar (Lower "role"), [ EVar (Lower "u") ])) )
   in
   let result = Smt.translate_expr config env expr in
   check bool "has ite" true (contains result "(ite");
@@ -1473,11 +1473,10 @@ let test_each_comprehension_standalone () =
          Ast.dummy_loc ~chapter:0
   in
   let expr =
-    Ast.EEach
-      ( [ { param_name = Lower "u"; param_type = TName (Upper "User") } ],
-        [],
-        None,
-        EApp (EVar (Lower "role"), [ EVar (Lower "u") ]) )
+    Ast.make_each
+      [ { param_name = Lower "u"; param_type = TName (Upper "User") } ]
+      [] None
+      (EApp (EVar (Lower "role"), [ EVar (Lower "u") ]))
   in
   let result = Smt.translate_expr config env expr in
   check bool "has as const" true (contains result "as const");
@@ -1494,11 +1493,10 @@ let test_aggregate_add () =
          Ast.dummy_loc ~chapter:0
   in
   let expr =
-    Ast.EEach
-      ( [ { param_name = Lower "u"; param_type = TName (Upper "User") } ],
-        [],
-        Some CombAdd,
-        EApp (EVar (Lower "score"), [ EVar (Lower "u") ]) )
+    Ast.make_each
+      [ { param_name = Lower "u"; param_type = TName (Upper "User") } ]
+      [] (Some CombAdd)
+      (EApp (EVar (Lower "score"), [ EVar (Lower "u") ]))
   in
   let result = Smt.translate_expr config env expr in
   check bool "has +" true (contains result "(+");
@@ -1515,11 +1513,10 @@ let test_aggregate_and () =
          Ast.dummy_loc ~chapter:0
   in
   let expr =
-    Ast.EEach
-      ( [ { param_name = Lower "u"; param_type = TName (Upper "User") } ],
-        [],
-        Some CombAnd,
-        EApp (EVar (Lower "active"), [ EVar (Lower "u") ]) )
+    Ast.make_each
+      [ { param_name = Lower "u"; param_type = TName (Upper "User") } ]
+      [] (Some CombAnd)
+      (EApp (EVar (Lower "active"), [ EVar (Lower "u") ]))
   in
   let result = Smt.translate_expr config env expr in
   check bool "has and" true (contains result "(and");
@@ -1538,11 +1535,11 @@ let test_aggregate_min_guarded () =
          Ast.dummy_loc ~chapter:0
   in
   let expr =
-    Ast.EEach
-      ( [ { param_name = Lower "u"; param_type = TName (Upper "User") } ],
-        [ GExpr (EApp (EVar (Lower "active"), [ EVar (Lower "u") ])) ],
-        Some CombMin,
-        EApp (EVar (Lower "score"), [ EVar (Lower "u") ]) )
+    Ast.make_each
+      [ { param_name = Lower "u"; param_type = TName (Upper "User") } ]
+      [ GExpr (EApp (EVar (Lower "active"), [ EVar (Lower "u") ])) ]
+      (Some CombMin)
+      (EApp (EVar (Lower "score"), [ EVar (Lower "u") ]))
   in
   let result = Smt.translate_expr config env expr in
   check bool "has <=" true (contains result "(<=");
@@ -1562,11 +1559,10 @@ let test_aggregate_add_empty () =
          Ast.dummy_loc ~chapter:0
   in
   let expr =
-    Ast.EEach
-      ( [ { param_name = Lower "u"; param_type = TName (Upper "User") } ],
-        [],
-        Some CombAdd,
-        EApp (EVar (Lower "score"), [ EVar (Lower "u") ]) )
+    Ast.make_each
+      [ { param_name = Lower "u"; param_type = TName (Upper "User") } ]
+      [] (Some CombAdd)
+      (EApp (EVar (Lower "score"), [ EVar (Lower "u") ]))
   in
   let result = Smt.translate_expr zero_config env expr in
   check string "empty add = identity" "0" result
@@ -1588,11 +1584,10 @@ let test_aggregate_decl_guard_injection () =
          [ GExpr (EApp (EVar (Lower "active"), [ EVar (Lower "u") ])) ]
   in
   let expr =
-    Ast.EEach
-      ( [ { param_name = Lower "u"; param_type = TName (Upper "User") } ],
-        [],
-        Some CombAdd,
-        EApp (EVar (Lower "score"), [ EVar (Lower "u") ]) )
+    Ast.make_each
+      [ { param_name = Lower "u"; param_type = TName (Upper "User") } ]
+      [] (Some CombAdd)
+      (EApp (EVar (Lower "score"), [ EVar (Lower "u") ]))
   in
   let result = Smt.translate_expr config env expr in
   check bool "has (active User_0)" true (contains result "(active User_0)");
@@ -1611,11 +1606,11 @@ let test_aggregate_add_real () =
          Ast.dummy_loc ~chapter:0
   in
   let expr =
-    Ast.EEach
-      ( [ { param_name = Lower "u"; param_type = TName (Upper "User") } ],
-        [ GExpr (EApp (EVar (Lower "active"), [ EVar (Lower "u") ])) ],
-        Some CombAdd,
-        EApp (EVar (Lower "real_score"), [ EVar (Lower "u") ]) )
+    Ast.make_each
+      [ { param_name = Lower "u"; param_type = TName (Upper "User") } ]
+      [ GExpr (EApp (EVar (Lower "active"), [ EVar (Lower "u") ])) ]
+      (Some CombAdd)
+      (EApp (EVar (Lower "real_score"), [ EVar (Lower "u") ]))
   in
   let result = Smt.translate_expr config env expr in
   check bool "has 0.0 identity" true (contains result "0.0");
@@ -1635,11 +1630,10 @@ let test_aggregate_add_real_empty () =
          Ast.dummy_loc ~chapter:0
   in
   let expr =
-    Ast.EEach
-      ( [ { param_name = Lower "u"; param_type = TName (Upper "User") } ],
-        [],
-        Some CombAdd,
-        EApp (EVar (Lower "real_score"), [ EVar (Lower "u") ]) )
+    Ast.make_each
+      [ { param_name = Lower "u"; param_type = TName (Upper "User") } ]
+      [] (Some CombAdd)
+      (EApp (EVar (Lower "real_score"), [ EVar (Lower "u") ]))
   in
   let result = Smt.translate_expr zero_config env expr in
   check string "empty real add = 0.0" "0.0" result
@@ -1654,11 +1648,10 @@ let test_aggregate_min_real () =
          Ast.dummy_loc ~chapter:0
   in
   let expr =
-    Ast.EEach
-      ( [ { param_name = Lower "u"; param_type = TName (Upper "User") } ],
-        [],
-        Some CombMin,
-        EApp (EVar (Lower "real_score"), [ EVar (Lower "u") ]) )
+    Ast.make_each
+      [ { param_name = Lower "u"; param_type = TName (Upper "User") } ]
+      [] (Some CombMin)
+      (EApp (EVar (Lower "real_score"), [ EVar (Lower "u") ]))
   in
   let result = Smt.translate_expr config env expr in
   check bool "has 0.0 seed" true (contains result "0.0");
@@ -1827,16 +1820,16 @@ let test_nested_quantifier_guards () =
   in
   (* all x: User | (some y: User | role y = role x) *)
   let expr =
-    Ast.EForall
-      ( [ { param_name = Lower "x"; param_type = TName (Upper "User") } ],
-        [],
-        EExists
-          ( [ { param_name = Lower "y"; param_type = TName (Upper "User") } ],
-            [],
-            EBinop
-              ( OpEq,
-                EApp (EVar (Lower "role"), [ EVar (Lower "y") ]),
-                EApp (EVar (Lower "role"), [ EVar (Lower "x") ]) ) ) )
+    Ast.make_forall
+      [ { param_name = Lower "x"; param_type = TName (Upper "User") } ]
+      []
+      (Ast.make_exists
+         [ { param_name = Lower "y"; param_type = TName (Upper "User") } ]
+         []
+         (EBinop
+            ( OpEq,
+              EApp (EVar (Lower "role"), [ EVar (Lower "y") ]),
+              EApp (EVar (Lower "role"), [ EVar (Lower "x") ]) )))
   in
   let result = Smt.translate_expr config env expr in
   (* Outer forall should NOT have the guard (nested quantifier handles its own).
@@ -1853,10 +1846,10 @@ let test_unguarded_rule_unchanged () =
          Ast.dummy_loc ~chapter:0
   in
   let expr =
-    Ast.EForall
-      ( [ { param_name = Lower "u"; param_type = TName (Upper "User") } ],
-        [],
-        EApp (EVar (Lower "name"), [ EVar (Lower "u") ]) )
+    Ast.make_forall
+      [ { param_name = Lower "u"; param_type = TName (Upper "User") } ]
+      []
+      (EApp (EVar (Lower "name"), [ EVar (Lower "u") ]))
   in
   let result = Smt.translate_expr config env expr in
   (* No guard injection — plain forall without => *)
@@ -1880,12 +1873,11 @@ let test_guard_substitution () =
   in
   (* all x: User | score x >= 0 — the guard "active u" should become "active x" *)
   let expr =
-    Ast.EForall
-      ( [ { param_name = Lower "x"; param_type = TName (Upper "User") } ],
-        [],
-        EBinop
-          (OpGe, EApp (EVar (Lower "score"), [ EVar (Lower "x") ]), ELitNat 0)
-      )
+    Ast.make_forall
+      [ { param_name = Lower "x"; param_type = TName (Upper "User") } ]
+      []
+      (EBinop
+         (OpGe, EApp (EVar (Lower "score"), [ EVar (Lower "x") ]), ELitNat 0))
   in
   let result = Smt.translate_expr config env expr in
   (* Guard should be substituted: (active x), not (active u) *)
@@ -2271,11 +2263,10 @@ let make_aggregate_env () =
 let test_aggregate_add_item () =
   let env = make_aggregate_env () in
   let expr =
-    Ast.EEach
-      ( [ { param_name = Lower "i"; param_type = TName (Upper "Item") } ],
-        [],
-        Some CombAdd,
-        EApp (EVar (Lower "price"), [ EVar (Lower "i") ]) )
+    Ast.make_each
+      [ { param_name = Lower "i"; param_type = TName (Upper "Item") } ]
+      [] (Some CombAdd)
+      (EApp (EVar (Lower "price"), [ EVar (Lower "i") ]))
   in
   let result = Smt.translate_expr config env expr in
   check bool "uses +" true (contains result "(+");
@@ -2286,11 +2277,11 @@ let test_aggregate_add_item () =
 let test_aggregate_add_guarded () =
   let env = make_aggregate_env () in
   let expr =
-    Ast.EEach
-      ( [ { param_name = Lower "i"; param_type = TName (Upper "Item") } ],
-        [ GExpr (EApp (EVar (Lower "available?"), [ EVar (Lower "i") ])) ],
-        Some CombAdd,
-        EApp (EVar (Lower "price"), [ EVar (Lower "i") ]) )
+    Ast.make_each
+      [ { param_name = Lower "i"; param_type = TName (Upper "Item") } ]
+      [ GExpr (EApp (EVar (Lower "available?"), [ EVar (Lower "i") ])) ]
+      (Some CombAdd)
+      (EApp (EVar (Lower "price"), [ EVar (Lower "i") ]))
   in
   let result = Smt.translate_expr config env expr in
   check bool "uses +" true (contains result "(+");
@@ -2301,11 +2292,10 @@ let test_aggregate_add_guarded () =
 let test_aggregate_mul () =
   let env = make_aggregate_env () in
   let expr =
-    Ast.EEach
-      ( [ { param_name = Lower "i"; param_type = TName (Upper "Item") } ],
-        [],
-        Some CombMul,
-        EApp (EVar (Lower "price"), [ EVar (Lower "i") ]) )
+    Ast.make_each
+      [ { param_name = Lower "i"; param_type = TName (Upper "Item") } ]
+      [] (Some CombMul)
+      (EApp (EVar (Lower "price"), [ EVar (Lower "i") ]))
   in
   let result = Smt.translate_expr config env expr in
   check bool "uses *" true (contains result "(*")
@@ -2313,11 +2303,10 @@ let test_aggregate_mul () =
 let test_aggregate_and_item () =
   let env = make_aggregate_env () in
   let expr =
-    Ast.EEach
-      ( [ { param_name = Lower "i"; param_type = TName (Upper "Item") } ],
-        [],
-        Some CombAnd,
-        EApp (EVar (Lower "available?"), [ EVar (Lower "i") ]) )
+    Ast.make_each
+      [ { param_name = Lower "i"; param_type = TName (Upper "Item") } ]
+      [] (Some CombAnd)
+      (EApp (EVar (Lower "available?"), [ EVar (Lower "i") ]))
   in
   let result = Smt.translate_expr config env expr in
   check bool "uses and" true (contains result "(and")
@@ -2325,11 +2314,11 @@ let test_aggregate_and_item () =
 let test_aggregate_and_guarded () =
   let env = make_aggregate_env () in
   let expr =
-    Ast.EEach
-      ( [ { param_name = Lower "i"; param_type = TName (Upper "Item") } ],
-        [ GExpr (EApp (EVar (Lower "available?"), [ EVar (Lower "i") ])) ],
-        Some CombAnd,
-        EApp (EVar (Lower "available?"), [ EVar (Lower "i") ]) )
+    Ast.make_each
+      [ { param_name = Lower "i"; param_type = TName (Upper "Item") } ]
+      [ GExpr (EApp (EVar (Lower "available?"), [ EVar (Lower "i") ])) ]
+      (Some CombAnd)
+      (EApp (EVar (Lower "available?"), [ EVar (Lower "i") ]))
   in
   let result = Smt.translate_expr config env expr in
   check bool "uses and" true (contains result "(and");
@@ -2340,11 +2329,11 @@ let test_aggregate_and_guarded () =
 let test_aggregate_or_guarded () =
   let env = make_aggregate_env () in
   let expr =
-    Ast.EEach
-      ( [ { param_name = Lower "i"; param_type = TName (Upper "Item") } ],
-        [ GExpr (EApp (EVar (Lower "available?"), [ EVar (Lower "i") ])) ],
-        Some CombOr,
-        EApp (EVar (Lower "available?"), [ EVar (Lower "i") ]) )
+    Ast.make_each
+      [ { param_name = Lower "i"; param_type = TName (Upper "Item") } ]
+      [ GExpr (EApp (EVar (Lower "available?"), [ EVar (Lower "i") ])) ]
+      (Some CombOr)
+      (EApp (EVar (Lower "available?"), [ EVar (Lower "i") ]))
   in
   let result = Smt.translate_expr config env expr in
   check bool "uses or" true (contains result "(or");
@@ -2355,11 +2344,10 @@ let test_aggregate_or_guarded () =
 let test_aggregate_or () =
   let env = make_aggregate_env () in
   let expr =
-    Ast.EEach
-      ( [ { param_name = Lower "i"; param_type = TName (Upper "Item") } ],
-        [],
-        Some CombOr,
-        EApp (EVar (Lower "available?"), [ EVar (Lower "i") ]) )
+    Ast.make_each
+      [ { param_name = Lower "i"; param_type = TName (Upper "Item") } ]
+      [] (Some CombOr)
+      (EApp (EVar (Lower "available?"), [ EVar (Lower "i") ]))
   in
   let result = Smt.translate_expr config env expr in
   check bool "uses or" true (contains result "(or")
@@ -2367,11 +2355,10 @@ let test_aggregate_or () =
 let test_aggregate_min () =
   let env = make_aggregate_env () in
   let expr =
-    Ast.EEach
-      ( [ { param_name = Lower "i"; param_type = TName (Upper "Item") } ],
-        [],
-        Some CombMin,
-        EApp (EVar (Lower "price"), [ EVar (Lower "i") ]) )
+    Ast.make_each
+      [ { param_name = Lower "i"; param_type = TName (Upper "Item") } ]
+      [] (Some CombMin)
+      (EApp (EVar (Lower "price"), [ EVar (Lower "i") ]))
   in
   let result = Smt.translate_expr config env expr in
   check bool "uses <" true (contains result "(<");
@@ -2380,11 +2367,10 @@ let test_aggregate_min () =
 let test_aggregate_max () =
   let env = make_aggregate_env () in
   let expr =
-    Ast.EEach
-      ( [ { param_name = Lower "i"; param_type = TName (Upper "Item") } ],
-        [],
-        Some CombMax,
-        EApp (EVar (Lower "price"), [ EVar (Lower "i") ]) )
+    Ast.make_each
+      [ { param_name = Lower "i"; param_type = TName (Upper "Item") } ]
+      [] (Some CombMax)
+      (EApp (EVar (Lower "price"), [ EVar (Lower "i") ]))
   in
   let result = Smt.translate_expr config env expr in
   check bool "uses >" true (contains result "(>");
@@ -2398,11 +2384,10 @@ let test_aggregate_empty_domain () =
       ~inject_guards:true
   in
   let expr =
-    Ast.EEach
-      ( [ { param_name = Lower "i"; param_type = TName (Upper "Item") } ],
-        [],
-        Some CombAdd,
-        EApp (EVar (Lower "price"), [ EVar (Lower "i") ]) )
+    Ast.make_each
+      [ { param_name = Lower "i"; param_type = TName (Upper "Item") } ]
+      [] (Some CombAdd)
+      (EApp (EVar (Lower "price"), [ EVar (Lower "i") ]))
   in
   let result = Smt.translate_expr zero_config env expr in
   check string "empty domain returns 0" "0" result
@@ -2414,11 +2399,10 @@ let test_aggregate_empty_domain_mul () =
       ~inject_guards:true
   in
   let expr =
-    Ast.EEach
-      ( [ { param_name = Lower "i"; param_type = TName (Upper "Item") } ],
-        [],
-        Some CombMul,
-        EApp (EVar (Lower "price"), [ EVar (Lower "i") ]) )
+    Ast.make_each
+      [ { param_name = Lower "i"; param_type = TName (Upper "Item") } ]
+      [] (Some CombMul)
+      (EApp (EVar (Lower "price"), [ EVar (Lower "i") ]))
   in
   let result = Smt.translate_expr zero_config env expr in
   check string "empty domain returns 1" "1" result
@@ -2430,11 +2414,10 @@ let test_aggregate_empty_domain_and () =
       ~inject_guards:true
   in
   let expr =
-    Ast.EEach
-      ( [ { param_name = Lower "i"; param_type = TName (Upper "Item") } ],
-        [],
-        Some CombAnd,
-        EApp (EVar (Lower "available?"), [ EVar (Lower "i") ]) )
+    Ast.make_each
+      [ { param_name = Lower "i"; param_type = TName (Upper "Item") } ]
+      [] (Some CombAnd)
+      (EApp (EVar (Lower "available?"), [ EVar (Lower "i") ]))
   in
   let result = Smt.translate_expr zero_config env expr in
   check string "empty domain returns true" "true" result
@@ -2446,11 +2429,10 @@ let test_aggregate_empty_domain_or () =
       ~inject_guards:true
   in
   let expr =
-    Ast.EEach
-      ( [ { param_name = Lower "i"; param_type = TName (Upper "Item") } ],
-        [],
-        Some CombOr,
-        EApp (EVar (Lower "available?"), [ EVar (Lower "i") ]) )
+    Ast.make_each
+      [ { param_name = Lower "i"; param_type = TName (Upper "Item") } ]
+      [] (Some CombOr)
+      (EApp (EVar (Lower "available?"), [ EVar (Lower "i") ]))
   in
   let result = Smt.translate_expr zero_config env expr in
   check string "empty domain returns false" "false" result
@@ -2463,11 +2445,10 @@ let test_aggregate_empty_domain_min () =
       ~inject_guards:true
   in
   let expr =
-    Ast.EEach
-      ( [ { param_name = Lower "i"; param_type = TName (Upper "Item") } ],
-        [],
-        Some CombMin,
-        EApp (EVar (Lower "price"), [ EVar (Lower "i") ]) )
+    Ast.make_each
+      [ { param_name = Lower "i"; param_type = TName (Upper "Item") } ]
+      [] (Some CombMin)
+      (EApp (EVar (Lower "price"), [ EVar (Lower "i") ]))
   in
   check_raises "empty domain min raises"
     (Failure "SMT: min/max over empty domain") (fun () ->
@@ -2480,11 +2461,10 @@ let test_aggregate_empty_domain_max () =
       ~inject_guards:true
   in
   let expr =
-    Ast.EEach
-      ( [ { param_name = Lower "i"; param_type = TName (Upper "Item") } ],
-        [],
-        Some CombMax,
-        EApp (EVar (Lower "price"), [ EVar (Lower "i") ]) )
+    Ast.make_each
+      [ { param_name = Lower "i"; param_type = TName (Upper "Item") } ]
+      [] (Some CombMax)
+      (EApp (EVar (Lower "price"), [ EVar (Lower "i") ]))
   in
   check_raises "empty domain max raises"
     (Failure "SMT: min/max over empty domain") (fun () ->

--- a/test/test_smt.ml
+++ b/test/test_smt.ml
@@ -311,12 +311,18 @@ let test_prime_expr () =
   let e2' = Smt.prime_expr e2 in
   match[@warning "-4"] e2' with
   | EForall (mb, metas) -> (
-      let _, _, body = Ast.unbind_quant mb metas in
+      let params, _, body = Ast.unbind_quant mb metas in
+      let bound_name =
+        match params with
+        | [ { param_name = Lower name; _ } ] -> name
+        | _ -> fail "Expected one quantified parameter"
+      in
       match body with
       | EBinop
           ( OpGe,
-            EApp (EPrimed (Lower "balance"), [ EVar (Lower "a") ]),
-            ELitNat 0 ) ->
+            EApp (EPrimed (Lower "balance"), [ EVar (Lower name) ]),
+            ELitNat 0 )
+        when String.equal name bound_name ->
           ()
       | _ ->
           fail

--- a/test/test_smt_substitution.ml
+++ b/test/test_smt_substitution.ml
@@ -53,7 +53,7 @@ let test_substitute_avoids_capture () =
   let t : Ast.type_expr = Ast.TName (Ast.Upper "T") in
   let param_y : Ast.param = { param_name = Ast.Lower "y"; param_type = t } in
   let body_x = Ast.EVar (Ast.Lower "x") in
-  let input = Ast.EForall ([ param_y ], [], body_x) in
+  let input = Ast.make_forall [ param_y ] [] body_x in
   let subst = [ ("x", Ast.EVar (Ast.Lower "y")) ] in
   let result = Smt.substitute_vars subst input in
   (* Expected: a forall whose binder has been alpha-renamed away from [y]
@@ -76,16 +76,16 @@ let test_substitute_preserves_alpha_equivalence () =
   let mk name : Ast.param = { param_name = Ast.Lower name; param_type = t } in
   (* [all a: T | f a]  vs  [all b: T | f b] — alpha-equivalent. *)
   let e1 =
-    Ast.EForall
-      ( [ mk "a" ],
-        [],
-        Ast.EApp (Ast.EVar (Ast.Lower "f"), [ Ast.EVar (Ast.Lower "a") ]) )
+    Ast.make_forall
+      [ mk "a" ]
+      []
+      (Ast.EApp (Ast.EVar (Ast.Lower "f"), [ Ast.EVar (Ast.Lower "a") ]))
   in
   let e2 =
-    Ast.EForall
-      ( [ mk "b" ],
-        [],
-        Ast.EApp (Ast.EVar (Ast.Lower "f"), [ Ast.EVar (Ast.Lower "b") ]) )
+    Ast.make_forall
+      [ mk "b" ]
+      []
+      (Ast.EApp (Ast.EVar (Ast.Lower "f"), [ Ast.EVar (Ast.Lower "b") ]))
   in
   let subst = [ ("f", Ast.EVar (Ast.Lower "g")) ] in
   let r1 = Smt.substitute_vars subst e1 in

--- a/test/test_util.ml
+++ b/test/test_util.ml
@@ -292,7 +292,7 @@ let[@warning "-44"] gen_bool_expr_at_depth =
                   ( depth - 1,
                     { world with vars = (pname, p.param_type) :: world.vars } )
               in
-              return (Ast.EForall ([ p ], [], body)) );
+              return (Ast.make_forall [ p ] [] body) );
             ( 1,
               let* p = gen_param_with world in
               let pname = Ast.lower_name p.param_name in
@@ -301,7 +301,7 @@ let[@warning "-44"] gen_bool_expr_at_depth =
                   ( depth - 1,
                     { world with vars = (pname, p.param_type) :: world.vars } )
               in
-              return (Ast.EExists ([ p ], [], body)) );
+              return (Ast.make_exists [ p ] [] body) );
           ])
 
 let gen_bool_expr world = gen_bool_expr_at_depth (2, world)

--- a/wasm/pant_wasm.ml
+++ b/wasm/pant_wasm.ml
@@ -38,7 +38,8 @@ let rec rename_expr (renames : (string * string) list) (e : Ast.expr) : Ast.expr
   | EApp (f, args) -> EApp (r f, List.map r args)
   | EBinop (op, e1, e2) -> EBinop (op, r e1, r e2)
   | EUnop (op, e1) -> EUnop (op, r e1)
-  | EForall (params, guards, body) ->
+  | EForall (mb, metas) ->
+      let params, guards, body = Ast.unbind_quant mb metas in
       let bound =
         List.map (fun (p : Ast.param) -> Ast.lower_name p.param_name) params
         @ bound_names_from_guards guards
@@ -49,11 +50,11 @@ let rec rename_expr (renames : (string * string) list) (e : Ast.expr) : Ast.expr
             (not (List.mem old_name bound)) && not (List.mem new_name bound))
           renames
       in
-      EForall
-        ( params,
-          List.map (rename_guard renames') guards,
-          rename_expr renames' body )
-  | EExists (params, guards, body) ->
+      Ast.make_forall params
+        (List.map (rename_guard renames') guards)
+        (rename_expr renames' body)
+  | EExists (mb, metas) ->
+      let params, guards, body = Ast.unbind_quant mb metas in
       let bound =
         List.map (fun (p : Ast.param) -> Ast.lower_name p.param_name) params
         @ bound_names_from_guards guards
@@ -64,11 +65,11 @@ let rec rename_expr (renames : (string * string) list) (e : Ast.expr) : Ast.expr
             (not (List.mem old_name bound)) && not (List.mem new_name bound))
           renames
       in
-      EExists
-        ( params,
-          List.map (rename_guard renames') guards,
-          rename_expr renames' body )
-  | EEach (params, guards, comb, body) ->
+      Ast.make_exists params
+        (List.map (rename_guard renames') guards)
+        (rename_expr renames' body)
+  | EEach (mb, metas, comb) ->
+      let params, guards, body = Ast.unbind_quant mb metas in
       let bound =
         List.map (fun (p : Ast.param) -> Ast.lower_name p.param_name) params
         @ bound_names_from_guards guards
@@ -79,11 +80,10 @@ let rec rename_expr (renames : (string * string) list) (e : Ast.expr) : Ast.expr
             (not (List.mem old_name bound)) && not (List.mem new_name bound))
           renames
       in
-      EEach
-        ( params,
-          List.map (rename_guard renames') guards,
-          comb,
-          rename_expr renames' body )
+      Ast.make_each params
+        (List.map (rename_guard renames') guards)
+        comb
+        (rename_expr renames' body)
   | ECond arms -> ECond (List.map (fun (g, c) -> (r g, r c)) arms)
   | ETuple es -> ETuple (List.map r es)
   | EProj (e1, n) -> EProj (r e1, n)
@@ -108,14 +108,16 @@ let rec free_vars (e : Ast.expr) : string list =
   | EApp (f, args) -> free_vars f @ List.concat_map free_vars args
   | EBinop (_, e1, e2) -> free_vars e1 @ free_vars e2
   | EUnop (_, e1) -> free_vars e1
-  | EForall (params, guards, body) | EExists (params, guards, body) ->
+  | EForall (mb, metas) | EExists (mb, metas) ->
+      let params, guards, body = Ast.unbind_quant mb metas in
       let bound =
         List.map (fun (p : Ast.param) -> Ast.lower_name p.param_name) params
         @ bound_names_from_guards guards
       in
       let inner = List.concat_map free_vars_guard guards @ free_vars body in
       List.filter (fun n -> not (List.mem n bound)) inner
-  | EEach (params, guards, _, body) ->
+  | EEach (mb, metas, _) ->
+      let params, guards, body = Ast.unbind_quant mb metas in
       let bound =
         List.map (fun (p : Ast.param) -> Ast.lower_name p.param_name) params
         @ bound_names_from_guards guards
@@ -151,7 +153,8 @@ let rec subst_var (name : string) (replacement : Ast.expr) (e : Ast.expr) :
   | EApp (f, args) -> EApp (s f, List.map s args)
   | EBinop (op, e1, e2) -> EBinop (op, s e1, s e2)
   | EUnop (op, e1) -> EUnop (op, s e1)
-  | EForall (params, guards, body) ->
+  | EForall (mb, metas) ->
+      let params, guards, body = Ast.unbind_quant mb metas in
       let bound =
         List.map (fun (p : Ast.param) -> Ast.lower_name p.param_name) params
       in
@@ -159,8 +162,11 @@ let rec subst_var (name : string) (replacement : Ast.expr) (e : Ast.expr) :
       else if List.exists (fun n -> List.mem n bound) (free_vars replacement)
       then e
       else
-        EForall (params, List.map (subst_guard name replacement) guards, s body)
-  | EExists (params, guards, body) ->
+        Ast.make_forall params
+          (List.map (subst_guard name replacement) guards)
+          (s body)
+  | EExists (mb, metas) ->
+      let params, guards, body = Ast.unbind_quant mb metas in
       let bound =
         List.map (fun (p : Ast.param) -> Ast.lower_name p.param_name) params
       in
@@ -168,8 +174,11 @@ let rec subst_var (name : string) (replacement : Ast.expr) (e : Ast.expr) :
       else if List.exists (fun n -> List.mem n bound) (free_vars replacement)
       then e
       else
-        EExists (params, List.map (subst_guard name replacement) guards, s body)
-  | EEach (params, guards, comb, body) ->
+        Ast.make_exists params
+          (List.map (subst_guard name replacement) guards)
+          (s body)
+  | EEach (mb, metas, comb) ->
+      let params, guards, body = Ast.unbind_quant mb metas in
       let bound =
         List.map (fun (p : Ast.param) -> Ast.lower_name p.param_name) params
       in
@@ -177,8 +186,9 @@ let rec subst_var (name : string) (replacement : Ast.expr) (e : Ast.expr) :
       else if List.exists (fun n -> List.mem n bound) (free_vars replacement)
       then e
       else
-        EEach
-          (params, List.map (subst_guard name replacement) guards, comb, s body)
+        Ast.make_each params
+          (List.map (subst_guard name replacement) guards)
+          comb (s body)
   | ECond arms -> ECond (List.map (fun (g, c) -> (s g, s c)) arms)
   | ETuple es -> ETuple (List.map s es)
   | EProj (e1, n) -> EProj (s e1, n)
@@ -249,17 +259,20 @@ let () =
        method initially e = Ast.EInitially e
 
        method forall params guards body =
-         Ast.EForall (js_array_to_list params, js_array_to_list guards, body)
+         Ast.make_forall (js_array_to_list params) (js_array_to_list guards)
+           body
 
        method each params guards body =
-         Ast.EEach (js_array_to_list params, js_array_to_list guards, None, body)
+         Ast.make_each (js_array_to_list params) (js_array_to_list guards) None
+           body
 
        method eachComb params guards comb body =
-         Ast.EEach
-           (js_array_to_list params, js_array_to_list guards, Some comb, body)
+         Ast.make_each (js_array_to_list params) (js_array_to_list guards)
+           (Some comb) body
 
        method exists params guards body =
-         Ast.EExists (js_array_to_list params, js_array_to_list guards, body)
+         Ast.make_exists (js_array_to_list params) (js_array_to_list guards)
+           body
 
        method opAnd = Ast.OpAnd
        method opOr = Ast.OpOr


### PR DESCRIPTION
## Patch 3: Reshape AST to use Bindlib mbinders; rewrite walkers

- Redefine ast.ml expr: `EForall of (expr, guarded_body) Binder.Mbinder.t * param_meta list`; similarly for EExists and EEach; add `and guarded_body = guard list * expr`.
- Introduce param_meta = { name : lower_ident; type_expr : type_expr } (mirrors param, kept for pretty-printing / error messages).
- Drop `[@@deriving show, eq]` from the `expr` (and `guard`, `guarded_body`) type declarations — Bindlib's mbinder is opaque to ppx_deriving.
- Hand-write `equal_expr : expr -> expr -> bool`: for EForall/EExists/EEach, unbind both sides with `Binder.Mbinder.unbind2` (or unbind + fresh-name rebind) and recurse, so alpha-equivalent expressions compare equal. For non-binder variants, delegate to the standard structural comparison.
- Hand-write `pp_expr : Format.formatter -> expr -> unit`: for EForall/EExists/EEach, unbind and use param_meta to recover the user-facing names + type annotations.
- Parser: in each quantifier production, allocate Binder.Var.t for each param, call Binder.Mbinder.bind, and attach the param_meta list alongside.
- Pretty printer: replace pattern matches on EForall (ps, gs, body) with `let vars, (gs, body) = Binder.Mbinder.unbind mb in ...`; use param_meta to recover the type annotations.
- smt_expr.ml: reimplement substitute_vars as a fold that walks the expression and calls Binder.Mbinder.subst on the quantifier nodes. Drop substitute_guards' bound-name bookkeeping — guards still need explicit threading, but the binder-level bookkeeping is gone.
- smt_expr.ml: reimplement prime_expr similarly.
- smt_doc.ml: free_vars = Binder.Mbinder.free_vars applied to the quantifier nodes plus a standard walk over non-binding constructors.
- smt_doc.ml: bind_head_params uses the rewritten free_vars (delete the in-file scope-tracking helpers scope_quantifier / scan_guards).
- check.ml / collect.ml / normalize.ml / json_output.ml / markdown_output.ml: update every match arm that destructured a quantifier, using Binder.Mbinder.unbind and converting the fresh Var.t values back to Lower identifiers via Binder.Var.name.
- Run `dune build` — no warnings. Run `dune test` — all existing tests pass. If any snapshot drift occurs (e.g., JSON field order for binder names), update the snapshot and include the diff in the patch for review.

## Changes
- Redefine ast.ml expr: `EForall of (expr, guarded_body) Binder.Mbinder.t * param_meta list`; similarly for EExists and EEach; add `and guarded_body = guard list * expr`.
- Introduce param_meta = { name : lower_ident; type_expr : type_expr } (mirrors param, kept for pretty-printing / error messages).
- Drop `[@@deriving show, eq]` from the `expr` (and `guard`, `guarded_body`) type declarations — Bindlib's mbinder is opaque to ppx_deriving.
- Hand-write `equal_expr : expr -> expr -> bool`: for EForall/EExists/EEach, unbind both sides with `Binder.Mbinder.unbind2` (or unbind + fresh-name rebind) and recurse, so alpha-equivalent expressions compare equal. For non-binder variants, delegate to the standard structural comparison.
- Hand-write `pp_expr : Format.formatter -> expr -> unit`: for EForall/EExists/EEach, unbind and use param_meta to recover the user-facing names + type annotations.
- Parser: in each quantifier production, allocate Binder.Var.t for each param, call Binder.Mbinder.bind, and attach the param_meta list alongside.
- Pretty printer: replace pattern matches on EForall (ps, gs, body) with `let vars, (gs, body) = Binder.Mbinder.unbind mb in ...`; use param_meta to recover the type annotations.
- smt_expr.ml: reimplement substitute_vars as a fold that walks the expression and calls Binder.Mbinder.subst on the quantifier nodes. Drop substitute_guards' bound-name bookkeeping — guards still need explicit threading, but the binder-level bookkeeping is gone.
- smt_expr.ml: reimplement prime_expr similarly.
- smt_doc.ml: free_vars = Binder.Mbinder.free_vars applied to the quantifier nodes plus a standard walk over non-binding constructors.
- smt_doc.ml: bind_head_params uses the rewritten free_vars (delete the in-file scope-tracking helpers scope_quantifier / scan_guards).
- check.ml / collect.ml / normalize.ml / json_output.ml / markdown_output.ml: update every match arm that destructured a quantifier, using Binder.Mbinder.unbind and converting the fresh Var.t values back to Lower identifiers via Binder.Var.name.
- Run `dune build` — no warnings. Run `dune test` — all existing tests pass. If any snapshot drift occurs (e.g., JSON field order for binder names), update the snapshot and include the diff in the patch for review.

## Files to Modify
- lib/ast.ml (modify): Change EForall / EExists / EEach to carry (expr, guarded_body) Binder.Mbinder.t plus a param_meta list for pretty-printing. Introduce param_meta = { name : lower_ident; type_expr : type_expr }. Drop `[@@deriving show, eq]` at the expr level and hand-write equal_expr / pp_expr (alpha-aware via unbind).
- lib/parser.mly (modify): Build quantifier / comprehension AST nodes via Binder.Mbinder.bind over the parsed params.
- lib/pretty.ml (modify): Unbind quantifiers to recover user-facing names + types for printing.
- lib/smt_expr.ml (modify): Rewrite substitute_vars, substitute_guards, prime_expr, prime_guards, unprime_expr as thin wrappers over Binder.Mbinder.subst / msubst. collect_body_guards uses unbind to descend.
- lib/smt_doc.ml (modify): Rewrite free_vars over Binder.Mbinder.free_vars. bind_head_params delegates scope tracking to the new free_vars.
- lib/smt.ml (modify): Update any direct pattern matches on EForall/EExists/EEach to unbind the mbinder.
- lib/check.ml (modify): Update quantifier type-checking to unbind and add bindings to the environment.
- lib/collect.ml (modify): Update declaration-gathering to handle the new AST shape.
- lib/json_output.ml (modify): Emit quantifiers by unbinding and writing user-facing names (byte-compatible with existing snapshots).
- lib/markdown_output.ml (modify): Same as json_output.ml.
- lib/normalize.ml (modify): Rewrite normal-form transformations on quantifiers via unbind/bind.
- lib/env.ml (modify): If any rule-guard storage references raw binder params, adapt it to the new param_meta type.

## Gameplan Specification

```
module BINDLIB_MIGRATION.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> After this gameplan, Pantagruel's AST binder sites (EForall,
> EExists, EEach) are represented by Bindlib's mbinder. Capture
> avoidance is enforced by the library; the hand-rolled walker
> family in lib/smt_expr.ml collapses to thin wrappers. The
> latent capture bug in substitute_vars is closed.

Expr.
Var.
Subst.
free? x: Var, e: Expr => Bool.
bound-by e: Expr, x: Var => Expr.
substitute x: Var, rep: Expr, e: Expr => Expr.
substitute-many s: Subst, e: Expr => Expr.
alpha-equivalent? e1: Expr, e2: Expr => Bool.
---
> Substitution is the identity when the variable is not free.
all x: Var, rep: Expr, e: Expr, free? x e = false | substitute x rep e = e.

> Capture-avoiding substitution.
all x: Var, y: Var, rep: Expr, e: Expr, free? x e, free? y rep = false | alpha-equivalent? (substitute x rep (bound-by e y)) (bound-by (substitute x rep e) y).

> Substitution respects alpha-equivalence.
all s: Subst, e1: Expr, e2: Expr, alpha-equivalent? e1 e2 | alpha-equivalent? (substitute-many s e1) (substitute-many s e2).

where

> ══════════════════════════════════════════
> REDUCED SURFACE
> ══════════════════════════════════════════
> The walker family (substitute_vars, prime_expr, free_vars)
> is implemented via Bindlib primitives. Helpers added by PR
> #110 (rename_var_refs, alpha_rename_binders) are removed.

SmtExpr.
hand-rolled-walkers s: SmtExpr => Nat0.
library-backed? s: SmtExpr => Bool.
---
> No hand-rolled capture-avoidance walkers remain.
all s: SmtExpr | library-backed? s.
all s: SmtExpr | hand-rolled-walkers s = 0.

```

## Patch Specification

```
module BINDLIB_MIGRATION_PATCH_3.

> Patch 3 reshapes binder sites to use Bindlib's mbinder. After
> this patch, substitution respects alpha-equivalence and free
> variables are computed by the library. The latent capture bug
> is closed as a consequence (tests activated in Patch 4).

Expr.
Subst.
substitute s: Subst, e: Expr => Expr.
alpha-equivalent? e1: Expr, e2: Expr => Bool.
---
> Substitution respects alpha-equivalence.
all s: Subst, e1: Expr, e2: Expr, alpha-equivalent? e1 e2 | alpha-equivalent? (substitute s e1) (substitute s e2).

```


## Implementation Notes

### Scope of the binder

The `Mbinder.t` binds **only the top-level quantifier params**. `GParam` / `GIn` names inside the guard list remain raw `lower_ident`s, and the walkers still filter the substitution domain manually for those. Reasons:

- The capture-prone case the gameplan calls out (top-level params shadowing rule symbols at SMT-emit time) is now library-handled.
- Reifying `GParam` / `GIn` as Bindlib vars would require changing the `guard` type itself — which is shared with `DeclRule` / `DeclAction` declaration guards (via `Env.rule_guards`). That ripples beyond Patch 3's blast radius.
- A locally-nameless fallback (mentioned in the opinions) would also benefit from this seam staying narrow.

### What `param_meta` actually is

I kept the existing `param` record verbatim — `{ param_name; param_type }` — rather than introducing a new `param_meta` type with renamed fields. The spec says "mirrors param", and reusing the type avoids translation noise at the dozens of declaration sites that already destructure `p.param_name`.

### Walker shape

`substitute_vars`, `prime_expr`, and `rename_var_refs` are not literal `Bindlib.msubst` calls. They each do **unbind → recurse-with-filtered-substitution → `Ast.make_*`-rebind**, which is Bindlib's idiomatic "operate under a binder" pattern. Behaviour on existing fixtures is preserved (the same name-filter logic the old walkers used, now scoped by the unbind result instead of an explicit `bound` parameter).

This means **the latent capture bug is not yet fully closed for the case where the substitution's *replacement* contains a `Lower n` that collides with an inner binder named `n`**. Bindlib's identity-based variable tracking only protects names that were reified as `Var.t` during boxing — a raw `EVar (Lower n)` in the replacement is opaque to it. Closing this requires either (a) routing every `substitute_vars` call through `bind_mvar` + `msubst` after also boxing the replacement, or (b) keeping an explicit alpha-rename pass at the binder. Patch 4 activates the test stubs from Patch 2; whichever direction it takes, the seam is in `Ast.make_*` / `Ast.box_expr` only.

### Equality semantics

`equal_expr` is alpha-aware via `Binder.Mbinder.equal` for quantifier bodies. `equal_params` deliberately compares **types only, not names** so that `all x: T | x` and `all y: T | y` are equal — without this, parsed-then-pretty-printed-then-reparsed expressions could spuriously inequate themselves under name freshening.

### lib_parser

`lib_parser/dune` now `copy_files` `binder.ml(i)` and links `bindlib`. The standalone parser library used by the WASM build needs the same Binder seam since `Ast.expr` references it.

### Test churn

`test/test_smt.ml` had ~30 quantifier construction sites; I bulk-converted them with a small one-shot python script (constructor-shape rewriter) rather than editing each by hand. The semantic content of those tests is unchanged.

### Setup note

Reproducing the build needs `bindlib` and `ocamlformat` (0.28.1, per `.ocamlformat`) installed in the project's local opam switch — not just the system default. The `lefthook` `pre-commit` hook runs `dune build @fmt` so missing `ocamlformat` blocks every commit until installed.