### PR TITLE
arity-overloading: rule families distinguished by arity under positional coherence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,12 @@ jobs:
         with:
           ocaml-compiler: "5.4.1"
 
+      - name: Use opam.ocaml.org archive cache
+        # erratique.ch (upstream for cmdliner, mtime, fpath, logs, uutf, ...)
+        # is frequently flaky; the community cache mirrors opam-repository
+        # archives behind a CDN, so opam only falls back to upstream on a miss.
+        run: opam option archive-mirrors=https://opam.ocaml.org/cache
+
       - name: Install dependencies
         run: |
           opam install ./pantagruel.opam --deps-only --with-test --with-doc
@@ -60,6 +66,9 @@ jobs:
         uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: "5.4.1"
+
+      - name: Use opam.ocaml.org archive cache
+        run: opam option archive-mirrors=https://opam.ocaml.org/cache
 
       - name: Install binaryen
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         # erratique.ch (upstream for cmdliner, mtime, fpath, logs, uutf, ...)
         # is frequently flaky; the community cache mirrors opam-repository
         # archives behind a CDN, so opam only falls back to upstream on a miss.
-        run: opam option archive-mirrors=https://opam.ocaml.org/cache
+        run: opam option archive-mirrors='["https://opam.ocaml.org/cache"]'
 
       - name: Install dependencies
         run: |
@@ -68,7 +68,7 @@ jobs:
           ocaml-compiler: "5.4.1"
 
       - name: Use opam.ocaml.org archive cache
-        run: opam option archive-mirrors=https://opam.ocaml.org/cache
+        run: opam option archive-mirrors='["https://opam.ocaml.org/cache"]'
 
       - name: Install binaryen
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,12 @@ jobs:
         with:
           ocaml-compiler: "5.4.1"
 
+      - name: Use opam.ocaml.org archive cache
+        # erratique.ch (upstream for cmdliner, mtime, fpath, logs, uutf, ...)
+        # is frequently flaky; the community cache mirrors opam-repository
+        # archives behind a CDN, so opam only falls back to upstream on a miss.
+        run: opam option archive-mirrors=https://opam.ocaml.org/cache
+
       - name: Install dependencies
         run: opam install ./pantagruel.opam --deps-only
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         # erratique.ch (upstream for cmdliner, mtime, fpath, logs, uutf, ...)
         # is frequently flaky; the community cache mirrors opam-repository
         # archives behind a CDN, so opam only falls back to upstream on a miss.
-        run: opam option archive-mirrors=https://opam.ocaml.org/cache
+        run: opam option archive-mirrors='["https://opam.ocaml.org/cache"]'
 
       - name: Install dependencies
         run: opam install ./pantagruel.opam --deps-only

--- a/lib/check.ml
+++ b/lib/check.ml
@@ -174,7 +174,10 @@ let rec infer_type ctx (expr : expr) : (ty, type_error) result =
          with "not a function". Fall back to [infer_type] (which uses
          [lookup_bare]) if no matching overload exists; that preserves
          list-indexing, list-search, and shim-based arity-mismatch diagnostics
-         for single-arity rules. *)
+         for single-arity rules. Qualified heads ([M::f]) take the same
+         arity-aware path via [lookup_qualified_term_arity] so imported
+         overload families dispatch to the right arity instead of the
+         first-overload shim. *)
       let n_args = List.length args in
       let* func_ty =
         match[@warning "-4"] func with
@@ -189,6 +192,13 @@ let rec infer_type ctx (expr : expr) : (ty, type_error) result =
                    uses the first-overload shim, so single-arity rules keep
                    their pre-overload ArityMismatch semantics. *)
                 infer_type ctx func)
+        | EQualified (Upper mod_name, name) -> (
+            match[@warning "-4"]
+              Env.lookup_qualified_term_arity mod_name name n_args ctx.env
+            with
+            | Some { kind = Env.KRule (TyFunc (_ :: _, _) as ty); _ } -> Ok ty
+            | Some { kind = Env.KClosure (ty, _); _ } -> Ok ty
+            | _ -> infer_type ctx func)
         | _ -> infer_type ctx func
       in
       check_application ctx func func_ty args
@@ -482,23 +492,41 @@ and check_quantifier ctx params guards body =
   infer_type ctx'' body
 
 and check_override ctx name pairs =
-  (* Determine the target overload's arity from the first key's shape. A
-     scalar key names an arity-1 rule; an N-tuple key names an arity-N rule.
-     All keys in a single override expression share an arity (enforced by
-     check_override_key below), so the first key is representative. *)
-  let target_arity =
+  (* Resolve against the declared overloads rather than the first key's
+     syntactic shape. An N-tuple key syntactically suggests an arity-N rule,
+     but a unary rule whose single parameter has a product type also accepts
+     tuple keys; pre-selecting by tuple length alone misclassifies the
+     latter. When a unique non-nullary overload exists, dispatch to it
+     directly and let [check_override_key] validate the tuple-vs-product
+     mapping. When multiple overloads exist, prefer the arity matching the
+     tuple shape. *)
+  let non_nullary_overloads =
+    List.filter_map
+      (fun (arity, (e : Env.entry)) ->
+        match[@warning "-4"] e.kind with
+        | Env.KRule (TyFunc ((_ :: _ as param_tys), Some ret_ty)) ->
+            Some (arity, (param_tys, ret_ty))
+        | _ -> None)
+      (Env.overloads_of name ctx.env)
+  in
+  let tuple_arity =
     match[@warning "-4"] pairs with
     | (ETuple parts, _) :: _ -> List.length parts
     | _ -> 1
   in
-  match[@warning "-4"] Env.lookup_term_arity name target_arity ctx.env with
-  | Some { kind = Env.KRule (TyFunc (param_tys, Some ret_ty)); _ }
-    when param_tys <> [] ->
-      (* Override key arity matches an overload's arity. For arity-1 rules
-         the key is a bare expression typed against the single parameter; for
-         arity-N rules the key must be an N-tuple whose components match the
-         parameter types componentwise. See Kroening & Strichman Ch. 7
-         (McCarthy's [store] applied to multi-index arrays). *)
+  let selected =
+    match non_nullary_overloads with
+    | [] -> None
+    | [ (_, ty_pair) ] -> Some ty_pair
+    | _ -> List.assoc_opt tuple_arity non_nullary_overloads
+  in
+  match selected with
+  | Some (param_tys, ret_ty) ->
+      (* See Kroening & Strichman Ch. 7 (McCarthy's [store] applied to
+         multi-index arrays). For arity-1 rules the key is a bare expression
+         typed against the single parameter (even if that parameter's type is
+         a product); for arity-N rules the key must be an N-tuple whose
+         components match the parameter types componentwise. *)
       let arity = List.length param_tys in
       let* _ =
         map_result
@@ -512,22 +540,13 @@ and check_override ctx name pairs =
           pairs
       in
       Ok (TyFunc (param_tys, Some ret_ty))
-  | _ -> (
-      (* No overload with [target_arity]. If the name has other overloads,
-         the rule exists but the key shape is wrong — produce
-         OverrideKeyArityMismatch against an actual overload's arity. If
-         the name is unknown entirely, it's an unbound reference. *)
-      match
-        List.find_opt
-          (fun (_, (e : Env.entry)) ->
-            match[@warning "-4"] e.kind with
-            | Env.KRule (TyFunc (_ :: _, _)) -> true
-            | _ -> false)
-          (Env.overloads_of name ctx.env)
-      with
-      | Some (actual_arity, _) ->
-          Error (OverrideKeyArityMismatch (name, actual_arity, ctx.loc))
-      | None -> Error (UnboundVariable (name, ctx.loc)))
+  | None -> (
+      (* Either no declaration at all (unbound), or there are overloads but
+         none matched the tuple shape (arity mismatch). *)
+      match non_nullary_overloads with
+      | [] -> Error (UnboundVariable (name, ctx.loc))
+      | (actual_arity, _) :: _ ->
+          Error (OverrideKeyArityMismatch (name, actual_arity, ctx.loc)))
 
 and check_override_key ctx name param_tys arity k =
   match[@warning "-4"] (arity, k) with

--- a/lib/check.ml
+++ b/lib/check.ml
@@ -168,23 +168,26 @@ let rec infer_type ctx (expr : expr) : (ty, type_error) result =
         | None -> Error (UnboundVariable (name, ctx.loc)))
   | EApp (func, args) ->
       (* Application heads are syntactically rule-only. If the head is a
-         bare lower identifier, probe [lookup_term] (rules and closures)
-         first — otherwise a parameter of the same name would mask the
-         rule and the application would fail with "not a function". Fall
-         back to [infer_type] (which uses [lookup_bare]) if the head isn't
-         a rule; that preserves list-indexing and list-search, whose
-         "function head" is actually a variable or a nullary rule
-         auto-applied to produce a list. *)
+         bare lower identifier, probe [lookup_term_arity] for the overload
+         whose arity matches the argument count — otherwise a parameter of
+         the same name would mask the rule and the application would fail
+         with "not a function". Fall back to [infer_type] (which uses
+         [lookup_bare]) if no matching overload exists; that preserves
+         list-indexing, list-search, and shim-based arity-mismatch diagnostics
+         for single-arity rules. *)
+      let n_args = List.length args in
       let* func_ty =
         match[@warning "-4"] func with
         | EVar (Lower name) -> (
-            match[@warning "-4"] Env.lookup_term name ctx.env with
+            match[@warning "-4"] Env.lookup_term_arity name n_args ctx.env with
             | Some { kind = Env.KRule (TyFunc (_ :: _, _) as ty); _ } -> Ok ty
             | Some { kind = Env.KClosure (ty, _); _ } -> Ok ty
             | _ ->
-                (* Nullary rules, variables, and missing entries — let the
-                   general [infer_type] path handle auto-apply / list
-                   indexing / unbound diagnostics. *)
+                (* No overload at this exact arity. Nullary rules,
+                   variables, list indexing, and unbound diagnostics flow
+                   through the general [infer_type] path — whose [lookup_bare]
+                   uses the first-overload shim, so single-arity rules keep
+                   their pre-overload ArityMismatch semantics. *)
                 infer_type ctx func)
         | _ -> infer_type ctx func
       in
@@ -479,10 +482,19 @@ and check_quantifier ctx params guards body =
   infer_type ctx'' body
 
 and check_override ctx name pairs =
-  match[@warning "-4"] Env.lookup_term name ctx.env with
+  (* Determine the target overload's arity from the first key's shape. A
+     scalar key names an arity-1 rule; an N-tuple key names an arity-N rule.
+     All keys in a single override expression share an arity (enforced by
+     check_override_key below), so the first key is representative. *)
+  let target_arity =
+    match[@warning "-4"] pairs with
+    | (ETuple parts, _) :: _ -> List.length parts
+    | _ -> 1
+  in
+  match[@warning "-4"] Env.lookup_term_arity name target_arity ctx.env with
   | Some { kind = Env.KRule (TyFunc (param_tys, Some ret_ty)); _ }
     when param_tys <> [] ->
-      (* Override key must match the rule's parameter arity. For arity-1 rules
+      (* Override key arity matches an overload's arity. For arity-1 rules
          the key is a bare expression typed against the single parameter; for
          arity-N rules the key must be an N-tuple whose components match the
          parameter types componentwise. See Kroening & Strichman Ch. 7
@@ -500,7 +512,22 @@ and check_override ctx name pairs =
           pairs
       in
       Ok (TyFunc (param_tys, Some ret_ty))
-  | _ -> Error (UnboundVariable (name, ctx.loc))
+  | _ -> (
+      (* No overload with [target_arity]. If the name has other overloads,
+         the rule exists but the key shape is wrong — produce
+         OverrideKeyArityMismatch against an actual overload's arity. If
+         the name is unknown entirely, it's an unbound reference. *)
+      match
+        List.find_opt
+          (fun (_, (e : Env.entry)) ->
+            match[@warning "-4"] e.kind with
+            | Env.KRule (TyFunc (_ :: _, _)) -> true
+            | _ -> false)
+          (Env.overloads_of name ctx.env)
+      with
+      | Some (actual_arity, _) ->
+          Error (OverrideKeyArityMismatch (name, actual_arity, ctx.loc))
+      | None -> Error (UnboundVariable (name, ctx.loc)))
 
 and check_override_key ctx name param_tys arity k =
   match[@warning "-4"] (arity, k) with

--- a/lib/check.ml
+++ b/lib/check.ml
@@ -415,7 +415,8 @@ and resolve_param_type env loc p =
       | Collect.RecursiveAlias _ | Collect.MultipleActions _
       | Collect.ActionNotLast _ | Collect.BuiltinRedefined _
       | Collect.DuplicateContext _ | Collect.UndefinedContext _
-      | Collect.ClosureTargetInvalid _ ) ->
+      | Collect.ClosureTargetInvalid _ | Collect.OverloadCoherenceViolation _ )
+    ->
       Error (UnboundType ("unknown", loc))
 
 (** Process guards, extending context and collecting additional bindings. When

--- a/lib/collect.ml
+++ b/lib/collect.ml
@@ -256,9 +256,10 @@ let collect_chapter_head ~chapter ~doc_contexts env
         Ok env
     | DeclClosure
         { name = Lower name; param; return_type; target = Lower target } ->
-        (* Validate: no duplicate rule name *)
+        (* Validate: no duplicate rule name. Closures are always arity-1, so
+           check for a same-arity collision. *)
         let* env =
-          match Env.lookup_term name env with
+          match Env.lookup_term_arity name 1 env with
           | Some existing when existing.module_origin = None ->
               Error (DuplicateRule (name, decl.loc, existing.loc))
           | _ -> Ok env
@@ -278,9 +279,11 @@ let collect_chapter_head ~chapter ~doc_contexts env
                        (Types.format_ty param_ty),
                      decl.loc ))
         in
-        (* Look up the target rule *)
+        (* Look up the target rule — closure targets are always unary, so
+           probe the arity-1 slot so unary targets are found even when the
+           name has other arity overloads. *)
         let* () =
-          match[@warning "-4"] Env.lookup_term target env with
+          match[@warning "-4"] Env.lookup_term_arity target 1 env with
           | Some { kind = Env.KRule ty; _ } -> (
               match[@warning "-4"] ty with
               (* T => T + Nothing (partial parent) *)

--- a/lib/collect.ml
+++ b/lib/collect.ml
@@ -4,6 +4,8 @@ open Ast
 open Types
 open Util
 
+type coherence_position = Param of int | Return [@@deriving show]
+
 type collect_error =
   | DuplicateDomain of string * loc * loc
   | DuplicateRule of string * loc * loc
@@ -15,6 +17,12 @@ type collect_error =
   | DuplicateContext of string * loc
   | UndefinedContext of string * loc
   | ClosureTargetInvalid of string * string * loc
+  | OverloadCoherenceViolation of {
+      name : string;
+      position : coherence_position;
+      first : string * ty * loc;
+      second : string * ty * loc;
+    }
 [@@deriving show]
 
 let is_builtin_type name =
@@ -59,6 +67,71 @@ let rec resolve_type env (te : type_expr) loc : (ty, collect_error) result =
   | TSum ts ->
       let* tys = map_result (fun t -> resolve_type env t loc) ts in
       Ok (TySum tys)
+
+(** Verify that a new rule declaration is coherent with any existing local
+    overloads of the same name. Coherence (positional): all overloads share the
+    return type, and at every shared parameter position both the name and type
+    agree. Only local declarations participate in the check — imported overloads
+    are considered a different family to keep cross-module ambiguity a separate
+    concern. *)
+let check_overload_coherence name (params : Ast.param list) param_types
+    (ret_ty : ty) (new_loc : Ast.loc) env : (unit, collect_error) result =
+  let new_arity = List.length params in
+  let rec check_against = function
+    | [] -> Ok ()
+    | (existing_arity, (entry : Env.entry)) :: rest ->
+        if entry.module_origin <> None then check_against rest
+        else
+          let existing_ret, existing_param_types =
+            match[@warning "-4"] entry.kind with
+            | Env.KRule (TyFunc (ptys, Some r))
+            | Env.KClosure (TyFunc (ptys, Some r), _) ->
+                (r, ptys)
+            | _ -> (TyNothing, [])
+          in
+          let* () =
+            if equal_ty existing_ret ret_ty then Ok ()
+            else
+              Error
+                (OverloadCoherenceViolation
+                   {
+                     name;
+                     position = Return;
+                     first = ("", existing_ret, entry.loc);
+                     second = ("", ret_ty, new_loc);
+                   })
+          in
+          let existing_params =
+            match Env.lookup_rule_guards_arity name existing_arity env with
+            | Some (ps, _) -> ps
+            | None -> []
+          in
+          let shared = min new_arity existing_arity in
+          let rec check_position i =
+            if i >= shared then Ok ()
+            else
+              let exp : Ast.param = List.nth existing_params i in
+              let newp : Ast.param = List.nth params i in
+              let exp_name = Ast.lower_name exp.param_name in
+              let newp_name = Ast.lower_name newp.param_name in
+              let exp_ty = List.nth existing_param_types i in
+              let newp_ty = List.nth param_types i in
+              if exp_name = newp_name && equal_ty exp_ty newp_ty then
+                check_position (i + 1)
+              else
+                Error
+                  (OverloadCoherenceViolation
+                     {
+                       name;
+                       position = Param i;
+                       first = (exp_name, exp_ty, entry.loc);
+                       second = (newp_name, newp_ty, new_loc);
+                     })
+          in
+          let* () = check_position 0 in
+          check_against rest
+  in
+  check_against (Env.overloads_of name env)
 
 (** Collect declarations from one chapter head. Uses multi-pass approach so
     declarations can reference each other regardless of order. *)
@@ -155,10 +228,16 @@ let collect_chapter_head ~chapter ~doc_contexts env
         in
         let proc_ty = TyFunc (param_types, Some ret_ty) in
         let* env =
-          match Env.lookup_term name env with
+          let new_arity = List.length params in
+          match Env.lookup_term_arity name new_arity env with
           | Some existing when existing.module_origin = None ->
               Error (DuplicateRule (name, decl.loc, existing.loc))
-          | _ -> Ok (Env.add_rule name proc_ty decl.loc ~chapter env)
+          | _ ->
+              let* () =
+                check_overload_coherence name params param_types ret_ty decl.loc
+                  env
+              in
+              Ok (Env.add_rule name proc_ty decl.loc ~chapter env)
         in
         let env = Env.add_rule_guards name params guards env in
         (* Add rule to each context's member list *)

--- a/lib/collect.ml
+++ b/lib/collect.ml
@@ -346,6 +346,15 @@ let collect_chapter_head ~chapter ~doc_contexts env
                      decl.loc ))
         in
         let closure_ty = TyFunc ([ param_ty ], Some (TyList param_ty)) in
+        (* Closures must satisfy positional coherence with any other
+           overloads of [name] already declared locally, just like rules.
+           Without this check, acceptance of e.g. [closure f/1] alongside
+           [rule f/2] with an incompatible shared-position type depends on
+           declaration order. *)
+        let* () =
+          check_overload_coherence name [ param ] [ param_ty ] (TyList param_ty)
+            decl.loc env
+        in
         Ok (Env.add_closure name closure_ty target decl.loc ~chapter env)
     | DeclDomain _ | DeclAlias _ ->
         Ok env (* Domains and aliases already done *)

--- a/lib/collect.ml
+++ b/lib/collect.ml
@@ -82,12 +82,11 @@ let check_overload_coherence name (params : Ast.param list) param_types
     | (existing_arity, (entry : Env.entry)) :: rest ->
         if entry.module_origin <> None then check_against rest
         else
-          let existing_ret, existing_param_types =
+          let existing_ret, existing_param_types, is_closure =
             match[@warning "-4"] entry.kind with
-            | Env.KRule (TyFunc (ptys, Some r))
-            | Env.KClosure (TyFunc (ptys, Some r), _) ->
-                (r, ptys)
-            | _ -> (TyNothing, [])
+            | Env.KRule (TyFunc (ptys, Some r)) -> (r, ptys, false)
+            | Env.KClosure (TyFunc (ptys, Some r), _) -> (r, ptys, true)
+            | _ -> (TyNothing, [], false)
           in
           let* () =
             if equal_ty existing_ret ret_ty then Ok ()
@@ -101,32 +100,66 @@ let check_overload_coherence name (params : Ast.param list) param_types
                      second = ("", ret_ty, new_loc);
                    })
           in
