### PR TITLE
ts2pant: ReadonlyMap interface fields + translate-record.ts extraction

### DIFF
--- a/tools/ts2pant/src/extract.ts
+++ b/tools/ts2pant/src/extract.ts
@@ -1,6 +1,8 @@
 import { Project, type SourceFile } from "ts-morph";
 import ts from "typescript";
 
+import { isMapType, isSetType } from "./translate-types.js";
+
 export type { SourceFile } from "ts-morph";
 
 export interface ExtractedProperty {
@@ -267,7 +269,12 @@ function collectNamedTypes(
     return;
   }
 
-  if (checker.isArrayType(type) || checker.isTupleType(type)) {
+  if (
+    checker.isArrayType(type) ||
+    checker.isTupleType(type) ||
+    isSetType(type) ||
+    isMapType(type)
+  ) {
     const typeArgs = checker.getTypeArguments(type as ts.TypeReference);
     for (const arg of typeArgs) {
       collectNamedTypes(arg, checker, visited);

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -1,6 +1,5 @@
 import type { SourceFile } from "ts-morph";
 import ts from "typescript";
-import { type NameRegistry, registerName } from "./name-registry.js";
 import type {
   OpaqueCombiner,
   OpaqueExpr,
@@ -9,6 +8,7 @@ import type {
 } from "./pant-ast.js";
 import { getAst } from "./pant-wasm.js";
 import { isKnownPureCall } from "./purity.js";
+import { translateRecordReturn } from "./translate-record.js";
 import {
   classifyFunction,
   findFunction,
@@ -28,7 +28,6 @@ import {
   mapTsType,
   type NumericStrategy,
   type SynthCell,
-  UNSUPPORTED_ANONYMOUS_RECORD,
 } from "./translate-types.js";
 import type { PantDeclaration, PropResult } from "./types.js";
 
@@ -57,7 +56,7 @@ interface NullishRewrite {
   mode: "take-lhs" | "take-rhs";
 }
 
-interface UniqueSupply {
+export interface UniqueSupply {
   n: number;
   synthCell?: SynthCell | undefined;
   nullishRewrite?: NullishRewrite | undefined;
@@ -128,12 +127,12 @@ type BodyResult =
   | { effect: MapMutation };
 
 /** Type guard for unsupported BodyResult. */
-function isBodyUnsupported(r: BodyResult): r is { unsupported: string } {
+export function isBodyUnsupported(r: BodyResult): r is { unsupported: string } {
   return "unsupported" in r;
 }
 
 /** Type guard for effect BodyResult. */
-function isBodyEffect(r: BodyResult): r is { effect: MapMutation } {
+export function isBodyEffect(r: BodyResult): r is { effect: MapMutation } {
   return "effect" in r;
 }
 
@@ -157,7 +156,7 @@ function rejectEffect(
 
 /** Extract the OpaqueExpr from a successful BodyResult, materializing any
  * deferred comprehension chain into a flat `each` at the boundary. */
-function bodyExpr(r: BodyResult): OpaqueExpr {
+export function bodyExpr(r: BodyResult): OpaqueExpr {
   if ("unsupported" in r) {
     throw new Error(`bodyExpr called on unsupported: ${r.unsupported}`);
   }
@@ -987,449 +986,6 @@ function translatePureBody(
       rhs,
     },
   ];
-}
-
-/**
- * Translate a function whose body returns an object literal
- * `{ f1: e1, f2: e2 }` into one equation per field of the return type.
- * Each equation shape: `all <params> | f_i (fn <args>) = e_i.` — the
- * field's accessor rule applied to the function application is equated
- * to the field's initializer expression.
- *
- * `new Set()` in a `[T]` field position is special-cased as "empty set"
- * and emits an assertion `all x: T | not (x in f_i (fn <args>))` instead
- * of an equation, since Pantagruel has no empty-list literal.
- *
- * Requirements:
- *   - Return type must be a named TypeScript interface/class/alias whose
- *     accessor rules are already declared elsewhere in the document.
- *   - The object literal must supply exactly one PropertyAssignment or
- *     ShorthandPropertyAssignment per declared field of the return type.
- *   - Initializers must translate as pure expressions (or be the
- *     `new Set()` special case above).
- */
-function translateRecordReturn(
-  lit: ts.ObjectLiteralExpression,
-  functionName: string,
-  params: Array<{ name: string; type: string }>,
-  fnNode: ts.FunctionDeclaration | ts.MethodDeclaration,
-  checker: ts.TypeChecker,
-  strategy: NumericStrategy,
-  scopedParams: ReadonlyMap<string, string>,
-  supply: UniqueSupply,
-  synthCell: SynthCell | undefined,
-  applyConst: (e: OpaqueExpr) => OpaqueExpr,
-): PropResult[] {
-  const ast = getAst();
-
-  // Resolve return type. Use the signature's declared return rather than
-  // the object literal's inferred type (which would be
-  // `{ f1: SetLike, ... }` with contextual widening not applied).
-  const sig = checker.getSignatureFromDeclaration(fnNode);
-  const returnType = sig?.getReturnType();
-  if (!returnType) {
-    return [
-      {
-        kind: "unsupported",
-        reason: `${functionName} — cannot resolve return type for record return`,
-      },
-    ];
-  }
-  const returnSymbol = returnType.aliasSymbol ?? returnType.symbol;
-  const returnTypeName = returnSymbol?.getName();
-  if (!returnTypeName) {
-    return [
-      {
-        kind: "unsupported",
-        reason: `${functionName} — cannot resolve return type name for record return`,
-      },
-    ];
-  }
-  // Anonymous record return (`returnTypeName === "__type"`): the
-  // `mapTsType` branch during signature translation has already
-  // registered the shape with the synth cell, so the synthesized
-  // domain and its accessor rules are declared by the time the body
-  // is translated. The field-emission loop below works unchanged — it
-  // iterates `returnType.getProperties()` (which enumerates the
-  // anonymous shape's declared fields just as well as an interface's)
-  // and emits one equation per field, applying each accessor rule to
-  // the function application. Reject only when the cell is missing or
-  // when upstream synth registration failed (field types unmangleable).
-  if (returnTypeName === "__type") {
-    if (!synthCell) {
-      return [
-        {
-          kind: "unsupported",
-          reason: `${functionName} — anonymous record return requires a synth cell`,
-        },
-      ];
-    }
-    if (returnType.getCallSignatures().length > 0) {
-      return [
-        {
-          kind: "unsupported",
-          reason: `${functionName} — callable anonymous return type`,
-        },
-      ];
-    }
-    // Re-run the (idempotent) synth-mapping to confirm registration
-    // actually succeeded for this shape. If a field type is unmangleable
-    // the synth returns the failure sentinel rather than a domain name,
-    // and the body emission below would otherwise reference accessor
-    // rules that were never declared.
-    const mapped = mapTsType(returnType, checker, strategy, synthCell);
-    if (mapped === UNSUPPORTED_ANONYMOUS_RECORD) {
-      return [
-        {
-          kind: "unsupported",
-          reason: `${functionName} — anonymous record return shape could not be synthesized`,
-        },
-      ];
-    }
-  }
-
-  // Collect declared fields. For named interfaces this is the declared
-  // property list; for anonymous records it's the same shape seen through
-  // the structural type's properties. Canonical order matches the synth's
-  // sorted order (by field name) so the emission stays deterministic.
-  const declaredFields = returnType
-    .getProperties()
-    .map((prop) => ({
-      name: prop.getName(),
-      type: checker.getTypeOfSymbolAtLocation(prop, fnNode),
-    }))
-    .sort((a, b) => a.name.localeCompare(b.name));
-
-  // Index literal properties by name. Reject unsupported property kinds
-  // and duplicate keys (the spec requires exactly one assignment per
-  // declared field).
-  const literalByName = new Map<string, ts.Expression>();
-  for (const prop of lit.properties) {
-    if (ts.isPropertyAssignment(prop)) {
-      if (!ts.isIdentifier(prop.name) && !ts.isStringLiteral(prop.name)) {
-        return [
-          {
-            kind: "unsupported",
-            reason: `${functionName} — record return with computed or non-simple key`,
-          },
-        ];
-      }
-      if (literalByName.has(prop.name.text)) {
-        return [
-          {
-            kind: "unsupported",
-            reason: `${functionName} — record return repeats field '${prop.name.text}'`,
-          },
-        ];
-      }
-      literalByName.set(prop.name.text, prop.initializer);
-    } else if (ts.isShorthandPropertyAssignment(prop)) {
-      if (literalByName.has(prop.name.text)) {
-        return [
-          {
-            kind: "unsupported",
-            reason: `${functionName} — record return repeats field '${prop.name.text}'`,
-          },
-        ];
-      }
-      literalByName.set(prop.name.text, prop.name);
-    } else {
-      return [
-        {
-          kind: "unsupported",
-          reason: `${functionName} — record return with spread/method/accessor property`,
-        },
-      ];
-    }
-  }
-
-  // Every declared field must be supplied. Extra fields on the literal
-  // are flagged separately below.
-  const missing = declaredFields
-    .filter((f) => !literalByName.has(f.name))
-    .map((f) => f.name);
-  if (missing.length > 0) {
-    return [
-      {
-        kind: "unsupported",
-        reason: `${functionName} — record return missing field(s): ${missing.join(", ")}`,
-      },
-    ];
-  }
-  const extras = [...literalByName.keys()].filter(
-    (n) => !declaredFields.some((f) => f.name === n),
-  );
-  if (extras.length > 0) {
-    return [
-      {
-        kind: "unsupported",
-        reason: `${functionName} — record return has extra field(s): ${extras.join(", ")}`,
-      },
-    ];
-  }
-
-  const argExprs = params.map((p) => ast.var(p.name));
-  const fnApp = ast.app(ast.var(functionName), argExprs);
-
-  // Rule parameters are implicitly in scope for body propositions, so we
-  // don't re-quantify over them — emission matches the existing single-
-  // equation path (`larger a b = cond ...`). Only fresh binders introduced
-  // by a field's translation (e.g., the empty-set membership binder) are
-  // quantified explicitly.
-  //
-  // Empty-set binders are *serialized* into the final assertion, so they
-  // must be valid Pantagruel identifiers and must not capture the function's
-  // own params. The synthCell branch already avoids both issues: its
-  // registry was seeded by translateSignature with every param name, so
-  // `cellRegisterName(synthCell, "x")` returns `x1` when `x` is a param.
-  // The fallback (no synthCell — direct callers / tests) seeds a local
-  // registry from `params` to preserve the same guarantees.
-  let localRegistry: NameRegistry = {
-    used: new Set(params.map((p) => p.name)),
-  };
-  const allocEmittedBinder = (hint: string): string => {
-    if (synthCell) {
-      return cellRegisterName(synthCell, hint);
-    }
-    const r = registerName(localRegistry, hint);
-    localRegistry = r.registry;
-    return r.name;
-  };
-
-  return emitRecordEquations(
-    lit,
-    fnApp,
-    declaredFields,
-    functionName,
-    checker,
-    strategy,
-    scopedParams,
-    supply,
-    synthCell,
-    applyConst,
-    allocEmittedBinder,
-  );
-}
-
-/**
- * Emit one equation per field of a record-typed receiver. Shared between
- * the top-level function return (receiver = function application) and
- * nested object-literal initializers (receiver = accessor application on
- * the outer record). Recurses when a field's initializer is itself an
- * object literal — translating a literal value under Pantagruel's
- * observational discipline requires decomposing it into per-accessor
- * equations, since there's no record-constructor expression to fall back
- * on.
- */
-function emitRecordEquations(
-  lit: ts.ObjectLiteralExpression,
-  receiverExpr: OpaqueExpr,
-  declaredFields: Array<{ name: string; type: ts.Type }>,
-  functionName: string,
-  checker: ts.TypeChecker,
-  strategy: NumericStrategy,
-  scopedParams: ReadonlyMap<string, string>,
-  supply: UniqueSupply,
-  synthCell: SynthCell | undefined,
-  applyConst: (e: OpaqueExpr) => OpaqueExpr,
-  allocEmittedBinder: (hint: string) => string,
-): PropResult[] {
-  const ast = getAst();
-
-  // Re-index the literal's properties by name for this level. Nested
-  // calls each index their own literal. Apply the same exact-field
-  // contract as the top-level record return: reject unsupported property
-  // kinds, duplicate keys, missing fields, and extra fields.
-  const literalByName = new Map<string, ts.Expression>();
-  for (const prop of lit.properties) {
-    if (ts.isPropertyAssignment(prop)) {
-      if (!ts.isIdentifier(prop.name) && !ts.isStringLiteral(prop.name)) {
-        return [
-          {
-            kind: "unsupported",
-            reason: `${functionName} — nested record literal with computed or non-simple key`,
-          },
-        ];
-      }
-      if (literalByName.has(prop.name.text)) {
-        return [
-          {
-            kind: "unsupported",
-            reason: `${functionName} — nested record literal repeats field '${prop.name.text}'`,
-          },
-        ];
-      }
-      literalByName.set(prop.name.text, prop.initializer);
-    } else if (ts.isShorthandPropertyAssignment(prop)) {
-      if (literalByName.has(prop.name.text)) {
-        return [
-          {
-            kind: "unsupported",
-            reason: `${functionName} — nested record literal repeats field '${prop.name.text}'`,
-          },
-        ];
-      }
-      literalByName.set(prop.name.text, prop.name);
-    } else {
-      return [
-        {
-          kind: "unsupported",
-          reason: `${functionName} — nested record literal with spread/method/accessor property`,
-        },
-      ];
-    }
-  }
-
-  const extras = [...literalByName.keys()].filter(
-    (n) => !declaredFields.some((f) => f.name === n),
-  );
-  if (extras.length > 0) {
-    return [
-      {
-        kind: "unsupported",
-        reason: `${functionName} — nested record literal has extra field(s): ${extras.join(", ")}`,
-      },
-    ];
-  }
-
-  const results: PropResult[] = [];
-  for (const field of declaredFields) {
-    const initializer = literalByName.get(field.name);
-    if (!initializer) {
-      return [
-        {
-          kind: "unsupported",
-          reason: `${functionName} — nested record literal missing field '${field.name}'`,
-        },
-      ];
-    }
-    const fieldApp = ast.app(ast.var(field.name), [receiverExpr]);
-
-    // `new Set()` → empty-set membership negation.
-    if (isEmptySetConstruction(initializer)) {
-      const elemType = getSetElementTypeName(
-        field.type,
-        checker,
-        strategy,
-        synthCell,
-      );
-      if (!elemType) {
-        return [
-          {
-            kind: "unsupported",
-            reason: `${functionName} — new Set() initializer on non-set field '${field.name}'`,
-          },
-        ];
-      }
-      const binderName = allocEmittedBinder("x");
-      const binderParam = ast.param(binderName, ast.tName(elemType));
-      const body = ast.unop(
-        ast.opNot(),
-        ast.binop(ast.opIn(), ast.var(binderName), fieldApp),
-      );
-      results.push({
-        kind: "assertion",
-        quantifiers: [binderParam],
-        body,
-      });
-      continue;
-    }
-
-    // Nested object literal → recursively decompose into per-subfield
-    // equations with `fieldApp` as the new receiver. Pantagruel has no
-    // record-constructor expression; the only way to specify a record
-    // value is observationally (equations on its accessors).
-    if (ts.isObjectLiteralExpression(initializer)) {
-      const subFields = field.type
-        .getProperties()
-        .map((prop) => ({
-          name: prop.getName(),
-          type: checker.getTypeOfSymbol(prop),
-        }))
-        .sort((a, b) => a.name.localeCompare(b.name));
-      const subResults = emitRecordEquations(
-        initializer,
-        fieldApp,
-        subFields,
-        `${functionName}.${field.name}`,
-        checker,
-        strategy,
-        scopedParams,
-        supply,
-        synthCell,
-        applyConst,
-        allocEmittedBinder,
-      );
-      const subUnsupported = subResults.find((p) => p.kind === "unsupported");
-      if (subUnsupported) {
-        return [subUnsupported];
-      }
-      results.push(...subResults);
-      continue;
-    }
-
-    const body = translateBodyExpr(
-      initializer,
-      checker,
-      strategy,
-      scopedParams,
-      undefined,
-      supply,
-    );
-    if (isBodyUnsupported(body)) {
-      return [
-        {
-          kind: "unsupported",
-          reason: `${functionName}.${field.name} — ${body.unsupported}`,
-        },
-      ];
-    }
-    if (isBodyEffect(body)) {
-      return [
-        {
-          kind: "unsupported",
-          reason: `${functionName}.${field.name} — effect outside statement position`,
-        },
-      ];
-    }
-    const rhs = applyConst(bodyExpr(body));
-    results.push({
-      kind: "equation",
-      quantifiers: [],
-      lhs: fieldApp,
-      rhs,
-    });
-  }
-
-  return results;
-}
-
-/** `new Set()` (zero args) — the only Set construction form we currently
- * translate. `new Set(iterable)` and subclass constructors are rejected. */
-function isEmptySetConstruction(expr: ts.Expression): boolean {
-  return (
-    ts.isNewExpression(expr) &&
-    ts.isIdentifier(expr.expression) &&
-    expr.expression.text === "Set" &&
-    (expr.arguments === undefined || expr.arguments.length === 0)
-  );
-}
-
-/** Return the Pantagruel type name of `T` in a `Set<T>` / `ReadonlySet<T>`
- * / `[T]` (array) field, or null if the field isn't set-shaped. */
-function getSetElementTypeName(
-  fieldType: ts.Type,
-  checker: ts.TypeChecker,
-  strategy: NumericStrategy,
-  synthCell: SynthCell | undefined,
-): string | null {
-  if (isSetType(fieldType) || checker.isArrayType(fieldType)) {
-    const typeArgs = checker.getTypeArguments(fieldType as ts.TypeReference);
-    if (typeArgs.length === 1) {
-      return mapTsType(typeArgs[0]!, checker, strategy, synthCell);
-    }
-  }
-  return null;
 }
 
 interface ExtractedBody {

--- a/tools/ts2pant/src/translate-record.ts
+++ b/tools/ts2pant/src/translate-record.ts
@@ -11,8 +11,10 @@ import {
 } from "./translate-body.js";
 import {
   cellRegisterName,
+  isAnonymousRecord,
   isMapType,
   isSetType,
+  lookupMapKV,
   mapTsType,
   type NumericStrategy,
   type SynthCell,
@@ -100,6 +102,25 @@ export function translateRecordReturn(
         {
           kind: "unsupported",
           reason: `${functionName} — callable anonymous return type`,
+        },
+      ];
+    }
+    if (returnType.getConstructSignatures().length > 0) {
+      return [
+        {
+          kind: "unsupported",
+          reason: `${functionName} — constructible anonymous return type`,
+        },
+      ];
+    }
+    if (
+      returnType.getStringIndexType() !== undefined ||
+      returnType.getNumberIndexType() !== undefined
+    ) {
+      return [
+        {
+          kind: "unsupported",
+          reason: `${functionName} — index-signature anonymous return type (unbounded dictionary, not a finite record)`,
         },
       ];
     }
@@ -230,6 +251,7 @@ export function translateRecordReturn(
   return emitRecordEquations(
     lit,
     fnApp,
+    returnType,
     declaredFields,
     functionName,
     checker,
@@ -255,6 +277,7 @@ export function translateRecordReturn(
 function emitRecordEquations(
   lit: ts.ObjectLiteralExpression,
   receiverExpr: OpaqueExpr,
+  receiverType: ts.Type,
   declaredFields: Array<{ name: string; type: ts.Type }>,
   functionName: string,
   checker: ts.TypeChecker,
@@ -265,6 +288,14 @@ function emitRecordEquations(
   applyConst: (e: OpaqueExpr) => OpaqueExpr,
   allocEmittedBinder: (hint: string) => string,
 ): PropResult[] {
+  // Stage A (named interface receiver): Map fields encode as a pair of
+  // binary rules — `<field>Key(receiver, k)` membership predicate plus a
+  // V-valued rule guarded by it (translate-types.ts interface-field branch).
+  // Stage B (synthesized anonymous record receiver): Map fields encode as
+  // a unary accessor returning a synthesized `KToVMap` domain, and the
+  // map's key predicate lives on the synthesized domain, not the record.
+  // We branch on this per Map-valued field below.
+  const receiverIsAnon = isAnonymousRecord(receiverType);
   const ast = getAst();
 
   // Re-index the literal's properties by name for this level. Nested
@@ -366,11 +397,23 @@ function emitRecordEquations(
       continue;
     }
 
-    // `new Map()` → empty-map key-predicate negation. The Stage A
-    // field-Map encoding in translate-types.ts emits a `<field>Key`
-    // predicate alongside the value rule; "empty" means no key is
-    // registered: `all k: K | ~(<field>Key receiver k)`.
+    // `new Map()` → empty-map key-predicate negation. The predicate being
+    // negated differs between Stage A and Stage B (see receiverIsAnon
+    // comment above):
+    //   Stage A: `all k: K | ~(<field>Key receiver k)` — the interface's
+    //     own binary membership predicate.
+    //   Stage B: `all k: K | ~(<kToVMapKey> (field receiver) k)` — the
+    //     synthesized map's key predicate, applied to the synth-domain
+    //     value that the unary accessor returns.
     if (isEmptyMapConstruction(initializer)) {
+      if (!isMapType(field.type)) {
+        return [
+          {
+            kind: "unsupported",
+            reason: `${functionName} — new Map() initializer on non-map field '${field.name}'`,
+          },
+        ];
+      }
       const keyType = getMapKeyTypeName(
         field.type,
         checker,
@@ -387,10 +430,36 @@ function emitRecordEquations(
       }
       const binderName = allocEmittedBinder("k");
       const binderParam = ast.param(binderName, ast.tName(keyType));
-      const keyPredApp = ast.app(ast.var(`${field.name}Key`), [
-        receiverExpr,
-        ast.var(binderName),
-      ]);
+      let keyPredApp: OpaqueExpr;
+      if (receiverIsAnon) {
+        const vType = getMapValueTypeName(
+          field.type,
+          checker,
+          strategy,
+          synthCell,
+        );
+        const synthEntry =
+          synthCell && vType
+            ? lookupMapKV(synthCell.synth, keyType, vType)
+            : undefined;
+        if (!synthEntry) {
+          return [
+            {
+              kind: "unsupported",
+              reason: `${functionName} — new Map() on anonymous record field '${field.name}' with unregistered synth entry`,
+            },
+          ];
+        }
+        keyPredApp = ast.app(ast.var(synthEntry.names.keyPred), [
+          fieldApp,
+          ast.var(binderName),
+        ]);
+      } else {
+        keyPredApp = ast.app(ast.var(`${field.name}Key`), [
+          receiverExpr,
+          ast.var(binderName),
+        ]);
+      }
       const body = ast.unop(ast.opNot(), keyPredApp);
       results.push({
         kind: "assertion",
@@ -398,6 +467,22 @@ function emitRecordEquations(
         body,
       });
       continue;
+    }
+
+    // Non-empty Map-valued initializer reaches the generic equation path
+    // below as a unary `field(receiver) = <init>`. That shape is only
+    // correct when the accessor is unary (Stage B) and the RHS has the
+    // synthesized domain type; it's always wrong for Stage A binary
+    // accessors, and for Stage B we don't currently translate any
+    // Map-producing expression other than `new Map()`. Reject both up
+    // front rather than emit invalid Pantagruel.
+    if (isMapType(field.type)) {
+      return [
+        {
+          kind: "unsupported",
+          reason: `${functionName} — Map-valued field '${field.name}' with non-empty initializer`,
+        },
+      ];
     }
 
     // Nested object literal → recursively decompose into per-subfield
@@ -415,6 +500,7 @@ function emitRecordEquations(
       const subResults = emitRecordEquations(
         initializer,
         fieldApp,
+        field.type,
         subFields,
         `${functionName}.${field.name}`,
         checker,
@@ -520,6 +606,23 @@ function getMapKeyTypeName(
     const typeArgs = checker.getTypeArguments(fieldType as ts.TypeReference);
     if (typeArgs.length === 2) {
       return mapTsType(typeArgs[0]!, checker, strategy, synthCell);
+    }
+  }
+  return null;
+}
+
+/** Return the Pantagruel type name of `V` in a `Map<K, V>` /
+ * `ReadonlyMap<K, V>` field, or null if the field isn't map-shaped. */
+function getMapValueTypeName(
+  fieldType: ts.Type,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  synthCell: SynthCell | undefined,
+): string | null {
+  if (isMapType(fieldType)) {
+    const typeArgs = checker.getTypeArguments(fieldType as ts.TypeReference);
+    if (typeArgs.length === 2) {
+      return mapTsType(typeArgs[1]!, checker, strategy, synthCell);
     }
   }
   return null;

--- a/tools/ts2pant/src/translate-record.ts
+++ b/tools/ts2pant/src/translate-record.ts
@@ -1,0 +1,526 @@
+import ts from "typescript";
+import { type NameRegistry, registerName } from "./name-registry.js";
+import type { OpaqueExpr } from "./pant-ast.js";
+import { getAst } from "./pant-wasm.js";
+import {
+  bodyExpr,
+  isBodyEffect,
+  isBodyUnsupported,
+  translateBodyExpr,
+  type UniqueSupply,
+} from "./translate-body.js";
+import {
+  cellRegisterName,
+  isMapType,
+  isSetType,
+  mapTsType,
+  type NumericStrategy,
+  type SynthCell,
+  UNSUPPORTED_ANONYMOUS_RECORD,
+} from "./translate-types.js";
+import type { PropResult } from "./types.js";
+
+/**
+ * Translate a function whose body returns an object literal
+ * `{ f1: e1, f2: e2 }` into one equation per field of the return type.
+ * Each equation shape: `all <params> | f_i (fn <args>) = e_i.` — the
+ * field's accessor rule applied to the function application is equated
+ * to the field's initializer expression.
+ *
+ * `new Set()` in a `[T]` field position is special-cased as "empty set"
+ * and emits an assertion `all x: T | not (x in f_i (fn <args>))` instead
+ * of an equation, since Pantagruel has no empty-list literal.
+ *
+ * Requirements:
+ *   - Return type must be a named TypeScript interface/class/alias whose
+ *     accessor rules are already declared elsewhere in the document.
+ *   - The object literal must supply exactly one PropertyAssignment or
+ *     ShorthandPropertyAssignment per declared field of the return type.
+ *   - Initializers must translate as pure expressions (or be the
+ *     `new Set()` special case above).
+ */
+export function translateRecordReturn(
+  lit: ts.ObjectLiteralExpression,
+  functionName: string,
+  params: Array<{ name: string; type: string }>,
+  fnNode: ts.FunctionDeclaration | ts.MethodDeclaration,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  scopedParams: ReadonlyMap<string, string>,
+  supply: UniqueSupply,
+  synthCell: SynthCell | undefined,
+  applyConst: (e: OpaqueExpr) => OpaqueExpr,
+): PropResult[] {
+  const ast = getAst();
+
+  // Resolve return type. Use the signature's declared return rather than
+  // the object literal's inferred type (which would be
+  // `{ f1: SetLike, ... }` with contextual widening not applied).
+  const sig = checker.getSignatureFromDeclaration(fnNode);
+  const returnType = sig?.getReturnType();
+  if (!returnType) {
+    return [
+      {
+        kind: "unsupported",
+        reason: `${functionName} — cannot resolve return type for record return`,
+      },
+    ];
+  }
+  const returnSymbol = returnType.aliasSymbol ?? returnType.symbol;
+  const returnTypeName = returnSymbol?.getName();
+  if (!returnTypeName) {
+    return [
+      {
+        kind: "unsupported",
+        reason: `${functionName} — cannot resolve return type name for record return`,
+      },
+    ];
+  }
+  // Anonymous record return (`returnTypeName === "__type"`): the
+  // `mapTsType` branch during signature translation has already
+  // registered the shape with the synth cell, so the synthesized
+  // domain and its accessor rules are declared by the time the body
+  // is translated. The field-emission loop below works unchanged — it
+  // iterates `returnType.getProperties()` (which enumerates the
+  // anonymous shape's declared fields just as well as an interface's)
+  // and emits one equation per field, applying each accessor rule to
+  // the function application. Reject only when the cell is missing or
+  // when upstream synth registration failed (field types unmangleable).
+  if (returnTypeName === "__type") {
+    if (!synthCell) {
+      return [
+        {
+          kind: "unsupported",
+          reason: `${functionName} — anonymous record return requires a synth cell`,
+        },
+      ];
+    }
+    if (returnType.getCallSignatures().length > 0) {
+      return [
+        {
+          kind: "unsupported",
+          reason: `${functionName} — callable anonymous return type`,
+        },
+      ];
+    }
+    // Re-run the (idempotent) synth-mapping to confirm registration
+    // actually succeeded for this shape. If a field type is unmangleable
+    // the synth returns the failure sentinel rather than a domain name,
+    // and the body emission below would otherwise reference accessor
+    // rules that were never declared.
+    const mapped = mapTsType(returnType, checker, strategy, synthCell);
+    if (mapped === UNSUPPORTED_ANONYMOUS_RECORD) {
+      return [
+        {
+          kind: "unsupported",
+          reason: `${functionName} — anonymous record return shape could not be synthesized`,
+        },
+      ];
+    }
+  }
+
+  // Collect declared fields. For named interfaces this is the declared
+  // property list; for anonymous records it's the same shape seen through
+  // the structural type's properties. Canonical order matches the synth's
+  // sorted order (by field name) so the emission stays deterministic.
+  const declaredFields = returnType
+    .getProperties()
+    .map((prop) => ({
+      name: prop.getName(),
+      type: checker.getTypeOfSymbolAtLocation(prop, fnNode),
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  // Index literal properties by name. Reject unsupported property kinds
+  // and duplicate keys (the spec requires exactly one assignment per
+  // declared field).
+  const literalByName = new Map<string, ts.Expression>();
+  for (const prop of lit.properties) {
+    if (ts.isPropertyAssignment(prop)) {
+      if (!ts.isIdentifier(prop.name) && !ts.isStringLiteral(prop.name)) {
+        return [
+          {
+            kind: "unsupported",
+            reason: `${functionName} — record return with computed or non-simple key`,
+          },
+        ];
+      }
+      if (literalByName.has(prop.name.text)) {
+        return [
+          {
+            kind: "unsupported",
+            reason: `${functionName} — record return repeats field '${prop.name.text}'`,
+          },
+        ];
+      }
+      literalByName.set(prop.name.text, prop.initializer);
+    } else if (ts.isShorthandPropertyAssignment(prop)) {
+      if (literalByName.has(prop.name.text)) {
+        return [
+          {
+            kind: "unsupported",
+            reason: `${functionName} — record return repeats field '${prop.name.text}'`,
+          },
+        ];
+      }
+      literalByName.set(prop.name.text, prop.name);
+    } else {
+      return [
+        {
+          kind: "unsupported",
+          reason: `${functionName} — record return with spread/method/accessor property`,
+        },
+      ];
+    }
+  }
+
+  // Every declared field must be supplied. Extra fields on the literal
+  // are flagged separately below.
+  const missing = declaredFields
+    .filter((f) => !literalByName.has(f.name))
+    .map((f) => f.name);
+  if (missing.length > 0) {
+    return [
+      {
+        kind: "unsupported",
+        reason: `${functionName} — record return missing field(s): ${missing.join(", ")}`,
+      },
+    ];
+  }
+  const extras = [...literalByName.keys()].filter(
+    (n) => !declaredFields.some((f) => f.name === n),
+  );
+  if (extras.length > 0) {
+    return [
+      {
+        kind: "unsupported",
+        reason: `${functionName} — record return has extra field(s): ${extras.join(", ")}`,
+      },
+    ];
+  }
+
+  const argExprs = params.map((p) => ast.var(p.name));
+  const fnApp = ast.app(ast.var(functionName), argExprs);
+
+  // Rule parameters are implicitly in scope for body propositions, so we
+  // don't re-quantify over them — emission matches the existing single-
+  // equation path (`larger a b = cond ...`). Only fresh binders introduced
+  // by a field's translation (e.g., the empty-set membership binder) are
+  // quantified explicitly.
+  //
+  // Empty-set binders are *serialized* into the final assertion, so they
+  // must be valid Pantagruel identifiers and must not capture the function's
+  // own params. The synthCell branch already avoids both issues: its
+  // registry was seeded by translateSignature with every param name, so
+  // `cellRegisterName(synthCell, "x")` returns `x1` when `x` is a param.
+  // The fallback (no synthCell — direct callers / tests) seeds a local
+  // registry from `params` to preserve the same guarantees.
+  let localRegistry: NameRegistry = {
+    used: new Set(params.map((p) => p.name)),
+  };
+  const allocEmittedBinder = (hint: string): string => {
+    if (synthCell) {
+      return cellRegisterName(synthCell, hint);
+    }
+    const r = registerName(localRegistry, hint);
+    localRegistry = r.registry;
+    return r.name;
+  };
+
+  return emitRecordEquations(
+    lit,
+    fnApp,
+    declaredFields,
+    functionName,
+    checker,
+    strategy,
+    scopedParams,
+    supply,
+    synthCell,
+    applyConst,
+    allocEmittedBinder,
+  );
+}
+
+/**
+ * Emit one equation per field of a record-typed receiver. Shared between
+ * the top-level function return (receiver = function application) and
+ * nested object-literal initializers (receiver = accessor application on
+ * the outer record). Recurses when a field's initializer is itself an
+ * object literal — translating a literal value under Pantagruel's
+ * observational discipline requires decomposing it into per-accessor
+ * equations, since there's no record-constructor expression to fall back
+ * on.
+ */
+function emitRecordEquations(
+  lit: ts.ObjectLiteralExpression,
+  receiverExpr: OpaqueExpr,
+  declaredFields: Array<{ name: string; type: ts.Type }>,
+  functionName: string,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  scopedParams: ReadonlyMap<string, string>,
+  supply: UniqueSupply,
+  synthCell: SynthCell | undefined,
+  applyConst: (e: OpaqueExpr) => OpaqueExpr,
+  allocEmittedBinder: (hint: string) => string,
+): PropResult[] {
+  const ast = getAst();
+
+  // Re-index the literal's properties by name for this level. Nested
+  // calls each index their own literal. Apply the same exact-field
+  // contract as the top-level record return: reject unsupported property
+  // kinds, duplicate keys, missing fields, and extra fields.
+  const literalByName = new Map<string, ts.Expression>();
+  for (const prop of lit.properties) {
+    if (ts.isPropertyAssignment(prop)) {
+      if (!ts.isIdentifier(prop.name) && !ts.isStringLiteral(prop.name)) {
+        return [
+          {
+            kind: "unsupported",
+            reason: `${functionName} — nested record literal with computed or non-simple key`,
+          },
+        ];
+      }
+      if (literalByName.has(prop.name.text)) {
+        return [
+          {
+            kind: "unsupported",
+            reason: `${functionName} — nested record literal repeats field '${prop.name.text}'`,
+          },
+        ];
+      }
+      literalByName.set(prop.name.text, prop.initializer);
+    } else if (ts.isShorthandPropertyAssignment(prop)) {
+      if (literalByName.has(prop.name.text)) {
+        return [
+          {
+            kind: "unsupported",
+            reason: `${functionName} — nested record literal repeats field '${prop.name.text}'`,
+          },
+        ];
+      }
+      literalByName.set(prop.name.text, prop.name);
+    } else {
+      return [
+        {
+          kind: "unsupported",
+          reason: `${functionName} — nested record literal with spread/method/accessor property`,
+        },
+      ];
+    }
+  }
+
+  const extras = [...literalByName.keys()].filter(
+    (n) => !declaredFields.some((f) => f.name === n),
+  );
+  if (extras.length > 0) {
+    return [
+      {
+        kind: "unsupported",
+        reason: `${functionName} — nested record literal has extra field(s): ${extras.join(", ")}`,
+      },
+    ];
+  }
+
+  const results: PropResult[] = [];
+  for (const field of declaredFields) {
+    const initializer = literalByName.get(field.name);
+    if (!initializer) {
+      return [
+        {
+          kind: "unsupported",
+          reason: `${functionName} — nested record literal missing field '${field.name}'`,
+        },
+      ];
+    }
+    const fieldApp = ast.app(ast.var(field.name), [receiverExpr]);
+
+    // `new Set()` → empty-set membership negation.
+    if (isEmptySetConstruction(initializer)) {
+      const elemType = getSetElementTypeName(
+        field.type,
+        checker,
+        strategy,
+        synthCell,
+      );
+      if (!elemType) {
+        return [
+          {
+            kind: "unsupported",
+            reason: `${functionName} — new Set() initializer on non-set field '${field.name}'`,
+          },
+        ];
+      }
+      const binderName = allocEmittedBinder("x");
+      const binderParam = ast.param(binderName, ast.tName(elemType));
+      const body = ast.unop(
+        ast.opNot(),
+        ast.binop(ast.opIn(), ast.var(binderName), fieldApp),
+      );
+      results.push({
+        kind: "assertion",
+        quantifiers: [binderParam],
+        body,
+      });
+      continue;
+    }
+
+    // `new Map()` → empty-map key-predicate negation. The Stage A
+    // field-Map encoding in translate-types.ts emits a `<field>Key`
+    // predicate alongside the value rule; "empty" means no key is
+    // registered: `all k: K | ~(<field>Key receiver k)`.
+    if (isEmptyMapConstruction(initializer)) {
+      const keyType = getMapKeyTypeName(
+        field.type,
+        checker,
+        strategy,
+        synthCell,
+      );
+      if (!keyType) {
+        return [
+          {
+            kind: "unsupported",
+            reason: `${functionName} — new Map() initializer on non-map field '${field.name}'`,
+          },
+        ];
+      }
+      const binderName = allocEmittedBinder("k");
+      const binderParam = ast.param(binderName, ast.tName(keyType));
+      const keyPredApp = ast.app(ast.var(`${field.name}Key`), [
+        receiverExpr,
+        ast.var(binderName),
+      ]);
+      const body = ast.unop(ast.opNot(), keyPredApp);
+      results.push({
+        kind: "assertion",
+        quantifiers: [binderParam],
+        body,
+      });
+      continue;
+    }
+
+    // Nested object literal → recursively decompose into per-subfield
+    // equations with `fieldApp` as the new receiver. Pantagruel has no
+    // record-constructor expression; the only way to specify a record
+    // value is observationally (equations on its accessors).
+    if (ts.isObjectLiteralExpression(initializer)) {
+      const subFields = field.type
+        .getProperties()
+        .map((prop) => ({
+          name: prop.getName(),
+          type: checker.getTypeOfSymbol(prop),
+        }))
+        .sort((a, b) => a.name.localeCompare(b.name));
+      const subResults = emitRecordEquations(
+        initializer,
+        fieldApp,
+        subFields,
+        `${functionName}.${field.name}`,
+        checker,
+        strategy,
+        scopedParams,
+        supply,
+        synthCell,
+        applyConst,
+        allocEmittedBinder,
+      );
+      const subUnsupported = subResults.find((p) => p.kind === "unsupported");
+      if (subUnsupported) {
+        return [subUnsupported];
+      }
+      results.push(...subResults);
+      continue;
+    }
+
+    const body = translateBodyExpr(
+      initializer,
+      checker,
+      strategy,
+      scopedParams,
+      undefined,
+      supply,
+    );
+    if (isBodyUnsupported(body)) {
+      return [
+        {
+          kind: "unsupported",
+          reason: `${functionName}.${field.name} — ${body.unsupported}`,
+        },
+      ];
+    }
+    if (isBodyEffect(body)) {
+      return [
+        {
+          kind: "unsupported",
+          reason: `${functionName}.${field.name} — effect outside statement position`,
+        },
+      ];
+    }
+    const rhs = applyConst(bodyExpr(body));
+    results.push({
+      kind: "equation",
+      quantifiers: [],
+      lhs: fieldApp,
+      rhs,
+    });
+  }
+
+  return results;
+}
+
+/** `new Set()` (zero args) — the only Set construction form we currently
+ * translate. `new Set(iterable)` and subclass constructors are rejected. */
+function isEmptySetConstruction(expr: ts.Expression): boolean {
+  return (
+    ts.isNewExpression(expr) &&
+    ts.isIdentifier(expr.expression) &&
+    expr.expression.text === "Set" &&
+    (expr.arguments === undefined || expr.arguments.length === 0)
+  );
+}
+
+/** Return the Pantagruel type name of `T` in a `Set<T>` / `ReadonlySet<T>`
+ * / `[T]` (array) field, or null if the field isn't set-shaped. */
+function getSetElementTypeName(
+  fieldType: ts.Type,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  synthCell: SynthCell | undefined,
+): string | null {
+  if (isSetType(fieldType) || checker.isArrayType(fieldType)) {
+    const typeArgs = checker.getTypeArguments(fieldType as ts.TypeReference);
+    if (typeArgs.length === 1) {
+      return mapTsType(typeArgs[0]!, checker, strategy, synthCell);
+    }
+  }
+  return null;
+}
+
+/** `new Map()` (zero args) — the only Map construction form we currently
+ * translate. `new Map(iterable)` and subclass constructors are rejected. */
+function isEmptyMapConstruction(expr: ts.Expression): boolean {
+  return (
+    ts.isNewExpression(expr) &&
+    ts.isIdentifier(expr.expression) &&
+    expr.expression.text === "Map" &&
+    (expr.arguments === undefined || expr.arguments.length === 0)
+  );
+}
+
+/** Return the Pantagruel type name of `K` in a `Map<K, V>` /
+ * `ReadonlyMap<K, V>` field, or null if the field isn't map-shaped. */
+function getMapKeyTypeName(
+  fieldType: ts.Type,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  synthCell: SynthCell | undefined,
+): string | null {
+  if (isMapType(fieldType)) {
+    const typeArgs = checker.getTypeArguments(fieldType as ts.TypeReference);
+    if (typeArgs.length === 2) {
+      return mapTsType(typeArgs[0]!, checker, strategy, synthCell);
+    }
+  }
+  return null;
+}

--- a/tools/ts2pant/src/translate-record.ts
+++ b/tools/ts2pant/src/translate-record.ts
@@ -494,7 +494,7 @@ function emitRecordEquations(
         .getProperties()
         .map((prop) => ({
           name: prop.getName(),
-          type: checker.getTypeOfSymbol(prop),
+          type: checker.getTypeOfSymbolAtLocation(prop, initializer),
         }))
         .sort((a, b) => a.name.localeCompare(b.name));
       const subResults = emitRecordEquations(

--- a/tools/ts2pant/src/translate-types.ts
+++ b/tools/ts2pant/src/translate-types.ts
@@ -666,11 +666,13 @@ export function isAnonymousRecord(type: ts.Type): boolean {
 }
 
 /**
- * Detect a TypeScript `Map<K, V>` by symbol name. Same caveat as `isSetType`.
+ * Detect a TypeScript `Map<K, V>` or `ReadonlyMap<K, V>` by symbol name.
+ * Same caveat as `isSetType`.
  */
 export function isMapType(type: ts.Type): boolean {
   const symbol = type.getSymbol();
-  return symbol?.getName() === "Map";
+  const name = symbol?.getName();
+  return name === "Map" || name === "ReadonlyMap";
 }
 
 /** Derive a short parameter name from a type name (first letter, lowercased). */

--- a/tools/ts2pant/tests/dogfood.test.mts
+++ b/tools/ts2pant/tests/dogfood.test.mts
@@ -45,3 +45,21 @@ describe("dogfood: src/name-registry.ts", () => {
     assertPantTypeChecks(output);
   });
 });
+
+describe("dogfood: src/translate-types.ts", () => {
+  const filePath = resolve(SRC, "translate-types.ts");
+
+  it("emptyMapSynth — translates and type-checks", async (t) => {
+    const doc = await buildDocumentFromPath(filePath, "emptyMapSynth");
+    const output = emitDocument(doc);
+    t.assert.snapshot(output);
+    assertPantTypeChecks(output);
+  });
+
+  it("emptyRecordSynth — translates and type-checks", async (t) => {
+    const doc = await buildDocumentFromPath(filePath, "emptyRecordSynth");
+    const output = emitDocument(doc);
+    t.assert.snapshot(output);
+    assertPantTypeChecks(output);
+  });
+});

--- a/tools/ts2pant/tests/dogfood.test.mts
+++ b/tools/ts2pant/tests/dogfood.test.mts
@@ -54,6 +54,22 @@ describe("dogfood: src/translate-types.ts", () => {
     const output = emitDocument(doc);
     t.assert.snapshot(output);
     assertPantTypeChecks(output);
+    // `MapSynth.byKV: ReadonlyMap<string, MapSynthEntry>` → Stage A
+    // encoding: a binary membership predicate alongside the value rule.
+    t.assert.match(output, /byKVKey m\d*: MapSynth, k: String => Bool\./u);
+    t.assert.match(
+      output,
+      /byKV m\d*: MapSynth, k: String, byKVKey m\d* k => MapSynthEntry\./u,
+    );
+    // `return { byKV: new Map(), emitted: new Set() }` → empty-map
+    // initializer emits Stage A membership-negation assertion.
+    t.assert.match(
+      output,
+      /all k\d*: String \| ~\(byKVKey emptyMapSynth k\d*\)\./u,
+    );
+    // `collectNamedTypes` recursion must follow `ReadonlyMap<K, V>` into V:
+    // `MapSynthEntry` is only reachable through `byKV`'s value type.
+    t.assert.match(output, /^MapSynthEntry\.$/mu);
   });
 
   it("emptyRecordSynth — translates and type-checks", async (t) => {
@@ -61,5 +77,19 @@ describe("dogfood: src/translate-types.ts", () => {
     const output = emitDocument(doc);
     t.assert.snapshot(output);
     assertPantTypeChecks(output);
+    // Same three invariants on the sibling RecordSynth type. Paired with
+    // the MapSynth case so a regression in any one of ReadonlyMap-field
+    // Stage A encoding, empty-map initializer emission, or
+    // collectNamedTypes recursion surfaces on a focused assertion rather
+    // than only on a compound snapshot.
+    t.assert.match(
+      output,
+      /byShapeKey r\d*: RecordSynth, k: String => Bool\./u,
+    );
+    t.assert.match(
+      output,
+      /all k\d*: String \| ~\(byShapeKey emptyRecordSynth k\d*\)\./u,
+    );
+    t.assert.match(output, /^RecordSynthEntry\.$/mu);
   });
 });

--- a/tools/ts2pant/tests/dogfood.test.mts.snapshot
+++ b/tools/ts2pant/tests/dogfood.test.mts.snapshot
@@ -5,3 +5,11 @@ exports[`dogfood: src/name-registry.ts > emptyNameRegistry — translates and ty
 exports[`dogfood: src/name-registry.ts > isUsed — translates and type-checks 1`] = `
 "module IsUsed.\\n\\nNameRegistry.\\nused n: NameRegistry => [String].\\nisUsed registry: NameRegistry, name: String => Bool.\\n\\n---\\n\\nisUsed registry name = (name in used registry).\\n"
 `;
+
+exports[`dogfood: src/translate-types.ts > emptyMapSynth — translates and type-checks 1`] = `
+"module EmptyMapSynth.\\n\\nMapSynthNames.\\ndomain m: MapSynthNames => String.\\nrule m: MapSynthNames => String.\\nkeyPred m: MapSynthNames => String.\\nMapSynthEntry.\\nnames m1: MapSynthEntry => MapSynthNames.\\nkType m1: MapSynthEntry => String.\\nvType m1: MapSynthEntry => String.\\nMapSynth.\\nbyKVKey m2: MapSynth, k: String => Bool.\\nbyKV m2: MapSynth, k: String, byKVKey m2 k => MapSynthEntry.\\nemitted m2: MapSynth => [String].\\nemptyMapSynth  => MapSynth.\\n\\n---\\n\\nall k1: String | ~(byKVKey emptyMapSynth k1).\\nall x: String | ~(x in emitted emptyMapSynth).\\n"
+`;
+
+exports[`dogfood: src/translate-types.ts > emptyRecordSynth — translates and type-checks 1`] = `
+"module EmptyRecordSynth.\\n\\nRecordSynthField.\\nname r: RecordSynthField => String.\\ntype r: RecordSynthField => String.\\nRecordSynthEntry.\\ndomain r1: RecordSynthEntry => String.\\nbinder r1: RecordSynthEntry => String.\\nfields r1: RecordSynthEntry => [RecordSynthField].\\nRecordSynth.\\nbyShapeKey r2: RecordSynth, k: String => Bool.\\nbyShape r2: RecordSynth, k: String, byShapeKey r2 k => RecordSynthEntry.\\nemitted r2: RecordSynth => [String].\\nemptyRecordSynth  => RecordSynth.\\n\\n---\\n\\nall k1: String | ~(byShapeKey emptyRecordSynth k1).\\nall x: String | ~(x in emitted emptyRecordSynth).\\n"
+`;


### PR DESCRIPTION
## Summary

Two logically-adjacent changes in one commit, both motivated by dogfooding ts2pant on its own source:

1. **\`ReadonlyMap<K, V>\` interface fields** now translate through the same Stage A field-Map encoding that \`Map<K, V>\` uses (\`isMapType\` already handled both \`Map\` and the \`Set\`/\`ReadonlySet\` twins, but was silently dropping \`ReadonlyMap\`).
2. **Empty \`new Map()\` initializers** in record-return object literals emit a symmetric-to-Set assertion: \`all k: K | ~(<field>Key <receiver> k)\` instead of falling through to the generic expression translator (which errored on \`new Map()\`).
3. **Type-reference following** (\`collectNamedTypes\` in \`extract.ts\`) recurses into Set/Map type arguments too — previously only \`isArrayType\`/\`isTupleType\` descended, so the V-type inside \`ReadonlyMap<K, V>\` wasn't being picked up as a named-type dependency.

Plus a **structural extraction**: \`translateRecordReturn\` / \`emitRecordEquations\` / the empty-Set / empty-Map helpers (~526 LOC) move from \`translate-body.ts\` into a new \`translate-record.ts\`. Pure refactor — behavior preserved — but \`translate-body.ts\` drops from ~4300 to ~3800 LOC and the record-return logic now lives in a module whose name matches its scope.

## Why

\`tools/ts2pant/src/translate-types.ts\` defines \`MapSynth\` with a \`ReadonlyMap<string, MapSynthEntry>\` field. Translating \`emptyMapSynth\` and \`emptyRecordSynth\` was blocked: the \`ReadonlyMap\` field emitted as a bare \`ReadonlyMap\` type name (not declared anywhere), and \`new Map()\` in the record literal produced an unsupported-operator error. Combined with #118's optional-param split, the pipeline can now translate \`newSynthCell\` into a two-head arity-overloaded rule family — self-translation progresses several steps further.

## What's in this PR

Commit \`8390d37\`: \`ts2pant: translate empty ReadonlyMap fields; extract translate-record.ts\`, 6 files changed (+569 / −452):

- \`tools/ts2pant/src/translate-types.ts\` — \`isMapType\` recognizes \`ReadonlyMap\` alongside \`Map\`.
- \`tools/ts2pant/src/translate-body.ts\` — record-return helpers removed here (moved to new file); gains \`export\` on \`UniqueSupply\` so the new file can share the type.
- \`tools/ts2pant/src/translate-record.ts\` — **new** (~526 LOC). \`translateRecordReturn\`, \`emitRecordEquations\`, \`isEmptySetConstruction\`, \`isEmptyMapConstruction\`, \`getSetElementTypeName\`, \`getMapKeyTypeName\`. Adds the empty-Map branch symmetric to empty-Set.
- \`tools/ts2pant/src/extract.ts\` — \`collectNamedTypes\` recurses into Set/Map type args.
- \`tools/ts2pant/tests/dogfood.test.mts\` — adds self-translation coverage for \`emptyMapSynth\` and \`emptyRecordSynth\`.
- \`tools/ts2pant/tests/dogfood.test.mts.snapshot\` — snapshots for the new dogfood cases.

## Test plan

- [x] \`npm test\` — 333/333 pass (up from 322 at branch-cut; the extra 11 are the new dogfood cases plus suite additions pulled in via rebase)
- [x] \`newSynthCell\` translates end-to-end combining this PR's fixes + arity-overloading from #119 + the optional-param split from #118. The emitted Pantagruel still fails \`pant\` on an unrelated issue (\`domain\` field appears in two interfaces → duplicate rule error) — that's a separate follow-up about field-name scoping across interfaces, not blocked by this PR's scope.
- [x] Rebased cleanly onto origin/master (one minor conflict: \`UniqueSupply\` is now \`export\`ed here since origin/master added the \`NullishRewrite\` field for #118's optional-param split).

## Related

- Unblocks further ts2pant self-translation progress alongside #118 (merged) and #119 (merged).
- Next blocker on self-translating \`newSynthCell\` is field-name collisions across interfaces (\`domain\` appears in both \`MapSynthNames\` and \`RecordSynthEntry\`) — distinct concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)