### PR TITLE
test: migrate property-based tests to QCheck2

### DIFF
--- a/test/test_lexer.ml
+++ b/test/test_lexer.ml
@@ -356,8 +356,8 @@ let test_leading_zeros () =
 
 let test_lexer_no_crash =
   QCheck_alcotest.to_alcotest
-    (QCheck.Test.make ~name:"lexer never crashes on arbitrary input" ~count:2000
-       QCheck.string (fun input ->
+    (QCheck2.Test.make ~name:"lexer never crashes on arbitrary input"
+       ~count:2000 ~print:Fun.id QCheck2.Gen.string (fun input ->
          (try
             let lexer = Lexer.create_from_string "<fuzz>" input in
             let rec drain () =

--- a/test/test_parser.ml
+++ b/test/test_parser.ml
@@ -669,8 +669,8 @@ let test_chained_comparison_parse () =
 
 let test_parser_no_crash =
   QCheck_alcotest.to_alcotest
-    (QCheck.Test.make ~name:"parser never crashes on arbitrary input"
-       ~count:2000 QCheck.string (fun input ->
+    (QCheck2.Test.make ~name:"parser never crashes on arbitrary input"
+       ~count:2000 ~print:Fun.id QCheck2.Gen.string (fun input ->
          (try ignore (parse input) with _ -> ());
          true))
 

--- a/test/test_pretty.ml
+++ b/test/test_pretty.ml
@@ -376,12 +376,13 @@ let test_roundtrip_type_exprs () =
 
 (* --- Property-based: random type expression round trips --- *)
 
-let arb_type_expr = Test_util.arb_type_expr
+let gen_type_expr = Test_util.gen_type_expr
+let print_type_expr = Test_util.print_type_expr
 
 let test_type_expr_roundtrip =
   QCheck_alcotest.to_alcotest
-    (QCheck.Test.make ~name:"type expr roundtrip" ~count:200 arb_type_expr
-       (fun te ->
+    (QCheck2.Test.make ~name:"type expr roundtrip" ~count:200
+       ~print:print_type_expr gen_type_expr (fun te ->
          let printed = Pretty.str_type_expr te in
          let spec = Printf.sprintf "module T.\nAlias = %s.\n---\n" printed in
          try

--- a/test/test_smt_property.ml
+++ b/test/test_smt_property.ml
@@ -2,7 +2,7 @@
     Pantagruel documents.
 
     Strategy: generate small documents via [Test_util.gen_document], filter via
-    [QCheck.assume] to those that type-check, then run the same structural
+    [QCheck2.assume] to those that type-check, then run the same structural
     invariants as Layer 1 ([Smt_check]) on the emitted SMT. Properties:
     - translation totality (no exception)
     - well-formed SMT (parses as sexps)
@@ -23,10 +23,10 @@ let kinds_pending_fix : string list = []
 let pp_doc = Test_util.print_document
 
 (** [accepted doc] returns the queries iff [doc] type-checks. Discards via
-    [QCheck.assume_fail] otherwise. *)
+    [QCheck2.assume_fail] otherwise. *)
 let accepted doc : Smt.query list =
   match Test_util.translate_to_queries doc with
-  | Error _ -> QCheck.assume_fail ()
+  | Error _ -> QCheck2.assume_fail ()
   | Ok qs -> qs
 
 (* ------------------------------------------------------------------ *)
@@ -66,9 +66,7 @@ let count = 200
 
 let mk_property ~name ~prop =
   QCheck_alcotest.to_alcotest
-    (QCheck.Test.make ~name ~count
-       (QCheck.set_print pp_doc Test_util.arb_document)
-       prop)
+    (QCheck2.Test.make ~name ~count ~print:pp_doc Test_util.gen_document prop)
 
 let () =
   Alcotest.run "SmtProperty"

--- a/test/test_smt_substitution.ml
+++ b/test/test_smt_substitution.ml
@@ -6,7 +6,9 @@
     baseline shipped from Patch 2. The bodies run against the Bindlib-backed AST
     landed in Patch 3 — quantifiers are built via [Ast.make_forall] and
     structural equality goes through [Ast.equal_expr], which unbinds
-    [Binder.Mbinder.t] for alpha-aware comparison. *)
+    [Binder.Mbinder.t] for alpha-aware comparison.
+
+    Property-based tests use QCheck2. *)
 
 open Alcotest
 open Pantagruel
@@ -123,7 +125,7 @@ let test_substitute_avoids_capture_in_gparam () =
 (* ------------------------------------------------------------------ *)
 (* Test 3: alpha-equivalent inputs produce alpha-equivalent outputs
    under substitute_vars. Smoke check on a hand-built pair; then a
-   QCheck generator pairs two quantifiers with renamed binders and
+   QCheck2 generator pairs two quantifiers with renamed binders and
    asserts alpha-equivalence is preserved across substitution.          *)
 (* ------------------------------------------------------------------ *)
 
@@ -148,29 +150,29 @@ let test_substitute_preserves_alpha_equivalence () =
   let r2 = Smt.substitute_vars subst e2 in
   check expr_testable "substitute_vars preserves alpha-equivalence" r1 r2
 
-(** QCheck property: pairs of alpha-equivalent quantifiers produce
+(** QCheck2 property: pairs of alpha-equivalent quantifiers produce
     alpha-equivalent results under a caller-chosen substitution. *)
 let prop_alpha_equiv_preserved =
-  let gen_names = QCheck.Gen.oneof_list [ "a"; "b"; "c"; "p"; "q"; "r" ] in
+  let gen_names = QCheck2.Gen.oneof_list [ "a"; "b"; "c"; "p"; "q"; "r" ] in
   let gen_fresh_pair =
-    QCheck.Gen.map
+    QCheck2.Gen.map
       (fun (n1, n2) -> if n1 = n2 then (n1, n1 ^ "_alt") else (n1, n2))
-      (QCheck.Gen.pair gen_names gen_names)
+      (QCheck2.Gen.pair gen_names gen_names)
   in
   let gen_body_ref name =
-    QCheck.Gen.oneof
+    QCheck2.Gen.oneof
       [
-        QCheck.Gen.return (Ast.EVar (Ast.Lower name));
-        QCheck.Gen.return
+        QCheck2.Gen.return (Ast.EVar (Ast.Lower name));
+        QCheck2.Gen.return
           (Ast.EApp (Ast.EVar (Ast.Lower "f"), [ Ast.EVar (Ast.Lower name) ]));
-        QCheck.Gen.return
+        QCheck2.Gen.return
           (Ast.EBinop (Ast.OpEq, Ast.EVar (Ast.Lower name), Ast.ELitNat 0));
       ]
   in
   let t : Ast.type_expr = Ast.TName (Ast.Upper "T") in
   let gen =
-    QCheck.Gen.bind gen_fresh_pair (fun (n1, n2) ->
-        QCheck.Gen.map
+    QCheck2.Gen.bind gen_fresh_pair (fun (n1, n2) ->
+        QCheck2.Gen.map
           (fun body1 ->
             let body2 =
               Smt.substitute_vars [ (n1, Ast.EVar (Ast.Lower n2)) ] body1
@@ -187,18 +189,15 @@ let prop_alpha_equiv_preserved =
             (e1, e2, subst))
           (gen_body_ref n1))
   in
-  let arb =
-    QCheck.make
-      ~print:(fun (e1, e2, subst) ->
-        Printf.sprintf "(%s, %s, [%s])" (Ast.show_expr e1) (Ast.show_expr e2)
-          (String.concat "; "
-             (List.map
-                (fun (k, v) -> Printf.sprintf "%s -> %s" k (Ast.show_expr v))
-                subst)))
-      gen
+  let print (e1, e2, subst) =
+    Printf.sprintf "(%s, %s, [%s])" (Ast.show_expr e1) (Ast.show_expr e2)
+      (String.concat "; "
+         (List.map
+            (fun (k, v) -> Printf.sprintf "%s -> %s" k (Ast.show_expr v))
+            subst))
   in
-  QCheck.Test.make ~count:100 ~name:"substitute preserves alpha-equivalence" arb
-    (fun (e1, e2, subst) ->
+  QCheck2.Test.make ~count:100 ~name:"substitute preserves alpha-equivalence"
+    ~print gen (fun (e1, e2, subst) ->
       let r1 = Smt.substitute_vars subst e1 in
       let r2 = Smt.substitute_vars subst e2 in
       Ast.equal_expr r1 r2)

--- a/test/test_solver.ml
+++ b/test/test_solver.ml
@@ -173,22 +173,22 @@ let test_format_counterexample_filters_unchanged () =
 
 let test_translate_display_name_no_crash =
   QCheck_alcotest.to_alcotest
-    (QCheck.Test.make ~name:"translate_display_name never crashes" ~count:1000
-       QCheck.string (fun s ->
+    (QCheck2.Test.make ~name:"translate_display_name never crashes" ~count:1000
+       ~print:Fun.id QCheck2.Gen.string (fun s ->
          ignore (Solver.translate_display_name s);
          true))
 
 let test_classify_term_no_crash =
   QCheck_alcotest.to_alcotest
-    (QCheck.Test.make ~name:"classify_term never crashes" ~count:1000
-       QCheck.string (fun s ->
+    (QCheck2.Test.make ~name:"classify_term never crashes" ~count:1000
+       ~print:Fun.id QCheck2.Gen.string (fun s ->
          ignore (Solver.classify_term s);
          true))
 
 let test_parse_solver_output_no_crash =
   QCheck_alcotest.to_alcotest
-    (QCheck.Test.make ~name:"parse_solver_output never crashes" ~count:1000
-       QCheck.string (fun s ->
+    (QCheck2.Test.make ~name:"parse_solver_output never crashes" ~count:1000
+       ~print:Fun.id QCheck2.Gen.string (fun s ->
          ignore (Solver.parse_solver_output s);
          true))
 

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -161,25 +161,31 @@ let test_compatible () =
 
 (* --- Property-based tests --- *)
 
-let arb_ty = Test_util.arb_ty
+let gen_ty = Test_util.gen_ty
+let print_ty = Test_util.print_ty
+let print_pair (a, b) = Printf.sprintf "(%s, %s)" (print_ty a) (print_ty b)
+
+let print_triple (a, b, c) =
+  Printf.sprintf "(%s, %s, %s)" (print_ty a) (print_ty b) (print_ty c)
 
 let test_subtype_reflexivity =
   QCheck_alcotest.to_alcotest
-    (QCheck.Test.make ~name:"subtype reflexivity" ~count:200 arb_ty (fun t ->
-         Types.is_subtype t t))
+    (QCheck2.Test.make ~name:"subtype reflexivity" ~count:200 ~print:print_ty
+       gen_ty (fun t -> Types.is_subtype t t))
 
 let test_subtype_transitivity =
   QCheck_alcotest.to_alcotest
-    (QCheck.Test.make ~name:"subtype transitivity" ~count:500
-       (QCheck.triple arb_ty arb_ty arb_ty) (fun (a, b, c) ->
+    (QCheck2.Test.make ~name:"subtype transitivity" ~count:500
+       ~print:print_triple (QCheck2.Gen.triple gen_ty gen_ty gen_ty)
+       (fun (a, b, c) ->
          if Types.is_subtype a b && Types.is_subtype b c then
            Types.is_subtype a c
          else true (* vacuously true *)))
 
 let test_join_commutativity =
   QCheck_alcotest.to_alcotest
-    (QCheck.Test.make ~name:"join commutativity" ~count:500
-       (QCheck.pair arb_ty arb_ty) (fun (a, b) ->
+    (QCheck2.Test.make ~name:"join commutativity" ~count:500 ~print:print_pair
+       (QCheck2.Gen.pair gen_ty gen_ty) (fun (a, b) ->
          match[@warning "-4"] (Types.join a b, Types.join b a) with
          | Ok x, Ok y -> Types.equal_ty x y
          | Error _, Error _ -> true (* both fail = commutative *)
@@ -187,25 +193,25 @@ let test_join_commutativity =
 
 let test_join_reflexivity =
   QCheck_alcotest.to_alcotest
-    (QCheck.Test.make ~name:"join reflexivity" ~count:200 arb_ty (fun t ->
-         Types.join t t = Ok t))
+    (QCheck2.Test.make ~name:"join reflexivity" ~count:200 ~print:print_ty
+       gen_ty (fun t -> Types.join t t = Ok t))
 
 let test_compatible_symmetry =
   QCheck_alcotest.to_alcotest
-    (QCheck.Test.make ~name:"compatible symmetry" ~count:500
-       (QCheck.pair arb_ty arb_ty) (fun (a, b) ->
+    (QCheck2.Test.make ~name:"compatible symmetry" ~count:500 ~print:print_pair
+       (QCheck2.Gen.pair gen_ty gen_ty) (fun (a, b) ->
          Types.compatible a b = Types.compatible b a))
 
 let test_subtype_implies_compatible =
   QCheck_alcotest.to_alcotest
-    (QCheck.Test.make ~name:"subtype implies compatible" ~count:500
-       (QCheck.pair arb_ty arb_ty) (fun (a, b) ->
+    (QCheck2.Test.make ~name:"subtype implies compatible" ~count:500
+       ~print:print_pair (QCheck2.Gen.pair gen_ty gen_ty) (fun (a, b) ->
          if Types.is_subtype a b then Types.compatible a b else true))
 
 let test_join_upper_bound =
   QCheck_alcotest.to_alcotest
-    (QCheck.Test.make ~name:"join is upper bound" ~count:500
-       (QCheck.pair arb_ty arb_ty) (fun (a, b) ->
+    (QCheck2.Test.make ~name:"join is upper bound" ~count:500 ~print:print_pair
+       (QCheck2.Gen.pair gen_ty gen_ty) (fun (a, b) ->
          match Types.join a b with
          | Ok lub -> Types.is_subtype a lub && Types.is_subtype b lub
          | Error _ -> true))

--- a/test/test_util.ml
+++ b/test/test_util.ml
@@ -70,9 +70,9 @@ let translate_to_queries (doc : Ast.document) : (Smt.query list, string) result
           in
           Ok (Smt.generate_queries config env doc))
 
-(** QCheck generator for Types.ty, depth-limited *)
+(** QCheck2 generator for Types.ty, depth-limited *)
 let[@warning "-44"] gen_ty_at_depth =
-  let open QCheck.Gen in
+  let open QCheck2.Gen in
   let base =
     oneof
       [
@@ -107,11 +107,11 @@ let[@warning "-44"] gen_ty_at_depth =
           ])
 
 let gen_ty = gen_ty_at_depth 2
-let arb_ty = QCheck.make ~print:Types.format_ty gen_ty
+let print_ty = Types.format_ty
 
-(** QCheck generator for Ast.type_expr, depth-limited *)
+(** QCheck2 generator for Ast.type_expr, depth-limited *)
 let[@warning "-44"] gen_type_expr_at_depth =
-  let open QCheck.Gen in
+  let open QCheck2.Gen in
   let names = [ "Nat"; "Bool"; "Int"; "String"; "Real"; "Nothing" ] in
   let base = oneof_list (List.map (fun n -> Ast.TName (Ast.Upper n)) names) in
   fix (fun self n ->
@@ -132,7 +132,7 @@ let[@warning "-44"] gen_type_expr_at_depth =
           ])
 
 let gen_type_expr = gen_type_expr_at_depth 2
-let arb_type_expr = QCheck.make ~print:Pretty.str_type_expr gen_type_expr
+let print_type_expr = Pretty.str_type_expr
 
 (** ============================================================ AST document
     generators (Layer 2 of the SMT-translator tests).
@@ -155,20 +155,19 @@ type gen_world = {
 }
 (** A minimal symbol world generated before any expression construction. *)
 
-(** Generate a list of exactly [n] elements from [g]. (The deprecated
-    [QCheck.Gen.list_repeat] does the same; this wrapper documents intent.) *)
-let list_of_size n g = QCheck.Gen.list_size (QCheck.Gen.return n) g
+(** Generate a list of exactly [n] elements from [g]. *)
+let list_of_size n g = QCheck2.Gen.list_size (QCheck2.Gen.return n) g
 
 (** Lower-case identifiers we cycle through. Some collisions are intentional —
     sharing names like [x]/[n] across rules is exactly what triggers the
     over-quantification bug we want Layer 2 to keep an eye on. *)
 let lower_pool = [ "x"; "y"; "n"; "k"; "u"; "v"; "a"; "b" ]
 
-let gen_lower : string QCheck.Gen.t =
-  let open QCheck.Gen in
+let gen_lower : string QCheck2.Gen.t =
+  let open QCheck2.Gen in
   oneof_list lower_pool
 
-let gen_domain_name : string QCheck.Gen.t = QCheck.Gen.oneof_list [ "X"; "Y" ]
+let gen_domain_name : string QCheck2.Gen.t = QCheck2.Gen.oneof_list [ "X"; "Y" ]
 
 let mk_param name ty : Ast.param =
   { Ast.param_name = Ast.Lower name; param_type = ty }
@@ -176,15 +175,15 @@ let mk_param name ty : Ast.param =
 let mk_located v : 'a Ast.located =
   { Ast.loc = Ast.dummy_loc; value = v; doc = []; doc_adjacent = false }
 
-let gen_param_with world : Ast.param QCheck.Gen.t =
-  let open QCheck.Gen in
+let gen_param_with world : Ast.param QCheck2.Gen.t =
+  let open QCheck2.Gen in
   let* name = gen_lower in
   let* ty = oneof_list world.base_types in
   return (mk_param name ty)
 
 (** Generate a small world: 1–2 domains, 0–4 rules, 0–2 vars. *)
-let gen_world : gen_world QCheck.Gen.t =
-  let open QCheck.Gen in
+let gen_world : gen_world QCheck2.Gen.t =
+  let open QCheck2.Gen in
   let* n_domains = int_range 1 2 in
   let domains = List.filteri (fun i _ -> i < n_domains) [ "X"; "Y" ] in
   let base_types =
@@ -229,7 +228,7 @@ let visible_vars vars =
     that introduce fresh params (the patterns that exercise the
     over-quantification bug). *)
 let[@warning "-44"] gen_bool_expr_at_depth =
-  let open QCheck.Gen in
+  let open QCheck2.Gen in
   let lit = oneof_list [ Ast.ELitBool true; Ast.ELitBool false ] in
   let var_of world =
     let vars = visible_vars world.vars in
@@ -308,8 +307,8 @@ let gen_bool_expr world = gen_bool_expr_at_depth (2, world)
 
 (** Build a chapter from a world: the rules become declarations in the head; the
     body is 1–3 generated boolean propositions. *)
-let gen_chapter (world : gen_world) : Ast.chapter QCheck.Gen.t =
-  let open QCheck.Gen in
+let gen_chapter (world : gen_world) : Ast.chapter QCheck2.Gen.t =
+  let open QCheck2.Gen in
   let head =
     List.map (fun d -> mk_located (Ast.DeclDomain (Ast.Upper d))) world.domains
     @ List.map
@@ -331,8 +330,8 @@ let gen_chapter (world : gen_world) : Ast.chapter QCheck.Gen.t =
   return { Ast.head; body; checks = []; trailing_docs = [] }
 
 (** Top-level document generator. *)
-let gen_document : Ast.document QCheck.Gen.t =
-  let open QCheck.Gen in
+let gen_document : Ast.document QCheck2.Gen.t =
+  let open QCheck2.Gen in
   let* world = gen_world in
   let* chapter = gen_chapter world in
   return
@@ -343,10 +342,7 @@ let gen_document : Ast.document QCheck.Gen.t =
       chapters = [ chapter ];
     }
 
-(** Pretty-print a generated document for QCheck shrinking output. There is no
+(** Pretty-print a generated document for QCheck2 shrinking output. There is no
     top-level pretty-printer for full documents, so fall back to the derived
     [show_document]. *)
 let print_document doc = Ast.show_document doc
-
-let arb_document : Ast.document QCheck.arbitrary =
-  QCheck.make ~print:print_document gen_document


### PR DESCRIPTION
## Summary
- Migrates all test-suite QCheck v1 usage to QCheck2 (Gen, Test.make, assume_fail).
- Drops the `arb_*` wrappers in `Test_util` in favor of bare generators paired with `print_*` helpers that each consumer wires into `~print` at the `Test.make` callsite.
- `QCheck.string` fuzz inputs become `QCheck2.Gen.string` with an explicit `~print:Fun.id`, so shrunk counter-examples still render.

## Why
QCheck v1's `arbitrary`/separate-shrinker API is superseded by QCheck2's integrated, tree-based shrinking — that's where qcheck-core development lives. `QCheck_alcotest.to_alcotest` already consumes `QCheck2.Test.t` (current type alias `QCheck.Test.t = QCheck2.Test.t`), so this is a purely mechanical migration with no behavior change at the framework layer.

## Test plan
- [x] `dune build` clean
- [x] `dune test` — 16 test suites pass, 0 failures
- [x] Both Layer-1 (`Smt_invariants`) and Layer-2 (`SmtProperty`) property tests still run under the new generator
- [x] No remaining references to `QCheck.` / `arb_*` wrappers

🤖 Generated with [Claude Code](https://claude.com/claude-code)