+          (* Closures do not populate [Env.rule_guards], so the formal
+             parameter names required for positional coherence aren't
+             available. Skip the positional name-check for a closure
+             overload — return-type coherence above still runs, and the
+             param-type check [check_position] would normally do is also
+             performed here against [existing_param_types]. *)
           let existing_params =
             match Env.lookup_rule_guards_arity name existing_arity env with
-            | Some (ps, _) -> ps
-            | None -> []
+            | Some (ps, _) -> Some ps
+            | None -> None
           in
           let shared = min new_arity existing_arity in
           let rec check_position i =
             if i >= shared then Ok ()
             else
-              let exp : Ast.param = List.nth existing_params i in
               let newp : Ast.param = List.nth params i in
-              let exp_name = Ast.lower_name exp.param_name in
               let newp_name = Ast.lower_name newp.param_name in
-              let exp_ty = List.nth existing_param_types i in
               let newp_ty = List.nth param_types i in
-              if exp_name = newp_name && equal_ty exp_ty newp_ty then
-                check_position (i + 1)
-              else
-                Error
-                  (OverloadCoherenceViolation
-                     {
-                       name;
-                       position = Param i;
-                       first = (exp_name, exp_ty, entry.loc);
-                       second = (newp_name, newp_ty, new_loc);
-                     })
+              let exp_ty = List.nth existing_param_types i in
+              match existing_params with
+              | None when is_closure ->
+                  (* Closure has no formal-name metadata. Check type
+                     agreement only; skip positional name comparison. *)
+                  if equal_ty exp_ty newp_ty then check_position (i + 1)
+                  else
+                    Error
+                      (OverloadCoherenceViolation
+                         {
+                           name;
+                           position = Param i;
+                           first = ("", exp_ty, entry.loc);
+                           second = (newp_name, newp_ty, new_loc);
+                         })
+              | None ->
+                  (* Non-closure missing rule_guards entry shouldn't happen;
+                     defensively compare types only. *)
+                  if equal_ty exp_ty newp_ty then check_position (i + 1)
+                  else
+                    Error
+                      (OverloadCoherenceViolation
+                         {
+                           name;
+                           position = Param i;
+                           first = ("", exp_ty, entry.loc);
+                           second = (newp_name, newp_ty, new_loc);
+                         })
+              | Some ps ->
+                  let exp : Ast.param = List.nth ps i in
+                  let exp_name = Ast.lower_name exp.param_name in
+                  if exp_name = newp_name && equal_ty exp_ty newp_ty then
+                    check_position (i + 1)
+                  else
+                    Error
+                      (OverloadCoherenceViolation
+                         {
+                           name;
+                           position = Param i;
+                           first = (exp_name, exp_ty, entry.loc);
+                           second = (newp_name, newp_ty, new_loc);
+                         })
           in
           let* () = check_position 0 in
           check_against rest

--- a/lib/collect.mli
+++ b/lib/collect.mli
@@ -1,5 +1,10 @@
 (** Pass 1: Collect declarations from all chapters *)
 
+(** Which coordinate of a rule family two arity-overloads disagree on. Used by
+    [OverloadCoherenceViolation] to discriminate between param-position
+    mismatches and return-type mismatches. *)
+type coherence_position = Param of int | Return [@@deriving show]
+
 type collect_error =
   | DuplicateDomain of string * Ast.loc * Ast.loc
   | DuplicateRule of string * Ast.loc * Ast.loc
@@ -11,6 +16,17 @@ type collect_error =
   | DuplicateContext of string * Ast.loc
   | UndefinedContext of string * Ast.loc
   | ClosureTargetInvalid of string * string * Ast.loc
+  | OverloadCoherenceViolation of {
+      name : string;
+      position : coherence_position;
+      first : string * Types.ty * Ast.loc;
+      second : string * Types.ty * Ast.loc;
+    }
+      (** Two declarations of [name] with different arities disagree on the
+          parameter name/type at a shared position, or on the return type. The
+          [first] tuple describes the previously-declared overload at that
+          coordinate; [second] describes the new declaration. At [Return]
+          position the name field is the empty string (unused). *)
 [@@deriving show]
 
 val resolve_type :

--- a/lib/env.ml
+++ b/lib/env.ml
@@ -254,11 +254,14 @@ let in_action_context env = Option.is_some env.action
 (** Lookup a type by name *)
 let lookup_type name env = StringMap.find_opt name env.types
 
-(** Lookup a term (rule or closure) by name. Compatibility shim — returns the
-    first overload by ascending arity. Arity-aware callers should use
-    [lookup_term_arity] to pick a specific overload. *)
+(** Lookup a term (rule or closure) by name. Returns [Some entry] only when
+    [name] has exactly one declared overload — callers that need a specific
+    arity in the presence of multiple overloads must use [lookup_term_arity].
+    Previously this returned the lowest-arity overload as a compatibility shim,
+    but that silently picked the wrong shape for name-only callers (e.g. closure
+    target validation) once arity overloads landed. *)
 let lookup_term name env =
-  match overloads_of name env with [] -> None | (_, e) :: _ -> Some e
+  match overloads_of name env with [ (_, e) ] -> Some e | _ -> None
 
 (** Lookup a term (rule or closure) by name AND arity. Returns exactly the
     overload whose declared arity matches. *)
@@ -268,13 +271,20 @@ let lookup_term_arity name arity env = TermMap.find_opt (name, arity) env.terms
 let lookup_var name env = StringMap.find_opt name env.vars
 
 (** Lookup for bare-atom references in value position: try variables first, then
-    fall back to term entries. Patch 1 shim: accepts any arity. Patch 3 will
-    tighten this to nullary-only to preserve Pantagruel's no-first-class-
-    functions discipline in the overload world. *)
+    fall back to term entries. A bare reference auto-applies a nullary rule, so
+    probe the arity-0 slot first; if none, return any overload so that
+    downstream arity-checking surfaces an ArityMismatch (preserving the
+    pre-overload diagnostic shape for single-arity rules and producing a similar
+    error when a user bare-references an overloaded name with no nullary
+    member). *)
 let lookup_bare name env =
   match StringMap.find_opt name env.vars with
   | Some _ as e -> e
