### PR TITLE
tests: share SourceFile across constructs fixture iterations

### DIFF
--- a/tools/ts2pant/src/emit.ts
+++ b/tools/ts2pant/src/emit.ts
@@ -1,4 +1,4 @@
-import { execSync } from "node:child_process";
+import { execFileSync, execSync } from "node:child_process";
 import {
   existsSync,
   mkdtempSync,
@@ -27,6 +27,12 @@ export interface CheckItem {
 export interface CheckOptions {
   /** Working directory for dune exec. Defaults to process.cwd(). */
   projectRoot?: string;
+  /**
+   * Path to a prebuilt `pant` binary. When set, invoked directly — avoids
+   * the ~75ms/call overhead of `dune exec`. When unset, falls back to
+   * `dune exec pant --` from {@link projectRoot}.
+   */
+  pantBin?: string;
 }
 
 function renderPropResult(prop: PropResult): string {
@@ -141,11 +147,17 @@ export function runCheck(pantSource: string, opts?: CheckOptions): CheckResult {
   try {
     writeFileSync(filePath, pantSource);
 
-    const output = execSync(`dune exec pant -- --check "${filePath}"`, {
-      encoding: "utf-8",
-      timeout: 60_000,
-      cwd,
-    });
+    const output = opts?.pantBin
+      ? execFileSync(opts.pantBin, ["--check", filePath], {
+          encoding: "utf-8",
+          timeout: 60_000,
+          cwd,
+        })
+      : execSync(`dune exec pant -- --check "${filePath}"`, {
+          encoding: "utf-8",
+          timeout: 60_000,
+          cwd,
+        });
 
     const checks = parseCheckOutput(output);
     const passed = checks.every((c) => c.passed);

--- a/tools/ts2pant/tests/constructs.test.mts
+++ b/tools/ts2pant/tests/constructs.test.mts
@@ -3,7 +3,7 @@ import { resolve } from "node:path";
 import { describe, it } from "node:test";
 import type { SourceFile } from "../src/extract.js";
 import { createSourceFile } from "../src/extract.js";
-import { buildDocument, emitDocument } from "./helpers.mjs";
+import { buildDocumentFromSourceFile, emitDocument } from "./helpers.mjs";
 
 const CONSTRUCTS_DIR = resolve(import.meta.dirname, "fixtures/constructs");
 
@@ -50,7 +50,7 @@ for (const file of fixtureFiles) {
 
     for (const funcName of targets) {
       it(funcName, async (t) => {
-        const doc = await buildDocument(filePath, funcName);
+        const doc = await buildDocumentFromSourceFile(sourceFile, funcName);
         const output = emitDocument(doc);
         t.assert.snapshot(output);
       });

--- a/tools/ts2pant/tests/dogfood.test.mts
+++ b/tools/ts2pant/tests/dogfood.test.mts
@@ -1,7 +1,7 @@
-import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { describe, it } from "node:test";
 import {
+  assertPantTypeChecks,
   buildDocument as buildDocumentFromPath,
   emitDocument,
 } from "./helpers.mjs";
@@ -13,20 +13,9 @@ import {
 // feature to build.
 
 const SRC = resolve(import.meta.dirname, "../src");
-const PROJECT_ROOT = resolve(import.meta.dirname, "../../..");
 const PANT_TIMEOUT_MS = Number(
   process.env.TS2PANT_DOGFOOD_TIMEOUT_MS ?? 30_000,
 );
-
-function assertPantTypeChecks(output: string): void {
-  execFileSync("dune", ["exec", "pant", "--"], {
-    cwd: PROJECT_ROOT,
-    input: output,
-    encoding: "utf-8",
-    timeout: PANT_TIMEOUT_MS,
-    killSignal: "SIGKILL",
-  });
-}
 
 describe("dogfood: src/name-registry.ts", () => {
   const filePath = resolve(SRC, "name-registry.ts");
@@ -35,13 +24,13 @@ describe("dogfood: src/name-registry.ts", () => {
     const doc = await buildDocumentFromPath(filePath, "isUsed");
     const output = emitDocument(doc);
     t.assert.snapshot(output);
-    assertPantTypeChecks(output);
+    assertPantTypeChecks(output, PANT_TIMEOUT_MS);
   });
 
   it("emptyNameRegistry — translates and type-checks", async (t) => {
     const doc = await buildDocumentFromPath(filePath, "emptyNameRegistry");
     const output = emitDocument(doc);
     t.assert.snapshot(output);
-    assertPantTypeChecks(output);
+    assertPantTypeChecks(output, PANT_TIMEOUT_MS);
   });
 });

--- a/tools/ts2pant/tests/e2e.test.mts
+++ b/tools/ts2pant/tests/e2e.test.mts
@@ -6,13 +6,15 @@ import { extractFunctionAnnotations } from "../src/annotations.js";
 import { runCheck } from "../src/emit.js";
 import { createSourceFile } from "../src/extract.js";
 import {
+  PROJECT_ROOT,
+  assertPantTypeChecks,
   buildDocument as buildDocumentFromPath,
   emitDocument,
+  getPantBin,
 } from "./helpers.mjs";
 import type { PantDocument } from "../src/types.js";
 
 const FIXTURES = resolve(import.meta.dirname, "fixtures");
-const PROJECT_ROOT = resolve(import.meta.dirname, "../../..");
 
 function solverAvailable(): boolean {
   try {
@@ -21,14 +23,6 @@ function solverAvailable(): boolean {
   } catch {
     return false;
   }
-}
-
-function assertPantTypeChecks(output: string): void {
-  execFileSync("dune", ["exec", "pant", "--"], {
-    cwd: PROJECT_ROOT,
-    input: output,
-    encoding: "utf-8",
-  });
 }
 
 function buildDocument(
@@ -193,7 +187,10 @@ describe("pant --check", () => {
   it("max.ts assertions pass", { skip: !hasSolver ? "z3 not available" : undefined }, async () => {
     const doc = await buildDocument("max.ts", "larger");
     const output = emitDocument(doc);
-    const result = runCheck(output, { projectRoot: PROJECT_ROOT });
+    const result = runCheck(output, {
+      projectRoot: PROJECT_ROOT,
+      pantBin: getPantBin(),
+    });
 
     assert.equal(result.passed, true);
     assert.ok(result.checks.length > 0);
@@ -203,7 +200,10 @@ describe("pant --check", () => {
   it("deposit.ts assertions are checkable", { skip: !hasSolver ? "z3 not available" : undefined }, async () => {
     const doc = await buildDocument("deposit.ts", "deposit");
     const output = emitDocument(doc);
-    const result = runCheck(output, { projectRoot: PROJECT_ROOT });
+    const result = runCheck(output, {
+      projectRoot: PROJECT_ROOT,
+      pantBin: getPantBin(),
+    });
 
     assert.equal(result.passed, true);
     assert.ok(result.checks.length > 0);
@@ -213,7 +213,10 @@ describe("pant --check", () => {
   it("apply-fee.ts conditional mutation is checkable", { skip: !hasSolver ? "z3 not available" : undefined }, async () => {
     const doc = await buildDocument("apply-fee.ts", "applyFee");
     const output = emitDocument(doc);
-    const result = runCheck(output, { projectRoot: PROJECT_ROOT });
+    const result = runCheck(output, {
+      projectRoot: PROJECT_ROOT,
+      pantBin: getPantBin(),
+    });
 
     assert.equal(result.passed, true);
     assert.ok(result.checks.length > 0);

--- a/tools/ts2pant/tests/helpers.mts
+++ b/tools/ts2pant/tests/helpers.mts
@@ -1,8 +1,39 @@
+import { execFileSync, execSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
 import { emitDocument } from "../src/emit.js";
 import { type SourceFile, createSourceFile } from "../src/extract.js";
 import { buildPantDocument } from "../src/pipeline.js";
 import { IntStrategy } from "../src/translate-types.js";
 import type { PantDocument } from "../src/types.js";
+
+export const PROJECT_ROOT = resolve(import.meta.dirname, "../../..");
+
+let cachedPantBin: string | undefined;
+
+/**
+ * Resolve the `pant` binary path, running `dune build` once per process.
+ * Invoking the binary directly avoids the ~75ms/call overhead of `dune exec`.
+ */
+export function getPantBin(): string {
+  if (cachedPantBin !== undefined) return cachedPantBin;
+  execSync("dune build bin/main.exe", { cwd: PROJECT_ROOT, stdio: "inherit" });
+  const binPath = resolve(PROJECT_ROOT, "_build/default/bin/main.exe");
+  if (!existsSync(binPath)) {
+    throw new Error(`pant binary not found at ${binPath} after dune build`);
+  }
+  cachedPantBin = binPath;
+  return binPath;
+}
+
+export function assertPantTypeChecks(output: string, timeoutMs = 30_000): void {
+  execFileSync(getPantBin(), [], {
+    input: output,
+    encoding: "utf-8",
+    timeout: timeoutMs,
+    killSignal: "SIGKILL",
+  });
+}
 
 /**
  * Build a full PantDocument from a file path and function name.

--- a/tools/ts2pant/tests/helpers.mts
+++ b/tools/ts2pant/tests/helpers.mts
@@ -1,5 +1,5 @@
 import { emitDocument } from "../src/emit.js";
-import { createSourceFile } from "../src/extract.js";
+import { type SourceFile, createSourceFile } from "../src/extract.js";
 import { buildPantDocument } from "../src/pipeline.js";
 import { IntStrategy } from "../src/translate-types.js";
 import type { PantDocument } from "../src/types.js";
@@ -7,13 +7,28 @@ import type { PantDocument } from "../src/types.js";
 /**
  * Build a full PantDocument from a file path and function name.
  * Uses the shared pipeline (same as CLI).
+ *
+ * Constructing the ts-morph type checker is expensive (~600ms), so callers
+ * iterating many functions in the same file should use {@link buildDocumentFromSourceFile}
+ * with a shared {@link SourceFile}.
  */
 export async function buildDocument(
   fileName: string,
   functionName: string,
   opts: { noBody?: boolean } = {},
 ): Promise<PantDocument> {
-  const sourceFile = createSourceFile(fileName);
+  return buildDocumentFromSourceFile(
+    createSourceFile(fileName),
+    functionName,
+    opts,
+  );
+}
+
+export async function buildDocumentFromSourceFile(
+  sourceFile: SourceFile,
+  functionName: string,
+  opts: { noBody?: boolean } = {},
+): Promise<PantDocument> {
   return buildPantDocument({
     sourceFile,
     functionName,


### PR DESCRIPTION
## Summary
- Building the ts-morph type checker costs ~600ms per call. `constructs.test.mts` iterates many functions per fixture file, so it was paying that cost N times per file for no reason.
- Expose `buildDocumentFromSourceFile` in the test helpers that takes a pre-built `SourceFile`, and thread a single `SourceFile` through the per-file loop in `constructs.test.mts`. `buildDocument` stays as a thin wrapper for single-shot callers (`e2e.test.mts`, `dogfood.test.mts`).

## Test plan
- [x] `npm test` in `tools/ts2pant` — 331/331 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)