### PR TITLE
lang: remove Nothing from user-facing type surface

### DIFF
--- a/.claude/skills/write-spec/SKILL.md
+++ b/.claude/skills/write-spec/SKILL.md
@@ -201,7 +201,7 @@ When the "maybe there, maybe not" status needs to be stored, compared, or aggreg
 ```
 {Loans} borrower b: Book => [Member].
 ---
-all b: Book | #(borrower b) =< 1.
+all b: Book | #(borrower b) <= 1.
 ```
 
 Absence is `#(borrower b) = 0`; presence-and-value is `(borrower b).1` after establishing `#(borrower b) = 1`. Use this when the optionality interacts with other set/list machinery (counts, membership, aggregation).
@@ -215,7 +215,7 @@ Only use this when the sentinel is a real domain value, not a stand-in for "miss
 ### How to choose
 
 - **Is this a precondition on the caller?** → guard (1)
-- **Is the absence itself data the spec reasons about?** → `[T]` with `=< 1` (2)
+- **Is the absence itself data the spec reasons about?** → `[T]` with `<= 1` (2)
 - **Does the codomain already contain a natural empty element?** → sentinel (3)
 
 When in doubt, start with (1). It composes cleanly with the rest of the language and matches how partial functions are handled in classical model-oriented specification.

--- a/.claude/skills/write-spec/SKILL.md
+++ b/.claude/skills/write-spec/SKILL.md
@@ -38,7 +38,7 @@ Write domain declarations and type aliases. Show the user what you have so far.
 Ask: What information is associated with each entity? What properties can change over time?
 
 - Each answer becomes a rule declaration (`owner a: Account => User.`).
-- Clarify return types precisely: is it one value or many? Can it be absent? (`User + Nothing` vs `User` vs `[User]`)
+- Clarify return types precisely: is it one value or many? Can it be absent? See **Modeling Optional Values** below — Pantagruel has no `Maybe`/`Option` type; use guards or list-lifting.
 - Ask about nullary rules (global state): "Is there anything true of the system as a whole, not tied to a specific entity?"
 
 Write rule declarations. Run `pant <file>` to check for type errors.
@@ -176,6 +176,50 @@ Interpret results with the user:
 
 Declaration guards on rules (e.g., `score u: User, active u => Nat.`) are automatically injected as antecedents in SMT queries. This means the solver treats guarded functions as partial — it won't produce counterexamples that apply a function outside its declared domain. When writing guards, consider that they will constrain all verification queries involving that function.
 
+## Modeling Optional Values
+
+Pantagruel has no `Maybe`/`Option` type. **Do not use `T + Nothing`** — `Nothing` has no inhabitants, and the language does not support sum-type projection, so there is no value to return and no way to case-split on it. Sum types work for disjoint alternatives that both carry data (e.g. `Success * Result + Failure * Reason`), not for "present-or-absent."
+
+When a rule's value may not exist for every input, choose one of the following. The first is the default.
+
+### 1. Partial function via guard (preferred)
+
+Declare the rule with a guard that captures when it's defined. Pantagruel injects the guard as an antecedent in SMT queries, so the solver treats the rule as partial and won't fabricate counterexamples outside its domain.
+
+```
+{Loans} borrower b: Book, ~available? b => Member.
+```
+
+This reads "for a checked-out book, the borrower is a member." The rule simply has no meaning when `available? b` holds — callers must establish the guard to use it.
+
+This is the Z / VDM / B / Event-B idiom (`f: A ⇸ B`, `dom f`) and is the natural fit whenever "presence" is really a precondition on the caller rather than data the system stores about.
+
+### 2. Lift the codomain to a list (when optionality is first-class data)
+
+When the "maybe there, maybe not" status needs to be stored, compared, or aggregated over — not just guarded against at call sites — model it as a list constrained to length ≤ 1. This is Alloy's `lone` multiplicity.
+
+```
+{Loans} borrower b: Book => [Member].
+---
+all b: Book | #(borrower b) =< 1.
+```
+
+Absence is `#(borrower b) = 0`; presence-and-value is `(borrower b).1` after establishing `#(borrower b) = 1`. Use this when the optionality interacts with other set/list machinery (counts, membership, aggregation).
+
+### 3. Sentinel / distinguished element (rare)
+
+When the codomain has a genuine "empty" member with its own meaning — `0` for `Nat0`, `[]` for a list-typed rule, a domain element that *really is* a valid answer — make the function total and let that value encode absence.
+
+Only use this when the sentinel is a real domain value, not a stand-in for "missing." Conflating "zero balance" with "no account" is a bug waiting to happen.
+
+### How to choose
+
+- **Is this a precondition on the caller?** → guard (1)
+- **Is the absence itself data the spec reasons about?** → `[T]` with `=< 1` (2)
+- **Does the codomain already contain a natural empty element?** → sentinel (3)
+
+When in doubt, start with (1). It composes cleanly with the rest of the language and matches how partial functions are handled in classical model-oriented specification.
+
 ## Syntax Cheatsheet
 
 ### Document structure