-  | None -> lookup_term name env
+  | None -> (
+      match lookup_term_arity name 0 env with
+      | Some _ as e -> e
+      | None -> (
+          match overloads_of name env with (_, e) :: _ -> Some e | [] -> None))
 
 (** Fold over the terms namespace. Shim over the arity-keyed storage that keeps
     the old [(name -> entry -> acc -> acc)] callback signature. Each overload is
@@ -446,6 +456,16 @@ let lookup_qualified_term mod_name name env =
             | None -> None
           else None)
     env.imported_terms None
+
+(** Lookup a term by module, name, AND arity in the import index. Returns
+    exactly the overload whose declared arity matches. *)
+let lookup_qualified_term_arity mod_name name arity env =
+  match TermMap.find_opt (name, arity) env.imported_terms with
+  | Some entries -> (
+      match List.find_opt (fun (m, _) -> m = mod_name) entries with
+      | Some (_, entry) -> Some entry
+      | None -> None)
+  | None -> None
 
 (** Check if a type name is ambiguous across imports. Returns Some
     [module_names] if ambiguous, None otherwise *)

--- a/lib/env.ml
+++ b/lib/env.ml
@@ -60,8 +60,18 @@ type t = {
       (** Context declarations: context name -> member function names *)
   rule_guards : (Ast.param list * Ast.guard list) TermMap.t;
       (** Declaration guards keyed by (rule name, arity): formal params +
-          guards. Keying by arity mirrors the term namespace so per-overload
-          guards stay distinct. *)
+          guards. Holds LOCAL declarations plus any unambiguously-imported
+          guards (single-origin entries from [imported_rule_guards]). Imports
+          whose (name, arity) is exported by more than one module are excluded
+          here — they remain reachable via [lookup_qualified_rule_guards_arity].
+      *)
+  imported_rule_guards :
+    (string * (Ast.param list * Ast.guard list)) list TermMap.t;
+      (** Import index: (name, arity) -> [(module, guards)]. Mirrors
+          [imported_terms] so that two modules exporting the same
+          [(name, arity)] don't clobber each other's declaration guards.
+          Qualified guard lookup reads directly from this index; flat
+          [rule_guards] only promotes single-origin entries. *)
   action : string option;  (** Action in current chapter (for prime checking) *)
   action_contexts : string list;
       (** Active contexts for current action (for primed-in-context enforcement)
@@ -81,6 +91,7 @@ let empty module_name =
     current_module = module_name;
     contexts = StringMap.empty;
     rule_guards = TermMap.empty;
+    imported_rule_guards = TermMap.empty;
     action = None;
     action_contexts = [];
     local_vars = [];
@@ -229,6 +240,16 @@ let lookup_rule_guards name env =
 (** Lookup rule guards by [(name, arity)]. *)
 let lookup_rule_guards_arity name arity env =
   TermMap.find_opt (name, arity) env.rule_guards
+
+(** Lookup rule guards by module, name, AND arity in the import index. Returns
+    exactly the overload's guards exported by [mod_name]. *)
+let lookup_qualified_rule_guards_arity mod_name name arity env =
+  match TermMap.find_opt (name, arity) env.imported_rule_guards with
+  | Some entries -> (
+      match List.find_opt (fun (m, _) -> m = mod_name) entries with
+      | Some (_, guards) -> Some guards
+      | None -> None)
+  | None -> None
 
 (** Store declaration metadata for a rule (params + guards). Arity is derived
     from the param list. Unlike the pre-overloading version, stores the record
@@ -389,8 +410,21 @@ let add_import env other origin_module =
             else TermMap.add key ((origin_module, entry) :: existing) index)
       other_map index
   in
+  let add_to_guards_index index other_rule_guards =
+    TermMap.fold
+      (fun key guards index ->
+        let existing =
+          match TermMap.find_opt key index with Some lst -> lst | None -> []
+        in
+        if List.exists (fun (m, _) -> m = origin_module) existing then index
+        else TermMap.add key ((origin_module, guards) :: existing) index)
+      other_rule_guards index
+  in
   let imported_types = add_to_type_index env.imported_types other.types in
   let imported_terms = add_to_term_index env.imported_terms other.terms in
+  let imported_rule_guards =
+    add_to_guards_index env.imported_rule_guards other.rule_guards
+  in
   let flat_of_type_index index =
     StringMap.fold
       (fun name entries acc ->
@@ -413,24 +447,28 @@ let add_import env other origin_module =
         | _ -> acc)
       index TermMap.empty
   in
+  let flat_of_guards_index index =
+    TermMap.fold
+      (fun key entries acc ->
+        match entries with
+        | [ (_, guards) ] -> TermMap.add key guards acc
+        | _ -> acc)
+      index TermMap.empty
+  in
   let merged_contexts =
     StringMap.fold
       (fun name members acc -> StringMap.add name members acc)
       other.contexts env.contexts
   in
-  let merged_rule_guards =
-    TermMap.fold
-      (fun key guards acc -> TermMap.add key guards acc)
-      other.rule_guards env.rule_guards
-  in
   {
     env with
     imported_types;
     imported_terms;
+    imported_rule_guards;
     types = flat_of_type_index imported_types;
     terms = flat_of_term_index imported_terms;
     contexts = merged_contexts;
-    rule_guards = merged_rule_guards;
+    rule_guards = flat_of_guards_index imported_rule_guards;
   }
 
 (** Lookup a type by module and name in the import index *)

--- a/lib/env.ml
+++ b/lib/env.ml
@@ -22,30 +22,46 @@ type entry = {
 
 module StringMap = Map.Make (String)
 
+(** Arity-keyed map for the term namespace. Keyed by [(name, arity)] so rules
+    can be overloaded by arity under positional coherence. Single-arity rules
+    continue to have one entry per name. *)
+module TermKey = struct
+  type t = string * int
+
+  let compare = Stdlib.compare
+end
+
+module TermMap = Map.Make (TermKey)
+
 type t = {
   types : entry StringMap.t;  (** Type namespace: domains and aliases *)
-  terms : entry StringMap.t;
+  terms : entry TermMap.t;
       (** Term namespace: rules (KRule) and closures (KClosure) only. Variables
-          live in [vars]. Separating the two namespaces lets application heads /
-          primed / override positions resolve against [terms] without being
-          shadowed by same-named parameters — the six-of-seven syntactic
-          positions in which a lower identifier can appear are rule-only; only
-          bare-atom references are ambiguous, and those resolve through
-          [lookup_bare] with var-first-then-nullary-rule fallback. *)
+          live in [vars]. Keyed by [(name, arity)] to allow arity-overloading
+          under positional coherence. Separating the two namespaces lets
+          application heads / primed / override positions resolve against
+          [terms] without being shadowed by same-named parameters — the six-of-
+          seven syntactic positions in which a lower identifier can appear are
+          rule-only; only bare-atom references are ambiguous, and those resolve
+          through [lookup_bare] with var-first-then-nullary-rule fallback. *)
   vars : entry StringMap.t;
       (** Variable namespace: KVar only. Parameters, quantifier binders, and
           shorthand-bound values. Separated from [terms] so a param named the
           same as a same-named rule no longer overwrites the rule in lookup. *)
   imported_types : (string * entry) list StringMap.t;
       (** Import index: name -> [(module, entry)] for types *)
-  imported_terms : (string * entry) list StringMap.t;
-      (** Import index: name -> [(module, entry)] for terms (rules). Imports
-          never include variables ([add_import] filters [KVar]). *)
+  imported_terms : (string * entry) list TermMap.t;
+      (** Import index: (name, arity) -> [(module, entry)] for terms (rules).
+          Imports never include variables ([add_import] filters [KVar]). Arity-
+          keyed so module A exporting f/1 and f/2 imports cleanly; two modules
+          exporting the same (name, arity) remain an ambiguous collision. *)
   current_module : string;  (** Current module name *)
   contexts : string list StringMap.t;
       (** Context declarations: context name -> member function names *)
-  rule_guards : (Ast.param list * Ast.guard list) StringMap.t;
-      (** Declaration guards keyed by rule name: formal params + guards *)
+  rule_guards : (Ast.param list * Ast.guard list) TermMap.t;
+      (** Declaration guards keyed by (rule name, arity): formal params +
+          guards. Keying by arity mirrors the term namespace so per-overload
+          guards stay distinct. *)
   action : string option;  (** Action in current chapter (for prime checking) *)
   action_contexts : string list;
       (** Active contexts for current action (for primed-in-context enforcement)
@@ -58,13 +74,13 @@ type t = {
 let empty module_name =
   {
     types = StringMap.empty;
-    terms = StringMap.empty;
+    terms = TermMap.empty;
     vars = StringMap.empty;
     imported_types = StringMap.empty;
-    imported_terms = StringMap.empty;
+    imported_terms = TermMap.empty;
     current_module = module_name;
     contexts = StringMap.empty;
-    rule_guards = StringMap.empty;
+    rule_guards = TermMap.empty;
     action = None;
     action_contexts = [];
     local_vars = [];
@@ -78,13 +94,24 @@ let empty module_name =
 let shadow_reporter : (string -> ty -> ty -> Ast.loc -> Ast.loc -> unit) ref =
   ref (fun _ _ _ _ _ -> ())
 
+(** Extract the arity implied by a KRule / KClosure entry's type. For any
+    TyFunc, arity is the length of the param list. Non-TyFunc kinds shouldn't
+    land in [terms] but we default to 0 defensively. *)
+let entry_arity (e : entry) : int =
+  match[@warning "-4"] e.kind with
+  | KRule (TyFunc (params, _)) | KClosure (TyFunc (params, _), _) ->
+      List.length params
+  | _ -> 0
+
 (** Add a raw entry to the type namespace *)
 let add_type_entry name entry env =
   { env with types = StringMap.add name entry env.types }
 
-(** Add a raw entry to the term namespace *)
+(** Add a raw entry to the term namespace. Arity is inferred from the entry's
+    type (param list of a KRule / KClosure TyFunc). *)
 let add_term_entry name entry env =
-  { env with terms = StringMap.add name entry env.terms }
+  let arity = entry_arity entry in
+  { env with terms = TermMap.add (name, arity) entry env.terms }
 
 (** Add a domain to the type namespace *)
 let add_domain name loc ~chapter env =
@@ -100,14 +127,20 @@ let add_alias name ty loc ~chapter env =
   in
   { env with types = StringMap.add name entry env.types }
 
-(** Add a rule to the term namespace *)
+(** Compute the arity implied by a rule/closure type. *)
+let arity_of_ty (ty : ty) : int =
+  match[@warning "-4"] ty with
+  | TyFunc (params, _) -> List.length params
+  | _ -> 0
+
+(** Add a rule to the term namespace, keyed by [(name, arity)]. *)
 let add_rule name ty loc ~chapter env =
   let entry =
     { kind = KRule ty; loc; module_origin = None; decl_chapter = chapter }
   in
-  { env with terms = StringMap.add name entry env.terms }
+  { env with terms = TermMap.add (name, arity_of_ty ty) entry env.terms }
 
-(** Add a closure rule to the term namespace *)
+(** Add a closure rule to the term namespace, keyed by [(name, arity)]. *)
 let add_closure name ty target loc ~chapter env =
   let entry =
     {
@@ -117,17 +150,30 @@ let add_closure name ty target loc ~chapter env =
       decl_chapter = chapter;
     }
   in
-  { env with terms = StringMap.add name entry env.terms }
+  { env with terms = TermMap.add (name, arity_of_ty ty) entry env.terms }
+
+(** Collect every overload of [name] in the term namespace, sorted by ascending
+    arity. Returns [] when no declaration of [name] exists. *)
+let overloads_of name env =
+  TermMap.fold
+    (fun (n, arity) entry acc ->
+      if n = name then (arity, entry) :: acc else acc)
+    env.terms []
+  |> List.sort (fun (a, _) (b, _) -> compare a b)
+
+(** Whether [name] has two or more arity overloads. Used by SMT emission to
+    decide whether to mangle the output symbol with an arity suffix. *)
+let name_is_overloaded name env = List.length (overloads_of name env) >= 2
 
 (** Add a variable to the var namespace (also tracks as local var). If [name]
-    matches an existing nullary declaration in [terms] (rule or closure), fire
-    the shadow reporter so the check layer can emit a warning — nullary
-    rules/closures auto-apply in bare-atom position, so a same-named variable
-    genuinely eclipses a binding the user could otherwise reach by bare
-    reference. Non-nullary collisions are not shadowing (syntactic position
-    disambiguates) and don't warn. *)
+    matches a nullary declaration in [terms] (rule or closure), fire the shadow
+    reporter so the check layer can emit a warning — nullary rules/closures
+    auto-apply in bare-atom position, so a same-named variable genuinely
+    eclipses a binding the user could otherwise reach by bare reference. Non-
+    nullary collisions are not shadowing (syntactic position disambiguates) and
+    don't warn. *)
 let add_var name ty env =
-  (match[@warning "-4"] StringMap.find_opt name env.terms with
+  (match[@warning "-4"] TermMap.find_opt (name, 0) env.terms with
   | Some { kind = KRule (TyFunc ([], Some ret)); loc = rule_loc; _ }
   | Some { kind = KClosure (TyFunc ([], Some ret), _); loc = rule_loc; _ } ->
       !shadow_reporter name ret ty rule_loc Ast.dummy_loc
@@ -169,16 +215,30 @@ let add_rule_to_context ctx_name rule_name env =
 (** Lookup a context by name *)
 let lookup_context name env = StringMap.find_opt name env.contexts
 
-(** Lookup rule guards by name *)
-let lookup_rule_guards name env = StringMap.find_opt name env.rule_guards
+(** Lookup rule guards by name. Compatibility shim — returns the first
+    overload's guards. Arity-aware callers should use [lookup_rule_guards_arity]
+    once Patch 3/4 migrates them. *)
+let lookup_rule_guards name env =
+  TermMap.fold
+    (fun (n, _) guards acc ->
+      match acc with
+      | Some _ -> acc
+      | None -> if n = name then Some guards else None)
+    env.rule_guards None
 
-(** Store declaration guards for a rule *)
+(** Lookup rule guards by [(name, arity)]. *)
+let lookup_rule_guards_arity name arity env =
+  TermMap.find_opt (name, arity) env.rule_guards
+
+(** Store declaration guards for a rule. Arity is derived from the param list.
+*)
 let add_rule_guards name params guards env =
   if guards = [] then env
   else
+    let arity = List.length params in
     {
       env with
-      rule_guards = StringMap.add name (params, guards) env.rule_guards;
+      rule_guards = TermMap.add (name, arity) (params, guards) env.rule_guards;
     }
 
 (** Set the active action contexts *)
@@ -193,43 +253,45 @@ let in_action_context env = Option.is_some env.action
 (** Lookup a type by name *)
 let lookup_type name env = StringMap.find_opt name env.types
 
-(** Lookup a term (rule or closure) by name. Does not fall back to variables —
-    callers using this for application heads, primed references, override LHS,
-    or qualifier resolution get rule-only semantics. *)
-let lookup_term name env = StringMap.find_opt name env.terms
+(** Lookup a term (rule or closure) by name. Compatibility shim — returns the
+    first overload by ascending arity. Arity-aware callers should use
+    [lookup_term_arity] to pick a specific overload. *)
+let lookup_term name env =
+  match overloads_of name env with [] -> None | (_, e) :: _ -> Some e
+
+(** Lookup a term (rule or closure) by name AND arity. Returns exactly the
+    overload whose declared arity matches. *)
+let lookup_term_arity name arity env = TermMap.find_opt (name, arity) env.terms
 
 (** Lookup a variable by name. *)
 let lookup_var name env = StringMap.find_opt name env.vars
 
 (** Lookup for bare-atom references in value position: try variables first, then
-    fall back to nullary rules (for auto-application). This is the one syntactic
-    position where rule and var names can refer to the same lexical token;
-    variables shadow nullary rules (their entries in [vars] were added later and
-    the user presumably meant the local binding).
-
-    Non-nullary rules in this position would indicate a first-class function
-    reference; Pantagruel has no first-class functions, so this is an error
-    upstream, but we still return the rule entry so the caller can produce a
-    meaningful error rather than an unbound-variable one. *)
+    fall back to term entries. Patch 1 shim: accepts any arity. Patch 3 will
+    tighten this to nullary-only to preserve Pantagruel's no-first-class-
+    functions discipline in the overload world. *)
 let lookup_bare name env =
   match StringMap.find_opt name env.vars with
   | Some _ as e -> e
-  | None -> StringMap.find_opt name env.terms
+  | None -> lookup_term name env
 
-(** Fold over the terms namespace (rules and closures). *)
-let fold_terms f env init = StringMap.fold f env.terms init
+(** Fold over the terms namespace. Shim over the arity-keyed storage that keeps
+    the old [(name -> entry -> acc -> acc)] callback signature. Each overload is
+    visited as a separate (name, entry) pair; callers that don't know about
+    overloads will see the same name repeated. *)
+let fold_terms f env init =
+  TermMap.fold (fun (n, _) entry acc -> f n entry acc) env.terms init
 
 (** Iterate over the terms namespace (rules and closures). *)
-let iter_terms f env = StringMap.iter f env.terms
+let iter_terms f env = TermMap.iter (fun (n, _) entry -> f n entry) env.terms
 
 (** Fold over every binding in both [terms] and [vars]. Used where callers need
     the union (e.g., sort collection for SMT preamble). Fold order: [terms]
-    first, then [vars]. The two namespaces are disjoint in well-formed programs,
-    but if a name appeared in both the [vars] entry would be visited second (and
-    so could override in a last-write-wins folder). Current callers are
-    order-insensitive. *)
+    first, then [vars]. *)
 let fold_all_terms f env init =
-  let acc = StringMap.fold f env.terms init in
+  let acc =
+    TermMap.fold (fun (n, _) entry acc -> f n entry acc) env.terms init
+  in
   StringMap.fold f env.vars acc
 
 (** Fold over the types namespace *)
@@ -238,8 +300,11 @@ let fold_types f env init = StringMap.fold f env.types init
 (** Iterate over the types namespace *)
 let iter_types f env = StringMap.iter f env.types
 
-(** Get bindings of the terms namespace (rules and closures only). *)
-let bindings_terms env = StringMap.bindings env.terms
+(** Get bindings of the terms namespace. Each overload is its own (name, entry)
+    pair; single-arity rules continue to have one entry per name. *)
+let bindings_terms env =
+  TermMap.fold (fun (n, _) entry acc -> (n, entry) :: acc) env.terms []
+  |> List.rev
 
 (** Get bindings of the types namespace *)
 let bindings_types env = StringMap.bindings env.types
@@ -268,16 +333,22 @@ let with_vars vars env =
 
 (** Get all exported names (for module system). Variables are never exported —
     only rules, closures, domains, and aliases cross module boundaries — so
-    [vars] is ignored here. *)
+    [vars] is ignored here. Overloaded names appear once in the term list. *)
 let exports env =
   let type_names = StringMap.bindings env.types |> List.map fst in
-  let term_names = StringMap.bindings env.terms |> List.map fst in
+  let term_names =
+    TermMap.fold (fun (n, _) _ acc -> n :: acc) env.terms []
+    |> List.sort_uniq String.compare
+  in
   (type_names, term_names)
 
 (** Add another environment's exports to the import index, then rebuild flat
-    maps with only unambiguous imports *)
+    maps with only unambiguous imports. Term imports are keyed by
+    [(name, arity)] so overload families from a single module merge into the
+    importer's term namespace cleanly, while same-(name, arity) exports from two
+    modules remain ambiguous. *)
 let add_import env other origin_module =
-  let add_to_index index other_map =
+  let add_to_type_index index other_map =
     StringMap.fold
       (fun name entry index ->
         match entry.kind with
@@ -288,14 +359,28 @@ let add_import env other origin_module =
               | Some lst -> lst
               | None -> []
             in
-            (* Avoid adding duplicates from the same module *)
             if List.exists (fun (m, _) -> m = origin_module) existing then index
             else StringMap.add name ((origin_module, entry) :: existing) index)
       other_map index
   in
-  let imported_types = add_to_index env.imported_types other.types in
-  let imported_terms = add_to_index env.imported_terms other.terms in
-  let flat_of_index index =
+  let add_to_term_index index other_map =
+    TermMap.fold
+      (fun key entry index ->
+        match entry.kind with
+        | KVar _ -> index
+        | KDomain | KAlias _ | KRule _ | KClosure _ ->
+            let existing =
+              match TermMap.find_opt key index with
+              | Some lst -> lst
+              | None -> []
+            in
+            if List.exists (fun (m, _) -> m = origin_module) existing then index
+            else TermMap.add key ((origin_module, entry) :: existing) index)
+      other_map index
+  in
+  let imported_types = add_to_type_index env.imported_types other.types in
+  let imported_terms = add_to_term_index env.imported_terms other.terms in
+  let flat_of_type_index index =
     StringMap.fold
       (fun name entries acc ->
         match entries with
@@ -306,24 +391,33 @@ let add_import env other origin_module =
         | _ -> acc)
       index StringMap.empty
   in
-  (* Merge contexts from imported module *)
+  let flat_of_term_index index =
+    TermMap.fold
+      (fun key entries acc ->
+        match entries with
+        | [ (origin, entry) ] ->
+            TermMap.add key
+              { entry with module_origin = Some origin; decl_chapter = -1 }
+              acc
+        | _ -> acc)
+      index TermMap.empty
+  in
   let merged_contexts =
     StringMap.fold
       (fun name members acc -> StringMap.add name members acc)
       other.contexts env.contexts
   in
-  (* Merge rule guards from imported module *)
   let merged_rule_guards =
-    StringMap.fold
-      (fun name guards acc -> StringMap.add name guards acc)
+    TermMap.fold
+      (fun key guards acc -> TermMap.add key guards acc)
       other.rule_guards env.rule_guards
   in
   {
     env with
     imported_types;
     imported_terms;
-    types = flat_of_index imported_types;
-    terms = flat_of_index imported_terms;
+    types = flat_of_type_index imported_types;
+    terms = flat_of_term_index imported_terms;
     contexts = merged_contexts;
     rule_guards = merged_rule_guards;
   }
@@ -337,14 +431,20 @@ let lookup_qualified_type mod_name name env =
       | None -> None)
   | None -> None
 
-(** Lookup a term by module and name in the import index *)
+(** Lookup a term by module and name in the import index. Compatibility shim —
+    returns the first overload of [name] exported by [mod_name]. *)
 let lookup_qualified_term mod_name name env =
-  match StringMap.find_opt name env.imported_terms with
-  | Some entries -> (
-      match List.find_opt (fun (m, _) -> m = mod_name) entries with
-      | Some (_, entry) -> Some entry
-      | None -> None)
-  | None -> None
+  TermMap.fold
+    (fun (n, _) entries acc ->
+      match acc with
+      | Some _ -> acc
+      | None ->
+          if n = name then
+            match List.find_opt (fun (m, _) -> m = mod_name) entries with
+            | Some (_, entry) -> Some entry
+            | None -> None
+          else None)
+    env.imported_terms None
 
 (** Check if a type name is ambiguous across imports. Returns Some
     [module_names] if ambiguous, None otherwise *)
@@ -354,36 +454,48 @@ let ambiguous_type_modules name env =
   | _ -> None
 
 (** Check if a term name is ambiguous across imports. Returns Some
-    [module_names] if ambiguous, None otherwise *)
+    [module_names] if ambiguous, None otherwise. With arity-keyed imports, a
+    name is ambiguous when *any* arity overload is declared in multiple modules
+    — collected across arities and deduplicated. *)
 let ambiguous_term_modules name env =
-  match StringMap.find_opt name env.imported_terms with
-  | Some entries when List.length entries > 1 -> Some (List.map fst entries)
-  | _ -> None
+  let all_entries =
+    TermMap.fold
+      (fun (n, _) entries acc -> if n = name then entries @ acc else acc)
+      env.imported_terms []
+  in
+  let modules = List.map fst all_entries |> List.sort_uniq String.compare in
+  if List.length modules > 1 then Some modules else None
 
 (** Filter environment for visibility in a chapter head. Declaration in chapter
     N is visible in heads of chapters M >= N. Imports (decl_chapter = -1) are
     always visible. *)
 let visible_in_head chapter_idx env =
-  let filter_map m =
+  let filter_string_map m =
     StringMap.filter (fun _ entry -> entry.decl_chapter <= chapter_idx) m
+  in
+  let filter_term_map m =
+    TermMap.filter (fun _ entry -> entry.decl_chapter <= chapter_idx) m
   in
   {
     env with
-    types = filter_map env.types;
-    terms = filter_map env.terms;
-    vars = filter_map env.vars;
+    types = filter_string_map env.types;
+    terms = filter_term_map env.terms;
+    vars = filter_string_map env.vars;
   }
 
 (** Filter environment for visibility in a chapter body. Declaration in chapter
     N is visible in bodies of chapters M >= N-1. Imports (decl_chapter = -1) are
     always visible. *)
 let visible_in_body chapter_idx env =
-  let filter_map m =
+  let filter_string_map m =
     StringMap.filter (fun _ entry -> entry.decl_chapter <= chapter_idx + 1) m
+  in
+  let filter_term_map m =
+    TermMap.filter (fun _ entry -> entry.decl_chapter <= chapter_idx + 1) m
   in
   {
     env with
-    types = filter_map env.types;
-    terms = filter_map env.terms;
-    vars = filter_map env.vars;
+    types = filter_string_map env.types;
+    terms = filter_term_map env.terms;
+    vars = filter_string_map env.vars;
   }

--- a/lib/env.ml
+++ b/lib/env.ml
@@ -317,6 +317,18 @@ let fold_terms f env init =
 (** Iterate over the terms namespace (rules and closures). *)
 let iter_terms f env = TermMap.iter (fun (n, _) entry -> f n entry) env.terms
 
+(** Fold over every [(module, name, arity, entry)] pairing in the imported-
+    terms index. Iterates entries that came from more than one module as
+    separate pairings, exposing full provenance for callers that need
+    module-qualified SMT emission. *)
+let fold_imported_terms f env init =
+  TermMap.fold
+    (fun (name, arity) entries acc ->
+      List.fold_left
+        (fun acc (origin, entry) -> f origin name arity entry acc)
+        acc entries)
+    env.imported_terms init
+
 (** Fold over every binding in both [terms] and [vars]. Used where callers need
     the union (e.g., sort collection for SMT preamble). Fold order: [terms]
     first, then [vars]. *)
@@ -513,17 +525,21 @@ let ambiguous_type_modules name env =
   | _ -> None
 
 (** Check if a term name is ambiguous across imports. Returns Some
-    [module_names] if ambiguous, None otherwise. With arity-keyed imports, a
-    name is ambiguous when *any* arity overload is declared in multiple modules
-    — collected across arities and deduplicated. *)
+    [module_names] if ambiguous, None otherwise. A name is ambiguous only when
+    at least one [(name, arity)] bucket is exported by more than one module;
+    disjoint-arity imports (A::f/1 + B::f/2) remain unambiguous because arity
+    syntactically disambiguates the call site. *)
 let ambiguous_term_modules name env =
-  let all_entries =
+  let modules =
     TermMap.fold
-      (fun (n, _) entries acc -> if n = name then entries @ acc else acc)
+      (fun (n, _) entries acc ->
+        if n = name && List.length entries > 1 then
+          List.rev_append (List.map fst entries) acc
+        else acc)
       env.imported_terms []
+    |> List.sort_uniq String.compare
   in
-  let modules = List.map fst all_entries |> List.sort_uniq String.compare in
-  if List.length modules > 1 then Some modules else None
+  match modules with [] -> None | _ -> Some modules
 
 (** Filter environment for visibility in a chapter head. Declaration in chapter
     N is visible in heads of chapters M >= N. Imports (decl_chapter = -1) are

--- a/lib/env.ml
+++ b/lib/env.ml
@@ -230,16 +230,17 @@ let lookup_rule_guards name env =
 let lookup_rule_guards_arity name arity env =
   TermMap.find_opt (name, arity) env.rule_guards
 
-(** Store declaration guards for a rule. Arity is derived from the param list.
-*)
+(** Store declaration metadata for a rule (params + guards). Arity is derived
+    from the param list. Unlike the pre-overloading version, stores the record
+    even when [guards] is empty, so that coherence checks on subsequent arity
+    overloads can recover the shared-position parameter names from the env
+    without a parallel storage mechanism. *)
 let add_rule_guards name params guards env =
-  if guards = [] then env
-  else
-    let arity = List.length params in
-    {
-      env with
-      rule_guards = TermMap.add (name, arity) (params, guards) env.rule_guards;
-    }
+  let arity = List.length params in
+  {
+    env with
+    rule_guards = TermMap.add (name, arity) (params, guards) env.rule_guards;
+  }
 
 (** Set the active action contexts *)
 let with_action_contexts ctxs env = { env with action_contexts = ctxs }

--- a/lib/env.mli
+++ b/lib/env.mli
@@ -89,6 +89,12 @@ val lookup_bare : string -> t -> entry option
 val fold_terms : (string -> entry -> 'a -> 'a) -> t -> 'a -> 'a
 val iter_terms : (string -> entry -> unit) -> t -> unit
 
+val fold_imported_terms :
+  (string -> string -> int -> entry -> 'a -> 'a) -> t -> 'a -> 'a
+(** Fold over every [(module, name, arity, entry)] pairing in the imported-
+    terms index. Entries exported by more than one module are visited once per
+    module so callers can emit module-qualified SMT declarations. *)
+
 val fold_all_terms : (string -> entry -> 'a -> 'a) -> t -> 'a -> 'a
 (** Fold over both rules/closures ([terms]) and variables ([vars]). *)
 

--- a/lib/env.mli
+++ b/lib/env.mli
@@ -49,6 +49,12 @@ val lookup_rule_guards_arity :
   string -> int -> t -> (Ast.param list * Ast.guard list) option
 (** Arity-aware rule-guard lookup. *)
 
+val lookup_qualified_rule_guards_arity :
+  string -> string -> int -> t -> (Ast.param list * Ast.guard list) option
+(** Arity-aware qualified rule-guard lookup: returns exactly the overload's
+    guards exported by [mod_name]. Used by SMT guard injection so that imported
+    overloads don't collide when two modules export the same [(name, arity)]. *)
+
 val add_rule_guards : string -> Ast.param list -> Ast.guard list -> t -> t
 val with_action_contexts : string list -> t -> t
 val is_local_var : string -> t -> bool

--- a/lib/env.mli
+++ b/lib/env.mli
@@ -56,7 +56,9 @@ val in_action_context : t -> bool
 val lookup_type : string -> t -> entry option
 
 val lookup_term : string -> t -> entry option
-(** Compatibility shim — returns the first overload (ascending arity). *)
+(** Returns [Some entry] only when [name] has exactly one overload. Callers that
+    need a specific arity in the presence of multiple overloads must use
+    [lookup_term_arity]. *)
 
 val lookup_term_arity : string -> int -> t -> entry option
 (** Arity-aware term lookup: returns exactly the overload whose declared arity
@@ -107,6 +109,11 @@ val exports : t -> string list * string list
 val add_import : t -> t -> string -> t
 val lookup_qualified_type : string -> string -> t -> entry option
 val lookup_qualified_term : string -> string -> t -> entry option
+
+val lookup_qualified_term_arity : string -> string -> int -> t -> entry option
+(** Arity-aware qualified term lookup: returns exactly the overload whose
+    declared arity matches, among [mod_name]'s exports of [name]. *)
+
 val ambiguous_type_modules : string -> t -> string list option
 val ambiguous_term_modules : string -> t -> string list option
 val visible_in_head : int -> t -> t

--- a/lib/env.mli
+++ b/lib/env.mli
@@ -19,6 +19,10 @@ type entry = {
 
 module StringMap : Map.S with type key = string
 
+module TermMap : Map.S with type key = string * int
+(** Arity-keyed map for the term namespace. Keyed by [(name, arity)] so rules
+    can be overloaded by arity under positional coherence. *)
+
 type t
 
 val empty : string -> t
@@ -37,7 +41,14 @@ val clear_action : t -> t
 val add_context : string -> string list -> t -> t
 val add_rule_to_context : string -> string -> t -> t
 val lookup_context : string -> t -> string list option
+
 val lookup_rule_guards : string -> t -> (Ast.param list * Ast.guard list) option
+(** Compatibility shim — returns the first overload's guards. *)
+
+val lookup_rule_guards_arity :
+  string -> int -> t -> (Ast.param list * Ast.guard list) option
+(** Arity-aware rule-guard lookup. *)
+
 val add_rule_guards : string -> Ast.param list -> Ast.guard list -> t -> t
 val with_action_contexts : string list -> t -> t
 val is_local_var : string -> t -> bool
@@ -45,14 +56,27 @@ val in_action_context : t -> bool
 val lookup_type : string -> t -> entry option
 
 val lookup_term : string -> t -> entry option
-(** Lookup a rule or closure (no variable fallback). *)
+(** Compatibility shim — returns the first overload (ascending arity). *)
+
+val lookup_term_arity : string -> int -> t -> entry option
+(** Arity-aware term lookup: returns exactly the overload whose declared arity
+    matches. *)
+
+val overloads_of : string -> t -> (int * entry) list
+(** Every overload of [name] sorted by ascending arity. [] when no declaration
+    exists. *)
+
+val name_is_overloaded : string -> t -> bool
+(** True iff [name] has two or more arity overloads. Used to decide whether the
+    SMT emitter mangles the output symbol with an arity suffix. *)
 
 val lookup_var : string -> t -> entry option
 (** Lookup a variable only. *)
 
 val lookup_bare : string -> t -> entry option
 (** Bare-atom (value-position) lookup: variables first, then rules. The one site
-    where rule and variable namespaces may legitimately collide. *)
+    where rule and variable namespaces may legitimately collide. Patch 1 shim
+    returns any arity; Patch 3 tightens to nullary-only. *)
 
 val fold_terms : (string -> entry -> 'a -> 'a) -> t -> 'a -> 'a
 val iter_terms : (string -> entry -> unit) -> t -> unit

--- a/lib/error.ml
+++ b/lib/error.ml
@@ -148,7 +148,7 @@ let format_collect_error err =
                 at %s uses '%s: %s', this declaration uses '%s: %s'. \
                 Arity-overloaded rules must share parameter names and types at \
                 every shared position."
-               name i (format_loc first_loc) first_name
+               name (i + 1) (format_loc first_loc) first_name
                (Types.format_ty first_ty) second_name
                (Types.format_ty second_ty)))
 

--- a/lib/error.ml
+++ b/lib/error.ml
@@ -128,6 +128,29 @@ let format_collect_error err =
       fmt loc (Printf.sprintf "Undefined context '%s'" name)
   | ClosureTargetInvalid (name, reason, loc) ->
       fmt loc (Printf.sprintf "Invalid closure '%s': %s" name reason)
+  | OverloadCoherenceViolation { name; position; first; second } -> (
+      let _, first_ty, first_loc = first in
+      let _, second_ty, second_loc = second in
+      match position with
+      | Return ->
+          fmt second_loc
+            (Printf.sprintf
+               "Overloads of '%s' disagree on return type: expected %s (from \
+                earlier declaration at %s), got %s"
+               name (Types.format_ty first_ty) (format_loc first_loc)
+               (Types.format_ty second_ty))
+      | Param i ->
+          let first_name, _, _ = first in
+          let second_name, _, _ = second in
+          fmt second_loc
+            (Printf.sprintf
+               "Overloads of '%s' disagree at position %d: earlier declaration \
+                at %s uses '%s: %s', this declaration uses '%s: %s'. \
+                Arity-overloaded rules must share parameter names and types at \
+                every shared position."
+               name i (format_loc first_loc) first_name
+               (Types.format_ty first_ty) second_name
+               (Types.format_ty second_ty)))
 
 (** Format a type warning with location prefix *)
 let format_type_warning err =

--- a/lib/json_output.ml
+++ b/lib/json_output.ml
@@ -249,9 +249,10 @@ let decl_to_json env (decl_loc : declaration located) =
         @ match resolved with Some t -> [ ("resolved", t) ] | None -> [])
   | DeclRule { name; params; guards; return_type; contexts } ->
       let name = Ast.lower_name name in
-      (* Look up resolved type from environment *)
+      (* Look up resolved type for the specific overload whose arity matches
+         this declaration's param count. *)
       let resolved =
-        match Env.lookup_term name env with
+        match Env.lookup_term_arity name (List.length params) env with
         | Some { kind = Env.KRule ty; _ } -> Some (ty_to_json ty)
         | Some
             {
@@ -307,8 +308,9 @@ let decl_to_json env (decl_loc : declaration located) =
           ])
   | DeclClosure { name; param; return_type; target } ->
       let name = Ast.lower_name name in
+      (* Closures are structurally arity-1. *)
       let resolved =
-        match Env.lookup_term name env with
+        match Env.lookup_term_arity name 1 env with
         | Some { kind = Env.KClosure (ty, _); _ } -> Some (ty_to_json ty)
         | Some
             { kind = Env.KDomain | Env.KAlias _ | Env.KRule _ | Env.KVar _; _ }
@@ -384,7 +386,10 @@ let types_to_json env =
   in
   `Assoc items
 
-(** Extract rule definitions from environment *)
+(** Extract rule definitions from environment. When a name has two or more arity
+    overloads, each overload's JSON key is mangled with "/N" (e.g. "foo/2") to
+    avoid Assoc key collisions. Single-arity rules keep their bare name so
+    non-overloaded fixtures emit byte-identical JSON. *)
 let rules_to_json env =
   let bindings = Env.bindings_terms env in
   let items =
@@ -394,8 +399,13 @@ let rules_to_json env =
         | Env.KRule ty | Env.KClosure (ty, _) -> (
             match ty with
             | Types.TyFunc (params, ret) ->
+                let key =
+                  if Env.name_is_overloaded name env then
+                    Printf.sprintf "%s/%d" name (List.length params)
+                  else name
+                in
                 Some
-                  ( name,
+                  ( key,
                     `Assoc
                       [
                         ("params", `List (List.map ty_to_json params));

--- a/lib/smt.ml
+++ b/lib/smt.ml
@@ -141,7 +141,18 @@ let rec translate_expr config env (e : expr) =
   | ELitNat n -> string_of_int n
   | ELitReal f -> Printf.sprintf "%.17g" f
   | ELitString s -> Printf.sprintf "\"%s\"" (String.escaped s)
-  | EVar (Lower name) -> sanitize_ident name
+  | EVar (Lower name) -> (
+      match(* Bare-atom reference: either a variable / parameter, or a nullary
+         rule auto-applied. Route variables through sanitize_ident (they
+         live in a separate namespace and are never arity-overloaded);
+         route rules through smt_rule_name so an overloaded nullary rule
+         gets its arity-0 mangled form. *)
+           [@warning "-4"]
+        Env.lookup_bare name env
+      with
+      | Some { kind = Env.KRule _ | Env.KClosure _; _ } ->
+          smt_rule_name env name 0
+      | _ -> sanitize_ident name)
   | EDomain (Upper name) ->
       (* Domain as a set value shouldn't appear standalone — OpIn, OpSubset,
          and OpCard all handle EDomain specially. If we reach here, it's an
@@ -150,7 +161,10 @@ let rec translate_expr config env (e : expr) =
         (Printf.sprintf
            "SMT translation: EDomain '%s' appeared in standalone position" name)
   | EQualified (_, name) -> sanitize_ident name
-  | EPrimed (Lower name) -> sanitize_ident name ^ "_prime"
+  | EPrimed (Lower name) ->
+      (* Bare primed reference: always a nullary rule (arity 0) in action
+         context. Mangle via smt_rule_name when the name is overloaded. *)
+      smt_rule_name env name 0 ^ "_prime"
   | EApp (func, args) -> translate_app config env func args
   | ETuple exprs ->
       let ts = List.map (translate_expr config env) exprs in
@@ -238,7 +252,7 @@ and translate_app config env func args =
              compared componentwise against the args, yielding a conjunctive
              guard — McCarthy's [store] extended to multi-index arrays
              (Kroening & Strichman Ch. 7). *)
-          let sname = sanitize_ident name in
+          let sname = smt_rule_name env name (List.length args) in
           let args_str = List.map (translate_expr config env) args in
           let applied_args = String.concat " " args_str in
           (match args_str with
@@ -281,10 +295,11 @@ and translate_app config env func args =
           in
           build_chain pairs
       | _ ->
+          let arity = List.length args in
           let func_str =
             match[@warning "-4"] func with
-            | EVar (Lower name) -> sanitize_ident name
-            | EPrimed (Lower name) -> sanitize_ident name ^ "_prime"
+            | EVar (Lower name) -> smt_rule_name env name arity
+            | EPrimed (Lower name) -> smt_rule_name env name arity ^ "_prime"
             | _ -> translate_expr config env func
           in
           let args_str = List.map (translate_expr config env) args in
@@ -1332,10 +1347,12 @@ let build_invariant_value_terms config env =
     (fun name entry acc ->
       match entry.Env.kind with
       | Env.KRule ty | Env.KClosure (ty, _) -> (
-          let sname = sanitize_ident name in
           match[@warning "-4"] decompose_func_ty ty with
-          | Some ([], _ret) -> sname :: acc
+          | Some ([], _ret) ->
+              let sname = smt_rule_name env name 0 in
+              sname :: acc
           | Some ([ param_ty ], _ret) -> (
+              let sname = smt_rule_name env name 1 in
               match param_ty with
               | TyDomain dname ->
                   let elems = domain_elements dname (bound_for config dname) in
@@ -1462,14 +1479,19 @@ let generate_init_invariant_query config env init_props ~index
     assertion_names = [];
   }
 
-(** Collect all rule names from env that should be renamed for BMC steps *)
+(** Collect all rule-symbol names from env that should be renamed for BMC steps.
+    Each arity overload contributes its mangled name so the BMC renamer
+    substitutes step-indexed copies consistently with the preamble emission. *)
 let collect_rule_names env =
   Env.fold_terms
     (fun name entry acc ->
       match entry.Env.kind with
       | Env.KRule ty | Env.KClosure (ty, _) -> (
-          let sname = sanitize_ident name in
-          match decompose_func_ty ty with Some _ -> sname :: acc | None -> acc)
+          match decompose_func_ty ty with
+          | Some (params, _ret) ->
+              let sname = smt_rule_name env name (List.length params) in
+              sname :: acc
+          | None -> acc)
       | Env.KDomain | Env.KAlias _ | Env.KVar _ -> acc)
     env []
 
@@ -1503,15 +1525,16 @@ let declare_step_functions config env steps =
     (fun name entry ->
       match entry.Env.kind with
       | Env.KRule ty | Env.KClosure (ty, _) -> (
-          let sname = sanitize_ident name in
           match decompose_func_ty ty with
           | Some ([], ret) ->
+              let sname = smt_rule_name env name 0 in
               for i = 0 to steps do
                 Buffer.add_string buf
                   (Printf.sprintf "(declare-const %s_s%d %s)\n" sname i
                      (sort_of_ty ret))
               done
           | Some (params, ret) ->
+              let sname = smt_rule_name env name (List.length params) in
               let param_sorts =
                 String.concat " " (List.map sort_of_ty params)
               in
@@ -1977,17 +2000,23 @@ let build_cond_value_terms config env cond =
   in
   List.concat_map
     (fun name ->
-      match[@warning "-4"] Env.lookup_term name env with
-      | Some { kind = Env.KRule ty; _ }
-      | Some { kind = Env.KClosure (ty, _); _ } -> (
-          let sname = sanitize_ident name in
-          match[@warning "-4"] decompose_func_ty ty with
-          | Some ([], _) -> [ sname ]
-          | Some ([ TyDomain dname ], _) when List.mem dname quant_domains ->
-              let elems = domain_elements dname (bound_for config dname) in
-              List.map (fun e -> Printf.sprintf "(%s %s)" sname e) elems
+      (* Iterate every arity overload of this name so conditional exhaustiveness
+         queries cover the full family. Each overload gets its (possibly
+         mangled) SMT symbol from smt_rule_name. *)
+      List.concat_map
+        (fun (arity, (entry : Env.entry)) ->
+          match[@warning "-4"] entry.Env.kind with
+          | Env.KRule ty | Env.KClosure (ty, _) -> (
+              let sname = smt_rule_name env name arity in
+              match[@warning "-4"] decompose_func_ty ty with
+              | Some ([], _) -> [ sname ]
+              | Some ([ TyDomain dname ], _) when List.mem dname quant_domains
+                ->
+                  let elems = domain_elements dname (bound_for config dname) in
+                  List.map (fun e -> Printf.sprintf "(%s %s)" sname e) elems
+              | _ -> [])
           | _ -> [])
-      | _ -> [])
+        (Env.overloads_of name env))
     refs
 
 (** Generate exhaustiveness query for a single cond expression *)

--- a/lib/smt.ml
+++ b/lib/smt.ml
@@ -28,9 +28,12 @@ include Smt_expr
 let alpha_rename_binders env (params : Ast.param list) (guards : Ast.guard list)
     (body : Ast.expr) : Ast.param list * Ast.guard list * Ast.expr =
   let is_rule_name name =
-    match[@warning "-4"] Env.lookup_term name env with
-    | Some { kind = Env.KRule _ | Env.KClosure _; _ } -> true
-    | _ -> false
+    List.exists
+      (fun (_, (e : Env.entry)) ->
+        match[@warning "-4"] e.kind with
+        | Env.KRule _ | Env.KClosure _ -> true
+        | _ -> false)
+      (Env.overloads_of name env)
   in
   let binder_names =
     let from_params =
@@ -160,7 +163,11 @@ let rec translate_expr config env (e : expr) =
       failwith
         (Printf.sprintf
            "SMT translation: EDomain '%s' appeared in standalone position" name)
-  | EQualified (_, name) -> sanitize_ident name
+  | EQualified (_, name) ->
+      (* Bare qualified reference is always a nullary rule/domain auto-apply.
+         Mangle via smt_rule_name when the name is overloaded so it matches
+         the corresponding declaration in the SMT preamble. *)
+      smt_rule_name env name 0
   | EPrimed (Lower name) ->
       (* Bare primed reference: always a nullary rule (arity 0) in action
          context. Mangle via smt_rule_name when the name is overloaded. *)
@@ -300,6 +307,7 @@ and translate_app config env func args =
             match[@warning "-4"] func with
             | EVar (Lower name) -> smt_rule_name env name arity
             | EPrimed (Lower name) -> smt_rule_name env name arity ^ "_prime"
+            | EQualified (_, name) -> smt_rule_name env name arity
             | _ -> translate_expr config env func
           in
           let args_str = List.map (translate_expr config env) args in

--- a/lib/smt.ml
+++ b/lib/smt.ml
@@ -1061,12 +1061,15 @@ let build_value_terms config env (params : param list) =
       (fun name entry acc ->
         match entry.Env.kind with
         | Env.KRule ty | Env.KClosure (ty, _) -> (
-            let sname = sanitize_ident name in
             match[@warning "-4"] decompose_func_ty ty with
             | Some ([], _ret) ->
-                (* Nullary rule: include current and primed *)
+                (* Nullary rule: include current and primed. Route through
+                   smt_rule_name so overloaded rules query the same
+                   arity-mangled symbol the preamble declared. *)
+                let sname = smt_rule_name env name 0 in
                 sname :: (sname ^ "_prime") :: acc
             | Some ([ param_ty ], _ret) ->
+                let sname = smt_rule_name env name 1 in
                 (* Unary rule: apply to each matching param *)
                 let from_params =
                   List.filter_map

--- a/lib/smt.ml
+++ b/lib/smt.ml
@@ -163,11 +163,14 @@ let rec translate_expr config env (e : expr) =
       failwith
         (Printf.sprintf
            "SMT translation: EDomain '%s' appeared in standalone position" name)
-  | EQualified (_, name) ->
+  | EQualified (Upper mod_name, name) ->
       (* Bare qualified reference is always a nullary rule/domain auto-apply.
-         Mangle via smt_rule_name when the name is overloaded so it matches
-         the corresponding declaration in the SMT preamble. *)
-      smt_rule_name env name 0
+         Route through [smt_qualified_rule_name] so unambiguous imports share
+         the unqualified symbol emitted by [declare_functions], while
+         same-(name, arity) imports from two modules get distinct module-
+         prefixed symbols (matching the qualified declarations in the
+         preamble). *)
+      smt_qualified_rule_name env mod_name name 0
   | EPrimed (Lower name) ->
       (* Bare primed reference: always a nullary rule (arity 0) in action
          context. Mangle via smt_rule_name when the name is overloaded. *)
@@ -307,7 +310,8 @@ and translate_app config env func args =
             match[@warning "-4"] func with
             | EVar (Lower name) -> smt_rule_name env name arity
             | EPrimed (Lower name) -> smt_rule_name env name arity ^ "_prime"
-            | EQualified (_, name) -> smt_rule_name env name arity
+            | EQualified (Upper mod_name, name) ->
+                smt_qualified_rule_name env mod_name name arity
             | _ -> translate_expr config env func
           in
           let args_str = List.map (translate_expr config env) args in

--- a/lib/smt_doc.ml
+++ b/lib/smt_doc.ml
@@ -303,11 +303,12 @@ let collect_frame_exprs _config env contexts =
         (fun name entry acc ->
           match entry.Env.kind with
           | Env.KRule ty when not (List.mem name all_members) -> (
-              let sname = sanitize_ident name in
               match decompose_func_ty ty with
               | Some ([], _ret) ->
+                  let sname = smt_rule_name env name 0 in
                   (name, Printf.sprintf "(= %s_prime %s)" sname sname) :: acc
               | Some (params, _ret) ->
+                  let sname = smt_rule_name env name (List.length params) in
                   let param_sorts = List.map sort_of_ty params in
                   let param_names =
                     List.mapi (fun i _ -> Printf.sprintf "frame_x_%d" i) params

--- a/lib/smt_expr.ml
+++ b/lib/smt_expr.ml
@@ -405,9 +405,21 @@ let collect_body_guards ?(bound = []) env (e : expr) : expr list =
             List.combine formal_names args
           else []
         in
+        let n_args = List.length args in
+        (* Guard lookup falls back to arity-0 when arity-n_args has no
+           guards — this handles list-search on a guarded nullary list-
+           returning rule (e.g. [colors red]: colors is arity-0 but the
+           application has 1 arg; its declaration guards live under the
+           nullary key). subst_for already zeros out the substitution
+           when formal_params and args lengths disagree. *)
+        let lookup_guards name =
+          match Env.lookup_rule_guards_arity name n_args env with
+          | Some _ as r -> r
+          | None -> Env.lookup_rule_guards_arity name 0 env
+        in
         (match[@warning "-4"] func with
         | EVar (Lower name) -> (
-            match Env.lookup_rule_guards name env with
+            match lookup_guards name with
             | Some (formal_params, rule_guards) ->
                 let subst = subst_for formal_params in
                 List.iter
@@ -422,7 +434,7 @@ let collect_body_guards ?(bound = []) env (e : expr) : expr list =
             | None -> ())
         | EPrimed (Lower name) -> (
             (* Primed application: collect guards in primed form *)
-            match Env.lookup_rule_guards name env with
+            match lookup_guards name with
             | Some (formal_params, rule_guards) ->
                 let subst = subst_for formal_params in
                 List.iter
@@ -440,10 +452,10 @@ let collect_body_guards ?(bound = []) env (e : expr) : expr list =
     | EVar (Lower name) -> (
         match(* Nullary auto-applied rule with guards *)
              [@warning "-4"]
-          Env.lookup_term name env
+          Env.lookup_term_arity name 0 env
         with
         | Some { kind = Env.KRule (TyFunc ([], Some _)); _ } -> (
-            match Env.lookup_rule_guards name env with
+            match Env.lookup_rule_guards_arity name 0 env with
             | Some (_, rule_guards) ->
                 List.iter
                   (fun (g : guard) ->
@@ -456,10 +468,10 @@ let collect_body_guards ?(bound = []) env (e : expr) : expr list =
     | EPrimed (Lower name) -> (
         match(* Nullary auto-applied primed rule with guards *)
              [@warning "-4"]
-          Env.lookup_term name env
+          Env.lookup_term_arity name 0 env
         with
         | Some { kind = Env.KRule (TyFunc ([], Some _)); _ } -> (
-            match Env.lookup_rule_guards name env with
+            match Env.lookup_rule_guards_arity name 0 env with
             | Some (_, rule_guards) ->
                 List.iter
                   (fun (g : guard) ->

--- a/lib/smt_preamble.ml
+++ b/lib/smt_preamble.ml
@@ -144,35 +144,56 @@ let decompose_func_ty = function
   | TyList _ | TyProduct _ | TySum _ ->
       None
 
-(** Generate function declarations from the environment *)
+(** Generate function declarations from the environment. Declares every flat
+    terms entry (locals and unambiguous imports) under its [smt_rule_name], then
+    declares every qualified-only entry (same-(name, arity) imported from
+    multiple modules) under its [smt_qualified_rule_name] so the SMT side has a
+    distinct symbol per module and [EQualified] translation always resolves to
+    something declared. *)
 let declare_functions env =
   let buf = Buffer.create 256 in
+  let emit_rule sname ty =
+    match decompose_func_ty ty with
+    | Some ([], ret) ->
+        Buffer.add_string buf
+          (Printf.sprintf "(declare-const %s %s)\n" sname (sort_of_ty ret));
+        Buffer.add_string buf
+          (Printf.sprintf "(declare-const %s_prime %s)\n" sname (sort_of_ty ret))
+    | Some (params, ret) ->
+        let param_sorts = String.concat " " (List.map sort_of_ty params) in
+        Buffer.add_string buf
+          (Printf.sprintf "(declare-fun %s (%s) %s)\n" sname param_sorts
+             (sort_of_ty ret));
+        Buffer.add_string buf
+          (Printf.sprintf "(declare-fun %s_prime (%s) %s)\n" sname param_sorts
+             (sort_of_ty ret))
+    | None -> ()
+  in
   Env.iter_terms
     (fun name entry ->
       match entry.Env.kind with
-      | Env.KRule ty | Env.KClosure (ty, _) -> (
-          match decompose_func_ty ty with
-          | Some ([], ret) ->
-              let sname = smt_rule_name env name 0 in
-              Buffer.add_string buf
-                (Printf.sprintf "(declare-const %s %s)\n" sname (sort_of_ty ret));
-              Buffer.add_string buf
-                (Printf.sprintf "(declare-const %s_prime %s)\n" sname
-                   (sort_of_ty ret))
-          | Some (params, ret) ->
-              let sname = smt_rule_name env name (List.length params) in
-              let param_sorts =
-                String.concat " " (List.map sort_of_ty params)
-              in
-              Buffer.add_string buf
-                (Printf.sprintf "(declare-fun %s (%s) %s)\n" sname param_sorts
-                   (sort_of_ty ret));
-              Buffer.add_string buf
-                (Printf.sprintf "(declare-fun %s_prime (%s) %s)\n" sname
-                   param_sorts (sort_of_ty ret))
-          | None -> ())
+      | Env.KRule ty | Env.KClosure (ty, _) ->
+          let arity =
+            match decompose_func_ty ty with
+            | Some (params, _) -> List.length params
+            | None -> 0
+          in
+          emit_rule (smt_rule_name env name arity) ty
       | Env.KDomain | Env.KAlias _ | Env.KVar _ -> ())
     env;
+  (* Emit declarations for qualified-only imports. When a (name, arity) is in
+     the flat terms map [iter_terms] already declared it; skip those to avoid
+     a duplicate. Otherwise declare one symbol per module that exports it. *)
+  Env.fold_imported_terms
+    (fun mod_name name arity (entry : Env.entry) () ->
+      match Env.lookup_term_arity name arity env with
+      | Some _ -> ()
+      | None -> (
+          match entry.Env.kind with
+          | Env.KRule ty | Env.KClosure (ty, _) ->
+              emit_rule (smt_qualified_rule_name env mod_name name arity) ty
+          | Env.KDomain | Env.KAlias _ | Env.KVar _ -> ()))
+    env ();
   Buffer.contents buf
 
 (** Generate closure axioms for a single closure rule. Produces finite-unrolling

--- a/lib/smt_preamble.ml
+++ b/lib/smt_preamble.ml
@@ -151,15 +151,16 @@ let declare_functions env =
     (fun name entry ->
       match entry.Env.kind with
       | Env.KRule ty | Env.KClosure (ty, _) -> (
-          let sname = sanitize_ident name in
           match decompose_func_ty ty with
           | Some ([], ret) ->
+              let sname = smt_rule_name env name 0 in
               Buffer.add_string buf
                 (Printf.sprintf "(declare-const %s %s)\n" sname (sort_of_ty ret));
               Buffer.add_string buf
                 (Printf.sprintf "(declare-const %s_prime %s)\n" sname
                    (sort_of_ty ret))
           | Some (params, ret) ->
+              let sname = smt_rule_name env name (List.length params) in
               let param_sorts =
                 String.concat " " (List.map sort_of_ty params)
               in
@@ -180,10 +181,17 @@ let declare_functions env =
 let generate_closure_axiom config env ~is_prime closure_name target_name
     domain_name =
   let bound = bound_for config domain_name in
-  let cname = sanitize_ident closure_name ^ if is_prime then "_prime" else "" in
-  let tname = sanitize_ident target_name ^ if is_prime then "_prime" else "" in
+  (* Closures and their targets are structurally unary. Mangle via
+     smt_rule_name so that overloaded families (rare for closures but
+     possible for targets) produce the correct arity-1 SMT symbol. *)
+  let cname =
+    smt_rule_name env closure_name 1 ^ if is_prime then "_prime" else ""
+  in
+  let tname =
+    smt_rule_name env target_name 1 ^ if is_prime then "_prime" else ""
+  in
   (* Determine target shape to generate the right step expression *)
-  let target_entry = Env.lookup_term target_name env in
+  let target_entry = Env.lookup_term_arity target_name 1 env in
   let target_is_list =
     match[@warning "-4"] target_entry with
     | Some { kind = Env.KRule (TyFunc (_, Some (TyList _))); _ } -> true
@@ -329,9 +337,9 @@ let collect_type_constraint_exprs ?(constrain_primed = true) _config env =
     (fun name entry ->
       match entry.Env.kind with
       | Env.KRule ty -> (
-          let sname = sanitize_ident name in
           match decompose_func_ty ty with
           | Some (params, ret) ->
+              let sname = smt_rule_name env name (List.length params) in
               let params_sorts = List.map sort_of_ty params in
               let param_names =
                 List.mapi (fun i _ -> Printf.sprintf "x_%d" i) params

--- a/lib/smt_types.ml
+++ b/lib/smt_types.ml
@@ -235,13 +235,17 @@ let sanitize_ident name =
   |> String.of_seq
 
 (** SMT symbol name for a rule or closure reference. When the name has two or
-    more arity overloads in [env], the symbol is mangled with an arity suffix
-    ([foo_1], [foo_2]) so each overload gets a distinct SMT function symbol;
-    single-arity rules keep their unmangled form to preserve existing snapshot
-    output. *)
+    more arity overloads in [env], the symbol is mangled with an arity-tagged
+    suffix ([foo$1], [foo$2]) so each overload gets a distinct SMT function
+    symbol; single-arity rules keep their unmangled form to preserve existing
+    snapshot output. The [$] separator is injective against [sanitize_ident]:
+    Pantagruel lower identifiers permit only [a-zA-Z0-9-_?!] (and sanitize maps
+    those into [a-zA-Z0-9_]), so a sanitized identifier can never contain [$].
+    That guarantees an unrelated rule literally named [foo_1] cannot collide
+    with [foo/1]'s mangled form. *)
 let smt_rule_name env name arity =
   if Env.name_is_overloaded name env then
-    sanitize_ident name ^ "_" ^ string_of_int arity
+    sanitize_ident name ^ "$" ^ string_of_int arity
   else sanitize_ident name
 
 (** Wrap a query generator: reset per-query auxiliary state (cond defaults and

--- a/lib/smt_types.ml
+++ b/lib/smt_types.ml
@@ -248,6 +248,21 @@ let smt_rule_name env name arity =
     sanitize_ident name ^ "$" ^ string_of_int arity
   else sanitize_ident name
 
+(** SMT symbol for an [EQualified] reference. When [(name, arity)] lives in the
+    flat terms map (unambiguous import — exactly one origin), the qualified call
+    shares a symbol with the unqualified one so that [all x | A::f x = f x]
+    asserts the identity two users would expect. When it's reachable only via
+    the qualified lookup (two or more modules export the same [(name, arity)]),
+    each qualified call gets a distinct module-prefixed symbol. [$] is injective
+    against [sanitize_ident] for both the module and the name component, so
+    [A$f$1] can't collide with anything a user could write literally. *)
+let smt_qualified_rule_name env mod_name name arity =
+  match Env.lookup_term_arity name arity env with
+  | Some _ -> smt_rule_name env name arity
+  | None ->
+      sanitize_ident mod_name ^ "$" ^ sanitize_ident name ^ "$"
+      ^ string_of_int arity
+
 (** Wrap a query generator: reset per-query auxiliary state (cond defaults and
     fallback constants), run the generator, and insert any accumulated
     declarations into the output. *)

--- a/lib/smt_types.ml
+++ b/lib/smt_types.ml
@@ -234,6 +234,16 @@ let sanitize_ident name =
       match c with '-' -> '_' | '?' -> 'p' | '!' -> 'b' | _ -> c)
   |> String.of_seq
 
+(** SMT symbol name for a rule or closure reference. When the name has two or
+    more arity overloads in [env], the symbol is mangled with an arity suffix
+    ([foo_1], [foo_2]) so each overload gets a distinct SMT function symbol;
+    single-arity rules keep their unmangled form to preserve existing snapshot
+    output. *)
+let smt_rule_name env name arity =
+  if Env.name_is_overloaded name env then
+    sanitize_ident name ^ "_" ^ string_of_int arity
+  else sanitize_ident name
+
 (** Wrap a query generator: reset per-query auxiliary state (cond defaults and
     fallback constants), run the generator, and insert any accumulated
     declarations into the output. *)

--- a/test/test_check.ml
+++ b/test/test_check.ml
@@ -522,6 +522,35 @@ let test_env_disjoint_imports () =
   check bool "Bar not ambiguous" true
     (Option.is_none (Env.ambiguous_type_modules "Bar" env))
 
+let test_env_disjoint_arity_not_ambiguous () =
+  (* Regression: A exports f/1 and B exports f/2. Arity already
+     disambiguates the call, so [ambiguous_term_modules] must not
+     union modules across arities. *)
+  let env =
+    make_import_env
+      [
+        ( "MOD_A",
+          [],
+          [
+            ("f", Env.KRule (Types.TyFunc ([ Types.TyNat ], Some Types.TyBool)));
+          ] );
+        ( "MOD_B",
+          [],
+          [
+            ( "f",
+              Env.KRule
+                (Types.TyFunc ([ Types.TyNat; Types.TyNat ], Some Types.TyBool))
+            );
+          ] );
+      ]
+  in
+  check bool "f/1 unambiguously imported" true
+    (Option.is_some (Env.lookup_term_arity "f" 1 env));
+  check bool "f/2 unambiguously imported" true
+    (Option.is_some (Env.lookup_term_arity "f" 2 env));
+  check bool "f not reported as ambiguous across disjoint arities" true
+    (Option.is_none (Env.ambiguous_term_modules "f" env))
+
 (* --- Integration tests: imports with collect + check --- *)
 
 let test_unambiguous_import_type () =
@@ -2010,6 +2039,8 @@ let () =
           test_case "ambiguous import" `Quick test_env_ambiguous_import;
           test_case "qualified lookup" `Quick test_env_qualified_lookup;
           test_case "disjoint imports" `Quick test_env_disjoint_imports;
+          test_case "disjoint arities not ambiguous" `Quick
+            test_env_disjoint_arity_not_ambiguous;
         ] );
       ( "import resolution",
         [

--- a/test/test_check.ml
+++ b/test/test_check.ml
@@ -841,6 +841,23 @@ f = true.
 f 1 = false.
 |}
 
+let test_overload_closure_plus_rule () =
+  (* Regression: mixing a closure f/1 with a rule f/2 previously crashed
+     the positional-coherence check because closures don't populate
+     [Env.rule_guards], so [List.nth existing_params 0] raised on the
+     missing formal-name metadata. Return-type agreement and positional
+     type agreement still run; only the name check is skipped for the
+     closure overload. *)
+  check_ok
+    {|module TEST.
+Block.
+parent b: Block => Block + Nothing.
+ancestor b: Block => [Block] = closure parent.
+ancestor b: Block, root: Block => [Block].
+---
+true.
+|}
+
 let test_family_proposition_no_application () =
   (* A proposition that mentions the family's params without applying any
      overload binds under the family-wide position-indexed types: `a` is
@@ -1982,6 +1999,8 @@ let () =
             test_overload_dispatch_by_arity;
           test_case "nullary + unary family" `Quick
             test_overload_nullary_plus_unary;
+          test_case "closure + rule in same family" `Quick
+            test_overload_closure_plus_rule;
           test_case "family-wide proposition without application" `Quick
             test_family_proposition_no_application;
         ] );

--- a/test/test_check.ml
+++ b/test/test_check.ml
@@ -725,12 +725,134 @@ Foo.
 |}
 
 let test_local_duplicate_proc_still_errors () =
-  (* Two local rules with same name still error *)
+  (* Two local rules with the same name and same arity still error — under
+     arity-overloading this fires DuplicateRule before the return-type
+     coherence check, because same (name, arity) is a true duplicate. *)
   check_fails {|
 Foo.
 do-thing f: Foo => Bool.
 do-thing f: Foo => Nat.
 ---
+|}
+
+(* --- Arity-overloading tests --- *)
+
+(* Helper: assert the collection pass errors with a specific Collect.collect_error
+   matcher. *)
+let check_collect_error str pred =
+  let doc = parse str in
+  match
+    Collect.collect_all
+      ~base_env:
+        (Env.empty (Option.fold ~none:"" ~some:Ast.upper_name doc.module_name))
+      doc
+  with
+  | Ok _ -> fail "Expected a collection error"
+  | Error e ->
+      if not (pred e) then
+        fail
+          (Printf.sprintf "Wrong error type: %s" (Collect.show_collect_error e))
+
+let test_two_arity_overload_ok () =
+  (* Coherent family: position 0 is a:Nat across both heads, return type
+     matches, only the 2-arity head adds position 1 (b:Foo). *)
+  check_ok
+    {|module TEST.
+Foo.
+f a: Nat, b: Foo => Bool.
+f a: Nat => Bool.
+---
+true.
+|}
+
+let test_overload_param_type_mismatch () =
+  check_collect_error
+    {|module TEST.
+Foo.
+f a: Nat, b: Foo => Bool.
+f a: Real => Bool.
+---
+true.
+|}
+    (function[@warning "-4"]
+    | Collect.OverloadCoherenceViolation { position = Param 0; _ } -> true
+    | _ -> false)
+
+let test_overload_param_name_mismatch () =
+  check_collect_error
+    {|module TEST.
+f a: Nat, b: Real => Bool.
+f x: Nat => Bool.
+---
+true.
+|}
+    (function[@warning "-4"]
+    | Collect.OverloadCoherenceViolation { position = Param 0; _ } -> true
+    | _ -> false)
+
+let test_overload_return_mismatch () =
+  check_collect_error
+    {|module TEST.
+f a: Nat, b: Real => Bool.
+f a: Nat => Nat.
+---
+true.
+|}
+    (function[@warning "-4"]
+    | Collect.OverloadCoherenceViolation { position = Return; _ } -> true
+    | _ -> false)
+
+let test_overload_same_arity_still_duplicate () =
+  check_collect_error
+    {|module TEST.
+f a: Nat => Bool.
+f a: Nat => Bool.
+---
+true.
+|}
+    (function[@warning "-4"]
+    | Collect.DuplicateRule _ -> true
+    | _ -> false)
+
+let test_overload_dispatch_by_arity () =
+  (* Proposition body applies both the arity-1 and arity-2 heads; each
+     dispatches to its own overload. *)
+  check_ok
+    {|module TEST.
+Foo.
+f a: Nat, b: Foo => Bool.
+f a: Nat => Bool.
+---
+f 3 = true.
+all a: Nat, b: Foo | f a b = false.
+|}
+
+let test_overload_nullary_plus_unary () =
+  (* Bare reference auto-applies the nullary overload; applied reference
+     dispatches to the unary. (Use 1 not 0 so the literal has type Nat; a
+     bare 0 infers as Nat0, which is a supertype of Nat and would fail
+     subtype checking against the unary f's Nat parameter.) *)
+  check_ok
+    {|module TEST.
+f => Bool.
+f a: Nat => Bool.
+---
+f = true.
+f 1 = false.
+|}
+
+let test_family_proposition_no_application () =
+  (* A proposition that mentions the family's params without applying any
+     overload binds under the family-wide position-indexed types: `a` is
+     Nat (position 0), `b` is Foo (position 1). Well-formed regardless of
+     which overload (if any) is active. *)
+  check_ok
+    {|module TEST.
+Foo.
+f a: Nat, b: Foo => Bool.
+f a: Nat => Bool.
+---
+all a: Nat, b: Foo | f a = f a b.
 |}
 
 (* --- Context tests --- *)
@@ -1827,6 +1949,24 @@ let () =
             test_arithmetic_type_mismatch;
           test_case "list search numeric forbidden" `Quick
             test_list_search_numeric_forbidden;
+        ] );
+      ( "arity overloading",
+        [
+          test_case "two-arity family accepted" `Quick
+            test_two_arity_overload_ok;
+          test_case "param type mismatch at shared position" `Quick
+            test_overload_param_type_mismatch;
+          test_case "param name mismatch at shared position" `Quick
+            test_overload_param_name_mismatch;
+          test_case "return type mismatch" `Quick test_overload_return_mismatch;
+          test_case "same-arity duplicate still errors" `Quick
+            test_overload_same_arity_still_duplicate;
+          test_case "dispatch by arity in body" `Quick
+            test_overload_dispatch_by_arity;
+          test_case "nullary + unary family" `Quick
+            test_overload_nullary_plus_unary;
+          test_case "family-wide proposition without application" `Quick
+            test_family_proposition_no_application;
         ] );
       ( "env import",
         [

--- a/test/test_check.ml
+++ b/test/test_check.ml
@@ -870,6 +870,27 @@ f = true.
 f 1 = false.
 |}
 
+let test_overload_closure_incoherent_rejected () =
+  (* Regression: a closure declaration must participate in positional
+     coherence like any other rule in the overload family. Here the rule
+     ancestor/2 is declared first with Nat at position 0; the subsequent
+     closure ancestor/1 has Block at position 0, which is incompatible.
+     The DeclClosure branch previously skipped [check_overload_coherence],
+     so this ordering was accepted even though the reversed ordering (which
+     flows through DeclRule's check) was rejected. *)
+  check_collect_error
+    {|module TEST.
+Block.
+parent b: Block => Block + Nothing.
+ancestor a: Nat, b: Block => [Block].
+ancestor b: Block => [Block] = closure parent.
+---
+true.
+|}
+    (function[@warning "-4"]
+    | Collect.OverloadCoherenceViolation { position = Param 0; _ } -> true
+    | _ -> false)
+
 let test_overload_closure_plus_rule () =
   (* Regression: mixing a closure f/1 with a rule f/2 previously crashed
      the positional-coherence check because closures don't populate
@@ -2030,6 +2051,8 @@ let () =
             test_overload_nullary_plus_unary;
           test_case "closure + rule in same family" `Quick
             test_overload_closure_plus_rule;
+          test_case "closure incoherent with rule rejected" `Quick
+            test_overload_closure_incoherent_rejected;
           test_case "family-wide proposition without application" `Quick
             test_family_proposition_no_application;
         ] );

--- a/test/test_check.ml
+++ b/test/test_check.ml
@@ -1495,6 +1495,21 @@ g a1: A, b1: B => A.
 all a: A, b: B | g a b = f[(a, b) |-> a] a b.
 |}
 
+let test_override_unary_product_param_tuple_key_ok () =
+  (* Regression: a unary rule whose single parameter has a product type must
+     still accept a tuple-literal override key. Pre-fix, check_override
+     pre-computed target_arity from the key's syntactic shape and rejected
+     this as an arity mismatch against a nonexistent arity-2 overload. *)
+  check_ok
+    {|module TEST.
+
+A.
+B.
+f p: A * B => Nat.
+---
+all a: A, b: B, p: A * B | f[(a, b) |-> 1] p = 1.
+|}
+
 let test_projection_out_of_bounds () =
   check_error {|module TEST.
 
@@ -1907,6 +1922,8 @@ let () =
           test_case "declaration guards" `Quick test_declaration_guards_in_rules;
           test_case "Override N-ary tuple key OK" `Quick
             test_override_nary_tuple_key_ok;
+          test_case "Override unary product-param tuple key OK" `Quick
+            test_override_unary_product_param_tuple_key_ok;
         ] );
       ( "invalid",
         [


### PR DESCRIPTION
## Summary

Allow two or more rule declarations to share a name when they have different arities, under **positional coherence**: at every shared parameter position across overloads, both the parameter name and type must agree, and the return type must agree across all overloads.

```pantagruel
f a: Nat, b: Real => Bool.
f a: Nat => Bool.
---
f 3 = true.
all a: Nat, b: Real | f a b = false.
```

Each overload is an independent mathematical function that happens to share a name with its siblings. Arity-discrimination is purely syntactic — every use site immediately fixes an arity, so resolution is unambiguous without type inference. Type-overloading (same arity, different types at a position) is explicitly **not** part of this change.

## Motivation

TypeScript's optional-parameter idiom — `function f(p?: T): R { return ... p ?? default ... }` — has no clean encoding when the single signature carries `T + Nothing`: `Nothing` is uninhabited, so there's no value to compare `p` against. Arity-overloading lets ts2pant translate the idiom as two rule heads (one with `p`, one without). That follow-on lives in #118 and depends on this PR.

## What's in the PR

Five commits, sequential on the branch:

| # | Commit | Scope |
|---|--------|-------|
| 1 | \`env: key terms namespace by (name, arity)\` | TermMap keyed by \`(string, int)\`. New API: \`lookup_term_arity\`, \`lookup_rule_guards_arity\`, \`overloads_of\`, \`name_is_overloaded\`. Old \`lookup_term\`, \`bindings_terms\`, \`fold_terms\` preserved as shims that return the first-overload / visit each overload as a separate binding. Import merging is now per-(name, arity). |
| 2 | \`collect: enforce positional coherence\` | New \`OverloadCoherenceViolation { name; position; first; second }\` variant (position = \`Param i\` \| \`Return\`). \`DuplicateRule\` fires on identical \`(name, arity)\`; coherence check fires on shared-position disagreements. \`add_rule_guards\` stores params unconditionally so the coherence check can recover existing overloads' parameter names. |
| 3 | \`check: arity-aware rule dispatch\` | \`EApp(EVar name, args)\` / \`EPrimed(name, args)\` probe \`lookup_term_arity\` with \`List.length args\`; \`EOverride\` keys by key-shape (bare = arity 1; N-tuple = arity N). Fallback to \`infer_type\` preserves list-indexing / nullary auto-apply paths. |
| 4 | \`smt: conditional arity mangling\` | New \`smt_rule_name\` in \`smt_types.ml\` appends \`_N\` iff \`name_is_overloaded\`; single-arity rules emit with their unmangled SMT symbol so every existing snapshot is byte-identical. Wired through 8 sites (preamble declare-fun, step-declare, application lowering, BMC renamer, guard injection, frame conditions, value-term enumeration). Frame conditions iterate per-overload — each overload gets its own \`_prime\` declaration. |
| 5 | \`json_output + tests\` | JSON rule keys mangle as \`name/N\` when overloaded, otherwise bare name. Eight new unit tests for the coherence check + dispatch behavior. |

Design notes are in [\`.claude/plans/ok-let-s-proceed-under-tranquil-lynx.md\`](https://github.com/subsetpark/pantagruel/blob/arity-overloading/.claude/plans/ok-let-s-proceed-under-tranquil-lynx.md) if the background reasoning is helpful.

## Test plan

- [x] **\`arity overloading\` group** in \`test_check.ml\` covers the positive shape, both negative coherence cases (param type / name at shared position, return type), duplicate-still-errors, dispatch by arity, nullary+unary, and the family-wide proposition case (\`a > b\` binds under position-indexed types even without any application)
- [x] All existing tests pass (739/739, up from 730 pre-rebase; origin/master added 9 during the rebase window)
- [x] \`pant --check\` on an overloaded spec (\`newSynthCell r: NameRegistry / newSynthCell\`) emits well-formed SMT and runs to invariant-consistency SAT
- [x] No snapshot drift on existing single-arity fixtures (conditional mangling guarantee)

## Related

- **Dependencies:** none — rebases cleanly on \`origin/master\` (resolved through git's three-way merge against the concurrent bindlib-migration work; no manual conflict resolution needed).
- **Unblocks:** #118 (ts2pant translates optional-param-with-default as two arity overloads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)