### PR TITLE
ts2pant: Kleene μ-search for let/while counter-increment loops

### DIFF
--- a/tools/ts2pant/CLAUDE.md
+++ b/tools/ts2pant/CLAUDE.md
@@ -450,9 +450,12 @@ syntactic match:
 - Predicate must reference the loop counter as a *free variable*
   (otherwise the loop is a no-op or divergence, not a μ-search).
   `expressionReferencesNames` is scope-aware: parameters of nested
-  arrow/function expressions (plain, destructured object or array, and
-  a named function expression's own name) all shadow outer bindings,
-  and object-literal property *keys* don't count as references.
+  function-likes — arrow functions, function expressions, object/class
+  methods, getters/setters, and constructors — all shadow outer
+  bindings. Plain identifiers, destructured object/array patterns,
+  nested destructuring, and a named function expression's own name are
+  all collected. Object-literal property keys and non-computed
+  method-name tokens don't count as references.
 - Init and predicate must be side-effect-free. The purity screen lives
   alongside the TDZ check in `inlineConstBindings`, not in the recognizer
   itself; it rejects assignments, bare `++`/`--`, and unknown-pure calls.

--- a/tools/ts2pant/CLAUDE.md
+++ b/tools/ts2pant/CLAUDE.md
@@ -416,17 +416,19 @@ into `ast.each([], [gIn(binder, arrExpr), ...guards], projection)` at the chain 
 
 ### Kleene Minimization (While-Loop μ-Search)
 
-**Standard name:** Kleene μ-operator / bounded minimization.
+**Standard name:** Kleene μ-operator / unbounded minimization (with an
+explicit lower-bound guard `j >= INIT`).
 **Reference:** Kleene, *General Recursive Functions of Natural Numbers*,
 Math. Ann. 112 (1936); Kroening & Strichman, *Decision Procedures* Ch. 4
-(quantifier elimination over bounded integer ranges).
+(quantifier elimination over integer ranges).
 
 `let counter = INIT; while (P(counter)) { counter++ }` is the canonical
 "find the least integer ≥ INIT satisfying ¬P" pattern. Pure-body translation
 recognizes this exact statement pair in the prelude scan and emits
-`min over each j: Nat, j >= INIT, ~P(j) | j`, which is Pantagruel's direct
-target for μ-minimization (`ast.eachComb` with `combMin`). The loop counter
-is replaced inside the predicate by a fresh comprehension binder, and the
+`min over each j: Int, j >= INIT, ~P(j) | j` (binder type follows the
+active `NumericStrategy`), which is Pantagruel's direct target for
+μ-minimization (`ast.eachComb` with `combMin`). The loop counter is
+replaced inside the predicate by a fresh comprehension binder, and the
 resulting expression flows through the standard `inlineConstBindings`
 substitution closure — so any post-loop reference to the counter inlines
 the `min over each` directly into the consumer expression.
@@ -436,7 +438,7 @@ let suffix = 1;
 while (used.has(suffix)) { suffix++; }
 return suffix;
 // →
-foo used = (min over each j: Nat, j >= 1, ~(j in used) | j).
+foo used = (min over each j: Int, j >= 1, ~(j in used) | j).
 ```
 
 **Recognizer scope (`recognizeMuSearch` in `translate-body.ts`).** Conservative
@@ -466,15 +468,19 @@ round-trip through Pantagruel's parser (`$N` from `freshHygienicBinder`
 does not — `$` isn't legal). When a `synthCell` is plumbed through (the
 normal pipeline), `cellRegisterName(synthCell, "j")` yields a kebab-cased,
 collision-suffixed name (`j`, then `j1`, `j2`, …). Standalone test paths
-without a synthCell fall back to `j${nextSupply(supply)}`, which produces
-`j1`, `j2`, … but doesn't coordinate with the rest of the document.
+without a synthCell fall back to `j${nextSupply(supply)}` — not globally
+coordinated with the rest of the document, but locally collision-safe:
+`translateMuSearchInit` iterates the supply in a `do`/`while` against
+`new Set(scopedParams.values())` so the fresh binder cannot alias any
+Pant name already bound in the current frame.
 
 **SMT note.** `pant` type-checks the emitted form, but `pant --check`
-currently rejects `each j: Nat | …` with "comprehension parameter must be
-a domain type" — the SMT backend only enumerates user-defined domains, not
-unbounded `Nat`. End-to-end SMT verification of a μ-search result therefore
-needs either an explicit upper-bound guard or backend support for bounded
-`Nat` enumeration, neither of which is in scope here.
+currently rejects an `each j: Int | …` (or `Nat`) with "comprehension
+parameter must be a domain type" — the SMT backend only enumerates
+user-defined domains, not unbounded integers. End-to-end SMT verification
+of a μ-search result therefore needs either an explicit upper-bound guard
+or backend support for bounded integer enumeration, neither of which is
+in scope here.
 
 ## PR #84 Post-Mortem: Why Standard Algorithms Matter
 

--- a/tools/ts2pant/CLAUDE.md
+++ b/tools/ts2pant/CLAUDE.md
@@ -445,8 +445,13 @@ syntactic match:
   initializer (translated as the comprehension's lower-bound RHS).
 - Immediately followed by a `while` whose body is exactly one statement: an
   `ExpressionStatement` wrapping `i++` or `++i` on the same identifier.
-- No purity/side-effect pre-screening on init or predicate. Anything that
-  fails to translate downstream surfaces with its natural error message.
+- Predicate must reference the loop counter (otherwise the loop is a no-op
+  or divergence, not a μ-search).
+- Init and predicate must be side-effect-free. The purity screen lives
+  alongside the TDZ check in `inlineConstBindings`, not in the recognizer
+  itself; it rejects assignments, bare `++`/`--`, and unknown-pure calls.
+  `translateBodyExpr` has no handler for `++`/`--`, so without this screen
+  `while (used.has(i++)) i++;` would silently lower to garbage.
 
 Compound bodies (`{ i++; foo(); }`), counter aliasing (`while (P) { j++; }`),
 `const` counters, `i += 1` / `i = i + 1` updates, and bare `while` without a

--- a/tools/ts2pant/CLAUDE.md
+++ b/tools/ts2pant/CLAUDE.md
@@ -447,13 +447,20 @@ syntactic match:
   initializer (translated as the comprehension's lower-bound RHS).
 - Immediately followed by a `while` whose body is exactly one statement: an
   `ExpressionStatement` wrapping `i++` or `++i` on the same identifier.
-- Predicate must reference the loop counter (otherwise the loop is a no-op
-  or divergence, not a μ-search).
+- Predicate must reference the loop counter as a *free variable*
+  (otherwise the loop is a no-op or divergence, not a μ-search).
+  `expressionReferencesNames` is scope-aware, so a counter-named
+  parameter inside a nested arrow (`xs.some(i => …)`) does not count
+  as a free reference to the outer `i`.
 - Init and predicate must be side-effect-free. The purity screen lives
   alongside the TDZ check in `inlineConstBindings`, not in the recognizer
   itself; it rejects assignments, bare `++`/`--`, and unknown-pure calls.
   `translateBodyExpr` has no handler for `++`/`--`, so without this screen
   `while (used.has(i++)) i++;` would silently lower to garbage.
+- Active `NumericStrategy` must be discrete (`IntStrategy`). Under
+  `RealStrategy` the comprehension would range over a dense domain while
+  `counter++` enumerates `INIT, INIT+1, …`; `translateMuSearchInit`
+  returns an explicit error in that case.
 
 Compound bodies (`{ i++; foo(); }`), counter aliasing (`while (P) { j++; }`),
 `const` counters, `i += 1` / `i = i + 1` updates, and bare `while` without a

--- a/tools/ts2pant/CLAUDE.md
+++ b/tools/ts2pant/CLAUDE.md
@@ -449,9 +449,10 @@ syntactic match:
   `ExpressionStatement` wrapping `i++` or `++i` on the same identifier.
 - Predicate must reference the loop counter as a *free variable*
   (otherwise the loop is a no-op or divergence, not a μ-search).
-  `expressionReferencesNames` is scope-aware, so a counter-named
-  parameter inside a nested arrow (`xs.some(i => …)`) does not count
-  as a free reference to the outer `i`.
+  `expressionReferencesNames` is scope-aware: parameters of nested
+  arrow/function expressions (plain, destructured object or array, and
+  a named function expression's own name) all shadow outer bindings,
+  and object-literal property *keys* don't count as references.
 - Init and predicate must be side-effect-free. The purity screen lives
   alongside the TDZ check in `inlineConstBindings`, not in the recognizer
   itself; it rejects assignments, bare `++`/`--`, and unknown-pure calls.

--- a/tools/ts2pant/CLAUDE.md
+++ b/tools/ts2pant/CLAUDE.md
@@ -414,6 +414,63 @@ into `ast.each([], [gIn(binder, arrExpr), ...guards], projection)` at the chain 
 `.map` rewrites the projection via `ast.substituteBinder(callbackBody, callbackBinder, receiver.expr)`;
 `.reduce` fuses the pending chain into an `eachComb` instead of triggering materialization.
 
+### Kleene Minimization (While-Loop μ-Search)
+
+**Standard name:** Kleene μ-operator / bounded minimization.
+**Reference:** Kleene, *General Recursive Functions of Natural Numbers*,
+Math. Ann. 112 (1936); Kroening & Strichman, *Decision Procedures* Ch. 4
+(quantifier elimination over bounded integer ranges).
+
+`let counter = INIT; while (P(counter)) { counter++ }` is the canonical
+"find the least integer ≥ INIT satisfying ¬P" pattern. Pure-body translation
+recognizes this exact statement pair in the prelude scan and emits
+`min over each j: Nat, j >= INIT, ~P(j) | j`, which is Pantagruel's direct
+target for μ-minimization (`ast.eachComb` with `combMin`). The loop counter
+is replaced inside the predicate by a fresh comprehension binder, and the
+resulting expression flows through the standard `inlineConstBindings`
+substitution closure — so any post-loop reference to the counter inlines
+the `min over each` directly into the consumer expression.
+
+```text
+let suffix = 1;
+while (used.has(suffix)) { suffix++; }
+return suffix;
+// →
+foo used = (min over each j: Nat, j >= 1, ~(j in used) | j).
+```
+
+**Recognizer scope (`recognizeMuSearch` in `translate-body.ts`).** Conservative
+syntactic match:
+- `let` (not `const`/`var`), single declarator, simple identifier, any
+  initializer (translated as the comprehension's lower-bound RHS).
+- Immediately followed by a `while` whose body is exactly one statement: an
+  `ExpressionStatement` wrapping `i++` or `++i` on the same identifier.
+- No purity/side-effect pre-screening on init or predicate. Anything that
+  fails to translate downstream surfaces with its natural error message.
+
+Compound bodies (`{ i++; foo(); }`), counter aliasing (`while (P) { j++; }`),
+`const` counters, `i += 1` / `i = i + 1` updates, and bare `while` without a
+preceding `let` all fall through to `extractReturnExpression`'s normal
+rejection path. Extending the recognizer to cover those is straightforward
+when a need arises; the canonical `i++` form covers `name-registry.ts`'s
+`registerName` and `translate-signature.ts`'s `shortParamName`, the two
+μ-search sites in ts2pant's own source.
+
+**Comprehension binder allocation.** The comprehension's binder must
+round-trip through Pantagruel's parser (`$N` from `freshHygienicBinder`
+does not — `$` isn't legal). When a `synthCell` is plumbed through (the
+normal pipeline), `cellRegisterName(synthCell, "j")` yields a kebab-cased,
+collision-suffixed name (`j`, then `j1`, `j2`, …). Standalone test paths
+without a synthCell fall back to `j${nextSupply(supply)}`, which produces
+`j1`, `j2`, … but doesn't coordinate with the rest of the document.
+
+**SMT note.** `pant` type-checks the emitted form, but `pant --check`
+currently rejects `each j: Nat | …` with "comprehension parameter must be
+a domain type" — the SMT backend only enumerates user-defined domains, not
+unbounded `Nat`. End-to-end SMT verification of a μ-search result therefore
+needs either an explicit upper-bound guard or backend support for bounded
+`Nat` enumeration, neither of which is in scope here.
+
 ## PR #84 Post-Mortem: Why Standard Algorithms Matter
 
 The initial const-inlining implementation used ad-hoc string-name substitution rather

--- a/tools/ts2pant/src/purity.ts
+++ b/tools/ts2pant/src/purity.ts
@@ -35,6 +35,7 @@
  * Ref: Talpin & Jouvelot, "The Type and Effect Discipline", I&C 1994.
  */
 import ts from "typescript";
+import { isSetType } from "./translate-types.js";
 
 // ---------------------------------------------------------------------------
 // Tier 1a — Known-pure builtin allowlists
@@ -475,6 +476,16 @@ function isKnownPureCallInner(
           expr.arguments.every((arg) => expressionIsPure(arg, checker))
         );
       }
+    }
+
+    // Set / ReadonlySet — .has(x) is a pure membership test. Same
+    // eager-evaluation rule as Map.has: the receiver and args must also
+    // be pure.
+    if (isSetType(receiverType) && methodName === "has") {
+      return (
+        expressionIsPure(receiver, checker) &&
+        expr.arguments.every((arg) => expressionIsPure(arg, checker))
+      );
     }
 
     // Array methods

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -1683,6 +1683,40 @@ function expressionReferencesNames(
   return nodeReferencesNames(unwrapExpression(expr), names);
 }
 
+/** Walk a binding pattern (identifier, object, array) and collect every
+ *  identifier it binds, including nested patterns and rest elements. */
+function collectBindingNames(name: ts.BindingName, out: Set<string>): void {
+  if (ts.isIdentifier(name)) {
+    out.add(name.text);
+    return;
+  }
+  for (const element of name.elements) {
+    if (ts.isBindingElement(element)) {
+      collectBindingNames(element.name, out);
+    }
+  }
+}
+
+/** Collect default-value expressions from anywhere inside a binding
+ *  pattern. These are evaluated in the enclosing scope, not the binding's
+ *  own scope. */
+function collectBindingDefaults(
+  name: ts.BindingName,
+  out: ts.Expression[],
+): void {
+  if (ts.isIdentifier(name)) {
+    return;
+  }
+  for (const element of name.elements) {
+    if (ts.isBindingElement(element)) {
+      if (element.initializer) {
+        out.push(element.initializer);
+      }
+      collectBindingDefaults(element.name, out);
+    }
+  }
+}
+
 function nodeReferencesNames(node: ts.Node, names: Set<string>): boolean {
   if (names.size === 0) {
     return false;
@@ -1695,20 +1729,55 @@ function nodeReferencesNames(node: ts.Node, names: Set<string>): boolean {
   if (ts.isPropertyAccessExpression(node)) {
     return nodeReferencesNames(node.expression, names);
   }
-  // Nested function scopes: parameter names shadow outer bindings inside
-  // the body, but parameter default-value expressions are evaluated in
+  // Object-literal property key: `{ foo: expr }` — `foo` is a syntactic
+  // key, not a variable reference. Only the initializer references
+  // free vars, and computed-property-name expressions are evaluated in
   // the outer scope.
+  if (ts.isPropertyAssignment(node)) {
+    if (
+      ts.isComputedPropertyName(node.name) &&
+      nodeReferencesNames(node.name.expression, names)
+    ) {
+      return true;
+    }
+    return nodeReferencesNames(node.initializer, names);
+  }
+  // Shorthand `{ foo }` *is* sugar for `{ foo: foo }` — the identifier
+  // at that position is a variable reference. Default value (`{ foo = e }`
+  // in destructuring-assignment form) evaluates in the outer scope.
+  if (ts.isShorthandPropertyAssignment(node)) {
+    if (names.has(node.name.text)) {
+      return true;
+    }
+    if (node.objectAssignmentInitializer) {
+      return nodeReferencesNames(node.objectAssignmentInitializer, names);
+    }
+    return false;
+  }
+  // Nested function scopes: all parameter bindings (including nested
+  // identifiers inside destructuring patterns and a named function
+  // expression's own name) shadow outer bindings inside the body. All
+  // default-value expressions — top-level and nested — are evaluated in
+  // the outer scope before bindings take effect.
   if (ts.isArrowFunction(node) || ts.isFunctionExpression(node)) {
     for (const p of node.parameters) {
       if (p.initializer && nodeReferencesNames(p.initializer, names)) {
         return true;
       }
+      const nestedDefaults: ts.Expression[] = [];
+      collectBindingDefaults(p.name, nestedDefaults);
+      for (const d of nestedDefaults) {
+        if (nodeReferencesNames(d, names)) {
+          return true;
+        }
+      }
     }
     const shadowed = new Set<string>();
     for (const p of node.parameters) {
-      if (ts.isIdentifier(p.name)) {
-        shadowed.add(p.name.text);
-      }
+      collectBindingNames(p.name, shadowed);
+    }
+    if (ts.isFunctionExpression(node) && node.name) {
+      shadowed.add(node.name.text);
     }
     const innerNames = new Set<string>();
     for (const n of names) {

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -1274,6 +1274,20 @@ function describeRejectedBody(body: ts.Block, checker: ts.TypeChecker): string {
     return "empty body";
   }
   if (stmts.length > 1) {
+    // `let counter = INIT; while (...) { ... }` that failed `recognizeMuSearch`
+    // — typically a compound while body. Report a μ-search-specific
+    // reason before the generic let/var rejection fires.
+    for (let i = 0; i < stmts.length - 1; i++) {
+      const a = stmts[i]!;
+      const b = stmts[i + 1]!;
+      if (
+        ts.isVariableStatement(a) &&
+        a.declarationList.flags & ts.NodeFlags.Let &&
+        ts.isWhileStatement(b)
+      ) {
+        return "unsupported while-loop shape (not a recognized μ-search)";
+      }
+    }
     // Check for specific rejection reasons in leading statements
     for (const stmt of stmts) {
       if (ts.isVariableStatement(stmt)) {
@@ -1521,10 +1535,21 @@ function translateMuSearchInit(
   // Binder type follows the active NumericStrategy so the comprehension
   // stays consistent with how `number` is emitted elsewhere. A hardcoded
   // `Nat` would exclude negative INITs from the search domain and
-  // diverge from the containing body's numeric type.
+  // diverge from the containing body's numeric type. Real is rejected:
+  // μ-search enumerates the discrete sequence `INIT, INIT+1, …` from
+  // `counter++`, whereas `min over each j: Real, j >= INIT, ~P(j) | j`
+  // ranges over a dense domain — e.g. `while (i * i < 2) i++` would
+  // return √2 instead of 2.
+  const counterType = strategy.mapNumber();
+  if (counterType === "Real") {
+    return {
+      error:
+        "μ-search is only supported for discrete numeric strategies (got Real)",
+    };
+  }
   return {
     value: ast.eachComb(
-      [ast.param(jName, ast.tName(strategy.mapNumber()))],
+      [ast.param(jName, ast.tName(counterType))],
       [
         ast.gExpr(ast.binop(ast.opGe(), ast.var(jName), initExpr)),
         ast.gExpr(ast.unop(ast.opNot(), predExpr)),
@@ -1646,26 +1671,55 @@ function blockHasNoSideEffects(
   return false;
 }
 
-/** Check whether a TS expression references any variable name from the given set.
- *  Only checks identifier *uses* (variable references), not syntactic name
- *  positions like property names in `a.balance` or method names in `a.foo()`. */
+/** Check whether a TS expression references any variable name from the given
+ *  set as a free variable. Scope-aware: nested function/arrow parameters
+ *  shadow outer bindings, so `xs.some(i => i > 0)` does not report dependence
+ *  on an outer `i`. Default-value expressions and property-access `.name`
+ *  tokens are handled specially. */
 function expressionReferencesNames(
   expr: ts.Expression,
   names: Set<string>,
 ): boolean {
-  expr = unwrapExpression(expr);
-  if (ts.isIdentifier(expr)) {
-    return names.has(expr.text);
+  return nodeReferencesNames(unwrapExpression(expr), names);
+}
+
+function nodeReferencesNames(node: ts.Node, names: Set<string>): boolean {
+  if (names.size === 0) {
+    return false;
   }
-  // For property access, only recurse into the object expression —
-  // the .name identifier is a syntactic token, not a variable reference.
-  if (ts.isPropertyAccessExpression(expr)) {
-    return expressionReferencesNames(expr.expression, names);
+  if (ts.isIdentifier(node)) {
+    return names.has(node.text);
+  }
+  // Property access: the `.name` token is a syntactic position, not a
+  // variable reference.
+  if (ts.isPropertyAccessExpression(node)) {
+    return nodeReferencesNames(node.expression, names);
+  }
+  // Nested function scopes: parameter names shadow outer bindings inside
+  // the body, but parameter default-value expressions are evaluated in
+  // the outer scope.
+  if (ts.isArrowFunction(node) || ts.isFunctionExpression(node)) {
+    for (const p of node.parameters) {
+      if (p.initializer && nodeReferencesNames(p.initializer, names)) {
+        return true;
+      }
+    }
+    const shadowed = new Set<string>();
+    for (const p of node.parameters) {
+      if (ts.isIdentifier(p.name)) {
+        shadowed.add(p.name.text);
+      }
+    }
+    const innerNames = new Set<string>();
+    for (const n of names) {
+      if (!shadowed.has(n)) {
+        innerNames.add(n);
+      }
+    }
+    return nodeReferencesNames(node.body, innerNames);
   }
   return (
-    ts.forEachChild(expr, (child) =>
-      ts.isExpression(child) ? expressionReferencesNames(child, names) : false,
-    ) ?? false
+    ts.forEachChild(node, (child) => nodeReferencesNames(child, names)) ?? false
   );
 }
 
@@ -1703,7 +1757,16 @@ function expressionHasSideEffects(
   }
   if (ts.isCallExpression(expr)) {
     if (isKnownPureCall(expr, checker)) {
-      return expr.arguments.some((a) => expressionHasSideEffects(a, checker));
+      // Known-pure callees still require a pure callee expression —
+      // `makeString().trim()` passes the name-based builtin allowlist
+      // but the receiver `makeString()` is itself a user call with
+      // unknown effects. The Tier 1a checks in `isKnownPureCall`
+      // already enforce this for Map/Set/HO-array, but not for
+      // Math/String/Number/PURE_ARRAY entries, so we double-check here.
+      return (
+        expressionHasSideEffects(expr.expression, checker) ||
+        expr.arguments.some((a) => expressionHasSideEffects(a, checker))
+      );
     }
     return true;
   }

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -1761,13 +1761,22 @@ function nodeReferencesNames(node: ts.Node, names: Set<string>): boolean {
     }
     return false;
   }
-  // Nested function scopes: all parameter bindings (including nested
+  // Nested function-like scopes. Parameter bindings (including nested
   // identifiers inside destructuring patterns and a named function
   // expression's own name) shadow outer bindings inside the body.
   // Expressions evaluated before bindings take effect — top-level
-  // default values, nested default values, and computed property keys —
-  // are still walked in the outer scope.
-  if (ts.isArrowFunction(node) || ts.isFunctionExpression(node)) {
+  // default values, nested default values, computed destructuring
+  // keys, and a method/accessor's own computed property-name
+  // expression — are still walked in the outer scope. A method's
+  // non-computed name is a syntactic key and is not a reference.
+  if (
+    ts.isArrowFunction(node) ||
+    ts.isFunctionExpression(node) ||
+    ts.isMethodDeclaration(node) ||
+    ts.isGetAccessorDeclaration(node) ||
+    ts.isSetAccessorDeclaration(node) ||
+    ts.isConstructorDeclaration(node)
+  ) {
     for (const p of node.parameters) {
       if (p.initializer && nodeReferencesNames(p.initializer, names)) {
         return true;
@@ -1779,6 +1788,15 @@ function nodeReferencesNames(node: ts.Node, names: Set<string>): boolean {
           return true;
         }
       }
+    }
+    if (
+      (ts.isMethodDeclaration(node) ||
+        ts.isGetAccessorDeclaration(node) ||
+        ts.isSetAccessorDeclaration(node)) &&
+      ts.isComputedPropertyName(node.name) &&
+      nodeReferencesNames(node.name.expression, names)
+    ) {
+      return true;
     }
     const shadowed = new Set<string>();
     for (const p of node.parameters) {
@@ -1792,6 +1810,10 @@ function nodeReferencesNames(node: ts.Node, names: Set<string>): boolean {
       if (!shadowed.has(n)) {
         innerNames.add(n);
       }
+    }
+    // Overload signatures and ambient methods have no body.
+    if (!node.body) {
+      return false;
     }
     return nodeReferencesNames(node.body, innerNames);
   }

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -1190,7 +1190,7 @@ function recognizeMuSearch(
   }
   // Predicate must reference the counter; otherwise the loop is either a
   // no-op or a divergence, neither of which is a μ-search. Translating
-  // such a shape as `min over each j: Nat, j >= INIT, ~Q | j` (with Q
+  // such a shape as `min over each j: Int, j >= INIT, ~Q | j` (with Q
   // free of j) changes behavior at the non-terminating case.
   if (
     !expressionReferencesNames(whileStmt.expression, new Set([counterName]))
@@ -1457,13 +1457,14 @@ function translateBindingInit(
 }
 
 /**
- * Emit a `min over each j: Nat, j >= init, ~P(j) | j` expression for a
- * recognized μ-search binding. A fresh comprehension binder takes the place
- * of the loop counter inside the predicate. The binder is allocated through
- * the document-wide name registry (when present) so it never collides with
- * the function's own params or with type-derived rule binders; the `$N`
- * `freshHygienicBinder` form would not round-trip through Pantagruel's parser
- * since `$` isn't a legal identifier character.
+ * Emit a `min over each j: Int, j >= init, ~P(j) | j` expression for a
+ * recognized μ-search binding (binder type follows `strategy.mapNumber()`).
+ * A fresh comprehension binder takes the place of the loop counter inside
+ * the predicate. The binder is allocated through the document-wide name
+ * registry (when present) so it never collides with the function's own
+ * params or with type-derived rule binders; the `$N` `freshHygienicBinder`
+ * form would not round-trip through Pantagruel's parser since `$` isn't a
+ * legal identifier character.
  */
 function translateMuSearchInit(
   mu: MuSearch,
@@ -1517,9 +1518,13 @@ function translateMuSearchInit(
   }
   const predExpr = bodyExpr(predResult);
 
+  // Binder type follows the active NumericStrategy so the comprehension
+  // stays consistent with how `number` is emitted elsewhere. A hardcoded
+  // `Nat` would exclude negative INITs from the search domain and
+  // diverge from the containing body's numeric type.
   return {
     value: ast.eachComb(
-      [ast.param(jName, ast.tName("Nat"))],
+      [ast.param(jName, ast.tName(strategy.mapNumber()))],
       [
         ast.gExpr(ast.binop(ast.opGe(), ast.var(jName), initExpr)),
         ast.gExpr(ast.unop(ast.opNot(), predExpr)),

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -1113,13 +1113,16 @@ function isInterfaceFieldAccess(
  */
 /**
  * Recognize the Kleene μ-minimization pattern as a `let counter = init;`
- * statement followed by `while (P(counter)) { counter++; }`.
+ * statement followed by `while (P(counter)) counter++;` (with or without
+ * braces around the while body).
  *
  * Returns `{ counterName, initTsExpr, predicateTsExpr }` if the pair at
- * `stmts[idx]` and `stmts[idx + 1]` matches; null otherwise. The recognizer
- * is conservative: counter must be a single identifier with a side-effect-free
- * initializer, the predicate must be side-effect-free, and the loop body must
- * be exactly `counter++` or `++counter` (no compound bodies, no other writes).
+ * `stmts[idx]` and `stmts[idx + 1]` matches; null otherwise. Shape-only
+ * match: counter must be a single identifier with any initializer, and the
+ * loop body must be exactly `counter++` or `++counter` on the same
+ * identifier (no compound bodies, no other writes). Purity of the
+ * initializer and predicate is not pre-screened here — anything that
+ * fails to translate downstream surfaces with its natural error message.
  *
  * Standard name: Kleene μ-operator / bounded minimization.
  * Reference: Kleene, *General Recursive Functions of Natural Numbers*,
@@ -1155,16 +1158,19 @@ function recognizeMuSearch(
     return null;
   }
 
-  // Body must be a block containing exactly one `counter++` or `++counter`.
-  // Side-effect purity of init and predicate is not pre-screened here: the
-  // recognizer identifies the syntactic shape; the downstream translation
-  // surfaces any unsupported expressions with their natural error message.
+  // Body must be exactly one `counter++` or `++counter`, either as the
+  // direct child of the while (unbraced) or as the sole statement of a
+  // single-statement block. Side-effect purity of init and predicate is
+  // not pre-screened here: the recognizer identifies the syntactic shape;
+  // the downstream translation surfaces any unsupported expressions with
+  // their natural error message.
   const body = whileStmt.statement;
-  if (!ts.isBlock(body) || body.statements.length !== 1) {
-    return null;
-  }
-  const bodyStmt = body.statements[0]!;
-  if (!ts.isExpressionStatement(bodyStmt)) {
+  const bodyStmt: ts.Statement | null = ts.isBlock(body)
+    ? body.statements.length === 1
+      ? body.statements[0]!
+      : null
+    : body;
+  if (!bodyStmt || !ts.isExpressionStatement(bodyStmt)) {
     return null;
   }
   const update = bodyStmt.expression;

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -79,9 +79,24 @@ function isNullableTsType(type: ts.Type): boolean {
   return (type.flags & mask) !== 0;
 }
 
-interface ConstBinding {
-  tsName: string;
-  initializer: ts.Expression;
+/**
+ * Recognized prelude binding. The pure-body extractor consumes a sequence of
+ * these before the final return statement. Two shapes:
+ *
+ *   - `const`: ordinary `const x = e;` (let-elimination).
+ *   - `muSearch`: the `let counter = init; while (P(counter)) counter++;`
+ *     pair, recognized as Kleene μ-minimization and emitted as a synthetic
+ *     binding whose value is `min over each $j: Nat, $j >= init, ~P($j) | $j`.
+ *     See `recognizeMuSearch` and `emitMuSearch`.
+ */
+type ConstBinding =
+  | { kind: "const"; tsName: string; initializer: ts.Expression }
+  | { kind: "muSearch"; tsName: string; mu: MuSearch };
+
+interface MuSearch {
+  counterName: string;
+  initTsExpr: ts.Expression;
+  predicateTsExpr: ts.Expression;
 }
 
 /**
@@ -938,10 +953,7 @@ function translatePureBody(
 
   const supply = makeUniqueSupply(synthCell);
   const inlined = inlineConstBindings(
-    extracted.bindings.map((b) => ({
-      tsName: b.name,
-      initializer: b.initializer,
-    })),
+    extracted.bindings,
     checker,
     strategy,
     paramNames,
@@ -1006,7 +1018,7 @@ function translatePureBody(
 }
 
 interface ExtractedBody {
-  bindings: Array<{ name: string; initializer: ts.Expression }>;
+  bindings: ConstBinding[];
   returnExpr: ts.Expression | ts.IfStatement;
 }
 
@@ -1099,6 +1111,83 @@ function isInterfaceFieldAccess(
  *   - if/else with returns in both branches (produces a synthetic conditional)
  * Returns null if the body contains let/var bindings or effectful const initializers.
  */
+/**
+ * Recognize the Kleene μ-minimization pattern as a `let counter = init;`
+ * statement followed by `while (P(counter)) { counter++; }`.
+ *
+ * Returns `{ counterName, initTsExpr, predicateTsExpr }` if the pair at
+ * `stmts[idx]` and `stmts[idx + 1]` matches; null otherwise. The recognizer
+ * is conservative: counter must be a single identifier with a side-effect-free
+ * initializer, the predicate must be side-effect-free, and the loop body must
+ * be exactly `counter++` or `++counter` (no compound bodies, no other writes).
+ *
+ * Standard name: Kleene μ-operator / bounded minimization.
+ * Reference: Kleene, *General Recursive Functions of Natural Numbers*,
+ * Math. Ann. 112 (1936); Kroening & Strichman, *Decision Procedures* Ch. 4.
+ */
+function recognizeMuSearch(
+  stmts: readonly ts.Statement[],
+  idx: number,
+  _checker: ts.TypeChecker,
+): MuSearch | null {
+  if (idx + 1 >= stmts.length) {
+    return null;
+  }
+  const letStmt = stmts[idx]!;
+  const whileStmt = stmts[idx + 1]!;
+
+  if (!ts.isVariableStatement(letStmt)) {
+    return null;
+  }
+  if (!(letStmt.declarationList.flags & ts.NodeFlags.Let)) {
+    return null;
+  }
+  if (letStmt.declarationList.declarations.length !== 1) {
+    return null;
+  }
+  const decl = letStmt.declarationList.declarations[0]!;
+  if (!ts.isIdentifier(decl.name) || !decl.initializer) {
+    return null;
+  }
+  const counterName = decl.name.text;
+
+  if (!ts.isWhileStatement(whileStmt)) {
+    return null;
+  }
+
+  // Body must be a block containing exactly one `counter++` or `++counter`.
+  // Side-effect purity of init and predicate is not pre-screened here: the
+  // recognizer identifies the syntactic shape; the downstream translation
+  // surfaces any unsupported expressions with their natural error message.
+  const body = whileStmt.statement;
+  if (!ts.isBlock(body) || body.statements.length !== 1) {
+    return null;
+  }
+  const bodyStmt = body.statements[0]!;
+  if (!ts.isExpressionStatement(bodyStmt)) {
+    return null;
+  }
+  const update = bodyStmt.expression;
+  if (
+    !ts.isPostfixUnaryExpression(update) &&
+    !ts.isPrefixUnaryExpression(update)
+  ) {
+    return null;
+  }
+  if (update.operator !== ts.SyntaxKind.PlusPlusToken) {
+    return null;
+  }
+  if (!ts.isIdentifier(update.operand) || update.operand.text !== counterName) {
+    return null;
+  }
+
+  return {
+    counterName,
+    initTsExpr: decl.initializer,
+    predicateTsExpr: whileStmt.expression,
+  };
+}
+
 function extractReturnExpression(
   body: ts.Block,
   checker: ts.TypeChecker,
@@ -1110,35 +1199,48 @@ function extractReturnExpression(
     return null;
   }
 
-  const bindings: Array<{ name: string; initializer: ts.Expression }> = [];
+  const bindings: ConstBinding[] = [];
 
-  // Every statement before the last must be a const binding; any other shape
-  // rejects the whole body. The last statement is the return / if-else-return.
-  const last = stmts[stmts.length - 1]!;
-  for (const stmt of stmts.slice(0, -1)) {
+  // Every statement before the last must be either a const binding or a
+  // recognized μ-search pair (`let counter = init; while (P) counter++`).
+  // Any other shape rejects the whole body. The last statement is the
+  // return / if-else-return.
+  const lastIdx = stmts.length - 1;
+  let i = 0;
+  while (i < lastIdx) {
+    const mu = recognizeMuSearch(stmts, i, checker);
+    if (mu) {
+      bindings.push({ kind: "muSearch", tsName: mu.counterName, mu });
+      i += 2;
+      continue;
+    }
+
+    const stmt = stmts[i]!;
     if (!ts.isVariableStatement(stmt)) {
       return null;
     }
-
     const declList = stmt.declarationList;
-    // Reject let/var
     if (!(declList.flags & ts.NodeFlags.Const)) {
       return null;
     }
 
     for (const decl of declList.declarations) {
-      // Must have a simple identifier name and an initializer
       if (!ts.isIdentifier(decl.name) || !decl.initializer) {
         return null;
       }
-      // Reject effectful initializers
       if (expressionHasSideEffects(decl.initializer, checker)) {
         return null;
       }
-      bindings.push({ name: decl.name.text, initializer: decl.initializer });
+      bindings.push({
+        kind: "const",
+        tsName: decl.name.text,
+        initializer: decl.initializer,
+      });
     }
+    i += 1;
   }
 
+  const last = stmts[lastIdx]!;
   if (ts.isReturnStatement(last) && last.expression) {
     return { bindings, returnExpr: last.expression };
   }
@@ -1208,11 +1310,25 @@ function inlineConstBindings(
   | { error: string } {
   const ast = getAst();
 
-  // Phase 1: TDZ validation — reject forward/self references on TS AST
+  // Phase 1: TDZ validation — reject forward/self references on TS AST.
+  // For μ-search bindings, validate both the init and the predicate; the
+  // predicate may reference its own counter (that's the loop), so the
+  // counter is removed from the blocked set when checking the predicate.
   for (const [idx, binding] of bindings.entries()) {
     const blockedNames = new Set(bindings.slice(idx).map((b) => b.tsName));
-    if (expressionReferencesNames(binding.initializer, blockedNames)) {
-      return { error: "const initializer references a later binding" };
+    if (binding.kind === "const") {
+      if (expressionReferencesNames(binding.initializer, blockedNames)) {
+        return { error: "const initializer references a later binding" };
+      }
+    } else {
+      if (expressionReferencesNames(binding.mu.initTsExpr, blockedNames)) {
+        return { error: "while-loop init references a later binding" };
+      }
+      const predBlocked = new Set(blockedNames);
+      predBlocked.delete(binding.mu.counterName);
+      if (expressionReferencesNames(binding.mu.predicateTsExpr, predBlocked)) {
+        return { error: "while-loop predicate references a later binding" };
+      }
     }
   }
 
@@ -1237,23 +1353,33 @@ function inlineConstBindings(
         return acc;
       }
       const hygienicName = `$${nextSupply(supply)}`;
-      const initResult = translateBodyExpr(
-        binding.initializer,
-        checker,
-        strategy,
-        acc.scopedParams,
-        state,
-        supply,
-      );
-      if (isBodyUnsupported(initResult)) {
-        return { tag: "error", error: initResult.unsupported };
+      const initExpr =
+        binding.kind === "const"
+          ? translateBindingInit(
+              binding.initializer,
+              checker,
+              strategy,
+              acc.scopedParams,
+              state,
+              supply,
+            )
+          : translateMuSearchInit(
+              binding.mu,
+              checker,
+              strategy,
+              acc.scopedParams,
+              state,
+              supply,
+            );
+      if ("error" in initExpr) {
+        return { tag: "error", error: initExpr.error };
       }
       return {
         tag: "ok",
         scopedParams: withParam(acc.scopedParams, binding.tsName, hygienicName),
         translatedBindings: [
           ...acc.translatedBindings,
-          { hygienicName, initExpr: bodyExpr(initResult) },
+          { hygienicName, initExpr: initExpr.value },
         ],
       };
     },
@@ -1276,6 +1402,92 @@ function inlineConstBindings(
     );
 
   return { applyTo, scopedParams };
+}
+
+type BindingInitResult = { value: OpaqueExpr } | { error: string };
+
+function translateBindingInit(
+  initializer: ts.Expression,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  scopedParams: ReadonlyMap<string, string>,
+  state: SymbolicState | undefined,
+  supply: UniqueSupply,
+): BindingInitResult {
+  const result = translateBodyExpr(
+    initializer,
+    checker,
+    strategy,
+    scopedParams,
+    state,
+    supply,
+  );
+  if (isBodyUnsupported(result)) {
+    return { error: result.unsupported };
+  }
+  return { value: bodyExpr(result) };
+}
+
+/**
+ * Emit a `min over each j: Nat, j >= init, ~P(j) | j` expression for a
+ * recognized μ-search binding. A fresh comprehension binder takes the place
+ * of the loop counter inside the predicate. The binder is allocated through
+ * the document-wide name registry (when present) so it never collides with
+ * the function's own params or with type-derived rule binders; the `$N`
+ * `freshHygienicBinder` form would not round-trip through Pantagruel's parser
+ * since `$` isn't a legal identifier character.
+ */
+function translateMuSearchInit(
+  mu: MuSearch,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  scopedParams: ReadonlyMap<string, string>,
+  state: SymbolicState | undefined,
+  supply: UniqueSupply,
+): BindingInitResult {
+  const ast = getAst();
+
+  const initResult = translateBodyExpr(
+    mu.initTsExpr,
+    checker,
+    strategy,
+    scopedParams,
+    state,
+    supply,
+  );
+  if (isBodyUnsupported(initResult)) {
+    return { error: initResult.unsupported };
+  }
+  const initExpr = bodyExpr(initResult);
+
+  const jName = supply.synthCell
+    ? cellRegisterName(supply.synthCell, "j")
+    : `j${nextSupply(supply)}`;
+  const predicateScope = withParam(scopedParams, mu.counterName, jName);
+  const predResult = translateBodyExpr(
+    mu.predicateTsExpr,
+    checker,
+    strategy,
+    predicateScope,
+    state,
+    supply,
+  );
+  if (isBodyUnsupported(predResult)) {
+    return { error: predResult.unsupported };
+  }
+  const predExpr = bodyExpr(predResult);
+
+  return {
+    value: ast.eachComb(
+      [ast.param(jName, ast.tName("Nat"))],
+      [
+        ast.gExpr(ast.binop(ast.opGe(), ast.var(jName), initExpr)),
+        ast.gExpr(ast.unop(ast.opNot(), predExpr)),
+      ],
+      ast.combMin(),
+      ast.var(jName),
+    ),
+  };
 }
 
 function isGuardStatement(
@@ -3587,6 +3799,7 @@ function symbolicExecute(
             break;
           }
           bindings.push({
+            kind: "const",
             tsName: decl.name.text,
             initializer: decl.initializer,
           });

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -1697,10 +1697,11 @@ function collectBindingNames(name: ts.BindingName, out: Set<string>): void {
   }
 }
 
-/** Collect default-value expressions from anywhere inside a binding
- *  pattern. These are evaluated in the enclosing scope, not the binding's
- *  own scope. */
-function collectBindingDefaults(
+/** Collect sub-expressions of a binding pattern that are evaluated in the
+ *  enclosing scope before the bound names take effect: computed property
+ *  keys (`{ [expr]: x }`) and default-value expressions (`{ x = expr }` or
+ *  `[x = expr]`). */
+function collectBindingOuterScopeExprs(
   name: ts.BindingName,
   out: ts.Expression[],
 ): void {
@@ -1709,10 +1710,16 @@ function collectBindingDefaults(
   }
   for (const element of name.elements) {
     if (ts.isBindingElement(element)) {
+      if (
+        element.propertyName &&
+        ts.isComputedPropertyName(element.propertyName)
+      ) {
+        out.push(element.propertyName.expression);
+      }
       if (element.initializer) {
         out.push(element.initializer);
       }
-      collectBindingDefaults(element.name, out);
+      collectBindingOuterScopeExprs(element.name, out);
     }
   }
 }
@@ -1756,18 +1763,19 @@ function nodeReferencesNames(node: ts.Node, names: Set<string>): boolean {
   }
   // Nested function scopes: all parameter bindings (including nested
   // identifiers inside destructuring patterns and a named function
-  // expression's own name) shadow outer bindings inside the body. All
-  // default-value expressions — top-level and nested — are evaluated in
-  // the outer scope before bindings take effect.
+  // expression's own name) shadow outer bindings inside the body.
+  // Expressions evaluated before bindings take effect — top-level
+  // default values, nested default values, and computed property keys —
+  // are still walked in the outer scope.
   if (ts.isArrowFunction(node) || ts.isFunctionExpression(node)) {
     for (const p of node.parameters) {
       if (p.initializer && nodeReferencesNames(p.initializer, names)) {
         return true;
       }
-      const nestedDefaults: ts.Expression[] = [];
-      collectBindingDefaults(p.name, nestedDefaults);
-      for (const d of nestedDefaults) {
-        if (nodeReferencesNames(d, names)) {
+      const outerScopeExprs: ts.Expression[] = [];
+      collectBindingOuterScopeExprs(p.name, outerScopeExprs);
+      for (const e of outerScopeExprs) {
+        if (nodeReferencesNames(e, names)) {
           return true;
         }
       }

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -1121,8 +1121,10 @@ function isInterfaceFieldAccess(
  * match: counter must be a single identifier with any initializer, and the
  * loop body must be exactly `counter++` or `++counter` on the same
  * identifier (no compound bodies, no other writes). Purity of the
- * initializer and predicate is not pre-screened here — anything that
- * fails to translate downstream surfaces with its natural error message.
+ * initializer and predicate is screened in `inlineConstBindings`'s TDZ
+ * phase (alongside the sibling forward-reference check) rather than here —
+ * `translateBodyExpr` has no handler for bare `++`/`--` expressions, so a
+ * side-effectful init or predicate would otherwise lower silently.
  *
  * Standard name: Kleene μ-operator / bounded minimization.
  * Reference: Kleene, *General Recursive Functions of Natural Numbers*,
@@ -1329,6 +1331,11 @@ function inlineConstBindings(
   // For μ-search bindings, validate both the init and the predicate; the
   // predicate may reference its own counter (that's the loop), so the
   // counter is removed from the blocked set when checking the predicate.
+  // Side-effectful init or predicate (assignments, ++/--, unknown-pure
+  // calls) are also rejected here: translateBodyExpr has no explicit
+  // handler for ++/-- and silently falls through to `ast.var(getText())`,
+  // so without this screen a loop like `while (used.has(i++)) i++;`
+  // would lower to a Pant expression containing a bogus var `"i++"`.
   for (const [idx, binding] of bindings.entries()) {
     const blockedNames = new Set(bindings.slice(idx).map((b) => b.tsName));
     if (binding.kind === "const") {
@@ -1336,6 +1343,12 @@ function inlineConstBindings(
         return { error: "const initializer references a later binding" };
       }
     } else {
+      if (expressionHasSideEffects(binding.mu.initTsExpr, checker)) {
+        return { error: "while-loop init has side effects" };
+      }
+      if (expressionHasSideEffects(binding.mu.predicateTsExpr, checker)) {
+        return { error: "while-loop predicate has side effects" };
+      }
       if (expressionReferencesNames(binding.mu.initTsExpr, blockedNames)) {
         return { error: "while-loop init references a later binding" };
       }

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -1186,6 +1186,15 @@ function recognizeMuSearch(
   if (!ts.isIdentifier(update.operand) || update.operand.text !== counterName) {
     return null;
   }
+  // Predicate must reference the counter; otherwise the loop is either a
+  // no-op or a divergence, neither of which is a μ-search. Translating
+  // such a shape as `min over each j: Nat, j >= INIT, ~Q | j` (with Q
+  // free of j) changes behavior at the non-terminating case.
+  if (
+    !expressionReferencesNames(whileStmt.expression, new Set([counterName]))
+  ) {
+    return null;
+  }
 
   return {
     counterName,
@@ -1466,9 +1475,21 @@ function translateMuSearchInit(
   }
   const initExpr = bodyExpr(initResult);
 
-  const jName = supply.synthCell
-    ? cellRegisterName(supply.synthCell, "j")
-    : `j${nextSupply(supply)}`;
+  // `synthCell` path uses the document-wide NameRegistry (kebab-cased,
+  // numeric-suffixed) and is inherently collision-safe against other
+  // registered names. The standalone fallback has to guard itself against
+  // the current frame's Pant names — `scopedParams.values()` is the set
+  // the comprehension binder must avoid so predicate translation cannot
+  // alias a param to the fresh binder.
+  let jName: string;
+  if (supply.synthCell) {
+    jName = cellRegisterName(supply.synthCell, "j");
+  } else {
+    const usedNames = new Set(scopedParams.values());
+    do {
+      jName = `j${nextSupply(supply)}`;
+    } while (usedNames.has(jName));
+  }
   const predicateScope = withParam(scopedParams, mu.counterName, jName);
   const predResult = translateBodyExpr(
     mu.predicateTsExpr,

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -471,7 +471,7 @@ exports[`expressions-set.ts > contains 1`] = `
 `;
 
 exports[`expressions-while-mu-search.ts > compoundWhileBody 1`] = `
-"module CompoundWhileBody.\\n\\ncompound-while-body used: [Int] => Int.\\n\\n---\\n\\n> UNSUPPORTED: compound-while-body — let/var bindings not supported.\\n"
+"module CompoundWhileBody.\\n\\ncompound-while-body used: [Int] => Int.\\n\\n---\\n\\n> UNSUPPORTED: compound-while-body — unsupported while-loop shape (not a recognized μ-search).\\n"
 `;
 
 exports[`expressions-while-mu-search.ts > firstUnusedSuffix 1`] = `

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -486,6 +486,10 @@ exports[`expressions-while-mu-search.ts > offsetUnusedSuffix 1`] = `
 "module OffsetUnusedSuffix.\\n\\noffset-unused-suffix used: [Int], offset: Int => Int.\\n\\n---\\n\\noffset-unused-suffix used offset = offset + (min over each j: Nat, j >= 1, ~(j in used) | j).\\n"
 `;
 
+exports[`expressions-while-mu-search.ts > unbracedWhileBody 1`] = `
+"module UnbracedWhileBody.\\n\\nunbraced-while-body used: [Int] => Int.\\n\\n---\\n\\nunbraced-while-body used = (min over each j: Nat, j >= 1, ~(j in used) | j).\\n"
+`;
+
 exports[`functions-class.ts > Account.deposit 1`] = `
 "module Deposit.\\n\\n~> Deposit @ a: Account, amount: Int.\\n\\n---\\n\\naccount--balance' a = account--balance a + amount.\\n"
 `;

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -470,6 +470,22 @@ exports[`expressions-set.ts > contains 1`] = `
 "module Contains.\\n\\ncontains xs: [String], x: String => Bool.\\n\\n---\\n\\ncontains xs x = (x in xs).\\n"
 `;
 
+exports[`expressions-while-mu-search.ts > compoundWhileBody 1`] = `
+"module CompoundWhileBody.\\n\\ncompound-while-body used: [Int] => Int.\\n\\n---\\n\\n> UNSUPPORTED: compound-while-body — let/var bindings not supported.\\n"
+`;
+
+exports[`expressions-while-mu-search.ts > firstUnusedSuffix 1`] = `
+"module FirstUnusedSuffix.\\n\\nfirst-unused-suffix used: [Int] => Int.\\n\\n---\\n\\nfirst-unused-suffix used = (min over each j: Nat, j >= 1, ~(j in used) | j).\\n"
+`;
+
+exports[`expressions-while-mu-search.ts > nextSlotPlusOne 1`] = `
+"module NextSlotPlusOne.\\n\\nnext-slot-plus-one used: [Int] => Int.\\n\\n---\\n\\nnext-slot-plus-one used = (min over each j: Nat, j >= 0, ~(j in used) | j) + 1.\\n"
+`;
+
+exports[`expressions-while-mu-search.ts > offsetUnusedSuffix 1`] = `
+"module OffsetUnusedSuffix.\\n\\noffset-unused-suffix used: [Int], offset: Int => Int.\\n\\n---\\n\\noffset-unused-suffix used offset = offset + (min over each j: Nat, j >= 1, ~(j in used) | j).\\n"
+`;
+
 exports[`functions-class.ts > Account.deposit 1`] = `
 "module Deposit.\\n\\n~> Deposit @ a: Account, amount: Int.\\n\\n---\\n\\naccount--balance' a = account--balance a + amount.\\n"
 `;

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -475,19 +475,19 @@ exports[`expressions-while-mu-search.ts > compoundWhileBody 1`] = `
 `;
 
 exports[`expressions-while-mu-search.ts > firstUnusedSuffix 1`] = `
-"module FirstUnusedSuffix.\\n\\nfirst-unused-suffix used: [Int] => Int.\\n\\n---\\n\\nfirst-unused-suffix used = (min over each j: Nat, j >= 1, ~(j in used) | j).\\n"
+"module FirstUnusedSuffix.\\n\\nfirst-unused-suffix used: [Int] => Int.\\n\\n---\\n\\nfirst-unused-suffix used = (min over each j: Int, j >= 1, ~(j in used) | j).\\n"
 `;
 
 exports[`expressions-while-mu-search.ts > nextSlotPlusOne 1`] = `
-"module NextSlotPlusOne.\\n\\nnext-slot-plus-one used: [Int] => Int.\\n\\n---\\n\\nnext-slot-plus-one used = (min over each j: Nat, j >= 0, ~(j in used) | j) + 1.\\n"
+"module NextSlotPlusOne.\\n\\nnext-slot-plus-one used: [Int] => Int.\\n\\n---\\n\\nnext-slot-plus-one used = (min over each j: Int, j >= 0, ~(j in used) | j) + 1.\\n"
 `;
 
 exports[`expressions-while-mu-search.ts > offsetUnusedSuffix 1`] = `
-"module OffsetUnusedSuffix.\\n\\noffset-unused-suffix used: [Int], offset: Int => Int.\\n\\n---\\n\\noffset-unused-suffix used offset = offset + (min over each j: Nat, j >= 1, ~(j in used) | j).\\n"
+"module OffsetUnusedSuffix.\\n\\noffset-unused-suffix used: [Int], offset: Int => Int.\\n\\n---\\n\\noffset-unused-suffix used offset = offset + (min over each j: Int, j >= 1, ~(j in used) | j).\\n"
 `;
 
 exports[`expressions-while-mu-search.ts > unbracedWhileBody 1`] = `
-"module UnbracedWhileBody.\\n\\nunbraced-while-body used: [Int] => Int.\\n\\n---\\n\\nunbraced-while-body used = (min over each j: Nat, j >= 1, ~(j in used) | j).\\n"
+"module UnbracedWhileBody.\\n\\nunbraced-while-body used: [Int] => Int.\\n\\n---\\n\\nunbraced-while-body used = (min over each j: Int, j >= 1, ~(j in used) | j).\\n"
 `;
 
 exports[`functions-class.ts > Account.deposit 1`] = `

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-while-mu-search.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-while-mu-search.ts
@@ -1,0 +1,54 @@
+// Kleene μ-minimization: `let i = INIT; while (P(i)) i++;` recognized in
+// pure function bodies and translated to `min over each $j: Nat,
+// $j >= INIT, ~P($j) | $j`. Reference: Kleene, *General Recursive Functions
+// of Natural Numbers*, Math. Ann. 112 (1936); Kroening & Strichman,
+// *Decision Procedures* Ch. 4.
+//
+// The counter binding flows through the existing const-inlining substitution
+// machinery, so post-loop references to the counter resolve transparently —
+// the consumer sees a `min over each` expression in place of the counter.
+
+/** Find the smallest i >= 1 not present in `used`. Canonical μ-search. */
+export function firstUnusedSuffix(used: ReadonlySet<number>): number {
+  let i = 1;
+  while (used.has(i)) {
+    i++;
+  }
+  return i;
+}
+
+/** Counter is referenced in a downstream expression: the substitution
+ *  inlines the `min over each` directly into the `+ 1`. */
+export function nextSlotPlusOne(used: ReadonlySet<number>): number {
+  let i = 0;
+  while (used.has(i)) {
+    i++;
+  }
+  return i + 1;
+}
+
+/** μ-search alongside an ordinary const binding: both flow through the
+ *  same prelude scan and substitution closure. */
+export function offsetUnusedSuffix(
+  used: ReadonlySet<number>,
+  offset: number,
+): number {
+  const base = offset;
+  let i = 1;
+  while (used.has(i)) {
+    i++;
+  }
+  return base + i;
+}
+
+/** Compound while body — recognizer rejects (more than one statement),
+ *  then `extractReturnExpression` rejects on the `let` binding it can't
+ *  consume. Locks in the conservative behavior. */
+export function compoundWhileBody(used: ReadonlySet<number>): number {
+  let i = 0;
+  while (used.has(i)) {
+    i++;
+    i++;
+  }
+  return i;
+}

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-while-mu-search.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-while-mu-search.ts
@@ -52,3 +52,11 @@ export function compoundWhileBody(used: ReadonlySet<number>): number {
   }
   return i;
 }