@@ -204,7 +248,7 @@ User.
 
 // Type alias
 Point = Nat * Nat.
-Result = Value + Nothing.
+Outcome = Success + Failure.            // sum: both arms carry data
 
 // Rule (with return type)
 owner d: Document => User.
@@ -237,10 +281,10 @@ ancestor b: Block => [Block] = closure parent.
 ### Types
 
 ```
-Nat Nat0 Int Real Bool String Nothing   // primitives
+Nat Nat0 Int Real Bool String           // primitives
 [T]                                     // list
 T * U                                   // product
-T + U                                   // sum (either/or)
+T + U                                   // sum (both arms must be inhabited)
 ```
 
 Numeric hierarchy: `Nat < Nat0 < Int < Real`
@@ -353,17 +397,18 @@ Chapter 1 uses `available?` and `borrower` without declaring them. Chapter 2 wil
 
 **User**: `available?` is whether a book can be checked out. `borrower` is who has it — could be nobody if it's available.
 
-**Agent**:
+**Agent**: Since `borrower` has no value when a book is available, we have two idiomatic choices: make it a partial function guarded by `~available?`, or lift it to `[Member]` with at most one element. The guard version reads more directly here — a book only has a borrower when it's checked out:
 
 ```
 where
 
 > Glossary for checkout terms.
 {Loans} available? b: Book => Bool.
-{Loans} borrower b: Book => Member + Nothing.
+{Loans} borrower b: Book, ~available? b => Member.
 ---
-all b: Book | available? b <-> borrower b = nothing.
 ```
+
+The guard on `borrower` means the checker treats it as undefined when `available? b` holds, so we don't need a separate "no-borrower" sentinel. Callers that need the borrower must first establish `~available? b`.
 
 Are there any other concepts used here that need further definition, or is this the leaf level?
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -405,7 +405,15 @@ Outcome = Success + Failure.
 Users = [User].
 ```
 
-**Optional values.** Pantagruel has no `Maybe`/`Option` type. To express "this value may or may not exist," use a **guarded rule** (partial function) or a **list with at most one element** — see *Guards* and *List types* below. Sum types are for disjoint alternatives that both carry data, not for presence/absence.
+**Optional values.** Pantagruel has no `Maybe`/`Option` type. To express "this value may or may not exist," use a **guarded rule** (partial function) or a **list with at most one element** — see *Guards* and *List types* below. The list-lifted form constrains the length to at most one via a cardinality invariant:
+
+```
+lookup i: Nat => [Color].
+---
+all i: Nat | #(lookup i) <= 1.
+```
+
+Here `#` is the cardinality operator and `<= 1` enforces at most one element — absence is `#(lookup i) = 0`, presence is `(lookup i).1`. Sum types are for disjoint alternatives that both carry data, not for presence/absence.
 
 ### Rule Declaration
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -121,7 +121,6 @@ Every expression in Pantagruel is assigned a type from the following universe.
 | `Int` | All integers (..., −1, 0, 1, ...) |
 | `Real` | Real numbers |
 | `String` | Text strings |
-| `Nothing` | The empty type (uninhabited — no values) |
 
 **Domain types.** Each domain declaration `D.` introduces a distinct type `D`. Domain types are pairwise unrelated, and unrelated to all built-in types.
 
@@ -133,7 +132,7 @@ Every expression in Pantagruel is assigned a type from the following universe.
 |-------------|--------|---------|
 | List | `[T]` | `[User]`, `[[Nat]]` |
 | Product | `T * U`, `T * U * V`, ... | `Nat * Nat`, `Point * Color` |
-| Sum | `T + U`, `T + U + V`, ... | `Value + Nothing` |
+| Sum | `T + U`, `T + U + V`, ... | `Success + Failure` |
 
 Product and sum types must have at least two components. They are **positional**: `Nat * Bool` and `Bool * Nat` are distinct types.
 
