### PR TITLE
ts2pant: list-lift encoding for optionals; ?? / ?. lowerings

### DIFF
--- a/tools/ts2pant/CLAUDE.md
+++ b/tools/ts2pant/CLAUDE.md
@@ -116,12 +116,43 @@ body, emit frame conditions (`prop' obj = prop obj`) for everything not in the s
 
 ### Option-Type Elimination (Nullish Coalescing, Optional Chaining)
 
-**Standard name:** Option/Maybe elimination.
-**Reference:** Dafny Reference Manual (nullable types, preconditions).
+**Standard name:** Option/Maybe elimination via Alloy `lone` multiplicity.
+**Reference:** Dafny Reference Manual (nullable types, preconditions);
+Jackson, *Software Abstractions* 2nd ed. (Alloy multiplicities: `one`, `lone`, `some`).
 
-`x ?? y` becomes `cond x ~= Nothing => x, true => y`. `x?.prop` becomes
-`cond x ~= Nothing => prop x, true => Nothing`. This is the lifting encoding —
-partiality expressed as conditional expressions over the `Nothing` value.
+Pantagruel retired `Nothing` from its user-facing type surface — there is
+no writable "absence" type and no sum destructuring. Optionality is encoded
+in the type language via **list-lift**: `T | null` / `T | undefined` maps
+to `[T]`, a list of length 0 or 1 (Alloy's `lone` multiplicity). Type-level
+unions fold the null marker into the list wrapper: `A | B | null` → `[A + B]`.
+
+Under list-lift, `??` and `?.` have a universal lowering — the empty-list
+cardinality test `#x = 0` replaces the absent `~= Nothing` check, and list
+indexing `(x 1)` replaces singleton extraction:
+
+- `x ?? y` with `x: [T]`:
+  - `y: T` (non-nullable default) → `cond #x = 0 => y, true => (x 1)`
+    (result `T`).
+  - `y: [T]` (nested nullable) → `cond #x = 0 => y, true => x`
+    (result `[T]`).
+  - `x` not nullable in TS → `x` alone (`??` degenerates; no case-split).
+- `x?.prop` with `x: [T]`, `prop: T => U` → `each t in x | prop t`
+  (result `[U]`). Functor lift: empty stays empty; singleton becomes
+  `[prop v]`. Chains `x?.a?.b` compose as comprehensions over
+  comprehensions — each step lifts through the list.
+
+Nullability is determined from the TS type at the AST location (presence
+of `null` / `undefined` / `void` in the union), not from the emitted Pant
+type — so we avoid misclassifying genuine arrays (`number[]`) as optional.
+See `isNullableTsType` and the `QuestionQuestionToken` / `questionDotToken`
+branches in `translate-body.ts`.
+
+Optional parameters (`p?: P`) list-lift to `p: [P]` via `mapTsType`'s
+union-with-`undefined` handling; `p ?? c` inside the body expands to the
+cardinality case-split above, giving one list-lifted signature rather than
+multiple arity overloads. This preserves one-source-one-target for
+everything reached through the general lowering — no special-case
+detection at the signature level.
 
 ### Partial Rules (Map<K, V>)
 
@@ -164,13 +195,18 @@ recursive `mapTsType` calls: `Map<string, Map<string, number>>` emits
 `StringToIntMap` first and then `StringToStringToIntMapMap` whose V
 references it.
 
-**Why this encoding, not `V + Nothing`?** Pantagruel has no first-class
-`Nothing` expression value and no sum destructuring. With a sum-typed return,
-`.has` has no clean translation and `.get` cannot be used in arithmetic /
-comparisons without a lifting operation the language doesn't provide. The
+**Why this encoding, not `[V]` list-lift?** `Nothing` is no longer part of
+Pantagruel's user-facing type surface, and list-lift (`[V]`, length 0 or 1)
+is the type-level answer for plain nullable unions — see "Option-Type
+Elimination" above. For Map lookups it would still be unsatisfactory: `.has`
+would force `#(get c k) = 1` case-splits at every use site, arithmetic on
+`.get(k)` results would need an unfold-the-singleton idiom, and distinct
+maps sharing a key would not automatically have independent lookups. The
 guarded-rule encoding trades a small semantic gap (absent keys are
-uninterpreted rather than explicitly `undefined`) for a much richer set of
-usable specifications.
+uninterpreted rather than explicitly "missing") for a much richer set of
+usable specifications — declaration guards inject the membership antecedent
+into SMT queries automatically, so `.get` participates in arithmetic and
+comparisons without a lifting operation.
 
 **Why synthesize a sort per `(K, V)`?** Following McCarthy's theory of
 arrays: the synthesized sort is the array sort, distinct values of that sort

--- a/tools/ts2pant/README.md
+++ b/tools/ts2pant/README.md
@@ -150,7 +150,7 @@ This works with any function declared as `asserts condition` -- Node's `assert`,
 | `Set<T>` | `[T]` (membership via `.has(x)` → `x in`, cardinality via `.size` → `#`; uniqueness is not tracked) |
 | `Map<K, V>` field on `interface` | two rules: `<name>Key c: C, k: K => Bool` and `<name> c: C, k: K, <name>Key c k => V` (read via `.get(k)` → `<name> c k`, membership via `.has(k)` → `<name>Key c k`; mutation via `.set(k, v)` / `.delete(k)` → Pantagruel N-ary override `<name>[(c, k) \|-> v]` on each modified rule) |
 | `Map<K, V>` in any other type position (parameter, return, nested) | synthesizes a handle domain per `(K, V)` pair per module: `KToVMap.` plus the same rule pair as above, with the user's interface replaced by the synthesized domain. Non-identifier `K`/`V` are mangled — `[String]` → `ListString`, `A + B` → `AOrB`, `A * B` → `AAndB`. `.get(k)` → `kToVMap m k`, `.has(k)` → `kToVMapKey m k`. `.set(k, v)` / `.delete(k)` emit the same override-based mutation encoding as the interface-field case. Nested Maps register bottom-up (e.g., `Map<string, Map<string, number>>` emits `StringToIntMap` then `StringToStringToIntMapMap`). |
-| `T \| null` / `T \| undefined` | `T + Nothing` |
+| `T \| null` / `T \| undefined` | `[T]` (list-lift encoding — length 0 or 1; Alloy `lone` multiplicity) |
 | `interface Foo { ... }` | `Foo.` (domain) + rules for each property |
 
 ### Annotations and entailment checking

--- a/tools/ts2pant/src/pipeline.ts
+++ b/tools/ts2pant/src/pipeline.ts
@@ -3,12 +3,7 @@ import { extractFunctionAnnotationsAndOverrides } from "./annotations.js";
 import { extractReferencedTypes, getChecker } from "./extract.js";
 import { loadAst, loadParser, rewriteAnnotation } from "./pant-wasm.js";
 import { translateBody } from "./translate-body.js";
