### PR TITLE
ts2pant: pure-path IRSC-style intermediate representation

### DIFF
--- a/tools/ts2pant/CLAUDE.md
+++ b/tools/ts2pant/CLAUDE.md
@@ -638,7 +638,7 @@ canonicalized receiver), not program-variable names. Three reasons:
 |-------|---------------------|--------|
 | 1 | Foundation: types, build (Var/Lit/Identifier), emit, subst, `--use-ir` flag, anchor fixture | ✅ landed |
 | 2 | Optional chaining `?.` → `Each` | ✅ landed |
-| 3 | Nullish coalescing `??` → `Cond` | pending |
+| 3 | Nullish coalescing `??` → `Cond` | ✅ landed |
 | 4 | μ-search → `Comb(min, Each)` | pending |
 | 5 | `.length` / `.size` → `App(card, [x])` | pending |
 | 6 | Const-binding inlining → `Let` (cross-cutting pure + mutating) | pending |

--- a/tools/ts2pant/CLAUDE.md
+++ b/tools/ts2pant/CLAUDE.md
@@ -40,6 +40,7 @@ These cover the full scope of ts2pant's translation work:
 | Frame problem in specifications | Borgida et al., ["And Nothing Else Changes"](https://www.researchgate.net/publication/221555223_And_Nothing_Else_Changes_The_Frame_Problem_in_Procedure_Specifications), IEEE TSE 1995 | Definitive treatment of frame conditions in procedure specifications |
 | Capture-avoiding substitution | [Locally Nameless Representation](https://boarders.github.io/posts/locally-nameless/) (Charguéraud 2012) | Alternative to named substitution; useful background for understanding why hygiene matters |
 | Partial functions / option types | [Dafny Reference Manual](https://dafny.org/dafny/DafnyRef/DafnyRef) | Nullable types, preconditions, `modifies` clauses — practical verification language patterns |
+| IRSC / SSA-based IR | Vekris, Cosman, Jhala, ["Refinement Types for TypeScript"](https://arxiv.org/pdf/1604.02480), PLDI 2016 | Lifting surface-syntax recognizers into a typed intermediate representation via SSA-style translation; precedent for the IR introduced in §"Intermediate Representation" |
 
 ## Architecture
 
@@ -581,7 +582,7 @@ conditions, not a unit-returning expression.
 
 ### Body output
 
-```
+```text
 IRBody = {
   equations: IREquation[];   // one per record-return field, or one for non-record return; in mutating mode, one per modified rule
   assertions: IRAssertExit[]; // empty-Set / empty-Map initializers

--- a/tools/ts2pant/CLAUDE.md
+++ b/tools/ts2pant/CLAUDE.md
@@ -639,9 +639,9 @@ canonicalized receiver), not program-variable names. Three reasons:
 | 1 | Foundation: types, build (Var/Lit/Identifier), emit, subst, `--use-ir` flag, anchor fixture | ✅ landed |
 | 2 | Optional chaining `?.` → `Each` | ✅ landed |
 | 3 | Nullish coalescing `??` → `Cond` | ✅ landed |
-| 4 | μ-search → `Comb(min, Each)` | pending |
-| 5 | `.length` / `.size` → `App(card, [x])` | pending |
-| 6 | Const-binding inlining → `Let` (cross-cutting pure + mutating) | pending |
+| 4 | μ-search → `Comb(min, Each)` | deferred → bundled into Stage 6 |
+| 5 | `.length` / `.size` → `Unop(card, x)` | ✅ landed |
+| 6 | Const-binding inlining → `Let` (cross-cutting pure + mutating) **+ μ-search** | pending |
 | 7 | Chain fusion → `Each` composition | pending |
 | 8 | Pure-path cutover (delete `IRWrap`, delete legacy pure-path) | pending |
 | 9 | Mutating-path SSA: write-keyed `LetIf`, `Write` IR nodes | pending |

--- a/tools/ts2pant/CLAUDE.md
+++ b/tools/ts2pant/CLAUDE.md
@@ -637,7 +637,7 @@ canonicalized receiver), not program-variable names. Three reasons:
 | Stage | Recognizer / scope | Status |
 |-------|---------------------|--------|
 | 1 | Foundation: types, build (Var/Lit/Identifier), emit, subst, `--use-ir` flag, anchor fixture | ✅ landed |
-| 2 | Optional chaining `?.` → `Each` | pending |
+| 2 | Optional chaining `?.` → `Each` | ✅ landed |
 | 3 | Nullish coalescing `??` → `Cond` | pending |
 | 4 | μ-search → `Comb(min, Each)` | pending |
 | 5 | `.length` / `.size` → `App(card, [x])` | pending |

--- a/tools/ts2pant/CLAUDE.md
+++ b/tools/ts2pant/CLAUDE.md
@@ -642,8 +642,8 @@ canonicalized receiver), not program-variable names. Three reasons:
 | 4 | μ-search → `Comb(min, Each)` | partial — substitution mechanism is on IR (Stage 6); the comprehension construction itself is still in `translateMuSearchInit` (legacy OpaqueExpr) and migrates to native `Comb(min, Each)` in a future stage |
 | 5 | `.length` / `.size` → `Unop(card, x)` | ✅ landed |
 | 6 | Const-binding inlining → `Let` (pure path) | ✅ landed (mutating-path const-bindings stay on legacy `applyTo` until Stage 9) |
-| 7 | Chain fusion → `Each` composition | pending |
-| 8 | Pure-path cutover (delete `IRWrap`, delete legacy pure-path) | pending |
+| 7 | Chain fusion → `Each` composition | ✅ tracked via IRWrap (anchors locked); native IR construction deferred — see "Note on chain fusion" below |
+| 8 | Pure-path cutover — delete legacy code where possible (IRWrap survives for chain-fusion outputs) | pending |
 | 9 | Mutating-path SSA: write-keyed `LetIf`, `Write` IR nodes | pending |
 | 10 | Frame conditions → IR pass | pending |
 | 11 | Mutating-path cutover, final cleanup | pending |
@@ -652,6 +652,21 @@ The `--use-ir` flag (env var `TS2PANT_USE_IR=1`) routes the pure path through
 the IR pipeline. Default off until Stage 8 cutover. Per-stage gate is the
 `tests/ir-equivalence.test.mts` smoke test (string-equal output between
 legacy and IR pipelines on the anchor fixtures).
+
+**Note on chain fusion (Stage 7).** `.filter`/`.map`/`.reduce` chains
+already produce semantically-identical output through the `IRWrap`
+fallback path: legacy `translateArrayMethod` and `translateReduceCall`
+materialize an OpaqueExpr `each(...)` / `eachComb(...)`, which `ir-build`
+wraps. Locked-in IR-equivalence anchors confirm byte-equality across all
+shapes (`activeNames`, `nameLengths`, `highScores` from
+`expressions-array.ts`; the full `expressions-reduce.ts` suite). Native
+IR construction (a real `Each` IR node assembled in `ir-build`) is
+**intentionally deferred** because the existing 300+ lines of TS-AST
+inspection in legacy would translate to ~200 lines of mechanical
+duplication producing identical output — the architectural payoff is
+only at Stage 8 cutover (deleting the legacy code). We keep `IRWrap`
+in place for chain-fusion outputs through Stage 8 and reconsider once
+the mutating-path migration (Stage 9) settles the IR shape.
 
 ## PR #84 Post-Mortem: Why Standard Algorithms Matter
 

--- a/tools/ts2pant/CLAUDE.md
+++ b/tools/ts2pant/CLAUDE.md
@@ -639,9 +639,9 @@ canonicalized receiver), not program-variable names. Three reasons:
 | 1 | Foundation: types, build (Var/Lit/Identifier), emit, subst, `--use-ir` flag, anchor fixture | ✅ landed |
 | 2 | Optional chaining `?.` → `Each` | ✅ landed |
 | 3 | Nullish coalescing `??` → `Cond` | ✅ landed |
-| 4 | μ-search → `Comb(min, Each)` | deferred → bundled into Stage 6 |
+| 4 | μ-search → `Comb(min, Each)` | partial — substitution mechanism is on IR (Stage 6); the comprehension construction itself is still in `translateMuSearchInit` (legacy OpaqueExpr) and migrates to native `Comb(min, Each)` in a future stage |
 | 5 | `.length` / `.size` → `Unop(card, x)` | ✅ landed |
-| 6 | Const-binding inlining → `Let` (cross-cutting pure + mutating) **+ μ-search** | pending |
+| 6 | Const-binding inlining → `Let` (pure path) | ✅ landed (mutating-path const-bindings stay on legacy `applyTo` until Stage 9) |
 | 7 | Chain fusion → `Each` composition | pending |
 | 8 | Pure-path cutover (delete `IRWrap`, delete legacy pure-path) | pending |
 | 9 | Mutating-path SSA: write-keyed `LetIf`, `Write` IR nodes | pending |

--- a/tools/ts2pant/CLAUDE.md
+++ b/tools/ts2pant/CLAUDE.md
@@ -518,6 +518,141 @@ result is now in scope; consumers other than the μ-search aggregate (`#`,
 explicit upper-bound guard or a domain-typed iterator and emit a targeted
 diagnostic otherwise.
 
+## Intermediate Representation
+
+ts2pant has accumulated ~18 surface-syntax recognizers in `src/translate-body.ts`
+that cross-talk through `BodyResult`, `state.writes`, and the document-wide
+`SynthCell` / `NameRegistry`. Each new TS pattern (μ-search, optional chaining,
+Set mutation, …) adds another recognizer plus state-merge logic. PR #84's
+post-mortem (below) names this exact failure mode.
+
+The structural fix is to lift the recognizers behind a small typed
+**intermediate representation** so each surface pattern lowers via a TS→IR
+rewrite and the Pant emitter reads only IR forms. The reference precedent is
+**IRSC** from Vekris, Cosman, Jhala, "Refinement Types for TypeScript"
+([PLDI 2016, arxiv:1604.02480](https://arxiv.org/pdf/1604.02480)). Their
+motivating quote — *"FRSC, while syntactically similar to TS, is not entirely
+suitable for refinement type checking in its current form, due to features
+like assignment. To overcome this challenge we translate FRSC to a functional
+language IRSC through a Static Single Assignment (SSA) transformation"* — is
+exactly our situation.
+
+The IR is being introduced incrementally over 11 stages on a single branch.
+Stage status lives in §"IR Migration Status" below; deviations from IRSC
+live in §"Divergences from IRSC".
+
+### Files
+
+- `src/ir.ts` — `IRExpr` / `IRStmt` / `IRBody` ADTs with constructor helpers.
+- `src/ir-build.ts` — TS-AST → IR (with `IRWrap` escape hatch during migration).
+- `src/ir-emit.ts` — IR → `OpaqueExpr` / `PropResult[]` lowering.
+- `src/ir-subst.ts` — IR-level capture-avoiding substitution.
+
+### Two layers
+
+Pure / value-position uses **`IRExpr`**; effect / statement-position uses
+**`IRStmt`**. IRSC merges these via `u⟨e⟩` hole contexts; we keep them
+separate because Pantagruel's mutating output is a list of equations + frame
+conditions, not a unit-returning expression.
+
+### `IRExpr` — 10 forms
+
+| Form | Lowers to | TS shapes that produce it |
+|------|-----------|---------------------------|
+| `Var(name, primed?)` | `ast.var` / `ast.primed` | identifier; primed for next-state references in mutating bodies |
+| `Lit(literal)` | `ast.litNat` / `ast.litBool` / `ast.litString` | numeric / string / boolean literal |
+| `App(head, args)` | `ast.app` / `ast.binop` / `ast.unop` (head-dispatched) | binops, method calls (receiver as first arg), qualified field accessors, builtins (`in`, `#`, `=`, comparison) |
+| `Cond([(g, v)])` | `ast.cond` | ternary, early-return if-conversion, `??` lowering, conditional mutation merge |
+| `Let(name, value, body)` | substituted out at emit (Pant has no `let`) | `const x = e1; ... return e2` (Stage 6+) |
+| `Each(binder, src, [g], proj)` | `ast.each` | for-of Shape A/B, `?.` lowering, `.filter`/`.map` chain |
+| `Comb(comb, init?, each)` | `ast.eachComb` (with optional binop fold for non-identity init) | `.reduce`, μ-search (`Comb(min, ...)`) |
+| `Forall(binder, type, guard?, body)` | `ast.forall` | `all x: T \| ...` quantifier emission |
+| `Exists(binder, type, guard?, body)` | `ast.exists` | `some x: T \| ...` quantifier emission |
+| `IRWrap(OpaqueExpr)` | identity | **migration-only escape hatch**; deleted at Stage 8 cutover |
+
+### `IRStmt` — 4 forms
+
+| Form | Lowers to | Notes |
+|------|-----------|-------|
+| `Write(target, value)` | one primed equation per modified rule | `target` is a descriptor (`property-field` / `map-entry` / `set-member`); op is on the descriptor |
+| `LetIf(φ-vars, cond, then, else, cont)` | branching mutation merge via cond-merge of overrides | **`φ-vars` are write-keys**, not program names — see §"Divergences from IRSC" |
+| `Seq(stmts)` | sequential composition | trivial |
+| `Assert(quants, body)` | `kind: "assertion"` `PropResult` | empty-Set / empty-Map field initializers |
+
+### Body output
+
+```
+IRBody = {
+  equations: IREquation[];   // one per record-return field, or one for non-record return; in mutating mode, one per modified rule
+  assertions: IRAssertExit[]; // empty-Set / empty-Map initializers
+  frames: IREquation[];       // identity equations for unmodified rules
+}
+```
+
+### Divergences from IRSC
+
+Two deliberate divergences. Both are documented here so a future agent doesn't
+"fix" them back to paper-faithful IRSC.
+
+**1. No `FieldAccess` form.** ts2pant lowers `e.f` to `App(qualified-rule,
+[e])` at construction time via `qualifyFieldAccess`. Adding a `FieldAccess`
+form would force every consumer to check both shapes and reintroduces the
+cross-talk problem. The qualified-rule pattern is already the invariant at
+`translate-body.ts:2378`.
+
+**2. Hybrid SSA scope.** IRSC uses SSA over program names for *all*
+assignments. We use ordinary `Let` (no φ) for const-bindings and `LetIf`
+only for branching mutation, with φ-vars as **write-keys** (rule-name +
+canonicalized receiver), not program-variable names. Three reasons:
+
+- `inlineConstBindings` (translate-body.ts) is already a working right-fold
+  substitution closure — the standard let-elimination algorithm. SSA-then-
+  de-SSA would replace a debugged algorithm with a redundant one.
+- Pantagruel has no `let` in the output. Full SSA means SSA-construct then
+  SSA-destruct via substitution — twice the substitution machinery.
+- The mutating path's existing φ-merge is already keyed by write-keys
+  (translate-body.ts merge loop). What we're calling `LetIf` is a renaming
+  of that merge, not a new SSA discipline.
+
+### Invariants
+
+- **Opaque AST constraint.** Every property an IR pass needs to query must be
+  a discriminator on the IR ADT, never on the lowered `OpaqueExpr`. No
+  syntactic peeking on `OpaqueExpr` from any IR pass.
+- **Hygienic binders.** IR binder names (`Let.name`, `Each.binder`,
+  `Forall.binder`, `Exists.binder`) come from the document-wide
+  `UniqueSupply` / `cellRegisterName`. They cannot collide with parameter
+  names or accessor rules. `ir-subst.ts` relies on this for straight
+  name-based rewriting without α-renaming.
+- **`Write` is statement-only.** Never appears in `IRExpr`. A method call
+  that lowers to a `Write` is a statement; one that lowers to an `App` is
+  an expression. The lowerer rejects Writes appearing in expression
+  position.
+- **`Cond` is value-position.** `LetIf` is statement-position with non-empty
+  φ-vars. The two never overlap; the rule prevents the recognizer-redundancy
+  bug that the IR is meant to eliminate.
+
+### IR Migration Status
+
+| Stage | Recognizer / scope | Status |
+|-------|---------------------|--------|
+| 1 | Foundation: types, build (Var/Lit/Identifier), emit, subst, `--use-ir` flag, anchor fixture | ✅ landed |
+| 2 | Optional chaining `?.` → `Each` | pending |
+| 3 | Nullish coalescing `??` → `Cond` | pending |
+| 4 | μ-search → `Comb(min, Each)` | pending |
+| 5 | `.length` / `.size` → `App(card, [x])` | pending |
+| 6 | Const-binding inlining → `Let` (cross-cutting pure + mutating) | pending |
+| 7 | Chain fusion → `Each` composition | pending |
+| 8 | Pure-path cutover (delete `IRWrap`, delete legacy pure-path) | pending |
+| 9 | Mutating-path SSA: write-keyed `LetIf`, `Write` IR nodes | pending |
+| 10 | Frame conditions → IR pass | pending |
+| 11 | Mutating-path cutover, final cleanup | pending |
+
+The `--use-ir` flag (env var `TS2PANT_USE_IR=1`) routes the pure path through
+the IR pipeline. Default off until Stage 8 cutover. Per-stage gate is the
+`tests/ir-equivalence.test.mts` smoke test (string-equal output between
+legacy and IR pipelines on the anchor fixtures).
+
 ## PR #84 Post-Mortem: Why Standard Algorithms Matter
 
 The initial const-inlining implementation used ad-hoc string-name substitution rather

--- a/tools/ts2pant/src/ir-build.ts
+++ b/tools/ts2pant/src/ir-build.ts
@@ -1,16 +1,14 @@
 /**
  * TS-AST → IR construction.
  *
- * Stage 1 scope: handles `Var` (Identifier), `Lit` (numeric / string /
- * boolean literal), and the trivial cases of `App` (free function call
- * with all args themselves IR-buildable). Everything else falls back to
- * the legacy `translateBodyExpr` and wraps the result in `IRWrap` — so
- * the IR pipeline is end-to-end exercisable without committing to
- * full coverage in one stage.
+ * Stages migrated to native IR construction (latest first):
+ * - Stage 2: Optional chaining `x?.f` → `Each(t, x, [], App(qualified-rule, [t]))`.
+ * - Stage 1: `Var` (Identifier), `Lit` (numeric / string / boolean
+ *   literal). Trivial cases of `App` (free function call with all args
+ *   themselves IR-buildable). Everything else falls back to legacy
+ *   `translateBodyExpr` and wraps in `IRWrap`.
  *
- * Subsequent stages migrate one recognizer at a time from
- * `translate-body.ts` into this file; each migration removes one
- * `IRWrap` fallback and adds a native IR construction. By Stage 8
+ * Subsequent stages (3+) migrate one recognizer at a time. By Stage 8
  * (pure-path cutover) the `IRWrap` escape hatch is deleted entirely.
  *
  * See `ir.ts` and CLAUDE.md §IR for the form table.
@@ -19,6 +17,7 @@
 import ts from "typescript";
 import {
   type IRExpr,
+  irAppName,
   irLitBool,
   irLitNat,
   irLitString,
@@ -26,8 +25,12 @@ import {
   irWrap,
 } from "./ir.js";
 import {
+  ambiguousFieldMsg,
   bodyExpr,
+  freshHygienicBinder,
   isBodyUnsupported,
+  isNullableTsType,
+  qualifyFieldAccess,
   translateBodyExpr,
   type UniqueSupply,
 } from "./translate-body.js";
@@ -39,10 +42,9 @@ import type { NumericStrategy } from "./translate-types.js";
  * Returns either an `IRExpr` (success) or `{ unsupported: string }` to
  * propagate translation rejections through the existing convention.
  *
- * Stage 1: native IR construction for Identifier / NumericLiteral /
- * StringLiteral / true / false; falls back to `translateBodyExpr` +
- * `IRWrap` for everything else (so Cond, App, etc. all go through
- * IRWrap until their dedicated stages migrate them).
+ * Non-natively-built forms fall back to `translateBodyExpr` + `IRWrap`
+ * so the IR pipeline is end-to-end exercisable without committing to
+ * full coverage in one stage.
  */
 export function buildIR(
   expr: ts.Expression,
@@ -83,11 +85,63 @@ export function buildIR(
     return irVar(renamed);
   }
 
-  // Stage 1 fallback: translate via the legacy pipeline and wrap the
-  // result. Subsequent stages migrate specific recognizers (Cond, App,
-  // Each, Comb, Forall, Exists) into native IR construction here.
-  // `state` is undefined because pure-path bodies don't read symbolic
-  // state; mutating-path migration happens in Stage 9.
+  // Stage 2: Optional chain `x?.prop` (and tail of a chain marked by
+  // NodeFlags.OptionalChain) under list-lift. With `x: [T]` on the Pant
+  // side, the functor-lift encoding is `each $n in x | prop $n`, giving
+  // `[U]` — empty when x is null/empty, singleton when x is present.
+  // Chains compose as nested Each comprehensions: `x?.a.b` becomes
+  // `Each($n', Each($n, x, [], a $n), [], b $n')`. When the receiver is
+  // not nullable in TS, `?.` degenerates to `.` and falls through.
+  if (ts.isPropertyAccessExpression(expr)) {
+    const inOptionalChain = (expr.flags & ts.NodeFlags.OptionalChain) !== 0;
+    if (inOptionalChain) {
+      let shouldLift = false;
+      if (expr.questionDotToken !== undefined) {
+        const receiverTsType = checker.getTypeAtLocation(expr.expression);
+        shouldLift = isNullableTsType(receiverTsType);
+      } else if (ts.isOptionalChain(expr.expression)) {
+        shouldLift = true;
+      }
+      if (shouldLift) {
+        const prop = expr.name.text;
+        const receiverTsType = checker.getTypeAtLocation(expr.expression);
+        const ruleName = qualifyFieldAccess(
+          receiverTsType,
+          prop,
+          checker,
+          strategy,
+          supply.synthCell,
+        );
+        if (ruleName === null) {
+          return { unsupported: ambiguousFieldMsg(prop) };
+        }
+        const innerIR = buildIR(
+          expr.expression,
+          checker,
+          strategy,
+          paramNames,
+          supply,
+        );
+        if (isBuildUnsupported(innerIR)) {
+          return innerIR;
+        }
+        const binderName = freshHygienicBinder(supply);
+        return {
+          kind: "each",
+          binder: binderName,
+          src: innerIR,
+          guards: [],
+          proj: irAppName(ruleName, [irVar(binderName)]),
+        };
+      }
+    }
+  }
+
+  // Fallback: translate via the legacy pipeline and wrap. Subsequent
+  // stages migrate specific recognizers (Cond, App, Comb, Forall,
+  // Exists) into native IR construction here. `state` is undefined
+  // because pure-path bodies don't read symbolic state; mutating-path
+  // migration happens in Stage 9.
   const legacy = translateBodyExpr(
     expr,
     checker,

--- a/tools/ts2pant/src/ir-build.ts
+++ b/tools/ts2pant/src/ir-build.ts
@@ -37,7 +37,7 @@ import {
   translateBodyExpr,
   type UniqueSupply,
 } from "./translate-body.js";
-import type { NumericStrategy } from "./translate-types.js";
+import { isSetType, type NumericStrategy } from "./translate-types.js";
 
 /**
  * Translate a TypeScript expression to IR.
@@ -86,6 +86,35 @@ export function buildIR(
   if (ts.isIdentifier(expr)) {
     const renamed = paramNames.get(expr.text) ?? expr.text;
     return irVar(renamed);
+  }
+
+  // Stage 5: `.length` (Array) / `.size` (Set) → `Unop(card, x)`. Plain
+  // property access on a non-optional, non-effectful receiver where the
+  // property is the cardinality slot. Falls through (to legacy / qualified
+  // field access) for property names other than `length`/`size`, and for
+  // receivers that are neither Array nor Set.
+  if (
+    ts.isPropertyAccessExpression(expr) &&
+    !(expr.flags & ts.NodeFlags.OptionalChain) &&
+    (expr.name.text === "length" || expr.name.text === "size")
+  ) {
+    const receiverTsType = checker.getTypeAtLocation(expr.expression);
+    const isArray =
+      expr.name.text === "length" && checker.isArrayType(receiverTsType);
+    const isSet = expr.name.text === "size" && isSetType(receiverTsType);
+    if (isArray || isSet) {
+      const objIR = buildIR(
+        expr.expression,
+        checker,
+        strategy,
+        paramNames,
+        supply,
+      );
+      if (isBuildUnsupported(objIR)) {
+        return objIR;
+      }
+      return irUnop("card", objIR);
+    }
   }
 
   // Stage 2: Optional chain `x?.prop` (and tail of a chain marked by

--- a/tools/ts2pant/src/ir-build.ts
+++ b/tools/ts2pant/src/ir-build.ts
@@ -1,0 +1,115 @@
+/**
+ * TS-AST → IR construction.
+ *
+ * Stage 1 scope: handles `Var` (Identifier), `Lit` (numeric / string /
+ * boolean literal), and the trivial cases of `App` (free function call
+ * with all args themselves IR-buildable). Everything else falls back to
+ * the legacy `translateBodyExpr` and wraps the result in `IRWrap` — so
+ * the IR pipeline is end-to-end exercisable without committing to
+ * full coverage in one stage.
+ *
+ * Subsequent stages migrate one recognizer at a time from
+ * `translate-body.ts` into this file; each migration removes one
+ * `IRWrap` fallback and adds a native IR construction. By Stage 8
+ * (pure-path cutover) the `IRWrap` escape hatch is deleted entirely.
+ *
+ * See `ir.ts` and CLAUDE.md §IR for the form table.
+ */
+
+import ts from "typescript";
+import {
+  type IRExpr,
+  irLitBool,
+  irLitNat,
+  irLitString,
+  irVar,
+  irWrap,
+} from "./ir.js";
+import {
+  bodyExpr,
+  isBodyUnsupported,
+  translateBodyExpr,
+  type UniqueSupply,
+} from "./translate-body.js";
+import type { NumericStrategy } from "./translate-types.js";
+
+/**
+ * Translate a TypeScript expression to IR.
+ *
+ * Returns either an `IRExpr` (success) or `{ unsupported: string }` to
+ * propagate translation rejections through the existing convention.
+ *
+ * Stage 1: native IR construction for Identifier / NumericLiteral /
+ * StringLiteral / true / false; falls back to `translateBodyExpr` +
+ * `IRWrap` for everything else (so Cond, App, etc. all go through
+ * IRWrap until their dedicated stages migrate them).
+ */
+export function buildIR(
+  expr: ts.Expression,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  paramNames: ReadonlyMap<string, string>,
+  supply: UniqueSupply,
+): IRExpr | { unsupported: string } {
+  // Boolean keywords
+  if (expr.kind === ts.SyntaxKind.TrueKeyword) {
+    return irLitBool(true);
+  }
+  if (expr.kind === ts.SyntaxKind.FalseKeyword) {
+    return irLitBool(false);
+  }
+
+  // Non-negative numeric literal: nat (negative literals require `Unop(Neg,
+  // ...)` and aren't part of the Stage 1 scope; they fall through to
+  // IRWrap via the legacy path).
+  if (ts.isNumericLiteral(expr)) {
+    const n = Number(expr.text);
+    if (Number.isFinite(n) && Number.isInteger(n) && n >= 0) {
+      return irLitNat(n);
+    }
+  }
+
+  // String literal
+  if (ts.isStringLiteral(expr) || ts.isNoSubstitutionTemplateLiteral(expr)) {
+    return irLitString(expr.text);
+  }
+
+  // Plain identifier — resolve through the param-name map (which renames
+  // TS parameter names to Pant names) so a `Var(name)` in IR refers to
+  // the Pant-side name. Mirrors the existing identifier-translation site
+  // in translate-body.ts.
+  if (ts.isIdentifier(expr)) {
+    const renamed = paramNames.get(expr.text) ?? expr.text;
+    return irVar(renamed);
+  }
+
+  // Stage 1 fallback: translate via the legacy pipeline and wrap the
+  // result. Subsequent stages migrate specific recognizers (Cond, App,
+  // Each, Comb, Forall, Exists) into native IR construction here.
+  // `state` is undefined because pure-path bodies don't read symbolic
+  // state; mutating-path migration happens in Stage 9.
+  const legacy = translateBodyExpr(
+    expr,
+    checker,
+    strategy,
+    paramNames,
+    undefined,
+    supply,
+  );
+  if (isBodyUnsupported(legacy)) {
+    return { unsupported: legacy.unsupported };
+  }
+  if ("effect" in legacy) {
+    return {
+      unsupported:
+        "collection mutation in IR-build expression position (Stage 9)",
+    };
+  }
+  return irWrap(bodyExpr(legacy));
+}
+
+export function isBuildUnsupported(
+  r: IRExpr | { unsupported: string },
+): r is { unsupported: string } {
+  return "unsupported" in r;
+}

--- a/tools/ts2pant/src/ir-build.ts
+++ b/tools/ts2pant/src/ir-build.ts
@@ -17,10 +17,13 @@
 import ts from "typescript";
 import {
   type IRExpr,
+  irAppExpr,
   irAppName,
+  irBinop,
   irLitBool,
   irLitNat,
   irLitString,
+  irUnop,
   irVar,
   irWrap,
 } from "./ir.js";
@@ -135,6 +138,43 @@ export function buildIR(
         };
       }
     }
+  }
+
+  // Stage 3: Nullish coalescing `x ?? y` under list-lift. With `x: [T]`
+  // on the Pant side, `#x = 0` is the null test:
+  //   - `y: T` (non-nullable default) → `cond #x = 0 => y, true => (x 1)`
+  //   - `y: [T]` (nested nullable) → `cond #x = 0 => y, true => x`
+  //   - `x` not nullable in TS → `??` degenerates to just `x`.
+  // See CLAUDE.md "Option-Type Elimination" for the broader encoding.
+  if (
+    ts.isBinaryExpression(expr) &&
+    expr.operatorToken.kind === ts.SyntaxKind.QuestionQuestionToken
+  ) {
+    const leftTsType = checker.getTypeAtLocation(expr.left);
+    const leftIR = buildIR(expr.left, checker, strategy, paramNames, supply);
+    if (isBuildUnsupported(leftIR)) {
+      return leftIR;
+    }
+    if (!isNullableTsType(leftTsType)) {
+      // LHS can never be nullish — `??` degenerates.
+      return leftIR;
+    }
+    const rightIR = buildIR(expr.right, checker, strategy, paramNames, supply);
+    if (isBuildUnsupported(rightIR)) {
+      return rightIR;
+    }
+    const rightTsType = checker.getTypeAtLocation(expr.right);
+    const cardZero = irBinop("eq", irUnop("card", leftIR), irLitNat(0));
+    const presentBranch: IRExpr = isNullableTsType(rightTsType)
+      ? leftIR
+      : irAppExpr(leftIR, [irLitNat(1)]);
+    return {
+      kind: "cond",
+      arms: [
+        [cardZero, rightIR],
+        [irLitBool(true), presentBranch],
+      ],
+    };
   }
 
   // Fallback: translate via the legacy pipeline and wrap. Subsequent

--- a/tools/ts2pant/src/ir-build.ts
+++ b/tools/ts2pant/src/ir-build.ts
@@ -20,6 +20,8 @@ import {
   irAppExpr,
   irAppName,
   irBinop,
+  irCond,
+  irEach,
   irLitBool,
   irLitNat,
   irLitString,
@@ -158,13 +160,12 @@ export function buildIR(
           return innerIR;
         }
         const binderName = freshHygienicBinder(supply);
-        return {
-          kind: "each",
-          binder: binderName,
-          src: innerIR,
-          guards: [],
-          proj: irAppName(ruleName, [irVar(binderName)]),
-        };
+        return irEach(
+          binderName,
+          innerIR,
+          [],
+          irAppName(ruleName, [irVar(binderName)]),
+        );
       }
     }
   }
@@ -197,13 +198,10 @@ export function buildIR(
     const presentBranch: IRExpr = isNullableTsType(rightTsType)
       ? leftIR
       : irAppExpr(leftIR, [irLitNat(1)]);
-    return {
-      kind: "cond",
-      arms: [
-        [cardZero, rightIR],
-        [irLitBool(true), presentBranch],
-      ],
-    };
+    return irCond([
+      [cardZero, rightIR],
+      [irLitBool(true), presentBranch],
+    ]);
   }
 
   // Fallback: translate via the legacy pipeline and wrap. Subsequent

--- a/tools/ts2pant/src/ir-emit.ts
+++ b/tools/ts2pant/src/ir-emit.ts
@@ -24,7 +24,6 @@ import type {
   IRStmt,
   IRUnop,
 } from "./ir.js";
-import { substIR } from "./ir-subst.js";
 import type {
   OpaqueBinop,
   OpaqueCombiner,
@@ -166,8 +165,20 @@ export function lowerExpr(e: IRExpr): OpaqueExpr {
 
     case "let": {
       // Pant has no let — inline the value into the body via
-      // capture-avoiding substitution (ir-subst.ts).
-      return lowerExpr(substIR(e.body, e.name, e.value));
+      // `substituteBinder` (Pant's capture-avoiding substitution at the
+      // OpaqueExpr layer). Right-fold semantics drop out of recursive
+      // lowering: `Let(a, ea, Let(b, eb, body))` lowers the inner Let
+      // first (substituting b), then the outer (substituting a) — so
+      // an `eb` that references `a` still gets resolved correctly. We
+      // intentionally call `substituteBinder` here rather than `substIR`
+      // because the body may contain `IRWrap(...)` (legacy fallback
+      // output) that ir-subst can't traverse, and `substituteBinder`
+      // operates uniformly on the lowered OpaqueExpr.
+      return ast.substituteBinder(
+        lowerExpr(e.body),
+        e.name,
+        lowerExpr(e.value),
+      );
     }
 
     case "each": {

--- a/tools/ts2pant/src/ir-emit.ts
+++ b/tools/ts2pant/src/ir-emit.ts
@@ -1,0 +1,387 @@
+/**
+ * IR → OpaqueExpr lowering.
+ *
+ * Walks `IRExpr` and produces `OpaqueExpr` via `pant-ast.ts` constructors.
+ * The IR is read-only here; build is in `ir-build.ts`.
+ *
+ * Stage 1 scope: handles `Var`, `Lit`, `App` (all heads), `Cond`, `Each`,
+ * `Comb`, `Forall`, `Exists`, and the migration-only `IRWrap` escape
+ * hatch. `Let` substitutes inline at lowering time (Pant has no `let`).
+ *
+ * Statement-layer lowering (Write, LetIf, Seq, Assert) is wired up in
+ * Stage 9.
+ *
+ * See CLAUDE.md §IR for the form-by-form lowering rationale.
+ */
+
+import type {
+  IRAssertExit,
+  IRBinop,
+  IRCombiner,
+  IREquation,
+  IRExpr,
+  IRHead,
+  IRStmt,
+  IRUnop,
+} from "./ir.js";
+import { substIR } from "./ir-subst.js";
+import type {
+  OpaqueBinop,
+  OpaqueCombiner,
+  OpaqueExpr,
+  OpaqueParam,
+  OpaqueUnop,
+} from "./pant-ast.js";
+import { getAst } from "./pant-wasm.js";
+
+// --------------------------------------------------------------------------
+// Operator dispatch
+// --------------------------------------------------------------------------
+
+/** `IRBinop` → `OpaqueBinop`. One switch case per Pant op. */
+function lowerBinop(op: IRBinop): OpaqueBinop {
+  const ast = getAst();
+  switch (op) {
+    case "and":
+      return ast.opAnd();
+    case "or":
+      return ast.opOr();
+    case "impl":
+      return ast.opImpl();
+    case "iff":
+      return ast.opIff();
+    case "eq":
+      return ast.opEq();
+    case "neq":
+      return ast.opNeq();
+    case "lt":
+      return ast.opLt();
+    case "gt":
+      return ast.opGt();
+    case "le":
+      return ast.opLe();
+    case "ge":
+      return ast.opGe();
+    case "in":
+      return ast.opIn();
+    case "subset":
+      return ast.opSubset();
+    case "add":
+      return ast.opAdd();
+    case "sub":
+      return ast.opSub();
+    case "mul":
+      return ast.opMul();
+    case "div":
+      return ast.opDiv();
+    default: {
+      const _exhaustive: never = op;
+      void _exhaustive;
+      throw new Error("unreachable: IRBinop");
+    }
+  }
+}
+
+function lowerUnop(op: IRUnop): OpaqueUnop {
+  const ast = getAst();
+  switch (op) {
+    case "not":
+      return ast.opNot();
+    case "neg":
+      return ast.opNeg();
+    case "card":
+      return ast.opCard();
+    default: {
+      const _exhaustive: never = op;
+      void _exhaustive;
+      throw new Error("unreachable: IRUnop");
+    }
+  }
+}
+
+function lowerCombiner(c: IRCombiner): OpaqueCombiner {
+  const ast = getAst();
+  switch (c) {
+    case "add":
+      return ast.combAdd();
+    case "mul":
+      return ast.combMul();
+    case "and":
+      return ast.combAnd();
+    case "or":
+      return ast.combOr();
+    case "min":
+      return ast.combMin();
+    case "max":
+      return ast.combMax();
+    default: {
+      const _exhaustive: never = c;
+      void _exhaustive;
+      throw new Error("unreachable: IRCombiner");
+    }
+  }
+}
+
+// --------------------------------------------------------------------------
+// IRExpr → OpaqueExpr
+// --------------------------------------------------------------------------
+
+/**
+ * Lower an `IRExpr` to an `OpaqueExpr`.
+ *
+ * `Let` is inlined via capture-avoiding substitution at lowering time —
+ * the let-elimination is a separate pass in `ir-subst.ts` that callers
+ * may run before `lowerExpr`, but `lowerExpr` itself also handles `Let`
+ * by substituting the value into the body (see `ir-subst.ts` for the
+ * shared substitution discipline).
+ */
+export function lowerExpr(e: IRExpr): OpaqueExpr {
+  const ast = getAst();
+  switch (e.kind) {
+    case "var":
+      return e.primed ? ast.primed(e.name) : ast.var(e.name);
+
+    case "lit": {
+      const v = e.value;
+      switch (v.kind) {
+        case "nat":
+          return ast.litNat(v.value);
+        case "bool":
+          return ast.litBool(v.value);
+        case "string":
+          return ast.litString(v.value);
+        default: {
+          const _exhaustive: never = v;
+          void _exhaustive;
+          throw new Error("unreachable: IRLiteral");
+        }
+      }
+    }
+
+    case "app":
+      return lowerApp(e.head, e.args.map(lowerExpr));
+
+    case "cond":
+      return ast.cond(e.arms.map(([g, v]) => [lowerExpr(g), lowerExpr(v)]));
+
+    case "let": {
+      // Pant has no let — inline the value into the body via
+      // capture-avoiding substitution (ir-subst.ts).
+      return lowerExpr(substIR(e.body, e.name, e.value));
+    }
+
+    case "each": {
+      const param = ast.param(
+        e.binder,
+        ast.tName(e.binderType ?? unknownBinderType()),
+      );
+      const guards = [
+        ast.gIn(e.binder, lowerExpr(e.src)),
+        ...e.guards.map((g) => ast.gExpr(lowerExpr(g))),
+      ];
+      // For comprehensions over a list expression, the binder is bound by
+      // a `gIn` guard, not by a `param` of its own — so `params` is empty
+      // and `guards` carries the binder. This matches the existing usage:
+      // `ast.each([], [ast.gIn(binder, src), ...], proj)`.
+      void param;
+      return ast.each([], guards, lowerExpr(e.proj));
+    }
+
+    case "comb": {
+      const each = e.each;
+      const guards = [
+        ast.gIn(each.binder, lowerExpr(each.src)),
+        ...each.guards.map((g) => ast.gExpr(lowerExpr(g))),
+      ];
+      const combExpr = ast.eachComb(
+        [],
+        guards,
+        lowerCombiner(e.combiner),
+        lowerExpr(each.proj),
+      );
+      // Identity-elision: `Comb(add, 0, ...)` collapses to the bare
+      // comprehension; non-identity `init` folds in via the
+      // corresponding Pant binop.
+      if (e.init === undefined || isIdentityFor(e.combiner, e.init)) {
+        return combExpr;
+      }
+      return ast.binop(
+        combinerToBinop(e.combiner),
+        lowerExpr(e.init),
+        combExpr,
+      );
+    }
+
+    case "forall": {
+      const param: OpaqueParam = ast.param(e.binder, ast.tName(e.binderType));
+      const guards = e.guard ? [ast.gExpr(lowerExpr(e.guard))] : [];
+      return ast.forall([param], guards, lowerExpr(e.body));
+    }
+
+    case "exists": {
+      const param: OpaqueParam = ast.param(e.binder, ast.tName(e.binderType));
+      const guards = e.guard ? [ast.gExpr(lowerExpr(e.guard))] : [];
+      return ast.exists([param], guards, lowerExpr(e.body));
+    }
+
+    case "ir-wrap":
+      return e.expr;
+    default: {
+      const _exhaustive: never = e;
+      void _exhaustive;
+      throw new Error("unreachable: IRExpr");
+    }
+  }
+}
+
+function lowerApp(head: IRHead, args: OpaqueExpr[]): OpaqueExpr {
+  const ast = getAst();
+  switch (head.kind) {
+    case "name": {
+      const fn = head.primed ? ast.primed(head.name) : ast.var(head.name);
+      return ast.app(fn, args);
+    }
+    case "binop": {
+      if (args.length !== 2) {
+        throw new Error(
+          `IRBinop "${head.op}" requires 2 args, got ${args.length}`,
+        );
+      }
+      return ast.binop(lowerBinop(head.op), args[0]!, args[1]!);
+    }
+    case "unop": {
+      if (args.length !== 1) {
+        throw new Error(
+          `IRUnop "${head.op}" requires 1 arg, got ${args.length}`,
+        );
+      }
+      return ast.unop(lowerUnop(head.op), args[0]!);
+    }
+    default: {
+      const _exhaustive: never = head;
+      void _exhaustive;
+      throw new Error("unreachable: IRHead");
+    }
+  }
+}
+
+// --------------------------------------------------------------------------
+// Combiner identity helpers
+// --------------------------------------------------------------------------
+
+function combinerToBinop(c: IRCombiner): OpaqueBinop {
+  const ast = getAst();
+  switch (c) {
+    case "add":
+      return ast.opAdd();
+    case "mul":
+      return ast.opMul();
+    case "and":
+      return ast.opAnd();
+    case "or":
+      return ast.opOr();
+    case "min":
+    case "max":
+      // No binop equivalent — caller must not request init-folding for
+      // min/max. Identity-elision (`isIdentityFor`) returns false for
+      // these, but `e.init !== undefined` reaching here is a bug.
+      throw new Error(
+        `Comb combiner "${c}" has no binop fold; init must be undefined`,
+      );
+    default: {
+      const _exhaustive: never = c;
+      void _exhaustive;
+      throw new Error("unreachable: IRCombiner");
+    }
+  }
+}
+
+function isIdentityFor(c: IRCombiner, init: IRExpr): boolean {
+  if (init.kind !== "lit") {
+    return false;
+  }
+  const v = init.value;
+  switch (c) {
+    case "add":
+      return v.kind === "nat" && v.value === 0;
+    case "mul":
+      return v.kind === "nat" && v.value === 1;
+    case "and":
+      return v.kind === "bool" && v.value === true;
+    case "or":
+      return v.kind === "bool" && v.value === false;
+    case "min":
+    case "max":
+      return false;
+    default: {
+      const _exhaustive: never = c;
+      void _exhaustive;
+      return false;
+    }
+  }
+}
+
+// --------------------------------------------------------------------------
+// IRStmt and IRBody — Stage 1 stubs (will expand in Stage 9+)
+// --------------------------------------------------------------------------
+
+/**
+ * Lower an `IRStmt` list. Stage 1 throws — statement-layer emission is
+ * Stage 9+ work. The signature is reserved here so call sites can be
+ * stubbed without circular dependencies.
+ */
+export function lowerStmts(_stmts: IRStmt[]): never {
+  throw new Error(
+    "IRStmt lowering not implemented yet — Stage 9 introduces this",
+  );
+}
+
+/**
+ * Lower an `IREquation` to a `PropResult`-shaped object suitable for
+ * pushing into the propositions array. Caller wraps in `kind: "equation"`.
+ */
+export function lowerEquation(eq: IREquation): {
+  quantifiers: OpaqueParam[];
+  guards: ReturnType<typeof getAst>["gExpr"] extends (e: OpaqueExpr) => infer G
+    ? G[]
+    : never;
+  lhs: OpaqueExpr;
+  rhs: OpaqueExpr;
+} {
+  const ast = getAst();
+  return {
+    quantifiers: eq.quantifiers.map((q) =>
+      ast.param(q.name, ast.tName(q.type)),
+    ),
+    guards: (eq.guards ?? []).map((g) => ast.gExpr(lowerExpr(g))),
+    lhs: lowerExpr(eq.lhs),
+    rhs: lowerExpr(eq.rhs),
+  };
+}
+
+export function lowerAssert(a: IRAssertExit): {
+  quantifiers: OpaqueParam[];
+  guards: ReturnType<typeof getAst>["gExpr"] extends (e: OpaqueExpr) => infer G
+    ? G[]
+    : never;
+  body: OpaqueExpr;
+} {
+  const ast = getAst();
+  return {
+    quantifiers: a.quantifiers.map((q) => ast.param(q.name, ast.tName(q.type))),
+    guards: (a.guards ?? []).map((g) => ast.gExpr(lowerExpr(g))),
+    body: lowerExpr(a.body),
+  };
+}
+
+// --------------------------------------------------------------------------
+// Diagnostics
+// --------------------------------------------------------------------------
+
+function unknownBinderType(): string {
+  // An `Each` form should always carry a binderType once Stage 4 (μ-search,
+  // which canonically introduces a typed `j: Nat` binder) lands. Until
+  // then, leaving binderType undefined falls back to a placeholder so
+  // emission proceeds — but `pant --check` will reject the result.
+  return "Unknown";
+}

--- a/tools/ts2pant/src/ir-emit.ts
+++ b/tools/ts2pant/src/ir-emit.ts
@@ -28,6 +28,7 @@ import type {
   OpaqueBinop,
   OpaqueCombiner,
   OpaqueExpr,
+  OpaqueGuard,
   OpaqueParam,
   OpaqueUnop,
 } from "./pant-ast.js";
@@ -349,9 +350,7 @@ export function lowerStmts(_stmts: IRStmt[]): never {
  */
 export function lowerEquation(eq: IREquation): {
   quantifiers: OpaqueParam[];
-  guards: ReturnType<typeof getAst>["gExpr"] extends (e: OpaqueExpr) => infer G
-    ? G[]
-    : never;
+  guards: OpaqueGuard[];
   lhs: OpaqueExpr;
   rhs: OpaqueExpr;
 } {
@@ -368,9 +367,7 @@ export function lowerEquation(eq: IREquation): {
 
 export function lowerAssert(a: IRAssertExit): {
   quantifiers: OpaqueParam[];
-  guards: ReturnType<typeof getAst>["gExpr"] extends (e: OpaqueExpr) => infer G
-    ? G[]
-    : never;
+  guards: OpaqueGuard[];
   body: OpaqueExpr;
 } {
   const ast = getAst();

--- a/tools/ts2pant/src/ir-emit.ts
+++ b/tools/ts2pant/src/ir-emit.ts
@@ -182,19 +182,10 @@ export function lowerExpr(e: IRExpr): OpaqueExpr {
     }
 
     case "each": {
-      const param = ast.param(
-        e.binder,
-        ast.tName(e.binderType ?? unknownBinderType()),
-      );
       const guards = [
         ast.gIn(e.binder, lowerExpr(e.src)),
         ...e.guards.map((g) => ast.gExpr(lowerExpr(g))),
       ];
-      // For comprehensions over a list expression, the binder is bound by
-      // a `gIn` guard, not by a `param` of its own — so `params` is empty
-      // and `guards` carries the binder. This matches the existing usage:
-      // `ast.each([], [ast.gIn(binder, src), ...], proj)`.
-      void param;
       return ast.each([], guards, lowerExpr(e.proj));
     }
 
@@ -388,16 +379,4 @@ export function lowerAssert(a: IRAssertExit): {
     guards: (a.guards ?? []).map((g) => ast.gExpr(lowerExpr(g))),
     body: lowerExpr(a.body),
   };
-}
-
-// --------------------------------------------------------------------------
-// Diagnostics
-// --------------------------------------------------------------------------
-
-function unknownBinderType(): string {
-  // An `Each` form should always carry a binderType once Stage 4 (μ-search,
-  // which canonically introduces a typed `j: Nat` binder) lands. Until
-  // then, leaving binderType undefined falls back to a placeholder so
-  // emission proceeds — but `pant --check` will reject the result.
-  return "Unknown";
 }

--- a/tools/ts2pant/src/ir-emit.ts
+++ b/tools/ts2pant/src/ir-emit.ts
@@ -257,6 +257,11 @@ function lowerApp(head: IRHead, args: OpaqueExpr[]): OpaqueExpr {
       }
       return ast.unop(lowerUnop(head.op), args[0]!);
     }
+    case "expr": {
+      // Arbitrary expression head — list-indexing `(x 1)`, etc.
+      // Mirrors Pant's `ast.app(fn: OpaqueExpr, args)`.
+      return ast.app(lowerExpr(head.expr), args);
+    }
     default: {
       const _exhaustive: never = head;
       void _exhaustive;

--- a/tools/ts2pant/src/ir-emit.ts
+++ b/tools/ts2pant/src/ir-emit.ts
@@ -14,15 +14,16 @@
  * See CLAUDE.md §IR for the form-by-form lowering rationale.
  */
 
-import type {
-  IRAssertExit,
-  IRBinop,
-  IRCombiner,
-  IREquation,
-  IRExpr,
-  IRHead,
-  IRStmt,
-  IRUnop,
+import {
+  type IRAssertExit,
+  type IRBinop,
+  type IRCombiner,
+  type IREquation,
+  type IRExpr,
+  type IRFoldCombiner,
+  type IRHead,
+  type IRUnop,
+  isFoldComb,
 } from "./ir.js";
 import type {
   OpaqueBinop,
@@ -202,10 +203,14 @@ export function lowerExpr(e: IRExpr): OpaqueExpr {
         lowerCombiner(e.combiner),
         lowerExpr(each.proj),
       );
-      // Identity-elision: `Comb(add, 0, ...)` collapses to the bare
-      // comprehension; non-identity `init` folds in via the
-      // corresponding Pant binop.
-      if (e.init === undefined || isIdentityFor(e.combiner, e.init)) {
+      // min/max have no `init` by construction (forbidden at the IR
+      // type level). Foldable combiners get identity-elision and a
+      // binop-fold for non-identity `init`.
+      if (
+        !isFoldComb(e) ||
+        e.init === undefined ||
+        isIdentityFor(e.combiner, e.init)
+      ) {
         return combExpr;
       }
       return ast.binop(
@@ -277,7 +282,7 @@ function lowerApp(head: IRHead, args: OpaqueExpr[]): OpaqueExpr {
 // Combiner identity helpers
 // --------------------------------------------------------------------------
 
-function combinerToBinop(c: IRCombiner): OpaqueBinop {
+function combinerToBinop(c: IRFoldCombiner): OpaqueBinop {
   const ast = getAst();
   switch (c) {
     case "add":
@@ -288,23 +293,15 @@ function combinerToBinop(c: IRCombiner): OpaqueBinop {
       return ast.opAnd();
     case "or":
       return ast.opOr();
-    case "min":
-    case "max":
-      // No binop equivalent — caller must not request init-folding for
-      // min/max. Identity-elision (`isIdentityFor`) returns false for
-      // these, but `e.init !== undefined` reaching here is a bug.
-      throw new Error(
-        `Comb combiner "${c}" has no binop fold; init must be undefined`,
-      );
     default: {
       const _exhaustive: never = c;
       void _exhaustive;
-      throw new Error("unreachable: IRCombiner");
+      throw new Error("unreachable: IRFoldCombiner");
     }
   }
 }
 
-function isIdentityFor(c: IRCombiner, init: IRExpr): boolean {
+function isIdentityFor(c: IRFoldCombiner, init: IRExpr): boolean {
   if (init.kind !== "lit") {
     return false;
   }
@@ -318,9 +315,6 @@ function isIdentityFor(c: IRCombiner, init: IRExpr): boolean {
       return v.kind === "bool" && v.value === true;
     case "or":
       return v.kind === "bool" && v.value === false;
-    case "min":
-    case "max":
-      return false;
     default: {
       const _exhaustive: never = c;
       void _exhaustive;
@@ -330,19 +324,8 @@ function isIdentityFor(c: IRCombiner, init: IRExpr): boolean {
 }
 
 // --------------------------------------------------------------------------
-// IRStmt and IRBody — Stage 1 stubs (will expand in Stage 9+)
+// IREquation / IRAssertExit lowering
 // --------------------------------------------------------------------------
-
-/**
- * Lower an `IRStmt` list. Stage 1 throws — statement-layer emission is
- * Stage 9+ work. The signature is reserved here so call sites can be
- * stubbed without circular dependencies.
- */
-export function lowerStmts(_stmts: IRStmt[]): never {
-  throw new Error(
-    "IRStmt lowering not implemented yet — Stage 9 introduces this",
-  );
-}
 
 /**
  * Lower an `IREquation` to a `PropResult`-shaped object suitable for

--- a/tools/ts2pant/src/ir-subst.ts
+++ b/tools/ts2pant/src/ir-subst.ts
@@ -38,7 +38,10 @@ export function substIR(body: IRExpr, name: string, value: IRExpr): IRExpr {
     case "app":
       return {
         kind: "app",
-        head: body.head,
+        head:
+          body.head.kind === "expr"
+            ? { kind: "expr", expr: substIR(body.head.expr, name, value) }
+            : body.head,
         args: body.args.map((a) => substIR(a, name, value)),
       };
 

--- a/tools/ts2pant/src/ir-subst.ts
+++ b/tools/ts2pant/src/ir-subst.ts
@@ -30,6 +30,7 @@ import {
   irExists,
   irForall,
   irLet,
+  isFoldComb,
 } from "./ir.js";
 
 /**
@@ -83,6 +84,9 @@ export function substIR(body: IRExpr, name: string, value: IRExpr): IRExpr {
 
     case "comb": {
       const each = substIR(body.each, name, value) as IRExprEach;
+      if (!isFoldComb(body)) {
+        return irComb(body.combiner, each);
+      }
       const init =
         body.init !== undefined ? substIR(body.init, name, value) : undefined;
       return irComb(body.combiner, each, init);

--- a/tools/ts2pant/src/ir-subst.ts
+++ b/tools/ts2pant/src/ir-subst.ts
@@ -20,7 +20,17 @@
  * α-renaming pass added.
  */
 
-import type { IRExpr } from "./ir.js";
+import {
+  type IRExpr,
+  type IRExprEach,
+  irApp,
+  irComb,
+  irCond,
+  irEach,
+  irExists,
+  irForall,
+  irLet,
+} from "./ir.js";
 
 /**
  * Substitute every free occurrence of `name` in `body` with `value`.
@@ -36,34 +46,30 @@ export function substIR(body: IRExpr, name: string, value: IRExpr): IRExpr {
       return body;
 
     case "app":
-      return {
-        kind: "app",
-        head:
-          body.head.kind === "expr"
-            ? { kind: "expr", expr: substIR(body.head.expr, name, value) }
-            : body.head,
-        args: body.args.map((a) => substIR(a, name, value)),
-      };
+      return irApp(
+        body.head.kind === "expr"
+          ? { kind: "expr", expr: substIR(body.head.expr, name, value) }
+          : body.head,
+        body.args.map((a) => substIR(a, name, value)),
+      );
 
     case "cond":
-      return {
-        kind: "cond",
-        arms: body.arms.map(([g, v]) => [
+      return irCond(
+        body.arms.map(([g, v]): [IRExpr, IRExpr] => [
           substIR(g, name, value),
           substIR(v, name, value),
         ]),
-      };
+      );
 
     case "let":
       // Let always evaluates `value` in the outer scope (substitute it),
       // and only substitutes in the body if the let's binder doesn't
       // shadow `name`.
-      return {
-        kind: "let",
-        name: body.name,
-        value: substIR(body.value, name, value),
-        body: body.name === name ? body.body : substIR(body.body, name, value),
-      };
+      return irLet(
+        body.name,
+        substIR(body.value, name, value),
+        body.name === name ? body.body : substIR(body.body, name, value),
+      );
 
     case "each": {
       const src = substIR(body.src, name, value);
@@ -72,31 +78,14 @@ export function substIR(body: IRExpr, name: string, value: IRExpr): IRExpr {
         ? body.guards
         : body.guards.map((g) => substIR(g, name, value));
       const proj = shadowed ? body.proj : substIR(body.proj, name, value);
-      return body.binderType !== undefined
-        ? {
-            kind: "each",
-            binder: body.binder,
-            binderType: body.binderType,
-            src,
-            guards,
-            proj,
-          }
-        : { kind: "each", binder: body.binder, src, guards, proj };
+      return irEach(body.binder, src, guards, proj, body.binderType);
     }
 
     case "comb": {
-      const each = substIR(body.each, name, value) as Extract<
-        IRExpr,
-        { kind: "each" }
-      >;
-      return body.init !== undefined
-        ? {
-            kind: "comb",
-            combiner: body.combiner,
-            init: substIR(body.init, name, value),
-            each,
-          }
-        : { kind: "comb", combiner: body.combiner, each };
+      const each = substIR(body.each, name, value) as IRExprEach;
+      const init =
+        body.init !== undefined ? substIR(body.init, name, value) : undefined;
+      return irComb(body.combiner, each, init);
     }
 
     case "forall": {
@@ -107,20 +96,7 @@ export function substIR(body: IRExpr, name: string, value: IRExpr): IRExpr {
           ? substIR(body.guard, name, value)
           : undefined;
       const newBody = shadowed ? body.body : substIR(body.body, name, value);
-      return newGuard !== undefined
-        ? {
-            kind: "forall",
-            binder: body.binder,
-            binderType: body.binderType,
-            guard: newGuard,
-            body: newBody,
-          }
-        : {
-            kind: "forall",
-            binder: body.binder,
-            binderType: body.binderType,
-            body: newBody,
-          };
+      return irForall(body.binder, body.binderType, newBody, newGuard);
     }
 
     case "exists": {
@@ -131,20 +107,7 @@ export function substIR(body: IRExpr, name: string, value: IRExpr): IRExpr {
           ? substIR(body.guard, name, value)
           : undefined;
       const newBody = shadowed ? body.body : substIR(body.body, name, value);
-      return newGuard !== undefined
-        ? {
-            kind: "exists",
-            binder: body.binder,
-            binderType: body.binderType,
-            guard: newGuard,
-            body: newBody,
-          }
-        : {
-            kind: "exists",
-            binder: body.binder,
-            binderType: body.binderType,
-            body: newBody,
-          };
+      return irExists(body.binder, body.binderType, newBody, newGuard);
     }
 
     case "ir-wrap":

--- a/tools/ts2pant/src/ir-subst.ts
+++ b/tools/ts2pant/src/ir-subst.ts
@@ -83,6 +83,9 @@ export function substIR(body: IRExpr, name: string, value: IRExpr): IRExpr {
     }
 
     case "comb": {
+      // body.each is statically IRExprEach by the IRExpr definition (and the
+      // irComb constructor enforces it on the build side); the cast restores
+      // that narrowing after substIR's IRExpr → IRExpr signature widens it.
       const each = substIR(body.each, name, value) as IRExprEach;
       if (!isFoldComb(body)) {
         return irComb(body.combiner, each);

--- a/tools/ts2pant/src/ir-subst.ts
+++ b/tools/ts2pant/src/ir-subst.ts
@@ -111,16 +111,14 @@ export function substIR(body: IRExpr, name: string, value: IRExpr): IRExpr {
     }
 
     case "ir-wrap":
-      // OpaqueExpr is opaque from TypeScript — substitution into an
-      // already-lowered expression goes through `pant-ast.ts`'s
-      // `substituteBinder`. But that requires lowering `value` first,
-      // which means we need a callback. For Stage 1 we don't expect any
-      // path that constructs a `Let` whose body contains an `IRWrap`
-      // referring to the bound name (ir-build wraps wholesale OpaqueExpr
-      // for unimplemented forms; the bound name `name` couldn't appear
-      // inside a wrapped form by construction). Once Stage 6 lands
-      // const-binding inlining, this case needs a strategy.
-      return body;
+      // Substitution into an already-lowered OpaqueExpr cannot happen at
+      // the IR layer (OpaqueExpr is opaque from TypeScript). Routing
+      // `Let` through `lowerExpr` + `ast.substituteBinder` is the
+      // only correct path; failing fast here prevents a future caller
+      // from silently dropping a substitution by hitting this case.
+      throw new Error(
+        "substIR cannot substitute inside ir-wrap; lower first and use ast.substituteBinder",
+      );
     default: {
       const _exhaustive: never = body;
       void _exhaustive;

--- a/tools/ts2pant/src/ir-subst.ts
+++ b/tools/ts2pant/src/ir-subst.ts
@@ -1,0 +1,164 @@
+/**
+ * IR-level capture-avoiding substitution.
+ *
+ * Mirrors the Barendregt-convention discipline used at the OpaqueExpr
+ * layer (`pant-ast.ts:substituteBinder`), but operates on `IRExpr` nodes
+ * so we don't have to lower → substitute → re-lift twice through the
+ * substitution machinery. See `ir.ts` §"Hybrid SSA scope" for the
+ * rationale.
+ *
+ * Stage 1 scope: handles all current `IRExpr` forms. Stage 6 (const-binding
+ * migration) will exercise this against `Let` heavily; Stage 9 will add
+ * IRStmt substitution for write-keyed `LetIf` φ-vars.
+ *
+ * **Hygiene assumption**: IR binders (`Let.name`, `Each.binder`,
+ * `Forall.binder`, `Exists.binder`) come from the document-wide
+ * `UniqueSupply` / `cellRegisterName` and are guaranteed not to collide
+ * with parameter names or accessor rules. We therefore implement
+ * substitution as straight name-based rewrite without α-renaming. If
+ * binder allocation ever loses this property, this file needs an
+ * α-renaming pass added.
+ */
+
+import type { IRExpr } from "./ir.js";
+
+/**
+ * Substitute every free occurrence of `name` in `body` with `value`.
+ * Capture is avoided by skipping subterms that re-bind `name` (Let,
+ * Each, Forall, Exists, and Each-as-comprehension binders).
+ */
+export function substIR(body: IRExpr, name: string, value: IRExpr): IRExpr {
+  switch (body.kind) {
+    case "var":
+      return body.name === name && !body.primed ? value : body;
+
+    case "lit":
+      return body;
+
+    case "app":
+      return {
+        kind: "app",
+        head: body.head,
+        args: body.args.map((a) => substIR(a, name, value)),
+      };
+
+    case "cond":
+      return {
+        kind: "cond",
+        arms: body.arms.map(([g, v]) => [
+          substIR(g, name, value),
+          substIR(v, name, value),
+        ]),
+      };
+
+    case "let":
+      // Let always evaluates `value` in the outer scope (substitute it),
+      // and only substitutes in the body if the let's binder doesn't
+      // shadow `name`.
+      return {
+        kind: "let",
+        name: body.name,
+        value: substIR(body.value, name, value),
+        body: body.name === name ? body.body : substIR(body.body, name, value),
+      };
+
+    case "each": {
+      const src = substIR(body.src, name, value);
+      const shadowed = body.binder === name;
+      const guards = shadowed
+        ? body.guards
+        : body.guards.map((g) => substIR(g, name, value));
+      const proj = shadowed ? body.proj : substIR(body.proj, name, value);
+      return body.binderType !== undefined
+        ? {
+            kind: "each",
+            binder: body.binder,
+            binderType: body.binderType,
+            src,
+            guards,
+            proj,
+          }
+        : { kind: "each", binder: body.binder, src, guards, proj };
+    }
+
+    case "comb": {
+      const each = substIR(body.each, name, value) as Extract<
+        IRExpr,
+        { kind: "each" }
+      >;
+      return body.init !== undefined
+        ? {
+            kind: "comb",
+            combiner: body.combiner,
+            init: substIR(body.init, name, value),
+            each,
+          }
+        : { kind: "comb", combiner: body.combiner, each };
+    }
+
+    case "forall": {
+      const shadowed = body.binder === name;
+      const newGuard = shadowed
+        ? body.guard
+        : body.guard !== undefined
+          ? substIR(body.guard, name, value)
+          : undefined;
+      const newBody = shadowed ? body.body : substIR(body.body, name, value);
+      return newGuard !== undefined
+        ? {
+            kind: "forall",
+            binder: body.binder,
+            binderType: body.binderType,
+            guard: newGuard,
+            body: newBody,
+          }
+        : {
+            kind: "forall",
+            binder: body.binder,
+            binderType: body.binderType,
+            body: newBody,
+          };
+    }
+
+    case "exists": {
+      const shadowed = body.binder === name;
+      const newGuard = shadowed
+        ? body.guard
+        : body.guard !== undefined
+          ? substIR(body.guard, name, value)
+          : undefined;
+      const newBody = shadowed ? body.body : substIR(body.body, name, value);
+      return newGuard !== undefined
+        ? {
+            kind: "exists",
+            binder: body.binder,
+            binderType: body.binderType,
+            guard: newGuard,
+            body: newBody,
+          }
+        : {
+            kind: "exists",
+            binder: body.binder,
+            binderType: body.binderType,
+            body: newBody,
+          };
+    }
+
+    case "ir-wrap":
+      // OpaqueExpr is opaque from TypeScript — substitution into an
+      // already-lowered expression goes through `pant-ast.ts`'s
+      // `substituteBinder`. But that requires lowering `value` first,
+      // which means we need a callback. For Stage 1 we don't expect any
+      // path that constructs a `Let` whose body contains an `IRWrap`
+      // referring to the bound name (ir-build wraps wholesale OpaqueExpr
+      // for unimplemented forms; the bound name `name` couldn't appear
+      // inside a wrapped form by construction). Once Stage 6 lands
+      // const-binding inlining, this case needs a strategy.
+      return body;
+    default: {
+      const _exhaustive: never = body;
+      void _exhaustive;
+      throw new Error("unreachable: IRExpr in substIR");
+    }
+  }
+}

--- a/tools/ts2pant/src/ir.ts
+++ b/tools/ts2pant/src/ir.ts
@@ -346,6 +346,16 @@ export const irVar = (name: string, primed = false): IRExpr => ({
   primed,
 });
 
+/**
+ * **Precondition**: `value` must be a non-negative safe integer.
+ * Negative integers and reals lower as `Unop(neg, ...)` / `App(...)` —
+ * see `IRLiteral`. Callers are responsible for the check; the constructor
+ * does not validate at runtime, in keeping with the codebase's
+ * trust-internal-code / validate-at-boundaries convention.
+ * Caller sites today (all in `ir-build.ts`): the numeric-literal branch
+ * guards `Number.isFinite(n) && Number.isInteger(n) && n >= 0`; the `??`
+ * lowering uses literal `0` and `1`.
+ */
 export const irLitNat = (value: number): IRExpr => ({
   kind: "lit",
   value: { kind: "nat", value },

--- a/tools/ts2pant/src/ir.ts
+++ b/tools/ts2pant/src/ir.ts
@@ -146,9 +146,8 @@ export type IRExpr =
    */
   | { kind: "let"; name: string; value: IRExpr; body: IRExpr }
   /**
-   * List comprehension. `params` ranges over `src`-keyed binders;
-   * `guards` filter; `proj` is the projected expression.
-   * Lowers to `ast.each(...)`.
+   * List comprehension. `binder` ranges over `src`; `guards` filter;
+   * `proj` is the projected expression. Lowers to `ast.each(...)`.
    */
   | {
       kind: "each";

--- a/tools/ts2pant/src/ir.ts
+++ b/tools/ts2pant/src/ir.ts
@@ -99,10 +99,17 @@ export type IRBinop =
 export type IRUnop = "not" | "neg" | "card";
 
 /**
+ * Combiners with a corresponding Pant binop, suitable for non-identity
+ * `init` folding. `Comb(add, 5, ...)` lowers to `5 + (+ over each ...)`,
+ * etc. min/max have no binop equivalent and so cannot carry `init`.
+ */
+export type IRFoldCombiner = "add" | "mul" | "and" | "or";
+
+/**
  * Combiner for `Comb(...)`. Mirrors Pant's `combAdd`/`combMul`/`combAnd`/
  * `combOr`/`combMin`/`combMax`.
  */
-export type IRCombiner = "add" | "mul" | "and" | "or" | "min" | "max";
+export type IRCombiner = IRFoldCombiner | "min" | "max";
 
 // --------------------------------------------------------------------------
 // Expression forms (pure, value-position)
@@ -152,12 +159,24 @@ export type IRExpr =
       proj: IRExpr;
     }
   /**
-   * Aggregate over a comprehension. `init` is optional with
-   * identity-elision (e.g. `0` for `add`, `1` for `mul`) handled at
-   * lowering time, not by callers. Lowers to `ast.eachComb(...)`,
-   * with `init` folded in via `ast.binop` if non-identity.
+   * Aggregate over a comprehension with a foldable combiner (add/mul/
+   * and/or). `init` is optional with identity-elision (e.g. `0` for
+   * `add`, `1` for `mul`) handled at lowering time, not by callers.
+   * Lowers to `ast.eachComb(...)`, with `init` folded in via
+   * `ast.binop` if non-identity.
    */
-  | { kind: "comb"; combiner: IRCombiner; init?: IRExpr; each: IRExprEach }
+  | {
+      kind: "comb";
+      combiner: IRFoldCombiner;
+      init?: IRExpr;
+      each: IRExprEach;
+    }
+  /**
+   * Aggregate over a comprehension with min/max. No `init` because Pant
+   * has no `min`/`max` binop to fold a seed through; the type forbids
+   * it so the lowering can't crash on a malformed node.
+   */
+  | { kind: "comb"; combiner: "min" | "max"; each: IRExprEach }
   /**
    * Universal quantifier. Lowers to `ast.forall(...)`.
    */
@@ -403,14 +422,24 @@ export const irEach = (
     ? { kind: "each", binder, binderType, src, guards, proj }
     : { kind: "each", binder, src, guards, proj };
 
-export const irComb = (
+export function irComb(
+  combiner: IRFoldCombiner,
+  each: IRExprEach,
+  init?: IRExpr,
+): IRExpr;
+export function irComb(combiner: "min" | "max", each: IRExprEach): IRExpr;
+export function irComb(
   combiner: IRCombiner,
   each: IRExprEach,
   init?: IRExpr,
-): IRExpr =>
-  init !== undefined
+): IRExpr {
+  if (combiner === "min" || combiner === "max") {
+    return { kind: "comb", combiner, each };
+  }
+  return init !== undefined
     ? { kind: "comb", combiner, init, each }
     : { kind: "comb", combiner, each };
+}
 
 export const irForall = (
   binder: string,
@@ -471,3 +500,13 @@ export const irStmtAssert = (
 export const isIRWrap = (
   e: IRExpr,
 ): e is Extract<IRExpr, { kind: "ir-wrap" }> => e.kind === "ir-wrap";
+
+/**
+ * Narrow a `Comb(...)` to its foldable variant. TypeScript does not
+ * auto-narrow on a secondary discriminator across a same-kind union, so
+ * callers that need to access `init` must route through this guard.
+ */
+export const isFoldComb = (
+  e: Extract<IRExpr, { kind: "comb" }>,
+): e is Extract<IRExpr, { kind: "comb"; combiner: IRFoldCombiner }> =>
+  e.combiner !== "min" && e.combiner !== "max";

--- a/tools/ts2pant/src/ir.ts
+++ b/tools/ts2pant/src/ir.ts
@@ -1,0 +1,387 @@
+/**
+ * Intermediate Representation for ts2pant.
+ *
+ * This is a Pant-adapted variant of IRSC from Vekris, Cosman, Jhala
+ * "Refinement Types for TypeScript" (PLDI 2016, arxiv:1604.02480). The IR
+ * sits between the TypeScript AST and the Pantagruel emitter; surface-syntax
+ * simplifiers (early-return if-conversion, optional chaining, nullish
+ * coalescing, chain fusion, μ-search, etc.) land as TS→IR rewrites in
+ * `ir-build.ts`, and the emitter in `ir-emit.ts` reads only IR forms.
+ *
+ * Two divergences from IRSC, both deliberate (see CLAUDE.md §IR):
+ *
+ * 1. **No FieldAccess form.** ts2pant lowers `e.f` to `App(qualified-rule,
+ *    [e])` at construction time via `qualifyFieldAccess`. Preserving that
+ *    invariant prevents a class of cross-talk bugs where consumers must
+ *    check both shapes.
+ *
+ * 2. **Hybrid SSA scope.** IRSC uses SSA over program names for *all*
+ *    assignments. We use ordinary `Let` (no φ) for const-bindings and
+ *    `LetIf` only for branching mutation, with φ-vars as **write-keys**
+ *    (rule-name + canonicalized receiver), not program names. Three
+ *    reasons: the existing right-fold substitution closure is already a
+ *    debugged let-elimination algorithm; Pant has no `let` in the output,
+ *    so SSA-construct + SSA-destruct would double the substitution
+ *    machinery; the mutating path's existing φ-merge is already keyed by
+ *    write-keys.
+ *
+ * The IR has two layers: `IRExpr` (pure, value-position) and `IRStmt`
+ * (effect, statement-position). IRSC merges these via `u⟨e⟩` hole
+ * contexts; we keep them separate because Pantagruel's mutating output is
+ * a list of equations + frame conditions, not a unit-returning expression.
+ *
+ * **Migration status**: see CLAUDE.md §IR "IR Migration Status".
+ */
+
+import type { OpaqueExpr } from "./pant-ast.js";
+
+// --------------------------------------------------------------------------
+// Literals
+// --------------------------------------------------------------------------
+
+/**
+ * Literal values appearing in `Lit(...)`. Mirrors Pant's lit constructors:
+ * `litNat` for non-negative integers, `litBool`, `litString`. Negative
+ * integers and reals are emitted as `Unop(Neg, Lit(...))` /
+ * `App(...)` rather than as native literal forms because Pant has no
+ * dedicated negative-literal or real-literal constructor at the AST level.
+ */
+export type IRLiteral =
+  | { kind: "nat"; value: number }
+  | { kind: "bool"; value: boolean }
+  | { kind: "string"; value: string };
+
+// --------------------------------------------------------------------------
+// Application heads
+// --------------------------------------------------------------------------
+
+/**
+ * The function/operator at the head of an `App`. Three shapes:
+ *
+ * - `name` — a plain rule, function, or parameter reference. Lowers to
+ *   `ast.app(ast.var(name), [...])`. Use `primed = true` for next-state
+ *   references in mutating bodies (lowers to `ast.primed(name)`).
+ *
+ * - `binop` / `unop` — Pant's built-in operators. Lower to `ast.binop(op,
+ *   l, r)` / `ast.unop(op, e)` directly. Centralising op identity here
+ *   means a Pant op rename is one switch case in `ir-emit.ts`.
+ *
+ * - `card` — list cardinality `#x`. Folded under `unop` semantically but
+ *   surfaced separately for emit clarity (it's the only Pant unop that
+ *   commonly appears inline in TS source as `.length` or `.size`).
+ */
+export type IRHead =
+  | { kind: "name"; name: string; primed?: boolean }
+  | { kind: "binop"; op: IRBinop }
+  | { kind: "unop"; op: IRUnop };
+
+export type IRBinop =
+  | "and"
+  | "or"
+  | "impl"
+  | "iff"
+  | "eq"
+  | "neq"
+  | "lt"
+  | "gt"
+  | "le"
+  | "ge"
+  | "in"
+  | "subset"
+  | "add"
+  | "sub"
+  | "mul"
+  | "div";
+
+export type IRUnop = "not" | "neg" | "card";
+
+/**
+ * Combiner for `Comb(...)`. Mirrors Pant's `combAdd`/`combMul`/`combAnd`/
+ * `combOr`/`combMin`/`combMax`.
+ */
+export type IRCombiner = "add" | "mul" | "and" | "or" | "min" | "max";
+
+// --------------------------------------------------------------------------
+// Expression forms (pure, value-position)
+// --------------------------------------------------------------------------
+
+/**
+ * Pure value-position IR. Ten forms total. Each form's invariants are
+ * documented inline; do not add forms ad-hoc — additions go through
+ * CLAUDE.md §IR review.
+ */
+export type IRExpr =
+  /** Variable / parameter reference. `primed = true` means next-state. */
+  | { kind: "var"; name: string; primed?: boolean }
+  /** Literal value (nat, bool, string). */
+  | { kind: "lit"; value: IRLiteral }
+  /**
+   * Function or operator application. `head` selects the lowering
+   * (named ref, binop, unop). Method calls lower with the receiver as
+   * `args[0]`. Qualified field accessors (`e.f` → `App(name="qualified",
+   * [e])`) lower the same way.
+   */
+  | { kind: "app"; head: IRHead; args: IRExpr[] }
+  /**
+   * Multi-armed conditional (value position). Last arm canonically
+   * `(true, default)`. Mirrors Pant's `cond` constructor and the
+   * existing `ast.cond([[g, v], [true, d]])` invariant.
+   */
+  | { kind: "cond"; arms: Array<[IRExpr, IRExpr]> }
+  /**
+   * Hygienic let-binding. Substituted out at emission (Pant has no
+   * `let`). Names come from the document-wide `UniqueSupply` /
+   * `cellRegisterName` so they don't collide with parameters or
+   * accessor rules.
+   */
+  | { kind: "let"; name: string; value: IRExpr; body: IRExpr }
+  /**
+   * List comprehension. `params` ranges over `src`-keyed binders;
+   * `guards` filter; `proj` is the projected expression.
+   * Lowers to `ast.each(...)`.
+   */
+  | {
+      kind: "each";
+      binder: string;
+      binderType?: string;
+      src: IRExpr;
+      guards: IRExpr[];
+      proj: IRExpr;
+    }
+  /**
+   * Aggregate over a comprehension. `init` is optional with
+   * identity-elision (e.g. `0` for `add`, `1` for `mul`) handled at
+   * lowering time, not by callers. Lowers to `ast.eachComb(...)`,
+   * with `init` folded in via `ast.binop` if non-identity.
+   */
+  | { kind: "comb"; combiner: IRCombiner; init?: IRExpr; each: IRExprEach }
+  /**
+   * Universal quantifier. Lowers to `ast.forall(...)`.
+   */
+  | {
+      kind: "forall";
+      binder: string;
+      binderType: string;
+      guard?: IRExpr;
+      body: IRExpr;
+    }
+  /**
+   * Existential quantifier. Lowers to `ast.exists(...)`.
+   */
+  | {
+      kind: "exists";
+      binder: string;
+      binderType: string;
+      guard?: IRExpr;
+      body: IRExpr;
+    }
+  /**
+   * **Migration-only escape hatch.** Carries an already-translated
+   * `OpaqueExpr` so old-pipeline outputs are valid IR by construction.
+   * Removed at the Stage 8 pure-path cutover.
+   */
+  | { kind: "ir-wrap"; expr: OpaqueExpr };
+
+/**
+ * `IRExpr` constrained to be a comprehension. Used as the
+ * operand of `Comb` so we statically forbid `Comb(_, _, IRWrap(...))`
+ * etc. — only an actual `each` form makes sense as a combiner argument.
+ */
+export type IRExprEach = Extract<IRExpr, { kind: "each" }>;
+
+// --------------------------------------------------------------------------
+// Statement forms (effect, statement-position)
+// --------------------------------------------------------------------------
+
+/**
+ * Write target — what a `Write` modifies. A descriptor (not an expression)
+ * because the Pant lowering for each kind is structurally different:
+ *
+ * - `property-field`: emits one primed equation `prop' obj = value`.
+ * - `map-entry`: emits one tuple-keyed override on the value rule + one on
+ *   the membership predicate (the "delete drops value override at same
+ *   key" coupling lives in the lowering, not the IR).
+ * - `set-member`: emits one element-keyed override on the membership rule;
+ *   `op = "clear"` resets and uses `false` fallthrough.
+ *
+ * Stage 9 introduces this; Stage 1 only declares the type.
+ */
+export type IRWriteTarget =
+  | {
+      kind: "property-field";
+      ruleName: string;
+      objExpr: IRExpr;
+    }
+  | {
+      kind: "map-entry";
+      ruleName: string;
+      keyPredName: string;
+      ownerType: string;
+      keyType: string;
+      objExpr: IRExpr;
+      keyExpr: IRExpr;
+      op: "set" | "delete";
+    }
+  | {
+      kind: "set-member";
+      ruleName: string;
+      ownerType: string;
+      elemType: string;
+      objExpr: IRExpr;
+      elemExpr: IRExpr | null;
+      op: "add" | "delete" | "clear";
+    };
+
+/**
+ * Effect / statement-position IR. Four forms total. `Write` is statement-
+ * only — never an `IRExpr` — because making it value-level reintroduces
+ * the effect/value discriminant hazard at every traversal.
+ */
+export type IRStmt =
+  /** Write to a target with a value (or null for `clear`-like ops). */
+  | { kind: "write"; target: IRWriteTarget; value: IRExpr | null }
+  /**
+   * Branching mutation merge. **`phiVars` are write-keys**, not program
+   * variable names — see ir.ts §"Hybrid SSA scope" rationale.
+   * Stage 9 introduces this; Stage 1 only declares the type.
+   */
+  | {
+      kind: "let-if";
+      phiVars: string[];
+      cond: IRExpr;
+      then: IRStmt[];
+      else: IRStmt[];
+      continuation: IRStmt[];
+    }
+  /** Statement sequencing. */
+  | { kind: "seq"; stmts: IRStmt[] }
+  /**
+   * Universally-quantified Bool assertion exit form. Carries the
+   * empty-Set / empty-Map initializer emissions that aren't equations.
+   * Mirrors `PropResult`'s `kind: "assertion"`.
+   */
+  | {
+      kind: "assert";
+      quantifiers: Array<{ name: string; type: string }>;
+      body: IRExpr;
+    };
+
+// --------------------------------------------------------------------------
+// Body output
+// --------------------------------------------------------------------------
+
+/**
+ * The result of translating a function body to IR. Not a single `IRExpr`
+ * because surface bodies produce multiple propositions (record returns
+ * decompose into one equation per field; mutating bodies produce
+ * equations + frame conditions; empty-Set initializers produce
+ * assertions).
+ */
+export interface IRBody {
+  /**
+   * Pure-path equations. For non-record returns, exactly one entry;
+   * for record returns, one per declared return-type field; for
+   * mutating bodies, one per modified rule.
+   */
+  equations: IREquation[];
+  /** Universally-quantified assertions (empty-Set / empty-Map fields). */
+  assertions: IRAssertExit[];
+  /**
+   * Mutating-path identity equations for unmodified rules. Stage 10
+   * populates this; before then it's empty.
+   */
+  frames: IREquation[];
+}
+
+/**
+ * One equation. `quantifiers` is empty for non-quantified equations;
+ * non-empty for the `all m, k | R' m k = ...` shape from Map/Set
+ * mutation.
+ */
+export interface IREquation {
+  quantifiers: Array<{ name: string; type: string }>;
+  guards?: IRExpr[];
+  lhs: IRExpr;
+  rhs: IRExpr;
+}
+
+export interface IRAssertExit {
+  quantifiers: Array<{ name: string; type: string }>;
+  guards?: IRExpr[];
+  body: IRExpr;
+}
+
+// --------------------------------------------------------------------------
+// Constructors (terse helpers, all type-checked)
+// --------------------------------------------------------------------------
+
+export const irVar = (name: string, primed = false): IRExpr => ({
+  kind: "var",
+  name,
+  primed,
+});
+
+export const irLitNat = (value: number): IRExpr => ({
+  kind: "lit",
+  value: { kind: "nat", value },
+});
+
+export const irLitBool = (value: boolean): IRExpr => ({
+  kind: "lit",
+  value: { kind: "bool", value },
+});
+
+export const irLitString = (value: string): IRExpr => ({
+  kind: "lit",
+  value: { kind: "string", value },
+});
+
+export const irApp = (head: IRHead, args: IRExpr[]): IRExpr => ({
+  kind: "app",
+  head,
+  args,
+});
+
+export const irAppName = (name: string, args: IRExpr[]): IRExpr => ({
+  kind: "app",
+  head: { kind: "name", name },
+  args,
+});
+
+export const irAppPrimed = (name: string, args: IRExpr[]): IRExpr => ({
+  kind: "app",
+  head: { kind: "name", name, primed: true },
+  args,
+});
+
+export const irBinop = (op: IRBinop, lhs: IRExpr, rhs: IRExpr): IRExpr => ({
+  kind: "app",
+  head: { kind: "binop", op },
+  args: [lhs, rhs],
+});
+
+export const irUnop = (op: IRUnop, arg: IRExpr): IRExpr => ({
+  kind: "app",
+  head: { kind: "unop", op },
+  args: [arg],
+});
+
+export const irCond = (arms: Array<[IRExpr, IRExpr]>): IRExpr => ({
+  kind: "cond",
+  arms,
+});
+
+export const irLet = (name: string, value: IRExpr, body: IRExpr): IRExpr => ({
+  kind: "let",
+  name,
+  value,
+  body,
+});
+
+export const irWrap = (expr: OpaqueExpr): IRExpr => ({ kind: "ir-wrap", expr });
+
+// Type guards (small, useful for migration code)
+
+export const isIRWrap = (
+  e: IRExpr,
+): e is Extract<IRExpr, { kind: "ir-wrap" }> => e.kind === "ir-wrap";

--- a/tools/ts2pant/src/ir.ts
+++ b/tools/ts2pant/src/ir.ts
@@ -392,7 +392,79 @@ export const irLet = (name: string, value: IRExpr, body: IRExpr): IRExpr => ({
   body,
 });
 
+export const irEach = (
+  binder: string,
+  src: IRExpr,
+  guards: IRExpr[],
+  proj: IRExpr,
+  binderType?: string,
+): IRExpr =>
+  binderType !== undefined
+    ? { kind: "each", binder, binderType, src, guards, proj }
+    : { kind: "each", binder, src, guards, proj };
+
+export const irComb = (
+  combiner: IRCombiner,
+  each: IRExprEach,
+  init?: IRExpr,
+): IRExpr =>
+  init !== undefined
+    ? { kind: "comb", combiner, init, each }
+    : { kind: "comb", combiner, each };
+
+export const irForall = (
+  binder: string,
+  binderType: string,
+  body: IRExpr,
+  guard?: IRExpr,
+): IRExpr =>
+  guard !== undefined
+    ? { kind: "forall", binder, binderType, guard, body }
+    : { kind: "forall", binder, binderType, body };
+
+export const irExists = (
+  binder: string,
+  binderType: string,
+  body: IRExpr,
+  guard?: IRExpr,
+): IRExpr =>
+  guard !== undefined
+    ? { kind: "exists", binder, binderType, guard, body }
+    : { kind: "exists", binder, binderType, body };
+
 export const irWrap = (expr: OpaqueExpr): IRExpr => ({ kind: "ir-wrap", expr });
+
+// IRStmt constructors. Stage 9 introduces the IRStmt layer; the helpers
+// here mirror each variant's shape so callers don't drift into hand-built
+// objects when statement-position forms start landing.
+
+export const irStmtWrite = (
+  target: IRWriteTarget,
+  value: IRExpr | null,
+): IRStmt => ({ kind: "write", target, value });
+
+export const irStmtLetIf = (
+  phiVars: string[],
+  cond: IRExpr,
+  thenBranch: IRStmt[],
+  elseBranch: IRStmt[],
+  continuation: IRStmt[],
+): IRStmt => ({
+  kind: "let-if",
+  phiVars,
+  cond,
+  // biome-ignore lint/suspicious/noThenProperty: IRStmt ADT shape uses `then`/`else` for branching mutation merge; matches IRSC discipline.
+  then: thenBranch,
+  else: elseBranch,
+  continuation,
+});
+
+export const irStmtSeq = (stmts: IRStmt[]): IRStmt => ({ kind: "seq", stmts });
+
+export const irStmtAssert = (
+  quantifiers: Array<{ name: string; type: string }>,
+  body: IRExpr,
+): IRStmt => ({ kind: "assert", quantifiers, body });
 
 // Type guards (small, useful for migration code)
 

--- a/tools/ts2pant/src/ir.ts
+++ b/tools/ts2pant/src/ir.ts
@@ -56,7 +56,7 @@ export type IRLiteral =
 // --------------------------------------------------------------------------
 
 /**
- * The function/operator at the head of an `App`. Three shapes:
+ * The function/operator at the head of an `App`. Four shapes:
  *
  * - `name` — a plain rule, function, or parameter reference. Lowers to
  *   `ast.app(ast.var(name), [...])`. Use `primed = true` for next-state
@@ -66,14 +66,17 @@ export type IRLiteral =
  *   l, r)` / `ast.unop(op, e)` directly. Centralising op identity here
  *   means a Pant op rename is one switch case in `ir-emit.ts`.
  *
- * - `card` — list cardinality `#x`. Folded under `unop` semantically but
- *   surfaced separately for emit clarity (it's the only Pant unop that
- *   commonly appears inline in TS source as `.length` or `.size`).
+ * - `expr` — an arbitrary expression head. Mirrors Pant's
+ *   `ast.app(fn: OpaqueExpr, args: OpaqueExpr[])` signature, where `fn`
+ *   can be any expression (e.g. list-indexing `(x 1)` is application
+ *   of list `x` to argument `1`, with `x` being any expression — not
+ *   necessarily a named identifier).
  */
 export type IRHead =
   | { kind: "name"; name: string; primed?: boolean }
   | { kind: "binop"; op: IRBinop }
-  | { kind: "unop"; op: IRUnop };
+  | { kind: "unop"; op: IRUnop }
+  | { kind: "expr"; expr: IRExpr };
 
 export type IRBinop =
   | "and"
@@ -351,6 +354,17 @@ export const irAppName = (name: string, args: IRExpr[]): IRExpr => ({
 export const irAppPrimed = (name: string, args: IRExpr[]): IRExpr => ({
   kind: "app",
   head: { kind: "name", name, primed: true },
+  args,
+});
+
+/**
+ * Application with an arbitrary expression head. Used for list-indexing
+ * (`(x 1)` is `App(expr=x, [Lit(1)])`) and other cases where the
+ * applied "function" is itself an expression rather than a named ref.
+ */
+export const irAppExpr = (head: IRExpr, args: IRExpr[]): IRExpr => ({
+  kind: "app",
+  head: { kind: "expr", expr: head },
   args,
 });
 

--- a/tools/ts2pant/src/ir.ts
+++ b/tools/ts2pant/src/ir.ts
@@ -263,12 +263,16 @@ export type IRStmt =
   | { kind: "write"; target: IRWriteTarget; value: IRExpr | null }
   /**
    * Branching mutation merge. **`phiVars` are write-keys**, not program
-   * variable names — see ir.ts §"Hybrid SSA scope" rationale.
+   * variable names — see ir.ts §"Hybrid SSA scope" rationale. The tuple
+   * type enforces non-empty φ-vars at the type level, mirroring the
+   * `LetIf` invariant from CLAUDE.md §IR — a `let-if` with no φ-vars
+   * is structurally a value-position `Cond`, and the discrimination
+   * between the two must hold statically.
    * Stage 9 introduces this; Stage 1 only declares the type.
    */
   | {
       kind: "let-if";
-      phiVars: string[];
+      phiVars: [string, ...string[]];
       cond: IRExpr;
       then: IRStmt[];
       else: IRStmt[];
@@ -472,7 +476,7 @@ export const irStmtWrite = (
 ): IRStmt => ({ kind: "write", target, value });
 
 export const irStmtLetIf = (
-  phiVars: string[],
+  phiVars: [string, ...string[]],
   cond: IRExpr,
   thenBranch: IRStmt[],
   elseBranch: IRStmt[],

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -1,5 +1,7 @@
 import type { SourceFile } from "ts-morph";
 import ts from "typescript";
+import { buildIR, isBuildUnsupported } from "./ir-build.js";
+import { lowerExpr } from "./ir-emit.js";
 import type {
   OpaqueCombiner,
   OpaqueExpr,
@@ -33,6 +35,17 @@ import {
   toPantTermName,
 } from "./translate-types.js";
 import type { PantDeclaration, PropResult } from "./types.js";
+
+/**
+ * Read the `TS2PANT_USE_IR` env var safely from globalThis without
+ * pulling in @types/node into the tsconfig. The flag routes the
+ * pure-path return-expression translation through the IR pipeline
+ * (Stage 1 — see CLAUDE.md §"Intermediate Representation").
+ */
+function useIRPipeline(): boolean {
+  const g = globalThis as { process?: { env?: Record<string, string> } };
+  return g.process?.env?.["TS2PANT_USE_IR"] === "1";
+}
 
 // --- Const-binding inlining infrastructure (let-elimination) ---
 
@@ -1342,20 +1355,46 @@ function translatePureBody(
     ];
   }
 
-  const body = translateBodyExpr(
-    extracted.returnExpr,
-    checker,
-    strategy,
-    inlined.scopedParams,
-    undefined,
-    supply,
-  );
+  // IR pipeline: when `TS2PANT_USE_IR=1` is set in the environment,
+  // route the return-expression translation through the IR (ir-build →
+  // ir-emit). Stage 1 of the IR migration: pure-path only, with `IRWrap`
+  // covering forms not yet natively built. See CLAUDE.md §"Intermediate
+  // Representation" for the migration roadmap.
+  let terminal: OpaqueExpr;
+  // IR pipeline only handles Expression returns in Stage 1; an
+  // IfStatement returnExpr (TS allows `if (c) return a; return b` to
+  // be lifted into a single conditional return — see
+  // `extractReturnExpression`) still goes through the legacy path until
+  // Stage 8 cutover wires up `Cond` / early-return handling natively.
+  if (useIRPipeline() && ts.isExpression(extracted.returnExpr)) {
+    const ir = buildIR(
+      extracted.returnExpr,
+      checker,
+      strategy,
+      inlined.scopedParams,
+      supply,
+    );
+    if (isBuildUnsupported(ir)) {
+      return [{ kind: "unsupported", reason: ir.unsupported }];
+    }
+    terminal = lowerExpr(ir);
+  } else {
+    const body = translateBodyExpr(
+      extracted.returnExpr,
+      checker,
+      strategy,
+      inlined.scopedParams,
+      undefined,
+      supply,
+    );
 
-  if (isBodyUnsupported(body)) {
-    return [{ kind: "unsupported", reason: body.unsupported }];
+    if (isBodyUnsupported(body)) {
+      return [{ kind: "unsupported", reason: body.unsupported }];
+    }
+
+    terminal = bodyExpr(body);
   }
 
-  const terminal = bodyExpr(body);
   const merged =
     inlined.arms.length === 0
       ? terminal

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -1357,10 +1357,9 @@ function translatePureBody(
 
   // IR pipeline: when `TS2PANT_USE_IR=1` is set in the environment,
   // route the return-expression translation through the IR (ir-build →
-  // ir-emit). Stage 1 of the IR migration: pure-path only, with `IRWrap`
-  // covering forms not yet natively built. See CLAUDE.md §"Intermediate
-  // Representation" for the migration roadmap.
-  let terminal: OpaqueExpr;
+  // ir-emit). See CLAUDE.md §"Intermediate Representation" for the
+  // migration roadmap.
+  let rhs: OpaqueExpr;
   // IR pipeline only handles Expression returns in Stage 1; an
   // IfStatement returnExpr (TS allows `if (c) return a; return b` to
   // be lifted into a single conditional return — see
@@ -1377,7 +1376,39 @@ function translatePureBody(
     if (isBuildUnsupported(ir)) {
       return [{ kind: "unsupported", reason: ir.unsupported }];
     }
-    terminal = lowerExpr(ir);
+    // Stage 6: build IR `Let` nodes around the body for each const-
+    // binding instead of applying the legacy `applyTo` substitution
+    // closure. lowerExpr's Let case calls Pant's `substituteBinder`,
+    // which is the same primitive `applyTo` used — so the result is
+    // semantically identical to the legacy path. Right-fold semantics
+    // are preserved: outermost Let is the first binding, innermost is
+    // the body.
+    //
+    // Early-return arms (PR #129 if-conversion) are already OpaqueExprs
+    // containing hygienic-name references. Lower the IR terminal, merge
+    // it with the arms into a `cond`, then wrap the result as IRWrap
+    // inside the Let chain — substituteBinder traverses opaque
+    // expressions, so hygienic names inside arms get substituted by the
+    // Let chain just like names inside the IR body.
+    let bodyIR = ir;
+    if (inlined.arms.length > 0) {
+      const terminalExpr = lowerExpr(bodyIR);
+      const mergedExpr = ast.cond([
+        ...inlined.arms.map(([g, v]) => [g, v] as [OpaqueExpr, OpaqueExpr]),
+        [ast.litBool(true), terminalExpr] as [OpaqueExpr, OpaqueExpr],
+      ]);
+      bodyIR = { kind: "ir-wrap", expr: mergedExpr };
+    }
+    for (let i = inlined.translatedBindings.length - 1; i >= 0; i--) {
+      const tb = inlined.translatedBindings[i]!;
+      bodyIR = {
+        kind: "let",
+        name: tb.hygienicName,
+        value: { kind: "ir-wrap", expr: tb.initExpr },
+        body: bodyIR,
+      };
+    }
+    rhs = lowerExpr(bodyIR);
   } else {
     const body = translateBodyExpr(
       extracted.returnExpr,
@@ -1392,17 +1423,16 @@ function translatePureBody(
       return [{ kind: "unsupported", reason: body.unsupported }];
     }
 
-    terminal = bodyExpr(body);
+    const terminal = bodyExpr(body);
+    const merged =
+      inlined.arms.length === 0
+        ? terminal
+        : ast.cond([
+            ...inlined.arms.map(([g, v]) => [g, v] as [OpaqueExpr, OpaqueExpr]),
+            [ast.litBool(true), terminal] as [OpaqueExpr, OpaqueExpr],
+          ]);
+    rhs = inlined.applyTo(merged);
   }
-
-  const merged =
-    inlined.arms.length === 0
-      ? terminal
-      : ast.cond([
-          ...inlined.arms.map(([g, v]) => [g, v] as [OpaqueExpr, OpaqueExpr]),
-          [ast.litBool(true), terminal] as [OpaqueExpr, OpaqueExpr],
-        ]);
-  const rhs = inlined.applyTo(merged);
 
   const argExprs = params.map((p) => ast.var(p.name));
   const lhs = ast.app(ast.var(functionName), argExprs);
@@ -1810,7 +1840,19 @@ function describeRejectedBody(body: ts.Block, checker: ts.TypeChecker): string {
  * is substituted first, so each step naturally resolves references to earlier
  * bindings that are already embedded in the result.
  */
-function inlineConstBindings(
+/**
+ * One translated const-binding: a hygienic name (`$N`) and the
+ * already-translated initializer as an OpaqueExpr. Exposed so the IR
+ * pipeline (Stage 6+) can wrap these in `IRWrap`-valued IR `Let` nodes
+ * and let `lowerExpr`'s `substituteBinder` do the substitution at
+ * lowering time, replacing the legacy `applyTo` closure.
+ */
+export interface TranslatedBinding {
+  hygienicName: string;
+  initExpr: OpaqueExpr;
+}
+
+export function inlineConstBindings(
   bindings: ConstBinding[],
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
@@ -1820,6 +1862,7 @@ function inlineConstBindings(
 ):
   | {
       applyTo: (expr: OpaqueExpr) => OpaqueExpr;
+      translatedBindings: ReadonlyArray<TranslatedBinding>;
       scopedParams: ReadonlyMap<string, string>;
       arms: ReadonlyArray<readonly [OpaqueExpr, OpaqueExpr]>;
     }
@@ -1983,7 +2026,7 @@ function inlineConstBindings(
       expr,
     );
 
-  return { applyTo, scopedParams, arms };
+  return { applyTo, translatedBindings, scopedParams, arms };
 }
 
 type BindingInitResult = { value: OpaqueExpr } | { error: string };

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -74,7 +74,7 @@ function nextSupply(supply: UniqueSupply): number {
   return value;
 }
 
-function freshHygienicBinder(supply: UniqueSupply): string {
+export function freshHygienicBinder(supply: UniqueSupply): string {
   return `$${nextSupply(supply)}`;
 }
 
@@ -84,7 +84,7 @@ function freshHygienicBinder(supply: UniqueSupply): string {
  * sites to decide whether the receiver needs the cardinality-based lowering
  * (nullable) or can pass through as-is (already concrete).
  */
-function isNullableTsType(type: ts.Type): boolean {
+export function isNullableTsType(type: ts.Type): boolean {
   const mask = ts.TypeFlags.Null | ts.TypeFlags.Undefined | ts.TypeFlags.Void;
   if (type.isUnion()) {
     return type.types.some((t) => (t.flags & mask) !== 0);
@@ -1443,7 +1443,7 @@ interface ExtractedBody {
  *  (built-in types, type parameters, anonymous shapes with no synth
  *  context) still fall back to the bare kebab'd field name — those
  *  don't collide with qualified rule names. */
-function qualifyFieldAccess(
+export function qualifyFieldAccess(
   receiverType: ts.Type,
   fieldName: string,
   checker: ts.TypeChecker,
@@ -1466,7 +1466,7 @@ function qualifyFieldAccess(
   return toPantTermName(fieldName);
 }
 
-function ambiguousFieldMsg(fieldName: string): string {
+export function ambiguousFieldMsg(fieldName: string): string {
   return (
     `property access .${fieldName}: ambiguous owner — ` +
     `union/intersection members declare this field on multiple distinct ` +

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -1,5 +1,6 @@
 import type { SourceFile } from "ts-morph";
 import ts from "typescript";
+import { irLet, irWrap } from "./ir.js";
 import { buildIR, isBuildUnsupported } from "./ir-build.js";
 import { lowerExpr } from "./ir-emit.js";
 import type {
@@ -1401,12 +1402,7 @@ function translatePureBody(
     }
     for (let i = inlined.translatedBindings.length - 1; i >= 0; i--) {
       const tb = inlined.translatedBindings[i]!;
-      bodyIR = {
-        kind: "let",
-        name: tb.hygienicName,
-        value: { kind: "ir-wrap", expr: tb.initExpr },
-        body: bodyIR,
-      };
+      bodyIR = irLet(tb.hygienicName, irWrap(tb.initExpr), bodyIR);
     }
     rhs = lowerExpr(bodyIR);
   } else {

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -230,6 +230,10 @@ exports[`expressions-if-early-return.ts > unbracedArm 1`] = `
 "module UnbracedArm.\\n\\nunbraced-arm n: Int => Int.\\n\\n---\\n\\nunbraced-arm n = (cond n < 0 => 0, true => n).\\n"
 `;
 
+exports[`expressions-ir-anchor.ts > effectiveValue 1`] = `
+"module EffectiveValue.\\n\\nCache.\\ncache--fallback c1: Cache => Int.\\ncache--value c1: Cache => [Int].\\neffective-value c: Cache, factor: Int => Int.\\n\\n---\\n\\neffective-value c factor = (cond factor > 0 => (cond #(cache--value c) = 0 => cache--fallback c, true => (cache--value c) 1) * factor, true => (cond #(cache--value c) = 0 => cache--fallback c, true => (cache--value c) 1)).\\n"
+`;
+
 exports[`expressions-literals.ts > fortyTwo 1`] = `
 "module FortyTwo.\\n\\nforty-two  => Int.\\n\\n---\\n\\nforty-two = 42.\\n"
 `;

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-ir-anchor.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-ir-anchor.ts
@@ -1,0 +1,15 @@
+// Stage 1 anchor for the IR migration. Exercises the *minimum interesting
+// body* — const binding, `??`, property read, conditional — that the IR
+// pipeline must handle (via IRWrap fallback in Stage 1; via native IR
+// construction by the time of cutover). See CLAUDE.md §"Intermediate
+// Representation".
+
+interface Cache {
+  fallback: number;
+  value: number | null;
+}
+
+export function effectiveValue(c: Cache, factor: number): number {
+  const base = c.value ?? c.fallback;
+  return factor > 0 ? base * factor : base;
+}

--- a/tools/ts2pant/tests/ir-equivalence.test.mts
+++ b/tools/ts2pant/tests/ir-equivalence.test.mts
@@ -54,6 +54,15 @@ const ANCHORS: Array<{ file: string; functions: string[] }> = [
     file: "expressions-optional-default.ts",
     functions: ["makePoint", "makeConfig", "usesOptionalDirectly"],
   },
+  // Stage 5: `.length` / `.size` cardinality
+  {
+    file: "expressions-array.ts",
+    functions: ["count"],
+  },
+  {
+    file: "expressions-set.ts",
+    functions: ["cardinality"],
+  },
 ];
 
 async function emitWithFlag(

--- a/tools/ts2pant/tests/ir-equivalence.test.mts
+++ b/tools/ts2pant/tests/ir-equivalence.test.mts
@@ -63,6 +63,26 @@ const ANCHORS: Array<{ file: string; functions: string[] }> = [
     file: "expressions-set.ts",
     functions: ["cardinality"],
   },
+  // Stage 6: const-binding inlining via IR Let nodes (initializers are
+  // IRWrap of legacy-translated OpaqueExpr; substitution flows through
+  // lowerExpr's substituteBinder rather than the legacy `applyTo`
+  // closure). Includes μ-search bindings, which still go through
+  // `translateMuSearchInit` for the comprehension construction (the
+  // recognizer + lowering stay legacy; only the binding-substitution
+  // mechanism is on IR — see WORKING-NOTES Decisions deferred).
+  {
+    file: "expressions-const-bindings.ts",
+    functions: [
+      "simpleConst",
+      "chainedConst",
+      "constWithPropAccess",
+      "constInTernary",
+    ],
+  },
+  {
+    file: "expressions-while-mu-search.ts",
+    functions: ["firstUnusedSuffix", "nextSlotPlusOne", "offsetUnusedSuffix"],
+  },
 ];
 
 async function emitWithFlag(

--- a/tools/ts2pant/tests/ir-equivalence.test.mts
+++ b/tools/ts2pant/tests/ir-equivalence.test.mts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { readdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { before, describe, it } from "node:test";
+import { createSourceFile } from "../src/extract.js";
+import { loadAst } from "../src/pant-wasm.js";
+import { buildDocumentFromSourceFile, emitDocument } from "./helpers.mjs";
+
+before(async () => {
+  await loadAst();
+});
+
+/**
+ * Per-stage IR equivalence gate.
+ *
+ * Translates each anchor function with `TS2PANT_USE_IR=0` (legacy
+ * pipeline) and `TS2PANT_USE_IR=1` (IR pipeline), then asserts the
+ * emitted strings are identical. This is the smoke-test gate; the
+ * fuller cutover gate runs `pant --ast` on both outputs and structurally
+ * compares the resulting OCaml AST. Snapshot equality is brittle for
+ * binder-allocation orderings; for now string equality suffices because
+ * Stage 1's IRWrap fallback is a true no-op.
+ *
+ * As stages migrate recognizers from legacy to IR, this test set grows
+ * to cover the migrated forms. By Stage 8 (pure-path cutover) it covers
+ * the entire pure path.
+ */
+
+const CONSTRUCTS_DIR = resolve(import.meta.dirname, "fixtures/constructs");
+
+/**
+ * Anchor fixtures the IR pipeline should produce identical output for at
+ * the current stage. The list grows monotonically as stages migrate.
+ */
+const ANCHORS: Array<{ file: string; functions: string[] }> = [
+  {
+    file: "expressions-ir-anchor.ts",
+    functions: ["effectiveValue"],
+  },
+];
+
+async function emitWithFlag(
+  filePath: string,
+  funcName: string,
+  useIR: boolean,
+): Promise<string> {
+  // Mutate the env var, build, then restore — the underlying
+  // translateBody reads `process.env.TS2PANT_USE_IR` per-call.
+  const g = globalThis as { process?: { env?: Record<string, string> } };
+  const env = g.process?.env;
+  if (!env) {
+    throw new Error("ir-equivalence test requires Node process.env");
+  }
+  const prior = env["TS2PANT_USE_IR"];
+  env["TS2PANT_USE_IR"] = useIR ? "1" : "0";
+  try {
+    const sf = createSourceFile(filePath);
+    const doc = await buildDocumentFromSourceFile(sf, funcName);
+    return emitDocument(doc);
+  } finally {
+    if (prior === undefined) {
+      delete env["TS2PANT_USE_IR"];
+    } else {
+      env["TS2PANT_USE_IR"] = prior;
+    }
+  }
+}
+
+describe("Stage 1 IR-equivalence: legacy and IR produce identical output", () => {
+  for (const { file, functions } of ANCHORS) {
+    const filePath = resolve(CONSTRUCTS_DIR, file);
+    for (const funcName of functions) {
+      it(`${file} > ${funcName}`, async () => {
+        const legacy = await emitWithFlag(filePath, funcName, false);
+        const ir = await emitWithFlag(filePath, funcName, true);
+        assert.equal(
+          ir,
+          legacy,
+          `IR pipeline output differs from legacy for ${funcName}`,
+        );
+      });
+    }
+  }
+
+  it("anchor file fixture exists and has the expected exports", () => {
+    const files = readdirSync(CONSTRUCTS_DIR);
+    assert.ok(
+      files.includes("expressions-ir-anchor.ts"),
+      "expressions-ir-anchor.ts must exist",
+    );
+  });
+});

--- a/tools/ts2pant/tests/ir-equivalence.test.mts
+++ b/tools/ts2pant/tests/ir-equivalence.test.mts
@@ -37,6 +37,13 @@ const ANCHORS: Array<{ file: string; functions: string[] }> = [
     file: "expressions-ir-anchor.ts",
     functions: ["effectiveValue"],
   },
+  // Stage 2: optional chaining `?.` (the `??` cases stay on the legacy
+  // path until Stage 3, but the IR-equivalence test still asserts byte-
+  // equality, which holds because IRWrap fallback covers `??`).
+  {
+    file: "expressions-nullish.ts",
+    functions: ["maybeBalance", "maybeOwnerId", "maybeOwnerIdOptional"],
+  },
 ];
 
 async function emitWithFlag(

--- a/tools/ts2pant/tests/ir-equivalence.test.mts
+++ b/tools/ts2pant/tests/ir-equivalence.test.mts
@@ -37,12 +37,22 @@ const ANCHORS: Array<{ file: string; functions: string[] }> = [
     file: "expressions-ir-anchor.ts",
     functions: ["effectiveValue"],
   },
-  // Stage 2: optional chaining `?.` (the `??` cases stay on the legacy
-  // path until Stage 3, but the IR-equivalence test still asserts byte-
-  // equality, which holds because IRWrap fallback covers `??`).
+  // Stages 2 (`?.`) + 3 (`??`): the entire expressions-nullish.ts fixture.
   {
     file: "expressions-nullish.ts",
-    functions: ["maybeBalance", "maybeOwnerId", "maybeOwnerIdOptional"],
+    functions: [
+      "defaultToZero",
+      "preferLeft",
+      "maybeBalance",
+      "nonNullDefault",
+      "maybeOwnerId",
+      "maybeOwnerIdOptional",
+    ],
+  },
+  // Stage 3: optional-parameter list-lift + `??` default
+  {
+    file: "expressions-optional-default.ts",
+    functions: ["makePoint", "makeConfig", "usesOptionalDirectly"],
   },
 ];
 

--- a/tools/ts2pant/tests/ir-equivalence.test.mts
+++ b/tools/ts2pant/tests/ir-equivalence.test.mts
@@ -83,6 +83,26 @@ const ANCHORS: Array<{ file: string; functions: string[] }> = [
     file: "expressions-while-mu-search.ts",
     functions: ["firstUnusedSuffix", "nextSlotPlusOne", "offsetUnusedSuffix"],
   },
+  // Stage 7: chain fusion (.filter/.map/.reduce). These work via the
+  // IRWrap fallback today (legacy materialization produces an
+  // OpaqueExpr `each(...)` that ir-build wraps); native IR construction
+  // in ir-build replaces the fallback in Stage 7 itself.
+  {
+    file: "expressions-array.ts",
+    functions: ["activeNames", "nameLengths", "highScores"],
+  },
+  {
+    file: "expressions-reduce.ts",
+    functions: [
+      "sumAmounts",
+      "productValues",
+      "allActive",
+      "anyActive",
+      "sumFromBase",
+      "subtractAll",
+      "sumAmountsRight",
+    ],
+  },
 ];
 
 async function emitWithFlag(


### PR DESCRIPTION
## Summary

Stand up an **IRSC-style intermediate representation** between the TypeScript AST and the Pantagruel emitter, then migrate the pure-path surface-syntax recognizers to TS→IR rewrites. Drains the cross-talk hazard documented in PR #84's post-mortem (recognizers interoperating through `BodyResult`, `state.writes`, and the doc-wide `SynthCell` accumulate bugs as new TS patterns get bolted on).

Reference: Vekris, Cosman, Jhala, *""Refinement Types for TypeScript""* ([PLDI 2016, arxiv:1604.02480](https://arxiv.org/pdf/1604.02480)). Their FRSC→IRSC SSA transformation is the precedent; ts2pant's IR is Pant-adapted (statement layer kept separate; const-binding inlining preserved as ordinary `Let` rather than full SSA — see CLAUDE.md §IR ""Divergences from IRSC"" for the rationale).

**Scope of this PR**: pure-path migration only (Stages 1–7). The mutating-path migration (Stages 8–11) is a separate follow-up PR — the IR-shape decisions there depend on architectural questions that warrant their own design pass. Full design notes for the mutating-path work are in §""Mutating-path follow-up"" below.

## What's in this PR

### Per-stage gate

`tools/ts2pant/tests/ir-equivalence.test.mts` runs each anchor with `TS2PANT_USE_IR=0` (legacy pipeline) and `=1` (IR pipeline) and asserts byte-equal emitted strings. **30 anchors** locked in across stages 1–7 covering: const + `??` + property + conditional (anchor); optional chaining and chains; `??` and optional-parameter list-lift; `.length` / `.size` cardinality; const bindings + μ-search; `.filter`/`.map`/`.reduce` chain fusion.

### Stages landed

| # | Scope | Commit |
|---|-------|--------|
| 1 | IR foundation (`src/ir.ts`, `src/ir-build.ts`, `src/ir-emit.ts`, `src/ir-subst.ts`), CLAUDE.md §IR, `--use-ir` flag, anchor fixture, equivalence test scaffold | `3a10dcd` |
| 2 | Optional chaining `?.` → `Each(\$n, x, [], App(qualified-rule, [\$n]))` | `b6c005e` |
| 3 | Nullish coalescing `??` → `Cond(...)` (added 4th `IRHead` variant for arbitrary expression-position application — list-indexing `(x 1)`) | `5f99f6a` |
| 4 | μ-search → folded into Stage 6 (recognizer is structurally tied to const-binding) | — |
| 5 | `.length` / `.size` → `Unop(card, x)` | `7fdf723` |
| 6 | Pure-path const-binding inlining via IR `Let` (substitution mechanism moves to `lowerExpr` + Pant's `substituteBinder`) | `c79e45c` |
| 7 | Chain fusion: 10 IR-equivalence anchors locked through `IRWrap`; native IR construction deferred (see §""Stage 7 deferral"") | `5411805` |

### Design highlights (full detail in CLAUDE.md §IR)

**Two layers**: `IRExpr` (10 forms — value-position) and `IRStmt` (4 forms — effect-position, types only in this PR). IRSC merges these via `u⟨e⟩` hole contexts; we keep them separate because Pantagruel's mutating output is a list of equations + frame conditions, not a unit-returning expression.

**Two deliberate divergences from IRSC** (documented so a future agent doesn't try to ""fix"" them back):

1. **No `FieldAccess` form.** ts2pant lowers `e.f` to `App(qualified-rule, [e])` at construction time via `qualifyFieldAccess`. Adding `FieldAccess` would force every consumer to check both shapes — exactly the cross-talk problem the IR is meant to eliminate.
2. **Hybrid SSA scope.** IRSC uses SSA over program names for *all* assignments. We use ordinary `Let` (no φ) for const-bindings and reserve `LetIf` for branching mutation, with φ-vars as **write-keys** (rule-name + canonicalized receiver), not program names. Three reasons: (a) `inlineConstBindings` is already a working right-fold substitution closure (the standard let-elimination algorithm — duplicating it in SSA wins nothing); (b) Pantagruel has no `let` in the output, so SSA-then-de-SSA doubles the substitution machinery; (c) the mutating path's existing φ-merge is already keyed by write-keys.

**Six failure modes designed against** (full detail in CLAUDE.md §IR ""Invariants""): opaque AST constraint, substitution primitive boundary, effect/value discriminant, canonicalization explicitness, modified-props sharing across cloned states, `pant --check` μ-search rejection.

### Stage 7 deferral (chain fusion)

`.filter`/`.map`/`.reduce` chains already produce byte-identical output through the `IRWrap` fallback path — legacy `translateArrayMethod` + `translateReduceCall` materialize an OpaqueExpr `each(...)` / `eachComb(...)`, and `ir-build` wraps it. The 10 chain anchors confirm equivalence.

The native IR construction (a real `Each` IR node assembled in `ir-build`) is **intentionally deferred**: the legacy ~300 LOC of intricate TS-AST inspection (arrow-body parsing, binop classification, `substituteBinder` composition) would translate to ~200 LOC of mechanical duplication producing semantically identical output — the architectural payoff is only at deletion time. We keep `IRWrap` for chain-fusion outputs and reconsider after the mutating-path settles the IR shape.

### Files

**New:**
- `tools/ts2pant/src/ir.ts` — 10 `IRExpr` + 4 `IRStmt` forms, constructors, type guards
- `tools/ts2pant/src/ir-build.ts` — TS-AST → IR with `IRWrap` fallback
- `tools/ts2pant/src/ir-emit.ts` — IR → `OpaqueExpr`, operator dispatch tables
- `tools/ts2pant/src/ir-subst.ts` — capture-avoiding substitution under hygienic-binders assumption
- `tools/ts2pant/tests/fixtures/constructs/expressions-ir-anchor.ts` — anchor (const + `??` + property + conditional)
- `tools/ts2pant/tests/ir-equivalence.test.mts` — per-stage smoke gate

**Modified:**
- `tools/ts2pant/src/translate-body.ts` — `translatePureBody` IR routing; exported helpers used by `ir-build`; `inlineConstBindings` exposes `translatedBindings`
- `tools/ts2pant/CLAUDE.md` — new top-level §""Intermediate Representation"" with form table, IRSC reference, divergences, invariants, IR Migration Status table

### Test plan

- [x] `cd tools/ts2pant && TS2PANT_USE_IR=0 npx tsx --test tests/*.test.mts` — 277/277 pass
- [x] `cd tools/ts2pant && TS2PANT_USE_IR=1 npx tsx --test tests/*.test.mts` — 277/277 pass (IR pipeline produces byte-equal output to legacy on all 30 anchors)
- [x] `cd tools/ts2pant && npx tsc --noEmit` — clean
- [x] `cd tools/ts2pant && npx biome check src` — clean
- [x] `dune test` (core pant) — unchanged

---

## Mutating-path follow-up (Stages 8–11)

The pure-path migration is structurally complete. The mutating-path work is a separate-shaped problem — **architectural, not mechanical** — and needs its own design pass. This section documents the design notes so the follow-up PR has a starting point.

### Why split

Stages 2–7 are *recognizer migrations*: ""this surface pattern produces this IR shape, here's the rewrite."" The output is byte-equivalent to legacy by construction. Stages 9–11 touch:

- `symbolicExecute`'s clone/merge/install/emit pipeline (~700 LOC at translate-body.ts:3398)
- `state.writes` / `state.writtenKeys` / `state.modifiedProps` accumulator that's *shared across cloned states* (intentionally — Shape A loops emit equations directly into propositions and bypass `state.writes`, so `modifiedProps` is the only place that records *that* a property was touched; frame conditions read this)
- The ""delete drops value override at same key"" coupling on `MapRuleWriteEntry` that prevented us from splitting per-rule in PR #127 — a constraint the IR-emit step has to honor
- For-of Shape A/B/C catamorphism translation — Shape A emits direct equations from inside an `each` quantifier, which is sound only because the binder ranges over distinct elements (TLA+ semantics)
- Frame-condition generation (`generateFrameConditions`, translate-body.ts:5051) reads `state.modifiedProps` accumulated by every write site

These aren't recognizer-shaped. Each one is a design question.

### IR shape for mutating paths

The Stage 1 plan defined `IRStmt` with four forms (currently types-only):

```ts
type IRStmt =
  | { kind: ""write""; target: IRWriteTarget; value: IRExpr | null }
  | { kind: ""let-if""; phiVars: string[]; cond: IRExpr;
      then: IRStmt[]; else: IRStmt[]; continuation: IRStmt[] }
  | { kind: ""seq""; stmts: IRStmt[] }
  | { kind: ""assert""; quantifiers: ...; body: IRExpr };
```

Where `IRWriteTarget` is a discriminated descriptor (`property-field` / `map-entry` / `set-member`). The lowering for each kind preserves the existing semantics:

- `property-field` → one primed equation `prop' obj = value`.
- `map-entry` → tuple-keyed override on the value rule + one on the membership predicate (the ""delete drops value override at same key"" coupling stays in the lowering, not the IR — same as PR #127's reasoning).
- `set-member` → element-keyed override on the membership rule; `op = ""clear""` resets and uses `false` fallthrough.

`LetIf`'s **`phiVars` are write-keys, not program names** — the deliberate divergence from IRSC's program-name SSA. The mutating path's existing φ-merge in `cloneSymbolicState` + the if-merge loop is already keyed by write-keys; `LetIf` is a renaming of that merge, not a new SSA discipline.

### Stage 9 — Mutating-path SSA construction

**Goal**: introduce write-keyed `LetIf` for branching mutation. Migrate property assignment, Map.set/.delete, Set.add/.delete/.clear from direct `state.writes` mutation to IR `Write` nodes. `symbolicExecute` walks IR statements rather than TS AST.

**Approach**:

1. **Build mutating bodies as `IRStmt[]` first**, then run a second pass that lowers IR statements into the existing `PropResult[]` shape. The `state.writes` accumulator becomes an *implementation detail of the lowering pass*, not a user-visible interface.

2. **`Write` install logic moves to IR-emit.** Today's `installMapWrite` / `installSetWrite` / property write paths become switch arms in `lowerStmts(IRStmt[]): PropResult[]` — keyed on `target.kind`. The Map ""delete drops value override"" coupling lives here (one `Write { op: ""delete"" }` lowers into both an entry on `entries-key` membership and a drop on `entries` value).

3. **Branch merging via `LetIf`.** When `symbolicExecute` (or its IR-walking equivalent) sees `if (g) { S1 } else { S2 } S_cont`, it builds `LetIf(phiVars, g, S1_ir, S2_ir, S_cont_ir)`. φ-vars are computed by walking S1 and S2 for `Write` targets and collecting write-keys. The lowering in `ir-emit` reproduces the current cond-merge logic for each write-key.

4. **For-of Shape A/B/C** — open question. Shape A emits `forall` quantifier equations directly into propositions, bypassing `state.writes`. Two options for IR:
   - **(a)** Keep the bypass — `Each` produces a side-output of equations, just like today.
   - **(b)** Make `Each` produce a list of `Write`s (one per binder iteration), with the IR emitter recognizing the universal-quantifier shape.
   
   (a) preserves current correctness and is simpler. (b) is more uniform but requires the IR to encode TLA+'s ""distinct binder values"" semantics so frame conditions don't conflict with per-iteration writes. **Recommendation**: (a) first, revisit only if it forces another cross-talk surface.

5. **`SymbolicState.canonicalize` becomes an explicit IR pass input.** Today it's an ambient closure on the cell; in IR it's threaded through the lowering as a parameter so reads-through-aliases work the same way.

### Stage 10 — Frame conditions migrate to IR pass

**Goal**: `state.modifiedProps` becomes a derived view from walking IR statements (`LetIf` φ-vars + `Write.target.ruleName`) rather than an accumulator updated during TS-AST traversal.

This decouples frame-condition generation from the order of recognizer execution. Today, `state.modifiedProps` is *shared across cloned states* because Shape A loops emit equations directly into propositions and bypass `state.writes`; in IR, the Shape A side-output (per Stage 9 §4 option (a)) needs to register its `modifiedProps` separately. Or — if Stage 9 picks option (b) — the IR walker visits all `Write`s including those inside `Each` and the sharing complication goes away.

### Stage 11 — Mutating-path cutover

**Goal**: `translate-body.ts` becomes a thin entry point. `symbolicExecute`, `installMapWrite`, `installSetWrite`, `mergeOverrides`, and the bulk of mutating logic move into `ir-build.ts` + `ir-emit.ts`. Final CLAUDE.md ""IR Migration Status"" update.

### Open design questions for the follow-up

1. **`Each` side-output vs. uniform `Write`s** (Stage 9 §4) — pick (a) or (b) explicitly with a rationale.
2. **`extractArrowBody` for IR** — chain fusion (Stage 7 deferred) needs an IR-returning arrow-body extractor; this overlaps with mutating-path arrow-body translation (e.g., `forEach` callbacks). Design a single shared utility.
3. **Chain fusion native migration** — once the mutating-path IR shape is settled, decide whether to do the ~200 LOC duplication or leave `IRWrap` in place. Estimate after Stage 11.
4. **Frame-condition timing** — should frame conditions be emitted lazily (on demand during IR lowering) or eagerly (after the IR walk completes)? The current `generateFrameConditions` is eager; IR could do either.

### Suggested PR ordering for the follow-up

- **Follow-up PR 1**: Stages 9 + 10 together. Standing up `IRStmt` lowering and frame conditions in one shot is cleaner than splitting — they're mutually constraining.
- **Follow-up PR 2**: Stage 11 cutover (delete legacy mutating-path code). Optionally bundles the chain-fusion native migration + IRWrap deletion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)