### PR TITLE
ts2pant: M1 — imperative IR + conditional normalization

### DIFF
--- a/tools/ts2pant/CLAUDE.md
+++ b/tools/ts2pant/CLAUDE.md
@@ -642,12 +642,10 @@ canonicalized receiver), not program-variable names. Three reasons:
 | 3 | Nullish coalescing `??` → `Cond` | ✅ landed |
 | 4 | μ-search → `Comb(min, Each)` | partial — substitution mechanism is on IR (Stage 6); the comprehension construction itself is still in `translateMuSearchInit` (legacy OpaqueExpr) and migrates to native `Comb(min, Each)` in a future stage |
 | 5 | `.length` / `.size` → `Unop(card, x)` | ✅ landed |
-| 6 | Const-binding inlining → `Let` (pure path) | ✅ landed (mutating-path const-bindings stay on legacy `applyTo` until Stage 9) |
+| 6 | Const-binding inlining → `Let` (pure path) | ✅ landed (mutating-path const-bindings stay on legacy `applyTo` until workstream M3) |
 | 7 | Chain fusion → `Each` composition | ✅ tracked via IRWrap (anchors locked); native IR construction deferred — see "Note on chain fusion" below |
 | 8 | Pure-path cutover — delete legacy code where possible (IRWrap survives for chain-fusion outputs) | pending |
-| 9 | Mutating-path SSA: write-keyed `LetIf`, `Write` IR nodes | pending |
-| 10 | Frame conditions → IR pass | pending |
-| 11 | Mutating-path cutover, final cleanup | pending |
+| 9–11 | **Superseded** by `workstreams/ts2pant-imperative-ir.md` — mutating-path SSA, frame conditions, and final cutover re-form on top of an IRSC-faithful imperative IR layer (Layer 1) with normalization passes. See workstream M1 (conditionals), M2 (assign + μ-search), M3 (iteration + mutation). | superseded |
 
 The `--use-ir` flag (env var `TS2PANT_USE_IR=1`) routes the pure path through
 the IR pipeline. Default off until Stage 8 cutover. Per-stage gate is the
@@ -667,7 +665,26 @@ inspection in legacy would translate to ~200 lines of mechanical
 duplication producing identical output — the architectural payoff is
 only at Stage 8 cutover (deleting the legacy code). We keep `IRWrap`
 in place for chain-fusion outputs through Stage 8 and reconsider once
-the mutating-path migration (Stage 9) settles the IR shape.
+the mutating-path work (workstream M3) settles the Layer 1 → Layer 2
+lowering shape.
+
+### Imperative IR Workstream (supersedes Stages 9–11)
+
+After Stage 8, ts2pant moves to a layered architecture: **Layer 1** is a
+TS-faithful imperative IR (`Block`, `Cond`, `Foreach`, `Assign`, `For`,
+`While`, `Return`, …) where normalization passes collapse syntactic
+equivalences (increment spellings, conditional families, iteration
+families) into a small canonical vocabulary. **Layer 2** is today's
+`IRExpr`/`IRStmt` (Pant-shaped expression IR). **Layer 3** is `OpaqueExpr`.
+Lowering goes Layer 1 → Layer 2 → Layer 3.
+
+The full milestone breakdown — vocabulary lock at M1, conditionals (M1),
+assign + μ-search (M2), iteration + mutation (M3, where the former Stages
+9–11 land), deferred classes (M4 equality/nullish, M5 property access),
+cleanup (M6) — lives in `workstreams/ts2pant-imperative-ir.md`. Decisions
+on canonical forms, conservative-refusal policy, hard-rule-per-class
+migration, and the `Foreach`-with-statement-body rationale are recorded
+there.
 
 ## PR #84 Post-Mortem: Why Standard Algorithms Matter
 

--- a/tools/ts2pant/CLAUDE.md
+++ b/tools/ts2pant/CLAUDE.md
@@ -670,21 +670,67 @@ lowering shape.
 
 ### Imperative IR Workstream (supersedes Stages 9–11)
 
-After Stage 8, ts2pant moves to a layered architecture: **Layer 1** is a
-TS-faithful imperative IR (`Block`, `Cond`, `Foreach`, `Assign`, `For`,
-`While`, `Return`, …) where normalization passes collapse syntactic
-equivalences (increment spellings, conditional families, iteration
-families) into a small canonical vocabulary. **Layer 2** is today's
-`IRExpr`/`IRStmt` (Pant-shaped expression IR). **Layer 3** is `OpaqueExpr`.
-Lowering goes Layer 1 → Layer 2 → Layer 3.
+ts2pant has a layered architecture: **Layer 1** is a TS-faithful imperative
+IR (`Block`, `Cond`, `Foreach`, `Assign`, `For`, `While`, `Return`, …) in
+`src/ir1.ts` where normalization passes collapse syntactic equivalences
+(increment spellings, conditional families, iteration families) into a
+small canonical vocabulary. **Layer 2** is today's `IRExpr`/`IRStmt` in
+`src/ir.ts` (Pant-shaped expression IR). **Layer 3** is `OpaqueExpr`.
+Lowering: TS AST → Layer 1 (`ir1-build.ts`) → Layer 2 (`ir1-lower.ts`) →
+OpaqueExpr (`ir-emit.ts`).
 
-The full milestone breakdown — vocabulary lock at M1, conditionals (M1),
-assign + μ-search (M2), iteration + mutation (M3, where the former Stages
-9–11 land), deferred classes (M4 equality/nullish, M5 property access),
-cleanup (M6) — lives in `workstreams/ts2pant-imperative-ir.md`. Decisions
-on canonical forms, conservative-refusal policy, hard-rule-per-class
-migration, and the `Foreach`-with-statement-body rationale are recorded
-there.
+The full milestone breakdown lives in
+`workstreams/ts2pant-imperative-ir.md`. Decisions on canonical forms,
+conservative-refusal policy, hard-rule-per-class migration, and the
+`Foreach`-with-statement-body rationale are recorded there.
+
+**M1 (imperative-ir-conditionals): landed.** Conditional value forms —
+if-with-returns (single, two-branch, multi-arm chain), ternary chains
+(right-associative flatten), switch without fall-through, `&&`/`||` when
+both operands are statically Bool-typed — all collapse to a single
+canonical `Cond([(g, v)], otherwise)`. The L1 path is always-on; the
+legacy `translateIfStatement` and inline ternary handler are deleted.
+Switch was previously fully unsupported; it now translates with the
+caveat that every case must end in `return EXPR`, default is required
+and last, and case labels must be literal. `&&`/`||` Bool-type detection
+is in `purity.ts:isStaticallyBoolTyped` (apparent-type walk requiring
+every union/intersection constituent to satisfy `BooleanLike`).
+
+**The `from-l2` adapter** (`ir1.ts`'s `IR1Expr.from-l2`) is the explicit
+transitional mechanism for sub-expressions whose normalization is not
+the current milestone's concern (e.g., guard expressions inside an L1
+conditional — their internal structure is M2/M3 territory). The adapter
+wraps a pre-built Layer 2 `IRExpr` and lowers verbatim. Lifetime:
+shrinks at M3 (more sub-expressions reach L1 natively); deleted at M6.
+Do not introduce new uses outside the build pipeline's scoped
+sub-expression delegation.
+
+**Locked decisions** (re-litigation requires explicit user sign-off):
+- Layer 1 vocabulary is locked at M1. Forms can be added in later
+  milestones (e.g., `IsNullish` primitive at M4) but the existing forms
+  cannot be changed. Forms unused in M1 (`assign`, `foreach`, `for`,
+  `while`, `throw`, `expr-stmt`, statement-position `cond-stmt`) are
+  declared at the type level; their constructors throw
+  `not-implemented` until the milestone that introduces them lands.
+- **No `IR1Wrap` form.** Layer 1 is not an escape-hatch layer — the
+  build pass either produces L1 or rejects with `unsupported`. The
+  `from-l2` form is *not* a wrap-anything escape hatch; it's a scoped
+  delegation point with a defined lifetime.
+- **Conservative-refusal policy 3(b).** When the build pass cannot prove
+  an equivalence (switch fall-through, `==`-on-non-Bool, default-not-last,
+  non-Bool short-circuit, non-literal switch case label, object-literal
+  in a value-position arm), the function rejects with a specific
+  `unsupported` reason rather than emitting potentially-incorrect Pant.
+- **Hard rule per equivalence class** (workstream decision 4): every
+  TS construct in a given equivalence class moves to the L1 path in
+  one milestone. Half-migrated classes coexisting with legacy
+  recognizers are forbidden — that is the cross-talk hazard the IR is
+  meant to retire.
+- **Mutation lands with iteration in M3.** `Foreach` body must be a
+  *statement* admitting `Assign` to support Shape A (uniform iterator
+  write), Shape B (accumulator fold), and `.reduce` desugaring
+  uniformly. The former Stages 9–11 (mutating-path SSA, frame
+  conditions, mutating-path cutover) re-form inside M3.
 
 ## PR #84 Post-Mortem: Why Standard Algorithms Matter
 

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -41,6 +41,7 @@ import type { OpaqueExpr } from "./pant-ast.js";
 import { isStaticallyBoolTyped } from "./purity.js";
 import type { SymbolicState, UniqueSupply } from "./translate-body.js";
 import {
+  bodyExpr,
   expressionHasSideEffects,
   extractReturnFromBranch,
   isBodyUnsupported,
@@ -143,7 +144,10 @@ function buildSubExpr(expr: ts.Expression, ctx: L1BuildContext): L1BuildResult {
       unsupported: "collection mutation cannot appear in a conditional arm",
     };
   }
-  return ir1FromL2(irWrap(result.expr));
+  // Materialize any deferred .filter()/.map() chain into a flat each(...)
+  // before wrapping — using result.expr directly would drop the traversal
+  // and lower the bare projection body instead.
+  return ir1FromL2(irWrap(bodyExpr(result)));
 }
 
 // ---------------------------------------------------------------------------
