### PR TITLE
smt: sound μ-search translation for min-over-each Nat

### DIFF
--- a/lib/smt.ml
+++ b/lib/smt.ml
@@ -640,6 +640,96 @@ and translate_aggregate config env (comb : combiner) params guards body =
   let inner_config =
     { config with quant_bound = local_bound @ config.quant_bound }
   in
+  (* μ-search: `min over each j: Nat|Nat0|Int, G₁(j), …, Gₙ(j) | j` compiles
+     to a Skolem-style least-witness encoding instead of enumerating the
+     (unbounded) iterator. Detected shape: CombMin, single numeric-typed
+     param, body is exactly the binder, all guards are plain expressions.
+     Emits a fresh Int constant r along with:
+       (assert (and <type-bound[r]> G₁(r) … Gₙ(r)))
+       (assert (forall ((j Int)) (=> (and <type-bound[j]> (< j r) Gᵢ(j)…) false)))
+     where <type-bound[x]> is `(>= x 1)` for Nat, `(>= x 0)` for Nat0, absent
+     for Int. The result string is r. *)
+  let mu_search =
+    match comb with
+    | CombMin -> (
+        match resolve_numeric_comprehension_binding env params with
+        | Error _ -> None
+        | Ok (binder_name, binder_ty, bindings) -> (
+            let all_gexpr =
+              List.for_all
+                (function GExpr _ -> true | GIn _ | GParam _ -> false)
+                guards
+            in
+            if not all_gexpr then None
+            else
+              match[@warning "-4"] body with
+              | EVar (Lower n) when n = binder_name ->
+                  Some (binder_name, binder_ty, bindings)
+              | _ -> None))
+    | CombAdd | CombMul | CombAnd | CombOr | CombMax -> None
+  in
+  match mu_search with
+  | Some (binder_name, binder_ty, bindings) ->
+      let env_inner = Env.with_vars bindings env in
+      let r = fresh_fallback ~kind:"mu" ~sort:"Int" in
+      let pname = sanitize_ident binder_name in
+      let guard_templates =
+        List.filter_map
+          (function
+            | GExpr e -> Some (translate_expr inner_config env_inner e)
+            | GIn _ | GParam _ -> None)
+          guards
+      in
+      let type_lower_bound name =
+        match binder_ty with
+        | TyNat -> Some (Printf.sprintf "(>= %s 1)" name)
+        | TyNat0 -> Some (Printf.sprintf "(>= %s 0)" name)
+        | TyInt -> None
+        | TyBool | TyReal | TyString | TyNothing | TyDomain _ | TyList _
+        | TyProduct _ | TySum _ | TyFunc _ ->
+            None
+      in
+      let sub_with ~to_ template = replace_word ~from:pname ~to_ template in
+      let r_guards =
+        Option.to_list (type_lower_bound r)
+        @ List.map (sub_with ~to_:r) guard_templates
+      in
+      let assert_r =
+        match r_guards with
+        | [] -> "true"
+        | [ g ] -> g
+        | gs -> Printf.sprintf "(and %s)" (String.concat " " gs)
+      in
+      add_fallback_assert assert_r;
+      let j_name = Printf.sprintf "_mu_j_%s" r in
+      let j_guards =
+        Option.to_list (type_lower_bound j_name)
+        @ [ Printf.sprintf "(< %s %s)" j_name r ]
+        @ List.map (sub_with ~to_:j_name) guard_templates
+      in
+      let forall_body =
+        match j_guards with
+        | [] -> "false"
+        | [ g ] -> Printf.sprintf "(=> %s false)" g
+        | gs -> Printf.sprintf "(=> (and %s) false)" (String.concat " " gs)
+      in
+      add_fallback_assert
+        (Printf.sprintf "(forall ((%s Int)) %s)" j_name forall_body);
+      r
+  | None ->
+      translate_aggregate_finite config env inner_config comb params guards body
+
+and translate_aggregate_finite config env inner_config (comb : combiner) params
+    guards body =
+  let local_bound =
+    List.map (fun (p : param) -> Ast.lower_name p.param_name) params
+    @ List.concat_map
+        (function
+          | GParam p -> [ Ast.lower_name p.param_name ]
+          | GIn (n, _) -> [ Ast.lower_name n ]
+          | GExpr _ -> [])
+        guards
+  in
   let expanded =
     expand_comprehension translate_expr inner_config env params guards body
   in