@@ -146,8 +145,6 @@ Products are constructed with parentheses — `(1, 2)` — and accessed with pro
 The **subtype** relation *S* ≤ *T*, read "*S* fits where *T* is expected," is a partial order on types. It is defined by the following rules, closed under reflexivity and transitivity.
 
 **Reflexivity.** Every type is a subtype of itself: *T* ≤ *T*.
-
-**Bottom.** `Nothing` is a subtype of every type: `Nothing` ≤ *T* for all *T*. Since `Nothing` is uninhabited, this is vacuously safe — there is no `Nothing` value that could violate the expectations of *T*.
 
 **Numeric chain.** The numeric types form a chain of strict inclusions:
 
@@ -176,7 +173,6 @@ Each `Nat` value is also a `Nat0` value, each `Nat0` value is also an `Int` valu
 | `Nat * Bool` ≤ `Int * Bool` | Yes | `Nat` ≤ `Int` and `Bool` ≤ `Bool` |
 | `Int` ≤ `Nat` | No | `Int` is above `Nat` in the chain |
 | `Bool` ≤ `Nat` | No | Incomparable |
-| `Nothing` ≤ `[User]` | Yes | Bottom type |
 | `User` ≤ `String` | No | Incomparable domain types |
 
 ### Least Upper Bound (Join)
@@ -185,7 +181,7 @@ The **join** of two types, written *S* ⊔ *T*, is the smallest type that both *
 
 **Equal types.** *T* ⊔ *T* = *T*.
 
-**Subtype pairs.** When *S* ≤ *T*, then *S* ⊔ *T* = *T*. This covers the numeric chain (`Nat` ⊔ `Int` = `Int`, `Nat0` ⊔ `Real` = `Real`) and the bottom type (`Nothing` ⊔ *T* = *T*).
+**Subtype pairs.** When *S* ≤ *T*, then *S* ⊔ *T* = *T*. This covers the numeric chain: `Nat` ⊔ `Int` = `Int`, `Nat0` ⊔ `Real` = `Real`.
 
 **Compound types.** The join is computed position by position:
 
@@ -405,9 +401,11 @@ Creates a named alias for a type expression:
 
 ```
 Point = Nat * Nat.
-Result = Value + Nothing.
+Outcome = Success + Failure.
 Users = [User].
 ```
+
+**Optional values.** Pantagruel has no `Maybe`/`Option` type. To express "this value may or may not exist," use a **guarded rule** (partial function) or a **list with at most one element** — see *Guards* and *List types* below. Sum types are for disjoint alternatives that both carry data, not for presence/absence.
 
 ### Rule Declaration
 
@@ -434,16 +432,14 @@ origin => Point.
 Declares a rule as the non-reflexive transitive closure of another rule:
 
 ```
-parent b: Block => Block + Nothing.
+parent b: Block => [Block].
 ancestor b: Block => [Block] = closure parent.
 ```
 
 **Syntax**: `name param => [T] = closure target.`
 
 - The closure always returns `[T]` — the set of all elements reachable from the parameter by one or more applications of the target rule.
-- The target rule must have one of these shapes:
-  - `T => T + Nothing` — a partial endorelation (single parent, may be absent)
-  - `T => [T]` — a multi-valued endorelation (multiple children)
+- The target rule must have shape `T => [T]` — an endorelation represented as a list of related elements per input. The empty list encodes "no relation for this input" (a partial relation); a list of length ≤ 1 encodes a partial function; longer lists encode multi-valued relations.
 - The parameter type must match the domain type `T` of the target.
 - The closure is **non-reflexive**: `ancestor b` does not include `b` itself (unless `b` is reachable from itself through a cycle).
 - Closure rules are **derived** — they do not receive frame conditions in SMT verification. Their post-state (`ancestor'`) is automatically derived from the target's post-state (`parent'`).
@@ -453,7 +449,7 @@ ancestor b: Block => [Block] = closure parent.
 
 ```
 Block.
-parent b: Block => Block + Nothing.
+parent b: Block => [Block].
 ancestor b: Block => [Block] = closure parent.
 ---
 all b: Block | ~(b in ancestor b).

