### PR TITLE
ts2pant: generalize if-early-return to any prelude position

### DIFF
--- a/tools/ts2pant/CLAUDE.md
+++ b/tools/ts2pant/CLAUDE.md
@@ -505,14 +505,18 @@ coordinated with the rest of the document, but locally collision-safe:
 Pant name already bound in the current frame.
 
 **SMT note.** `pant --check` accepts the emitted form via a sound Skolem
-least-witness encoding (PR #126): `min over each j: T, G | j` with
-`T ∈ {Nat, Nat0, Int}` compiles to a fresh Int constant `r` together with
-`(and <type-bound[r]> G(r))` and a `(forall ((j Int)) (=> (and …
-(< j r) G(j)) false))` "no smaller witness" assertion. End-to-end
-verification of a μ-search result is now in scope; consumers other than
-the μ-search aggregate (`#`, `+/*/and/or/max over`, bare `each`,
-membership, subset) still require an explicit upper-bound guard or a
-domain-typed iterator and emit a targeted diagnostic otherwise.
+least-witness encoding (PR #126). On the checker side, `min over each j: T,
+G | j` is supported for integer sorts `T ∈ {Nat, Nat0, Int}`, compiling to
+a fresh Int constant `r` together with `(and <type-bound[r]> G(r))` and a
+`(forall ((j Int)) (=> (and … (< j r) G(j)) false))` "no smaller witness"
+assertion. ts2pant itself only has `IntStrategy` and `RealStrategy` (there
+is no `NatStrategy`), so the translator-emitted μ-search form uses `Int`
+in practice; the checker's `Nat`/`Nat0` support is exercised by hand-written
+specs rather than ts2pant output. End-to-end verification of a μ-search
+result is now in scope; consumers other than the μ-search aggregate (`#`,
+`+/*/and/or/max over`, bare `each`, membership, subset) still require an
+explicit upper-bound guard or a domain-typed iterator and emit a targeted
+diagnostic otherwise.
 
 ## PR #84 Post-Mortem: Why Standard Algorithms Matter
 

--- a/tools/ts2pant/CLAUDE.md
+++ b/tools/ts2pant/CLAUDE.md
@@ -95,6 +95,25 @@ c2 => e2, true => e3`. Process the statement list **bottom-up**: the final `retu
 is the base case; each `if (c) return e` becomes one arm of a conditional whose
 else-branch is the translation of remaining statements.
 
+**Pure-path scope.** `extractReturnExpression`'s prelude scan accepts a
+`recognizeEarlyReturnArm` shape — `if (P) return E;` with no `else` and a body
+that is exactly one return-with-expression — at any position before the
+terminal statement, interleaved with const bindings and recognized μ-search
+pairs. Each arm's predicate and value are translated under the scope visible
+at its position (so they see prior bindings via hygienic `$N` substitution),
+accumulated into `inlineConstBindings`'s `arms: [pred, val][]` field, and
+materialized into a single `cond` whose catch-all is the terminal expression.
+The if-with-else terminal-position handler is unchanged — it remains the
+target for *complete-dispatch* `if/else` returning from both branches.
+
+Constraints (mirrored by `extractReturnFromBranch` for terminal-position
+branches): no else, single-return body, side-effect-free predicate and value,
+TDZ-clean (no reference to bindings declared after the arm). Arms combined
+with a record-typed return are not yet supported — per-field `cond`
+decomposition would require every arm value to be an object literal of the
+same shape, and is left as a follow-on to keep the if-conversion change
+self-contained.
+
 ### Uninterpreted Functions (General Function Calls)
 
 **Standard name:** EUF (Equality with Uninterpreted Functions).
@@ -485,13 +504,15 @@ coordinated with the rest of the document, but locally collision-safe:
 `new Set(scopedParams.values())` so the fresh binder cannot alias any
 Pant name already bound in the current frame.
 
-**SMT note.** `pant` type-checks the emitted form, but `pant --check`
-currently rejects an `each j: Int | …` (or `Nat`) with "comprehension
-parameter must be a domain type" — the SMT backend only enumerates
-user-defined domains, not unbounded integers. End-to-end SMT verification
-of a μ-search result therefore needs either an explicit upper-bound guard
-or backend support for bounded integer enumeration, neither of which is
-in scope here.
+**SMT note.** `pant --check` accepts the emitted form via a sound Skolem
+least-witness encoding (PR #126): `min over each j: T, G | j` with
+`T ∈ {Nat, Nat0, Int}` compiles to a fresh Int constant `r` together with
+`(and <type-bound[r]> G(r))` and a `(forall ((j Int)) (=> (and …
+(< j r) G(j)) false))` "no smaller witness" assertion. End-to-end
+verification of a μ-search result is now in scope; consumers other than
+the μ-search aggregate (`#`, `+/*/and/or/max over`, bare `each`,
+membership, subset) still require an explicit upper-bound guard or a
+domain-typed iterator and emit a targeted diagnostic otherwise.
 
 ## PR #84 Post-Mortem: Why Standard Algorithms Matter
 

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -91,7 +91,17 @@ function isNullableTsType(type: ts.Type): boolean {
  */
 type ConstBinding =
   | { kind: "const"; tsName: string; initializer: ts.Expression }
-  | { kind: "muSearch"; tsName: string; mu: MuSearch };
+  | { kind: "muSearch"; tsName: string; mu: MuSearch }
+  | {
+      kind: "earlyReturn";
+      predicateExpr: ts.Expression;
+      valueExpr: ts.Expression;
+    };
+
+/** Names a binding introduces into scope (none for an early-return arm). */
+function bindingNames(b: ConstBinding): readonly string[] {
+  return b.kind === "earlyReturn" ? [] : [b.tsName];
+}
 
 interface MuSearch {
   counterName: string;
@@ -1293,6 +1303,21 @@ function translatePureBody(
     ts.isExpression(extracted.returnExpr) &&
     ts.isObjectLiteralExpression(extracted.returnExpr)
   ) {
+    if (inlined.arms.length > 0) {
+      // Record return + early-return arms would need per-field cond
+      // decomposition (each f_i emits `f_i (...) = cond P_k => f_i E_k, …,
+      // true => f_i terminal`), which requires every arm value to also be
+      // an object literal of the same shape. Out of scope for the initial
+      // if-conversion generalization — punt with a targeted message.
+      return [
+        {
+          kind: "unsupported",
+          reason:
+            `${functionName} — early-return arms combined with record ` +
+            `return are not yet supported`,
+        },
+      ];
+    }
     return translateRecordReturn(
       extracted.returnExpr,
       functionName,
@@ -1320,7 +1345,15 @@ function translatePureBody(
     return [{ kind: "unsupported", reason: body.unsupported }];
   }
 
-  const rhs = inlined.applyTo(bodyExpr(body));
+  const terminal = bodyExpr(body);
+  const merged =
+    inlined.arms.length === 0
+      ? terminal
+      : ast.cond([
+          ...inlined.arms.map(([g, v]) => [g, v] as [OpaqueExpr, OpaqueExpr]),
+          [ast.litBool(true), terminal] as [OpaqueExpr, OpaqueExpr],
+        ]);
+  const rhs = inlined.applyTo(merged);
 
   const argExprs = params.map((p) => ast.var(p.name));
   const lhs = ast.app(ast.var(functionName), argExprs);
@@ -1522,6 +1555,44 @@ function recognizeMuSearch(
   };
 }
 
+/**
+ * Recognize a prelude *early-return arm*: an `IfStatement` whose body is
+ * exactly one return-with-expression and which has no `else` clause. Such a
+ * statement contributes one arm `(predicate, returnValue)` to a synthetic
+ * `cond` that wraps the rest of the function body — the standard
+ * if-conversion of an early-exit guard (Allen et al. POPL 1983).
+ *
+ * Mirrors the body-shape constraint of `extractReturnFromBranch` so that
+ * prelude-position and terminal-position if-conversion accept the same
+ * branch shapes. An if with an `else` falls through to the existing
+ * terminal-position handling unchanged.
+ */
+function recognizeEarlyReturnArm(
+  stmt: ts.Statement,
+): { predicateExpr: ts.Expression; valueExpr: ts.Expression } | null {
+  if (!ts.isIfStatement(stmt)) {
+    return null;
+  }
+  if (stmt.elseStatement) {
+    return null;
+  }
+  const body = stmt.thenStatement;
+  let returnStmt: ts.Statement | null = null;
+  if (ts.isReturnStatement(body)) {
+    returnStmt = body;
+  } else if (ts.isBlock(body) && body.statements.length === 1) {
+    returnStmt = body.statements[0]!;
+  }
+  if (
+    !returnStmt ||
+    !ts.isReturnStatement(returnStmt) ||
+    !returnStmt.expression
+  ) {
+    return null;
+  }
+  return { predicateExpr: stmt.expression, valueExpr: returnStmt.expression };
+}
+
 function extractReturnExpression(
   body: ts.Block,
   checker: ts.TypeChecker,
@@ -1546,6 +1617,13 @@ function extractReturnExpression(
     if (mu) {
       bindings.push({ kind: "muSearch", tsName: mu.counterName, mu });
       i += 2;
+      continue;
+    }
+
+    const arm = recognizeEarlyReturnArm(stmts[i]!);
+    if (arm) {
+      bindings.push({ kind: "earlyReturn", ...arm });
+      i += 1;
       continue;
     }
 
@@ -1591,22 +1669,39 @@ function describeRejectedBody(body: ts.Block, checker: ts.TypeChecker): string {
     return "empty body";
   }
   if (stmts.length > 1) {
-    // `let counter = INIT; while (...) { ... }` that failed `recognizeMuSearch`
-    // — typically a compound while body. Report a μ-search-specific
-    // reason before the generic let/var rejection fires.
-    for (let i = 0; i < stmts.length - 1; i++) {
-      const a = stmts[i]!;
-      const b = stmts[i + 1]!;
+    const lastIdx = stmts.length - 1;
+    // Walk the prelude with the same recognizers `extractReturnExpression`
+    // uses, so the reported reason matches the first pattern that actually
+    // failed rather than a heuristic guess.
+    let i = 0;
+    while (i < lastIdx) {
+      if (recognizeMuSearch(stmts, i, checker)) {
+        i += 2;
+        continue;
+      }
+      const stmt = stmts[i]!;
+      if (recognizeEarlyReturnArm(stmt)) {
+        i += 1;
+        continue;
+      }
+      // An if-shaped statement that didn't match recognizeEarlyReturnArm:
+      // diagnose precisely.
+      if (ts.isIfStatement(stmt)) {
+        if (stmt.elseStatement) {
+          return "if-with-else only supported as the final statement";
+        }
+        return "if-with-return body must be a single return statement";
+      }
+      // A let; while pair where recognizeMuSearch failed — probably a
+      // compound while body or non-`i++` body.
       if (
-        ts.isVariableStatement(a) &&
-        a.declarationList.flags & ts.NodeFlags.Let &&
-        ts.isWhileStatement(b)
+        ts.isVariableStatement(stmt) &&
+        stmt.declarationList.flags & ts.NodeFlags.Let &&
+        i + 1 < stmts.length &&
+        ts.isWhileStatement(stmts[i + 1]!)
       ) {
         return "unsupported while-loop shape (not a recognized μ-search)";
       }
-    }
-    // Check for specific rejection reasons in leading statements
-    for (const stmt of stmts) {
       if (ts.isVariableStatement(stmt)) {
         const declList = stmt.declarationList;
         if (!(declList.flags & ts.NodeFlags.Const)) {
@@ -1621,6 +1716,22 @@ function describeRejectedBody(body: ts.Block, checker: ts.TypeChecker): string {
           }
         }
       }
+      if (ts.isExpressionStatement(stmt)) {
+        return "expression statement before return (only const / μ-search / if-early-return allowed)";
+      }
+      return "local bindings or multiple statements before return";
+    }
+    // Prelude scanned cleanly — the rejection must be at the terminal
+    // statement (e.g., trailing if without else, or non-return).
+    const last = stmts[lastIdx]!;
+    if (ts.isIfStatement(last) && !last.elseStatement) {
+      return "if-without-else as final statement (use `if (P) return E` for early-return arms or add an else branch)";
+    }
+    if (!ts.isReturnStatement(last)) {
+      return "final statement must be a return";
+    }
+    if (!last.expression) {
+      return "return without expression";
     }
     return "local bindings or multiple statements before return";
   }
@@ -1654,6 +1765,7 @@ function inlineConstBindings(
   | {
       applyTo: (expr: OpaqueExpr) => OpaqueExpr;
       scopedParams: ReadonlyMap<string, string>;
+      arms: ReadonlyArray<readonly [OpaqueExpr, OpaqueExpr]>;
     }
   | { error: string } {
   const ast = getAst();
@@ -1668,12 +1780,14 @@ function inlineConstBindings(
   // so without this screen a loop like `while (used.has(i++)) i++;`
   // would lower to a Pant expression containing a bogus var `"i++"`.
   for (const [idx, binding] of bindings.entries()) {
-    const blockedNames = new Set(bindings.slice(idx).map((b) => b.tsName));
+    const blockedNames = new Set(
+      bindings.slice(idx).flatMap((b) => bindingNames(b) as string[]),
+    );
     if (binding.kind === "const") {
       if (expressionReferencesNames(binding.initializer, blockedNames)) {
         return { error: "const initializer references a later binding" };
       }
-    } else {
+    } else if (binding.kind === "muSearch") {
       if (expressionHasSideEffects(binding.mu.initTsExpr, checker)) {
         return { error: "while-loop init has side effects" };
       }
@@ -1688,13 +1802,34 @@ function inlineConstBindings(
       if (expressionReferencesNames(binding.mu.predicateTsExpr, predBlocked)) {
         return { error: "while-loop predicate references a later binding" };
       }
+    } else {
+      // earlyReturn arm — predicate and value must be pure and may not refer
+      // to bindings declared after this point. The arm itself binds nothing,
+      // so `blockedNames` here just contains the names of later const /
+      // μ-search bindings (earlyReturn entries contribute nothing).
+      if (expressionHasSideEffects(binding.predicateExpr, checker)) {
+        return { error: "early-return predicate has side effects" };
+      }
+      if (expressionHasSideEffects(binding.valueExpr, checker)) {
+        return { error: "early-return value has side effects" };
+      }
+      if (expressionReferencesNames(binding.predicateExpr, blockedNames)) {
+        return { error: "early-return predicate references a later binding" };
+      }
+      if (expressionReferencesNames(binding.valueExpr, blockedNames)) {
+        return { error: "early-return value references a later binding" };
+      }
     }
   }
 
   // Phase 2: translate initializers as a left fold, threading scopedParams
-  // and translatedBindings through the accumulator. Errors short-circuit
-  // subsequent work via the `tag: "error"` discriminant; successful steps
-  // return a fresh map via `withParam` so no `.set`-style mutation remains.
+  // and translatedBindings through the accumulator. Early-return arms are
+  // accumulated alongside (they don't introduce a name, but their predicate
+  // and value are translated under the scope visible at their position so
+  // references to earlier bindings resolve to the correct hygienic `$N`
+  // names). Errors short-circuit subsequent work via the `tag: "error"`
+  // discriminant; successful steps return a fresh map via `withParam` so no
+  // `.set`-style mutation remains.
   type Acc =
     | {
         tag: "ok";
@@ -1703,6 +1838,7 @@ function inlineConstBindings(
           hygienicName: string;
           initExpr: OpaqueExpr;
         }>;
+        arms: ReadonlyArray<readonly [OpaqueExpr, OpaqueExpr]>;
       }
     | { tag: "error"; error: string };
 
@@ -1710,6 +1846,36 @@ function inlineConstBindings(
     (acc, binding) => {
       if (acc.tag === "error") {
         return acc;
+      }
+      if (binding.kind === "earlyReturn") {
+        const predRes = translateBindingInit(
+          binding.predicateExpr,
+          checker,
+          strategy,
+          acc.scopedParams,
+          state,
+          supply,
+        );
+        if ("error" in predRes) {
+          return { tag: "error", error: predRes.error };
+        }
+        const valRes = translateBindingInit(
+          binding.valueExpr,
+          checker,
+          strategy,
+          acc.scopedParams,
+          state,
+          supply,
+        );
+        if ("error" in valRes) {
+          return { tag: "error", error: valRes.error };
+        }
+        return {
+          tag: "ok",
+          scopedParams: acc.scopedParams,
+          translatedBindings: acc.translatedBindings,
+          arms: [...acc.arms, [predRes.value, valRes.value] as const],
+        };
       }
       const hygienicName = `$${nextSupply(supply)}`;
       const initExpr =
@@ -1740,9 +1906,10 @@ function inlineConstBindings(
           ...acc.translatedBindings,
           { hygienicName, initExpr: initExpr.value },
         ],
+        arms: acc.arms,
       };
     },
-    { tag: "ok", scopedParams: baseParams, translatedBindings: [] },
+    { tag: "ok", scopedParams: baseParams, translatedBindings: [], arms: [] },
   );
 
   if (folded.tag === "error") {
@@ -1752,7 +1919,7 @@ function inlineConstBindings(
   // Phase 3: right-fold substitution closure. `reduceRight` applies the last
   // binding first so references to earlier bindings inside its init remain
   // unresolved — they get substituted in subsequent iterations.
-  const { scopedParams, translatedBindings } = folded;
+  const { scopedParams, translatedBindings, arms } = folded;
   const applyTo = (expr: OpaqueExpr): OpaqueExpr =>
     translatedBindings.reduceRight(
       (acc, { hygienicName, initExpr }) =>
@@ -1760,7 +1927,7 @@ function inlineConstBindings(
       expr,
     );
 
-  return { applyTo, scopedParams };
+  return { applyTo, scopedParams, arms };
 }
 
 type BindingInitResult = { value: OpaqueExpr } | { error: string };

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -1299,27 +1299,26 @@ function translatePureBody(
   // Pantagruel has no record-constructor syntax — its interfaces are opaque
   // domains exposed only through per-field accessor rules — so this is the
   // natural shape.
-  if (
+  //
+  // Per-field decomposition only handles the canonical "object-literal
+  // terminal with no arms" shape. Object literals in other positions (early-
+  // return arm values, branches of an if/else terminal) would otherwise fall
+  // through to translateBodyExpr's `ast.var(getText())` fallback and emit
+  // garbage Pantagruel — reject those uniformly.
+  const armHasObjLit = extracted.bindings.some(
+    (b) =>
+      b.kind === "earlyReturn" && ts.isObjectLiteralExpression(b.valueExpr),
+  );
+  const terminalIsObjLit =
     ts.isExpression(extracted.returnExpr) &&
-    ts.isObjectLiteralExpression(extracted.returnExpr)
-  ) {
-    if (inlined.arms.length > 0) {
-      // Record return + early-return arms would need per-field cond
-      // decomposition (each f_i emits `f_i (...) = cond P_k => f_i E_k, …,
-      // true => f_i terminal`), which requires every arm value to also be
-      // an object literal of the same shape. Out of scope for the initial
-      // if-conversion generalization — punt with a targeted message.
-      return [
-        {
-          kind: "unsupported",
-          reason:
-            `${functionName} — early-return arms combined with record ` +
-            `return are not yet supported`,
-        },
-      ];
-    }
+    ts.isObjectLiteralExpression(extracted.returnExpr);
+  const terminalIfHasObjLitBranch =
+    ts.isIfStatement(extracted.returnExpr) &&
+    ifTerminalHasObjLitBranch(extracted.returnExpr, checker);
+
+  if (terminalIsObjLit && inlined.arms.length === 0) {
     return translateRecordReturn(
-      extracted.returnExpr,
+      extracted.returnExpr as ts.ObjectLiteralExpression,
       functionName,
       params,
       node,
@@ -1330,6 +1329,17 @@ function translatePureBody(
       synthCell,
       inlined.applyTo,
     );
+  }
+
+  if (terminalIsObjLit || armHasObjLit || terminalIfHasObjLitBranch) {
+    return [
+      {
+        kind: "unsupported",
+        reason:
+          `${functionName} — record return combined with early-return ` +
+          `arms or if/else branches is not yet supported`,
+      },
+    ];
   }
 
   const body = translateBodyExpr(
@@ -1738,6 +1748,13 @@ function describeRejectedBody(body: ts.Block, checker: ts.TypeChecker): string {
   const stmt = stmts[0]!;
   if (ts.isReturnStatement(stmt) && !stmt.expression) {
     return "return without expression";
+  }
+  if (
+    ts.isIfStatement(stmt) &&
+    !stmt.elseStatement &&
+    recognizeEarlyReturnArm(stmt) !== null
+  ) {
+    return "if-without-else as final statement (use `if (P) return E` for early-return arms or add an else branch)";
   }
   return "non-translatable control flow";
 }
@@ -2766,6 +2783,26 @@ function extractReturnFromBranch(
     }
   }
   return null;
+}
+
+function ifTerminalHasObjLitBranch(
+  stmt: ts.IfStatement,
+  checker: ts.TypeChecker,
+): boolean {
+  const branchHasObjLit = (branch: ts.Statement): boolean => {
+    const ret = extractReturnFromBranch(branch, checker);
+    return ret !== null && ts.isObjectLiteralExpression(ret);
+  };
+  if (branchHasObjLit(stmt.thenStatement)) {
+    return true;
+  }
+  if (!stmt.elseStatement) {
+    return false;
+  }
+  if (ts.isIfStatement(stmt.elseStatement)) {
+    return ifTerminalHasObjLitBranch(stmt.elseStatement, checker);
+  }
+  return branchHasObjLit(stmt.elseStatement);
 }
 
 /** Get element type name for an array-typed TS expression, or null. */

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -206,6 +206,30 @@ exports[`expressions-const-pure-calls.ts > constStringMethod 1`] = `
 "module ConstStringMethod.\\n\\nconst-string-method s: String => Int.\\n\\n---\\n\\nconst-string-method s = index-of s \\"x\\".\\n"
 `;
 
+exports[`expressions-if-early-return.ts > armBetweenBindings 1`] = `
+"module ArmBetweenBindings.\\n\\narm-between-bindings n: Int => Int.\\n\\n---\\n\\narm-between-bindings n = (cond n + 1 < 0 => 0, true => n + 1 + (n + 1)).\\n"
+`;
+
+exports[`expressions-if-early-return.ts > armThenMuSearch 1`] = `
+"module ArmThenMuSearch.\\n\\narm-then-mu-search n: Int, used: [Int] => Int.\\n\\n---\\n\\narm-then-mu-search n used = (cond n < 0 => 0, true => (min over each j: Int, j >= 1, ~(j in used) | j)).\\n"
+`;
+
+exports[`expressions-if-early-return.ts > bindingThenArm 1`] = `
+"module BindingThenArm.\\n\\nbinding-then-arm n: Int => Int.\\n\\n---\\n\\nbinding-then-arm n = (cond n + n < 0 => 0, true => n + n).\\n"
+`;
+
+exports[`expressions-if-early-return.ts > singleArm 1`] = `
+"module SingleArm.\\n\\nsingle-arm n: Int => Int.\\n\\n---\\n\\nsingle-arm n = (cond n < 0 => 0, true => n + 1).\\n"
+`;
+
+exports[`expressions-if-early-return.ts > twoArms 1`] = `
+"module TwoArms.\\n\\ntwo-arms n: Int => Int.\\n\\n---\\n\\ntwo-arms n = (cond n < 0 => -1, n = 0 => 0, true => n + 1).\\n"
+`;
+
+exports[`expressions-if-early-return.ts > unbracedArm 1`] = `
+"module UnbracedArm.\\n\\nunbraced-arm n: Int => Int.\\n\\n---\\n\\nunbraced-arm n = (cond n < 0 => 0, true => n).\\n"
+`;
+
 exports[`expressions-literals.ts > fortyTwo 1`] = `
 "module FortyTwo.\\n\\nforty-two  => Int.\\n\\n---\\n\\nforty-two = 42.\\n"
 `;

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-if-early-return.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-if-early-return.ts
@@ -1,0 +1,47 @@
+// If-early-return generalized to any prelude position.
+// `if (P) return E;` (no else, single-statement return body) becomes one
+// arm of a synthetic cond whose catch-all is the rest of the body.
+
+/** single arm + terminal */
+export function singleArm(n: number): number {
+  if (n < 0) return 0;
+  return n + 1;
+}
+
+/** const binding before arm — predicate sees prior binding */
+export function bindingThenArm(n: number): number {
+  const doubled = n + n;
+  if (doubled < 0) return 0;
+  return doubled;
+}
+
+/** arm between bindings — terminal sees both bindings */
+export function armBetweenBindings(n: number): number {
+  const a = n + 1;
+  if (a < 0) return 0;
+  const b = a + a;
+  return b;
+}
+
+/** two arms — first match wins */
+export function twoArms(n: number): number {
+  if (n < 0) return -1;
+  if (n === 0) return 0;
+  return n + 1;
+}
+
+/** arm body uses an unbraced bare return */
+export function unbracedArm(n: number): number {
+  if (n < 0) return 0;
+  return n;
+}
+
+/** μ-search after early-return arm */
+export function armThenMuSearch(n: number, used: ReadonlySet<number>): number {
+  if (n < 0) return 0;
+  let j = 1;
+  while (used.has(j)) {
+    j++;
+  }
+  return j;
+}

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -389,8 +389,79 @@ describe("if-early-return prelude arms", () => {
     if (props[0]?.kind === "unsupported") {
       assert.match(
         props[0].reason,
-        /early-return arms combined with record return/u,
+        /record return combined with early-return arms or if\/else branches/u,
       );
+    }
+  });
+
+  it("rejects record-shaped arm value with non-literal terminal", () => {
+    const source = `
+      interface Pair { a: number; b: number }
+      declare function makePair(n: number): Pair;
+      export function f(n: number): Pair {
+        if (n < 0) return { a: 0, b: 0 };
+        return makePair(n);
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "f",
+      strategy: IntStrategy,
+    });
+    assert.equal(props.length, 1);
+    assert.equal(props[0]?.kind, "unsupported");
+    if (props[0]?.kind === "unsupported") {
+      assert.match(
+        props[0].reason,
+        /record return combined with early-return arms or if\/else branches/u,
+      );
+    }
+  });
+
+  it("rejects record-shaped if/else terminal branches", () => {
+    const source = `
+      interface Pair { a: number; b: number }
+      export function f(n: number): Pair {
+        if (n < 0) {
+          return { a: 0, b: 0 };
+        } else {
+          return { a: n, b: n + 1 };
+        }
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "f",
+      strategy: IntStrategy,
+    });
+    assert.equal(props.length, 1);
+    assert.equal(props[0]?.kind, "unsupported");
+    if (props[0]?.kind === "unsupported") {
+      assert.match(
+        props[0].reason,
+        /record return combined with early-return arms or if\/else branches/u,
+      );
+    }
+  });
+
+  it("emits trailing-if diagnostic for single `if (P) return E;` body", () => {
+    const source = `
+      export function f(n: number): number {
+        if (n < 0) return 0;
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "f",
+      strategy: IntStrategy,
+    });
+    assert.equal(props.length, 1);
+    assert.equal(props[0]?.kind, "unsupported");
+    if (props[0]?.kind === "unsupported") {
+      assert.match(props[0].reason, /if-without-else as final statement/u);
     }
   });
 });

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -178,6 +178,219 @@ describe("unsupported patterns", () => {
   });
 });
 
+describe("if-early-return prelude arms", () => {
+  it("translates a single early-return arm followed by a return", () => {
+    const source = `
+      export function f(n: number): number {
+        if (n < 0) return 0;
+        return n + 1;
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "f",
+      strategy: IntStrategy,
+    });
+    assert.equal(props.length, 1);
+    const prop = props[0]!;
+    assert.equal(prop.kind, "equation");
+    if (prop.kind === "equation") {
+      const ast = getAst();
+      assert.equal(ast.strExpr(prop.rhs), "cond n < 0 => 0, true => n + 1");
+    }
+  });
+
+  it("threads const bindings through both the arm and the catch-all", () => {
+    const source = `
+      export function f(n: number): number {
+        const doubled = n + n;
+        if (doubled < 0) return 0;
+        return doubled;
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "f",
+      strategy: IntStrategy,
+    });
+    const prop = props[0]!;
+    assert.equal(prop.kind, "equation");
+    if (prop.kind === "equation") {
+      const ast = getAst();
+      assert.equal(
+        ast.strExpr(prop.rhs),
+        "cond n + n < 0 => 0, true => n + n",
+      );
+    }
+  });
+
+  it("supports an arm between two const bindings", () => {
+    const source = `
+      export function f(n: number): number {
+        const a = n + 1;
+        if (a < 0) return 0;
+        const b = a + a;
+        return b;
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "f",
+      strategy: IntStrategy,
+    });
+    const prop = props[0]!;
+    assert.equal(prop.kind, "equation");
+    if (prop.kind === "equation") {
+      const ast = getAst();
+      assert.equal(
+        ast.strExpr(prop.rhs),
+        "cond n + 1 < 0 => 0, true => n + 1 + (n + 1)",
+      );
+    }
+  });
+
+  it("supports multiple arms — first match wins", () => {
+    const source = `
+      export function f(n: number): number {
+        if (n < 0) return -1;
+        if (n === 0) return 0;
+        return n + 1;
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "f",
+      strategy: IntStrategy,
+    });
+    const prop = props[0]!;
+    assert.equal(prop.kind, "equation");
+    if (prop.kind === "equation") {
+      const ast = getAst();
+      assert.equal(
+        ast.strExpr(prop.rhs),
+        "cond n < 0 => -1, n = 0 => 0, true => n + 1",
+      );
+    }
+  });
+
+  it("composes arms with a μ-search prelude", () => {
+    const source = `
+      export function f(n: number, used: ReadonlySet<number>): number {
+        if (n < 0) return 0;
+        let j = 1;
+        while (used.has(j)) { j++; }
+        return j;
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "f",
+      strategy: IntStrategy,
+    });
+    const prop = props[0]!;
+    assert.equal(prop.kind, "equation");
+    if (prop.kind === "equation") {
+      const ast = getAst();
+      assert.match(ast.strExpr(prop.rhs), /^cond n < 0 => 0, true => /u);
+      assert.match(ast.strExpr(prop.rhs), /min over each j\d*: Int/u);
+    }
+  });
+
+  it("rejects an if-with-multi-statement body in prelude position", () => {
+    const source = `
+      export function f(n: number): number {
+        if (n < 0) {
+          const x = 1;
+          return x;
+        }
+        return n;
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "f",
+      strategy: IntStrategy,
+    });
+    assert.equal(props.length, 1);
+    assert.equal(props[0]?.kind, "unsupported");
+    if (props[0]?.kind === "unsupported") {
+      assert.match(props[0].reason, /single return statement/u);
+    }
+  });
+
+  it("rejects an if-with-else in non-final position", () => {
+    const source = `
+      export function f(n: number): number {
+        if (n < 0) {
+          return 0;
+        } else {
+          return -n;
+        }
+        return n;
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "f",
+      strategy: IntStrategy,
+    });
+    assert.equal(props.length, 1);
+    assert.equal(props[0]?.kind, "unsupported");
+    if (props[0]?.kind === "unsupported") {
+      assert.match(props[0].reason, /if-with-else only supported as the final/u);
+    }
+  });
+
+  it("rejects an arm whose value references a later binding (TDZ)", () => {
+    const source = `
+      export function f(n: number): number {
+        if (n < 0) return later;
+        const later = n + 1;
+        return later;
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "f",
+      strategy: IntStrategy,
+    });
+    assert.equal(props.length, 1);
+    assert.equal(props[0]?.kind, "unsupported");
+  });
+
+  it("rejects early-return + record return (per-field cond decomposition not yet supported)", () => {
+    const source = `
+      interface Pair { a: number; b: number }
+      export function f(n: number): Pair {
+        if (n < 0) return { a: 0, b: 0 };
+        return { a: n, b: n + 1 };
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "f",
+      strategy: IntStrategy,
+    });
+    assert.equal(props.length, 1);
+    assert.equal(props[0]?.kind, "unsupported");
+    if (props[0]?.kind === "unsupported") {
+      assert.match(
+        props[0].reason,
+        /early-return arms combined with record return/u,
+      );
+    }
+  });
+});
+
 describe("translateCallExpr", () => {
   it("should translate free function call as uninterpreted application", () => {
     const source = `

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -215,6 +215,7 @@ describe("if-early-return prelude arms", () => {
       functionName: "f",
       strategy: IntStrategy,
     });
+    assert.equal(props.length, 1);
     const prop = props[0]!;
     assert.equal(prop.kind, "equation");
     if (prop.kind === "equation") {
@@ -241,6 +242,7 @@ describe("if-early-return prelude arms", () => {
       functionName: "f",
       strategy: IntStrategy,
     });
+    assert.equal(props.length, 1);
     const prop = props[0]!;
     assert.equal(prop.kind, "equation");
     if (prop.kind === "equation") {
@@ -266,6 +268,7 @@ describe("if-early-return prelude arms", () => {
       functionName: "f",
       strategy: IntStrategy,
     });
+    assert.equal(props.length, 1);
     const prop = props[0]!;
     assert.equal(prop.kind, "equation");
     if (prop.kind === "equation") {
@@ -292,6 +295,7 @@ describe("if-early-return prelude arms", () => {
       functionName: "f",
       strategy: IntStrategy,
     });
+    assert.equal(props.length, 1);
     const prop = props[0]!;
     assert.equal(prop.kind, "equation");
     if (prop.kind === "equation") {


### PR DESCRIPTION
## Summary

- The pure-body extractor now accepts `if (P) return E;` (no else, single-statement return body) at any prelude position, not just as the final statement. This is the standard if-conversion algorithm (Allen et al. POPL 1983; Flanagan et al. PLDI 1993). The mutating path already had non-final `if (g) return;` support via `symbolicExecute`; the pure path now matches.
- Each arm becomes one `cond` arm with the rest of the body as the catch-all: `cond P1 => E1, …, true => terminal`. Arms interleave with `const` bindings and recognized μ-search pairs; predicate and value see prior bindings via the existing hygienic `\$N` substitution closure.
- `describeRejectedBody` now walks the prelude with the same recognizers `extractReturnExpression` uses, so the reported reason matches the first pattern that actually failed (targeted messages for if-with-else-in-prelude, multi-statement if-body, expression-statement-before-return, trailing if-without-else) instead of the previous heuristic guess.
- Probing `registerName` (the named dogfood target) now reports the actual next blocker — `if-with-return body must be a single return statement` — rather than the misleading \"unsupported while-loop shape\" diagnostic.

## Implementation

- New `earlyReturn` variant on `ConstBinding` carrying predicate and value TS expressions. The arm introduces no new name, so it threads through `inlineConstBindings` without touching `scopedParams`.
- `extractReturnExpression` adds a third match in the prelude scan, before the const/μ-search/let-while triage.
- `inlineConstBindings` accumulates arm `[pred, val]` pairs through phase 2 (each translated under the scope visible at its position) and returns them via a new `arms` field. Phase 3's right-fold substitution closure is unchanged — applied once to the assembled `cond`.
- `translatePureBody` builds the final RHS as `cond P1 => E1, …, Pn => En, true => terminal` when arms are present. Existing if-statement-as-final-expression handling stays in `translateIfStatement` untouched.

## Known limitation

Early-return arms combined with a record-typed return are rejected with a targeted diagnostic. Per-field `cond` decomposition would require every arm value to be an object literal of the same shape — left for a follow-on to keep this change self-contained.

## CLAUDE.md

- \"If-Conversion\" section documents the generalized prelude scan and constraints.
- \"Kleene Minimization → SMT note\" corrected: μ-search is verifiable end-to-end via #126.

## Test plan

- [x] 6 new fixture cases in `expressions-if-early-return.ts` (single arm, binding-then-arm, arm-between-bindings, two arms, unbraced arm, arm + μ-search) — all snapshot and pant-typecheck.
- [x] 9 unit tests in `translate-body.test.mts` covering positive cases, μ-search composition, multi-arm, TDZ, multi-stmt body rejection, if-with-else mid-body rejection, and the rejected record-return combination.
- [x] 389/389 ts2pant tests pass (was 374); 16/16 core repo suites unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)