--- a/lib/smt.ml
+++ b/lib/smt.ml
@@ -669,17 +669,9 @@ and translate_aggregate config env (comb : combiner) params guards body =
     | CombAdd | CombMul | CombAnd | CombOr | CombMax -> None
   in
   match mu_search with
-  | Some (binder_name, binder_ty, bindings) ->
-      let env_inner = Env.with_vars bindings env in
+  | Some (binder_name, binder_ty, _bindings) ->
       let r = fresh_fallback ~kind:"mu" ~sort:"Int" in
-      let pname = sanitize_ident binder_name in
-      let guard_templates =
-        List.filter_map
-          (function
-            | GExpr e -> Some (translate_expr inner_config env_inner e)
-            | GIn _ | GParam _ -> None)
-          guards
-      in
+      let j_name = Printf.sprintf "_mu_j_%s" r in
       let type_lower_bound name =
         match binder_ty with
         | TyNat -> Some (Printf.sprintf "(>= %s 1)" name)
@@ -689,11 +681,37 @@ and translate_aggregate config env (comb : combiner) params guards body =
         | TyProduct _ | TySum _ | TyFunc _ ->
             None
       in
-      let sub_with ~to_ template = replace_word ~from:pname ~to_ template in
-      let r_guards =
-        Option.to_list (type_lower_bound r)
-        @ List.map (sub_with ~to_:r) guard_templates
+      (* Translate a guard after capture-avoiding AST substitution of the
+         μ-search binder with [repl]. Conjoins any list-search and
+         declaration guards uncovered in the substituted expression, matching
+         the shape of [translate_precondition] so the witness constraints are
+         sound. *)
+      let translate_guard_with repl g =
+        let sub = [ (binder_name, EVar (Lower repl)) ] in
+        let g' = substitute_vars sub g in
+        let repl_env = Env.with_vars [ (repl, binder_ty) ] env in
+        let body_str = translate_expr config repl_env g' in
+        if not config.inject_guards then body_str
+        else
+          let app_guards = collect_body_guards repl_env g' in
+          match app_guards with
+          | [] -> body_str
+          | _ ->
+              let guard_strs =
+                List.map (translate_expr config repl_env) app_guards
+              in
+              Printf.sprintf "(and %s %s)"
+                (String.concat " " guard_strs)
+                body_str
       in
+      let guards_at repl =
+        List.filter_map
+          (function
+            | GExpr e -> Some (translate_guard_with repl e)
+            | GIn _ | GParam _ -> None)
+          guards
+      in
+      let r_guards = Option.to_list (type_lower_bound r) @ guards_at r in
       let assert_r =
         match r_guards with
         | [] -> "true"
@@ -701,11 +719,10 @@ and translate_aggregate config env (comb : combiner) params guards body =
         | gs -> Printf.sprintf "(and %s)" (String.concat " " gs)
       in
       add_fallback_assert assert_r;
-      let j_name = Printf.sprintf "_mu_j_%s" r in
       let j_guards =
         Option.to_list (type_lower_bound j_name)
         @ [ Printf.sprintf "(< %s %s)" j_name r ]
-        @ List.map (sub_with ~to_:j_name) guard_templates
+        @ guards_at j_name
       in
       let forall_body =
         match j_guards with

--- a/lib/smt.ml
+++ b/lib/smt.ml
@@ -690,15 +690,21 @@ and translate_aggregate config env (comb : combiner) params guards body =
         let sub = [ (binder_name, EVar (Lower repl)) ] in
         let g' = substitute_vars sub g in
         let repl_env = Env.with_vars [ (repl, binder_ty) ] env in
-        let body_str = translate_expr config repl_env g' in
+        (* Thread the witness and any outer quantifier binders through
+           [quant_bound] so that primed-guard injection (via [prime_expr]
+           inside [collect_body_guards]) does not prime the Skolem witness
+           or outer-bound vars into undeclared [_mu_fallback_*_prime] atoms. *)
+        let bound_names = repl :: config.quant_bound in
+        let guard_config = { config with quant_bound = bound_names } in
+        let body_str = translate_expr guard_config repl_env g' in
         if not config.inject_guards then body_str
         else
