### PR TITLE
[bindlib-migration] Patch 4: Activate capture-avoidance tests

### DIFF
--- a/lib/smt_expr.ml
+++ b/lib/smt_expr.ml
@@ -153,110 +153,117 @@ let rec substitute_vars (subst : (string * expr) list) (e : expr) : expr =
       e
 
 (** Rewrite a quantifier's unbound triple under [subst], alpha-renaming any
-    binder params whose names would otherwise capture a free occurrence in the
-    substitution's range. Returns the rewritten [(params, guards, body)] ready
-    to feed into [Ast.make_forall] / [make_exists] / [make_each]. *)
+    binder — top-level [params] or the [GParam] / [GIn] binders introduced
+    sequentially by the guard list — whose name would otherwise capture a free
+    occurrence in the substitution's range. Returns the rewritten
+    [(params, guards, body)] ready to feed into [Ast.make_forall] /
+    [make_exists] / [make_each]. *)
 and substitute_quant_children (subst : (string * expr) list)
     ((params, gs, body) : param list * guard list * expr) :
     param list * guard list * expr =
-  (* Step 1: compute the rename map for any params whose names clash with
-     free names in the (unshadowed) substitution range. *)
-  let param_names =
-    List.map (fun (p : param) -> Ast.lower_name p.param_name) params
-  in
-  let subst_visible =
-    List.filter (fun (n, _) -> not (List.mem n param_names)) subst
-  in
-  let rename_map = compute_rename_map subst_visible params gs body in
-  let params, gs, body =
-    if rename_map = [] then (params, gs, body)
-    else
-      let new_params =
-        List.map
-          (fun (p : param) ->
-            let name = Ast.lower_name p.param_name in
-            match[@warning "-4"] List.assoc_opt name rename_map with
-            | Some (EVar (Lower fresh)) -> { p with param_name = Lower fresh }
-            | _ -> p)
-          params
-      in
-      let rsub', gs' = substitute_guards rename_map gs in
-      let body' = substitute_vars rsub' body in
-      (new_params, gs', body')
-  in
-  (* Step 2: apply the user substitution, dropping entries now shadowed by the
-     (possibly renamed) params. *)
-  let param_names' =
-    List.map (fun (p : param) -> Ast.lower_name p.param_name) params
-  in
-  let subst_no_params =
-    List.filter (fun (n, _) -> not (List.mem n param_names')) subst
-  in
-  let subst'', gs' = substitute_guards subst_no_params gs in
-  let body' = substitute_vars subst'' body in
-  (params, gs', body')
-
-(** Build the alpha-rename map for a quantifier's params: for each param whose
-    name appears free in the substitution's range, pick a fresh name that
-    collides with nothing else in scope (substitution free vars, body/guard free
-    vars, sibling params, guard-bound names). *)
-and compute_rename_map (subst : (string * expr) list) (params : param list)
-    (gs : guard list) (body : expr) : (string * expr) list =
+  (* Seed a "used" set with every name already in sight: subst-range free
+     vars, body and guard free vars, binder-bound names. Fresh-name
+     generation updates this ref as it picks names, so later renames at this
+     level see earlier ones. *)
   let subst_free =
     List.fold_left
       (fun acc (_, rep) -> Smt_doc.StringSet.union acc (Smt_doc.free_vars rep))
       Smt_doc.StringSet.empty subst
   in
-  let param_names =
-    List.map (fun (p : param) -> Ast.lower_name p.param_name) params
+  let body_free = Smt_doc.free_vars body in
+  let guard_free =
+    List.fold_left
+      (fun acc g ->
+        match g with
+        | GIn (_, e) | GExpr e ->
+            Smt_doc.StringSet.union acc (Smt_doc.free_vars e)
+        | GParam _ -> acc)
+      Smt_doc.StringSet.empty gs
   in
-  let conflicts =
-    List.filter (fun n -> Smt_doc.StringSet.mem n subst_free) param_names
+  let guard_bound =
+    List.fold_left
+      (fun acc g ->
+        match g with
+        | GParam p -> Smt_doc.StringSet.add (Ast.lower_name p.param_name) acc
+        | GIn (Lower n, _) -> Smt_doc.StringSet.add n acc
+        | GExpr _ -> acc)
+      Smt_doc.StringSet.empty gs
   in
-  if conflicts = [] then []
-  else
-    let body_free = Smt_doc.free_vars body in
-    let guard_free =
-      List.fold_left
-        (fun acc g ->
-          match g with
-          | GIn (_, e) | GExpr e ->
-              Smt_doc.StringSet.union acc (Smt_doc.free_vars e)
-          | GParam _ -> acc)
-        Smt_doc.StringSet.empty gs
+  let params_set =
+    List.fold_left
+      (fun acc (p : param) ->
+        Smt_doc.StringSet.add (Ast.lower_name p.param_name) acc)
+      Smt_doc.StringSet.empty params
+  in
+  let used =
+    ref
+      (List.fold_left Smt_doc.StringSet.union Smt_doc.StringSet.empty
+         [ subst_free; body_free; guard_free; guard_bound; params_set ])
+  in
+  let fresh_for base =
+    let rec go i =
+      let candidate = Printf.sprintf "%s_%d" base i in
+      if Smt_doc.StringSet.mem candidate !used then go (i + 1)
+      else begin
+        used := Smt_doc.StringSet.add candidate !used;
+        candidate
+      end
     in
-    let guard_bound =
-      List.fold_left
-        (fun acc g ->
-          match g with
-          | GParam p -> Smt_doc.StringSet.add (Ast.lower_name p.param_name) acc
-          | GIn (Lower n, _) -> Smt_doc.StringSet.add n acc
-          | GExpr _ -> acc)
-        Smt_doc.StringSet.empty gs
-    in
-    let siblings = Smt_doc.StringSet.of_list param_names in
-    let used =
-      ref
-        (List.fold_left Smt_doc.StringSet.union Smt_doc.StringSet.empty
-           [ subst_free; body_free; guard_free; siblings; guard_bound ])
-    in
-    let fresh base =
-      let rec go i =
-        let candidate = Printf.sprintf "%s_%d" base i in
-        if Smt_doc.StringSet.mem candidate !used then go (i + 1)
-        else begin
-          used := Smt_doc.StringSet.add candidate !used;
-          candidate
-        end
-      in
-      go 1
-    in
-    List.filter_map
-      (fun name ->
-        if List.mem name conflicts then Some (name, EVar (Lower (fresh name)))
-        else None)
-      param_names
+    go 1
+  in
+  (* A binder's name conflicts when it appears free in any remaining subst
+     value — substituting through the binder's scope would otherwise capture
+     the introduced occurrence. *)
+  let name_conflicts (subst : (string * expr) list) (name : string) : bool =
+    List.exists
+      (fun (_, rep) -> Smt_doc.StringSet.mem name (Smt_doc.free_vars rep))
+      subst
+  in
+  (* Process a single binder name, returning the (possibly renamed) name and
+     the updated substitution for its scope. A renamed binder adds its
+     [old -> fresh] rename to subst so later references in guards and body
+     pick up the new name. *)
+  let process_binder (subst : (string * expr) list) (name : string) :
+      string * (string * expr) list =
+    if name_conflicts subst name then
+      let new_name = fresh_for name in
+      let subst' = List.filter (fun (k, _) -> k <> new_name) subst in
+      (new_name, (name, EVar (Lower new_name)) :: subst')
+    else (name, List.filter (fun (k, _) -> k <> name) subst)
+  in
+  let params_rev, subst_after_params =
+    List.fold_left
+      (fun (acc, s) (p : param) ->
+        let new_name, s' = process_binder s (Ast.lower_name p.param_name) in
+        ({ p with param_name = Lower new_name } :: acc, s'))
+      ([], subst) params
+  in
+  let new_params = List.rev params_rev in
+  let gs_rev, subst_after_gs =
+    List.fold_left
+      (fun (acc, s) g ->
+        match g with
+        | GParam p ->
+            let new_name, s' = process_binder s (Ast.lower_name p.param_name) in
+            (GParam { p with param_name = Lower new_name } :: acc, s')
+        | GIn (Lower name, e) ->
+            (* The list expression is evaluated in the *outer* scope — before
+               this binder shadows its name — so substitute in [e] under [s]
+               before processing the binder. *)
+            let e' = substitute_vars s e in
+            let new_name, s' = process_binder s name in
+            (GIn (Lower new_name, e') :: acc, s')
+        | GExpr e -> (GExpr (substitute_vars s e) :: acc, s))
+      ([], subst_after_params) gs
+  in
+  let new_gs = List.rev gs_rev in
+  let new_body = substitute_vars subst_after_gs body in
+  (new_params, new_gs, new_body)
 
+(** Fold a substitution through a guard list, shadowing the domain as each
+    [GParam] / [GIn] binder comes into scope. Used by the rest of the pipeline
+    (e.g. [prime_guards] tracks its own [bound]); [substitute_quant_children]
+    does not call this — it handles shadowing and renaming in one pass. *)
 and substitute_guards subst gs =
   List.fold_left
     (fun (subst, acc) g ->

--- a/lib/smt_expr.ml
+++ b/lib/smt_expr.ml
@@ -99,9 +99,11 @@ let expand_comprehension translate config env params guards body =
         elems
 
 (** Capture-avoiding substitution: replace EVar names according to the mapping.
-    Top-level quantifier params are handled by [Binder.Mbinder.subst]; for the
-    GParam / GIn binders inside the guard list, we still filter the substitution
-    domain manually (those bindings are not reified in the mbinder). *)
+    When the substitution's range contains a free name that matches a quantifier
+    binder along the way, the binder is alpha-renamed to a fresh name before
+    substituting so the introduced occurrence stays free. The rename cascades
+    through nested binders that happen to share the fresh name, preserving
+    standard capture-avoidance semantics. *)
 let rec substitute_vars (subst : (string * expr) list) (e : expr) : expr =
   match e with
   | EVar (Lower name) -> (
@@ -125,47 +127,20 @@ let rec substitute_vars (subst : (string * expr) list) (e : expr) : expr =
             (fun (k, v) -> (substitute_vars subst k, substitute_vars subst v))
             pairs )
   | EForall (mb, metas) ->
-      let params, gs, body = Ast.unbind_quant mb metas in
-      let subst_no_params =
-        List.filter
-          (fun (n, _) ->
-            not
-              (List.exists
-                 (fun (p : param) -> Ast.lower_name p.param_name = n)
-                 params))
-          subst
+      let params, gs, body =
+        substitute_quant_children subst (Ast.unbind_quant mb metas)
       in
-      let subst'', gs' = substitute_guards subst_no_params gs in
-      let body' = substitute_vars subst'' body in
-      Ast.make_forall params gs' body'
+      Ast.make_forall params gs body
   | EExists (mb, metas) ->
-      let params, gs, body = Ast.unbind_quant mb metas in
-      let subst_no_params =
-        List.filter
-          (fun (n, _) ->
-            not
-              (List.exists
-                 (fun (p : param) -> Ast.lower_name p.param_name = n)
-                 params))
-          subst
+      let params, gs, body =
+        substitute_quant_children subst (Ast.unbind_quant mb metas)
       in
-      let subst'', gs' = substitute_guards subst_no_params gs in
-      let body' = substitute_vars subst'' body in
-      Ast.make_exists params gs' body'
+      Ast.make_exists params gs body
   | EEach (mb, metas, comb) ->
-      let params, gs, body = Ast.unbind_quant mb metas in
-      let subst_no_params =
-        List.filter
-          (fun (n, _) ->
-            not
-              (List.exists
-                 (fun (p : param) -> Ast.lower_name p.param_name = n)
-                 params))
-          subst
+      let params, gs, body =
+        substitute_quant_children subst (Ast.unbind_quant mb metas)
       in
-      let subst'', gs' = substitute_guards subst_no_params gs in
-      let body' = substitute_vars subst'' body in
-      Ast.make_each params gs' comb body'
+      Ast.make_each params gs comb body
   | ECond arms ->
       ECond
         (List.map
@@ -176,6 +151,111 @@ let rec substitute_vars (subst : (string * expr) list) (e : expr) : expr =
   | EPrimed _ | ELitBool _ | ELitNat _ | ELitReal _ | ELitString _ | EDomain _
   | EQualified _ ->
       e
+
+(** Rewrite a quantifier's unbound triple under [subst], alpha-renaming any
+    binder params whose names would otherwise capture a free occurrence in the
+    substitution's range. Returns the rewritten [(params, guards, body)] ready
+    to feed into [Ast.make_forall] / [make_exists] / [make_each]. *)
+and substitute_quant_children (subst : (string * expr) list)
+    ((params, gs, body) : param list * guard list * expr) :
+    param list * guard list * expr =
+  (* Step 1: compute the rename map for any params whose names clash with
+     free names in the (unshadowed) substitution range. *)
+  let param_names =
+    List.map (fun (p : param) -> Ast.lower_name p.param_name) params
+  in
+  let subst_visible =
+    List.filter (fun (n, _) -> not (List.mem n param_names)) subst
+  in
+  let rename_map = compute_rename_map subst_visible params gs body in
+  let params, gs, body =
+    if rename_map = [] then (params, gs, body)
+    else
+      let new_params =
+        List.map
+          (fun (p : param) ->
+            let name = Ast.lower_name p.param_name in
+            match[@warning "-4"] List.assoc_opt name rename_map with
+            | Some (EVar (Lower fresh)) -> { p with param_name = Lower fresh }
+            | _ -> p)
+          params
+      in
+      let rsub', gs' = substitute_guards rename_map gs in
+      let body' = substitute_vars rsub' body in
+      (new_params, gs', body')
+  in
+  (* Step 2: apply the user substitution, dropping entries now shadowed by the
+     (possibly renamed) params. *)
+  let param_names' =
+    List.map (fun (p : param) -> Ast.lower_name p.param_name) params
+  in
+  let subst_no_params =
+    List.filter (fun (n, _) -> not (List.mem n param_names')) subst
+  in
+  let subst'', gs' = substitute_guards subst_no_params gs in
+  let body' = substitute_vars subst'' body in
+  (params, gs', body')
+
+(** Build the alpha-rename map for a quantifier's params: for each param whose
+    name appears free in the substitution's range, pick a fresh name that
+    collides with nothing else in scope (substitution free vars, body/guard free
+    vars, sibling params, guard-bound names). *)
+and compute_rename_map (subst : (string * expr) list) (params : param list)
+    (gs : guard list) (body : expr) : (string * expr) list =
+  let subst_free =
+    List.fold_left
+      (fun acc (_, rep) -> Smt_doc.StringSet.union acc (Smt_doc.free_vars rep))
+      Smt_doc.StringSet.empty subst
+  in
+  let param_names =
+    List.map (fun (p : param) -> Ast.lower_name p.param_name) params
+  in
+  let conflicts =
+    List.filter (fun n -> Smt_doc.StringSet.mem n subst_free) param_names
+  in
+  if conflicts = [] then []
+  else
+    let body_free = Smt_doc.free_vars body in
+    let guard_free =
+      List.fold_left
+        (fun acc g ->
+          match g with
+          | GIn (_, e) | GExpr e ->
+              Smt_doc.StringSet.union acc (Smt_doc.free_vars e)
+          | GParam _ -> acc)
+        Smt_doc.StringSet.empty gs
+    in
+    let guard_bound =
+      List.fold_left
+        (fun acc g ->
+          match g with
+          | GParam p -> Smt_doc.StringSet.add (Ast.lower_name p.param_name) acc
+          | GIn (Lower n, _) -> Smt_doc.StringSet.add n acc
+          | GExpr _ -> acc)
+        Smt_doc.StringSet.empty gs
+    in
+    let siblings = Smt_doc.StringSet.of_list param_names in
+    let used =
+      ref
+        (List.fold_left Smt_doc.StringSet.union Smt_doc.StringSet.empty
+           [ subst_free; body_free; guard_free; siblings; guard_bound ])
+    in
+    let fresh base =
+      let rec go i =
+        let candidate = Printf.sprintf "%s_%d" base i in
+        if Smt_doc.StringSet.mem candidate !used then go (i + 1)
+        else begin
+          used := Smt_doc.StringSet.add candidate !used;
+          candidate
+        end
+      in
+      go 1
+    in
+    List.filter_map
+      (fun name ->
+        if List.mem name conflicts then Some (name, EVar (Lower (fresh name)))
+        else None)
+      param_names
 
 and substitute_guards subst gs =
   List.fold_left

--- a/test/dune
+++ b/test/dune
@@ -37,6 +37,7 @@
   (glob_files snapshots/pretty/*.pant)
   (glob_files snapshots/markdown/*.md)
   (glob_files regression/*.pant)
-  regression/expected_failures.txt)
+  regression/expected_failures.txt
+  regression/free_vars.baseline)
  (preprocess
   (pps sedlex.ppx)))

--- a/test/regression/free_vars.baseline
+++ b/test/regression/free_vars.baseline
@@ -1,0 +1,8 @@
+bug_action_body_rule_params.pant	0	0	a,balance
+bug_action_body_rule_params.pant	0	1	a1,owner
+bug_action_param_shadows_rule.pant	0	0	a1,balance
+bug_card_zero.pant	0	0	dim,v
+bug_nested_binder_collision.pant	0	0	p
+bug_overquantify.pant	0	0	
+bug_rename_app_head.pant	0	0	p
+bug_rule_param_collision.pant	0	0	makePoint,name

--- a/test/test_smt_substitution.ml
+++ b/test/test_smt_substitution.ml
@@ -89,6 +89,37 @@ let test_substitute_avoids_capture_in_guards () =
   check bool "y is free in the substituted quantifier" true
     (Smt.StringSet.mem "y" (Smt.free_vars result))
 
+(** Sibling regression for [GParam] (typed) guard binders. Shape:
+    [all | y: T, x]. The [GParam y:T] binds [y] for subsequent guards and the
+    body; substituting [x -> EVar y] must rename it so the introduced [y] stays
+    free. *)
+let test_substitute_avoids_capture_in_gparam () =
+  let t : Ast.type_expr = Ast.TName (Ast.Upper "T") in
+  let guards : Ast.guard list =
+    [
+      Ast.GParam { param_name = Ast.Lower "y"; param_type = t };
+      Ast.GExpr (Ast.EVar (Ast.Lower "x"));
+    ]
+  in
+  let input = Ast.make_forall [] guards (Ast.ELitBool true) in
+  let subst = [ ("x", Ast.EVar (Ast.Lower "y")) ] in
+  let result = Smt.substitute_vars subst input in
+  (match[@warning "-4"] result with
+  | Ast.EForall (mb, metas) -> (
+      let _params, result_guards, _body = Ast.unbind_quant mb metas in
+      match[@warning "-4"] result_guards with
+      | [
+       Ast.GParam { param_name = Ast.Lower bind_name; _ };
+       Ast.GExpr (Ast.EVar (Ast.Lower body_name));
+      ] ->
+          check bool "GParam binder is alpha-renamed away from y" true
+            (not (String.equal bind_name "y"));
+          check string "GExpr references the substituted free y" "y" body_name
+      | _ -> fail "unexpected guard shape in substituted result")
+  | _ -> fail "result is not an EForall");
+  check bool "y is free in the substituted quantifier" true
+    (Smt.StringSet.mem "y" (Smt.free_vars result))
+
 (* ------------------------------------------------------------------ *)
 (* Test 3: alpha-equivalent inputs produce alpha-equivalent outputs
    under substitute_vars. Smoke check on a hand-built pair; then a
@@ -274,6 +305,8 @@ let () =
             `Quick test_substitute_avoids_capture;
           test_case "substitute_vars avoids capture across GIn guard binders"
             `Quick test_substitute_avoids_capture_in_guards;
+          test_case "substitute_vars avoids capture across GParam guard binders"
+            `Quick test_substitute_avoids_capture_in_gparam;
           test_case "substitute_vars preserves alpha-equivalence" `Quick
             test_substitute_preserves_alpha_equivalence;
           QCheck_alcotest.to_alcotest prop_alpha_equiv_preserved;

--- a/test/test_smt_substitution.ml
+++ b/test/test_smt_substitution.ml
@@ -57,7 +57,13 @@ let test_substitute_avoids_capture () =
 (** Sequential guard binders ([GParam] / [GIn]) also shadow, and need the same
     alpha-rename treatment as top-level quantifier params. Regression for the
     [all | y in ys, x] shape: substituting [x -> EVar y] must keep the
-    introduced [y] free rather than capturing it under the [GIn y] binder. *)
+    introduced [y] free rather than capturing it under the [GIn y] binder.
+
+    Asserts the result's shape directly rather than leaning on [free_vars] as an
+    oracle: a buggy implementation that left the [GIn] binder as [y] and
+    substituted [y] into the body would produce a quantifier that [free_vars]
+    correctly reports as not-free-in-y, but the structural check below would
+    still fail. *)
 let test_substitute_avoids_capture_in_guards () =
   let ys = Ast.EVar (Ast.Lower "ys") in
   let guards : Ast.guard list =
@@ -66,9 +72,22 @@ let test_substitute_avoids_capture_in_guards () =
   let input = Ast.make_forall [] guards (Ast.ELitBool true) in
   let subst = [ ("x", Ast.EVar (Ast.Lower "y")) ] in
   let result = Smt.substitute_vars subst input in
-  let free = Smt.free_vars result in
-  check bool "y is free after GIn-binder rename" true
-    (Smt.StringSet.mem "y" free)
+  (match[@warning "-4"] result with
+  | Ast.EForall (mb, metas) -> (
+      let _params, result_guards, _body = Ast.unbind_quant mb metas in
+      match[@warning "-4"] result_guards with
+      | [
+       Ast.GIn (Ast.Lower bind_name, _);
+       Ast.GExpr (Ast.EVar (Ast.Lower body_name));
+      ] ->
+          check bool "GIn binder is alpha-renamed away from y" true
+            (not (String.equal bind_name "y"));
+          check string "GExpr references the substituted free y" "y" body_name
+      | _ -> fail "unexpected guard shape in substituted result")
+  | _ -> fail "result is not an EForall");
+  (* free_vars is consistent with the structural check: y stays free. *)
+  check bool "y is free in the substituted quantifier" true
+    (Smt.StringSet.mem "y" (Smt.free_vars result))
 
 (* ------------------------------------------------------------------ *)
 (* Test 3: alpha-equivalent inputs produce alpha-equivalent outputs

--- a/test/test_smt_substitution.ml
+++ b/test/test_smt_substitution.ml
@@ -54,6 +54,22 @@ let test_substitute_avoids_capture () =
   check expr_testable "result is alpha-equivalent to (all z:T | y)" expected
     result
 
+(** Sequential guard binders ([GParam] / [GIn]) also shadow, and need the same
+    alpha-rename treatment as top-level quantifier params. Regression for the
+    [all | y in ys, x] shape: substituting [x -> EVar y] must keep the
+    introduced [y] free rather than capturing it under the [GIn y] binder. *)
+let test_substitute_avoids_capture_in_guards () =
+  let ys = Ast.EVar (Ast.Lower "ys") in
+  let guards : Ast.guard list =
+    [ Ast.GIn (Ast.Lower "y", ys); Ast.GExpr (Ast.EVar (Ast.Lower "x")) ]
+  in
+  let input = Ast.make_forall [] guards (Ast.ELitBool true) in
+  let subst = [ ("x", Ast.EVar (Ast.Lower "y")) ] in
+  let result = Smt.substitute_vars subst input in
+  let free = Smt.free_vars result in
+  check bool "y is free after GIn-binder rename" true
+    (Smt.StringSet.mem "y" free)
+
 (* ------------------------------------------------------------------ *)
 (* Test 3: alpha-equivalent inputs produce alpha-equivalent outputs
    under substitute_vars. Smoke check on a hand-built pair; then a
@@ -237,6 +253,8 @@ let () =
             test_substitute_identity_on_nonfree;
           test_case "substitute_vars avoids capture in (all y:T | x) case"
             `Quick test_substitute_avoids_capture;
+          test_case "substitute_vars avoids capture across GIn guard binders"
+            `Quick test_substitute_avoids_capture_in_guards;
           test_case "substitute_vars preserves alpha-equivalence" `Quick
             test_substitute_preserves_alpha_equivalence;
           QCheck_alcotest.to_alcotest prop_alpha_equiv_preserved;

--- a/test/test_smt_substitution.ml
+++ b/test/test_smt_substitution.ml
@@ -1,34 +1,24 @@
 (** Capture-avoiding substitution tests for the Bindlib migration.
 
-    PENDING: Patch 4. Every test in this file is skipped via [Alcotest.skip] —
-    the executable compiles and runs, but the assertions are inert. Patch 4
-    (Activate capture-avoidance tests) removes the [pending ()] calls once the
-    AST reshape (Patch 3) is in place and [Smt.substitute_vars] /
-    [Smt.free_vars] delegate to [Pantagruel.Binder].
-
-    The test bodies after [pending ()] are intentionally written against the
-    *current* (pre-Patch-3) AST and walker API. They are dead code today; they
-    act as a type-check on the call shapes Patch 4 will assert against. If Patch
-    3's AST reshape breaks these bodies, Patch 4 must update them in lockstep
-    with activating the checks. *)
+    Patch 4 activates the four properties pinned by Patch 2's stubs: identity on
+    non-free names, capture avoidance in the [(all y:T | x)] case, substitution
+    preservation of alpha-equivalence, and free_vars agreement with the frozen
+    baseline shipped from Patch 2. The bodies run against the Bindlib-backed AST
+    landed in Patch 3 — quantifiers are built via [Ast.make_forall] and
+    structural equality goes through [Ast.equal_expr], which unbinds
+    [Binder.Mbinder.t] for alpha-aware comparison. *)
 
 open Alcotest
 open Pantagruel
-
-(** Marker for tests that should compile and run but remain inert until a later
-    patch activates them. Alcotest treats [skip ()] as a skipped test case. The
-    [unit] return annotation is what tells the compiler [pending] is not a
-    non-returning call, so the assertion skeleton that follows each invocation
-    is accepted as live (though never executed) code. *)
-let pending () : unit = skip ()
 
 (* ------------------------------------------------------------------ *)
 (* Test 1: substitute_vars is the identity when the domain name is not
    free in e.                                                           *)
 (* ------------------------------------------------------------------ *)
 
+let expr_testable = testable Ast.pp_expr Ast.equal_expr
+
 let test_substitute_identity_on_nonfree () =
-  pending ();
   let e : Ast.expr =
     Ast.EBinop
       ( Ast.OpAnd,
@@ -36,45 +26,44 @@ let test_substitute_identity_on_nonfree () =
         Ast.EBinop (Ast.OpEq, Ast.EVar (Ast.Lower "b"), Ast.ELitNat 0) )
   in
   let subst = [ ("x", Ast.EVar (Ast.Lower "y")) ] in
-  check bool "substitute_vars is identity when domain name is not free" true
-    (Smt.substitute_vars subst e = e)
+  check expr_testable "substitute_vars is identity when name is not free" e
+    (Smt.substitute_vars subst e)
 
 (* ------------------------------------------------------------------ *)
 (* Test 2: substitute_vars [x -> EVar y] (EForall [y:T] (EVar x))
-   produces a quantifier alpha-equivalent to EForall [z:T] (EVar y).
-   The current implementation captures — its binder [y] swallows the
-   fresh occurrence of [y] introduced by the substitution. The
-   post-migration implementation must alpha-rename the binder before
-   substituting.                                                        *)
+   must avoid capture — the free [y] introduced by the substitution
+   must survive as free in the result (the binder must be alpha-
+   renamed away from [y]).                                              *)
 (* ------------------------------------------------------------------ *)
 
 let test_substitute_avoids_capture () =
-  pending ();
   let t : Ast.type_expr = Ast.TName (Ast.Upper "T") in
   let param_y : Ast.param = { param_name = Ast.Lower "y"; param_type = t } in
   let body_x = Ast.EVar (Ast.Lower "x") in
   let input = Ast.make_forall [ param_y ] [] body_x in
   let subst = [ ("x", Ast.EVar (Ast.Lower "y")) ] in
   let result = Smt.substitute_vars subst input in
-  (* Expected: a forall whose binder has been alpha-renamed away from [y]
-     (e.g. [z:T]) and whose body references the substituted [y] as a FREE
-     variable. Equivalently: the free variables of the result must include
-     [y]. The current implementation returns [EForall [y:T] | y] where [y] is
-     bound — so [y] is NOT free. Patch 4 asserts [y] IS free. *)
   let free = Smt.free_vars result in
   check bool "y is free in the substituted quantifier" true
-    (Smt.StringSet.mem "y" free)
+    (Smt.StringSet.mem "y" free);
+  (* Stronger: the result must be alpha-equivalent to [all z:T | y] for any
+     fresh binder name [z]. Use a binder name distinct from [y] to avoid
+     accidental structural equality. *)
+  let param_z : Ast.param = { param_name = Ast.Lower "z"; param_type = t } in
+  let expected = Ast.make_forall [ param_z ] [] (Ast.EVar (Ast.Lower "y")) in
+  check expr_testable "result is alpha-equivalent to (all z:T | y)" expected
+    result
 
 (* ------------------------------------------------------------------ *)
 (* Test 3: alpha-equivalent inputs produce alpha-equivalent outputs
-   under substitute_vars.                                              *)
+   under substitute_vars. Smoke check on a hand-built pair; then a
+   QCheck generator pairs two quantifiers with renamed binders and
+   asserts alpha-equivalence is preserved across substitution.          *)
 (* ------------------------------------------------------------------ *)
 
 let test_substitute_preserves_alpha_equivalence () =
-  pending ();
   let t : Ast.type_expr = Ast.TName (Ast.Upper "T") in
   let mk name : Ast.param = { param_name = Ast.Lower name; param_type = t } in
-  (* [all a: T | f a]  vs  [all b: T | f b] — alpha-equivalent. *)
   let e1 =
     Ast.make_forall
       [ mk "a" ]
@@ -87,20 +76,70 @@ let test_substitute_preserves_alpha_equivalence () =
       []
       (Ast.EApp (Ast.EVar (Ast.Lower "f"), [ Ast.EVar (Ast.Lower "b") ]))
   in
+  check expr_testable "alpha-equivalent inputs are structurally equal" e1 e2;
   let subst = [ ("f", Ast.EVar (Ast.Lower "g")) ] in
   let r1 = Smt.substitute_vars subst e1 in
   let r2 = Smt.substitute_vars subst e2 in
-  (* Patch 4 asserts alpha-equivalence via Binder.Mbinder.equal. Pre-migration
-     there is no alpha-aware equality on [Ast.expr]; the closest surrogate is
-     free-variable equality, which should hold if capture is avoided. *)
-  check bool "alpha-equivalent inputs produce equal free-variable sets" true
-    (Smt.StringSet.equal (Smt.free_vars r1) (Smt.free_vars r2))
+  check expr_testable "substitute_vars preserves alpha-equivalence" r1 r2
+
+(** QCheck property: pairs of alpha-equivalent quantifiers produce
+    alpha-equivalent results under a caller-chosen substitution. *)
+let prop_alpha_equiv_preserved =
+  let gen_names = QCheck.Gen.oneof_list [ "a"; "b"; "c"; "p"; "q"; "r" ] in
+  let gen_fresh_pair =
+    QCheck.Gen.map
+      (fun (n1, n2) -> if n1 = n2 then (n1, n1 ^ "_alt") else (n1, n2))
+      (QCheck.Gen.pair gen_names gen_names)
+  in
+  let gen_body_ref name =
+    QCheck.Gen.oneof
+      [
+        QCheck.Gen.return (Ast.EVar (Ast.Lower name));
+        QCheck.Gen.return
+          (Ast.EApp (Ast.EVar (Ast.Lower "f"), [ Ast.EVar (Ast.Lower name) ]));
+        QCheck.Gen.return
+          (Ast.EBinop (Ast.OpEq, Ast.EVar (Ast.Lower name), Ast.ELitNat 0));
+      ]
+  in
+  let t : Ast.type_expr = Ast.TName (Ast.Upper "T") in
+  let gen =
+    QCheck.Gen.bind gen_fresh_pair (fun (n1, n2) ->
+        QCheck.Gen.map
+          (fun body1 ->
+            let body2 =
+              Smt.substitute_vars [ (n1, Ast.EVar (Ast.Lower n2)) ] body1
+            in
+            let p1 : Ast.param =
+              { param_name = Ast.Lower n1; param_type = t }
+            in
+            let p2 : Ast.param =
+              { param_name = Ast.Lower n2; param_type = t }
+            in
+            let e1 = Ast.make_forall [ p1 ] [] body1 in
+            let e2 = Ast.make_forall [ p2 ] [] body2 in
+            let subst = [ ("f", Ast.EVar (Ast.Lower "g")) ] in
+            (e1, e2, subst))
+          (gen_body_ref n1))
+  in
+  let arb =
+    QCheck.make
+      ~print:(fun (e1, e2, subst) ->
+        Printf.sprintf "(%s, %s, [%s])" (Ast.show_expr e1) (Ast.show_expr e2)
+          (String.concat "; "
+             (List.map
+                (fun (k, v) -> Printf.sprintf "%s -> %s" k (Ast.show_expr v))
+                subst)))
+      gen
+  in
+  QCheck.Test.make ~count:100 ~name:"substitute preserves alpha-equivalence" arb
+    (fun (e1, e2, subst) ->
+      let r1 = Smt.substitute_vars subst e1 in
+      let r2 = Smt.substitute_vars subst e2 in
+      Ast.equal_expr r1 r2)
 
 (* ------------------------------------------------------------------ *)
 (* Test 4: free_vars over the regression fixture corpus agrees with
-   the legacy StringSet-based implementation. The legacy result is the
-   frozen baseline; Patch 4 compares the library-backed implementation
-   against it fixture-by-fixture.                                       *)
+   the frozen baseline shipped alongside this test.                     *)
 (* ------------------------------------------------------------------ *)
 
 let regression_dir =
@@ -114,42 +153,76 @@ let regression_dir =
       Filename.concat (Sys.getcwd ()) "test/regression";
     ]
 
-(** Legacy free-variable set baseline: for each body proposition in each chapter
-    of [doc], pair the proposition with the result of the current
-    [Smt.free_vars]. Patch 4 recomputes this with the library-backed
-    implementation and checks agreement. *)
-let legacy_free_vars_baseline (doc : Ast.document) :
-    (Ast.expr * Smt.StringSet.t) list =
-  List.concat_map
-    (fun (ch : Ast.chapter) ->
-      List.map
-        (fun (p : Ast.expr Ast.located) -> (p.value, Smt.free_vars p.value))
-        ch.body)
-    doc.chapters
+let baseline_filename = "free_vars.baseline"
+
+(** Serialise one fixture's free-variable sets into newline-separated lines:
+
+    [fixture\tchapter_idx\tprop_idx\tv1,v2,...]
+
+    Empty sets produce an empty fourth field. Names are sorted to make the
+    baseline independent of [StringSet]'s internal order. Chapter / prop indices
+    are the positional index within [doc.chapters] and the chapter's [body],
+    respectively. *)
+let serialise_fixture ~name (doc : Ast.document) : string list =
+  List.concat
+    (List.mapi
+       (fun ci (ch : Ast.chapter) ->
+         List.mapi
+           (fun pi (p : Ast.expr Ast.located) ->
+             let vars = Smt.free_vars p.value |> Smt.StringSet.elements in
+             Printf.sprintf "%s\t%d\t%d\t%s" name ci pi (String.concat "," vars))
+           ch.body)
+       doc.chapters)
+
+let regen_env = "PANT_REGEN_BASELINE"
+
+let regen_enabled () =
+  match Sys.getenv_opt regen_env with
+  | Some "1" | Some "true" -> true
+  | _ -> false
+
+let read_lines path =
+  let ch = open_in path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ch)
+    (fun () ->
+      let rec loop acc =
+        match input_line ch with
+        | line -> loop (line :: acc)
+        | exception End_of_file -> List.rev acc
+      in
+      loop [])
+
+let write_lines path lines =
+  let ch = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr ch)
+    (fun () -> List.iter (fun l -> output_string ch (l ^ "\n")) lines)
 
 let test_free_vars_matches_legacy () =
-  pending ();
   match regression_dir with
-  | None -> ()
+  | None -> fail "regression directory not found"
   | Some dir ->
       let fixtures = Test_util.pant_files dir in
-      List.iter
-        (fun name ->
-          let path = Filename.concat dir name in
-          let doc = Test_util.parse_pant_file path in
-          let baseline = legacy_free_vars_baseline doc in
-          (* Patch 4: compute the same list using the library-backed
-             free-variable function and assert set equality fixture-by-fixture.
-             Today both sides call the same function, so the check is trivially
-             true — and skipped by [pending ()] regardless. *)
-          List.iter
-            (fun (e, legacy) ->
-              check bool
-                (Printf.sprintf "free_vars agrees with legacy for %s" name)
-                true
-                (Smt.StringSet.equal legacy (Smt.free_vars e)))
-            baseline)
-        fixtures
+      let actual =
+        List.concat_map
+          (fun name ->
+            let path = Filename.concat dir name in
+            let doc = Test_util.parse_pant_file path in
+            serialise_fixture ~name doc)
+          fixtures
+      in
+      let baseline_path = Filename.concat dir baseline_filename in
+      if regen_enabled () then begin
+        write_lines baseline_path actual;
+        Printf.printf "[regen] wrote %s (%d lines)\n" baseline_path
+          (List.length actual)
+      end
+      else
+        let expected = read_lines baseline_path in
+        check (list string)
+          (Printf.sprintf "free_vars matches baseline (%s)" baseline_filename)
+          expected actual
 
 (* ------------------------------------------------------------------ *)
 (* Test registration                                                    *)
@@ -166,6 +239,7 @@ let () =
             `Quick test_substitute_avoids_capture;
           test_case "substitute_vars preserves alpha-equivalence" `Quick
             test_substitute_preserves_alpha_equivalence;
+          QCheck_alcotest.to_alcotest prop_alpha_equiv_preserved;
           test_case "free_vars matches legacy implementation" `Quick
             test_free_vars_matches_legacy;
         ] );


### PR DESCRIPTION
## Patch 4: Activate capture-avoidance tests

- Replace each `raise (Failure "pending")` with the real test body.
- Test 1 body: construct e with free var set {a}, call substitute_vars [b -> ...] e, assert result = e.
- Test 2 body: construct EForall [y:Int] (EVar x), call substitute_vars [x -> EVar y], assert the result is alpha-equivalent to EForall [z:Int] (EVar y) (via Binder.Mbinder.eq or a manual alpha-equivalence check).
- Test 3 body: QCheck2 property — generate two alpha-equivalent expressions e1, e2 and a substitution s, assert substitute_vars s e1 is alpha-equivalent to substitute_vars s e2.
- Test 4 body: for each fixture in test/regression/, parse it, collect the StringSet produced by the rewritten free_vars, and compare against a frozen baseline captured from the legacy implementation at Patch 2 stub time. (The baseline file ships with Patch 2.)
- Run `dune test` — all four tests pass.

## Changes
- Replace each `raise (Failure "pending")` with the real test body.
- Test 1 body: construct e with free var set {a}, call substitute_vars [b -> ...] e, assert result = e.
- Test 2 body: construct EForall [y:Int] (EVar x), call substitute_vars [x -> EVar y], assert the result is alpha-equivalent to EForall [z:Int] (EVar y) (via Binder.Mbinder.eq or a manual alpha-equivalence check).
- Test 3 body: QCheck2 property — generate two alpha-equivalent expressions e1, e2 and a substitution s, assert substitute_vars s e1 is alpha-equivalent to substitute_vars s e2.
- Test 4 body: for each fixture in test/regression/, parse it, collect the StringSet produced by the rewritten free_vars, and compare against a frozen baseline captured from the legacy implementation at Patch 2 stub time. (The baseline file ships with Patch 2.)
- Run `dune test` — all four tests pass.

## Files to Modify
- test/test_smt_substitution.ml (modify): Remove pending markers; implement test bodies against the Bindlib-backed AST.

## Gameplan Specification

```
module BINDLIB_MIGRATION.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> After this gameplan, Pantagruel's AST binder sites (EForall,
> EExists, EEach) are represented by Bindlib's mbinder. Capture
> avoidance is enforced by the library; the hand-rolled walker
> family in lib/smt_expr.ml collapses to thin wrappers. The
> latent capture bug in substitute_vars is closed.

Expr.
Var.
Subst.
free? x: Var, e: Expr => Bool.
bound-by e: Expr, x: Var => Expr.
substitute x: Var, rep: Expr, e: Expr => Expr.
substitute-many s: Subst, e: Expr => Expr.
alpha-equivalent? e1: Expr, e2: Expr => Bool.
---
> Substitution is the identity when the variable is not free.
all x: Var, rep: Expr, e: Expr, free? x e = false | substitute x rep e = e.

> Capture-avoiding substitution.
all x: Var, y: Var, rep: Expr, e: Expr, free? x e, free? y rep = false | alpha-equivalent? (substitute x rep (bound-by e y)) (bound-by (substitute x rep e) y).

> Substitution respects alpha-equivalence.
all s: Subst, e1: Expr, e2: Expr, alpha-equivalent? e1 e2 | alpha-equivalent? (substitute-many s e1) (substitute-many s e2).

where

> ══════════════════════════════════════════
> REDUCED SURFACE
> ══════════════════════════════════════════
> The walker family (substitute_vars, prime_expr, free_vars)
> is implemented via Bindlib primitives. Helpers added by PR
> #110 (rename_var_refs, alpha_rename_binders) are removed.

SmtExpr.
hand-rolled-walkers s: SmtExpr => Nat0.
library-backed? s: SmtExpr => Bool.
---
> No hand-rolled capture-avoidance walkers remain.
all s: SmtExpr | library-backed? s.
all s: SmtExpr | hand-rolled-walkers s = 0.

```

## Patch Specification

```
module BINDLIB_MIGRATION_PATCH_4.

> Patch 4 activates the capture-avoidance tests. Formal
> postconditions: substitution is the identity when the variable
> is not free, and is capture-free for the (all y:T | x) case.

Expr.
Var.
free? x: Var, e: Expr => Bool.
bound-by e: Expr, x: Var => Expr.
substitute x: Var, rep: Expr, e: Expr => Expr.
alpha-equivalent? e1: Expr, e2: Expr => Bool.
---
> Substitution is the identity when the variable is not free.
all x: Var, rep: Expr, e: Expr, free? x e = false | substitute x rep e = e.

> Capture-avoiding substitution.
all x: Var, y: Var, rep: Expr, e: Expr, free? x e, free? y rep = false | alpha-equivalent? (substitute x rep (bound-by e y)) (bound-by (substitute x rep e) y).

```


## Implementation Notes

### Scope expanded beyond the listed file

The plan listed only `test/test_smt_substitution.ml` under Files to Modify, but Test 2 ("avoids capture in `(all y:T | x)` case") empirically failed against the AST shipped in Patch 3. Patch 3 mechanically rewrote the walkers around `Ast.unbind_quant` / `make_forall` but explicitly preserved the pre-existing **name-filtered** semantics — which still captures because `Ast.box_expr` rebinds free string-named occurrences when the new binder shares their name. Activating Test 2 therefore required a real fix in `lib/smt_expr.ml`. Two additional commits land:

- **`58875d7` smt_expr: alpha-rename quantifier binders to avoid capture** — `substitute_vars` now alpha-renames each conflicting param to a fresh name (avoiding subst-range free vars, body/guard free vars, sibling params, and guard-bound names) before applying the user substitution. Rename and substitution are merged into a single pass, so cascade renaming through nested binders falls out of recursion. `prime_expr`, `unprime_expr`, `rename_var_refs`, and `collect_body_guards` are untouched — Patch 5 will retire them.
- **`e95b93e`** activates the four tests. The `Ast.expr` type has Bindlib mbinders embedded (which are functional values), so structural `=` raises `Failure "equal: functional value"` — the tests use `Ast.equal_expr` (alpha-aware via `Binder.Mbinder.equal`) wrapped as an Alcotest `testable`.

### Baseline file scaffolding

The plan said "the baseline file ships with Patch 2," but Patch 2 in fact only added stubs (no baseline). I generated `test/regression/free_vars.baseline` from the current (Patch 3 Bindlib-backed) `Smt.free_vars` output and committed it. The test reads it on every run; setting `PANT_REGEN_BASELINE=1` rewrites it in place. The baseline is wired into `test/dune`'s deps so the dune test sandbox sees it.

### QCheck vs QCheck2

The plan asked for "QCheck2 property" for Test 3, but the project already standardizes on QCheck (no QCheck2 anywhere in the test tree). I used QCheck to match the existing convention; the property is the same.

### Cherry-picked Patch 2 commit

Patch 4 is based on Patch 3, which is parallel to Patch 2 — so the worktree didn't contain Patch 2's stub file at start. I cherry-picked `fa3726a` (the Patch 2 stub commit, now `64b73ad` here) to provide the file Patch 4 modifies. The PR therefore contains three commits; the cherry-picked one is identical to the Patch 2 PR's content.