--- a/lib/collect.ml
+++ b/lib/collect.ml
@@ -319,11 +319,7 @@ let collect_chapter_head ~chapter ~doc_contexts env
           match[@warning "-4"] Env.lookup_term_arity target 1 env with
           | Some { kind = Env.KRule ty; _ } -> (
               match[@warning "-4"] ty with
-              (* T => T + Nothing (partial parent) *)
-              | TyFunc ([ t1 ], Some (TySum [ t2; TyNothing ]))
-                when t1 = param_ty && t2 = param_ty ->
-                  Ok ()
-              (* T => [T] (multi-child) *)
+              (* T => [T] (zero-or-more children per node) *)
               | TyFunc ([ t1 ], Some (TyList t2))
                 when t1 = param_ty && t2 = param_ty ->
                   Ok ()
@@ -331,11 +327,8 @@ let collect_chapter_head ~chapter ~doc_contexts env
                   Error
                     (ClosureTargetInvalid
                        ( name,
-                         Printf.sprintf
-                           "target '%s' must have shape %s => %s + Nothing or \
-                            %s => [%s]"
+                         Printf.sprintf "target '%s' must have shape %s => [%s]"
                            target (Types.format_ty param_ty)
-                           (Types.format_ty param_ty) (Types.format_ty param_ty)
                            (Types.format_ty param_ty),
                          decl.loc )))
           | _ ->

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -19,7 +19,7 @@ type ty =
 (** Centralized builtin type registry. [TyNothing] is intentionally absent: it
     is an internal bottom type used for unification and default returns, not a
     user-writable type. Users express optionality via guarded rules or [[T]]
-    with a [#=< 1] invariant. *)
+    with a [#<= 1] invariant. *)
 let builtins =
   [
     ("Bool", TyBool);

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -16,7 +16,10 @@ type ty =
   | TyFunc of ty list * ty option  (** params, return; None = Void *)
 [@@deriving show, eq]
 
-(** Centralized builtin type registry *)
+(** Centralized builtin type registry. [TyNothing] is intentionally absent: it
+    is an internal bottom type used for unification and default returns, not a
+    user-writable type. Users express optionality via guarded rules or [[T]]
+    with a [#=< 1] invariant. *)
 let builtins =
   [
     ("Bool", TyBool);
@@ -25,7 +28,6 @@ let builtins =
     ("Int", TyInt);
     ("Real", TyReal);
     ("String", TyString);
-    ("Nothing", TyNothing);
   ]
 
 let builtin_of_name name = List.assoc_opt name builtins

--- a/samples/03-types.pant
+++ b/samples/03-types.pant
@@ -2,7 +2,7 @@ module TYPES.
 
 > Demonstration of all type features
 
-> Built-in types: Bool, Nat, Nat0, Int, Real, String, Nothing
+> Built-in types: Bool, Nat, Nat0, Int, Real, String
 > Nat = positive integers (1, 2, 3, ...)
 > Nat0 = non-negative integers (0, 1, 2, ...)
 > Numeric hierarchy: Nat < Nat0 < Int < Real
@@ -16,9 +16,8 @@ Point = Nat * Nat.
 Point3D = Nat * Nat * Nat.
 ColoredPoint = Point * Color.
 
-> Type aliases with sum types (unions)
-Result = Nat + Nothing.
-MaybeColor = Color + Nothing.
+> Type aliases with sum types (unions of two inhabited types)
+Tag = Color + Shape.
 
 > Type aliases with list types
 Colors = [Color].
@@ -30,7 +29,10 @@ origin => Point.
 red => Color.
 distance p: Point, q: Point => Real.
 colors => [Color].
-lookup i: Nat => Color + Nothing.
+
+> Optional return values: use a list constrained to length <= 1
+> (Pantagruel has no Maybe/Option type; see guards for the alternative idiom.)
+lookup i: Nat => [Color].
 
 ---
 > Tuple construction with parentheses

--- a/samples/03-types.pant
+++ b/samples/03-types.pant
@@ -53,6 +53,9 @@ red in colors.
 #colors >= 0.
 #Color >= 0.
 
+> Optional-value idiom: lookup returns at most one element
+all i: Nat | #(lookup i) <= 1.
+
 > Numeric operations respect the hierarchy
 all n: Nat, m: Nat0 | n + m >= 0.
 all x: Int, y: Real | x + y = y + x.

--- a/samples/09-closure.pant
+++ b/samples/09-closure.pant
@@ -1,5 +1,5 @@
 Block.
-parent b: Block => Block + Nothing.
+parent b: Block => [Block].
 ancestor b: Block => [Block] = closure parent.
 ---
 all b: Block | ~(b in ancestor b).

--- a/test/snapshots/json/03-types.json
+++ b/test/snapshots/json/03-types.json
@@ -265,6 +265,34 @@
           }
         },
         {
+          "doc": [
+            [ "Optional-value idiom: lookup returns at most one element" ]
+          ],
+          "expr": {
+            "forall": {
+              "params": [ { "name": "i", "type": "Nat" } ],
+              "guards": [],
+              "body": {
+                "binop": {
+                  "op": "le",
+                  "left": {
+                    "unop": {
+                      "op": "card",
+                      "arg": {
+                        "app": {
+                          "func": { "var": "lookup" },
+                          "args": [ { "var": "i" } ]
+                        }
+                      }
+                    }
+                  },
+                  "right": { "nat": 1 }
+                }
+              }
+            }
+          }
+        },
+        {
           "doc": [ [ "Numeric operations respect the hierarchy" ] ],
           "expr": {
             "forall": {

--- a/test/snapshots/json/03-types.json
+++ b/test/snapshots/json/03-types.json
@@ -10,10 +10,6 @@
     },
     "Colors": { "kind": "alias", "type": { "list": "Color" } },
     "Matrix": { "kind": "alias", "type": { "list": { "list": "Nat" } } },
-    "MaybeColor": {
-      "kind": "alias",
-      "type": { "sum": [ "Color", "Nothing" ] }
-    },
     "Point": { "kind": "alias", "type": { "product": [ "Nat", "Nat" ] } },
     "Point3D": {
       "kind": "alias",
@@ -23,8 +19,8 @@
       "kind": "alias",
       "type": { "list": { "product": [ "Nat", "Nat" ] } }
     },
-    "Result": { "kind": "alias", "type": { "sum": [ "Nat", "Nothing" ] } },
-    "Shape": { "kind": "domain" }
+    "Shape": { "kind": "domain" },
+    "Tag": { "kind": "alias", "type": { "sum": [ "Color", "Shape" ] } }
   },
   "rules": {
     "colors": { "params": [], "return": { "list": "Color" } },
@@ -34,10 +30,7 @@
       ],
       "return": "Real"
     },
-    "lookup": {
-      "params": [ "Nat" ],
-      "return": { "sum": [ "Color", "Nothing" ] }
-    },
+    "lookup": { "params": [ "Nat" ], "return": { "list": "Color" } },
     "origin": { "params": [], "return": { "product": [ "Nat", "Nat" ] } },
     "red": { "params": [], "return": "Color" }
   },
@@ -48,7 +41,7 @@
           "doc": [
             [ "Demonstration of all type features" ],
             [
-              "Built-in types: Bool, Nat, Nat0, Int, Real, String, Nothing",
+              "Built-in types: Bool, Nat, Nat0, Int, Real, String",
               "Nat = positive integers (1, 2, 3, ...)",
               "Nat0 = non-negative integers (0, 1, 2, ...)",
               "Numeric hierarchy: Nat < Nat0 < Int < Real"
@@ -81,17 +74,13 @@
           }
         },
         {
-          "doc": [ [ "Type aliases with sum types (unions)" ] ],
+          "doc": [
+            [ "Type aliases with sum types (unions of two inhabited types)" ]
+          ],
           "kind": "alias",
-          "name": "Result",
-          "type": { "sum": [ "Nat", "Nothing" ] },
-          "resolved": { "sum": [ "Nat", "Nothing" ] }
-        },
-        {
-          "kind": "alias",
-          "name": "MaybeColor",
-          "type": { "sum": [ "Color", "Nothing" ] },
-          "resolved": { "sum": [ "Color", "Nothing" ] }
+          "name": "Tag",
+          "type": { "sum": [ "Color", "Shape" ] },
+          "resolved": { "sum": [ "Color", "Shape" ] }
         },
         {
           "doc": [ [ "Type aliases with list types" ] ],
@@ -164,16 +153,19 @@
           }
         },
         {
+          "doc": [
+            [
+              "Optional return values: use a list constrained to length <= 1",
+              "(Pantagruel has no Maybe/Option type; see guards for the alternative idiom.)"
+            ]
+          ],
           "kind": "rule",
           "name": "lookup",
           "params": [ { "name": "i", "type": "Nat" } ],
           "guards": [],
-          "return": { "sum": [ "Color", "Nothing" ] },
+          "return": { "list": "Color" },
           "resolved": {
-            "func": {
-              "params": [ "Nat" ],
-              "return": { "sum": [ "Color", "Nothing" ] }
-            }
+            "func": { "params": [ "Nat" ], "return": { "list": "Color" } }
           }
         }
       ],

--- a/test/snapshots/json/09-closure.json
+++ b/test/snapshots/json/09-closure.json
@@ -5,10 +5,7 @@
   "types": { "Block": { "kind": "domain" } },
   "rules": {
     "ancestor": { "params": [ "Block" ], "return": { "list": "Block" } },
-    "parent": {
-      "params": [ "Block" ],
-      "return": { "sum": [ "Block", "Nothing" ] }
-    }
+    "parent": { "params": [ "Block" ], "return": { "list": "Block" } }
   },
   "chapters": [
     {
@@ -19,12 +16,9 @@
           "name": "parent",
           "params": [ { "name": "b", "type": "Block" } ],
           "guards": [],
-          "return": { "sum": [ "Block", "Nothing" ] },
+          "return": { "list": "Block" },
           "resolved": {
-            "func": {
-              "params": [ "Block" ],
-              "return": { "sum": [ "Block", "Nothing" ] }
-            }
+            "func": { "params": [ "Block" ], "return": { "list": "Block" } }
           }
         },
         {

--- a/test/snapshots/markdown/03-types.md
+++ b/test/snapshots/markdown/03-types.md
@@ -77,6 +77,10 @@ Numeric hierarchy: Nat < Nat0 < Int < Real
 
 #`Color` ≥ 0.
 
+> Optional-value idiom: lookup returns at most one element
+
+∀ *i*: `Nat` · #**lookup** *i* ≤ 1.
+
 > Numeric operations respect the hierarchy
 
 ∀ *n*: `Nat`, *m*: `Nat0` · *n* + *m* ≥ 0.

--- a/test/snapshots/markdown/03-types.md
+++ b/test/snapshots/markdown/03-types.md
@@ -1,6 +1,6 @@
 Demonstration of all type features
 
-Built-in types: Bool, Nat, Nat0, Int, Real, String, Nothing
+Built-in types: Bool, Nat, Nat0, Int, Real, String
 Nat = positive integers (1, 2, 3, ...)
 Nat0 = non-negative integers (0, 1, 2, ...)
 Numeric hierarchy: Nat < Nat0 < Int < Real
@@ -21,11 +21,9 @@ Numeric hierarchy: Nat < Nat0 < Int < Real
 
 `ColoredPoint` = `Point` × `Color`.
 
-> Type aliases with sum types (unions)
+> Type aliases with sum types (unions of two inhabited types)
 
-`Result` = `Nat` + `Nothing`.
-
-`MaybeColor` = `Color` + `Nothing`.
+`Tag` = `Color` + `Shape`.
 
 > Type aliases with list types
 
@@ -47,7 +45,9 @@ Numeric hierarchy: Nat < Nat0 < Int < Real
 
 **colors** ⇒ [`Color`].
 
-**lookup** *i*: `Nat` ⇒ `Color` + `Nothing`.
+> Optional return values: use a list constrained to length <= 1 (Pantagruel has no Maybe/Option type; see guards for the alternative idiom.)
+
+**lookup** *i*: `Nat` ⇒ [`Color`].
 
 ---
 

--- a/test/snapshots/markdown/09-closure.md
+++ b/test/snapshots/markdown/09-closure.md
@@ -4,7 +4,7 @@
 
 ### Rules
 
-**parent** *b*: `Block` ⇒ `Block` + `Nothing`.
+**parent** *b*: `Block` ⇒ [`Block`].
 
 **ancestor** *b*: `Block` ⇒ [`Block`] = closure **parent**.
 

--- a/test/snapshots/pretty/03-types.pant
+++ b/test/snapshots/pretty/03-types.pant
@@ -2,7 +2,7 @@ module TYPES.
 
 > Demonstration of all type features
 
-> Built-in types: Bool, Nat, Nat0, Int, Real, String, Nothing
+> Built-in types: Bool, Nat, Nat0, Int, Real, String
 > Nat = positive integers (1, 2, 3, ...)
 > Nat0 = non-negative integers (0, 1, 2, ...)
 > Numeric hierarchy: Nat < Nat0 < Int < Real
@@ -18,10 +18,9 @@ Point = Nat * Nat.
 Point3D = Nat * Nat * Nat.
 ColoredPoint = Point * Color.
 
-> Type aliases with sum types (unions)
+> Type aliases with sum types (unions of two inhabited types)
 
-Result = Nat + Nothing.
-MaybeColor = Color + Nothing.
+Tag = Color + Shape.
 
 > Type aliases with list types
 
@@ -35,7 +34,11 @@ origin => Point.
 red => Color.
 distance p: Point, q: Point => Real.
 colors => [Color].
-lookup i: Nat => Color + Nothing.
+
+> Optional return values: use a list constrained to length <= 1
+> (Pantagruel has no Maybe/Option type; see guards for the alternative idiom.)
+
+lookup i: Nat => [Color].
 
 ---
 

--- a/test/snapshots/pretty/03-types.pant
+++ b/test/snapshots/pretty/03-types.pant
@@ -65,6 +65,10 @@ red in colors.
 #colors >= 0.
 #Color >= 0.
 
+> Optional-value idiom: lookup returns at most one element
+
+all i: Nat | #(lookup i) <= 1.
+
 > Numeric operations respect the hierarchy
 
 all n: Nat, m: Nat0 | n + m >= 0.

--- a/test/snapshots/pretty/09-closure.pant
+++ b/test/snapshots/pretty/09-closure.pant
@@ -1,5 +1,5 @@
 Block.
-parent b: Block => Block + Nothing.
+parent b: Block => [Block].
 ancestor b: Block => [Block] = closure parent.
 
 ---

--- a/test/test_check.ml
+++ b/test/test_check.ml
@@ -881,7 +881,7 @@ let test_overload_closure_incoherent_rejected () =
   check_collect_error
     {|module TEST.
 Block.
-parent b: Block => Block + Nothing.
+parent b: Block => [Block].
 ancestor a: Nat, b: Block => [Block].
 ancestor b: Block => [Block] = closure parent.
 ---
@@ -901,7 +901,7 @@ let test_overload_closure_plus_rule () =
   check_ok
     {|module TEST.
 Block.
-parent b: Block => Block + Nothing.
+parent b: Block => [Block].
 ancestor b: Block => [Block] = closure parent.
 ancestor b: Block, root: Block => [Block].
 ---
@@ -1273,19 +1273,19 @@ and over each u: User | score u.
 (* --- Closure tests --- *)
 
 let test_closure_valid () =
-  (* Closure of T => T + Nothing target, returns [T] *)
+  (* Closure of T => [T] target (partial parent via empty list), returns [T] *)
   check_ok
     {|module TEST.
 
 Block.
-parent b: Block => Block + Nothing.
+parent b: Block => [Block].
 ancestor b: Block => [Block] = closure parent.
 ---
 all b: Block | ~(b in ancestor b).
 |}
 
 let test_closure_list_target () =
-  (* Closure of T => [T] target *)
+  (* Closure of T => [T] multi-child target *)
   check_ok
     {|module TEST.
 
@@ -1317,6 +1317,19 @@ Node.
 reachable n: Node => [Node] = closure nonexistent.
 ---
 |}
+
+let test_nothing_not_user_writable () =
+  (* [Nothing] is an internal-only bottom type; users cannot name it. *)
+  check_collect_error
+    {|module TEST.
+
+User.
+lookup i: Nat => User + Nothing.
+---
+|}
+    (function[@warning "-4"]
+    | Collect.UndefinedType ("Nothing", _) -> true
+    | _ -> false)
 
 let test_cond_valid () =
   check_ok
@@ -1690,8 +1703,8 @@ x => Nat.
   with _ -> ()
 
 let test_list_search_returns_nat () =
-  (* List-search xs x : Nat (not Nat + Nothing). Usable in a Nat context
-     such as comparison with a literal. *)
+  (* List-search xs x : Nat. Usable in a Nat context such as comparison
+     with a literal. *)
   check_ok
     {|module TEST.
 
@@ -2130,6 +2143,8 @@ let () =
           test_case "closure list target" `Quick test_closure_list_target;
           test_case "closure invalid target" `Quick test_closure_invalid_target;
           test_case "closure missing target" `Quick test_closure_missing_target;
+          test_case "Nothing not user-writable" `Quick
+            test_nothing_not_user_writable;
         ] );
       ( "cond",
         [

--- a/test/test_json_output.ml
+++ b/test/test_json_output.ml
@@ -61,7 +61,7 @@ let test_type_expr_to_json () =
   check bool "TProduct" true (Yojson.Basic.Util.member "product" j <> `Null);
   let j =
     Json_output.type_expr_to_json
-      (Ast.TSum [ TName (Upper "Nat"); TName (Upper "Nothing") ])
+      (Ast.TSum [ TName (Upper "Nat"); TName (Upper "Bool") ])
   in
   check bool "TSum" true (Yojson.Basic.Util.member "sum" j <> `Null)
 
@@ -236,7 +236,7 @@ let test_decl_to_json_closure () =
     parse_and_collect
       "module T.\n\n\
        Block.\n\
-       parent b: Block => Block + Nothing.\n\
+       parent b: Block => [Block].\n\
        ancestor b: Block => [Block] = closure parent.\n\
        ---\n"
   in

--- a/test/test_markdown.ml
+++ b/test/test_markdown.ml
@@ -307,7 +307,7 @@ let test_decl_closure () =
     render
       "module T.\n\
        Block.\n\
-       parent b: Block => Block + Nothing.\n\
+       parent b: Block => [Block].\n\
        ancestor b: Block => [Block] = closure parent.\n\
        ---\n"
   in

--- a/test/test_parser.ml
+++ b/test/test_parser.ml
@@ -82,7 +82,7 @@ let test_list_type () =
   | _ -> fail "Expected list type"
 
 let test_sum_type () =
-  let doc = parse "module TEST.\n\nResult = Nat + Nothing.\n---\n" in
+  let doc = parse "module TEST.\n\nResult = Nat + Bool.\n---\n" in
   let chapter = List.hd doc.Ast.chapters in
   match[@warning "-4"] (List.hd chapter.Ast.head).Ast.value with
   | Ast.DeclAlias (Upper "Result", Ast.TSum _) -> ()
@@ -220,7 +220,7 @@ let test_closure () =
     parse
       "module TEST.\n\n\
        Block.\n\
-       parent b: Block => Block + Nothing.\n\
+       parent b: Block => [Block].\n\
        ancestor b: Block => [Block] = closure parent.\n\
        ---\n"
   in

--- a/test/test_smt.ml
+++ b/test/test_smt.ml
@@ -1085,7 +1085,7 @@ let test_domain_closure_bound_one () =
     parse_and_collect
       "module Test.\n\
        Block.\n\
-       parent b: Block => Block + Nothing.\n\
+       parent b: Block => [Block].\n\
        ancestor b: Block => [Block] = closure parent.\n\
        ---\n\
        all b: Block | ~(b in ancestor b).\n"
@@ -1690,7 +1690,7 @@ let test_closure_axiom_generation () =
     parse_and_collect
       "module Test.\n\
        Block.\n\
-       parent b: Block => Block + Nothing.\n\
+       parent b: Block => [Block].\n\
        ancestor b: Block => [Block] = closure parent.\n\
        ---\n\
        all b: Block | ~(b in ancestor b).\n"


### PR DESCRIPTION
## Summary

- Removes `Nothing` from the user-facing type surface. `TyNothing` stays internal-only as the bottom type for unification and default returns — users can no longer name it (`UndefinedType "Nothing"` on any reference).
- `T + Nothing` was never a workable optional type: `Nothing` has no inhabitants, and without sum-type projection there's no way to case-split on it. Guidance now directs users to guarded rules (Z/VDM partial-function idiom) or `[T]` with a `#=< 1` invariant (Alloy `lone` multiplicity).
- `REFERENCE.md` and the `write-spec` skill gain a "Modeling Optional Values" section walking through the three approaches (guard, list-lift, sentinel) and when to pick each.

### Code changes

- `lib/types.ml` — drop `("Nothing", TyNothing)` from the builtin registry.
- `lib/collect.ml` — closure matcher no longer accepts `T => T + Nothing`; error message points only at `T => [T]`. The `[T]` form already carried partial-function semantics via the empty list, so the closure feature is unaffected.
- `samples/03-types.pant`, `samples/09-closure.pant` — rewritten; snapshots regenerated.
- Tests — closure fixtures in `test_check.ml`, `test_smt.ml`, `test_parser.ml`, `test_markdown.ml`, `test_json_output.ml` switched to `=> [Block]`. New `test_nothing_not_user_writable` asserts the user-facing rejection.
- `.claude/skills/write-spec/SKILL.md` — primitives list and worked example updated; library-system example's `borrower` now uses the `~available?` guard instead of `Member + Nothing`.

### Follow-up (not in this PR)

`tools/ts2pant/src/translate-types.ts` still emits the string `"Nothing"` for TS `null`/`undefined`/`void`, and its "Option-Type Elimination" docs describe a `Nothing` expression value that was never legal Pantagruel. All 331 ts2pant tests still pass because they don't round-trip through `pant` on the affected paths, but TS code with nullable unions will now produce invalid Pantagruel. Belongs in ts2pant's own gameplan.

## Test plan

- [x] `dune build` — clean
- [x] `dune test` — all 16 suites, 743 tests pass
- [x] `tools/ts2pant && npm test` — 331/331 pass
- [x] Manual check: `pant` rejects `User + Nothing` with `Undefined type 'Nothing'`
- [ ] Reviewer sanity-check on the REFERENCE.md subtyping section — I removed the "Bottom" paragraph and the `Nothing ≤ [User]` example; want confirmation that no other prose implicitly relies on Nothing as a user-writable bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)