-          let app_guards = collect_body_guards repl_env g' in
+          let app_guards = collect_body_guards ~bound:bound_names repl_env g' in
           match app_guards with
           | [] -> body_str
           | _ ->
               let guard_strs =
-                List.map (translate_expr config repl_env) app_guards
+                List.map (translate_expr guard_config repl_env) app_guards
               in
               Printf.sprintf "(and %s %s)"
                 (String.concat " " guard_strs)

--- a/lib/smt_expr.ml
+++ b/lib/smt_expr.ml
@@ -24,9 +24,17 @@ let resolve_comprehension_binding env params guards =
       | Ok (TyDomain dname) ->
           let pn = Ast.lower_name p.param_name in
           Ok (pn, dname, None, [ (pn, TyDomain dname) ])
+      | Ok ((TyNat | TyNat0 | TyInt | TyReal) as ty) ->
+          Error
+            (Printf.sprintf
+               "SMT translation: comprehension over unbounded %s is only \
+                supported as μ-search (`min over each j: %s, … | j`); add an \
+                explicit upper-bound guard (e.g. `j < N`) to enable general \
+                enumeration"
+               (format_ty ty) (format_ty ty))
       | Ok
-          ( TyBool | TyNat | TyNat0 | TyInt | TyReal | TyString | TyNothing
-          | TyList _ | TyProduct _ | TySum _ | TyFunc _ )
+          ( TyBool | TyString | TyNothing | TyList _ | TyProduct _ | TySum _
+          | TyFunc _ )
       | Error _ ->
           Error "SMT translation: comprehension parameter must be a domain type"
       )
@@ -50,6 +58,26 @@ let resolve_comprehension_binding env params guards =
   | _ ->
       Error
         "SMT translation: multi-parameter comprehensions not supported in SMT"