@@ -465,13 +469,25 @@ function buildCaseLabel(
   label: ts.Expression,
   ctx: L1BuildContext,
 ): L1BuildResult {
+  // TS parses `case -1:` as a PrefixUnaryExpression(MinusToken,
+  // NumericLiteral) — handle it before the bare-NumericLiteral branch
+  // so negative literal labels stay in the supported subset rather
+  // than falling through as "must be a literal".
+  if (
+    ts.isPrefixUnaryExpression(label) &&
+    label.operator === ts.SyntaxKind.MinusToken &&
+    ts.isNumericLiteral(label.operand)
+  ) {
+    const n = Number(label.operand.text);
+    if (Number.isFinite(n) && Number.isInteger(n)) {
+      return ir1Unop("neg", ir1LitNat(n));
+    }
+    return { unsupported: "switch case label: non-integer numeric literal" };
+  }
   if (ts.isNumericLiteral(label)) {
     const n = Number(label.text);
     if (Number.isFinite(n) && Number.isInteger(n) && n >= 0) {
       return ir1LitNat(n);
-    }
-    if (Number.isFinite(n) && Number.isInteger(n) && n < 0) {
-      return ir1Unop("neg", ir1LitNat(-n));
     }
     return { unsupported: "switch case label: non-integer numeric literal" };
   }

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -19,10 +19,8 @@
  * within the workstream — see CLAUDE.md §"Imperative IR".
  *
  * **Hard rule per equivalence class** (workstream decision 4): every
- * conditional-value-shaped TS construct goes through this builder once
- * Patch 3 cuts over. During Patch 2, the path is gated by the
- * `TS2PANT_USE_L1=1` env var so legacy and L1 paths can be compared
- * byte-for-byte.
+ * conditional-value-shaped TS construct goes through this builder. There
+ * is no fall-through to a legacy handler — L1 rejection is terminal.
  */
 
 import ts from "typescript";
@@ -44,6 +42,7 @@ import { isStaticallyBoolTyped } from "./purity.js";
 import type { SymbolicState, UniqueSupply } from "./translate-body.js";
 import {
   expressionHasSideEffects,
+  extractReturnFromBranch,
   isBodyUnsupported,
   translateBodyExpr,
 } from "./translate-body.js";
@@ -321,7 +320,10 @@ function buildFromIfStatement(
     if (isL1Unsupported(guard)) {
       return guard;
     }
-    const thenExpr = extractReturnFromStatement(current.thenStatement);
+    const thenExpr = extractReturnFromBranch(
+      current.thenStatement,
+      ctx.checker,
+    );
     if (!thenExpr) {
       return {
         unsupported: "if-then branch must contain a single return-with-value",
@@ -338,7 +340,10 @@ function buildFromIfStatement(
       current = current.elseStatement;
       continue;
     }
-    const elseExpr = extractReturnFromStatement(current.elseStatement);
+    const elseExpr = extractReturnFromBranch(
+      current.elseStatement,
+      ctx.checker,
+    );
     if (!elseExpr) {
       return {
         unsupported: "if-else branch must contain a single return-with-value",
@@ -358,31 +363,6 @@ function buildFromIfStatement(
       elseValue,
     );
   }
-}
-
-/**
- * Extract `return EXPR` from a then/else branch — accepts either a
- * `ReturnStatement` directly or a `Block` containing exactly one
- * `ReturnStatement` (after filtering throws/asserts, which act as guards
- * but aren't represented in L1 expression position). Mirrors today's
- * `extractReturnFromBranch` in translate-body.ts:2841 but is kept local
- * to ir1-build.ts so the L1 builder doesn't depend on translate-body's
- * internal helpers staying exported.
- *
- * **Rejection of object-literal returns**: handled at `buildSubExpr`
- * (called downstream); not here.
- */
-function extractReturnFromStatement(stmt: ts.Statement): ts.Expression | null {
-  if (ts.isReturnStatement(stmt) && stmt.expression) {
-    return stmt.expression;
-  }
-  if (ts.isBlock(stmt) && stmt.statements.length === 1) {
-    const s = stmt.statements[0]!;
-    if (ts.isReturnStatement(s) && s.expression) {
-      return s.expression;
-    }
-  }
-  return null;
 }
 
 // ---------------------------------------------------------------------------
@@ -540,8 +520,8 @@ function extractCaseReturn(
   if (lastIdx > 0 && stmts[lastIdx]!.kind === ts.SyntaxKind.BreakStatement) {
     lastIdx--;
   }
-  // Also accept `{ return EXPR; }` block.
   const last: ts.Statement = stmts[lastIdx]!;
+  // Accept `{ return EXPR; }` block.
   if (
     ts.isBlock(last) &&
     last.statements.length === 1 &&
@@ -549,9 +529,6 @@ function extractCaseReturn(
     last.statements[0]!.expression
   ) {
     return last.statements[0]!.expression!;
-  }
-  if (lastIdx !== stmts.length - 1 && lastIdx < 0) {
-    return null;
   }
   // Only one effective statement allowed (after trailing-break trim).
   if (lastIdx !== 0) {

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -1,0 +1,595 @@
+/**
+ * TS AST → Layer 1 builder.
+ *
+ * **M1 scope** (workstream M1: imperative-ir-conditionals): conditional
+ * **value** forms only — ternary chains, if-with-returns, switch without
+ * fall-through, `&&`/`||` when both operands are statically Bool-typed.
+ * All collapse to one canonical L1 `cond([(g, v)], otherwise)` form.
+ *
+ * Sub-expressions inside conditionals (the guard, the value, the switch
+ * discriminant) are translated through the legacy `translateBodyExpr`
+ * pipeline and wrapped via the L1 `from-l2` adapter — see `ir1.ts`
+ * for the lifetime contract on that adapter.
+ *
+ * **Conservative-refusal policy 3(b)**: when the build pass cannot prove
+ * an equivalence (switch with possible fall-through, `==`/`===`-mixing
+ * default-not-last, non-Bool short-circuit, non-literal switch case,
+ * object-literal arms in a value-position cond), the function rejects
+ * with an `unsupported` reason. Lifting any of these is a follow-up
+ * within the workstream — see CLAUDE.md §"Imperative IR".
+ *
+ * **Hard rule per equivalence class** (workstream decision 4): every
+ * conditional-value-shaped TS construct goes through this builder once
+ * Patch 3 cuts over. During Patch 2, the path is gated by the
+ * `TS2PANT_USE_L1=1` env var so legacy and L1 paths can be compared
+ * byte-for-byte.
+ */
+
+import ts from "typescript";
+import { irWrap } from "./ir.js";
+import { lowerExpr } from "./ir-emit.js";
+import {
+  type IR1Expr,
+  ir1Binop,
+  ir1Cond,
+  ir1FromL2,
+  ir1LitBool,
+  ir1LitNat,
+  ir1LitString,
+  ir1Unop,
+} from "./ir1.js";
+import { lowerL1Expr } from "./ir1-lower.js";
+import type { OpaqueExpr } from "./pant-ast.js";
+import { isStaticallyBoolTyped } from "./purity.js";
+import type { SymbolicState, UniqueSupply } from "./translate-body.js";
+import {
+  expressionHasSideEffects,
+  isBodyUnsupported,
+  translateBodyExpr,
+} from "./translate-body.js";
+import type { NumericStrategy } from "./translate-types.js";
+
+/**
+ * Context threaded through L1 build. Mirrors the parameter set of
+ * `translateBodyExpr` so sub-expression delegation stays trivial.
+ */
+export interface L1BuildContext {
+  checker: ts.TypeChecker;
+  strategy: NumericStrategy;
+  paramNames: ReadonlyMap<string, string>;
+  state: SymbolicState | undefined;
+  supply: UniqueSupply;
+}
+
+export type L1BuildResult = IR1Expr | { unsupported: string };
+
+export const isL1Unsupported = (
+  r: L1BuildResult,
+): r is { unsupported: string } =>
+  typeof r === "object" && r !== null && "unsupported" in r;
+
+// ---------------------------------------------------------------------------
+// Recognizer entry — is this TS node a conditional shape M1 handles?
+// ---------------------------------------------------------------------------
+
+/**
+ * True when `node` is a conditional **value** form M1 normalizes:
+ * ternary, if-with-returns, switch w/o fall-through, or a Bool-typed
+ * `&&`/`||`. The Bool-type check requires the checker, so the function
+ * takes one as a parameter rather than being purely syntactic.
+ *
+ * `&&`/`||` with a non-Bool operand is *not* a conditional form for M1
+ * — it stays on the legacy translateOperator path (or, post-cutover,
+ * rejects as UNSUPPORTED at the call site).
+ */
+export function isL1ConditionalForm(
+  node: ts.Node,
+  checker: ts.TypeChecker,
+): boolean {
+  if (
+    ts.isConditionalExpression(node) ||
+    ts.isIfStatement(node) ||
+    ts.isSwitchStatement(node)
+  ) {
+    return true;
+  }
+  if (
+    ts.isBinaryExpression(node) &&
+    (node.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken ||
+      node.operatorToken.kind === ts.SyntaxKind.BarBarToken)
+  ) {
+    return (
+      isStaticallyBoolTyped(node.left, checker) &&
+      isStaticallyBoolTyped(node.right, checker)
+    );
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Sub-expression delegation: translate via legacy, wrap into L1 via from-l2
+// ---------------------------------------------------------------------------
+
+/**
+ * Translate a non-conditional sub-expression via the legacy pipeline and
+ * wrap as L1. Used for guards, values, and switch discriminants inside
+ * an L1 conditional during M1 — those positions receive arbitrary TS
+ * expressions whose normalization isn't M1's concern.
+ *
+ * Rejects collection-mutation sub-expressions (the legacy result type
+ * `BodyResult` admits an "effect" variant that's only valid in
+ * statement position; an L1 expression cannot host one).
+ */
+function buildSubExpr(expr: ts.Expression, ctx: L1BuildContext): L1BuildResult {
+  // Object literals don't lower to a Pantagruel value — Pant has no
+  // record-constructor expression syntax. Reject *before* translating
+  // so the error message is precise (legacy translateBodyExpr would
+  // produce garbage instead).
+  if (ts.isObjectLiteralExpression(expr)) {
+    return { unsupported: "object literal in conditional arm" };
+  }
+  const result = translateBodyExpr(
+    expr,
+    ctx.checker,
+    ctx.strategy,
+    ctx.paramNames,
+    ctx.state,
+    ctx.supply,
+  );
+  if (isBodyUnsupported(result)) {
+    return { unsupported: result.unsupported };
+  }
+  if ("effect" in result) {
+    return {
+      unsupported: "collection mutation cannot appear in a conditional arm",
+    };
+  }
+  return ir1FromL2(irWrap(result.expr));
+}
+
+// ---------------------------------------------------------------------------
+// Top-level dispatch
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a Layer 1 value-position conditional from a TS conditional shape.
+ * Dispatches on node kind; rejects with `unsupported` when the form
+ * cannot be canonicalized (per conservative-refusal policy 3(b)).
+ */
+export function buildL1Conditional(
+  expr: ts.Expression | ts.IfStatement | ts.SwitchStatement,
+  ctx: L1BuildContext,
+): L1BuildResult {
+  if (ts.isConditionalExpression(expr)) {
+    return buildFromTernary(expr, ctx);
+  }
+  if (ts.isIfStatement(expr)) {
+    return buildFromIfStatement(expr, ctx);
+  }
+  if (ts.isSwitchStatement(expr)) {
+    return buildFromSwitchStatement(expr, ctx);
+  }
+  if (
+    ts.isBinaryExpression(expr) &&
+    (expr.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken ||
+      expr.operatorToken.kind === ts.SyntaxKind.BarBarToken)
+  ) {
+    return buildFromShortCircuit(expr, ctx);
+  }
+  return { unsupported: "not a recognized conditional form" };
+}
+
+/**
+ * Compose an L1 cond from pre-built L1 arm pairs and a TS terminal.
+ *
+ * Caller responsibility: pre-built arms are typically wrapped via
+ * `ir1FromL2(irWrap(opaqueExpr))` from `inlineConstBindings`'s
+ * already-translated `arms: [OpaqueExpr, OpaqueExpr][]` list. Terminal
+ * is translated by this function — either as an L1 conditional shape
+ * (if it matches one) or as a plain expression delegated through the
+ * `from-l2` adapter.
+ *
+ * The flattening rule: if the terminal is itself a conditional that
+ * lowers to an L1 cond, its arms get appended to the prelude arms and
+ * its otherwise becomes the combined cond's otherwise. This produces
+ * one L1 cond node that the lowerer flattens to one L2 cond — matching
+ * today's legacy `cond([...arms, [true, terminal]])` materialization.
+ */
+export function buildL1ConditionalFromArms(
+  preludeArms: ReadonlyArray<readonly [IR1Expr, IR1Expr]>,
+  terminal: ts.Expression | ts.IfStatement | ts.SwitchStatement,
+  ctx: L1BuildContext,
+): L1BuildResult {
+  const builtArms: Array<readonly [IR1Expr, IR1Expr]> = [...preludeArms];
+
+  const terminalIsConditional =
+    ts.isIfStatement(terminal) ||
+    ts.isSwitchStatement(terminal) ||
+    (ts.isExpression(terminal) && isL1ConditionalForm(terminal, ctx.checker));
+
+  if (!terminalIsConditional) {
+    if (builtArms.length === 0) {
+      return { unsupported: "no conditional shape to build" };
+    }
+    if (!ts.isExpression(terminal)) {
+      return { unsupported: "unsupported terminal form" };
+    }
+    const otherwise = buildSubExpr(terminal, ctx);
+    if (isL1Unsupported(otherwise)) {
+      return otherwise;
+    }
+    return ir1Cond(
+      builtArms as [readonly [IR1Expr, IR1Expr], ...typeof builtArms],
+      otherwise,
+    );
+  }
+
+  // Terminal IS a conditional: build it as an L1 cond, then merge.
+  const terminalL1 = buildL1Conditional(terminal, ctx);
+  if (isL1Unsupported(terminalL1)) {
+    return terminalL1;
+  }
+  if (terminalL1.kind === "cond") {
+    for (const [g, v] of terminalL1.arms) {
+      builtArms.push([g, v] as const);
+    }
+    if (builtArms.length === 0) {
+      return { unsupported: "no conditional shape to build" };
+    }
+    return ir1Cond(
+      builtArms as [readonly [IR1Expr, IR1Expr], ...typeof builtArms],
+      terminalL1.otherwise,
+    );
+  }
+  // Terminal lowered to a non-cond L1 (e.g., switch with only default
+  // collapsed to its default value, or short-circuit returning a binop).
+  // Treat the L1 result as the otherwise.
+  if (builtArms.length === 0) {
+    return terminalL1;
+  }
+  return ir1Cond(
+    builtArms as [readonly [IR1Expr, IR1Expr], ...typeof builtArms],
+    terminalL1,
+  );
+}
+
+/**
+ * Lower an L1 build result to an `OpaqueExpr` ready to drop into the
+ * legacy pipeline. Combines `lowerL1Expr` and `lowerExpr` for callers
+ * that want a one-liner.
+ */
+export function lowerL1ToOpaque(l1: IR1Expr): OpaqueExpr {
+  return lowerExpr(lowerL1Expr(l1));
+}
+
+// ---------------------------------------------------------------------------
+// Ternary chain flattening (right-associative)
+// ---------------------------------------------------------------------------
+
+function buildFromTernary(
+  expr: ts.ConditionalExpression,
+  ctx: L1BuildContext,
+): L1BuildResult {
+  const arms: Array<readonly [IR1Expr, IR1Expr]> = [];
+  let current: ts.Expression = expr;
+  // Right-leaning chain: a ? x : (b ? y : (c ? z : w)) → flatten.
+  while (ts.isConditionalExpression(current)) {
+    const guard = buildSubExpr(current.condition, ctx);
+    if (isL1Unsupported(guard)) {
+      return guard;
+    }
+    const value = buildSubExpr(current.whenTrue, ctx);
+    if (isL1Unsupported(value)) {
+      return value;
+    }
+    arms.push([guard, value] as const);
+    current = current.whenFalse;
+  }
+  // Terminal else (non-ternary).
+  const otherwise = buildSubExpr(current, ctx);
+  if (isL1Unsupported(otherwise)) {
+    return otherwise;
+  }
+  if (arms.length === 0) {
+    // Cannot happen — we entered the loop because expr is a ternary.
+    return { unsupported: "ternary with no arms (unreachable)" };
+  }
+  return ir1Cond(
+    arms as [readonly [IR1Expr, IR1Expr], ...typeof arms],
+    otherwise,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// If-statement → cond (if-with-returns required for value position)
+// ---------------------------------------------------------------------------
+
+function buildFromIfStatement(
+  stmt: ts.IfStatement,
+  ctx: L1BuildContext,
+): L1BuildResult {
+  const arms: Array<readonly [IR1Expr, IR1Expr]> = [];
+  let current: ts.IfStatement = stmt;
+  while (true) {
+    if (!current.elseStatement) {
+      return {
+        unsupported:
+          "if-without-else cannot lower to value-position cond (need both branches)",
+      };
+    }
+    const guard = buildSubExpr(current.expression, ctx);
+    if (isL1Unsupported(guard)) {
+      return guard;
+    }
+    const thenExpr = extractReturnFromStatement(current.thenStatement);
+    if (!thenExpr) {
+      return {
+        unsupported: "if-then branch must contain a single return-with-value",
+      };
+    }
+    const thenValue = buildSubExpr(thenExpr, ctx);
+    if (isL1Unsupported(thenValue)) {
+      return thenValue;
+    }
+    arms.push([guard, thenValue] as const);
+
+    // Else: another IfStatement (chain) or a terminal block-with-return.
+    if (ts.isIfStatement(current.elseStatement)) {
+      current = current.elseStatement;
+      continue;
+    }
+    const elseExpr = extractReturnFromStatement(current.elseStatement);
+    if (!elseExpr) {
+      return {
+        unsupported: "if-else branch must contain a single return-with-value",
+      };
+    }
+    const elseValue = buildSubExpr(elseExpr, ctx);
+    if (isL1Unsupported(elseValue)) {
+      return elseValue;
+    }
+    if (arms.length === 0) {
+      return {
+        unsupported: "if-statement walk produced no arms (unreachable)",
+      };
+    }
+    return ir1Cond(
+      arms as [readonly [IR1Expr, IR1Expr], ...typeof arms],
+      elseValue,
+    );
+  }
+}
+
+/**
+ * Extract `return EXPR` from a then/else branch — accepts either a
+ * `ReturnStatement` directly or a `Block` containing exactly one
+ * `ReturnStatement` (after filtering throws/asserts, which act as guards
+ * but aren't represented in L1 expression position). Mirrors today's
+ * `extractReturnFromBranch` in translate-body.ts:2841 but is kept local
+ * to ir1-build.ts so the L1 builder doesn't depend on translate-body's
+ * internal helpers staying exported.
+ *
+ * **Rejection of object-literal returns**: handled at `buildSubExpr`
+ * (called downstream); not here.
+ */
+function extractReturnFromStatement(stmt: ts.Statement): ts.Expression | null {
+  if (ts.isReturnStatement(stmt) && stmt.expression) {
+    return stmt.expression;
+  }
+  if (ts.isBlock(stmt) && stmt.statements.length === 1) {
+    const s = stmt.statements[0]!;
+    if (ts.isReturnStatement(s) && s.expression) {
+      return s.expression;
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Switch → cond (cases as arms, default as otherwise)
+// ---------------------------------------------------------------------------
+
+function buildFromSwitchStatement(
+  stmt: ts.SwitchStatement,
+  ctx: L1BuildContext,
+): L1BuildResult {
+  // Validate clause structure: every case ends with `return`/`break`/
+  // `throw`; default is last (or the only clause); reject fall-through.
+  const clauses = stmt.caseBlock.clauses;
+  if (clauses.length === 0) {
+    return { unsupported: "empty switch" };
+  }
+
+  let defaultIdx: number = -1;
+  for (let i = 0; i < clauses.length; i++) {
+    if (ts.isDefaultClause(clauses[i]!)) {
+      if (i !== clauses.length - 1) {
+        return { unsupported: "switch default must be the last clause" };
+      }
+      defaultIdx = i;
+    }
+  }
+  if (defaultIdx === -1) {
+    return {
+      unsupported:
+        "switch without default; literal-union exhaustiveness deferred (workstream open question)",
+    };
+  }
+
+  // Discriminant must be side-effect-free — we structurally share it
+  // across arms, so re-evaluation would diverge from TS's once-evaluated
+  // semantics if it has effects.
+  if (expressionHasSideEffects(stmt.expression, ctx.checker)) {
+    return { unsupported: "switch discriminant has side effects" };
+  }
+  const disc = buildSubExpr(stmt.expression, ctx);
+  if (isL1Unsupported(disc)) {
+    return disc;
+  }
+
+  // Each non-default case: literal label, body ends in `return EXPR`.
+  // M1 only supports return-cases; break/throw cases are rejected
+  // (no coherent value-position lowering).
+  const arms: Array<readonly [IR1Expr, IR1Expr]> = [];
+  for (let i = 0; i < defaultIdx; i++) {
+    const clause = clauses[i] as ts.CaseClause;
+    const labelL1 = buildCaseLabel(clause.expression, ctx);
+    if (isL1Unsupported(labelL1)) {
+      return labelL1;
+    }
+    const ret = extractCaseReturn(clause);
+    if (!ret) {
+      return {
+        unsupported:
+          "switch case must end with `return EXPR` (no fall-through, no break/throw cases in M1)",
+      };
+    }
+    const value = buildSubExpr(ret, ctx);
+    if (isL1Unsupported(value)) {
+      return value;
+    }
+    arms.push([ir1Binop("eq", disc, labelL1), value] as const);
+  }
+
+  // Default clause.
+  const defaultClause = clauses[defaultIdx] as ts.DefaultClause;
+  const defaultRet = extractCaseReturn(defaultClause);
+  if (!defaultRet) {
+    return {
+      unsupported: "switch default must end with `return EXPR`",
+    };
+  }
+  const otherwise = buildSubExpr(defaultRet, ctx);
+  if (isL1Unsupported(otherwise)) {
+    return otherwise;
+  }
+
+  if (arms.length === 0) {
+    // Switch with only a default: collapse to just the default value.
+    return otherwise;
+  }
+  return ir1Cond(
+    arms as [readonly [IR1Expr, IR1Expr], ...typeof arms],
+    otherwise,
+  );
+}
+
+/**
+ * Switch case labels must be literal — number, string, or boolean.
+ * Non-literal labels (computed expressions) reject. Literal nat are
+ * built directly to avoid re-translating through the legacy pipeline,
+ * which is mechanical for literals but adds a `from-l2` wrap that
+ * doesn't simplify under structural equality.
+ */
+function buildCaseLabel(
+  label: ts.Expression,
+  ctx: L1BuildContext,
+): L1BuildResult {
+  if (ts.isNumericLiteral(label)) {
+    const n = Number(label.text);
+    if (Number.isFinite(n) && Number.isInteger(n) && n >= 0) {
+      return ir1LitNat(n);
+    }
+    if (Number.isFinite(n) && Number.isInteger(n) && n < 0) {
+      return ir1Unop("neg", ir1LitNat(-n));
+    }
+    return { unsupported: "switch case label: non-integer numeric literal" };
+  }
+  if (ts.isStringLiteral(label)) {
+    return ir1LitString(label.text);
+  }
+  if (label.kind === ts.SyntaxKind.TrueKeyword) {
+    return ir1LitBool(true);
+  }
+  if (label.kind === ts.SyntaxKind.FalseKeyword) {
+    return ir1LitBool(false);
+  }
+  // Could be a const-bound identifier, a property access (enum), etc.
+  // Defer those to a follow-up — M1 keeps switch labels strictly literal
+  // to avoid mis-treating non-literal labels as fall-through-eligible
+  // when their evaluation order matters.
+  void ctx;
+  return {
+    unsupported: "switch case label must be a literal (number/string/bool)",
+  };
+}
+
+/**
+ * Extract the `return EXPR` from a case clause. Accepts the canonical
+ * shape: a single `return EXPR;` statement (possibly preceded by a
+ * single `break;` that's structurally unreachable — but we reject
+ * `break` since it implies fall-through-by-omission elsewhere). Reject
+ * any case body containing more than one statement, or with a
+ * non-return last statement.
+ */
+function extractCaseReturn(
+  clause: ts.CaseClause | ts.DefaultClause,
+): ts.Expression | null {
+  // Filter to the structural body. Each case body is a list of
+  // statements at the top level (TS doesn't wrap them in a Block by
+  // default). M1 requires exactly one statement: `return EXPR;`.
+  const stmts = clause.statements;
+  if (stmts.length === 0) {
+    // Empty case body = fall-through. Reject.
+    return null;
+  }
+  // Walk past a trailing `break;` if present (no-op in a case body that
+  // ends with return — but if the *only* stmt is break, that's a
+  // statement-position effect M1 doesn't support).
+  let lastIdx = stmts.length - 1;
+  if (lastIdx > 0 && stmts[lastIdx]!.kind === ts.SyntaxKind.BreakStatement) {
+    lastIdx--;
+  }
+  // Also accept `{ return EXPR; }` block.
+  const last: ts.Statement = stmts[lastIdx]!;
+  if (
+    ts.isBlock(last) &&
+    last.statements.length === 1 &&
+    ts.isReturnStatement(last.statements[0]!) &&
+    last.statements[0]!.expression
+  ) {
+    return last.statements[0]!.expression!;
+  }
+  if (lastIdx !== stmts.length - 1 && lastIdx < 0) {
+    return null;
+  }
+  // Only one effective statement allowed (after trailing-break trim).
+  if (lastIdx !== 0) {
+    return null;
+  }
+  if (ts.isReturnStatement(last) && last.expression) {
+    return last.expression;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// && / || → cond (Bool-typed only)
+// ---------------------------------------------------------------------------
+
+function buildFromShortCircuit(
+  expr: ts.BinaryExpression,
+  ctx: L1BuildContext,
+): L1BuildResult {
+  if (
+    !isStaticallyBoolTyped(expr.left, ctx.checker) ||
+    !isStaticallyBoolTyped(expr.right, ctx.checker)
+  ) {
+    return {
+      unsupported:
+        "&&/|| requires both operands to be statically Bool-typed (workstream conservative-refusal 3(b))",
+    };
+  }
+  const left = buildSubExpr(expr.left, ctx);
+  if (isL1Unsupported(left)) {
+    return left;
+  }
+  const right = buildSubExpr(expr.right, ctx);
+  if (isL1Unsupported(right)) {
+    return right;
+  }
+  if (expr.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken) {
+    return ir1Binop("and", left, right);
+  }
+  return ir1Binop("or", left, right);
+}

--- a/tools/ts2pant/src/ir1-lower.ts
+++ b/tools/ts2pant/src/ir1-lower.ts
@@ -24,6 +24,7 @@
 
 import {
   type IRExpr,
+  type IRStmt,
   irAppExpr,
   irAppName,
   irBinop,
@@ -103,10 +104,11 @@ export function lowerL1Expr(e: IR1Expr): IRExpr {
  * targets. Until then, calling this function on any L1 statement is a
  * bug; M1 only constructs and lowers L1 *expressions*.
  *
- * The function signature is locked here so the L1 lowering API surface is
- * declared at M1; the body fills in at M3.
+ * The signature returns the eventual M3 type (`IRStmt[]`) so adding the
+ * real implementation in M3 is not a public type break — the body throws
+ * unconditionally until then.
  */
-export function lowerL1Stmt(s: IR1Stmt): never {
+export function lowerL1Stmt(s: IR1Stmt): IRStmt[] {
   void s;
   throw new Error(
     "lowerL1Stmt: Layer 1 statement lowering is M3 (iteration + mutation); " +

--- a/tools/ts2pant/src/ir1-lower.ts
+++ b/tools/ts2pant/src/ir1-lower.ts
@@ -1,0 +1,131 @@
+/**
+ * Layer 1 → Layer 2 lowering.
+ *
+ * Walks `IR1Expr` and produces L2 `IRExpr` (today's `ir.ts`). The downstream
+ * lowering Layer 2 → OpaqueExpr lives in `ir-emit.ts` and is unchanged.
+ *
+ * **M1 scope**: `var`, `lit`, `binop`, `unop`, `app`, `member`, `cond`, and
+ * the transitional `from-l2` form. Statement lowering (`lowerL1Stmt`) is
+ * declared but throws — it lands in M3 alongside iteration + mutation
+ * normalization.
+ *
+ * **Cond lowering — byte-equality with legacy.** L1 `cond({arms,
+ * otherwise})` produces L2 `irCond([...arms, [litBool(true), otherwise]])`,
+ * exactly the legacy `ast.cond([...arms, [litBool(true), default]])` shape
+ * the existing recognizers emit today. This is the cutover gate: M1's
+ * Patch 3 deletes legacy conditional handlers and snapshots must be
+ * byte-identical, which only holds if L1 → L2 produces the same L2 cond
+ * tree as the deleted code did.
+ *
+ * **Member lowering — already-qualified name.** L1 `member(receiver,
+ * name)` lowers to L2 `App(name=name, [receiver])`. The build pass is
+ * responsible for qualifying `name` to a rule (today's
+ * `qualifyFieldAccess` machinery). The lowering is mechanical: it does
+ * not consult a TypeChecker.
+ */
+
+import {
+  type IRExpr,
+  irAppExpr,
+  irAppName,
+  irBinop,
+  irCond,
+  irLitBool,
+  irLitNat,
+  irLitString,
+  irUnop,
+  irVar,
+} from "./ir.js";
+import type { IR1Expr, IR1Stmt } from "./ir1.js";
+
+/**
+ * Lower a Layer 1 expression to Layer 2 `IRExpr`.
+ */
+export function lowerL1Expr(e: IR1Expr): IRExpr {
+  switch (e.kind) {
+    case "var":
+      return irVar(e.name, e.primed ?? false);
+
+    case "lit": {
+      const v = e.value;
+      switch (v.kind) {
+        case "nat":
+          return irLitNat(v.value);
+        case "bool":
+          return irLitBool(v.value);
+        case "string":
+          return irLitString(v.value);
+        default: {
+          const _exhaustive: never = v;
+          void _exhaustive;
+          throw new Error("unreachable: IR1Literal");
+        }
+      }
+    }
+
+    case "binop":
+      return irBinop(e.op, lowerL1Expr(e.lhs), lowerL1Expr(e.rhs));
+
+    case "unop":
+      return irUnop(e.op, lowerL1Expr(e.arg));
+
+    case "app": {
+      // Specialize: a `var`-headed application lowers to L2 `App(name=...)`,
+      // which produces the cleanest OpaqueExpr (a named function call).
+      // Everything else lowers to L2 `App(expr=..., ...)`. Both are valid
+      // IR; the specialization is purely cosmetic — for snapshot
+      // byte-equality with the legacy path, which always emitted named
+      // applications when the callee was an identifier.
+      const args = e.args.map(lowerL1Expr);
+      if (e.callee.kind === "var" && !e.callee.primed) {
+        return irAppName(e.callee.name, args);
+      }
+      return irAppExpr(lowerL1Expr(e.callee), args);
+    }
+
+    case "member": {
+      // Member is already-qualified at build time (responsibility of the
+      // build pass; M1 doesn't construct `member` so this case is
+      // exercised only by unit tests with hand-built trees, which pass
+      // explicit qualified names). M5 (property-access normalization)
+      // is where the build-time qualification logic lands.
+      return irAppName(e.name, [lowerL1Expr(e.receiver)]);
+    }
+
+    case "cond": {
+      const armPairs: Array<[IRExpr, IRExpr]> = e.arms.map(([g, v]) => [
+        lowerL1Expr(g),
+        lowerL1Expr(v),
+      ]);
+      armPairs.push([irLitBool(true), lowerL1Expr(e.otherwise)]);
+      return irCond(armPairs);
+    }
+
+    case "from-l2":
+      return e.expr;
+
+    default: {
+      const _exhaustive: never = e;
+      void _exhaustive;
+      throw new Error("unreachable: IR1Expr");
+    }
+  }
+}
+
+/**
+ * Lower a Layer 1 statement to a list of L2 `IRStmt`. **Not implemented
+ * in M1** — statement lowering lands in M3 alongside iteration + mutation
+ * normalization, where L2's `Write` / `LetIf` / `Seq` forms become the
+ * targets. Until then, calling this function on any L1 statement is a
+ * bug; M1 only constructs and lowers L1 *expressions*.
+ *
+ * The function signature is locked here so the L1 lowering API surface is
+ * declared at M1; the body fills in at M3.
+ */
+export function lowerL1Stmt(s: IR1Stmt): never {
+  void s;
+  throw new Error(
+    "lowerL1Stmt: Layer 1 statement lowering is M3 (iteration + mutation); " +
+      "see workstreams/ts2pant-imperative-ir.md",
+  );
+}

--- a/tools/ts2pant/src/ir1-lower.ts
+++ b/tools/ts2pant/src/ir1-lower.ts
@@ -9,13 +9,11 @@
  * declared but throws — it lands in M3 alongside iteration + mutation
  * normalization.
  *
- * **Cond lowering — byte-equality with legacy.** L1 `cond({arms,
- * otherwise})` produces L2 `irCond([...arms, [litBool(true), otherwise]])`,
- * exactly the legacy `ast.cond([...arms, [litBool(true), default]])` shape
- * the existing recognizers emit today. This is the cutover gate: M1's
- * Patch 3 deletes legacy conditional handlers and snapshots must be
- * byte-identical, which only holds if L1 → L2 produces the same L2 cond
- * tree as the deleted code did.
+ * **Cond lowering.** L1 `cond({arms, otherwise})` produces L2
+ * `irCond([...arms, [litBool(true), otherwise]])`. The trailing
+ * `(true, otherwise)` arm is the canonical L2 cond shape; L1's
+ * separate `otherwise` field exists so consumers can't construct a
+ * value-position cond without a default.
  *
  * **Member lowering — already-qualified name.** L1 `member(receiver,
  * name)` lowers to L2 `App(name=name, [receiver])`. The build pass is
@@ -31,8 +29,6 @@ import {
   irBinop,
   irCond,
   irLitBool,
-  irLitNat,
-  irLitString,
   irUnop,
   irVar,
 } from "./ir.js";
@@ -46,22 +42,10 @@ export function lowerL1Expr(e: IR1Expr): IRExpr {
     case "var":
       return irVar(e.name, e.primed ?? false);
 
-    case "lit": {
-      const v = e.value;
-      switch (v.kind) {
-        case "nat":
-          return irLitNat(v.value);
-        case "bool":
-          return irLitBool(v.value);
-        case "string":
-          return irLitString(v.value);
-        default: {
-          const _exhaustive: never = v;
-          void _exhaustive;
-          throw new Error("unreachable: IR1Literal");
-        }
-      }
-    }
+    case "lit":
+      // L1 `lit` and L2 `lit` share the same shape (`IR1Literal = IRLiteral`),
+      // so the variant is structurally a valid `IRExpr`. Pass through.
+      return e;
 
     case "binop":
       return irBinop(e.op, lowerL1Expr(e.lhs), lowerL1Expr(e.rhs));

--- a/tools/ts2pant/src/ir1.ts
+++ b/tools/ts2pant/src/ir1.ts
@@ -37,43 +37,20 @@
  * `tools/ts2pant/CLAUDE.md` §"Imperative IR Workstream".
  */
 
-import type { IRExpr } from "./ir.js";
+import type { IRBinop, IRExpr, IRLiteral, IRUnop } from "./ir.js";
 
 // --------------------------------------------------------------------------
 // Literals, binops, unops
 // --------------------------------------------------------------------------
+//
+// L1 reuses the L2 atom types directly — literal/binop/unop operator names
+// have one source of truth across both layers. Lowering for `lit` is then
+// a structural pass-through (same shape on both sides); binop/unop still
+// need to wrap into L2's App-headed form during lowering.
 
-/**
- * Literal values appearing in `Lit(...)`. Mirrors L2 `IRLiteral` exactly —
- * same shape on both sides keeps lowering trivial.
- */
-export type IR1Literal =
-  | { kind: "nat"; value: number }
-  | { kind: "bool"; value: boolean }
-  | { kind: "string"; value: string };
-
-/**
- * Binary operators. Mirrors L2 `IRBinop` for direct lowering.
- */
-export type IR1Binop =
-  | "and"
-  | "or"
-  | "impl"
-  | "iff"
-  | "eq"
-  | "neq"
-  | "lt"
-  | "gt"
-  | "le"
-  | "ge"
-  | "in"
-  | "subset"
-  | "add"
-  | "sub"
-  | "mul"
-  | "div";
-
-export type IR1Unop = "not" | "neg" | "card";
+export type IR1Literal = IRLiteral;
+export type IR1Binop = IRBinop;
+export type IR1Unop = IRUnop;
 
 // --------------------------------------------------------------------------
 // Expression forms (value-position)
@@ -293,9 +270,17 @@ export const ir1Cond = (
 ): IR1Expr => ({ kind: "cond", arms, otherwise });
 
 /**
- * Transitional delegation to a pre-built Layer 2 IRExpr. See module doc
- * for lifetime — this scaffolds incremental migration and is deleted at
+ * Transitional delegation to a pre-built Layer 2 IRExpr. Use only inside
+ * `ir1-build.ts` for sub-expressions whose normalization is not the
+ * current milestone's concern, and in `translatePureBody`'s arm-cond
+ * assembly where `inlineConstBindings` produces pre-translated
+ * OpaqueExprs. See module doc for lifetime — shrinks at M3, deleted at
  * M6.
+ *
+ * @deprecated transitional; do not introduce new call sites outside the
+ * scoped sub-expression delegation in `ir1-build.ts` /
+ * `translate-body.ts:translatePureBody`. Lifetime is bounded by the
+ * workstream — see `workstreams/ts2pant-imperative-ir.md`.
  */
 export const ir1FromL2 = (expr: IRExpr): IR1Expr => ({
   kind: "from-l2",

--- a/tools/ts2pant/src/ir1.ts
+++ b/tools/ts2pant/src/ir1.ts
@@ -1,0 +1,374 @@
+/**
+ * Layer 1 Imperative Intermediate Representation for ts2pant.
+ *
+ * This is the IRSC-faithful imperative IR layer that sits between the
+ * TypeScript AST and ts2pant's existing Layer 2 IR (`IRExpr`/`IRStmt` in
+ * `ir.ts`). Layer 1 preserves TS's actual control-flow shape; normalization
+ * passes against L1 collapse operationally-equivalent TS surface forms
+ * (increment spellings, conditional families, iteration families) into a
+ * small canonical vocabulary. Lowering passes target ONE canonical input
+ * shape per construct.
+ *
+ * Reference: Vekris, Cosman, Jhala, *Refinement Types for TypeScript*
+ * (PLDI 2016, arxiv:1604.02480). Their FRSC→IRSC SSA transformation is
+ * the precedent. ts2pant's L1 is the FRSC analog (TS-shape preserved with
+ * canonicalized expressions); L2 (`ir.ts`) is the IRSC analog (Pant-shape
+ * pure expressions).
+ *
+ * **Vocabulary lock at M1.** The forms declared here are the locked Layer
+ * 1 vocabulary. Forms can be *added* in later milestones (e.g.,
+ * `IsNullish` primitive at M4) but the existing forms cannot be changed.
+ * Forms unused in M1 (`assign`, `foreach`, `for`, `while`, `throw`,
+ * `expr-stmt`, statement-position `cond-stmt`) are declared at the type
+ * level; their constructors throw `not-implemented` until the milestone
+ * that introduces them lands.
+ *
+ * **No `IR1Wrap` form.** Layer 1 is *not* an escape-hatch layer — the
+ * build pass either produces L1 or rejects with `unsupported`. An L1
+ * wrap-anything form would re-introduce the cross-talk problem the IR is
+ * meant to retire. The `from-l2` form is *not* a wrap-anything escape
+ * hatch — it is a scoped delegation point for sub-expressions whose
+ * normalization isn't this milestone's concern (e.g., guard expressions
+ * inside an L1 conditional during M1, when expression normalization
+ * itself is M2/M3 territory). By M3 the form shrinks; by M6 (legacy
+ * cleanup) it is deleted.
+ *
+ * **Migration status**: see `workstreams/ts2pant-imperative-ir.md` and
+ * `tools/ts2pant/CLAUDE.md` §"Imperative IR Workstream".
+ */
+
+import type { IRExpr } from "./ir.js";
+
+// --------------------------------------------------------------------------
+// Literals, binops, unops
+// --------------------------------------------------------------------------
+
+/**
+ * Literal values appearing in `Lit(...)`. Mirrors L2 `IRLiteral` exactly —
+ * same shape on both sides keeps lowering trivial.
+ */
+export type IR1Literal =
+  | { kind: "nat"; value: number }
+  | { kind: "bool"; value: boolean }
+  | { kind: "string"; value: string };
+
+/**
+ * Binary operators. Mirrors L2 `IRBinop` for direct lowering.
+ */
+export type IR1Binop =
+  | "and"
+  | "or"
+  | "impl"
+  | "iff"
+  | "eq"
+  | "neq"
+  | "lt"
+  | "gt"
+  | "le"
+  | "ge"
+  | "in"
+  | "subset"
+  | "add"
+  | "sub"
+  | "mul"
+  | "div";
+
+export type IR1Unop = "not" | "neg" | "card";
+
+// --------------------------------------------------------------------------
+// Expression forms (value-position)
+// --------------------------------------------------------------------------
+
+/**
+ * Layer 1 expressions. Seven forms preserve TS-shape canonicalization:
+ *
+ * - `var`, `lit` — literal references
+ * - `binop`, `unop` — arithmetic/logical/comparison operators
+ * - `app` — function or method application (callee is itself an IR1Expr)
+ * - `member` — property access; canonicalized so `obj.f` and `obj["f"]`
+ *   both build as `Member(obj, "f")` (the build-time canonicalization will
+ *   land in M5, but the form is locked here)
+ * - `cond` — multi-arm value-position conditional (M1 canonical form for
+ *   if-with-returns, ternary chains, switch w/o fall-through, &&/||
+ *   when Bool-typed)
+ *
+ * Plus one transitional form:
+ *
+ * - `from-l2` — scoped delegation to an already-built Layer 2 IRExpr.
+ *   See module doc for lifetime; this is *not* an IRWrap-style escape
+ *   hatch.
+ */
+export type IR1Expr =
+  /** Variable / parameter reference. `primed = true` means next-state. */
+  | { kind: "var"; name: string; primed?: boolean }
+  /** Literal value (nat, bool, string). */
+  | { kind: "lit"; value: IR1Literal }
+  /** Binary operator application. */
+  | { kind: "binop"; op: IR1Binop; lhs: IR1Expr; rhs: IR1Expr }
+  /** Unary operator application. */
+  | { kind: "unop"; op: IR1Unop; arg: IR1Expr }
+  /** Function or method application. Callee is itself an L1 expression. */
+  | { kind: "app"; callee: IR1Expr; args: IR1Expr[] }
+  /**
+   * Property access. Canonicalized form for `obj.f` and `obj["f"]`.
+   * Lowering qualifies `name` to a rule (today's `qualifyFieldAccess`).
+   */
+  | { kind: "member"; receiver: IR1Expr; name: string }
+  /**
+   * Multi-armed value-position conditional. Canonical form for if-with-
+   * returns, ternary chains, switch w/o fall-through, &&/|| when Bool-
+   * typed. `arms` is non-empty; `otherwise` is required at the
+   * expression level (else-branch is always present in a value-position
+   * conditional — there's no value if guards all fail).
+   */
+  | {
+      kind: "cond";
+      arms: ReadonlyArray<readonly [IR1Expr, IR1Expr]>;
+      otherwise: IR1Expr;
+    }
+  /**
+   * Transitional delegation to a pre-built Layer 2 IRExpr. Used for
+   * sub-expressions outside the current milestone's normalization
+   * concern (e.g., M1 conditional guards/values whose internal
+   * structure is M2/M3 territory).
+   *
+   * Lowering: emits the wrapped L2 IRExpr verbatim.
+   *
+   * **Lifetime**: shrinks at M3 (more sub-expressions reach L1
+   * natively); deleted at M6 (legacy cleanup). Do not introduce new
+   * uses outside the build pipeline's scoped sub-expression delegation.
+   */
+  | { kind: "from-l2"; expr: IRExpr };
+
+// --------------------------------------------------------------------------
+// Statement forms (effect-position)
+// --------------------------------------------------------------------------
+
+/**
+ * Layer 1 statements. Ten forms cover the imperative TS shape needed
+ * across the workstream. M1 actively uses `block`, `let`, `cond`, and
+ * `return`; the others are vocabulary-locked but their constructors
+ * throw until the milestone that introduces them lands:
+ *
+ * - `assign` — M2 (canonical form for `++`/`--`/compound-assign/`x = expr`)
+ * - `foreach`, `for`, `while` — M3 (iteration normalization)
+ * - `throw` — M3 (iteration body for guard-throw assertions)
+ * - `expr-stmt` — M3 (effect-bearing expressions in statement position)
+ * - statement-position `cond-stmt` — M3 (conditional with statement body,
+ *   e.g., `if (g) obj.p = v`)
+ */
+export type IR1Stmt =
+  /** Block of statements. Non-empty; single-statement blocks collapse. */
+  | { kind: "block"; stmts: ReadonlyArray<IR1Stmt> }
+  /** Hygienic let-binding. Inlined at lowering (Pant has no `let`). */
+  | { kind: "let"; name: string; value: IR1Expr }
+  /**
+   * Assignment. Canonical form for all increment/compound-assign/explicit
+   * mutation forms. Target is an L1 expression (typically `var` or
+   * `member`). Introduced in M2; constructor throws until then.
+   */
+  | { kind: "assign"; target: IR1Expr; value: IR1Expr }
+  /**
+   * Multi-armed statement-position conditional. Canonical form for
+   * `if (g) {body}` and conditional mutation. Introduced in M3 (when
+   * iteration + mutation land); constructor throws until then.
+   */
+  | {
+      kind: "cond-stmt";
+      arms: ReadonlyArray<readonly [IR1Expr, IR1Stmt]>;
+      otherwise: IR1Stmt | null;
+    }
+  /** Uniform iteration. Introduced in M3. */
+  | {
+      kind: "foreach";
+      binder: string;
+      source: IR1Expr;
+      body: IR1Stmt;
+    }
+  /**
+   * Generic counter-for; fallback when Foreach can't apply. Introduced
+   * in M3.
+   */
+  | {
+      kind: "for";
+      init: IR1Stmt | null;
+      cond: IR1Expr | null;
+      step: IR1Stmt | null;
+      body: IR1Stmt;
+    }
+  /**
+   * Bounded while loop (rejected if not provably bounded). Introduced
+   * in M3.
+   */
+  | { kind: "while"; cond: IR1Expr; body: IR1Stmt }
+  /** Return statement. Optional expression for void-returning bodies. */
+  | { kind: "return"; expr: IR1Expr | null }
+  /**
+   * Throw statement. Used as guard pattern (if-throw assertions).
+   * Introduced in M3.
+   */
+  | { kind: "throw"; expr: IR1Expr }
+  /**
+   * Bare expression-as-statement (effect-bearing call, etc.). Introduced
+   * in M3.
+   */
+  | { kind: "expr-stmt"; expr: IR1Expr };
+
+// --------------------------------------------------------------------------
+// Type guards
+// --------------------------------------------------------------------------
+
+export const isIR1FromL2 = (
+  e: IR1Expr,
+): e is Extract<IR1Expr, { kind: "from-l2" }> => e.kind === "from-l2";
+
+// --------------------------------------------------------------------------
+// Expression constructors
+// --------------------------------------------------------------------------
+
+export const ir1Var = (name: string, primed = false): IR1Expr => ({
+  kind: "var",
+  name,
+  primed,
+});
+
+export const ir1LitNat = (value: number): IR1Expr => ({
+  kind: "lit",
+  value: { kind: "nat", value },
+});
+
+export const ir1LitBool = (value: boolean): IR1Expr => ({
+  kind: "lit",
+  value: { kind: "bool", value },
+});
+
+export const ir1LitString = (value: string): IR1Expr => ({
+  kind: "lit",
+  value: { kind: "string", value },
+});
+
+export const ir1Binop = (
+  op: IR1Binop,
+  lhs: IR1Expr,
+  rhs: IR1Expr,
+): IR1Expr => ({ kind: "binop", op, lhs, rhs });
+
+export const ir1Unop = (op: IR1Unop, arg: IR1Expr): IR1Expr => ({
+  kind: "unop",
+  op,
+  arg,
+});
+
+export const ir1App = (callee: IR1Expr, args: IR1Expr[]): IR1Expr => ({
+  kind: "app",
+  callee,
+  args,
+});
+
+export const ir1Member = (receiver: IR1Expr, name: string): IR1Expr => ({
+  kind: "member",
+  receiver,
+  name,
+});
+
+/**
+ * Multi-armed value-position conditional. `arms` must be non-empty;
+ * `otherwise` is required (value position has no "no-value" exit).
+ *
+ * Type-level invariants:
+ * - Non-empty arms via tuple-rest pattern in the parameter type
+ * - `otherwise` cannot be `null` (vs the statement-position cond)
+ *
+ * Single-arm with otherwise = `cond([(g, v)], otherwise)`. Multi-arm
+ * `Cond([(g1, v1), (g2, v2)], default)` is the canonical form for
+ * if-chains, ternary chains, switch (cases as arms), and Bool-typed
+ * `&&`/`||`.
+ */
+export const ir1Cond = (
+  arms: readonly [
+    readonly [IR1Expr, IR1Expr],
+    ...ReadonlyArray<readonly [IR1Expr, IR1Expr]>,
+  ],
+  otherwise: IR1Expr,
+): IR1Expr => ({ kind: "cond", arms, otherwise });
+
+/**
+ * Transitional delegation to a pre-built Layer 2 IRExpr. See module doc
+ * for lifetime — this scaffolds incremental migration and is deleted at
+ * M6.
+ */
+export const ir1FromL2 = (expr: IRExpr): IR1Expr => ({
+  kind: "from-l2",
+  expr,
+});
+
+// --------------------------------------------------------------------------
+// Statement constructors
+// --------------------------------------------------------------------------
+
+/**
+ * Block of statements. Non-empty; single-statement blocks collapse to
+ * the inner statement at construction time so consumers don't need to
+ * distinguish `Block([s])` from `s`.
+ */
+export const ir1Block = (stmts: readonly [IR1Stmt, ...IR1Stmt[]]): IR1Stmt => {
+  if (stmts.length === 1) {
+    return stmts[0];
+  }
+  return { kind: "block", stmts };
+};
+
+export const ir1Let = (name: string, value: IR1Expr): IR1Stmt => ({
+  kind: "let",
+  name,
+  value,
+});
+
+export const ir1Return = (expr: IR1Expr | null): IR1Stmt => ({
+  kind: "return",
+  expr,
+});
+
+// --------------------------------------------------------------------------
+// Vocabulary-locked stubs (constructors throw until the milestone that
+// introduces them lands). Forms are declared in IR1Stmt at the type level
+// so consumers can pattern-match without runtime branch errors; the
+// constructors here surface premature use.
+// --------------------------------------------------------------------------
+
+const NOT_IMPL = (form: string, milestone: string): never => {
+  throw new Error(
+    `IR1 form '${form}' is vocabulary-locked but not implemented until ${milestone}; ` +
+      `see workstreams/ts2pant-imperative-ir.md`,
+  );
+};
+
+export const ir1Assign = (_target: IR1Expr, _value: IR1Expr): IR1Stmt =>
+  NOT_IMPL("assign", "M2 (assign + μ-search)");
+
+export const ir1CondStmt = (
+  _arms: ReadonlyArray<readonly [IR1Expr, IR1Stmt]>,
+  _otherwise: IR1Stmt | null,
+): IR1Stmt => NOT_IMPL("cond-stmt", "M3 (iteration + mutation)");
+
+export const ir1Foreach = (
+  _binder: string,
+  _source: IR1Expr,
+  _body: IR1Stmt,
+): IR1Stmt => NOT_IMPL("foreach", "M3 (iteration + mutation)");
+
+export const ir1For = (
+  _init: IR1Stmt | null,
+  _cond: IR1Expr | null,
+  _step: IR1Stmt | null,
+  _body: IR1Stmt,
+): IR1Stmt => NOT_IMPL("for", "M3 (iteration + mutation)");
+
+export const ir1While = (_cond: IR1Expr, _body: IR1Stmt): IR1Stmt =>
+  NOT_IMPL("while", "M3 (iteration + mutation)");
+
+export const ir1Throw = (_expr: IR1Expr): IR1Stmt =>
+  NOT_IMPL("throw", "M3 (iteration + mutation)");
+
+export const ir1ExprStmt = (_expr: IR1Expr): IR1Stmt =>
+  NOT_IMPL("expr-stmt", "M3 (iteration + mutation)");

--- a/tools/ts2pant/src/ir1.ts
+++ b/tools/ts2pant/src/ir1.ts
@@ -136,7 +136,7 @@ export type IR1Expr =
  */
 export type IR1Stmt =
   /** Block of statements. Non-empty; single-statement blocks collapse. */
-  | { kind: "block"; stmts: ReadonlyArray<IR1Stmt> }
+  | { kind: "block"; stmts: readonly [IR1Stmt, ...IR1Stmt[]] }
   /** Hygienic let-binding. Inlined at lowering (Pant has no `let`). */
   | { kind: "let"; name: string; value: IR1Expr }
   /**
@@ -152,7 +152,10 @@ export type IR1Stmt =
    */
   | {
       kind: "cond-stmt";
-      arms: ReadonlyArray<readonly [IR1Expr, IR1Stmt]>;
+      arms: readonly [
+        readonly [IR1Expr, IR1Stmt],
+        ...ReadonlyArray<readonly [IR1Expr, IR1Stmt]>,
+      ];
       otherwise: IR1Stmt | null;
     }
   /** Uniform iteration. Introduced in M3. */
@@ -332,7 +335,10 @@ export const ir1Assign = (_target: IR1Expr, _value: IR1Expr): IR1Stmt =>
   NOT_IMPL("assign", "M2 (assign + μ-search)");
 
 export const ir1CondStmt = (
-  _arms: ReadonlyArray<readonly [IR1Expr, IR1Stmt]>,
+  _arms: readonly [
+    readonly [IR1Expr, IR1Stmt],
+    ...ReadonlyArray<readonly [IR1Expr, IR1Stmt]>,
+  ],
   _otherwise: IR1Stmt | null,
 ): IR1Stmt => NOT_IMPL("cond-stmt", "M3 (iteration + mutation)");
 

--- a/tools/ts2pant/src/purity.ts
+++ b/tools/ts2pant/src/purity.ts
@@ -904,9 +904,10 @@ function isAllBool(t: ts.Type): boolean {
   }
   if (t.isIntersection()) {
     // Intersection narrowed to bool is still bool; require every
-    // constituent to be Bool. Intersections like `boolean & {}` are
-    // accepted because both constituents map to BooleanLike under
-    // structural type resolution.
+    // constituent to be Bool. In practice, intersections like
+    // `boolean & {}` are simplified by TypeScript's checker to
+    // `boolean` before we see them; the constituent check is a
+    // conservative guard for complex intersection shapes.
     return t.types.every(isAllBool);
   }
   return (t.flags & ts.TypeFlags.BooleanLike) !== 0;

--- a/tools/ts2pant/src/purity.ts
+++ b/tools/ts2pant/src/purity.ts
@@ -867,3 +867,47 @@ function expressionIsPure(
   // Unknown expression kind → conservative
   return false;
 }
+
+// ---------------------------------------------------------------------------
+// Bool-type detection (M1 imperative-IR workstream — &&/|| normalization)
+// ---------------------------------------------------------------------------
+
+/**
+ * True when every constituent of `expr`'s apparent type satisfies the
+ * `BooleanLike` flag (`boolean`, `true`, `false`, the synthesized union
+ * `true | false`). Returns false for `boolean | undefined`, `any`,
+ * `unknown`, and any union that includes a non-Bool constituent.
+ *
+ * Used by the L1 conditional builder to gate `&&`/`||` normalization
+ * (workstream M1 / `workstreams/ts2pant-imperative-ir.md`): TS short-
+ * circuit on non-Bool operands has truthy/falsy semantics that diverge
+ * from `Cond`'s Boolean-guard semantics, so non-Bool short-circuit is
+ * rejected (conservative-refusal policy 3(b)).
+ *
+ * The check uses the apparent type at the location, walks union
+ * constituents, and requires every constituent to be Bool. Optional
+ * Bools (`boolean | undefined`) reject — the user must disambiguate via
+ * `??` first. Bool literal types (`true`, `false`) and unions of them
+ * accept.
+ */
+export function isStaticallyBoolTyped(
+  expr: ts.Expression,
+  checker: ts.TypeChecker,
+): boolean {
+  const t = checker.getTypeAtLocation(expr);
+  return isAllBool(t);
+}
+
+function isAllBool(t: ts.Type): boolean {
+  if (t.isUnion()) {
+    return t.types.every(isAllBool);
+  }
+  if (t.isIntersection()) {
+    // Intersection narrowed to bool is still bool; require every
+    // constituent to be Bool. Intersections like `boolean & {}` are
+    // accepted because both constituents map to BooleanLike under
+    // structural type resolution.
+    return t.types.every(isAllBool);
+  }
+  return (t.flags & ts.TypeFlags.BooleanLike) !== 0;
+}

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -2803,7 +2803,7 @@ export function translateBodyExpr(
   return { unsupported: "non-expression statement" };
 }
 
-function extractReturnFromBranch(
+export function extractReturnFromBranch(
   stmt: ts.Statement,
   checker: ts.TypeChecker,
 ): ts.Expression | null {

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -1,8 +1,16 @@
 import type { SourceFile } from "ts-morph";
 import ts from "typescript";
-import { irLet, irWrap } from "./ir.js";
+import { type IRExpr, irLet, irWrap } from "./ir.js";
 import { buildIR, isBuildUnsupported } from "./ir-build.js";
 import { lowerExpr } from "./ir-emit.js";
+import { type IR1Expr, ir1FromL2 } from "./ir1.js";
+import {
+  buildL1Conditional,
+  buildL1ConditionalFromArms,
+  isL1ConditionalForm,
+  isL1Unsupported,
+  lowerL1ToOpaque,
+} from "./ir1-build.js";
 import type {
   OpaqueCombiner,
   OpaqueExpr,
@@ -46,6 +54,18 @@ import type { PantDeclaration, PropResult } from "./types.js";
 function useIRPipeline(): boolean {
   const g = globalThis as { process?: { env?: Record<string, string> } };
   return g.process?.env?.["TS2PANT_USE_IR"] === "1";
+}
+
+/**
+ * True if the imperative-IR (Layer 1) conditional pipeline is enabled
+ * via `TS2PANT_USE_L1=1`. M1 patch 2 uses this flag to gate the L1
+ * conditional builder during validation; patch 3 deletes the flag and
+ * makes L1 always-on for conditional value forms (workstream
+ * `workstreams/ts2pant-imperative-ir.md`, milestone M1).
+ */
+function useL1Pipeline(): boolean {
+  const g = globalThis as { process?: { env?: Record<string, string> } };
+  return g.process?.env?.["TS2PANT_USE_L1"] === "1";
 }
 
 // --- Const-binding inlining infrastructure (let-elimination) ---
@@ -349,7 +369,7 @@ type WriteEntry = PropertyWriteEntry | MapRuleWriteEntry | SetRuleWriteEntry;
  * whenever a new const binding is inlined so the in-flight `applyConst`
  * stays in sync with the state.
  */
-interface SymbolicState {
+export interface SymbolicState {
   writes: ReadonlyMap<string, WriteEntry>;
   // Keys *written during the current branch* (reset on clone). Used by the
   // if-merge algorithm to determine which locations are "touched."
@@ -1361,12 +1381,87 @@ function translatePureBody(
   // ir-emit). See CLAUDE.md §"Intermediate Representation" for the
   // migration roadmap.
   let rhs: OpaqueExpr;
-  // IR pipeline only handles Expression returns in Stage 1; an
-  // IfStatement returnExpr (TS allows `if (c) return a; return b` to
-  // be lifted into a single conditional return — see
-  // `extractReturnExpression`) still goes through the legacy path until
-  // Stage 8 cutover wires up `Cond` / early-return handling natively.
-  if (useIRPipeline() && ts.isExpression(extracted.returnExpr)) {
+
+  // Layer 1 imperative-IR conditional pipeline (workstream M1, gated on
+  // `TS2PANT_USE_L1=1` during patch 2; always-on after patch 3 cutover).
+  // Routes when the body has prelude arms (early-return if-conversion)
+  // or a conditional terminal (if/switch/ternary/Bool-typed &&/||) —
+  // exactly the cases where L1 normalization unifies recognition.
+  // Plain non-conditional returns fall through to the existing IR or
+  // legacy path.
+  const l1IsConditionalReturn =
+    ts.isIfStatement(extracted.returnExpr) ||
+    ts.isSwitchStatement(extracted.returnExpr) ||
+    (ts.isExpression(extracted.returnExpr) &&
+      isL1ConditionalForm(extracted.returnExpr, checker));
+  if (useL1Pipeline() && (inlined.arms.length > 0 || l1IsConditionalReturn)) {
+    const l1Ctx = {
+      checker,
+      strategy,
+      paramNames: inlined.scopedParams,
+      state: undefined as SymbolicState | undefined,
+      supply,
+    };
+    // Wrap pre-translated arm OpaqueExprs as L1 from-l2 expressions so
+    // the L1 cond-builder can compose them with the L1-translated
+    // terminal. Each arm's guard and value are independent
+    // sub-expressions whose internal normalization isn't M1's concern;
+    // M2/M3 will progressively replace these wraps with native L1
+    // construction.
+    const preludeL1: Array<readonly [IR1Expr, IR1Expr]> = inlined.arms.map(
+      ([g, v]) => [ir1FromL2(irWrap(g)), ir1FromL2(irWrap(v))] as const,
+    );
+    const built = buildL1ConditionalFromArms(
+      preludeL1,
+      extracted.returnExpr,
+      l1Ctx,
+    );
+    if (!isL1Unsupported(built)) {
+      // Wrap the lowered cond in IRWrap so the const-binding Let chain
+      // (Stage 6) can substitute hygienic-name references inside it via
+      // Pant's `substituteBinder`. This mirrors the IR-pipeline branch
+      // below — a uniform IRWrap-wrapped body lets the same Let chain
+      // work whether the body came from the IR builder or the L1 cond
+      // builder.
+      let bodyIR: IRExpr = irWrap(lowerL1ToOpaque(built));
+      for (let i = inlined.translatedBindings.length - 1; i >= 0; i--) {
+        const tb = inlined.translatedBindings[i]!;
+        bodyIR = irLet(tb.hygienicName, irWrap(tb.initExpr), bodyIR);
+      }
+      rhs = lowerExpr(bodyIR);
+    } else {
+      // L1 rejected — fall through to legacy. Patch 2 keeps both paths
+      // available so dogfood can measure rejection rate. Patch 3 deletes
+      // the legacy paths and the rejection becomes terminal.
+      const body = translateBodyExpr(
+        extracted.returnExpr,
+        checker,
+        strategy,
+        inlined.scopedParams,
+        undefined,
+        supply,
+      );
+      if (isBodyUnsupported(body)) {
+        return [
+          {
+            kind: "unsupported",
+            reason: `${functionName} — ${built.unsupported} (L1) / ${body.unsupported} (legacy)`,
+          },
+        ];
+      }
+      const terminal = bodyExpr(body);
+      const merged =
+        inlined.arms.length === 0
+          ? terminal
+          : ast.cond([
+              ...inlined.arms.map(
+                ([g, v]) => [g, v] as [OpaqueExpr, OpaqueExpr],
+              ),
+              [ast.litBool(true), terminal] as [OpaqueExpr, OpaqueExpr],
+            ]);
+      rhs = inlined.applyTo(merged);
+    }
+  } else if (useIRPipeline() && ts.isExpression(extracted.returnExpr)) {
     const ir = buildIR(
       extracted.returnExpr,
       checker,
@@ -1444,7 +1539,7 @@ function translatePureBody(
 
 interface ExtractedBody {
   bindings: ConstBinding[];
-  returnExpr: ts.Expression | ts.IfStatement;
+  returnExpr: ts.Expression | ts.IfStatement | ts.SwitchStatement;
 }
 
 /**
@@ -1732,6 +1827,13 @@ function extractReturnExpression(
     return { bindings, returnExpr: last.expression };
   }
   if (ts.isIfStatement(last) && last.elseStatement) {
+    return { bindings, returnExpr: last };
+  }
+  // Switch as a terminal — only when L1 is enabled. Under USE_L1=0
+  // switches still fall through to the normal rejection path because
+  // there is no legacy switch translator. Under USE_L1=1, the L1
+  // conditional builder accepts switches in this position.
+  if (ts.isSwitchStatement(last) && useL1Pipeline()) {
     return { bindings, returnExpr: last };
   }
 
@@ -2414,7 +2516,7 @@ function unwrapExpression(expr: ts.Expression): ts.Expression {
   return expr;
 }
 
-function expressionHasSideEffects(
+export function expressionHasSideEffects(
   expr: ts.Expression,
   checker: ts.TypeChecker,
 ): boolean {
@@ -2486,6 +2588,30 @@ export function translateBodyExpr(
 
   if (ts.isExpression(expr)) {
     expr = unwrapExpression(expr);
+  }
+
+  // Layer 1 imperative-IR conditional pipeline (workstream M1, gated on
+  // `TS2PANT_USE_L1=1` during patch 2). Routes if-statement, ternary,
+  // switch, and Bool-typed `&&`/`||` through the L1 builder. Other forms
+  // and L1 rejections fall through to the legacy handlers below.
+  if (useL1Pipeline()) {
+    if (
+      ts.isIfStatement(expr) ||
+      ts.isSwitchStatement(expr) ||
+      isL1ConditionalForm(expr, checker)
+    ) {
+      const l1 = buildL1Conditional(
+        expr as ts.Expression | ts.IfStatement | ts.SwitchStatement,
+        { checker, strategy, paramNames, state, supply },
+      );
+      if (!isL1Unsupported(l1)) {
+        return { expr: lowerL1ToOpaque(l1) };
+      }
+      // L1 rejected — under USE_L1=1 with patch 2, fall through to the
+      // legacy handlers so dogfood / existing fixtures still translate.
+      // Patch 3 deletes the legacy conditional paths and the rejection
+      // becomes terminal.
+    }
   }
 
   // if/else statement -> cond

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -56,18 +56,6 @@ function useIRPipeline(): boolean {
   return g.process?.env?.["TS2PANT_USE_IR"] === "1";
 }
 
-/**
- * True if the imperative-IR (Layer 1) conditional pipeline is enabled
- * via `TS2PANT_USE_L1=1`. M1 patch 2 uses this flag to gate the L1
- * conditional builder during validation; patch 3 deletes the flag and
- * makes L1 always-on for conditional value forms (workstream
- * `workstreams/ts2pant-imperative-ir.md`, milestone M1).
- */
-function useL1Pipeline(): boolean {
-  const g = globalThis as { process?: { env?: Record<string, string> } };
-  return g.process?.env?.["TS2PANT_USE_L1"] === "1";
-}
-
 // --- Const-binding inlining infrastructure (let-elimination) ---
 
 /**
@@ -1382,19 +1370,16 @@ function translatePureBody(
   // migration roadmap.
   let rhs: OpaqueExpr;
 
-  // Layer 1 imperative-IR conditional pipeline (workstream M1, gated on
-  // `TS2PANT_USE_L1=1` during patch 2; always-on after patch 3 cutover).
+  // Layer 1 imperative-IR conditional pipeline (workstream M1).
   // Routes when the body has prelude arms (early-return if-conversion)
-  // or a conditional terminal (if/switch/ternary/Bool-typed &&/||) —
-  // exactly the cases where L1 normalization unifies recognition.
-  // Plain non-conditional returns fall through to the existing IR or
-  // legacy path.
+  // or a conditional terminal (if/switch/ternary/Bool-typed `&&`/`||`).
+  // Plain non-conditional returns fall through to the IR or legacy path.
   const l1IsConditionalReturn =
     ts.isIfStatement(extracted.returnExpr) ||
     ts.isSwitchStatement(extracted.returnExpr) ||
     (ts.isExpression(extracted.returnExpr) &&
       isL1ConditionalForm(extracted.returnExpr, checker));
-  if (useL1Pipeline() && (inlined.arms.length > 0 || l1IsConditionalReturn)) {
+  if (inlined.arms.length > 0 || l1IsConditionalReturn) {
     const l1Ctx = {
       checker,
       strategy,
@@ -1416,51 +1401,23 @@ function translatePureBody(
       extracted.returnExpr,
       l1Ctx,
     );
-    if (!isL1Unsupported(built)) {
-      // Wrap the lowered cond in IRWrap so the const-binding Let chain
-      // (Stage 6) can substitute hygienic-name references inside it via
-      // Pant's `substituteBinder`. This mirrors the IR-pipeline branch
-      // below — a uniform IRWrap-wrapped body lets the same Let chain
-      // work whether the body came from the IR builder or the L1 cond
-      // builder.
-      let bodyIR: IRExpr = irWrap(lowerL1ToOpaque(built));
-      for (let i = inlined.translatedBindings.length - 1; i >= 0; i--) {
-        const tb = inlined.translatedBindings[i]!;
-        bodyIR = irLet(tb.hygienicName, irWrap(tb.initExpr), bodyIR);
-      }
-      rhs = lowerExpr(bodyIR);
-    } else {
-      // L1 rejected — fall through to legacy. Patch 2 keeps both paths
-      // available so dogfood can measure rejection rate. Patch 3 deletes
-      // the legacy paths and the rejection becomes terminal.
-      const body = translateBodyExpr(
-        extracted.returnExpr,
-        checker,
-        strategy,
-        inlined.scopedParams,
-        undefined,
-        supply,
-      );
-      if (isBodyUnsupported(body)) {
-        return [
-          {
-            kind: "unsupported",
-            reason: `${functionName} — ${built.unsupported} (L1) / ${body.unsupported} (legacy)`,
-          },
-        ];
-      }
-      const terminal = bodyExpr(body);
-      const merged =
-        inlined.arms.length === 0
-          ? terminal
-          : ast.cond([
-              ...inlined.arms.map(
-                ([g, v]) => [g, v] as [OpaqueExpr, OpaqueExpr],
-              ),
-              [ast.litBool(true), terminal] as [OpaqueExpr, OpaqueExpr],
-            ]);
-      rhs = inlined.applyTo(merged);
+    if (isL1Unsupported(built)) {
+      return [
+        {
+          kind: "unsupported",
+          reason: `${functionName} — ${built.unsupported}`,
+        },
+      ];
     }
+    // Wrap the lowered cond in IRWrap so the const-binding Let chain
+    // (Stage 6) can substitute hygienic-name references inside it via
+    // Pant's `substituteBinder`.
+    let bodyIR: IRExpr = irWrap(lowerL1ToOpaque(built));
+    for (let i = inlined.translatedBindings.length - 1; i >= 0; i--) {
+      const tb = inlined.translatedBindings[i]!;
+      bodyIR = irLet(tb.hygienicName, irWrap(tb.initExpr), bodyIR);
+    }
+    rhs = lowerExpr(bodyIR);
   } else if (useIRPipeline() && ts.isExpression(extracted.returnExpr)) {
     const ir = buildIR(
       extracted.returnExpr,
@@ -1829,11 +1786,11 @@ function extractReturnExpression(
   if (ts.isIfStatement(last) && last.elseStatement) {
     return { bindings, returnExpr: last };
   }
-  // Switch as a terminal — only when L1 is enabled. Under USE_L1=0
-  // switches still fall through to the normal rejection path because
-  // there is no legacy switch translator. Under USE_L1=1, the L1
-  // conditional builder accepts switches in this position.
-  if (ts.isSwitchStatement(last) && useL1Pipeline()) {
+  // Switch as a terminal — handled by the L1 conditional builder
+  // (workstream M1). The L1 path requires a default that's last, every
+  // case ending in `return EXPR`, and only literal case labels;
+  // anything else surfaces as UNSUPPORTED at build time.
+  if (ts.isSwitchStatement(last)) {
     return { bindings, returnExpr: last };
   }
 
@@ -2590,83 +2547,25 @@ export function translateBodyExpr(
     expr = unwrapExpression(expr);
   }
 
-  // Layer 1 imperative-IR conditional pipeline (workstream M1, gated on
-  // `TS2PANT_USE_L1=1` during patch 2). Routes if-statement, ternary,
-  // switch, and Bool-typed `&&`/`||` through the L1 builder. Other forms
-  // and L1 rejections fall through to the legacy handlers below.
-  if (useL1Pipeline()) {
-    if (
-      ts.isIfStatement(expr) ||
-      ts.isSwitchStatement(expr) ||
-      isL1ConditionalForm(expr, checker)
-    ) {
-      const l1 = buildL1Conditional(
-        expr as ts.Expression | ts.IfStatement | ts.SwitchStatement,
-        { checker, strategy, paramNames, state, supply },
-      );
-      if (!isL1Unsupported(l1)) {
-        return { expr: lowerL1ToOpaque(l1) };
-      }
-      // L1 rejected — under USE_L1=1 with patch 2, fall through to the
-      // legacy handlers so dogfood / existing fixtures still translate.
-      // Patch 3 deletes the legacy conditional paths and the rejection
-      // becomes terminal.
-    }
-  }
-
-  // if/else statement -> cond
-  if (ts.isIfStatement(expr)) {
-    return translateIfStatement(
-      expr,
-      checker,
-      strategy,
-      paramNames,
-      state,
-      supply,
+  // Layer 1 imperative-IR conditional pipeline (workstream M1).
+  // Conditional value forms — if/else statements, ternaries, switch,
+  // and Bool-typed `&&`/`||` — flow through `buildL1Conditional` and
+  // collapse to one canonical `Cond` form. The legacy if-statement and
+  // ternary handlers were deleted at the M1 patch-3 cutover; L1
+  // rejection here is terminal (no fall-through).
+  if (
+    ts.isIfStatement(expr) ||
+    ts.isSwitchStatement(expr) ||
+    isL1ConditionalForm(expr, checker)
+  ) {
+    const l1 = buildL1Conditional(
+      expr as ts.Expression | ts.IfStatement | ts.SwitchStatement,
+      { checker, strategy, paramNames, state, supply },
     );
-  }
-
-  // Ternary: a ? b : c -> cond([[a, b], [true, c]])
-  if (ts.isConditionalExpression(expr)) {
-    const cond = translateBodyExpr(
-      expr.condition,
-      checker,
-      strategy,
-      paramNames,
-      state,
-      supply,
-    );
-    if (isBodyUnsupported(cond)) {
-      return cond;
+    if (isL1Unsupported(l1)) {
+      return { unsupported: l1.unsupported };
     }
-    const whenTrue = translateBodyExpr(
-      expr.whenTrue,
-      checker,
-      strategy,
-      paramNames,
-      state,
-      supply,
-    );
-    if (isBodyUnsupported(whenTrue)) {
-      return whenTrue;
-    }
-    const whenFalse = translateBodyExpr(
-      expr.whenFalse,
-      checker,
-      strategy,
-      paramNames,
-      state,
-      supply,
-    );
-    if (isBodyUnsupported(whenFalse)) {
-      return whenFalse;
-    }
-    return {
-      expr: ast.cond([
-        [bodyExpr(cond), bodyExpr(whenTrue)],
-        [ast.litBool(true), bodyExpr(whenFalse)],
-      ]),
-    };
+    return { expr: lowerL1ToOpaque(l1) };
   }
 
   // Property access with special array operations
@@ -2902,66 +2801,6 @@ export function translateBodyExpr(
   }
 
   return { unsupported: "non-expression statement" };
-}
-
-function translateIfStatement(
-  stmt: ts.IfStatement,
-  checker: ts.TypeChecker,
-  strategy: NumericStrategy,
-  paramNames: ReadonlyMap<string, string>,
-  state: SymbolicState | undefined,
-  supply: UniqueSupply,
-): BodyResult {
-  const ast = getAst();
-
-  const cond = translateBodyExpr(
-    stmt.expression,
-    checker,
-    strategy,
-    paramNames,
-    state,
-    supply,
-  );
-  if (isBodyUnsupported(cond)) {
-    return cond;
-  }
-  const thenExpr = extractReturnFromBranch(stmt.thenStatement, checker);
-  const elseExpr = stmt.elseStatement
-    ? extractReturnFromBranch(stmt.elseStatement, checker)
-    : null;
-
-  if (thenExpr && elseExpr) {
-    const thenVal = translateBodyExpr(
-      thenExpr,
-      checker,
-      strategy,
-      paramNames,
-      state,
-      supply,
-    );
-    if (isBodyUnsupported(thenVal)) {
-      return thenVal;
-    }
-    const elseVal = translateBodyExpr(
-      elseExpr,
-      checker,
-      strategy,
-      paramNames,
-      state,
-      supply,
-    );
-    if (isBodyUnsupported(elseVal)) {
-      return elseVal;
-    }
-    return {
-      expr: ast.cond([
-        [bodyExpr(cond), bodyExpr(thenVal)],
-        [ast.litBool(true), bodyExpr(elseVal)],
-      ]),
-    };
-  }
-
-  return { unsupported: "if statement without return in both branches" };
 }
 
 function extractReturnFromBranch(

--- a/tools/ts2pant/tests/ir1-lower.test.mts
+++ b/tools/ts2pant/tests/ir1-lower.test.mts
@@ -1,0 +1,373 @@
+import assert from "node:assert/strict";
+import { before, describe, it } from "node:test";
+import {
+  irAppName,
+  irBinop,
+  irCond,
+  irLitBool,
+  irLitNat,
+  irUnop,
+  irVar,
+} from "../src/ir.js";
+import { lowerExpr } from "../src/ir-emit.js";
+import {
+  ir1App,
+  ir1Assign,
+  ir1Binop,
+  ir1Block,
+  ir1Cond,
+  ir1CondStmt,
+  ir1ExprStmt,
+  ir1For,
+  ir1Foreach,
+  ir1FromL2,
+  ir1Let,
+  ir1LitBool,
+  ir1LitNat,
+  ir1LitString,
+  ir1Member,
+  ir1Return,
+  ir1Throw,
+  ir1Unop,
+  ir1Var,
+  ir1While,
+} from "../src/ir1.js";
+import { lowerL1Expr, lowerL1Stmt } from "../src/ir1-lower.js";
+import { getAst, loadAst } from "../src/pant-wasm.js";
+
+before(async () => {
+  await loadAst();
+});
+
+// ---------------------------------------------------------------------------
+// L1 → L2 lowering: structural equality
+//
+// Each test builds an L1 expression and asserts that lowering produces an
+// L2 IRExpr structurally equal to a hand-built reference. Structural
+// equality on the L2 tree is the cutover gate for Patch 3 — if L1 lowering
+// matches the L2 trees today's legacy code produces, then deleting the
+// legacy paths cannot regress snapshots.
+// ---------------------------------------------------------------------------
+
+describe("lowerL1Expr — atoms", () => {
+  it("var lowers to L2 var", () => {
+    const l2 = lowerL1Expr(ir1Var("x"));
+    assert.deepEqual(l2, irVar("x", false));
+  });
+
+  it("primed var lowers to L2 primed var", () => {
+    const l2 = lowerL1Expr(ir1Var("x", true));
+    assert.deepEqual(l2, irVar("x", true));
+  });
+
+  it("lit nat / bool / string lower to corresponding L2 lit", () => {
+    assert.deepEqual(lowerL1Expr(ir1LitNat(42)), irLitNat(42));
+    assert.deepEqual(lowerL1Expr(ir1LitBool(true)), irLitBool(true));
+    assert.deepEqual(lowerL1Expr(ir1LitBool(false)), irLitBool(false));
+    assert.deepEqual(lowerL1Expr(ir1LitString("hi")), {
+      kind: "lit",
+      value: { kind: "string", value: "hi" },
+    });
+  });
+});
+
+describe("lowerL1Expr — operators", () => {
+  it("binop lowers to L2 binop", () => {
+    const l2 = lowerL1Expr(ir1Binop("add", ir1Var("a"), ir1Var("b")));
+    assert.deepEqual(l2, irBinop("add", irVar("a", false), irVar("b", false)));
+  });
+
+  it("unop lowers to L2 unop", () => {
+    const l2 = lowerL1Expr(ir1Unop("not", ir1Var("p")));
+    assert.deepEqual(l2, irUnop("not", irVar("p", false)));
+  });
+
+  it("nested binop preserves structure", () => {
+    // (a + b) * c
+    const l1 = ir1Binop(
+      "mul",
+      ir1Binop("add", ir1Var("a"), ir1Var("b")),
+      ir1Var("c"),
+    );
+    const l2 = lowerL1Expr(l1);
+    assert.deepEqual(
+      l2,
+      irBinop(
+        "mul",
+        irBinop("add", irVar("a", false), irVar("b", false)),
+        irVar("c", false),
+      ),
+    );
+  });
+});
+
+describe("lowerL1Expr — applications", () => {
+  it("var-headed app lowers to L2 named application", () => {
+    const l1 = ir1App(ir1Var("foo"), [ir1Var("a"), ir1Var("b")]);
+    const l2 = lowerL1Expr(l1);
+    assert.deepEqual(
+      l2,
+      irAppName("foo", [irVar("a", false), irVar("b", false)]),
+    );
+  });
+
+  it("zero-arity var-headed app lowers to L2 named application with no args", () => {
+    const l1 = ir1App(ir1Var("foo"), []);
+    const l2 = lowerL1Expr(l1);
+    assert.deepEqual(l2, irAppName("foo", []));
+  });
+
+  it("non-var-headed app lowers via L2 expr-headed application", () => {
+    // (cond ? f : g)(x) — pathological but syntactically valid
+    const l1 = ir1App(
+      ir1Cond([[ir1Var("c"), ir1Var("f")]], ir1Var("g")),
+      [ir1Var("x")],
+    );
+    const l2 = lowerL1Expr(l1);
+    // Just check the shape: head is expression-kind, args has one var.
+    assert.equal(l2.kind, "app");
+    if (l2.kind === "app") {
+      assert.equal(l2.head.kind, "expr");
+      assert.equal(l2.args.length, 1);
+    }
+  });
+
+  it("member lowers to qualified named application of receiver", () => {
+    // member(obj, "balance") → App(name="balance", [obj])
+    const l1 = ir1Member(ir1Var("obj"), "balance");
+    const l2 = lowerL1Expr(l1);
+    assert.deepEqual(l2, irAppName("balance", [irVar("obj", false)]));
+  });
+});
+
+describe("lowerL1Expr — cond (byte-equality with legacy ast.cond)", () => {
+  it("single-arm cond produces L2 cond with literal-true tail", () => {
+    // cond [(g, v)] otherwise=d  →  irCond [(g, v), (true, d)]
+    const l1 = ir1Cond([[ir1Var("g"), ir1Var("v")]], ir1Var("d"));
+    const l2 = lowerL1Expr(l1);
+    assert.deepEqual(
+      l2,
+      irCond([
+        [irVar("g", false), irVar("v", false)],
+        [irLitBool(true), irVar("d", false)],
+      ]),
+    );
+  });
+
+  it("multi-arm cond preserves arm order and emits literal-true tail", () => {
+    // cond [(g1, v1), (g2, v2), (g3, v3)] otherwise=d
+    const l1 = ir1Cond(
+      [
+        [ir1Var("g1"), ir1Var("v1")],
+        [ir1Var("g2"), ir1Var("v2")],
+        [ir1Var("g3"), ir1Var("v3")],
+      ],
+      ir1Var("d"),
+    );
+    const l2 = lowerL1Expr(l1);
+    assert.deepEqual(
+      l2,
+      irCond([
+        [irVar("g1", false), irVar("v1", false)],
+        [irVar("g2", false), irVar("v2", false)],
+        [irVar("g3", false), irVar("v3", false)],
+        [irLitBool(true), irVar("d", false)],
+      ]),
+    );
+  });
+
+  it("nested cond lowers recursively", () => {
+    // cond [(g, cond[(h, x)] y)] otherwise=z
+    const inner = ir1Cond([[ir1Var("h"), ir1Var("x")]], ir1Var("y"));
+    const outer = ir1Cond([[ir1Var("g"), inner]], ir1Var("z"));
+    const l2 = lowerL1Expr(outer);
+    const expectedInner = irCond([
+      [irVar("h", false), irVar("x", false)],
+      [irLitBool(true), irVar("y", false)],
+    ]);
+    assert.deepEqual(
+      l2,
+      irCond([
+        [irVar("g", false), expectedInner],
+        [irLitBool(true), irVar("z", false)],
+      ]),
+    );
+  });
+});
+
+describe("lowerL1Expr — from-l2 transitional adapter", () => {
+  it("from-l2 unwraps to the held L2 expression", () => {
+    const l2Inner = irBinop("add", irVar("a", false), irLitNat(1));
+    const l1 = ir1FromL2(l2Inner);
+    const lowered = lowerL1Expr(l1);
+    assert.equal(lowered, l2Inner); // identity, not just deep equal
+  });
+
+  it("from-l2 inside a cond arm composes correctly", () => {
+    // cond [(g, from-l2(a + 1))] otherwise=0  →
+    //   cond [(g, a+1), (true, 0)]
+    const l1 = ir1Cond(
+      [
+        [
+          ir1Var("g"),
+          ir1FromL2(irBinop("add", irVar("a", false), irLitNat(1))),
+        ],
+      ],
+      ir1LitNat(0),
+    );
+    const l2 = lowerL1Expr(l1);
+    assert.deepEqual(
+      l2,
+      irCond([
+        [
+          irVar("g", false),
+          irBinop("add", irVar("a", false), irLitNat(1)),
+        ],
+        [irLitBool(true), irLitNat(0)],
+      ]),
+    );
+  });
+});
+
+describe("L1 → L2 → OpaqueExpr — full pipeline byte-equality with legacy", () => {
+  // Verifies that lowering a hand-built L1 cond through L1 → L2 → OpaqueExpr
+  // produces the same Pantagruel string as a hand-built legacy `ast.cond`.
+  // This is the cutover gate: snapshots are byte-identical iff the full
+  // pipeline emits the same string at corresponding inputs.
+
+  it("ternary-shaped cond emits the legacy Pant string", () => {
+    const ast = getAst();
+
+    // Legacy: ast.cond([[a >= 0, a], [true, -a]])
+    const legacyCond = ast.cond([
+      [ast.binop(ast.opGe(), ast.var("a"), ast.litNat(0)), ast.var("a")],
+      [ast.litBool(true), ast.unop(ast.opNeg(), ast.var("a"))],
+    ]);
+
+    // L1: cond([(a >= 0, a)], otherwise=-a)
+    const l1 = ir1Cond(
+      [[ir1Binop("ge", ir1Var("a"), ir1LitNat(0)), ir1Var("a")]],
+      ir1Unop("neg", ir1Var("a")),
+    );
+    const l1Lowered = lowerExpr(lowerL1Expr(l1));
+
+    assert.equal(ast.strExpr(l1Lowered), ast.strExpr(legacyCond));
+  });
+
+  it("multi-arm cond emits the legacy Pant string", () => {
+    const ast = getAst();
+
+    // Legacy: cond([[g1, v1], [g2, v2], [true, d]])
+    const legacyCond = ast.cond([
+      [ast.var("g1"), ast.var("v1")],
+      [ast.var("g2"), ast.var("v2")],
+      [ast.litBool(true), ast.var("d")],
+    ]);
+
+    const l1 = ir1Cond(
+      [
+        [ir1Var("g1"), ir1Var("v1")],
+        [ir1Var("g2"), ir1Var("v2")],
+      ],
+      ir1Var("d"),
+    );
+    const l1Lowered = lowerExpr(lowerL1Expr(l1));
+
+    assert.equal(ast.strExpr(l1Lowered), ast.strExpr(legacyCond));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Vocabulary-locked stubs throw not-implemented
+// ---------------------------------------------------------------------------
+
+describe("vocabulary-locked stubs (M2/M3 forms)", () => {
+  it("ir1Assign throws not-implemented (M2)", () => {
+    assert.throws(() => ir1Assign(ir1Var("x"), ir1LitNat(1)), /M2/);
+  });
+
+  it("ir1CondStmt throws not-implemented (M3)", () => {
+    assert.throws(
+      () => ir1CondStmt([[ir1Var("g"), ir1Return(ir1Var("v"))]], null),
+      /M3/,
+    );
+  });
+
+  it("ir1Foreach throws not-implemented (M3)", () => {
+    assert.throws(
+      () => ir1Foreach("x", ir1Var("xs"), ir1Return(ir1Var("x"))),
+      /M3/,
+    );
+  });
+
+  it("ir1For throws not-implemented (M3)", () => {
+    assert.throws(
+      () => ir1For(null, null, null, ir1Return(null)),
+      /M3/,
+    );
+  });
+
+  it("ir1While throws not-implemented (M3)", () => {
+    assert.throws(
+      () => ir1While(ir1Var("g"), ir1Return(null)),
+      /M3/,
+    );
+  });
+
+  it("ir1Throw throws not-implemented (M3)", () => {
+    assert.throws(() => ir1Throw(ir1Var("err")), /M3/);
+  });
+
+  it("ir1ExprStmt throws not-implemented (M3)", () => {
+    assert.throws(() => ir1ExprStmt(ir1Var("e")), /M3/);
+  });
+
+  it("lowerL1Stmt throws — statement lowering is M3", () => {
+    const stmt = ir1Return(ir1Var("x"));
+    assert.throws(() => lowerL1Stmt(stmt), /M3/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Active statement constructors don't throw (vocabulary-active subset for M1)
+// ---------------------------------------------------------------------------
+
+describe("active statement constructors (block, let, return)", () => {
+  it("ir1Block constructs a block of two statements", () => {
+    const block = ir1Block([
+      ir1Let("x", ir1LitNat(1)),
+      ir1Return(ir1Var("x")),
+    ]);
+    assert.equal(block.kind, "block");
+  });
+
+  it("ir1Block collapses single-statement blocks", () => {
+    const inner = ir1Return(ir1Var("x"));
+    const collapsed = ir1Block([inner]);
+    assert.equal(collapsed, inner);
+  });
+
+  it("ir1Let constructs a let-binding", () => {
+    const stmt = ir1Let("x", ir1LitNat(42));
+    assert.equal(stmt.kind, "let");
+    if (stmt.kind === "let") {
+      assert.equal(stmt.name, "x");
+    }
+  });
+
+  it("ir1Return with expression", () => {
+    const stmt = ir1Return(ir1Var("x"));
+    assert.equal(stmt.kind, "return");
+    if (stmt.kind === "return") {
+      assert.deepEqual(stmt.expr, ir1Var("x"));
+    }
+  });
+
+  it("ir1Return with null (void return)", () => {
+    const stmt = ir1Return(null);
+    assert.equal(stmt.kind, "return");
+    if (stmt.kind === "return") {
+      assert.equal(stmt.expr, null);
+    }
+  });
+});

--- a/tools/ts2pant/tests/l1-plumbing.test.mts
+++ b/tools/ts2pant/tests/l1-plumbing.test.mts
@@ -1,22 +1,12 @@
 /**
- * Integration tests for the L1 imperative-IR plumbing
- * (workstream M1, patch 2).
+ * Regression tests for the L1 conditional pipeline (workstream M1).
  *
- * Sets `TS2PANT_USE_L1=1` for the duration of these tests so the L1
- * conditional pipeline is exercised end-to-end. Asserts:
- *
- * 1. **L1 conditional shapes translate** that the legacy pipeline
- *    currently rejects: switch (clean) becomes a cond.
- * 2. **L1 conservative-refusal cases** produce the expected UNSUPPORTED
- *    reasons: switch fall-through, switch default-not-last, switch
- *    without default, non-Bool `&&`/`||`, non-literal switch case label,
- *    object-literal arms.
- * 3. **L1 byte-equality with legacy** for forms both pipelines handle:
- *    if-with-returns, ternary, Bool-typed `&&`/`||`. Translating the
- *    same source under USE_L1=0 vs USE_L1=1 produces identical Pant.
- *
- * The byte-equality check is the cutover gate — Patch 3 deletes the
- * legacy paths, so snapshots can't change between the two runs.
+ * After M1 patch 3 (hard-rule cutover), all conditional value forms —
+ * if-with-returns, ternary chains, switch w/o fall-through, Bool-typed
+ * `&&`/`||` — flow through the L1 builder. These tests verify the
+ * resulting Pant for representative shapes and lock in the rejection
+ * reasons for cases the L1 builder conservatively refuses (workstream
+ * policy 3(b)).
  */
 
 import assert from "node:assert/strict";
@@ -30,36 +20,10 @@ before(async () => {
   await loadAst();
 });
 
-function withL1<T>(fn: () => T): T {
-  const prev = process.env.TS2PANT_USE_L1;
-  process.env.TS2PANT_USE_L1 = "1";
-  try {
-    return fn();
-  } finally {
-    if (prev === undefined) {
-      delete process.env.TS2PANT_USE_L1;
-    } else {
-      process.env.TS2PANT_USE_L1 = prev;
-    }
-  }
-}
-
-function withoutL1<T>(fn: () => T): T {
-  const prev = process.env.TS2PANT_USE_L1;
-  delete process.env.TS2PANT_USE_L1;
-  try {
-    return fn();
-  } finally {
-    if (prev !== undefined) {
-      process.env.TS2PANT_USE_L1 = prev;
-    }
-  }
-}
-
-function translate(source: string, name: string): {
-  unsupported: string | null;
-  pant: string | null;
-} {
+function translate(
+  source: string,
+  name: string,
+): { unsupported: string | null; pant: string | null } {
   const sourceFile = createSourceFileFromSource(source);
   const props = translateBody({
     sourceFile,
@@ -81,11 +45,11 @@ function translate(source: string, name: string): {
 }
 
 // ---------------------------------------------------------------------------
-// 1. L1 enables forms the legacy pipeline can't translate
+// L1 capabilities — switch, multi-arm if-chains, flat ternary chains
 // ---------------------------------------------------------------------------
 
 describe("L1: switch (clean) translates", () => {
-  it("switch with literal numeric cases and default → cond", () => {
+  it("switch with literal numeric cases and default → flat cond", () => {
     const source = `
       function classify(x: number): number {
         switch (x) {
@@ -95,14 +59,12 @@ describe("L1: switch (clean) translates", () => {
         }
       }
     `;
-    const { unsupported, pant } = withL1(() => translate(source, "classify"));
-    assert.equal(unsupported, null, "switch should translate under L1");
-    assert.match(pant!, /cond/);
-    assert.match(pant!, /x = 0/);
-    assert.match(pant!, /x = 1/);
-    assert.match(pant!, /100/);
-    assert.match(pant!, /200/);
-    assert.match(pant!, /300/);
+    const { unsupported, pant } = translate(source, "classify");
+    assert.equal(unsupported, null);
+    assert.equal(
+      pant,
+      "cond x = 0 => 100, x = 1 => 200, true => 300",
+    );
   });
 
   it("switch with string cases", () => {
@@ -115,9 +77,8 @@ describe("L1: switch (clean) translates", () => {
         }
       }
     `;
-    const { unsupported, pant } = withL1(() => translate(source, "tag"));
+    const { unsupported } = translate(source, "tag");
     assert.equal(unsupported, null);
-    assert.match(pant!, /cond/);
   });
 
   it("switch with only default collapses to the default value", () => {
@@ -128,36 +89,71 @@ describe("L1: switch (clean) translates", () => {
         }
       }
     `;
-    const { unsupported, pant } = withL1(() => translate(source, "constant"));
+    const { unsupported, pant } = translate(source, "constant");
     assert.equal(unsupported, null);
-    // No cond — just the literal.
     assert.equal(pant, "42");
   });
 });
 
+describe("L1: flat-cond canonicalization", () => {
+  it("right-leaning ternary chain flattens to one cond", () => {
+    const source = `
+      function bucket(n: number): number {
+        return n < 0 ? 0 : n < 10 ? 1 : n < 100 ? 2 : 3;
+      }
+    `;
+    const { unsupported, pant } = translate(source, "bucket");
+    assert.equal(unsupported, null);
+    assert.equal(
+      pant,
+      "cond n < 0 => 0, n < 10 => 1, n < 100 => 2, true => 3",
+    );
+  });
+
+  it("if/else-if/else chain flattens to one cond", () => {
+    const source = `
+      function classify(n: number): number {
+        if (n < 0) {
+          return -1;
+        } else if (n === 0) {
+          return 0;
+        } else {
+          return 1;
+        }
+      }
+    `;
+    const { unsupported, pant } = translate(source, "classify");
+    assert.equal(unsupported, null);
+    assert.equal(
+      pant,
+      "cond n < 0 => -1, n = 0 => 0, true => 1",
+    );
+  });
+
+  it("early-return arm + ternary terminal merges into one flat cond", () => {
+    const source = `
+      function nested(n: number): number {
+        if (n < 0) {
+          return -1;
+        }
+        return n === 0 ? 0 : 1;
+      }
+    `;
+    const { unsupported, pant } = translate(source, "nested");
+    assert.equal(unsupported, null);
+    assert.equal(
+      pant,
+      "cond n < 0 => -1, n = 0 => 0, true => 1",
+    );
+  });
+});
+
 // ---------------------------------------------------------------------------
-// 2. L1 rejection cases produce the expected UNSUPPORTED reasons
+// L1 conservative-refusal — locked rejection reasons (policy 3(b))
 // ---------------------------------------------------------------------------
 
 describe("L1: conservative-refusal rejection cases", () => {
-  it("switch without default rejects (literal-union exhaustiveness deferred)", () => {
-    const source = `
-      function noDefault(x: number): number {
-        switch (x) {
-          case 0: return 1;
-          case 1: return 2;
-        }
-        return 0;
-      }
-    `;
-    const { unsupported } = withL1(() => translate(source, "noDefault"));
-    // Either (a) the switch isn't recognized as a terminal because of the
-    // trailing `return 0`, or (b) the switch is recognized and rejected.
-    // Either way: not a clean translation.
-    assert.notEqual(unsupported, null);
-  });
-
-  it("switch with default not last rejects", () => {
+  it("switch with default not last rejects with specific reason", () => {
     const source = `
       function badOrder(x: number): number {
         switch (x) {
@@ -166,12 +162,12 @@ describe("L1: conservative-refusal rejection cases", () => {
         }
       }
     `;
-    const { unsupported } = withL1(() => translate(source, "badOrder"));
+    const { unsupported } = translate(source, "badOrder");
     assert.notEqual(unsupported, null);
     assert.match(unsupported!, /default must be the last/);
   });
 
-  it("switch with fall-through (case body not ending in return) rejects", () => {
+  it("switch fall-through (case body not ending in return) rejects", () => {
     const source = `
       function fallthrough(x: number): number {
         switch (x) {
@@ -181,23 +177,21 @@ describe("L1: conservative-refusal rejection cases", () => {
         }
       }
     `;
-    const { unsupported } = withL1(() => translate(source, "fallthrough"));
+    const { unsupported } = translate(source, "fallthrough");
     assert.notEqual(unsupported, null);
     assert.match(unsupported!, /case must end with `return EXPR`/);
   });
 
-  it("switch with break-only case rejects", () => {
+  it("switch break-only case rejects", () => {
     const source = `
       function breakOnly(x: number): number {
-        let r = 0;
         switch (x) {
           case 0: { break; }
           default: { return 0; }
         }
-        return r;
       }
     `;
-    const { unsupported } = withL1(() => translate(source, "breakOnly"));
+    const { unsupported } = translate(source, "breakOnly");
     assert.notEqual(unsupported, null);
   });
 
@@ -210,80 +204,58 @@ describe("L1: conservative-refusal rejection cases", () => {
         }
       }
     `;
-    const { unsupported } = withL1(() => translate(source, "nonLiteral"));
+    const { unsupported } = translate(source, "nonLiteral");
     assert.notEqual(unsupported, null);
     assert.match(unsupported!, /literal/);
   });
 
-  it("non-Bool && in conditional position rejects (with L1 hooked at &&/||)", () => {
-    // `a && b` where both operands are number — under L1 the &&/|| Bool
-    // typing check rejects. Without L1, this would translate as a binop.
-    // Under L1 the rejection falls through to legacy (patch 2 keeps both
-    // available); legacy handles non-Bool && by producing `a and b` via
-    // translateOperator. Under patch 2, the L1 path simply doesn't fire
-    // for non-Bool short-circuit (isL1ConditionalForm returns false), so
-    // we fall through cleanly. Verify the legacy path still works.
+  it("non-Bool && stays on the legacy operator path (degraded but accepted)", () => {
+    // Non-Bool `&&` / `||` is *not* an L1 conditional form — `isL1ConditionalForm`
+    // requires both operands Bool-typed. So `a && b` with `a: number` falls
+    // through to the legacy `translateOperator` path and lowers to `a and b`
+    // as a binop. Translation succeeds.
     const source = `
       function combine(a: number, b: number): number {
         return a && b;
       }
     `;
-    // L1 path won't recognize this as conditional (operands non-Bool),
-    // so isL1ConditionalForm returns false and translation proceeds via
-    // the legacy &&/|| binop path.
-    const { unsupported, pant } = withL1(() => translate(source, "combine"));
-    // Translation succeeds via legacy fallback.
+    const { unsupported, pant } = translate(source, "combine");
     assert.equal(unsupported, null);
     assert.match(pant!, /and/);
   });
 });
 
 // ---------------------------------------------------------------------------
-// 3. L1 byte-equality with legacy on shared forms (cutover gate)
+// Forms that already produced flat output before cutover are unchanged
 // ---------------------------------------------------------------------------
 
-describe("L1: byte-equality with legacy on shared forms", () => {
-  function translateBoth(source: string, name: string) {
-    const legacy = withoutL1(() => translate(source, name));
-    const l1 = withL1(() => translate(source, name));
-    return { legacy, l1 };
-  }
-
-  it("ternary translates identically under L1=0 and L1=1", () => {
+describe("L1: forms unchanged from pre-cutover", () => {
+  it("single ternary lowers to single-arm cond", () => {
     const source = `
       function abs(n: number): number {
         return n >= 0 ? n : -n;
       }
     `;
-    const { legacy, l1 } = translateBoth(source, "abs");
-    assert.equal(legacy.unsupported, null);
-    assert.equal(l1.unsupported, null);
-    assert.equal(legacy.pant, l1.pant);
+    const { unsupported, pant } = translate(source, "abs");
+    assert.equal(unsupported, null);
+    assert.equal(pant, "cond n >= 0 => n, true => -n");
   });
 
-  it("ternary chain: L1 flattens, legacy nests (expected divergence)", () => {
-    // Right-leaning ternary chain. L1's `buildFromTernary` flattens via
-    // recursive descent; legacy `translateBodyExpr` recurses, producing
-    // nested `cond [..., true => (cond ...)]`. Both are semantically
-    // equivalent; the L1 form is the canonical normalization.
+  it("single-arm early-return + plain terminal lowers correctly", () => {
     const source = `
-      function bucket(n: number): number {
-        return n < 0 ? 0 : n < 10 ? 1 : n < 100 ? 2 : 3;
+      function piecewise(n: number): number {
+        if (n < 0) {
+          return -1;
+        }
+        return n;
       }
     `;
-    const { legacy, l1 } = translateBoth(source, "bucket");
-    assert.equal(legacy.unsupported, null);
-    assert.equal(l1.unsupported, null);
-    // L1 produces flat: 4 arms in one cond.
-    assert.match(
-      l1.pant!,
-      /^cond n < 0 => 0, n < 10 => 1, n < 100 => 2, true => 3$/,
-    );
-    // Legacy nests; the strings genuinely differ.
-    assert.notEqual(legacy.pant, l1.pant);
+    const { unsupported, pant } = translate(source, "piecewise");
+    assert.equal(unsupported, null);
+    assert.equal(pant, "cond n < 0 => -1, true => n");
   });
 
-  it("if-with-returns translates identically under both modes", () => {
+  it("two-branch if/else translates to single-arm cond", () => {
     const source = `
       function abs2(n: number): number {
         if (n >= 0) {
@@ -293,98 +265,30 @@ describe("L1: byte-equality with legacy on shared forms", () => {
         }
       }
     `;
-    const { legacy, l1 } = translateBoth(source, "abs2");
-    assert.equal(legacy.unsupported, null);
-    assert.equal(l1.unsupported, null);
-    assert.equal(legacy.pant, l1.pant);
+    const { unsupported, pant } = translate(source, "abs2");
+    assert.equal(unsupported, null);
+    assert.equal(pant, "cond n >= 0 => n, true => -n");
   });
 
-  it("if/else-if/else chain: legacy rejects (unsupported), L1 flattens", () => {
-    // `if (g1) {return e1} else if (g2) {return e2} else {return e3}`.
-    // Legacy `translateIfStatement` only handles two-branch if/else
-    // (its `extractReturnFromBranch` rejects IfStatement-shaped else
-    // branches). L1's buildFromIfStatement walks the chain and produces
-    // one flat cond — a strict capability gain.
-    const source = `
-      function classify(n: number): number {
-        if (n < 0) {
-          return -1;
-        } else if (n === 0) {
-          return 0;
-        } else {
-          return 1;
-        }
-      }
-    `;
-    const { legacy, l1 } = translateBoth(source, "classify");
-    // Legacy doesn't support multi-arm if-chains.
-    assert.notEqual(legacy.unsupported, null);
-    // L1 produces the flat cond.
-    assert.equal(l1.unsupported, null);
-    assert.match(
-      l1.pant!,
-      /^cond n < 0 => -1, n = 0 => 0, true => 1$/,
-    );
-  });
-
-  it("Bool-typed && translates identically under both modes", () => {
+  it("Bool-typed && translates to binop", () => {
     const source = `
       function bothPositive(a: number, b: number): boolean {
         return a > 0 && b > 0;
       }
     `;
-    const { legacy, l1 } = translateBoth(source, "bothPositive");
-    assert.equal(legacy.unsupported, null);
-    assert.equal(l1.unsupported, null);
-    assert.equal(legacy.pant, l1.pant);
+    const { unsupported, pant } = translate(source, "bothPositive");
+    assert.equal(unsupported, null);
+    assert.equal(pant, "a > 0 and b > 0");
   });
 
-  it("Bool-typed || translates identically under both modes", () => {
+  it("Bool-typed || translates to binop", () => {
     const source = `
       function eitherPositive(a: number, b: number): boolean {
         return a > 0 || b > 0;
       }
     `;
-    const { legacy, l1 } = translateBoth(source, "eitherPositive");
-    assert.equal(legacy.unsupported, null);
-    assert.equal(l1.unsupported, null);
-    assert.equal(legacy.pant, l1.pant);
-  });
-
-  it("early-return arms translate identically under both modes", () => {
-    const source = `
-      function piecewise(n: number): number {
-        if (n < 0) {
-          return -1;
-        }
-        return n;
-      }
-    `;
-    const { legacy, l1 } = translateBoth(source, "piecewise");
-    assert.equal(legacy.unsupported, null);
-    assert.equal(l1.unsupported, null);
-    assert.equal(legacy.pant, l1.pant);
-  });
-
-  it("early-return arm + ternary terminal: L1 merges into one cond", () => {
-    // `if (P) return E; return ternary` — L1's buildL1ConditionalFromArms
-    // flattens the prelude arm with the ternary terminal into one cond.
-    // Legacy materializes them as nested cond at the arm-merge step.
-    const source = `
-      function nested(n: number): number {
-        if (n < 0) {
-          return -1;
-        }
-        return n === 0 ? 0 : 1;
-      }
-    `;
-    const { legacy, l1 } = translateBoth(source, "nested");
-    assert.equal(legacy.unsupported, null);
-    assert.equal(l1.unsupported, null);
-    assert.match(
-      l1.pant!,
-      /^cond n < 0 => -1, n = 0 => 0, true => 1$/,
-    );
-    assert.notEqual(legacy.pant, l1.pant);
+    const { unsupported, pant } = translate(source, "eitherPositive");
+    assert.equal(unsupported, null);
+    assert.equal(pant, "a > 0 or b > 0");
   });
 });

--- a/tools/ts2pant/tests/l1-plumbing.test.mts
+++ b/tools/ts2pant/tests/l1-plumbing.test.mts
@@ -1,0 +1,390 @@
+/**
+ * Integration tests for the L1 imperative-IR plumbing
+ * (workstream M1, patch 2).
+ *
+ * Sets `TS2PANT_USE_L1=1` for the duration of these tests so the L1
+ * conditional pipeline is exercised end-to-end. Asserts:
+ *
+ * 1. **L1 conditional shapes translate** that the legacy pipeline
+ *    currently rejects: switch (clean) becomes a cond.
+ * 2. **L1 conservative-refusal cases** produce the expected UNSUPPORTED
+ *    reasons: switch fall-through, switch default-not-last, switch
+ *    without default, non-Bool `&&`/`||`, non-literal switch case label,
+ *    object-literal arms.
+ * 3. **L1 byte-equality with legacy** for forms both pipelines handle:
+ *    if-with-returns, ternary, Bool-typed `&&`/`||`. Translating the
+ *    same source under USE_L1=0 vs USE_L1=1 produces identical Pant.
+ *
+ * The byte-equality check is the cutover gate — Patch 3 deletes the
+ * legacy paths, so snapshots can't change between the two runs.
+ */
+
+import assert from "node:assert/strict";
+import { before, describe, it } from "node:test";
+import { createSourceFileFromSource } from "../src/extract.js";
+import { getAst, loadAst } from "../src/pant-wasm.js";
+import { translateBody } from "../src/translate-body.js";
+import { IntStrategy } from "../src/translate-types.js";
+
+before(async () => {
+  await loadAst();
+});
+
+function withL1<T>(fn: () => T): T {
+  const prev = process.env.TS2PANT_USE_L1;
+  process.env.TS2PANT_USE_L1 = "1";
+  try {
+    return fn();
+  } finally {
+    if (prev === undefined) {
+      delete process.env.TS2PANT_USE_L1;
+    } else {
+      process.env.TS2PANT_USE_L1 = prev;
+    }
+  }
+}
+
+function withoutL1<T>(fn: () => T): T {
+  const prev = process.env.TS2PANT_USE_L1;
+  delete process.env.TS2PANT_USE_L1;
+  try {
+    return fn();
+  } finally {
+    if (prev !== undefined) {
+      process.env.TS2PANT_USE_L1 = prev;
+    }
+  }
+}
+
+function translate(source: string, name: string): {
+  unsupported: string | null;
+  pant: string | null;
+} {
+  const sourceFile = createSourceFileFromSource(source);
+  const props = translateBody({
+    sourceFile,
+    functionName: name,
+    strategy: IntStrategy,
+  });
+  if (props.length === 0) {
+    return { unsupported: "no propositions", pant: null };
+  }
+  const p = props[0]!;
+  if (p.kind === "unsupported") {
+    return { unsupported: p.reason, pant: null };
+  }
+  if (p.kind !== "equation") {
+    return { unsupported: `non-equation kind: ${p.kind}`, pant: null };
+  }
+  const ast = getAst();
+  return { unsupported: null, pant: ast.strExpr(p.rhs) };
+}
+
+// ---------------------------------------------------------------------------
+// 1. L1 enables forms the legacy pipeline can't translate
+// ---------------------------------------------------------------------------
+
+describe("L1: switch (clean) translates", () => {
+  it("switch with literal numeric cases and default → cond", () => {
+    const source = `
+      function classify(x: number): number {
+        switch (x) {
+          case 0: return 100;
+          case 1: return 200;
+          default: return 300;
+        }
+      }
+    `;
+    const { unsupported, pant } = withL1(() => translate(source, "classify"));
+    assert.equal(unsupported, null, "switch should translate under L1");
+    assert.match(pant!, /cond/);
+    assert.match(pant!, /x = 0/);
+    assert.match(pant!, /x = 1/);
+    assert.match(pant!, /100/);
+    assert.match(pant!, /200/);
+    assert.match(pant!, /300/);
+  });
+
+  it("switch with string cases", () => {
+    const source = `
+      function tag(s: string): number {
+        switch (s) {
+          case "a": return 1;
+          case "b": return 2;
+          default: return 0;
+        }
+      }
+    `;
+    const { unsupported, pant } = withL1(() => translate(source, "tag"));
+    assert.equal(unsupported, null);
+    assert.match(pant!, /cond/);
+  });
+
+  it("switch with only default collapses to the default value", () => {
+    const source = `
+      function constant(x: number): number {
+        switch (x) {
+          default: return 42;
+        }
+      }
+    `;
+    const { unsupported, pant } = withL1(() => translate(source, "constant"));
+    assert.equal(unsupported, null);
+    // No cond — just the literal.
+    assert.equal(pant, "42");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. L1 rejection cases produce the expected UNSUPPORTED reasons
+// ---------------------------------------------------------------------------
+
+describe("L1: conservative-refusal rejection cases", () => {
+  it("switch without default rejects (literal-union exhaustiveness deferred)", () => {
+    const source = `
+      function noDefault(x: number): number {
+        switch (x) {
+          case 0: return 1;
+          case 1: return 2;
+        }
+        return 0;
+      }
+    `;
+    const { unsupported } = withL1(() => translate(source, "noDefault"));
+    // Either (a) the switch isn't recognized as a terminal because of the
+    // trailing `return 0`, or (b) the switch is recognized and rejected.
+    // Either way: not a clean translation.
+    assert.notEqual(unsupported, null);
+  });
+
+  it("switch with default not last rejects", () => {
+    const source = `
+      function badOrder(x: number): number {
+        switch (x) {
+          default: return 0;
+          case 0: return 1;
+        }
+      }
+    `;
+    const { unsupported } = withL1(() => translate(source, "badOrder"));
+    assert.notEqual(unsupported, null);
+    assert.match(unsupported!, /default must be the last/);
+  });
+
+  it("switch with fall-through (case body not ending in return) rejects", () => {
+    const source = `
+      function fallthrough(x: number): number {
+        switch (x) {
+          case 0:
+          case 1: return 1;
+          default: return 0;
+        }
+      }
+    `;
+    const { unsupported } = withL1(() => translate(source, "fallthrough"));
+    assert.notEqual(unsupported, null);
+    assert.match(unsupported!, /case must end with `return EXPR`/);
+  });
+
+  it("switch with break-only case rejects", () => {
+    const source = `
+      function breakOnly(x: number): number {
+        let r = 0;
+        switch (x) {
+          case 0: { break; }
+          default: { return 0; }
+        }
+        return r;
+      }
+    `;
+    const { unsupported } = withL1(() => translate(source, "breakOnly"));
+    assert.notEqual(unsupported, null);
+  });
+
+  it("non-literal switch case label rejects", () => {
+    const source = `
+      function nonLiteral(x: number, k: number): number {
+        switch (x) {
+          case k: return 1;
+          default: return 0;
+        }
+      }
+    `;
+    const { unsupported } = withL1(() => translate(source, "nonLiteral"));
+    assert.notEqual(unsupported, null);
+    assert.match(unsupported!, /literal/);
+  });
+
+  it("non-Bool && in conditional position rejects (with L1 hooked at &&/||)", () => {
+    // `a && b` where both operands are number — under L1 the &&/|| Bool
+    // typing check rejects. Without L1, this would translate as a binop.
+    // Under L1 the rejection falls through to legacy (patch 2 keeps both
+    // available); legacy handles non-Bool && by producing `a and b` via
+    // translateOperator. Under patch 2, the L1 path simply doesn't fire
+    // for non-Bool short-circuit (isL1ConditionalForm returns false), so
+    // we fall through cleanly. Verify the legacy path still works.
+    const source = `
+      function combine(a: number, b: number): number {
+        return a && b;
+      }
+    `;
+    // L1 path won't recognize this as conditional (operands non-Bool),
+    // so isL1ConditionalForm returns false and translation proceeds via
+    // the legacy &&/|| binop path.
+    const { unsupported, pant } = withL1(() => translate(source, "combine"));
+    // Translation succeeds via legacy fallback.
+    assert.equal(unsupported, null);
+    assert.match(pant!, /and/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. L1 byte-equality with legacy on shared forms (cutover gate)
+// ---------------------------------------------------------------------------
+
+describe("L1: byte-equality with legacy on shared forms", () => {
+  function translateBoth(source: string, name: string) {
+    const legacy = withoutL1(() => translate(source, name));
+    const l1 = withL1(() => translate(source, name));
+    return { legacy, l1 };
+  }
+
+  it("ternary translates identically under L1=0 and L1=1", () => {
+    const source = `
+      function abs(n: number): number {
+        return n >= 0 ? n : -n;
+      }
+    `;
+    const { legacy, l1 } = translateBoth(source, "abs");
+    assert.equal(legacy.unsupported, null);
+    assert.equal(l1.unsupported, null);
+    assert.equal(legacy.pant, l1.pant);
+  });
+
+  it("ternary chain: L1 flattens, legacy nests (expected divergence)", () => {
+    // Right-leaning ternary chain. L1's `buildFromTernary` flattens via
+    // recursive descent; legacy `translateBodyExpr` recurses, producing
+    // nested `cond [..., true => (cond ...)]`. Both are semantically
+    // equivalent; the L1 form is the canonical normalization.
+    const source = `
+      function bucket(n: number): number {
+        return n < 0 ? 0 : n < 10 ? 1 : n < 100 ? 2 : 3;
+      }
+    `;
+    const { legacy, l1 } = translateBoth(source, "bucket");
+    assert.equal(legacy.unsupported, null);
+    assert.equal(l1.unsupported, null);
+    // L1 produces flat: 4 arms in one cond.
+    assert.match(
+      l1.pant!,
+      /^cond n < 0 => 0, n < 10 => 1, n < 100 => 2, true => 3$/,
+    );
+    // Legacy nests; the strings genuinely differ.
+    assert.notEqual(legacy.pant, l1.pant);
+  });
+
+  it("if-with-returns translates identically under both modes", () => {
+    const source = `
+      function abs2(n: number): number {
+        if (n >= 0) {
+          return n;
+        } else {
+          return -n;
+        }
+      }
+    `;
+    const { legacy, l1 } = translateBoth(source, "abs2");
+    assert.equal(legacy.unsupported, null);
+    assert.equal(l1.unsupported, null);
+    assert.equal(legacy.pant, l1.pant);
+  });
+
+  it("if/else-if/else chain: legacy rejects (unsupported), L1 flattens", () => {
+    // `if (g1) {return e1} else if (g2) {return e2} else {return e3}`.
+    // Legacy `translateIfStatement` only handles two-branch if/else
+    // (its `extractReturnFromBranch` rejects IfStatement-shaped else
+    // branches). L1's buildFromIfStatement walks the chain and produces
+    // one flat cond — a strict capability gain.
+    const source = `
+      function classify(n: number): number {
+        if (n < 0) {
+          return -1;
+        } else if (n === 0) {
+          return 0;
+        } else {
+          return 1;
+        }
+      }
+    `;
+    const { legacy, l1 } = translateBoth(source, "classify");
+    // Legacy doesn't support multi-arm if-chains.
+    assert.notEqual(legacy.unsupported, null);
+    // L1 produces the flat cond.
+    assert.equal(l1.unsupported, null);
+    assert.match(
+      l1.pant!,
+      /^cond n < 0 => -1, n = 0 => 0, true => 1$/,
+    );
+  });
+
+  it("Bool-typed && translates identically under both modes", () => {
+    const source = `
+      function bothPositive(a: number, b: number): boolean {
+        return a > 0 && b > 0;
+      }
+    `;
+    const { legacy, l1 } = translateBoth(source, "bothPositive");
+    assert.equal(legacy.unsupported, null);
+    assert.equal(l1.unsupported, null);
+    assert.equal(legacy.pant, l1.pant);
+  });
+
+  it("Bool-typed || translates identically under both modes", () => {
+    const source = `
+      function eitherPositive(a: number, b: number): boolean {
+        return a > 0 || b > 0;
+      }
+    `;
+    const { legacy, l1 } = translateBoth(source, "eitherPositive");
+    assert.equal(legacy.unsupported, null);
+    assert.equal(l1.unsupported, null);
+    assert.equal(legacy.pant, l1.pant);
+  });
+
+  it("early-return arms translate identically under both modes", () => {
+    const source = `
+      function piecewise(n: number): number {
+        if (n < 0) {
+          return -1;
+        }
+        return n;
+      }
+    `;
+    const { legacy, l1 } = translateBoth(source, "piecewise");
+    assert.equal(legacy.unsupported, null);
+    assert.equal(l1.unsupported, null);
+    assert.equal(legacy.pant, l1.pant);
+  });
+
+  it("early-return arm + ternary terminal: L1 merges into one cond", () => {
+    // `if (P) return E; return ternary` — L1's buildL1ConditionalFromArms
+    // flattens the prelude arm with the ternary terminal into one cond.
+    // Legacy materializes them as nested cond at the arm-merge step.
+    const source = `
+      function nested(n: number): number {
+        if (n < 0) {
+          return -1;
+        }
+        return n === 0 ? 0 : 1;
+      }
+    `;
+    const { legacy, l1 } = translateBoth(source, "nested");
+    assert.equal(legacy.unsupported, null);
+    assert.equal(l1.unsupported, null);
+    assert.match(
+      l1.pant!,
+      /^cond n < 0 => -1, n = 0 => 0, true => 1$/,
+    );
+    assert.notEqual(legacy.pant, l1.pant);
+  });
+});

--- a/workstreams/ts2pant-imperative-ir.md
+++ b/workstreams/ts2pant-imperative-ir.md
@@ -358,7 +358,7 @@ parallel if both are needed.
 | First slice = conditionals, not increment-only (1(b)) | Richer demonstration of the architecture earning its keep. Touches more recognizer surface area than μ-search alone. M1 conditionals + M2 assign + M3 iteration is a steeper but more honest validation curve than three small increments. |
 | No `If(cond, then, else)` separate from `Cond` | Single-armed if = `Cond([(g, body)], None)`. Multi-armed normalizes to the same form. One downstream pattern. |
 | No `Inc(target)` separate from `Assign` | `i++` builds as `Assign(i, BinOp(Add, Var(i), Lit(1)))`. The "+1 step" is a single arithmetic predicate at μ-search lowering, not a separate form. |
-| `&&`/`||` normalized only when Bool-typed | Truthy/falsy semantics on non-Bool values diverge from `Cond`'s Boolean guards. Conservative refusal on non-Bool. |
+| `&&`/`\|\|` normalized only when Bool-typed | Truthy/falsy semantics on non-Bool values diverge from `Cond`'s Boolean guards. Conservative refusal on non-Bool. |
 | `switch` fall-through rejected at L1 build | Each case must end in `break`/`return`/`throw`. Fall-through is a different control structure with no clean canonical form. |
 | `Reduce` desugared into `Let + Foreach + Assign` | IRSC-faithful (every iteration is `Foreach`; fold is a downstream pattern). Avoids a second iteration form. |
 | Workstream supersedes Stages 9–11 of `tools/ts2pant/CLAUDE.md` IR Migration Status; Stage 8 unchanged | Stage 8 (pure-path cutover, deleting legacy code subsumed by IR) depends only on PR #128 landing, not on this architecture. Stages 9–11 (mutating-path SSA, frame conditions, mutating-path cutover) re-form on the Layer 1 substrate inside M3. |

--- a/workstreams/ts2pant-imperative-ir.md
+++ b/workstreams/ts2pant-imperative-ir.md
@@ -1,0 +1,341 @@
+# Workstream: ts2pant Imperative IR (IRSC-Faithful Normalization Layer)
+
+## Vision
+
+Build a TypeScript-faithful imperative intermediate representation layer
+(Layer 1) between the TS AST and ts2pant's existing functional IR (Layer 2,
+today's `IRExpr`/`IRStmt`). Normalization passes against Layer 1 collapse
+operationally-equivalent TS surface forms — increment spellings, conditional
+families, iteration families — into a small canonical vocabulary. Lowering
+passes run against ONE canonical input shape per construct, so adding a new
+TS spelling never again requires extending a recognizer.
+
+Reference: Vekris/Cosman/Jhala, *Refinement Types for TypeScript* (PLDI
+2016, [arxiv:1604.02480](https://arxiv.org/pdf/1604.02480)). Their FRSC→IRSC
+SSA transformation is the precedent. ts2pant cited it but stopped short of
+building it. This workstream commits to it.
+
+## Current State
+
+After PR #128 lands (Stages 1–7 of the existing IR Migration Status table in
+`tools/ts2pant/CLAUDE.md`), ts2pant has a Pant-shaped expression IR
+(`IRExpr`: `Var`, `Lit`, `App`, `Cond`, `Let`, `Each`, `Comb`, `Forall`,
+`Exists`, `IRWrap`) plus a thin statement layer (`IRStmt`: `Write`, `LetIf`,
+`Seq`, `Assert`). TS-side recognizers in `tools/ts2pant/src/translate-body.ts`
+and `tools/ts2pant/src/ir-build.ts` build IR directly from TS-AST. Pure-path
+only.
+
+The proximate motivator for this workstream is PR #131
+(`recognizeMuSearch` accepting five surface spellings of the same `n ↦ n+1`
+step). Five recognizer cases for one semantic operation is the structural
+problem; this workstream retires it by moving normalization into a layer
+where syntactic variation collapses *before* recognition runs.
+
+This workstream **supersedes Stages 9–11** of the existing IR Migration
+Status table (mutating-path SSA, frame conditions, mutating-path cutover).
+**Stage 8** (pure-path cutover, deleting legacy code subsumed by IR) is
+unchanged and lands as currently described.
+
+## Key Challenges
+
+- **Equivalences that aren't equivalences.** Several surface forms look the
+  same but aren't: `==` vs `===` with non-Bool operands; `switch` with
+  fall-through vs if-chain; `.forEach(cb)` vs `for-of` when `cb` captures
+  `this` or returns from an enclosing scope; `&&`/`||` as expressions on
+  non-Bool values. The normalizer must refuse to canonicalize when it
+  can't prove equivalence. Conservative-refusal logic is itself nontrivial.
+- **Conservative-refusal cost.** Policy 3(b) — reject the function with
+  UNSUPPORTED at the normalizer when equivalence can't be proven. Real
+  fixtures will reveal whether this pessimism is acceptable or whether
+  some classes need pass-through-un-normalized as a fallback. Measured at
+  M1; policy may be revisited per equivalence class.
+- **Vocabulary lock-in at M1.** Layer 1 forms (`Foreach`, `Cond`, `Assign`,
+  etc.) are decided up front. Forms can be *added* later (e.g., `IsNullish`
+  primitive at M4) but not changed. Mid-stream re-litigation is the failure
+  mode the workstream is meant to prevent.
+- **Iteration shapes mutation.** `Foreach(binder, source, body)` with a
+  *statement* body (admitting `Assign`) is the canonical iteration form.
+  Shape A (uniform iterator write), Shape B (accumulator fold), and
+  `.reduce` desugaring all require statement-body iteration. This forces
+  the former Stages 9–11 mutating-path work to land *with* iteration
+  normalization in M3, not as a separate milestone.
+- **Hard rule per equivalence class.** During migration, an entire
+  equivalence class moves to the new path in one milestone — no
+  half-migrated classes co-existing with legacy recognizers. Faster to
+  ship, slower per milestone, prevents the cross-talk hazard the IR was
+  meant to retire.
+- **Opaque AST constraint unchanged.** All normalization happens on Layer 1
+  before any `OpaqueExpr` exists. No syntactic peeking on `OpaqueExpr` from
+  any normalization or lowering pass.
+
+## Milestones
+
+### Milestone 1: imperative-ir-conditionals
+
+**Definition of Done**:
+- New module `tools/ts2pant/src/ir1.ts` (Layer 1 IR types) declares the full
+  Layer 1 vocabulary. Statements: `Block`, `Let`, `Assign`, `Cond` (multi-arm
+  with optional else), `Foreach`, `For`, `While`, `Return`, `Throw`,
+  `ExprStmt`. Expressions: `Var`, `Lit`, `BinOp`, `UnOp`, `App`, `Member`,
+  `Cond`. (Forms unused in M1 are *declared* but unimplemented; vocabulary
+  is locked here.)
+- New module `tools/ts2pant/src/ir1-build.ts` translates TS AST → Layer 1
+  for the conditional surface forms only. Other forms still go through the
+  existing TS-AST → Layer 2 path.
+- Conditional surface-form normalization handles: if-chains (single-armed,
+  if/else, if/else-if/else), ternary chains (right-associative flatten),
+  `switch` without fall-through (every case ends in `break`/`return`/
+  `throw`; `default` last; non-fall-through cases collapse to one
+  `Cond` arm), `&&` and `||` as expressions when both operands are
+  statically Bool-typed. All collapse to one canonical `Cond` form.
+- Strict reject (3(b)): `switch` with any fall-through case, `default` not
+  last when case-set non-exhaustive, `&&`/`||` with non-Bool operands. Each
+  rejection produces an UNSUPPORTED with a specific reason.
+- New module `tools/ts2pant/src/ir1-lower.ts` lowers Layer 1 `Cond`
+  (statement and expression) to Layer 2 `Cond`. Other Layer 1 forms not
+  yet exercised.
+- `tools/ts2pant/CLAUDE.md` IR Migration Status table updated: Stages 9–11
+  marked superseded, pointer to this workstream. New "Imperative IR" section
+  documents the Layer 1 vocabulary and the conditional canonical form.
+- Hard rule honored: every conditional-shaped TS construct now goes through
+  Layer 1. Legacy conditional handlers in `translate-body.ts` deleted.
+- All existing `pant --check`-clean fixtures still pass; new fixtures cover
+  the conditional surface forms and the rejection cases.
+
+**Why this is a safe pause point**: Conditionals are a self-contained
+equivalence class. Every other recognizer remains on the TS-AST → Layer 2
+path. The Layer 1 vocabulary is declared but only one normalization pass
+exercises it. Codebase translates the same set of TS programs as before
+M1, plus newly-translatable ones (conditional families that weren't
+previously recognized uniformly).
+
+**Unlocks**: M2 (assign + μ-search) builds on the Layer 1 vocabulary that
+M1 declares. The architecture is proven on a richer equivalence class than
+PR #131's increment-only motivator, so M2 is incremental rather than
+exploratory.
+
+**Open Questions**:
+- Switch exhaustiveness: M1 uses syntactic check (default-last). Type-based
+  exhaustiveness (literal-union switch with no default) is deferred — leave
+  as UNSUPPORTED with a reason.
+- Real-fixture pessimism rate from conservative refusal: measured during M1.
+  If a high fraction of `&&`/`||` uses involve non-Bool operands, M4 may
+  need to land before M3.
+
+---
+
+### Milestone 2: imperative-ir-assign-mu-search
+
+**Definition of Done**:
+- `ir1-build.ts` extends to translate increment surface forms: `i++`, `++i`,
+  `i--`, `--i`, `i += k`, `-=`, `*=`, `/=`, `%=`, `i = i ⊕ k` (commutative
+  ops only), `i = k ⊕ i` (same). All collapse to canonical
+  `Assign(target, value)` with the value reconstructed as the appropriate
+  `BinOp`.
+- `recognizeMuSearch` rewritten to match against Layer 1: pattern
+  `Block([Let(i, init), While(p, Assign(i, BinOp(Add, Var(i), Lit(1))))])`.
+  One pattern, no `isPlusOneStep` helper. PR #131's recognizer extension
+  is structurally subsumed.
+- All five `+1` step spellings produce byte-identical Pant output (snapshot
+  equality with M1's pre-rewrite output).
+- `ir1-lower.ts` extends to handle Layer 1 `Assign` in pure-path contexts
+  (read-modify-write of a const-bound accumulator, μ-search counter). Full
+  mutation semantics deferred to M3.
+- Legacy increment recognizer code deleted; hard rule honored for the
+  increment equivalence class.
+- New fixtures cover non-increment uses of `Assign` reachable in pure-path
+  (e.g., `let acc = 0; for (...) acc += ...; return acc` — but only the
+  μ-search-shaped cases land here; the iteration body remains on the
+  legacy path until M3).
+
+**Why this is a safe pause point**: Assign and μ-search form a coherent
+slice. The Layer 1 vocabulary is now exercised by two normalization classes,
+proving the architecture composes. Iteration with `Assign` in body still
+goes through legacy recognizers (Shape A/B are unchanged).
+
+**Unlocks**: M3 — iteration normalization can now use `Assign` in body
+position without inventing a new form. Mutation work (former Stages 9–11)
+re-forms on top of `Assign`.
+
+**Open Questions**:
+- `i = f(i)` (arbitrary self-update, e.g. iterate-to-fixpoint): build as
+  Layer 1 `Assign(i, App(f, [Var(i)]))` and let the lowering pass decide
+  rejection. Recognizer for iterate-to-fixpoint is its own future work,
+  out of scope.
+- Decrement μ-search (`i--` with `while (P(i))`): canonical form admits
+  it, but the SMT lowering for `min over each j: Int, j <= INIT, ~P(j) | j`
+  needs verification on a fixture before declaring supported. M2 lands the
+  syntax; the encoding is M2 if straightforward, deferred otherwise.
+
+---
+
+### Milestone 3: imperative-ir-iteration-mutation
+
+**Definition of Done**:
+- `ir1-build.ts` extends to translate iteration surface forms:
+  `for (const x of arr) {body}`, `arr.forEach(x => {body})`,
+  `for (let i = 0; i < arr.length; i++) {body using arr[i]}` (when `arr[i]`
+  is read-only), `arr.reduce((a, x) => f(a, x), init)`. All collapse to
+  canonical `Foreach(binder, source, body)` with statement-body. `.reduce`
+  desugars into `Block([Let(acc, init), Foreach(x, arr,
+  Assign(acc, App(f, [Var(acc), Var(x)]))), Return(Var(acc))])`.
+- Strict reject (3(b)): `forEach` callback that captures `this` or returns
+  early through enclosing scope; for-loop with non-`.length` bound or
+  non-`++` step that can't normalize to Foreach (falls through to `For` or
+  rejection).
+- New `ir1-lower.ts` pass classifies `Foreach` bodies: pattern
+  `Foreach(x, src, Assign(Member(x, p), e))` → Shape A
+  (`all x in src | p' x = e`); pattern
+  `Foreach(x, src, Assign(Member(a, p), BinOp(op, Member(a, p), f(x))))` → Shape B
+  (`p' a = p a op (combOp over each x in src | f x)`); pattern
+  `Let(acc, init); Foreach(x, src, Assign(acc, body))` followed by
+  `Return(acc)` → fold (`init op (combOp over each x in src | step x)`).
+  Frame-condition synthesis runs on the Layer 1 → Layer 2 lowering output.
+- Layer 2 `Write` and `LetIf` (the mutating-path forms PR #128 introduced)
+  are now driven by the Layer 1 `Assign` lowering, not by direct TS-AST →
+  Layer 2 translation. The "write-key" SSA discipline lands here as a
+  Layer 1 → Layer 2 pass, not as a Layer 2 internal form.
+- Legacy iteration recognizers (`extractStructuredIteration`, the Shape A/B
+  branches in `translate-body.ts`, the chain-fusion handling for `.reduce`)
+  deleted. Hard rule honored.
+- Mutating-path cutover: every TS construct that produces a primed equation
+  now flows through Layer 1. The former Stages 9–11 are complete.
+
+**Why this is a safe pause point**: Iteration and mutation are a coherent
+unit (one shapes the other). Both pure-path and mutating-path now flow
+through Layer 1 for the three normalization classes (conditionals,
+assign/μ-search, iteration). Property access, equality, and nullish-check
+normalization remain on the legacy expression path — but those are
+expression-level orthogonal classes; the architectural backbone is
+complete.
+
+**Unlocks**: M4 (equality/nullish) and M5 (property access) become
+optional, low-risk follow-ups. M6 (cleanup) deletes whatever legacy code
+remains in `translate-body.ts`.
+
+**Open Questions**:
+- Index-for over `.length` with mutating writes through `arr[i]`: today's
+  legacy code rejects this. Layer 1 normalization could handle it via
+  `Foreach(x, arr, Assign(Member(x, ...), ...))` if `arr[i] = …` is read
+  back during the same iteration. Risk of subtle aliasing semantics; deferred
+  unless a fixture demands it.
+- Frame-condition emission ordering: the Layer 1 → Layer 2 lowering pass
+  must produce frames in a stable order (deterministic across runs). Today's
+  `state.modifiedProps` is a Set with insertion-order iteration; the pass
+  needs the same guarantee.
+
+---
+
+### Milestone 4 (deferred): equality-nullish-normalization
+
+**Definition of Done**:
+- New Layer 1 primitive `IsNullish(expr)`. Surface forms `x == null`,
+  `x === null || x === undefined`, `x === undefined`, `typeof x === 'undefined'`
+  all collapse to `IsNullish(Var(x))`.
+- `BinOp(===, …)` is the canonical equality form; `BinOp(==, …)` rejected
+  unless we can prove operand types Bool/numeric/string-literal-equivalent.
+- Existing `??` and `?.` lowerings (currently on Layer 2 since Stages 2–3)
+  are revisited if their interaction with `IsNullish` simplifies — but no
+  redesign required; the goal is M4 absorbs the equality/nullish equivalence
+  class without disturbing existing forms.
+- Hard rule honored for the equality/nullish class.
+
+**Why this is a safe pause point**: Equality and nullish are
+expression-only; no statement-level forms touched. All other classes
+already on Layer 1 from M1–M3.
+
+**Unlocks**: M6 cleanup can delete more legacy expression-handling code.
+
+**Open Questions**:
+- Whether to land at all. Decided post-M3 based on real-fixture pressure
+  from M1's conservative-refusal measurements. May absorb into M3 if
+  pressure is high.
+
+---
+
+### Milestone 5 (deferred): property-access-normalization
+
+**Definition of Done**:
+- Layer 1 `Member(receiver, name)` is canonical for both `obj.name` and
+  `obj["name-literal"]`. Computed access `obj[expr]` stays as
+  `App(index, [obj, expr])` and is rejected unless type system resolves
+  to a known field set.
+- Hard rule honored.
+
+**Why this is a safe pause point**: Property access is a small,
+self-contained equivalence class.
+
+**Unlocks**: M6 cleanup of the last legacy expression handling.
+
+**Open Questions**:
+- Likely absorbed into whichever earlier milestone first needs uniform
+  property-access shape (probably M3, when Foreach bodies do
+  `Assign(Member(x, p), …)` and need a single Member form). Standalone
+  milestone only if not absorbed.
+
+---
+
+### Milestone 6: legacy-recognizer-cleanup
+
+**Definition of Done**:
+- `tools/ts2pant/src/translate-body.ts` slimmed to the Layer 1 → Layer 2
+  lowering plumbing only. All TS-AST → Layer 2 direct paths deleted.
+- `IRWrap` form deleted from `IRExpr` (the migration escape hatch is no
+  longer reachable).
+- IR Migration Status table in `tools/ts2pant/CLAUDE.md` removed (or
+  archived); replaced by a "Layer 1 → Layer 2 → Pant" architecture
+  description anchored on this workstream.
+- Single-pipeline default: `--use-ir` flag (env `TS2PANT_USE_IR=1`) deleted
+  or made always-on.
+- All snapshots stable; no behavioral change relative to M3 + (M4|M5 if
+  landed).
+
+**Why this is a safe pause point**: End state of the workstream. The
+codebase has one translation pipeline, one IR vocabulary, one normalization
+discipline. The recognizer-extension treadmill is retired.
+
+**Unlocks**: Future TS surface support is a normalization-pass extension
+(small, localized) instead of a recognizer addition.
+
+## Dependency Graph
+
+```text
+1 (imperative-ir-conditionals)        → []
+2 (imperative-ir-assign-mu-search)    → [1]
+3 (imperative-ir-iteration-mutation)  → [2]
+4 (equality-nullish-normalization)    → [3]   (deferred; may absorb into 3)
+5 (property-access-normalization)     → [3]   (deferred; may absorb into 3)
+6 (legacy-recognizer-cleanup)         → [3, 4, 5]
+```
+
+PR #128 must merge before M1 begins. M1–M3 are strictly sequential because
+each adds a class to the same Layer 1 vocabulary and the hard-rule
+constraint forbids partial migration of a class. M4 and M5 can run in
+parallel if both are needed.
+
+## Open Questions
+
+| Question | Notes | Resolve By |
+|----------|-------|------------|
+| Conservative-refusal pessimism rate | Measure during M1 on real fixtures. If high, M4 may need to land before M3 or policy may relax to pass-through-un-normalized for specific forms. | M1 |
+| `Reduce` as own L1 form vs desugared | Decided: desugared into `Let + Foreach + Assign`. IRSC-faithful. May revisit if downstream pattern recognition proves brittle. | Decided in design (this doc) |
+| M4 standalone vs absorbed into M3 | Depends on M1 pessimism measurement and how much equality/nullish lives inside iteration bodies. | Post-M2 |
+| M5 standalone vs absorbed | Property access likely absorbed into M3 (Foreach bodies need `Member`). | Post-M2 |
+| Decrement μ-search (`i--`) SMT encoding | Layer 1 admits it; SMT lowering needs verification on a fixture. | M2 |
+| Index-for with mutating `arr[i] = …` writes | Aliasing semantics non-trivial. Deferred unless a fixture demands it. | Post-M3 |
+
+## Decisions Made
+
+| Decision | Rationale |
+|----------|-----------|
+| Layer 1 vocabulary locked at M1 | Mid-stream re-litigation of canonical forms is the failure mode the workstream is meant to prevent. Forms can be *added* later (e.g., `IsNullish` at M4) but not changed. |
+| Conservative refusal = reject the function (3(b)) | Cleaner architecturally; matches the "find equivalences that are actually equivalences" discipline. Pessimism measured per-class; policy revisitable per-class if real fixtures hurt. |
+| Hard rule per equivalence class (4) | Faster per milestone, prevents the cross-talk hazard the IR was meant to retire. No half-migrated classes coexisting with legacy recognizers. |
+| Mutation lands with iteration in M3 (5(b)) | `Foreach` body must be a *statement* (admit `Assign`) to support Shape A, Shape B, and `.reduce` desugaring uniformly. Iteration normalization without `Assign` would force splitting the form. The former Stages 9–11 re-form inside M3. |
+| First slice = conditionals, not increment-only (1(b)) | Richer demonstration of the architecture earning its keep. Touches more recognizer surface area than μ-search alone. M1 conditionals + M2 assign + M3 iteration is a steeper but more honest validation curve than three small increments. |
+| No `If(cond, then, else)` separate from `Cond` | Single-armed if = `Cond([(g, body)], None)`. Multi-armed normalizes to the same form. One downstream pattern. |
+| No `Inc(target)` separate from `Assign` | `i++` builds as `Assign(i, BinOp(Add, Var(i), Lit(1)))`. The "+1 step" is a single arithmetic predicate at μ-search lowering, not a separate form. |
+| `&&`/`||` normalized only when Bool-typed | Truthy/falsy semantics on non-Bool values diverge from `Cond`'s Boolean guards. Conservative refusal on non-Bool. |
+| `switch` fall-through rejected at L1 build | Each case must end in `break`/`return`/`throw`. Fall-through is a different control structure with no clean canonical form. |
+| `Reduce` desugared into `Let + Foreach + Assign` | IRSC-faithful (every iteration is `Foreach`; fold is a downstream pattern). Avoids a second iteration form. |
+| Workstream supersedes Stages 9–11 of `tools/ts2pant/CLAUDE.md` IR Migration Status; Stage 8 unchanged | Stage 8 (pure-path cutover, deleting legacy code subsumed by IR) depends only on PR #128 landing, not on this architecture. Stages 9–11 (mutating-path SSA, frame conditions, mutating-path cutover) re-form on the Layer 1 substrate inside M3. |

--- a/workstreams/ts2pant-imperative-ir.md
+++ b/workstreams/ts2pant-imperative-ir.md
@@ -70,7 +70,30 @@ unchanged and lands as currently described.
 
 ## Milestones
 
-### Milestone 1: imperative-ir-conditionals
+### Milestone 1: imperative-ir-conditionals — ✅ landed
+
+**Status**: landed across four stacked commits on
+`zax--ts2pant-imperative-ir-workstream`:
+
+- Patch 1 (`9e3b185`) — L1 vocabulary (`ir1.ts`) + lowering (`ir1-lower.ts`)
+  + unit tests. ~880 lines of new code, no plumbing changes.
+- Patch 2 (`7600ec3`) — L1 builder (`ir1-build.ts`) +
+  `isStaticallyBoolTyped` (`purity.ts`) + plumbing into `translate-body.ts`
+  gated on `TS2PANT_USE_L1=1`. New L1-plumbing integration tests.
+  Validation: byte-identical output for all 431 existing tests under both
+  flag states.
+- Patch 3 (`9bbb25c`) — hard-rule cutover. Flag deleted, legacy
+  `translateIfStatement` and inline ternary handler removed. Net −257
+  lines. 469 tests pass under always-on L1.
+- Patch 4 — docs (this commit).
+
+**Pessimism rate**: 0 — no existing fixture or dogfood case rejects under
+the conservative-refusal policy. The `&&`/`||` Bool-type predicate
+accepts every site reached by current fixtures because non-Bool
+short-circuit isn't an L1-conditional form (it falls through to the
+legacy `translateOperator` path, which Patch 3 left intact for non-
+conditional uses including `.reduce` callbacks). Real-fixture pessimism
+will surface only as new TS code drops in; revisit policy if that happens.
 
 **Definition of Done**:
 - New module `tools/ts2pant/src/ir1.ts` (Layer 1 IR types) declares the full


### PR DESCRIPTION
## Summary

Lands the workstream architecture and **Milestone 1** (`imperative-ir-conditionals`) of the IRSC-faithful imperative IR rework documented in `workstreams/ts2pant-imperative-ir.md`.

ts2pant now has a layered IR architecture:

- **Layer 1** (`src/ir1.ts`) — TS-faithful imperative IR (`Block`, `Cond`, `Foreach`, `Assign`, `For`, `While`, `Return`, …) where normalization passes will collapse syntactic equivalences into a small canonical vocabulary. M1 only constructs the conditional and expression forms; statement forms beyond `Block`/`Let`/`Return` are vocabulary-locked but throw at construction until M2/M3.
- **Layer 2** (`src/ir.ts`) — today's Pant-shaped expression IR.
- **Layer 3** — `OpaqueExpr`.

Lowering: TS AST → Layer 1 (`ir1-build.ts`) → Layer 2 (`ir1-lower.ts`) → OpaqueExpr (`ir-emit.ts`).

## What M1 changes

All conditional **value** forms now flow through one canonical `Cond([(g, v)], otherwise)`:

| Surface form | Before | After |
|--------------|--------|-------|
| `if/else` w/ returns (two-branch) | translated by `translateIfStatement` | L1 `buildL1Conditional` |
| `if/else if/else` (multi-arm) | **unsupported** (legacy only handled two-branch) | flattened to one `Cond` |
| Ternary `a ? x : y` | translated inline in `translateBodyExpr` | L1 |
| Ternary chain `a ? x : (b ? y : z)` | nested cond | flattened to one `Cond` |
| `switch` w/o fall-through | **fully unsupported** | `case k:` → `(disc = k, value)` arm; `default` → `otherwise` |
| `&&`/`||` (Bool-typed) | binop via `translateOperator` | L1 `binop(and|or)` (byte-equal output, but routes through L1) |
| `&&`/`||` (non-Bool) | binop via `translateOperator` | unchanged — falls through to legacy (preserved for `.reduce` callbacks; tightening is M3) |

Conservative-refusal policy 3(b) — when L1 cannot prove an equivalence, it rejects with a specific `UNSUPPORTED` reason rather than emitting potentially-incorrect Pant. Locked rejection cases:

- `switch` with default not last
- `switch` with fall-through (case body not ending in `return EXPR`)
- `switch` without default (literal-union exhaustiveness deferred per workstream open question)
- `switch` with `break`-only or `throw`-only case (M1 only handles return-cases)
- `switch` with non-literal case label
- Object-literal arms in a value-position cond

## Out of scope (workstream tracking)

This PR is M1 only. **Conditional mutation** (`if (g) obj.p = v` in mutating bodies, driven by `symbolicExecute`'s cond-merge of writes) is a different equivalence class and lives in M3 because the body shape requires the `Assign` infrastructure that M2 introduces. The mutating-path switch reject in `translate-body.ts` stays.

`&&`/`||` in `.reduce` callback bodies stay on the legacy `translateOperator` path — to be tightened when M3 lands `.reduce` desugaring through `Foreach`.

## Patches

Four stacked commits, each leaving the codebase buildable and tested:

1. **Patch 1** (`9e3b185`) — Layer 1 vocabulary + lowering. Pure additions; no translation changes.
2. **Patch 2** (`7600ec3`) — L1 builder + `isStaticallyBoolTyped` + plumbing behind `TS2PANT_USE_L1=1`. Validation: byte-identical output for all 431 existing tests under both flag states.
3. **Patch 3** (`9bbb25c`) — hard-rule cutover. Flag deleted, `translateIfStatement` and inline ternary handler removed. Net **−257 lines**.
4. **Patch 4** (`a879729`) — docs. `tools/ts2pant/CLAUDE.md` §"Imperative IR Workstream" turned into a current-state reference; workstream M1 marked landed.

## Locked decisions (do not re-litigate without sign-off)

- **Vocabulary lock at M1.** Forms can be added in later milestones (e.g., `IsNullish` at M4) but existing forms cannot be changed.
- **No `IR1Wrap` form.** Layer 1 is not an escape-hatch layer. The `from-l2` form is a *scoped* delegation point with a defined lifetime (shrinks at M3, deleted at M6) — not a wrap-anything escape hatch.
- **Hard rule per equivalence class.** All conditional value forms moved to L1 in this milestone — no half-migrated coexistence with legacy recognizers.
- **Mutation lands with iteration in M3.** `Foreach` body must admit `Assign` to support Shape A / Shape B / `.reduce` desugaring uniformly.

Reference: Vekris, Cosman, Jhala, *Refinement Types for TypeScript* (PLDI 2016, [arxiv:1604.02480](https://arxiv.org/pdf/1604.02480)). Cited in tree pre-workstream; M1 commits to the FRSC→IRSC direction.

## Test plan

- [x] `just ts2pant-precommit` green: 447 unit + 22 integration = **469 tests pass**.
- [x] No existing fixture snapshot drifts — multi-arm shapes that L1 flattens differently aren't exercised by any current `tests/fixtures/constructs/*.ts`. The flattening behavior is exercised by new unit tests in `tests/l1-plumbing.test.mts`.
- [x] `pant --check` integration tests for `max.ts`, `deposit.ts`, `apply-fee.ts` continue to verify SMT-checkable output.
- [x] Dogfood (ts2pant translates its own source) passes — pessimism rate from conservative refusal is **zero** on existing code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)