-import {
-  classifyFunction,
-  detectOptionalParamDefault,
-  findFunction,
-  translateSignature,
-} from "./translate-signature.js";
+import { translateSignature } from "./translate-signature.js";
 import {
   cellEmitSynth,
   type NumericStrategy,
@@ -58,53 +53,14 @@ export async function buildPantDocument(
   const { propositionTexts: annotations, typeOverrides: overrides } =
     extractFunctionAnnotationsAndOverrides(sourceFile, functionName);
 
-  // Detect the optional-param-with-??-default idiom up front. When it
-  // matches, the function translates to two arity overloads (with-param and
-  // without-param) under Pantagruel's positional-coherence rules rather than
-  // one signature carrying a `T | Nothing` union that has no useful
-  // inhabitants.
-  //
-  // Gated to pure functions: nullishRewrite is only threaded through
-  // translatePureBody, so a mutating body like `obj.timeout = extra ?? 10`
-  // would emit two action heads while both body passes still hit the
-  // unsupported `??` operator. Fall back to the single-head path there.
-  const { node: fnNode } = findFunction(sourceFile, functionName);
-  const optSplit =
-    classifyFunction(fnNode, checker) === "pure"
-      ? detectOptionalParamDefault(fnNode)
-      : null;
-
-  // Translate signature first to claim the function's param names. When
-  // splitting, the "with-param" head's signature strips `| undefined` from
-  // the optional param's declared type; the paramNameMap from this head is
-  // the one we thread to annotation-rewriting (the full-arity head is the
-  // referent for any @pant mention of the optional param).
+  // Translate signature first to claim the function's param names.
   const { declaration: sigDecl, paramNameMap } = translateSignature(
     sourceFile,
     functionName,
     strategy,
     synthCell,
     overrides,
-    optSplit ? { unwrapOptionalParam: optSplit.paramName } : undefined,
   );
-
-  // Second signature (reduced arity) when splitting: same name, optional
-  // param dropped. Emitted alongside the full-arity head. Reuses the first
-  // head's param-name map so shared positions name their params identically
-  // — Pantagruel's positional coherence requires this, and without the
-  // reuse the synthCell's allocator would suffix the duplicate names.
-  let reducedSigDecl: typeof sigDecl | undefined;
-  if (optSplit) {
-    const { declaration } = translateSignature(
-      sourceFile,
-      functionName,
-      strategy,
-      synthCell,
-      overrides,
-      { excludeParam: optSplit.paramName, reuseParamNames: paramNameMap },
-    );
-    reducedSigDecl = declaration;
-  }
 
   // Extract and translate types (type-derived param names adapt to registry).
   // Pass the synthesizer so nested Maps inside interface-field V register too.
@@ -114,12 +70,7 @@ export async function buildPantDocument(
   // decls (one domain + membership predicate + guarded value rule per
   // unique (K, V)). Splice before sigDecl so the sig's references resolve.
   const synthDecls = cellEmitSynth(synthCell);
-  const declarations = [
-    ...typeDecls,
-    ...synthDecls,
-    sigDecl,
-    ...(reducedSigDecl ? [reducedSigDecl] : []),
-  ];
+  const declarations = [...typeDecls, ...synthDecls, sigDecl];
 
   const moduleName = baseName.charAt(0).toUpperCase() + baseName.slice(1);
   let doc: PantDocument = {
@@ -137,35 +88,8 @@ export async function buildPantDocument(
       strategy,
       declarations,
       synthCell,
-      ...(optSplit
-        ? {
-            nullishRewrite: {
-              paramName: optSplit.paramName,
-              mode: "take-lhs",
-            },
-          }
-        : {}),
     });
     doc = { ...doc, propositions: [...doc.propositions, ...bodyProps] };
-
-    // Second body translation for the reduced-arity head: substitute the
-    // default expression for the nullish-coalesce (take-rhs) and drop the
-    // optional param from scope.
-    if (optSplit) {
-      const reducedProps = translateBody({
-        sourceFile,
-        functionName,
-        strategy,
-        declarations,
-        synthCell,
-        nullishRewrite: {
-          paramName: optSplit.paramName,
-          mode: "take-rhs",
-        },
-        excludeParam: optSplit.paramName,
-      });
-      doc = { ...doc, propositions: [...doc.propositions, ...reducedProps] };
-    }
 
     // Drain any Map (K, V) pairs registered on demand during body translation
     // (e.g., `build().get(k)!` where `build`'s return type wasn't surfaced

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -1469,17 +1469,26 @@ export function translateBodyExpr(
       return obj;
     }
     // Optional chain `x?.prop` under list-lift. With `x: [T]` on the Pant
-    // side, the functor-lift encoding is `each t in x | prop t`, giving
+    // side, the functor-lift encoding is `each $n in x | prop $n`, giving
     // `[U]` — empty when x is null/empty, singleton when x is present.
-    // This composes cleanly through nested `?.` (each step is another
-    // comprehension over the list result). When the receiver is not
-    // nullable in TS, `?.` degenerates to `.` and falls through.
-    if (expr.questionDotToken !== undefined) {
-      const receiverTsType = checker.getTypeAtLocation(expr.expression);
-      if (isNullableTsType(receiverTsType)) {
-        const binderName = supply.synthCell
-          ? cellRegisterName(supply.synthCell, "t")
-          : freshHygienicBinder(supply);
+    // Chains compose as nested comprehensions: TS parses `x?.a.b` as outer
+    // `.b` (no questionDotToken) wrapping inner `x?.a` (questionDotToken),
+    // with the outer tail marked by `NodeFlags.OptionalChain`. Lift at the
+    // tail too, so `x?.a.b` becomes `each $n' in (each $n in x | a $n) | b $n'`
+    // rather than falling through to a plain property access on the list-
+    // lifted receiver. When the receiver is not nullable in TS, `?.`
+    // degenerates to `.` and falls through.
+    const inOptionalChain = (expr.flags & ts.NodeFlags.OptionalChain) !== 0;
+    if (inOptionalChain) {
+      let shouldLift = false;
+      if (expr.questionDotToken !== undefined) {
+        const receiverTsType = checker.getTypeAtLocation(expr.expression);
+        shouldLift = isNullableTsType(receiverTsType);
+      } else if (ts.isOptionalChain(expr.expression)) {
+        shouldLift = true;
+      }
+      if (shouldLift) {
+        const binderName = freshHygienicBinder(supply);
         return {
           expr: ast.each(
             [],

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -44,28 +44,12 @@ import type { PantDeclaration, PropResult } from "./types.js";
  * translates to primed rules on the cell), unlike the prior closure over a
  * `let counter = 0`.
  */
-/**
- * When set, rewrites `<paramName> ?? <rhs>` nullish-coalescing expressions at
- * translation time. Used by the optional-param-with-default split to emit two
- * rule heads from a single TS function: the "with-param" variant translates
- * the coalesce as the LHS (param), the "without-param" variant as the RHS
- * (default expression).
- */
-interface NullishRewrite {
-  paramName: string;
-  mode: "take-lhs" | "take-rhs";
-}
-
 export interface UniqueSupply {
   n: number;
   synthCell?: SynthCell | undefined;
-  nullishRewrite?: NullishRewrite | undefined;
 }
-function makeUniqueSupply(
-  synthCell?: SynthCell,
-  nullishRewrite?: NullishRewrite,
-): UniqueSupply {
-  return { n: 0, synthCell, nullishRewrite };
+function makeUniqueSupply(synthCell?: SynthCell): UniqueSupply {
+  return { n: 0, synthCell };
 }
 
 function nextSupply(supply: UniqueSupply): number {
@@ -76,6 +60,20 @@ function nextSupply(supply: UniqueSupply): number {
 
 function freshHygienicBinder(supply: UniqueSupply): string {
   return `$${nextSupply(supply)}`;
+}
+
+/**
+ * True when a TypeScript type includes `null`, `undefined`, or `void` —
+ * i.e., when `mapTsType` will list-lift it to `[T]`. Used at `??` and `?.`
+ * sites to decide whether the receiver needs the cardinality-based lowering
+ * (nullable) or can pass through as-is (already concrete).
+ */
+function isNullableTsType(type: ts.Type): boolean {
+  const mask = ts.TypeFlags.Null | ts.TypeFlags.Undefined | ts.TypeFlags.Void;
+  if (type.isUnion()) {
+    return type.types.some((t) => (t.flags & mask) !== 0);
+  }
+  return (type.flags & mask) !== 0;
 }
 
 interface ConstBinding {
@@ -798,21 +796,6 @@ export interface TranslateBodyOptions {
    * (b) dispatch `.get`/`.has` on non-interface-field Map receivers.
    */
   synthCell?: SynthCell | undefined;
-  /**
-   * Rewrite directive for `<paramName> ?? <rhs>` expressions. When the
-   * optional-param-with-default detector finds a splittable function, the
-   * pipeline calls translateBody twice: once with mode "take-lhs" (emits
-   * the full-arity head referencing the param) and once with mode
-   * "take-rhs" + excludeParam set (emits the reduced-arity head with the
-   * default substituted and the optional param dropped from scope).
-   */
-  nullishRewrite?: NullishRewrite | undefined;
-  /**
-   * When set, omit this parameter from the paramList / paramNames that the
-   * body-translator threads. Paired with nullishRewrite "take-rhs" so the
-   * reduced-arity body sees no reference to the now-defaulted param.
-   */
-  excludeParam?: string | undefined;
 }
 
 /**
@@ -823,15 +806,7 @@ export interface TranslateBodyOptions {
  * plus frame conditions for unmodified rules.
  */
 export function translateBody(opts: TranslateBodyOptions): PropResult[] {
-  const {
-    sourceFile,
-    functionName,
-    strategy,
-    declarations,
-    synthCell,
-    nullishRewrite,
-    excludeParam,
-  } = opts;
+  const { sourceFile, functionName, strategy, declarations, synthCell } = opts;
   const checker = sourceFile.getProject().getTypeChecker().compilerObject;
   const { node, className } = findFunction(sourceFile, functionName);
   // Strip class qualifier for use in Pantagruel identifiers
@@ -857,9 +832,6 @@ export function translateBody(opts: TranslateBodyOptions): PropResult[] {
 
   if (sig) {
     for (const param of sig.getParameters()) {
-      if (excludeParam !== undefined && param.name === excludeParam) {
-        continue;
-      }
       const paramType = checker.getTypeOfSymbol(param);
       // Pass the synthesizer so Map parameters resolve to their synthesized
       // domain names (idempotent; the signature pass already registered
@@ -883,7 +855,6 @@ export function translateBody(opts: TranslateBodyOptions): PropResult[] {
       strategy,
       paramNames,
       synthCell,
-      nullishRewrite,
     );
   } else {
     return translateMutatingBody(
@@ -905,7 +876,6 @@ function translatePureBody(
   strategy: NumericStrategy,
   paramNames: ReadonlyMap<string, string>,
   synthCell?: SynthCell,
-  nullishRewrite?: NullishRewrite,
 ): PropResult[] {
   const ast = getAst();
 
@@ -919,7 +889,7 @@ function translatePureBody(
     return [{ kind: "unsupported", reason: `${functionName} — ${reason}` }];
   }
 
-  const supply = makeUniqueSupply(synthCell, nullishRewrite);
+  const supply = makeUniqueSupply(synthCell);
   const inlined = inlineConstBindings(
     extracted.bindings.map((b) => ({
       tsName: b.name,
@@ -1498,6 +1468,27 @@ export function translateBodyExpr(
     if (isBodyUnsupported(obj)) {
       return obj;
     }
+    // Optional chain `x?.prop` under list-lift. With `x: [T]` on the Pant
+    // side, the functor-lift encoding is `each t in x | prop t`, giving
+    // `[U]` — empty when x is null/empty, singleton when x is present.
+    // This composes cleanly through nested `?.` (each step is another
+    // comprehension over the list result). When the receiver is not
+    // nullable in TS, `?.` degenerates to `.` and falls through.
+    if (expr.questionDotToken !== undefined) {
+      const receiverTsType = checker.getTypeAtLocation(expr.expression);
+      if (isNullableTsType(receiverTsType)) {
+        const binderName = supply.synthCell
+          ? cellRegisterName(supply.synthCell, "t")
+          : freshHygienicBinder(supply);
+        return {
+          expr: ast.each(
+            [],
+            [ast.gIn(binderName, bodyExpr(obj))],
+            ast.app(ast.var(prop), [ast.var(binderName)]),
+          ),
+        };
+      }
+    }
     // .length (array) / .size (Set) -> #obj
     if (prop === "length" || prop === "size") {
       const receiverType = checker.getTypeAtLocation(expr.expression);
@@ -1557,28 +1548,62 @@ export function translateBodyExpr(
 
   // Binary expression
   if (ts.isBinaryExpression(expr)) {
-    // Nullish-coalescing rewrite: when the pipeline has registered a rewrite
-    // for `<paramName> ?? <rhs>` and this expression matches, translate only
-    // one side per the rewrite mode. Enables the optional-param-with-default
-    // idiom to split into two arity overloads. A non-matching ?? (param name
-    // differs, or rewrite not active) falls through to the generic
-    // unsupported-operator path below.
-    if (
-      expr.operatorToken.kind === ts.SyntaxKind.QuestionQuestionToken &&
-      supply.nullishRewrite &&
-      ts.isIdentifier(expr.left) &&
-      expr.left.text === supply.nullishRewrite.paramName
-    ) {
-      const picked =
-        supply.nullishRewrite.mode === "take-lhs" ? expr.left : expr.right;
-      return translateBodyExpr(
-        picked,
+    // Nullish-coalescing lowering under the list-lift encoding.
+    // `x ?? y` where `x: T | null` translates to `x: [T]` on the Pant side,
+    // with `#x = 0` as the null test. The result type depends on `y`:
+    //   - `y: T`      (default, non-nullable)  → result `T`;
+    //                 emit `cond #x = 0 => y, true => (x 1)`.
+    //   - `y: [T]`    (nested nullable)         → result `[T]`;
+    //                 emit `cond #x = 0 => y, true => x`.
+    // When `x` is not nullable in TS, `??` is semantically a no-op — emit
+    // just the LHS. This matches Dafny's nullable-typed fromMaybe pattern
+    // (Dafny Reference Manual §"Nullable Types"). See CLAUDE.md "Option-
+    // Type Elimination" for the broader encoding.
+    if (expr.operatorToken.kind === ts.SyntaxKind.QuestionQuestionToken) {
+      const leftTsType = checker.getTypeAtLocation(expr.left);
+      const leftResult = translateBodyExpr(
+        expr.left,
         checker,
         strategy,
         paramNames,
         state,
         supply,
       );
+      if (isBodyUnsupported(leftResult)) {
+        return leftResult;
+      }
+      if (!isNullableTsType(leftTsType)) {
+        // LHS can never be nullish — `??` degenerates to just the LHS.
+        return leftResult;
+      }
+      const rightResult = translateBodyExpr(
+        expr.right,
+        checker,
+        strategy,
+        paramNames,
+        state,
+        supply,
+      );
+      if (isBodyUnsupported(rightResult)) {
+        return rightResult;
+      }
+      const xExpr = bodyExpr(leftResult);
+      const yExpr = bodyExpr(rightResult);
+      const rightTsType = checker.getTypeAtLocation(expr.right);
+      const cardZero = ast.binop(
+        ast.opEq(),
+        ast.unop(ast.opCard(), xExpr),
+        ast.litNat(0),
+      );
+      const presentBranch = isNullableTsType(rightTsType)
+        ? xExpr
+        : ast.app(xExpr, [ast.litNat(1)]);
+      return {
+        expr: ast.cond([
+          [cardZero, yExpr],
+          [ast.litBool(true), presentBranch],
+        ]),
+      };
     }
     const op = translateOperator(expr.operatorToken.kind);
     if (op === null) {

--- a/tools/ts2pant/src/translate-signature.ts
+++ b/tools/ts2pant/src/translate-signature.ts
@@ -856,121 +856,12 @@ export function shortParamName(
 /**
  * Translate a TypeScript function signature to a Pantagruel declaration.
  */
-/**
- * Detect the optional-param-with-??-default idiom:
- *
- *   function f(a: A, p?: P): R { return ... p ?? defaultExpr ... }
- *
- * Preconditions for a clean split into two arity overloads:
- *  - Exactly one parameter is optional (has a `?:` marker).
- *  - Every reference to the optional param inside the function body is the
- *    LHS of a `??` operator whose RHS is the default expression. All such
- *    occurrences share the same default expression (same TS AST node) so the
- *    two-head emission is unambiguous.
- *
- * Returns the detected triple or null when the pattern doesn't match. When
- * null is returned the caller falls back to the single-signature path, and
- * any `??` in the body surfaces as its usual unsupported-operator error.
- */
-export function detectOptionalParamDefault(
-  node: ts.FunctionDeclaration | ts.MethodDeclaration,
-): { paramName: string; defaultExpr: ts.Expression } | null {
-  if (!node.body) {
-    return null;
-  }
-
-  const optionalParams = node.parameters.filter(
-    (p) => p.questionToken !== undefined,
-  );
-  if (optionalParams.length !== 1) {
-    return null;
-  }
-  const optParam = optionalParams[0]!;
-  if (!ts.isIdentifier(optParam.name)) {
-    return null;
-  }
-  const paramName = optParam.name.text;
-
-  const nullishUses: ts.BinaryExpression[] = [];
-  let hasNonNullishUse = false;
-  const visit = (cur: ts.Node): void => {
-    if (ts.isIdentifier(cur) && cur.text === paramName) {
-      const parent = cur.parent;
-      // Filter out non-reference occurrences: declaration sites and key /
-      // member positions where the identifier is a name, not a value. These
-      // positions happen to be lexically identical to the param name (e.g.
-      // `{ registry: registry ?? ... }` — the key shares the name with the
-      // value reference on the RHS) but they do not count as uses.
-      // A ShorthandPropertyAssignment's name IS a value reference (it stands
-      // for `{ foo: foo }`), so it DOES count. All other "name" positions
-      // below are keys or binders, not references to the param.
-      const isReferencePosition = !(
-        (parent && ts.isParameter(parent)) ||
-        (parent && ts.isPropertyAssignment(parent) && parent.name === cur) ||
-        (parent &&
-          ts.isPropertyAccessExpression(parent) &&
-          parent.name === cur) ||
-        (parent && ts.isPropertySignature(parent) && parent.name === cur) ||
-        (parent && ts.isPropertyDeclaration(parent) && parent.name === cur) ||
-        (parent && ts.isMethodDeclaration(parent) && parent.name === cur) ||
-        (parent && ts.isMethodSignature(parent) && parent.name === cur) ||
-        (parent && ts.isBindingElement(parent) && parent.name === cur)
-      );
-      if (!isReferencePosition) {
-        // skip
-      } else if (
-        parent &&
-        ts.isBinaryExpression(parent) &&
-        parent.operatorToken.kind === ts.SyntaxKind.QuestionQuestionToken &&
-        parent.left === cur
-      ) {
-        nullishUses.push(parent);
-      } else {
-        hasNonNullishUse = true;
-      }
-    }
-    ts.forEachChild(cur, visit);
-  };
-  visit(node.body);
-
-  if (nullishUses.length === 0 || hasNonNullishUse) {
-    return null;
-  }
-
-  // Every occurrence must share the same RHS (structurally — we compare
-  // against the first's text). Different defaults would require a cond
-  // lowering that we don't support here.
-  const firstDefault = nullishUses[0]!.right;
-  const firstText = firstDefault.getText();
-  for (let i = 1; i < nullishUses.length; i++) {
-    if (nullishUses[i]!.right.getText() !== firstText) {
-      return null;
-    }
-  }
-
-  return { paramName, defaultExpr: firstDefault };
-}
-
 export function translateSignature(
   sourceFile: SourceFile,
   functionName: string,
   strategy: NumericStrategy,
   synthCell?: SynthCell,
   overrides?: Map<string, string>,
-  opts?: {
-    /** When set, emit this param with its non-undefined type (strip `| Nothing`).
-     *  Pairs with the "take-lhs" body variant in the optional-param split. */
-    unwrapOptionalParam?: string;
-    /** When set, omit this param from the emitted signature. Pairs with the
-     *  "take-rhs" body variant so the reduced-arity head has one fewer param. */
-    excludeParam?: string;
-    /** Pre-existing TS-name → Pant-name mapping. Takes precedence over the
-     *  synthCell's name allocator. Used by the reduced-arity head of an
-     *  optional-param split so that both overloads name position i
-     *  identically (positional-coherence requirement on the Pantagruel
-     *  side). */
-    reuseParamNames?: ReadonlyMap<string, string>;
-  },
 ): TranslatedSignature {
   const checker = sourceFile.getProject().getTypeChecker().compilerObject;
   const { node, className } = findFunction(sourceFile, functionName);
@@ -996,30 +887,12 @@ export function translateSignature(
   }
 
   for (const param of sig.getParameters()) {
-    if (opts?.excludeParam === param.name) {
-      continue;
-    }
     const symbolType = checker.getTypeOfSymbol(param);
-    // For an unwrapped optional param, use the declared TypeNode's type
-    // (without the `| undefined` union TS synthesized for `?:`). Falling back
-    // to symbolType when no TypeNode is available keeps non-annotated params
-    // working.
-    let resolvedType = symbolType;
-    if (opts?.unwrapOptionalParam === param.name) {
-      const decls = param.declarations ?? [];
-      for (const d of decls) {
-        if (ts.isParameter(d) && d.type) {
-          resolvedType = checker.getTypeFromTypeNode(d.type);
-          break;
-        }
-      }
-    }
-    const defaultType = mapTsType(resolvedType, checker, strategy, synthCell);
+    const defaultType = mapTsType(symbolType, checker, strategy, synthCell);
     const paramType = overrides?.get(param.name) ?? defaultType;
-    const reusedName = opts?.reuseParamNames?.get(param.name);
-    const pantName =
-      reusedName ??
-      (synthCell ? cellRegisterName(synthCell, param.name) : param.name);
+    const pantName = synthCell
+      ? cellRegisterName(synthCell, param.name)
+      : param.name;
     params.push({ name: pantName, type: paramType });
     paramNameMap.set(param.name, pantName);
   }

--- a/tools/ts2pant/src/translate-types.ts
+++ b/tools/ts2pant/src/translate-types.ts
@@ -21,11 +21,23 @@ import type { PantDeclaration } from "./types.js";
 export const UNSUPPORTED_ANONYMOUS_RECORD = "__unsupported_anon_record__";
 
 /**
+ * Sentinel returned by `mapTsType` for TypeScript `null` / `undefined` /
+ * `void`. Pantagruel retired `Nothing` from the user-facing type surface —
+ * there is no writable type for "absence". In a union (`T | null`) the
+ * union-combining code strips this marker and emits `[T]`, the list-lift
+ * encoding of optionality (Alloy's `lone` multiplicity; length 0 or 1).
+ * The value is not a valid Pantagruel identifier — emission of a type
+ * containing this raw string will be visibly broken rather than silently
+ * producing a domain reference that doesn't resolve.
+ */
+export const NULL_MARKER = "__null__";
+
+/**
  * Mangle a Pantagruel type string into an identifier-safe fragment suitable
  * for embedding inside a synthesized Map domain name.
  *   "String"           → "String"
  *   "[String]"         → "ListString"
- *   "String + Nothing" → "StringOrNothing"
+ *   "String + Int"     → "StringOrInt"
  *   "A * B"            → "AAndB"
  * Returns null if the mangled result still contains non-identifier chars
  * (e.g., a bare `Map<...>` literal from a Map in value position with no
@@ -477,7 +489,7 @@ export function mapTsType(
     flags & ts.TypeFlags.Undefined ||
     flags & ts.TypeFlags.Void
   ) {
-    return "Nothing";
+    return NULL_MARKER;
   }
 
   // Tuple (check before array since tuples are also type references)
@@ -533,10 +545,21 @@ export function mapTsType(
     const parts = type.types.map((t) =>
       mapTsType(t, checker, strategy, synthCell),
     );
-    // Deduplicate (e.g. boolean literal collapse)
+    // Deduplicate (e.g. boolean literal collapse, `null | undefined` → one marker)
     const unique = parts.filter((v, i, a) => a.indexOf(v) === i);
-    // Sort Nothing to the end for consistent output
-    unique.sort((a, b) => (a === "Nothing" ? 1 : b === "Nothing" ? -1 : 0));
+    const nonNull = unique.filter((p) => p !== NULL_MARKER);
+    // List-lift encoding for optionality: `T | null` → `[T]`,
+    // `A | B | null` → `[A + B]`. Pantagruel has no `Nothing` at the user
+    // surface, so a union containing null/undefined/void wraps the rest
+    // in a list of length 0 or 1 (Alloy `lone` multiplicity).
+    if (nonNull.length !== unique.length) {
+      if (nonNull.length === 0) {
+        // Degenerate `null | undefined` with no non-null members — keep
+        // the sentinel so emission fails visibly.
+        return NULL_MARKER;
+      }
+      return `[${nonNull.join(" + ")}]`;
+    }
     return unique.join(" + ");
   }
 

--- a/tools/ts2pant/src/translate-types.ts
+++ b/tools/ts2pant/src/translate-types.ts
@@ -21,16 +21,22 @@ import type { PantDeclaration } from "./types.js";
 export const UNSUPPORTED_ANONYMOUS_RECORD = "__unsupported_anon_record__";
 
 /**
- * Sentinel returned by `mapTsType` for TypeScript `null` / `undefined` /
- * `void`. Pantagruel retired `Nothing` from the user-facing type surface —
- * there is no writable type for "absence". In a union (`T | null`) the
- * union-combining code strips this marker and emits `[T]`, the list-lift
- * encoding of optionality (Alloy's `lone` multiplicity; length 0 or 1).
- * The value is not a valid Pantagruel identifier — emission of a type
- * containing this raw string will be visibly broken rather than silently
- * producing a domain reference that doesn't resolve.
+ * TypeScript type flags for `null` / `undefined` / `void`. Pantagruel
+ * retired `Nothing` from the user-facing type surface — there is no
+ * writable type for "absence". `mapTsType` handles these only inside a
+ * union (`T | null` → `[T]` via list-lift / Alloy's `lone` multiplicity).
+ * A top-level `null` / `undefined` / `void` has no Pantagruel encoding
+ * and falls through to `checker.typeToString`, matching the generic
+ * unsupported-shape fallback and keeping any internal marker from
+ * leaking into emitted declarations.
  */
-export const NULL_MARKER = "__null__";
+const NULLISH_FLAGS =
+  ts.TypeFlags.Null | ts.TypeFlags.Undefined | ts.TypeFlags.Void;
+
+/** True for TypeScript `null` / `undefined` / `void`. */
+function isTsNullish(type: ts.Type): boolean {
+  return (type.flags & NULLISH_FLAGS) !== 0;
+}
 
 /**
  * Mangle a Pantagruel type string into an identifier-safe fragment suitable
@@ -484,13 +490,10 @@ export function mapTsType(
   if (flags & ts.TypeFlags.Boolean || flags & ts.TypeFlags.BooleanLiteral) {
     return "Bool";
   }
-  if (
-    flags & ts.TypeFlags.Null ||
-    flags & ts.TypeFlags.Undefined ||
-    flags & ts.TypeFlags.Void
-  ) {
-    return NULL_MARKER;
-  }
+  // Top-level `null` / `undefined` / `void` have no Pantagruel encoding.
+  // Fall through to the generic `checker.typeToString` fallback below so
+  // the unsupported string reflects the source rather than an internal
+  // sentinel. Null handling for unions happens in the union branch.
 
   // Tuple (check before array since tuples are also type references)
   if (checker.isTupleType(type)) {
@@ -542,23 +545,25 @@ export function mapTsType(
     if (type.types.every((t) => t.flags & ts.TypeFlags.BooleanLiteral)) {
       return "Bool";
     }
-    const parts = type.types.map((t) =>
+    // List-lift encoding for optionality: strip null/undefined/void before
+    // recursing so the internal "nothing" marker never escapes to callers.
+    // `T | null` → `[T]`, `A | B | null` → `[A + B]`. Pantagruel has no
+    // `Nothing` at the user surface — a union with null/undefined/void
+    // wraps the rest in a list of length 0 or 1 (Alloy `lone`).
+    const hasNullish = type.types.some(isTsNullish);
+    const nonNullTypes = type.types.filter((t) => !isTsNullish(t));
+    if (nonNullTypes.length === 0) {
+      // Degenerate `null | undefined` — no non-null members. Fall through
+      // to the generic checker fallback below so the broken output mirrors
+      // the source rather than an internal sentinel.
+      return checker.typeToString(type);
+    }
+    const parts = nonNullTypes.map((t) =>
       mapTsType(t, checker, strategy, synthCell),
     );
-    // Deduplicate (e.g. boolean literal collapse, `null | undefined` → one marker)
     const unique = parts.filter((v, i, a) => a.indexOf(v) === i);
-    const nonNull = unique.filter((p) => p !== NULL_MARKER);
-    // List-lift encoding for optionality: `T | null` → `[T]`,
-    // `A | B | null` → `[A + B]`. Pantagruel has no `Nothing` at the user
-    // surface, so a union containing null/undefined/void wraps the rest
-    // in a list of length 0 or 1 (Alloy `lone` multiplicity).
-    if (nonNull.length !== unique.length) {
-      if (nonNull.length === 0) {
-        // Degenerate `null | undefined` with no non-null members — keep
-        // the sentinel so emission fails visibly.
-        return NULL_MARKER;
-      }
-      return `[${nonNull.join(" + ")}]`;
+    if (hasNullish) {
+      return `[${unique.join(" + ")}]`;
     }
     return unique.join(" + ");
   }

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -323,23 +323,39 @@ exports[`expressions-misc.ts > negate 1`] = `
 `;
 
 exports[`expressions-misc.ts > nonNull 1`] = `
-"module NonNull.\\n\\nnonNull x: Int + Nothing => Int.\\n\\n---\\n\\nnonNull x = x.\\n"
+"module NonNull.\\n\\nnonNull x: [Int] => Int.\\n\\n---\\n\\nnonNull x = x.\\n"
 `;
 
 exports[`expressions-misc.ts > parenAdd 1`] = `
 "module ParenAdd.\\n\\nparenAdd a: Int, b: Int => Int.\\n\\n---\\n\\nparenAdd a b = a + b.\\n"
 `;
 
+exports[`expressions-nullish.ts > defaultToZero 1`] = `
+"module DefaultToZero.\\n\\ndefaultToZero x: [Int] => Int.\\n\\n---\\n\\ndefaultToZero x = (cond #x = 0 => 0, true => x 1).\\n"
+`;
+
+exports[`expressions-nullish.ts > maybeBalance 1`] = `
+"module MaybeBalance.\\n\\nAccount.\\nbalance a1: Account => Int.\\nmaybeBalance a: [Account] => [Int].\\n\\n---\\n\\nmaybeBalance a = (each t in a | balance t).\\n"
+`;
+
+exports[`expressions-nullish.ts > nonNullDefault 1`] = `
+"module NonNullDefault.\\n\\nnonNullDefault x: Int => Int.\\n\\n---\\n\\nnonNullDefault x = x.\\n"
+`;
+
+exports[`expressions-nullish.ts > preferLeft 1`] = `
+"module PreferLeft.\\n\\npreferLeft x: [Int], y: [Int] => [Int].\\n\\n---\\n\\npreferLeft x y = (cond #x = 0 => y, true => x).\\n"
+`;
+
 exports[`expressions-optional-default.ts > makeConfig 1`] = `
-"module MakeConfig.\\n\\nConfig.\\ntimeout c: Config => Int.\\nmakeConfig base: Int, extra: Int => Config.\\nmakeConfig base: Int => Config.\\n\\n---\\n\\ntimeout (makeConfig base extra) = base + extra.\\ntimeout (makeConfig base) = base + 10.\\n"
+"module MakeConfig.\\n\\nConfig.\\ntimeout c: Config => Int.\\nmakeConfig base: Int, extra: [Int] => Config.\\n\\n---\\n\\ntimeout (makeConfig base extra) = base + (cond #extra = 0 => 10, true => extra 1).\\n"
 `;
 
 exports[`expressions-optional-default.ts > makePoint 1`] = `
-"module MakePoint.\\n\\nPoint.\\nx p: Point => Int.\\ny p: Point => Int.\\nmakePoint initial: Int => Point.\\nmakePoint  => Point.\\n\\n---\\n\\nx (makePoint initial) = initial.\\ny (makePoint initial) = 0.\\nx makePoint = 0.\\ny makePoint = 0.\\n"
+"module MakePoint.\\n\\nPoint.\\nx p: Point => Int.\\ny p: Point => Int.\\nmakePoint initial: [Int] => Point.\\n\\n---\\n\\nx (makePoint initial) = (cond #initial = 0 => 0, true => initial 1).\\ny (makePoint initial) = 0.\\n"
 `;
 
 exports[`expressions-optional-default.ts > usesOptionalDirectly 1`] = `
-"module UsesOptionalDirectly.\\n\\nusesOptionalDirectly value: Int + Nothing => Int.\\n\\n---\\n\\n> UNSUPPORTED: operator QuestionQuestionToken.\\n"
+"module UsesOptionalDirectly.\\n\\nusesOptionalDirectly value: [Int] => Int.\\n\\n---\\n\\nusesOptionalDirectly value = (cond #value = 0 => 0 + (cond #value = 0 => 1, true => value 1), true => value 1).\\n"
 `;
 
 exports[`expressions-property.ts > effectiveBalance 1`] = `
@@ -687,7 +703,7 @@ exports[`types-composite.ts > getPoint 1`] = `
 `;
 
 exports[`types-composite.ts > getResult 1`] = `
-"module GetResult.\\n\\nValue.\\ndata v1: Value => String.\\ngetResult v: Value + Nothing => Value + Nothing.\\n\\n---\\n\\ngetResult v = v.\\n"
+"module GetResult.\\n\\nValue.\\ndata v1: Value => String.\\ngetResult v: [Value] => [Value].\\n\\n---\\n\\ngetResult v = v.\\n"
 `;
 
 exports[`types-composite.ts > getStatus 1`] = `
@@ -695,7 +711,7 @@ exports[`types-composite.ts > getStatus 1`] = `
 `;
 
 exports[`types-primitives.ts > getAssignee 1`] = `
-"module GetAssignee.\\n\\nTask.\\nassignee t1: Task => String + Nothing.\\ngetAssignee t: Task => String + Nothing.\\n\\n---\\n\\ngetAssignee t = assignee t.\\n"
+"module GetAssignee.\\n\\nTask.\\nassignee t1: Task => [String].\\ngetAssignee t: Task => [String].\\n\\n---\\n\\ngetAssignee t = assignee t.\\n"
 `;
 
 exports[`types-primitives.ts > getBalance 1`] = `

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -335,7 +335,15 @@ exports[`expressions-nullish.ts > defaultToZero 1`] = `
 `;
 
 exports[`expressions-nullish.ts > maybeBalance 1`] = `
-"module MaybeBalance.\\n\\nAccount.\\nbalance a1: Account => Int.\\nmaybeBalance a: [Account] => [Int].\\n\\n---\\n\\nmaybeBalance a = (each t in a | balance t).\\n"
+"module MaybeBalance.\\n\\nAccount.\\nbalance a1: Account => Int.\\nowner a1: Account => Owner.\\nOwner.\\nid o: Owner => Int.\\nmaybeBalance a: [Account] => [Int].\\n\\n---\\n\\nmaybeBalance a = (each $0 in a | balance $0).\\n"
+`;
+
+exports[`expressions-nullish.ts > maybeOwnerId 1`] = `
+"module MaybeOwnerId.\\n\\nAccount.\\nbalance a1: Account => Int.\\nowner a1: Account => Owner.\\nOwner.\\nid o: Owner => Int.\\nmaybeOwnerId a: [Account] => [Int].\\n\\n---\\n\\nmaybeOwnerId a = (each $1 in (each $0 in a | owner $0) | id $1).\\n"
+`;
+
+exports[`expressions-nullish.ts > maybeOwnerIdOptional 1`] = `
+"module MaybeOwnerIdOptional.\\n\\nAccount.\\nbalance a1: Account => Int.\\nowner a1: Account => Owner.\\nOwner.\\nid o: Owner => Int.\\nmaybeOwnerIdOptional a: [Account] => [Int].\\n\\n---\\n\\nmaybeOwnerIdOptional a = (each $1 in (each $0 in a | owner $0) | id $1).\\n"
 `;
 
 exports[`expressions-nullish.ts > nonNullDefault 1`] = `

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-map.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-map.ts
@@ -5,7 +5,7 @@
 // The value rule is guarded by the membership predicate. Declaration guards
 // are automatically injected as antecedents in SMT queries, so absent keys
 // say nothing about the value — a cleaner specification semantics than
-// modeling partiality as `V + Nothing`.
+// modeling partiality via the list-lift encoding `[V]`.
 
 interface Cache {
   entries: Map<string, number>;

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-nullish.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-nullish.ts
@@ -8,6 +8,11 @@
 
 interface Account {
   readonly balance: number;
+  readonly owner: Owner;
+}
+
+interface Owner {
+  readonly id: number;
 }
 
 /** `x ?? y` with non-nullable default → `cond #x = 0 => y, true => (x 1)`.
@@ -30,4 +35,20 @@ export function maybeBalance(a: Account | null): number | undefined {
 /** `??` on a non-nullable LHS degenerates to just the LHS. */
 export function nonNullDefault(x: number): number {
   return x ?? 0;
+}
+
+/** Mixed chain `x?.a.b`: TS parses this with `?.` only on the first hop;
+ *  the trailing `.b` must still be lifted over the comprehension produced
+ *  by `?.a`. Expect `each $n in x | id ($m ∘ owner) $n` — the tail access
+ *  composes inside the same outer lift. */
+export function maybeOwnerId(a: Account | null): number | undefined {
+  return a?.owner.id;
+}
+
+/** Double-guarded chain `x?.a?.b`: both hops get `?.` — each step adds
+ *  another comprehension layer over the list-lift result of the previous. */
+export function maybeOwnerIdOptional(
+  a: Account | null,
+): number | undefined {
+  return a?.owner?.id;
 }

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-nullish.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-nullish.ts
@@ -1,0 +1,33 @@
+// Nullish-coalescing (`??`) and optional chaining (`?.`) under the
+// list-lift encoding. An optional TS type `T | null` translates to `[T]`,
+// so `#x = 0` is the null test and `(x 1)` extracts the singleton.
+//
+// See CLAUDE.md "Option-Type Elimination" for the encoding; REFERENCE.md
+// (Pantagruel core) documents the `[T]` + cardinality-invariant idiom as
+// Alloy `lone` multiplicity.
+
+interface Account {
+  readonly balance: number;
+}
+
+/** `x ?? y` with non-nullable default → `cond #x = 0 => y, true => (x 1)`.
+ *  Result type is `Int` (the non-null narrowing). */
+export function defaultToZero(x: number | null): number {
+  return x ?? 0;
+}
+
+/** `x ?? y` with nullable default → `cond #x = 0 => y, true => x`.
+ *  Both arms stay `[Int]`; the list-lift propagates to the return. */
+export function preferLeft(x: number | null, y: number | null): number | null {
+  return x ?? y;
+}
+
+/** `x?.prop` functor lift → `each t in x | prop t` : `[Int]`. */
+export function maybeBalance(a: Account | null): number | undefined {
+  return a?.balance;
+}
+
+/** `??` on a non-nullable LHS degenerates to just the LHS. */
+export function nonNullDefault(x: number): number {
+  return x ?? 0;
+}

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-optional-default.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-optional-default.ts
@@ -1,16 +1,15 @@
-// Optional parameter with a `??`-default. ts2pant detects the idiom and
-// emits two Pantagruel arity overloads: one with the param, one without.
-// Coherence (same name, same type at position 0 across both heads, same
-// return type) is enforced by the core language.
+// Optional parameter with a `??`-default under the general list-lift
+// lowering: an optional TS param `p?: P` list-lifts to `p: [P]` and each
+// `p ?? c` use expands to `cond #p = 0 => c, true => (p 1)`.
 
 export interface Point {
   readonly x: number;
   readonly y: number;
 }
 
-/** Single optional param, literal default. Translates to two heads:
- *    makePoint initial: Int => Point.
- *    makePoint             => Point.
+/** Single optional param, literal default. Translates to:
+ *    makePoint initial: [Int] => Point.
+ *    x (makePoint initial) = (cond #initial = 0 => 0, true => initial 1).
  */
 export function makePoint(initial?: number): Point {
   return { x: initial ?? 0, y: 0 };
@@ -20,17 +19,14 @@ export interface Config {
   readonly timeout: number;
 }
 
-/** Optional param comes after a required one. The required param is shared
- *  across both overloads (position 0); the optional is only in the longer
- *  head. Default is also a literal. */
+/** Optional param after a required one — same list-lift treatment; the
+ *  required param passes through unchanged. */
 export function makeConfig(base: number, extra?: number): Config {
   return { timeout: base + (extra ?? 10) };
 }
 
-/** Negative: optional param is used outside a `??` expression — ts2pant
- *  leaves the signature as the single `T + Nothing` form and body emission
- *  falls back to the existing unsupported-operator error when it encounters
- *  a bare reference it can't reduce. */
+/** Multiple `??` uses on the same optional param — each expands
+ *  independently, producing nested `cond` expressions. */
 export function usesOptionalDirectly(value?: number): number {
   return value ?? 0 + (value ?? 1);
 }

--- a/tools/ts2pant/tests/fixtures/constructs/types-composite.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/types-composite.ts
@@ -60,7 +60,7 @@ export function getPoint(): Point {
   return [0, 0];
 }
 
-/** union alias → Value + Nothing */
+/** union alias with null → [Value] (list-lift; length 0 or 1) */
 export function getResult(v: Value | null): Value | null {
   return v;
 }

--- a/tools/ts2pant/tests/fixtures/constructs/types-primitives.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/types-primitives.ts
@@ -28,7 +28,7 @@ export function isActive(u: User): boolean {
   return u.active;
 }
 
-/** string | null → String + Nothing */
+/** string | null → [String] (list-lift; length 0 or 1) */
 export function getAssignee(t: Task): string | null {
   return t.assignee;
 }

--- a/tools/ts2pant/tests/translate-signature.test.mts
+++ b/tools/ts2pant/tests/translate-signature.test.mts
@@ -4,7 +4,6 @@ import { createSourceFileFromSource, getChecker } from "../src/extract.js";
 import { getAst, loadAst } from "../src/pant-wasm.js";
 import {
   classifyFunction,
-  detectOptionalParamDefault,
   findFunction,
   translateSignature,
 } from "../src/translate-signature.js";
@@ -512,79 +511,3 @@ describe("@pant-type override", () => {
   });
 });
 
-describe("detectOptionalParamDefault", () => {
-  it("matches the ??-default idiom", () => {
-    const source = `
-      function makePoint(initial?: number): { x: number; y: number } {
-        return { x: initial ?? 0, y: 0 };
-      }
-    `;
-    const sourceFile = createSourceFileFromSource(source);
-    const { node } = findFunction(sourceFile, "makePoint");
-    const result = detectOptionalParamDefault(node);
-    assert.notEqual(result, null);
-    assert.equal(result?.paramName, "initial");
-    assert.equal(result?.defaultExpr.getText(), "0");
-  });
-
-  it("rejects an optional param used outside ??", () => {
-    const source = `
-      function f(value?: number): number {
-        return value ?? 1 + value;
-      }
-    `;
-    const sourceFile = createSourceFileFromSource(source);
-    const { node } = findFunction(sourceFile, "f");
-    // The trailing bare \`value\` reference disqualifies the split.
-    assert.equal(detectOptionalParamDefault(node), null);
-  });
-
-  it("rejects when two ??-uses disagree on the default expression", () => {
-    const source = `
-      function f(value?: number): number {
-        return (value ?? 0) + (value ?? 1);
-      }
-    `;
-    const sourceFile = createSourceFileFromSource(source);
-    const { node } = findFunction(sourceFile, "f");
-    assert.equal(detectOptionalParamDefault(node), null);
-  });
-
-  it("rejects when no parameter is optional", () => {
-    const source = `
-      function f(value: number): number {
-        return value;
-      }
-    `;
-    const sourceFile = createSourceFileFromSource(source);
-    const { node } = findFunction(sourceFile, "f");
-    assert.equal(detectOptionalParamDefault(node), null);
-  });
-
-  it("rejects when multiple parameters are optional", () => {
-    const source = `
-      function f(a?: number, b?: number): number {
-        return (a ?? 0) + (b ?? 0);
-      }
-    `;
-    const sourceFile = createSourceFileFromSource(source);
-    const { node } = findFunction(sourceFile, "f");
-    assert.equal(detectOptionalParamDefault(node), null);
-  });
-
-  it("ignores same-named record-literal keys", () => {
-    // The key `value:` in `{ value: value ?? 0 }` is lexically the param
-    // name but is a property key, not a reference. The detection must not
-    // mistake it for an out-of-?? use.
-    const source = `
-      function f(value?: number): { value: number } {
-        return { value: value ?? 0 };
-      }
-    `;
-    const sourceFile = createSourceFileFromSource(source);
-    const { node } = findFunction(sourceFile, "f");
-    const result = detectOptionalParamDefault(node);
-    assert.notEqual(result, null);
-    assert.equal(result?.paramName, "value");
-  });
-});

--- a/tools/ts2pant/tests/translate-types.test.mts
+++ b/tools/ts2pant/tests/translate-types.test.mts
@@ -9,7 +9,6 @@ import {
 import {
   IntStrategy,
   mapTsType,
-  NULL_MARKER,
   RealStrategy,
   translateTypes,
 } from "../src/translate-types.js";
@@ -177,17 +176,19 @@ describe("recursive type following", () => {
 });
 
 describe("mapTsType", () => {
-  it("lone undefined returns NULL_MARKER sentinel", () => {
-    // Lone null/undefined/void has no user-writable Pantagruel type —
-    // Nothing was retired from the user surface. mapTsType returns an
-    // internal sentinel that fails visibly if it reaches emission.
+  it("top-level undefined falls through to checker.typeToString", () => {
+    // Lone null/undefined/void has no Pantagruel encoding. mapTsType no
+    // longer returns an internal sentinel; it falls through to
+    // `checker.typeToString` so emission mirrors the source. The result
+    // is not a valid Pantagruel identifier, so downstream emission still
+    // fails visibly.
     const source = `interface Foo { val: undefined; }`;
     const sourceFile = createSourceFileFromSource(source);
     const checker = getChecker(sourceFile);
     const extracted = extractAllTypes(sourceFile);
     const prop = extracted.interfaces[0].properties[0];
 
-    assert.equal(mapTsType(prop.type, checker, IntStrategy), NULL_MARKER);
+    assert.equal(mapTsType(prop.type, checker, IntStrategy), "undefined");
   });
 
   it("list-lifts `T | null` to `[T]`", () => {

--- a/tools/ts2pant/tests/translate-types.test.mts
+++ b/tools/ts2pant/tests/translate-types.test.mts
@@ -9,6 +9,7 @@ import {
 import {
   IntStrategy,
   mapTsType,
+  NULL_MARKER,
   RealStrategy,
   translateTypes,
 } from "../src/translate-types.js";
@@ -176,13 +177,41 @@ describe("recursive type following", () => {
 });
 
 describe("mapTsType", () => {
-  it("handles undefined/void as Nothing", () => {
+  it("lone undefined returns NULL_MARKER sentinel", () => {
+    // Lone null/undefined/void has no user-writable Pantagruel type —
+    // Nothing was retired from the user surface. mapTsType returns an
+    // internal sentinel that fails visibly if it reaches emission.
     const source = `interface Foo { val: undefined; }`;
     const sourceFile = createSourceFileFromSource(source);
     const checker = getChecker(sourceFile);
     const extracted = extractAllTypes(sourceFile);
     const prop = extracted.interfaces[0].properties[0];
 
-    assert.equal(mapTsType(prop.type, checker, IntStrategy), "Nothing");
+    assert.equal(mapTsType(prop.type, checker, IntStrategy), NULL_MARKER);
+  });
+
+  it("list-lifts `T | null` to `[T]`", () => {
+    const source = `interface Foo { val: string | null; }`;
+    const sourceFile = createSourceFileFromSource(source);
+    const checker = getChecker(sourceFile);
+    const extracted = extractAllTypes(sourceFile);
+    const prop = extracted.interfaces[0].properties[0];
+
+    assert.equal(mapTsType(prop.type, checker, IntStrategy), "[String]");
+  });
+
+  it("list-lifts multi-arm union with null to `[A + B]`", () => {
+    const source = `
+      interface A { a: string; }
+      interface B { b: number; }
+      interface Foo { val: A | B | null; }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const checker = getChecker(sourceFile);
+    const extracted = extractAllTypes(sourceFile);
+    const foo = extracted.interfaces.find((i: any) => i.name === "Foo")!;
+    const prop = foo.properties[0];
+
+    assert.equal(mapTsType(prop.type, checker, IntStrategy), "[A + B]");
   });
 });

--- a/tools/ts2pant/tests/wasm-ast.test.mts
+++ b/tools/ts2pant/tests/wasm-ast.test.mts
@@ -65,8 +65,8 @@ describe("wasm AST constructors", async () => {
     assert.equal(ast.strTypeExpr(ast.tName("Int")), "Int");
     assert.equal(ast.strTypeExpr(ast.tList(ast.tName("User"))), "[User]");
     assert.equal(
-      ast.strTypeExpr(ast.tSum([ast.tName("Value"), ast.tName("Nothing")])),
-      "Value + Nothing",
+      ast.strTypeExpr(ast.tSum([ast.tName("Value"), ast.tName("Int")])),
+      "Value + Int",
     );
   });
 


### PR DESCRIPTION
## Summary

Follow-up to #123. ts2pant was still emitting `T + Nothing` for TS nullable types, which core `pant` now rejects. This PR:

- **Translates `T | null` / `T | undefined` to `[T]`** (Alloy `lone` multiplicity — length 0 or 1) in all type positions. Multi-arm unions with null fold into the list: `A | B | null` → `[A + B]`.
- **Implements `??` and `?.` lowerings** under list-lift. Cardinality `#x = 0` replaces the absent `~= Nothing` check; list indexing `(x 1)` replaces singleton extraction.
- **Removes the optional-param-with-`??`-default split**. The general lowering subsumes it — ~130 LOC of special-case detection becomes one canonical path.

### The lowerings

`x ?? y`:
- `y: T` (non-nullable default) → `cond #x = 0 => y, true => (x 1)` (result `T`).
- `y: [T]` (nested nullable) → `cond #x = 0 => y, true => x` (result `[T]`).
- `x` not nullable in TS → `x` alone (degenerate; no case-split).

`x?.prop` → `each t in x | prop t` (functor lift over the list). Empty stays empty, singleton becomes `[prop v]`. Chains compose — each `?.` step is another comprehension over the list result.

Nullability is read from the TS type at the AST location (presence of `null` / `undefined` / `void` in the union), **not** from the emitted Pant type — so genuine arrays (`number[]`) are never misclassified.

### What was removed

- `detectOptionalParamDefault` (78 LOC) and its 6 unit tests.
- `NullishRewrite` interface, `UniqueSupply.nullishRewrite` field, the body-level short-circuit.
- `translateSignature` opts (`unwrapOptionalParam`, `excludeParam`, `reuseParamNames`).
- Pipeline's `optSplit` detection, second `translateSignature` call, second `translateBody` pass, `reducedSigDecl` threading.

The fixture that exercised the split (`expressions-optional-default.ts`) now exercises the general lowering — same TypeScript input, new snapshot.

### Output change

`makePoint(initial?: number): Point` used to emit two arity overloads:

```text
makePoint initial: Int => Point.
makePoint           => Point.
x (makePoint initial) = initial.
x makePoint           = 0.
```

Now emits one list-lifted head with a cond:

```text
makePoint initial: [Int] => Point.
x (makePoint initial) = (cond #initial = 0 => 0, true => initial 1).
```

SMT-equivalent. Slight readability cost on this narrow pattern; trade-off is one canonical path for every `??`.

### Validation

- 333/333 ts2pant tests pass (down from 339 — removed the 6 detector tests).
- 145/145 core pant tests pass.
- Every new emission round-tripped manually through `pant`.
- `defaultToZero x: [Int] => Int.` with body `(cond #x = 0 => 0, true => x 1)` SMT-checked: invariants satisfiable, cond arms exhaustive.

## Test plan

- [x] \`npm test\` in \`tools/ts2pant/\` — all pass
- [x] \`dune test\` at repo root — all pass
- [x] Manual round-trip of new fixture snapshots through \`pant\`
- [ ] Reviewer sanity-check on the optional-param-default output diff in \`tests/constructs.test.mts.snapshot\` (makePoint, makeConfig, usesOptionalDirectly) — the arity-split → list-lift change is the biggest behavioral shift