+
+/** Unbraced while body — the body is an ExpressionStatement directly,
+ *  not wrapped in a Block. CLAUDE.md's canonical form permits this. */
+export function unbracedWhileBody(used: ReadonlySet<number>): number {
+  let i = 1;
+  while (used.has(i)) i++;
+  return i;
+}

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -1185,4 +1185,65 @@ describe("Kleene μ-search (while-loop minimum)", () => {
     assert.equal(props.length, 1);
     assert.equal(props[0]?.kind, "unsupported");
   });
+
+  it("destructured arrow params also shadow the outer counter", () => {
+    // Object/array patterns bind identifiers just as plain params do.
+    // The scope-aware check must descend into binding patterns to
+    // discover `i` is shadowed by `({ i })` or `([i])`.
+    const objSource = `
+      export function shadowedObj(): number {
+        let i = 0;
+        while ([{ i: 0 }].some(({ i }) => i > 0)) {
+          i++;
+        }
+        return i;
+      }
+    `;
+    const arrSource = `
+      export function shadowedArr(): number {
+        let i = 0;
+        while ([[0]].some(([i]) => i > 0)) {
+          i++;
+        }
+        return i;
+      }
+    `;
+    for (const [name, src] of [
+      ["shadowedObj", objSource],
+      ["shadowedArr", arrSource],
+    ] as const) {
+      const sourceFile = createSourceFileFromSource(src);
+      const props = translateBody({
+        sourceFile,
+        functionName: name,
+        strategy: IntStrategy,
+      });
+      assert.equal(props.length, 1);
+      assert.equal(props[0]?.kind, "unsupported", `${name} should be rejected`);
+    }
+  });
+
+  it("named function expression's own name shadows the outer counter", () => {
+    // `function i() {}` binds `i` inside its own body (for recursive
+    // self-reference), so `i > 0` inside the body refers to the function
+    // value, not to the outer counter.
+    const source = `
+      export function shadowedFnName(): number {
+        let i = 0;
+        while ((function i() { return false; })()) {
+          i++;
+        }
+        return i;
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "shadowedFnName",
+      strategy: IntStrategy,
+    });
+
+    assert.equal(props.length, 1);
+    assert.equal(props[0]?.kind, "unsupported");
+  });
 });

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -1223,6 +1223,44 @@ describe("Kleene μ-search (while-loop minimum)", () => {
     }
   });
 
+  it("computed destructuring key in a nested param sees the outer counter", () => {
+    // `({ [i]: x }) => …` — the computed key `[i]` is evaluated in the
+    // outer scope before the `x` binding takes effect, so it IS a real
+    // free reference to the outer counter `i`. The recognizer must
+    // accept this as a valid μ-search body. After the reshape, `used`
+    // is declared-but-unused, so the key also supplies the counter
+    // reference that the predicate-must-reference-counter check looks
+    // for.
+    const source = `
+      export function computedKeyRef(): number {
+        let i = 0;
+        while ([{}].some(({ [i]: x }: { [k: number]: number }) => x === 0)) {
+          i++;
+        }
+        return i;
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "computedKeyRef",
+      strategy: IntStrategy,
+    });
+
+    // A free-ref to `i` via the computed key makes this a recognized
+    // μ-search shape; regardless of whether downstream translation of
+    // the indexed-record predicate succeeds, the distinguishing
+    // property is that the recognizer does NOT reject it for "predicate
+    // does not reference counter".
+    assert.equal(props.length, 1);
+    if (props[0]?.kind === "unsupported") {
+      assert.doesNotMatch(
+        props[0].reason,
+        /predicate does not reference the counter|not a recognized μ-search/,
+      );
+    }
+  });
+
   it("named function expression's own name shadows the outer counter", () => {
     // `function i() {}` binds `i` inside its own body (for recursive
     // self-reference), so `i > 0` inside the body refers to the function

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -859,7 +859,7 @@ describe("structured iteration (for-of, forEach, reduce)", () => {
 });
 
 describe("Kleene μ-search (while-loop minimum)", () => {
-  it("translates `let i = INIT; while (P(i)) i++` as `min over each j: Nat, j >= INIT, ~P(j) | j`", () => {
+  it("translates `let i = INIT; while (P(i)) i++` as `min over each j: Int, j >= INIT, ~P(j) | j`", () => {
     const source = `
       export function firstUnused(used: ReadonlySet<number>): number {
         let i = 1;
@@ -887,7 +887,7 @@ describe("Kleene μ-search (while-loop minimum)", () => {
       // The full pipeline (with synthCell) produces just `j`.
       assert.equal(
         ast.strExpr(prop.rhs),
-        "min over each j1: Nat, j1 >= 1, ~(j1 in used) | j1",
+        "min over each j1: Int, j1 >= 1, ~(j1 in used) | j1",
       );
     }
   });
@@ -916,7 +916,7 @@ describe("Kleene μ-search (while-loop minimum)", () => {
       const ast = getAst();
       assert.equal(
         ast.strExpr(prop.rhs),
-        "(min over each j1: Nat, j1 >= 0, ~(j1 in used) | j1) + 1",
+        "(min over each j1: Int, j1 >= 0, ~(j1 in used) | j1) + 1",
       );
     }
   });
@@ -946,7 +946,7 @@ describe("Kleene μ-search (while-loop minimum)", () => {
       const ast = getAst();
       assert.equal(
         ast.strExpr(prop.rhs),
-        "k + (min over each j2: Nat, j2 >= 1, ~(j2 in used) | j2)",
+        "k + (min over each j2: Int, j2 >= 1, ~(j2 in used) | j2)",
       );
     }
   });
@@ -1060,7 +1060,7 @@ describe("Kleene μ-search (while-loop minimum)", () => {
       const ast = getAst();
       assert.equal(
         ast.strExpr(prop.rhs),
-        "min over each j1: Nat, j1 >= 1, ~(j1 in used) | j1",
+        "min over each j1: Int, j1 >= 1, ~(j1 in used) | j1",
       );
     }
   });

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { createSourceFileFromSource } from "../src/extract.js";
 import { getAst, loadAst } from "../src/pant-wasm.js";
 import { translateBody } from "../src/translate-body.js";
-import { IntStrategy } from "../src/translate-types.js";
+import { IntStrategy, RealStrategy } from "../src/translate-types.js";
 
 before(async () => {
   await loadAst();
@@ -881,13 +881,12 @@ describe("Kleene μ-search (while-loop minimum)", () => {
     assert.equal(prop.kind, "equation");
     if (prop.kind === "equation") {
       const ast = getAst();
-      // No synthCell in this standalone test path, so the comprehension
-      // binder falls back to `j${nextSupply}` — supply slot 0 was consumed
-      // by the binding's hygienic placeholder, so `j1` is correct here.
-      // The full pipeline (with synthCell) produces just `j`.
-      assert.equal(
+      // Match any `jN` binder and assert consistent use throughout the
+      // comprehension. The specific `N` depends on UniqueSupply slot
+      // consumption and shouldn't break hygiene refactors.
+      assert.match(
         ast.strExpr(prop.rhs),
-        "min over each j1: Int, j1 >= 1, ~(j1 in used) | j1",
+        /^min over each (j\d+): Int, \1 >= 1, ~\(\1 in used\) \| \1$/,
       );
     }
   });
@@ -914,9 +913,9 @@ describe("Kleene μ-search (while-loop minimum)", () => {
     assert.equal(prop.kind, "equation");
     if (prop.kind === "equation") {
       const ast = getAst();
-      assert.equal(
+      assert.match(
         ast.strExpr(prop.rhs),
-        "(min over each j1: Int, j1 >= 0, ~(j1 in used) | j1) + 1",
+        /^\(min over each (j\d+): Int, \1 >= 0, ~\(\1 in used\) \| \1\) \+ 1$/,
       );
     }
   });
@@ -944,9 +943,9 @@ describe("Kleene μ-search (while-loop minimum)", () => {
     assert.equal(prop.kind, "equation");
     if (prop.kind === "equation") {
       const ast = getAst();
-      assert.equal(
+      assert.match(
         ast.strExpr(prop.rhs),
-        "k + (min over each j2: Int, j2 >= 1, ~(j2 in used) | j2)",
+        /^k \+ \(min over each (j\d+): Int, \1 >= 1, ~\(\1 in used\) \| \1\)$/,
       );
     }
   });
@@ -1058,9 +1057,9 @@ describe("Kleene μ-search (while-loop minimum)", () => {
     assert.equal(prop.kind, "equation");
     if (prop.kind === "equation") {
       const ast = getAst();
-      assert.equal(
+      assert.match(
         ast.strExpr(prop.rhs),
-        "min over each j1: Int, j1 >= 1, ~(j1 in used) | j1",
+        /^min over each (j\d+): Int, \1 >= 1, ~\(\1 in used\) \| \1$/,
       );
     }
   });
@@ -1130,6 +1129,56 @@ describe("Kleene μ-search (while-loop minimum)", () => {
     const props = translateBody({
       sourceFile,
       functionName: "bogus",
+      strategy: IntStrategy,
+    });
+
+    assert.equal(props.length, 1);
+    assert.equal(props[0]?.kind, "unsupported");
+  });
+
+  it("rejects RealStrategy because the dense domain breaks `counter++`", () => {
+    // μ-search enumerates `INIT, INIT+1, …` discretely. Under
+    // RealStrategy the comprehension would range over a dense domain
+    // and could return a value the loop never visits (e.g. √2 when
+    // `while (i * i < 2) i++` should terminate at 2).
+    const source = `
+      export function overReal(used: ReadonlySet<number>): number {
+        let i = 0;
+        while (used.has(i)) {
+          i++;
+        }
+        return i;
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "overReal",
+      strategy: RealStrategy,
+    });
+
+    assert.equal(props.length, 1);
+    assert.equal(props[0]?.kind, "unsupported");
+  });
+
+  it("counter references inside shadowing arrow params do not count as free refs", () => {
+    // `[1].some(i => ...)` shadows the outer counter `i`. The predicate
+    // does NOT reference the outer counter, so recognizeMuSearch rejects
+    // the shape rather than falsely lowering it to a μ-search whose
+    // search-domain guard is free of `j`.
+    const source = `
+      export function shadowed(): number {
+        let i = 0;
+        while ([1, 2, 3].some(i => i > 0)) {
+          i++;
+        }
+        return i;
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "shadowed",
       strategy: IntStrategy,
     });
 

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -1060,4 +1060,28 @@ describe("Kleene μ-search (while-loop minimum)", () => {
       );
     }
   });
+
+  it("rejects when the predicate does not reference the counter", () => {
+    // `while (Q) i++` with Q free of i is not a μ-search: it is a no-op
+    // (Q false) or a divergence (Q true). Lowering it as
+    // `min over each j | ~Q` would change behavior in the divergent case.
+    const source = `
+      export function bogus(used: ReadonlySet<number>, flag: boolean): number {
+        let i = 1;
+        while (flag) {
+          i++;
+        }
+        return i;
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "bogus",
+      strategy: IntStrategy,
+    });
+
+    assert.equal(props.length, 1);
+    assert.equal(props[0]?.kind, "unsupported");
+  });
 });

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -1263,12 +1263,15 @@ describe("Kleene μ-search (while-loop minimum)", () => {
 
   it("named function expression's own name shadows the outer counter", () => {
     // `function i() {}` binds `i` inside its own body (for recursive
-    // self-reference), so `i > 0` inside the body refers to the function
-    // value, not to the outer counter.
+    // self-reference), so the reference to `i` inside the body refers
+    // to the function value, not to the outer counter. The predicate
+    // therefore has no free reference to the outer `i`, and
+    // recognizeMuSearch rejects on the "predicate doesn't reference
+    // counter" path — that rejection is the distinguishing signal.
     const source = `
       export function shadowedFnName(): number {
         let i = 0;
-        while ((function i() { return false; })()) {
+        while ((function i(): boolean { return i.length > 0; })()) {
           i++;
         }
         return i;
@@ -1283,5 +1286,59 @@ describe("Kleene μ-search (while-loop minimum)", () => {
 
     assert.equal(props.length, 1);
     assert.equal(props[0]?.kind, "unsupported");
+    if (props[0]?.kind === "unsupported") {
+      // The rejection must be attributable to the shadowing → no free
+      // counter reference, not to some unrelated downstream error.
+      assert.match(
+        props[0].reason,
+        /not a recognized μ-search/,
+      );
+    }
+  });
+
+  it("object/class method scopes shadow outer bindings", () => {
+    // `({ test(i) { return i > 0; } }).test(0)` — the method's
+    // parameter `i` shadows the outer counter. The predicate has no
+    // free reference to the outer `i`, so the recognizer rejects.
+    const methodSource = `
+      export function shadowedMethod(): number {
+        let i = 0;
+        while (({ test(i: number): boolean { return i > 0; } }).test(0)) {
+          i++;
+        }
+        return i;
+      }
+    `;
+    // `({ i() { return 0; } }).i()` — the method name `i` is a
+    // syntactic key, not a free reference.
+    const methodNameSource = `
+      export function shadowedMethodName(): number {
+        let i = 0;
+        while (({ i(): number { return 0; } }).i()) {
+          i++;
+        }
+        return i;
+      }
+    `;
+    for (const [name, src] of [
+      ["shadowedMethod", methodSource],
+      ["shadowedMethodName", methodNameSource],
+    ] as const) {
+      const sourceFile = createSourceFileFromSource(src);
+      const props = translateBody({
+        sourceFile,
+        functionName: name,
+        strategy: IntStrategy,
+      });
+      assert.equal(props.length, 1);
+      assert.equal(props[0]?.kind, "unsupported", `${name} should be rejected`);
+      if (props[0]?.kind === "unsupported") {
+        assert.match(
+          props[0].reason,
+          /not a recognized μ-search/,
+          `${name} should reject on μ-search path`,
+        );
+      }
+    }
   });
 });

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -996,10 +996,14 @@ describe("Kleene μ-search (while-loop minimum)", () => {
   });
 
   it("rejects when the counter is `const` instead of `let`", () => {
+    // Body contains a canonical `i++` so the rejection is specifically
+    // attributable to the `const` declarator, not to the body shape.
     const source = `
       export function constCounter(used: ReadonlySet<number>): number {
         const i = 0;
-        while (used.has(i)) {}
+        while (used.has(i)) {
+          i++;
+        }
         return i;
       }
     `;
@@ -1059,6 +1063,54 @@ describe("Kleene μ-search (while-loop minimum)", () => {
         "min over each j1: Nat, j1 >= 1, ~(j1 in used) | j1",
       );
     }
+  });
+
+  it("rejects when the initializer has side effects", () => {
+    // `start++` in the init would otherwise lower to a bogus var since
+    // `translateBodyExpr` has no handler for bare `++`/`--`. The TDZ
+    // phase in inlineConstBindings catches this explicitly.
+    const source = `
+      export function bogusInit(used: ReadonlySet<number>, start: number): number {
+        let i = start++;
+        while (used.has(i)) {
+          i++;
+        }
+        return i;
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "bogusInit",
+      strategy: IntStrategy,
+    });
+
+    assert.equal(props.length, 1);
+    assert.equal(props[0]?.kind, "unsupported");
+  });
+
+  it("rejects when the predicate has side effects", () => {
+    // `used.has(i++)` embeds a `++` inside the predicate — the TDZ
+    // side-effect screen short-circuits before translation rather than
+    // silently lowering `i++` via the `ast.var(getText())` fallback.
+    const source = `
+      export function bogusPred(used: ReadonlySet<number>): number {
+        let i = 0;
+        while (used.has(i++)) {
+          i++;
+        }
+        return i;
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "bogusPred",
+      strategy: IntStrategy,
+    });
+
+    assert.equal(props.length, 1);
+    assert.equal(props[0]?.kind, "unsupported");
   });
 
   it("rejects when the predicate does not reference the counter", () => {

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -857,3 +857,207 @@ describe("structured iteration (for-of, forEach, reduce)", () => {
     }
   });
 });
+
+describe("Kleene μ-search (while-loop minimum)", () => {
+  it("translates `let i = INIT; while (P(i)) i++` as `min over each j: Nat, j >= INIT, ~P(j) | j`", () => {
+    const source = `
+      export function firstUnused(used: ReadonlySet<number>): number {
+        let i = 1;
+        while (used.has(i)) {
+          i++;
+        }
+        return i;
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "firstUnused",
+      strategy: IntStrategy,
+    });
+
+    assert.equal(props.length, 1);
+    const prop = props[0]!;
+    assert.equal(prop.kind, "equation");
+    if (prop.kind === "equation") {
+      const ast = getAst();
+      // No synthCell in this standalone test path, so the comprehension
+      // binder falls back to `j${nextSupply}` — supply slot 0 was consumed
+      // by the binding's hygienic placeholder, so `j1` is correct here.
+      // The full pipeline (with synthCell) produces just `j`.
+      assert.equal(
+        ast.strExpr(prop.rhs),
+        "min over each j1: Nat, j1 >= 1, ~(j1 in used) | j1",
+      );
+    }
+  });
+
+  it("inlines the μ-result into downstream expressions", () => {
+    const source = `
+      export function nextSlot(used: ReadonlySet<number>): number {
+        let i = 0;
+        while (used.has(i)) {
+          i++;
+        }
+        return i + 1;
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "nextSlot",
+      strategy: IntStrategy,
+    });
+
+    assert.equal(props.length, 1);
+    const prop = props[0]!;
+    assert.equal(prop.kind, "equation");
+    if (prop.kind === "equation") {
+      const ast = getAst();
+      assert.equal(
+        ast.strExpr(prop.rhs),
+        "(min over each j1: Nat, j1 >= 0, ~(j1 in used) | j1) + 1",
+      );
+    }
+  });
+
+  it("composes μ-search with leading const bindings via shared inlining", () => {
+    const source = `
+      export function offset(used: ReadonlySet<number>, k: number): number {
+        const base = k;
+        let i = 1;
+        while (used.has(i)) {
+          i++;
+        }
+        return base + i;
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "offset",
+      strategy: IntStrategy,
+    });
+
+    assert.equal(props.length, 1);
+    const prop = props[0]!;
+    assert.equal(prop.kind, "equation");
+    if (prop.kind === "equation") {
+      const ast = getAst();
+      assert.equal(
+        ast.strExpr(prop.rhs),
+        "k + (min over each j2: Nat, j2 >= 1, ~(j2 in used) | j2)",
+      );
+    }
+  });
+
+  it("rejects while bodies with more than one statement", () => {
+    const source = `
+      export function compound(used: ReadonlySet<number>): number {
+        let i = 0;
+        while (used.has(i)) {
+          i++;
+          i++;
+        }
+        return i;
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "compound",
+      strategy: IntStrategy,
+    });
+
+    assert.equal(props.length, 1);
+    assert.equal(props[0]?.kind, "unsupported");
+  });
+
+  it("rejects when the loop body increments a different variable", () => {
+    const source = `
+      export function aliased(used: ReadonlySet<number>): number {
+        let i = 0;
+        let j = 0;
+        while (used.has(i)) {
+          j++;
+        }
+        return i;
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "aliased",
+      strategy: IntStrategy,
+    });
+
+    assert.equal(props.length, 1);
+    assert.equal(props[0]?.kind, "unsupported");
+  });
+
+  it("rejects when the counter is `const` instead of `let`", () => {
+    const source = `
+      export function constCounter(used: ReadonlySet<number>): number {
+        const i = 0;
+        while (used.has(i)) {}
+        return i;
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "constCounter",
+      strategy: IntStrategy,
+    });
+
+    assert.equal(props.length, 1);
+    assert.equal(props[0]?.kind, "unsupported");
+  });
+
+  it("rejects when no `let` precedes the while", () => {
+    const source = `
+      export function bareWhile(used: ReadonlySet<number>): number {
+        while (used.has(0)) {}
+        return 0;
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "bareWhile",
+      strategy: IntStrategy,
+    });
+
+    assert.equal(props.length, 1);
+    assert.equal(props[0]?.kind, "unsupported");
+  });
+
+  it("accepts prefix `++counter` as well as postfix `counter++`", () => {
+    const source = `
+      export function prefixInc(used: ReadonlySet<number>): number {
+        let i = 1;
+        while (used.has(i)) {
+          ++i;
+        }
+        return i;
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "prefixInc",
+      strategy: IntStrategy,
+    });
+
+    assert.equal(props.length, 1);
+    const prop = props[0]!;
+    assert.equal(prop.kind, "equation");
+    if (prop.kind === "equation") {
+      const ast = getAst();
+      assert.equal(
+        ast.strExpr(prop.rhs),
+        "min over each j1: Nat, j1 >= 1, ~(j1 in used) | j1",
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Recognizes the canonical counter-increment loop pattern in pure function bodies — `let counter = INIT; while (P(counter)) counter++;` — as **Kleene μ-minimization** (Kleene 1936), and emits Pantagruel's direct target: `min over each j: Nat, j >= INIT, ~P(j) | j` (via `ast.eachComb` + `ast.combMin`).
- The counter binding flows through the existing `inlineConstBindings` substitution closure, so post-loop references to the counter inline the `min over each` expression directly into the consumer — no special-case substitution.
- Two μ-search sites in ts2pant's own source (`name-registry.ts:registerName`, `translate-signature.ts:shortParamName`) motivate a general handler over special-casing.

## Design

- **`recognizeMuSearch`**: syntactic pattern match on `let` + `while` + single-statement `i++`/`++i` body. Conservative — compound bodies, aliased counters, `const` counters, and missing-`let` prefixes all fall through to the existing rejection path. No purity pre-screen; the recognizer identifies shape, translation handles semantics.
- **`translateMuSearchInit`**: allocates a fresh comprehension binder (via `cellRegisterName(synthCell, "j")` when available, else `j${nextSupply}`), scope-extends the counter→binder mapping, translates the predicate, and wraps in `eachComb`. `$N`-style hygienic binders don't round-trip through pant's parser (`$` isn't legal), so this explicit allocation matters.
- **Integration**: `ConstBinding` becomes a discriminated union (`kind: "const" | "muSearch"`). The prelude scan in `extractReturnExpression` tries μ-search first, falls back to the const-binding path. `inlineConstBindings` dispatches initializer translation on kind.
- The mutating-body path keeps its blanket `WhileStatement` rejection unchanged — μ-search is a pure pattern.

## Tests

- **Fixture**: `tests/fixtures/constructs/expressions-while-mu-search.ts` with 3 positive cases (canonical, downstream composition, alongside a const binding) + 1 negative (compound while body). Snapshot-locked.
- **Unit**: 8 new tests in `translate-body.test.mts` exercising the recognizer directly — positive translation, downstream inlining, composition with const bindings, prefix `++i`, and four rejections (compound body, aliased counter, const counter, bare while).
- All 350 ts2pant tests pass (342 → 350). Core `dune test` unchanged.

## SMT limitation (out of scope)

`pant` **type-checks** the emitted form, but `pant --check` currently rejects `each j: Nat | …` with *"comprehension parameter must be a domain type"* — the SMT backend doesn't enumerate unbounded `Nat`. End-to-end SMT verification of a μ-search result therefore needs either an explicit upper-bound guard on the comprehension or backend support for bounded `Nat` enumeration; neither is in scope here.

## Dogfood impact

This unblocks **one of three** blockers for `registerName` self-translation. The other two — `new Set(iterable)` copy-construction and `Set.prototype.add` mutation — remain their own follow-ups.

## Test plan

- [x] `cd tools/ts2pant && npm test` — 350/350 pass
- [x] `cd tools/ts2pant && node_modules/.bin/tsc --noEmit` — clean
- [x] `cd tools/ts2pant && npx biome check src` — clean
- [x] `dune test` (core pant) — unchanged, all green
- [x] Manual smoke: `pant <fixture-emission.pant>` type-checks cleanly
- [ ] Reviewer sanity-check: the decision to drop side-effect screening from the recognizer (so translation, not recognition, surfaces unsupported-predicate errors) is deliberate but worth a second eye

🤖 Generated with [Claude Code](https://claude.com/claude-code)