+
+(** Resolve a single-parameter numeric-typed comprehension binder (Nat / Nat0 /
+    Int). Unlike [resolve_comprehension_binding], does not synthesize a finite
+    domain — it is used by symbolic-predicate translations (currently just
+    μ-search minimization) that don't enumerate over a bounded set. Returns
+    [Error] for domain / list / membership bindings and multi-parameter
+    comprehensions so callers can fall back to the enumerating path. *)
+let resolve_numeric_comprehension_binding env params =
+  match params with
+  | [ (p : param) ] -> (
+      match Collect.resolve_type env p.param_type dummy_loc with
+      | Ok ((TyNat | TyNat0 | TyInt) as ty) ->
+          let pn = Ast.lower_name p.param_name in
+          Ok (pn, ty, [ (pn, ty) ])
+      | Ok
+          ( TyBool | TyReal | TyString | TyNothing | TyDomain _ | TyList _
+          | TyProduct _ | TySum _ | TyFunc _ )
+      | Error _ ->
+          Error "comprehension binder is not numeric")
+  | _ -> Error "comprehension binder is not numeric"
 
 (** Expand a comprehension over finite domain elements. Returns a list of
     (guard_str option, value_str) pairs for each domain element substitution.

--- a/lib/smt_expr.ml
+++ b/lib/smt_expr.ml
@@ -24,7 +24,7 @@ let resolve_comprehension_binding env params guards =
       | Ok (TyDomain dname) ->
           let pn = Ast.lower_name p.param_name in
           Ok (pn, dname, None, [ (pn, TyDomain dname) ])
-      | Ok ((TyNat | TyNat0 | TyInt | TyReal) as ty) ->
+      | Ok ((TyNat | TyNat0 | TyInt) as ty) ->
           Error
             (Printf.sprintf
                "SMT translation: comprehension over unbounded %s is only \
@@ -32,6 +32,11 @@ let resolve_comprehension_binding env params guards =
                 explicit upper-bound guard (e.g. `j < N`) to enable general \
                 enumeration"
                (format_ty ty) (format_ty ty))
+      | Ok TyReal ->
+          Error
+            "SMT translation: comprehension over unbounded Real is not \
+             supported in SMT; μ-search requires a discrete well-ordered \
+             numeric type"
       | Ok
           ( TyBool | TyString | TyNothing | TyList _ | TyProduct _ | TySum _
           | TyFunc _ )

--- a/samples/smt-examples/mu-search-ok.pant
+++ b/samples/smt-examples/mu-search-ok.pant
@@ -1,0 +1,15 @@
+> μ-search (Kleene minimization): the least Nat satisfying a predicate.
+> `min over each j: Nat, …, P(j) | j` compiles to a skolemized
+> least-witness assertion instead of enumeration — the SMT backend
+> cannot enumerate unbounded Nat, but it can check
+>   ∃r. P(r) ∧ ∀j. j < r ⇒ ¬P(j).
+module MuSearchOk.
+
+big? n: Nat => Bool.
+first-big => Nat.
+
+---
+
+all n: Nat | big? n <-> n >= 10.
+first-big = (min over each j: Nat, j >= 1, big? j | j).
+first-big = 10.

--- a/test/smt_check.ml
+++ b/test/smt_check.ml
@@ -294,6 +294,12 @@ let collect_failures (sexps : Sexp.t list) : failure list =
     | Sexp.Atom a -> (
         match fallback_kind_of_atom a with
         | None -> ()
+        | Some "mu" ->
+            (* μ-search emits a fresh Int constant as the Skolem witness for a
+               least-element assertion — it is not a translator approximation
+               but the faithful encoding of [min over each j: Nat | j]. See
+               [Smt.translate_aggregate]. *)
+            ()
         | Some kind ->
             if not (Hashtbl.mem seen_fallbacks (kind, a)) then begin
               Hashtbl.add seen_fallbacks (kind, a) ();

--- a/test/test_smt.ml
+++ b/test/test_smt.ml
@@ -1745,6 +1745,39 @@ let test_mu_search_guarded_predicate () =
   check bool "predicate appears applied to j witness" true
     (contains drained "(activep _mu_j_")
 
+let test_mu_search_nested_binder_capture () =
+  (* min over each j: Nat, (some j: Nat | p? j) | j — the inner quantifier
+     rebinds [j], so the outer μ-search substitution must NOT rewrite the
+     inner binder or its body. Regression against the old string-based
+     replace_word substitution, which would have rewritten both. *)
+  let env =
+    Env.empty ""
+    |> Env.add_rule "p?"
+         (Types.TyFunc ([ Types.TyNat ], Some Types.TyBool))
+         Ast.dummy_loc ~chapter:0
+  in
+  Smt.reset_fallbacks ();
+  let inner =
+    Ast.make_exists
+      [ { param_name = Lower "j"; param_type = TName (Upper "Nat") } ]
+      []
+      (EApp (EVar (Lower "p?"), [ EVar (Lower "j") ]))
+  in
+  let expr =
+    Ast.make_each
+      [ { param_name = Lower "j"; param_type = TName (Upper "Nat") } ]
+      [ GExpr inner ] (Some CombMin) (EVar (Lower "j"))
+  in
+  let _ = Smt.translate_expr config env expr in
+  let drained = Smt.drain_fallback_decls () in
+  (* Inner binder must still be bound as [j] (or alpha-renamed to avoid
+     collision with the outer witness) — never rewritten to the outer
+     μ-search witness constant. *)
+  check bool "inner exists keeps a j-family binder" true
+    (contains drained "(exists ((j " || contains drained "(exists ((j_");
+  check bool "inner binder not replaced by outer witness" true
+    (not (contains drained "(exists ((_mu_fallback"))
+
 let test_mu_search_max_rejected () =
   (* max over each j: Nat | j — unbounded above, must still error *)
   let env = Env.empty "" in
@@ -1807,6 +1840,8 @@ let comprehension_tests =
     test_case "μ-search int" `Quick test_mu_search_int;
     test_case "μ-search guarded predicate" `Quick
       test_mu_search_guarded_predicate;
+    test_case "μ-search nested binder capture" `Quick
+      test_mu_search_nested_binder_capture;
     test_case "μ-search max rejected" `Quick test_mu_search_max_rejected;
     test_case "card nat comprehension error" `Quick
       test_card_nat_comprehension_error;

--- a/test/test_smt.ml
+++ b/test/test_smt.ml
@@ -1663,6 +1663,128 @@ let test_aggregate_min_real () =
   check bool "has 0.0 seed" true (contains result "0.0");
   check bool "has <=" true (contains result "(<=")
 
+let test_mu_search_nat () =
+  (* min over each j: Nat, j >= 1 | j
+     → least-witness encoding: fresh r with
+       (assert (and (>= r 1) (>= r 1)))
+       (assert (forall ((_mu_j_r Int)) (=> (and (>= _mu_j_r 1) (< _mu_j_r r) (>= _mu_j_r 1)) false))) *)
+  let env = Env.empty "" in
+  Smt.reset_fallbacks ();
+  let expr =
+    Ast.make_each
+      [ { param_name = Lower "j"; param_type = TName (Upper "Nat") } ]
+      [ GExpr (EBinop (OpGe, EVar (Lower "j"), ELitNat 1)) ]
+      (Some CombMin) (EVar (Lower "j"))
+  in
+  let result = Smt.translate_expr config env expr in
+  check bool "returns fallback constant" true
+    (String.length result >= 12 && String.sub result 0 12 = "_mu_fallback");
+  let drained = Smt.drain_fallback_decls () in
+  check bool "declares fresh Int constant" true
+    (contains drained "_mu_fallback");
+  check bool "emits nat lower-bound on r" true (contains drained "(>= ");
+  check bool "emits forall over Int witness" true
+    (contains drained "(forall ((_mu_j_");
+  check bool "emits (< j r) ordering" true (contains drained "(< _mu_j_");
+  check bool "emits => false closure" true (contains drained "false")
+
+let test_mu_search_nat0 () =
+  (* min over each j: Nat0 | j — lower bound 0, no extra guards *)
+  let env = Env.empty "" in
+  Smt.reset_fallbacks ();
+  let expr =
+    Ast.make_each
+      [ { param_name = Lower "j"; param_type = TName (Upper "Nat0") } ]
+      [] (Some CombMin) (EVar (Lower "j"))
+  in
+  let result = Smt.translate_expr config env expr in
+  check bool "is fallback constant" true
+    (String.length result >= 3 && String.sub result 0 3 = "_mu");
+  let drained = Smt.drain_fallback_decls () in
+  check bool "emits (>= ... 0)" true (contains drained "0)")
+
+let test_mu_search_int () =
+  (* min over each j: Int, j >= -5 | j — Int has no implicit lower bound *)
+  let env = Env.empty "" in
+  Smt.reset_fallbacks ();
+  let expr =
+    Ast.make_each
+      [ { param_name = Lower "j"; param_type = TName (Upper "Int") } ]
+      [ GExpr (EBinop (OpGe, EVar (Lower "j"), EUnop (OpNeg, ELitNat 5))) ]
+      (Some CombMin) (EVar (Lower "j"))
+  in
+  let _ = Smt.translate_expr config env expr in
+  let drained = Smt.drain_fallback_decls () in
+  check bool "emits forall Int witness" true
+    (contains drained "(forall ((_mu_j_")
+
+let test_mu_search_guarded_predicate () =
+  (* min over each j: Nat, j >= 1, ~(active? j) | j
+     emits guard at both r and j witness *)
+  let env =
+    Env.empty ""
+    |> Env.add_rule "active?"
+         (Types.TyFunc ([ Types.TyNat ], Some Types.TyBool))
+         Ast.dummy_loc ~chapter:0
+  in
+  Smt.reset_fallbacks ();
+  let expr =
+    Ast.make_each
+      [ { param_name = Lower "j"; param_type = TName (Upper "Nat") } ]
+      [
+        GExpr (EBinop (OpGe, EVar (Lower "j"), ELitNat 1));
+        GExpr
+          (EUnop (OpNot, EApp (EVar (Lower "active?"), [ EVar (Lower "j") ])));
+      ]
+      (Some CombMin) (EVar (Lower "j"))
+  in
+  let _ = Smt.translate_expr config env expr in
+  let drained = Smt.drain_fallback_decls () in
+  check bool "predicate appears applied to r" true
+    (contains drained "(activep _mu_fallback");
+  check bool "predicate appears applied to j witness" true
+    (contains drained "(activep _mu_j_")
+
+let test_mu_search_max_rejected () =
+  (* max over each j: Nat | j — unbounded above, must still error *)
+  let env = Env.empty "" in
+  Smt.reset_fallbacks ();
+  let expr =
+    Ast.make_each
+      [ { param_name = Lower "j"; param_type = TName (Upper "Nat") } ]
+      [] (Some CombMax) (EVar (Lower "j"))
+  in
+  let raised =
+    try
+      let _ = Smt.translate_expr config env expr in
+      false
+    with Failure msg ->
+      contains msg "unbounded" || contains msg "μ-search"
+      || contains msg "domain type"
+  in
+  check bool "max over unbounded numeric errors" true raised
+
+let test_card_nat_comprehension_error () =
+  (* #(each j: Nat | j >= 1) — not a μ-search shape; must emit the refined
+     diagnostic pointing at μ-search / explicit bound. *)
+  let env = Env.empty "" in
+  let expr =
+    Ast.EUnop
+      ( OpCard,
+        Ast.make_each
+          [ { param_name = Lower "j"; param_type = TName (Upper "Nat") } ]
+          [ GExpr (EBinop (OpGe, EVar (Lower "j"), ELitNat 1)) ]
+          None (EVar (Lower "j")) )
+  in
+  let raised_with_hint =
+    try
+      let _ = Smt.translate_expr config env expr in
+      false
+    with Failure msg -> contains msg "μ-search" || contains msg "upper-bound"
+  in
+  check bool "refined diagnostic mentions μ-search or upper bound" true
+    raised_with_hint
+
 let comprehension_tests =
   [
     test_case "in each comprehension" `Quick test_in_each_comprehension;
@@ -1680,6 +1802,14 @@ let comprehension_tests =
     test_case "aggregate add real" `Quick test_aggregate_add_real;
     test_case "aggregate add real empty" `Quick test_aggregate_add_real_empty;
     test_case "aggregate min real" `Quick test_aggregate_min_real;
+    test_case "μ-search nat" `Quick test_mu_search_nat;
+    test_case "μ-search nat0" `Quick test_mu_search_nat0;
+    test_case "μ-search int" `Quick test_mu_search_int;
+    test_case "μ-search guarded predicate" `Quick
+      test_mu_search_guarded_predicate;
+    test_case "μ-search max rejected" `Quick test_mu_search_max_rejected;
+    test_case "card nat comprehension error" `Quick
+      test_card_nat_comprehension_error;
   ]
 
 (* --- Closure tests --- *)

--- a/test/test_smt.ml
+++ b/test/test_smt.ml
@@ -1778,6 +1778,38 @@ let test_mu_search_nested_binder_capture () =
   check bool "inner binder not replaced by outer witness" true
     (not (contains drained "(exists ((_mu_fallback"))
 
+let test_mu_search_primed_guard_witness () =
+  (* min over each j: Nat, guarded' j | j — where [guarded] has a declaration
+     guard [active? j]. When [collect_body_guards] walks the primed
+     application, it primes the substituted guard. Without threading the
+     witness into [~bound], the Skolem constant would be primed into an
+     undeclared [_mu_fallback_*_prime] atom. *)
+  let env =
+    Env.empty ""
+    |> Env.add_rule "guarded"
+         (Types.TyFunc ([ Types.TyNat ], Some Types.TyBool))
+         Ast.dummy_loc ~chapter:0
+    |> Env.add_rule "active?"
+         (Types.TyFunc ([ Types.TyNat ], Some Types.TyBool))
+         Ast.dummy_loc ~chapter:0
+    |> Env.add_rule_guards "guarded"
+         [ Ast.{ param_name = Lower "j"; param_type = TName (Upper "Nat") } ]
+         [ GExpr (EApp (EVar (Lower "active?"), [ EVar (Lower "j") ])) ]
+  in
+  Smt.reset_fallbacks ();
+  let expr =
+    Ast.make_each
+      [ { param_name = Lower "j"; param_type = TName (Upper "Nat") } ]
+      [ GExpr (EApp (EPrimed (Lower "guarded"), [ EVar (Lower "j") ])) ]
+      (Some CombMin) (EVar (Lower "j"))
+  in
+  let _ = Smt.translate_expr config env expr in
+  let drained = Smt.drain_fallback_decls () in
+  check bool "witness not primed into _mu_fallback_*_prime" true
+    (not (contains drained "_mu_fallback_0_prime"));
+  check bool "witness j-binder not primed" true
+    (not (contains drained "_mu_j__mu_fallback_0_prime"))
+
 let test_mu_search_max_rejected () =
   (* max over each j: Nat | j — unbounded above, must still error *)
   let env = Env.empty "" in
@@ -1842,6 +1874,8 @@ let comprehension_tests =
       test_mu_search_guarded_predicate;
     test_case "μ-search nested binder capture" `Quick
       test_mu_search_nested_binder_capture;
+    test_case "μ-search primed guard witness" `Quick
+      test_mu_search_primed_guard_witness;
     test_case "μ-search max rejected" `Quick test_mu_search_max_rejected;
     test_case "card nat comprehension error" `Quick
       test_card_nat_comprehension_error;

--- a/test/test_smt.ml
+++ b/test/test_smt.ml
@@ -1664,17 +1664,16 @@ let test_aggregate_min_real () =
   check bool "has <=" true (contains result "(<=")
 
 let test_mu_search_nat () =
-  (* min over each j: Nat, j >= 1 | j
+  (* min over each j: Nat | j
      → least-witness encoding: fresh r with
-       (assert (and (>= r 1) (>= r 1)))
-       (assert (forall ((_mu_j_r Int)) (=> (and (>= _mu_j_r 1) (< _mu_j_r r) (>= _mu_j_r 1)) false))) *)
+       (assert (>= r 1))
+       (assert (forall ((_mu_j_r Int)) (=> (and (>= _mu_j_r 1) (< _mu_j_r r)) false))) *)
   let env = Env.empty "" in
   Smt.reset_fallbacks ();
   let expr =
     Ast.make_each
       [ { param_name = Lower "j"; param_type = TName (Upper "Nat") } ]
-      [ GExpr (EBinop (OpGe, EVar (Lower "j"), ELitNat 1)) ]
-      (Some CombMin) (EVar (Lower "j"))
+      [] (Some CombMin) (EVar (Lower "j"))
   in
   let result = Smt.translate_expr config env expr in
   check bool "returns fallback constant" true
@@ -1682,7 +1681,10 @@ let test_mu_search_nat () =
   let drained = Smt.drain_fallback_decls () in
   check bool "declares fresh Int constant" true
     (contains drained "_mu_fallback");
-  check bool "emits nat lower-bound on r" true (contains drained "(>= ");
+  check bool "emits Nat >= 1 on witness" true
+    (contains drained "(>= _mu_fallback_0 1)");
+  check bool "emits Nat >= 1 on j witness" true
+    (contains drained "(>= _mu_j__mu_fallback_0 1)");
   check bool "emits forall over Int witness" true
     (contains drained "(forall ((_mu_j_");
   check bool "emits (< j r) ordering" true (contains drained "(< _mu_j_");
@@ -1701,7 +1703,10 @@ let test_mu_search_nat0 () =
   check bool "is fallback constant" true
     (String.length result >= 3 && String.sub result 0 3 = "_mu");
   let drained = Smt.drain_fallback_decls () in
-  check bool "emits (>= ... 0)" true (contains drained "0)")
+  check bool "emits Nat0 >= 0 on witness" true
+    (contains drained "(>= _mu_fallback_0 0)");
+  check bool "emits Nat0 >= 0 on j witness" true
+    (contains drained "(>= _mu_j__mu_fallback_0 0)")
 
 let test_mu_search_int () =
   (* min over each j: Int, j >= -5 | j — Int has no implicit lower bound. *)

--- a/test/test_smt.ml
+++ b/test/test_smt.ml
@@ -1704,7 +1704,7 @@ let test_mu_search_nat0 () =
   check bool "emits (>= ... 0)" true (contains drained "0)")
 
 let test_mu_search_int () =
-  (* min over each j: Int, j >= -5 | j — Int has no implicit lower bound *)
+  (* min over each j: Int, j >= -5 | j — Int has no implicit lower bound. *)
   let env = Env.empty "" in
   Smt.reset_fallbacks ();
   let expr =
@@ -1716,7 +1716,18 @@ let test_mu_search_int () =
   let _ = Smt.translate_expr config env expr in
   let drained = Smt.drain_fallback_decls () in
   check bool "emits forall Int witness" true
-    (contains drained "(forall ((_mu_j_")
+    (contains drained "(forall ((_mu_j_");
+  (* Regression guard against [type_lower_bound] accidentally treating TyInt
+     like Nat / Nat0 — the only [(>= X 0)] / [(>= X 1)] terms on the witness
+     or j-binder would come from such an implicit bound. *)
+  check bool "no implicit >= 0 on _mu_fallback_ witness" true
+    (not (contains drained "(>= _mu_fallback_0 0)"));
+  check bool "no implicit >= 1 on _mu_fallback_ witness" true
+    (not (contains drained "(>= _mu_fallback_0 1)"));
+  check bool "no implicit >= 0 on _mu_j_ binder" true
+    (not (contains drained "(>= _mu_j__mu_fallback_0 0)"));
+  check bool "no implicit >= 1 on _mu_j_ binder" true
+    (not (contains drained "(>= _mu_j__mu_fallback_0 1)"))
 
 let test_mu_search_guarded_predicate () =
   (* min over each j: Nat, j >= 1, ~(active? j) | j
@@ -1825,7 +1836,7 @@ let test_mu_search_max_rejected () =
       false
     with Failure msg ->
       contains msg "unbounded" || contains msg "μ-search"
-      || contains msg "domain type"
+      || contains msg "upper-bound"
   in
   check bool "max over unbounded numeric errors" true raised
 


### PR DESCRIPTION
## Summary

- The ts2pant Kleene μ-search recognizer (commit 7adf7b3) emits `min over each j: Nat, j >= INIT, ~P(j) | j` for `let i; while (P(i)) i++` loops, but `pant --check` rejected it because `resolve_comprehension_binding` required a finite domain iterator. This PR adds a sound Skolem/least-witness encoding so the emitted form is verifiable end-to-end.
- Scope is just the μ-search consumer shape (`CombMin` + numeric iterator + body-is-binder + only `GExpr` guards). Every other consumer of an unbounded numeric comprehension (`#`, `+/*/and/or over`, bare `each`, `in`, subset RHS) now fails with a targeted diagnostic pointing at μ-search or suggesting an explicit upper bound, instead of the old generic "comprehension parameter must be a domain type."
- Unblocks one of three blockers for `registerName` dogfooding. The other two (`new Set(iterable)`, `Set.add`) are unchanged.

## Encoding

For `min over each j: T, G₁(j), …, Gₙ(j) | j` with `T ∈ {Nat, Nat0, Int}`:

```smt
(declare-const r Int)
(assert (and <type-bound[r]> G₁(r) … Gₙ(r)))
(assert (forall ((j Int)) (=> (and <type-bound[j]> (< j r) Gᵢ(j)…) false)))
```

`<type-bound[x]>` is `(>= x 1)` for Nat, `(>= x 0)` for Nat0, absent for Int. This is Kleene's definition of μ, Skolemized — sound under both z3 and cvc5 (may return `unknown` on hard arithmetic, never `unsound-sat`). The result expression the translator returns is just `r`.

Emission reuses the existing `fresh_fallback` + `add_fallback_assert` infrastructure (same pattern as `translate_card`'s non-domain fallback). The finite-domain aggregate path is preserved verbatim in a new `translate_aggregate_finite` helper — no existing test changes behaviour.

`test/smt_check.ml` exempts the `mu` fallback kind from the structural-invariant check because the constant is a faithful skolemization, not a translator approximation (unlike `card_fallback` / `list_search_fallback` / `override_fallback`).

## Test plan

- [x] 6 new unit tests in `test/test_smt.ml` covering Nat/Nat0/Int iterators, guarded predicates, rejection of `max over each j: Nat` (unbounded above), and the refined cardinality diagnostic.
- [x] New end-to-end fixture `samples/smt-examples/mu-search-ok.pant`:
  ```
  all n: Nat | big? n <-> n >= 10.
  first-big = (min over each j: Nat, j >= 1, big? j | j).
  first-big = 10.
  ```
  `pant --check` → "Invariants are jointly satisfiable." A wrong variant (`first-big = 5`) is caught as a contradiction.
- [x] Full `dune runtest` — 16/16 suites pass.
- [x] Verified emitted SMT matches the designed encoding (`--dump-smt`).
- [ ] Repeat under `cvc5` if available on CI (locally only z3 was installed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)