### PR TITLE
ts2pant: M2 — Assign/While activation + μ-search L1 cutover

### DIFF
--- a/tools/ts2pant/CLAUDE.md
+++ b/tools/ts2pant/CLAUDE.md
@@ -703,14 +703,32 @@ every union/intersection constituent to satisfy `BooleanLike`).
 via `buildL1IncrementStep` in `ir1-build.ts`. The five `+1` spellings
 (`i++`, `++i`, `i += 1`, `i = i + 1`, `i = 1 + i`) produce *byte-
 identical* L1 output — that's the M2 architectural promise. μ-search
-recognition moves to L1: the TS-AST `recognizeLetWhilePair` is purely
-structural (consume let + while as a unit); the canonical-shape
-check (`BinOp(add, Var(c), Lit(1))`), predicate-references-counter
-check, and discrete-strategy check all live in the L1 path
-(`isCanonicalMuSearchForm` in `ir1-lower.ts` + the unified
-`translateMuSearchInit` body). Legacy `translateMuSearchInitLegacy`
-is deleted. Three additional `+1` spellings now translate (was just
-`i++`/`++i` pre-M2).
+recognition and lowering live entirely in the L1/L2 layers
+(`isCanonicalMuSearchForm` and `lowerL1MuSearch` in `ir1-lower.ts`,
+producing an L2 `comb-typed` expression that emits to OpaqueExpr in
+`ir-emit.ts`). The TS-AST `recognizeLetWhilePair` is purely
+structural (consumes the let + while pair) — `translate-body.ts`
+carries no Pantagruel-target awareness for μ-search. Three
+additional `+1` spellings now translate (was just `i++`/`++i`
+pre-M2).
+
+**Layering principle.** This is the architectural commitment that
+M2 ratifies and the M2 cleanup completes:
+
+1. **L1** (`ir1.ts`, `ir1-build.ts`) — canonicalized TypeScript
+   syntax. No Pantagruel-target awareness.
+2. **L1 → L2 lowering** (`ir1-lower.ts`) — the *only* layer that
+   knows Pantagruel-target patterns (μ-search recognition,
+   counter-binder substitution).
+3. **L2** (`ir.ts`) — Pantagruel-shaped expression IR. Includes
+   `comb-typed` for source-less typed comprehension (μ-search's
+   target).
+4. **L2 → OpaqueExpr** (`ir-emit.ts`) — mechanical emission.
+5. **`translate-body.ts`** — TS-AST orchestrator. Wires lowering
+   contexts; no target-language semantics.
+
+Deviations from this principle should be flagged in review and
+either justified explicitly or refactored.
 
 **The `from-l2` adapter** (`ir1.ts`'s `IR1Expr.from-l2`) is the explicit
 transitional mechanism for sub-expressions whose normalization is not

--- a/tools/ts2pant/CLAUDE.md
+++ b/tools/ts2pant/CLAUDE.md
@@ -696,6 +696,22 @@ and last, and case labels must be literal. `&&`/`||` Bool-type detection
 is in `purity.ts:isStaticallyBoolTyped` (apparent-type walk requiring
 every union/intersection constituent to satisfy `BooleanLike`).
 
+**M2 (imperative-ir-assign-mu-search): landed.** `ir1Assign` and
+`ir1While` activated. Increment surface forms (`i++`, `++i`, `i--`,
+`--i`, `i += k`, `i -= k`, `i = i ⊕ k`, `i = k ⊕ i` for commutative
+`⊕`) build to canonical L1 `Assign(target, BinOp(<op>, target, <k>))`
+via `buildL1IncrementStep` in `ir1-build.ts`. The five `+1` spellings
+(`i++`, `++i`, `i += 1`, `i = i + 1`, `i = 1 + i`) produce *byte-
+identical* L1 output — that's the M2 architectural promise. μ-search
+recognition moves to L1: the TS-AST `recognizeLetWhilePair` is purely
+structural (consume let + while as a unit); the canonical-shape
+check (`BinOp(add, Var(c), Lit(1))`), predicate-references-counter
+check, and discrete-strategy check all live in the L1 path
+(`isCanonicalMuSearchForm` in `ir1-lower.ts` + the unified
+`translateMuSearchInit` body). Legacy `translateMuSearchInitLegacy`
+is deleted. Three additional `+1` spellings now translate (was just
+`i++`/`++i` pre-M2).
+
 **The `from-l2` adapter** (`ir1.ts`'s `IR1Expr.from-l2`) is the explicit
 transitional mechanism for sub-expressions whose normalization is not
 the current milestone's concern (e.g., guard expressions inside an L1

--- a/tools/ts2pant/src/ir-emit.ts
+++ b/tools/ts2pant/src/ir-emit.ts
@@ -220,6 +220,18 @@ export function lowerExpr(e: IRExpr): OpaqueExpr {
       );
     }
 
+    case "comb-typed": {
+      // Source-less typed comprehension — `min over each j: T, g | proj`.
+      // Distinct from `comb` (which iterates a `src`); produces the
+      // typed-param form via `eachComb([param(b, type)], ...)`.
+      return ast.eachComb(
+        [ast.param(e.binder, ast.tName(e.binderType))],
+        e.guards.map((g) => ast.gExpr(lowerExpr(g))),
+        lowerCombiner(e.combiner),
+        lowerExpr(e.proj),
+      );
+    }
+
     case "forall": {
       const param: OpaqueParam = ast.param(e.binder, ast.tName(e.binderType));
       const guards = e.guard ? [ast.gExpr(lowerExpr(e.guard))] : [];

--- a/tools/ts2pant/src/ir-subst.ts
+++ b/tools/ts2pant/src/ir-subst.ts
@@ -95,6 +95,21 @@ export function substIR(body: IRExpr, name: string, value: IRExpr): IRExpr {
       return irComb(body.combiner, each, init);
     }
 
+    case "comb-typed": {
+      const shadowed = body.binder === name;
+      if (shadowed) {
+        return body;
+      }
+      return {
+        kind: "comb-typed",
+        combiner: body.combiner,
+        binder: body.binder,
+        binderType: body.binderType,
+        guards: body.guards.map((g) => substIR(g, name, value)),
+        proj: substIR(body.proj, name, value),
+      };
+    }
+
     case "forall": {
       const shadowed = body.binder === name;
       const newGuard = shadowed

--- a/tools/ts2pant/src/ir.ts
+++ b/tools/ts2pant/src/ir.ts
@@ -177,6 +177,26 @@ export type IRExpr =
    */
   | { kind: "comb"; combiner: "min" | "max"; each: IRExprEach }
   /**
+   * Aggregate over a *typed* comprehension with no source — `min over
+   * each j: T, g₁, …, gₙ | proj`. Distinct from `Comb(_, Each)` because
+   * `Each` requires a `src` (collection to iterate); `comb-typed`
+   * iterates over a primitive type. The canonical lowering target for
+   * μ-search (`min over each j: Int, j >= INIT, ¬P(j) | j`).
+   *
+   * Lowers to `ast.eachComb([param(binder, type)], guards, comb, proj)`.
+   *
+   * No `init` for the same reason as min/max `Comb` — Pant has no
+   * fold operator to seed.
+   */
+  | {
+      kind: "comb-typed";
+      combiner: "min" | "max";
+      binder: string;
+      binderType: string;
+      guards: IRExpr[];
+      proj: IRExpr;
+    }
+  /**
    * Universal quantifier. Lowers to `ast.forall(...)`.
    */
   | {
@@ -453,6 +473,26 @@ export function irComb(
     ? { kind: "comb", combiner, init, each }
     : { kind: "comb", combiner, each };
 }
+
+/**
+ * Aggregate over a typed comprehension with no source. The canonical
+ * lowering target for μ-search. See the `comb-typed` variant in
+ * `IRExpr` for the semantics.
+ */
+export const irCombTyped = (
+  combiner: "min" | "max",
+  binder: string,
+  binderType: string,
+  guards: IRExpr[],
+  proj: IRExpr,
+): IRExpr => ({
+  kind: "comb-typed",
+  combiner,
+  binder,
+  binderType,
+  guards,
+  proj,
+});
 
 export const irForall = (
   binder: string,

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -55,7 +55,11 @@ import {
 import { lowerL1Expr } from "./ir1-lower.js";
 import type { OpaqueExpr } from "./pant-ast.js";
 import { isStaticallyBoolTyped } from "./purity.js";
-import type { SymbolicState, UniqueSupply } from "./translate-body.js";
+import type {
+  MuSearch,
+  SymbolicState,
+  UniqueSupply,
+} from "./translate-body.js";
 import {
   bodyExpr,
   expressionHasSideEffects,
@@ -485,26 +489,21 @@ function buildCaseLabel(
   label: ts.Expression,
   ctx: L1BuildContext,
 ): L1BuildResult {
-  // TS parses `case -1:` as a PrefixUnaryExpression(MinusToken,
-  // NumericLiteral) — handle it before the bare-NumericLiteral branch
-  // so negative literal labels stay in the supported subset rather
-  // than falling through as "must be a literal".
-  if (
-    ts.isPrefixUnaryExpression(label) &&
-    label.operator === ts.SyntaxKind.MinusToken &&
-    ts.isNumericLiteral(label.operand)
-  ) {
-    const n = Number(label.operand.text);
-    if (Number.isFinite(n) && Number.isInteger(n)) {
-      return ir1Unop("neg", ir1LitNat(n));
-    }
-    return { unsupported: "switch case label: non-integer numeric literal" };
+  // Numeric literals: handles both plain `case 1:` and `case -1:`
+  // (TS parses the latter as PrefixUnary(MinusToken, NumericLiteral)).
+  const intLit = tryBuildL1IntegerLiteral(label);
+  if (intLit !== null) {
+    return intLit;
   }
-  if (ts.isNumericLiteral(label)) {
-    const n = Number(label.text);
-    if (Number.isFinite(n) && Number.isInteger(n) && n >= 0) {
-      return ir1LitNat(n);
-    }
+  // Reject non-integer numerics with a precise reason; non-numeric
+  // labels (string, bool, identifier) fall through to their own
+  // branches below.
+  if (
+    ts.isNumericLiteral(label) ||
+    (ts.isPrefixUnaryExpression(label) &&
+      label.operator === ts.SyntaxKind.MinusToken &&
+      ts.isNumericLiteral(label.operand))
+  ) {
     return { unsupported: "switch case label: non-integer numeric literal" };
   }
   if (ts.isStringLiteral(label)) {
@@ -691,7 +690,7 @@ export function buildL1IncrementStep(
     // can pattern-match `BinOp(add, Var(c), Lit(1))` byte-equally across
     // all five `+1` spellings. Non-literal RHS falls back to the legacy
     // sub-expression pipeline via `buildSubExpr`.
-    const litRhs = tryBuildL1NumericLiteral(expr.right);
+    const litRhs = tryBuildL1IntegerLiteral(expr.right);
     const rhs = litRhs ?? buildSubExpr(expr.right, ctx);
     if (isL1Unsupported(rhs)) {
       return rhs;
@@ -725,7 +724,7 @@ export function buildL1IncrementStep(
     const bIsCounter = ts.isIdentifier(b) && b.text === counterName;
     if (aIsCounter && !bIsCounter) {
       // `c = c ⊕ k`
-      const litK = tryBuildL1NumericLiteral(b);
+      const litK = tryBuildL1IntegerLiteral(b);
       const k = litK ?? buildSubExpr(b, ctx);
       if (isL1Unsupported(k)) {
         return k;
@@ -743,7 +742,7 @@ export function buildL1IncrementStep(
             "non-commutative operator with counter on the right of RHS",
         };
       }
-      const litK = tryBuildL1NumericLiteral(a);
+      const litK = tryBuildL1IntegerLiteral(a);
       const k = litK ?? buildSubExpr(a, ctx);
       if (isL1Unsupported(k)) {
         return k;
@@ -762,24 +761,35 @@ export function buildL1IncrementStep(
 }
 
 /**
- * Try to build a native L1 literal expression. Returns null for anything
- * that's not a non-negative integer numeric literal — those go through
- * `buildSubExpr` (which wraps via `from-l2`) at the caller.
+ * Build a native L1 integer-literal expression from a TS source.
+ * Accepts a plain non-negative `NumericLiteral` and `-N` written as
+ * `PrefixUnary(MinusToken, NumericLiteral)` (TS's representation of
+ * negative integer literals). Returns null for anything else — strings,
+ * booleans, identifier references, non-integer numerics — which the
+ * caller handles via its own fallback.
  *
- * The point: when the increment step is `i += 1` or `i = i + 1`, the
- * `1` must lower to a native L1 `LitNat(1)` so the μ-search recognizer
- * can pattern-match `BinOp(add, Var(c), Lit(1))` against it. If the
- * literal got wrapped via `from-l2` instead, the recognizer would see
- * `BinOp(add, Var(c), FromL2(...))` and fail.
+ * Critical for canonical-form matching: when the increment step is
+ * `i += 1` or `i = i + 1`, the `1` must lower to a native L1
+ * `LitNat(1)` so `isCanonicalMuSearchForm` can pattern-match
+ * `BinOp(add, Var(c), Lit(1))`. A `from-l2`-wrapped literal would
+ * defeat the canonical-shape check.
  */
-function tryBuildL1NumericLiteral(expr: ts.Expression): IR1Expr | null {
+function tryBuildL1IntegerLiteral(expr: ts.Expression): IR1Expr | null {
+  if (
+    ts.isPrefixUnaryExpression(expr) &&
+    expr.operator === ts.SyntaxKind.MinusToken &&
+    ts.isNumericLiteral(expr.operand)
+  ) {
+    const n = Number(expr.operand.text);
+    if (Number.isFinite(n) && Number.isInteger(n)) {
+      return ir1Unop("neg", ir1LitNat(n));
+    }
+    return null;
+  }
   if (ts.isNumericLiteral(expr)) {
     const n = Number(expr.text);
     if (Number.isFinite(n) && Number.isInteger(n) && n >= 0) {
       return ir1LitNat(n);
-    }
-    if (Number.isFinite(n) && Number.isInteger(n) && n < 0) {
-      return ir1Unop("neg", ir1LitNat(-n));
     }
   }
   return null;
@@ -845,23 +855,20 @@ function isCommutativeBinop(op: IR1Binop): boolean {
  * `Assign(Var(counter), BinOp(add, Var(counter), Lit(1)))`.
  */
 export function buildL1LetWhile(
-  counterName: string,
-  initExpr: ts.Expression,
-  predicateExpr: ts.Expression,
-  stepExpr: ts.Expression,
+  mu: MuSearch,
   ctx: L1BuildContext,
 ): L1StmtBuildResult {
-  const init = buildSubExpr(initExpr, ctx);
+  const init = buildSubExpr(mu.initTsExpr, ctx);
   if (isL1Unsupported(init)) {
     return init;
   }
-  const predicate = buildSubExpr(predicateExpr, ctx);
+  const predicate = buildSubExpr(mu.predicateTsExpr, ctx);
   if (isL1Unsupported(predicate)) {
     return predicate;
   }
-  const step = buildL1IncrementStep(stepExpr, counterName, ctx);
+  const step = buildL1IncrementStep(mu.stepExpr, mu.counterName, ctx);
   if (isL1StmtUnsupported(step)) {
     return step;
   }
-  return ir1Block([ir1Let(counterName, init), ir1While(predicate, step)]);
+  return ir1Block([ir1Let(mu.counterName, init), ir1While(predicate, step)]);
 }

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -63,6 +63,7 @@ import type {
 import {
   bodyExpr,
   expressionHasSideEffects,
+  expressionReferencesNames,
   extractReturnFromBranch,
   isBodyUnsupported,
   translateBodyExpr,
@@ -858,6 +859,19 @@ export function buildL1LetWhile(
   mu: MuSearch,
   ctx: L1BuildContext,
 ): L1StmtBuildResult {
+  // Structural sanity: a let+while pair where the while predicate
+  // doesn't reference the let-bound counter is either a no-op or
+  // a divergent loop. Reject at build time on the TS expression
+  // (free-var walk is straightforward there); post-translation the
+  // predicate is wrapped in `from-l2(irWrap(OpaqueExpr))` and the
+  // equivalent check would need a wasm helper to introspect OpaqueExpr.
+  if (
+    !expressionReferencesNames(mu.predicateTsExpr, new Set([mu.counterName]))
+  ) {
+    return {
+      unsupported: "while predicate does not reference the let-bound counter",
+    };
+  }
   const init = buildSubExpr(mu.initTsExpr, ctx);
   if (isL1Unsupported(init)) {
     return init;

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -633,7 +633,7 @@ export const isL1StmtUnsupported = (
  *
  *  - `c++` / `++c` → `Assign(Var(c), BinOp(add, Var(c), Lit(1)))`
  *  - `c--` / `--c` → `Assign(Var(c), BinOp(sub, Var(c), Lit(1)))`
- *  - `c += k`, `c -= k`, `c *= k`, `c /= k`, `c %= k`
+ *  - `c += k`, `c -= k`, `c *= k`, `c /= k`
  *      → `Assign(Var(c), BinOp(<op>, Var(c), <k>))`
  *  - `c = c ⊕ k` / `c = k ⊕ c` (commutative `⊕`)
  *      → `Assign(Var(c), BinOp(<op>, Var(c), <k>))`
@@ -679,7 +679,7 @@ export function buildL1IncrementStep(
 
   const opKind = expr.operatorToken.kind;
 
-  // Compound assignments: `c += k`, `c -= k`, `c *= k`, `c /= k`, `c %= k`
+  // Compound assignments: `c += k`, `c -= k`, `c *= k`, `c /= k`
   const compoundOp = compoundOpToBinop(opKind);
   if (compoundOp !== null) {
     if (!ts.isIdentifier(expr.left) || expr.left.text !== counterName) {

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -2,9 +2,18 @@
  * TS AST → Layer 1 builder.
  *
  * **M1 scope** (workstream M1: imperative-ir-conditionals): conditional
- * **value** forms only — ternary chains, if-with-returns, switch without
+ * **value** forms — ternary chains, if-with-returns, switch without
  * fall-through, `&&`/`||` when both operands are statically Bool-typed.
  * All collapse to one canonical L1 `cond([(g, v)], otherwise)` form.
+ *
+ * **M2 scope** (workstream M2: imperative-ir-assign-mu-search): increment
+ * surface forms (`i++`, `++i`, `i += k`, `i -= k`, `i = i ⊕ k`,
+ * `i = k ⊕ i`) build to canonical L1 `Assign(target, BinOp(<op>, target, <k>))`.
+ * The five `+1` spellings produce identical L1 output. The TS-AST level
+ * does NOT carry μ-search semantics — it only provides structural
+ * acceptance for the let+while pair; semantic recognition (predicate
+ * references counter, step is `+1`, discrete numeric strategy) lives
+ * entirely in `ir1-lower.ts`'s `recognizeAndLowerMuSearch`.
  *
  * Sub-expressions inside conditionals (the guard, the value, the switch
  * discriminant) are translated through the legacy `translateBodyExpr`
@@ -27,7 +36,10 @@ import ts from "typescript";
 import { irWrap } from "./ir.js";
 import { lowerExpr } from "./ir-emit.js";
 import {
+  type IR1Binop,
   type IR1Expr,
+  type IR1Stmt,
+  ir1Assign,
   ir1Binop,
   ir1Cond,
   ir1FromL2,
@@ -35,6 +47,7 @@ import {
   ir1LitNat,
   ir1LitString,
   ir1Unop,
+  ir1Var,
 } from "./ir1.js";
 import { lowerL1Expr } from "./ir1-lower.js";
 import type { OpaqueExpr } from "./pant-ast.js";
@@ -585,4 +598,220 @@ function buildFromShortCircuit(
     return ir1Binop("and", left, right);
   }
   return ir1Binop("or", left, right);
+}
+
+// ---------------------------------------------------------------------------
+// Increment-step normalization (M2)
+//
+// Collapse all surface spellings of an increment on a counter into one
+// canonical L1 `Assign(Var(c), BinOp(<op>, Var(c), <k>))`. The five `+1`
+// spellings (`i++`, `++i`, `i += 1`, `i = i + 1`, `i = 1 + i`) all
+// produce identical L1 output. Compound assignments (`i += k`) and
+// commutative explicit forms (`i = k * i`) build to the same Assign
+// shape with the appropriate op and operand.
+//
+// The TS-AST level here is purely structural — it does NOT validate
+// that the step is `+1`, that the step matches a μ-search shape, or
+// anything semantic about the surrounding context. The L1 recognizer in
+// `ir1-lower.ts:recognizeAndLowerMuSearch` is responsible for those
+// checks.
+// ---------------------------------------------------------------------------
+
+export type L1StmtBuildResult = IR1Stmt | { unsupported: string };
+
+export const isL1StmtUnsupported = (
+  r: L1StmtBuildResult,
+): r is { unsupported: string } =>
+  typeof r === "object" && r !== null && "unsupported" in r;
+
+/**
+ * Build an L1 increment-step `Assign` from a TS expression-statement
+ * body. Accepts six surface shapes on the named counter:
+ *
+ *  - `c++` / `++c` → `Assign(Var(c), BinOp(add, Var(c), Lit(1)))`
+ *  - `c--` / `--c` → `Assign(Var(c), BinOp(sub, Var(c), Lit(1)))`
+ *  - `c += k`, `c -= k`, `c *= k`, `c /= k`, `c %= k`
+ *      → `Assign(Var(c), BinOp(<op>, Var(c), <k>))`
+ *  - `c = c ⊕ k` / `c = k ⊕ c` (commutative `⊕`)
+ *      → `Assign(Var(c), BinOp(<op>, Var(c), <k>))`
+ *
+ * The non-`+1` cases produce a valid L1 form but the μ-search recognizer
+ * at L1 lowering rejects them. `i = k - i` (non-commutative on right)
+ * rejects here because canonical form requires the counter on the
+ * left side of the binop.
+ *
+ * Anything else — assignment to a different variable, non-binop RHS,
+ * non-literal `k` (not rejected here; the L1 recognizer handles it) —
+ * either rejects or builds a non-canonical Assign that downstream
+ * recognition won't match.
+ */
+export function buildL1IncrementStep(
+  expr: ts.Expression,
+  counterName: string,
+  ctx: L1BuildContext,
+): L1StmtBuildResult {
+  // `c++` / `++c` / `c--` / `--c`
+  if (ts.isPostfixUnaryExpression(expr) || ts.isPrefixUnaryExpression(expr)) {
+    if (!ts.isIdentifier(expr.operand) || expr.operand.text !== counterName) {
+      return { unsupported: "increment operand is not the counter" };
+    }
+    if (expr.operator === ts.SyntaxKind.PlusPlusToken) {
+      return ir1Assign(
+        ir1Var(counterName),
+        ir1Binop("add", ir1Var(counterName), ir1LitNat(1)),
+      );
+    }
+    if (expr.operator === ts.SyntaxKind.MinusMinusToken) {
+      return ir1Assign(
+        ir1Var(counterName),
+        ir1Binop("sub", ir1Var(counterName), ir1LitNat(1)),
+      );
+    }
+    return { unsupported: "unsupported unary increment operator" };
+  }
+
+  if (!ts.isBinaryExpression(expr)) {
+    return { unsupported: "step is not an assignment or increment" };
+  }
+
+  const opKind = expr.operatorToken.kind;
+
+  // Compound assignments: `c += k`, `c -= k`, `c *= k`, `c /= k`, `c %= k`
+  const compoundOp = compoundOpToBinop(opKind);
+  if (compoundOp !== null) {
+    if (!ts.isIdentifier(expr.left) || expr.left.text !== counterName) {
+      return {
+        unsupported: "compound-assignment target is not the counter",
+      };
+    }
+    // Prefer native L1 for numeric-literal RHS so the μ-search recognizer
+    // can pattern-match `BinOp(add, Var(c), Lit(1))` byte-equally across
+    // all five `+1` spellings. Non-literal RHS falls back to the legacy
+    // sub-expression pipeline via `buildSubExpr`.
+    const litRhs = tryBuildL1NumericLiteral(expr.right);
+    const rhs = litRhs ?? buildSubExpr(expr.right, ctx);
+    if (isL1Unsupported(rhs)) {
+      return rhs;
+    }
+    return ir1Assign(
+      ir1Var(counterName),
+      ir1Binop(compoundOp, ir1Var(counterName), rhs),
+    );
+  }
+
+  // Plain assignment: `c = c ⊕ k` or `c = k ⊕ c` (commutative ⊕ only).
+  if (opKind === ts.SyntaxKind.EqualsToken) {
+    if (!ts.isIdentifier(expr.left) || expr.left.text !== counterName) {
+      return { unsupported: "assignment target is not the counter" };
+    }
+    if (!ts.isBinaryExpression(expr.right)) {
+      return {
+        unsupported: "assignment RHS is not a binary expression",
+      };
+    }
+    const rhsOpKind = expr.right.operatorToken.kind;
+    const explicitOp = explicitOpToBinop(rhsOpKind);
+    if (explicitOp === null) {
+      return {
+        unsupported: "assignment RHS uses an unsupported binary operator",
+      };
+    }
+    const a = expr.right.left;
+    const b = expr.right.right;
+    const aIsCounter = ts.isIdentifier(a) && a.text === counterName;
+    const bIsCounter = ts.isIdentifier(b) && b.text === counterName;
+    if (aIsCounter && !bIsCounter) {
+      // `c = c ⊕ k`
+      const litK = tryBuildL1NumericLiteral(b);
+      const k = litK ?? buildSubExpr(b, ctx);
+      if (isL1Unsupported(k)) {
+        return k;
+      }
+      return ir1Assign(
+        ir1Var(counterName),
+        ir1Binop(explicitOp, ir1Var(counterName), k),
+      );
+    }
+    if (bIsCounter && !aIsCounter) {
+      // `c = k ⊕ c` — only commutative ops.
+      if (!isCommutativeBinop(explicitOp)) {
+        return {
+          unsupported:
+            "non-commutative operator with counter on the right of RHS",
+        };
+      }
+      const litK = tryBuildL1NumericLiteral(a);
+      const k = litK ?? buildSubExpr(a, ctx);
+      if (isL1Unsupported(k)) {
+        return k;
+      }
+      return ir1Assign(
+        ir1Var(counterName),
+        ir1Binop(explicitOp, ir1Var(counterName), k),
+      );
+    }
+    return {
+      unsupported: "assignment RHS does not reference counter exactly once",
+    };
+  }
+
+  return { unsupported: "step shape is not a recognized increment form" };
+}
+
+/**
+ * Try to build a native L1 literal expression. Returns null for anything
+ * that's not a non-negative integer numeric literal — those go through
+ * `buildSubExpr` (which wraps via `from-l2`) at the caller.
+ *
+ * The point: when the increment step is `i += 1` or `i = i + 1`, the
+ * `1` must lower to a native L1 `LitNat(1)` so the μ-search recognizer
+ * can pattern-match `BinOp(add, Var(c), Lit(1))` against it. If the
+ * literal got wrapped via `from-l2` instead, the recognizer would see
+ * `BinOp(add, Var(c), FromL2(...))` and fail.
+ */
+function tryBuildL1NumericLiteral(expr: ts.Expression): IR1Expr | null {
+  if (ts.isNumericLiteral(expr)) {
+    const n = Number(expr.text);
+    if (Number.isFinite(n) && Number.isInteger(n) && n >= 0) {
+      return ir1LitNat(n);
+    }
+    if (Number.isFinite(n) && Number.isInteger(n) && n < 0) {
+      return ir1Unop("neg", ir1LitNat(-n));
+    }
+  }
+  return null;
+}
+
+function compoundOpToBinop(kind: ts.SyntaxKind): IR1Binop | null {
+  switch (kind) {
+    case ts.SyntaxKind.PlusEqualsToken:
+      return "add";
+    case ts.SyntaxKind.MinusEqualsToken:
+      return "sub";
+    case ts.SyntaxKind.AsteriskEqualsToken:
+      return "mul";
+    case ts.SyntaxKind.SlashEqualsToken:
+      return "div";
+    default:
+      return null;
+  }
+}
+
+function explicitOpToBinop(kind: ts.SyntaxKind): IR1Binop | null {
+  switch (kind) {
+    case ts.SyntaxKind.PlusToken:
+      return "add";
+    case ts.SyntaxKind.MinusToken:
+      return "sub";
+    case ts.SyntaxKind.AsteriskToken:
+      return "mul";
+    case ts.SyntaxKind.SlashToken:
+      return "div";
+    default:
+      return null;
+  }
+}
+
+function isCommutativeBinop(op: IR1Binop): boolean {
+  return op === "add" || op === "mul";
 }

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -41,13 +41,16 @@ import {
   type IR1Stmt,
   ir1Assign,
   ir1Binop,
+  ir1Block,
   ir1Cond,
   ir1FromL2,
+  ir1Let,
   ir1LitBool,
   ir1LitNat,
   ir1LitString,
   ir1Unop,
   ir1Var,
+  ir1While,
 } from "./ir1.js";
 import { lowerL1Expr } from "./ir1-lower.js";
 import type { OpaqueExpr } from "./pant-ast.js";
@@ -814,4 +817,51 @@ function explicitOpToBinop(kind: ts.SyntaxKind): IR1Binop | null {
 
 function isCommutativeBinop(op: IR1Binop): boolean {
   return op === "add" || op === "mul";
+}
+
+// ---------------------------------------------------------------------------
+// μ-search L1 form construction (M2)
+//
+// Build the canonical L1 representation of a let+while+increment μ-search
+// prelude pair: `Block([Let(c, init), While(p, <step-Assign>)])`. The step
+// is built via `buildL1IncrementStep`. Sub-expressions (init, predicate)
+// flow through the legacy `translateBodyExpr` pipeline and wrap as
+// `from-l2` — same scoped delegation pattern M1 conditionals use.
+//
+// The TS-AST recognizer (`recognizeMuSearch` in `translate-body.ts`)
+// has already validated structural acceptance (let-decl + while-stmt +
+// expression-statement body) before this builder runs. Semantic
+// recognition (canonical step shape, predicate references counter,
+// strategy is discrete) lives in `ir1-lower.ts:isCanonicalMuSearchForm`.
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the L1 representation of a μ-search-shaped TS prelude:
+ *
+ *   `Block([Let(counter, init), While(predicate, step)])`
+ *
+ * `step` is the canonical L1 Assign produced by `buildL1IncrementStep`
+ * — for the five `+1` spellings, it's
+ * `Assign(Var(counter), BinOp(add, Var(counter), Lit(1)))`.
+ */
+export function buildL1LetWhile(
+  counterName: string,
+  initExpr: ts.Expression,
+  predicateExpr: ts.Expression,
+  stepExpr: ts.Expression,
+  ctx: L1BuildContext,
+): L1StmtBuildResult {
+  const init = buildSubExpr(initExpr, ctx);
+  if (isL1Unsupported(init)) {
+    return init;
+  }
+  const predicate = buildSubExpr(predicateExpr, ctx);
+  if (isL1Unsupported(predicate)) {
+    return predicate;
+  }
+  const step = buildL1IncrementStep(stepExpr, counterName, ctx);
+  if (isL1StmtUnsupported(step)) {
+    return step;
+  }
+  return ir1Block([ir1Let(counterName, init), ir1While(predicate, step)]);
 }

--- a/tools/ts2pant/src/ir1-lower.ts
+++ b/tools/ts2pant/src/ir1-lower.ts
@@ -115,3 +115,102 @@ export function lowerL1Stmt(s: IR1Stmt): IRStmt[] {
       "see workstreams/ts2pant-imperative-ir.md",
   );
 }
+
+// ---------------------------------------------------------------------------
+// μ-search L1 recognizer (M2)
+//
+// Pattern-match the canonical L1 form
+//   `Block([Let(c, init), While(p, Assign(Var(c), BinOp(add, Var(c), Lit(1))))])`
+// against an L1 statement built via `buildL1LetWhile`. Returns
+// `{ ok: true, init, predicate, counterName }` with the extracted
+// pieces, or `{ ok: false, unsupported }` with a specific reason.
+//
+// **Single source of μ-search semantics.** Today the TS-AST level also
+// validates step-is-`+1` and predicate-references-counter; M2 patch 3
+// strips those checks at TS-AST and relies on this recognizer. This
+// function is the canonical home for the canonical-shape check.
+// ---------------------------------------------------------------------------
+
+/**
+ * Result of recognizing the canonical μ-search L1 form.
+ */
+export type MuSearchRecognition =
+  | {
+      ok: true;
+      counterName: string;
+      init: IR1Expr;
+      predicate: IR1Expr;
+    }
+  | { ok: false; unsupported: string };
+
+/**
+ * Recognize the canonical μ-search L1 shape on the named counter.
+ */
+export function isCanonicalMuSearchForm(
+  form: IR1Stmt,
+  counterName: string,
+): MuSearchRecognition {
+  if (form.kind !== "block") {
+    return { ok: false, unsupported: "μ-search prelude must be a Block" };
+  }
+  if (form.stmts.length !== 2) {
+    return {
+      ok: false,
+      unsupported: "μ-search prelude must contain exactly Let + While",
+    };
+  }
+  const letStmt = form.stmts[0];
+  const whileStmt = form.stmts[1]!;
+  if (letStmt.kind !== "let") {
+    return {
+      ok: false,
+      unsupported: "first prelude statement must be a Let binding",
+    };
+  }
+  if (letStmt.name !== counterName) {
+    return {
+      ok: false,
+      unsupported: "Let binding name does not match counter",
+    };
+  }
+  if (whileStmt.kind !== "while") {
+    return {
+      ok: false,
+      unsupported: "second prelude statement must be a While loop",
+    };
+  }
+  const body = whileStmt.body;
+  if (body.kind !== "assign") {
+    return {
+      ok: false,
+      unsupported: "while body must be a single Assign step",
+    };
+  }
+  if (body.target.kind !== "var" || body.target.name !== counterName) {
+    return {
+      ok: false,
+      unsupported: "Assign target is not the counter",
+    };
+  }
+  const value = body.value;
+  if (
+    value.kind !== "binop" ||
+    value.op !== "add" ||
+    value.lhs.kind !== "var" ||
+    value.lhs.name !== counterName ||
+    value.rhs.kind !== "lit" ||
+    value.rhs.value.kind !== "nat" ||
+    value.rhs.value.value !== 1
+  ) {
+    return {
+      ok: false,
+      unsupported: "step is not a canonical `+1` increment",
+    };
+  }
+  return {
+    ok: true,
+    counterName,
+    init: letStmt.value,
+    predicate: whileStmt.cond,
+  };
+}

--- a/tools/ts2pant/src/ir1-lower.ts
+++ b/tools/ts2pant/src/ir1-lower.ts
@@ -132,65 +132,42 @@ export function lowerL1Stmt(s: IR1Stmt): IRStmt[] {
 // ---------------------------------------------------------------------------
 
 /**
- * Result of recognizing the canonical μ-search L1 form.
- */
-export type MuSearchRecognition =
-  | {
-      ok: true;
-      counterName: string;
-      init: IR1Expr;
-      predicate: IR1Expr;
-    }
-  | { ok: false; unsupported: string };
-
-/**
- * Recognize the canonical μ-search L1 shape on the named counter.
+ * Validate that an L1 form matches the canonical μ-search shape on the
+ * named counter. Returns `null` on success, an `{ unsupported }`
+ * descriptor with a specific reason on failure. The L1 form's
+ * sub-expressions (init, predicate) are not extracted — the caller
+ * already has them via the source `MuSearch` and re-translates them
+ * under binder substitution for the comprehension.
  */
 export function isCanonicalMuSearchForm(
   form: IR1Stmt,
   counterName: string,
-): MuSearchRecognition {
+): { unsupported: string } | null {
   if (form.kind !== "block") {
-    return { ok: false, unsupported: "μ-search prelude must be a Block" };
+    return { unsupported: "μ-search prelude must be a Block" };
   }
   if (form.stmts.length !== 2) {
     return {
-      ok: false,
       unsupported: "μ-search prelude must contain exactly Let + While",
     };
   }
   const letStmt = form.stmts[0];
   const whileStmt = form.stmts[1]!;
   if (letStmt.kind !== "let") {
-    return {
-      ok: false,
-      unsupported: "first prelude statement must be a Let binding",
-    };
+    return { unsupported: "first prelude statement must be a Let binding" };
   }
   if (letStmt.name !== counterName) {
-    return {
-      ok: false,
-      unsupported: "Let binding name does not match counter",
-    };
+    return { unsupported: "Let binding name does not match counter" };
   }
   if (whileStmt.kind !== "while") {
-    return {
-      ok: false,
-      unsupported: "second prelude statement must be a While loop",
-    };
+    return { unsupported: "second prelude statement must be a While loop" };
   }
   const body = whileStmt.body;
   if (body.kind !== "assign") {
-    return {
-      ok: false,
-      unsupported: "while body must be a single Assign step",
-    };
+    return { unsupported: "while body must be a single Assign step" };
   }
   if (body.target.kind !== "var" || body.target.name !== counterName) {
-    return {
-      ok: false,
-      unsupported: "Assign target is not the counter",
-    };
+    return { unsupported: "Assign target is not the counter" };
   }
   const value = body.value;
   if (
@@ -202,15 +179,7 @@ export function isCanonicalMuSearchForm(
     value.rhs.value.kind !== "nat" ||
     value.rhs.value.value !== 1
   ) {
-    return {
-      ok: false,
-      unsupported: "step is not a canonical `+1` increment",
-    };
+    return { unsupported: "step is not a canonical `+1` increment" };
   }
-  return {
-    ok: true,
-    counterName,
-    init: letStmt.value,
-    predicate: whileStmt.cond,
-  };
+  return null;
 }

--- a/tools/ts2pant/src/ir1-lower.ts
+++ b/tools/ts2pant/src/ir1-lower.ts
@@ -28,12 +28,17 @@ import {
   irAppExpr,
   irAppName,
   irBinop,
+  irCombTyped,
   irCond,
   irLitBool,
   irUnop,
   irVar,
+  irWrap,
 } from "./ir.js";
+import { lowerExpr } from "./ir-emit.js";
 import type { IR1Expr, IR1Stmt } from "./ir1.js";
+import { getAst } from "./pant-wasm.js";
+import type { NumericStrategy } from "./translate-types.js";
 
 /**
  * Lower a Layer 1 expression to Layer 2 `IRExpr`.
@@ -182,4 +187,140 @@ export function isCanonicalMuSearchForm(
     return { unsupported: "step is not a canonical `+1` increment" };
   }
   return null;
+}
+
+// ---------------------------------------------------------------------------
+// μ-search L1 → L2 lowering (M2 cleanup)
+//
+// `lowerL1MuSearch` is the single source of μ-search semantics. It
+// pattern-matches the canonical L1 form, validates the predicate
+// references the counter and the strategy is discrete, and produces
+// an L2 `comb-typed` expression. The L2 → OpaqueExpr step in
+// `ir-emit.ts` produces the same `min over each j: T, j >= INIT,
+// ¬P(j) | j` shape today's legacy `translateMuSearchInit` emits —
+// byte-equality is the cutover gate.
+//
+// The substitution counter→binder happens on the lowered OpaqueExpr
+// via `ast.substituteBinder` (Pant's capture-avoiding substitution
+// at the wasm layer) rather than re-translating the predicate under
+// a new scope. One translation per sub-expression — no double work.
+// ---------------------------------------------------------------------------
+
+/**
+ * Context for μ-search lowering. The binder allocator is a callback
+ * because the production path uses the synthCell-aware
+ * `cellRegisterName` (collision-safe against the document-wide
+ * NameRegistry) and standalone test paths fall back to a numeric
+ * supply with collision checks against `scopedParams`. Threading the
+ * synthCell + supply directly would couple `ir1-lower.ts` to
+ * `translate-body.ts` internals; the callback inverts the dependency.
+ */
+export interface MuSearchLowerCtx {
+  strategy: NumericStrategy;
+  /**
+   * Pant name for the counter in the current translation scope.
+   * Typically `scopedParams.get(counterName) ?? counterName`. Used
+   * as the variable name to substitute on the lowered predicate.
+   */
+  counterPantName: string;
+  /** Allocate a fresh binder name (e.g., `j`, `j1`, …). */
+  allocateBinder(hint: string): string;
+}
+
+/**
+ * Extract the L2 IRExpr from an L1 `from-l2` wrap, or return null if
+ * the L1 expression is not a `from-l2`.
+ */
+function extractFromL2(e: IR1Expr): IRExpr | null {
+  return e.kind === "from-l2" ? e.expr : null;
+}
+
+/**
+ * Lower an L1 μ-search-shaped form to an L2 `comb-typed`. Validates
+ * canonical shape, predicate-references-counter, and strategy.
+ *
+ * Caller responsibility: build the L1 form via `buildL1LetWhile`
+ * (which translates init and predicate sub-expressions through the
+ * legacy `translateBodyExpr` pipeline and wraps via `from-l2`).
+ *
+ * Returns `IRExpr` (an L2 `comb-typed`) on success, or
+ * `{ unsupported }` with a specific reason.
+ */
+export function lowerL1MuSearch(
+  form: IR1Stmt,
+  counterName: string,
+  ctx: MuSearchLowerCtx,
+): IRExpr | { unsupported: string } {
+  const rejection = isCanonicalMuSearchForm(form, counterName);
+  if (rejection !== null) {
+    return rejection;
+  }
+  // Strategy must be discrete. μ-search enumerates `INIT, INIT+1, …`;
+  // a Real binder would range over a dense domain and diverge from
+  // that semantics.
+  const counterType = ctx.strategy.mapNumber();
+  if (counterType === "Real") {
+    return {
+      unsupported:
+        "μ-search is only supported for discrete numeric strategies (got Real)",
+    };
+  }
+  // After `isCanonicalMuSearchForm` has validated, we know the form
+  // shape: Block([Let(c, init), While(p, Assign(c, c + 1))]).
+  // Re-destructure to extract the init and predicate sub-expressions.
+  if (form.kind !== "block" || form.stmts.length !== 2) {
+    // Unreachable — the canonical-shape check above already verified
+    // this. Defense in depth.
+    return { unsupported: "μ-search prelude shape changed unexpectedly" };
+  }
+  const letStmt = form.stmts[0];
+  const whileStmt = form.stmts[1]!;
+  if (letStmt.kind !== "let" || whileStmt.kind !== "while") {
+    return { unsupported: "μ-search prelude shape changed unexpectedly" };
+  }
+  // The init and predicate are wrapped in `from-l2` by
+  // `buildL1LetWhile` because their internal structure is not L1's
+  // concern (M1 / M2 architectural commitment). Unwrap them here.
+  const initL2 = extractFromL2(letStmt.value);
+  if (initL2 === null) {
+    return {
+      unsupported: "μ-search init is not a from-l2 wrap (build pipeline error)",
+    };
+  }
+  const predicateL2 = extractFromL2(whileStmt.cond);
+  if (predicateL2 === null) {
+    return {
+      unsupported:
+        "μ-search predicate is not a from-l2 wrap (build pipeline error)",
+    };
+  }
+  // Predicate-references-counter is a precondition checked at L1
+  // build time (see `buildL1LetWhile` in `ir1-build.ts`). Skipping
+  // here — the lowering trusts that the L1 form represents a
+  // well-formed let+while pair.
+  const ast = getAst();
+  const predicateOpaque = lowerExpr(predicateL2);
+  // Allocate the comprehension binder and substitute counter → binder
+  // on the lowered predicate. `substituteBinder` is Pant's
+  // capture-avoiding substitution at the wasm layer; it traverses
+  // OpaqueExpr correctly (the L2 IR cannot — `irWrap` holds an
+  // opaque expression that `substIR` refuses to enter).
+  const binder = ctx.allocateBinder("j");
+  const substitutedPredicate = ast.substituteBinder(
+    predicateOpaque,
+    ctx.counterPantName,
+    ast.var(binder),
+  );
+  // Build the L2 comb-typed:
+  //   min over each j: T, j >= INIT, ¬P[c := j] | j
+  return irCombTyped(
+    "min",
+    binder,
+    counterType,
+    [
+      irBinop("ge", irVar(binder), initL2),
+      irUnop("not", irWrap(substitutedPredicate)),
+    ],
+    irVar(binder),
+  );
 }

--- a/tools/ts2pant/src/ir1.ts
+++ b/tools/ts2pant/src/ir1.ts
@@ -18,10 +18,11 @@
  * **Vocabulary lock at M1.** The forms declared here are the locked Layer
  * 1 vocabulary. Forms can be *added* in later milestones (e.g.,
  * `IsNullish` primitive at M4) but the existing forms cannot be changed.
- * Forms unused in M1 (`assign`, `foreach`, `for`, `while`, `throw`,
- * `expr-stmt`, statement-position `cond-stmt`) are declared at the type
- * level; their constructors throw `not-implemented` until the milestone
- * that introduces them lands.
+ * Forms not yet active (`foreach`, `for`, `throw`, `expr-stmt`,
+ * statement-position `cond-stmt`) are declared at the type level; their
+ * constructors throw `not-implemented` until the milestone that
+ * introduces them lands. M1 activated `block`, `let`, `return`, and
+ * expression-position `cond`; M2 adds `assign` and `while`.
  *
  * **No `IR1Wrap` form.** Layer 1 is *not* an escape-hatch layer — the
  * build pass either produces L1 or rejects with `unsupported`. An L1
@@ -123,12 +124,12 @@ export type IR1Expr =
 
 /**
  * Layer 1 statements. Ten forms cover the imperative TS shape needed
- * across the workstream. M1 actively uses `block`, `let`, `cond`, and
- * `return`; the others are vocabulary-locked but their constructors
- * throw until the milestone that introduces them lands:
+ * across the workstream. Active in M1+M2: `block`, `let`, `return`,
+ * `cond` (expression-position via `IR1Expr`), `assign`, `while`. The
+ * remaining forms are vocabulary-locked but their constructors throw
+ * until the milestone that introduces them lands:
  *
- * - `assign` — M2 (canonical form for `++`/`--`/compound-assign/`x = expr`)
- * - `foreach`, `for`, `while` — M3 (iteration normalization)
+ * - `foreach`, `for` — M3 (iteration normalization)
  * - `throw` — M3 (iteration body for guard-throw assertions)
  * - `expr-stmt` — M3 (effect-bearing expressions in statement position)
  * - statement-position `cond-stmt` — M3 (conditional with statement body,
@@ -142,7 +143,7 @@ export type IR1Stmt =
   /**
    * Assignment. Canonical form for all increment/compound-assign/explicit
    * mutation forms. Target is an L1 expression (typically `var` or
-   * `member`). Introduced in M2; constructor throws until then.
+   * `member`). M2 actively uses this for the μ-search counter step.
    */
   | { kind: "assign"; target: IR1Expr; value: IR1Expr }
   /**
@@ -177,8 +178,9 @@ export type IR1Stmt =
       body: IR1Stmt;
     }
   /**
-   * Bounded while loop (rejected if not provably bounded). Introduced
-   * in M3.
+   * Bounded while loop. M2 actively uses this to represent the
+   * μ-search let/while/increment shape; general bounded-while lowering
+   * (accumulator iteration, fixed-point search) lands in M3.
    */
   | { kind: "while"; cond: IR1Expr; body: IR1Stmt }
   /** Return statement. Optional expression for void-returning bodies. */
@@ -331,8 +333,23 @@ const NOT_IMPL = (form: string, milestone: string): never => {
   );
 };
 
-export const ir1Assign = (_target: IR1Expr, _value: IR1Expr): IR1Stmt =>
-  NOT_IMPL("assign", "M2 (assign + μ-search)");
+/**
+ * Assignment / read-modify-write. Canonical form for all increment and
+ * compound-assignment surface spellings. M2 activates this form for the
+ * μ-search counter step; broader mutation patterns land in M3.
+ *
+ * `target` is typically `Var(name)` (a counter) or `Member(receiver,
+ * name)` (a property write); `value` is the new value, which for
+ * increment forms is `BinOp(<op>, target, <k>)`. The L1 → L2 lowering
+ * for `Assign` is *not* generic — only `recognizeAndLowerMuSearch` in
+ * `ir1-lower.ts` introspects the surrounding L1 shape and produces L2
+ * output for it. A standalone `Assign` reaching `lowerL1Stmt` rejects.
+ */
+export const ir1Assign = (target: IR1Expr, value: IR1Expr): IR1Stmt => ({
+  kind: "assign",
+  target,
+  value,
+});
 
 export const ir1CondStmt = (
   _arms: readonly [
@@ -355,8 +372,20 @@ export const ir1For = (
   _body: IR1Stmt,
 ): IR1Stmt => NOT_IMPL("for", "M3 (iteration + mutation)");
 
-export const ir1While = (_cond: IR1Expr, _body: IR1Stmt): IR1Stmt =>
-  NOT_IMPL("while", "M3 (iteration + mutation)");
+/**
+ * Bounded while loop. M2 activates this form to faithfully represent
+ * the let/while/increment shape of a μ-search-shaped TS body —
+ * `recognizeAndLowerMuSearch` in `ir1-lower.ts` introspects the
+ * `Block([Let, While(_, Assign)])` shape and lowers to `Comb(min, Each)`.
+ * General while-loop lowering (bounded fixed-point, accumulator
+ * iteration) lands in M3; until then a standalone `While` reaching
+ * `lowerL1Stmt` rejects.
+ */
+export const ir1While = (cond: IR1Expr, body: IR1Stmt): IR1Stmt => ({
+  kind: "while",
+  cond,
+  body,
+});
 
 export const ir1Throw = (_expr: IR1Expr): IR1Stmt =>
   NOT_IMPL("throw", "M3 (iteration + mutation)");

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -128,16 +128,15 @@ function bindingNames(b: ConstBinding): readonly string[] {
   return b.kind === "earlyReturn" ? [] : [b.tsName];
 }
 
-interface MuSearch {
+export interface MuSearch {
   counterName: string;
   initTsExpr: ts.Expression;
   predicateTsExpr: ts.Expression;
   /**
    * The expression-statement body of the while loop — the increment
-   * step. Carried so the L1 path (`recognizeAndLowerMuSearch` in
-   * `ir1-lower.ts`) can build the canonical L1 representation. The
-   * legacy `translateMuSearchInit` ignores this field; cutover at
-   * M2 patch 3 removes legacy entirely.
+   * step. Used by the L1 builder to construct the canonical
+   * `Block([Let, While(_, Assign)])` form for `isCanonicalMuSearchForm`
+   * to pattern-match against.
    */
   stepExpr: ts.Expression;
 }
@@ -2137,19 +2136,13 @@ function translateMuSearchInit(
     state,
     supply,
   };
-  const form = buildL1LetWhile(
-    mu.counterName,
-    mu.initTsExpr,
-    mu.predicateTsExpr,
-    mu.stepExpr,
-    l1Ctx,
-  );
+  const form = buildL1LetWhile(mu, l1Ctx);
   if (isL1StmtUnsupported(form)) {
     return { error: form.unsupported };
   }
-  const recognized = isCanonicalMuSearchForm(form, mu.counterName);
-  if (!recognized.ok) {
-    return { error: recognized.unsupported };
+  const rejection = isCanonicalMuSearchForm(form, mu.counterName);
+  if (rejection !== null) {
+    return { error: rejection.unsupported };
   }
 
   // Predicate must reference the counter; otherwise the loop is either

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -2345,7 +2345,7 @@ function blockHasNoSideEffects(
  *  shadow outer bindings, so `xs.some(i => i > 0)` does not report dependence
  *  on an outer `i`. Default-value expressions and property-access `.name`
  *  tokens are handled specially. */
-function expressionReferencesNames(
+export function expressionReferencesNames(
   expr: ts.Expression,
   names: Set<string>,
 ): boolean {

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -7,10 +7,13 @@ import { type IR1Expr, ir1FromL2 } from "./ir1.js";
 import {
   buildL1Conditional,
   buildL1ConditionalFromArms,
+  buildL1LetWhile,
   isL1ConditionalForm,
+  isL1StmtUnsupported,
   isL1Unsupported,
   lowerL1ToOpaque,
 } from "./ir1-build.js";
+import { isCanonicalMuSearchForm } from "./ir1-lower.js";
 import type {
   OpaqueCombiner,
   OpaqueExpr,
@@ -54,6 +57,18 @@ import type { PantDeclaration, PropResult } from "./types.js";
 function useIRPipeline(): boolean {
   const g = globalThis as { process?: { env?: Record<string, string> } };
   return g.process?.env?.["TS2PANT_USE_IR"] === "1";
+}
+
+/**
+ * True if the imperative-IR (Layer 1) μ-search pipeline is enabled via
+ * `TS2PANT_USE_L1_MUSEARCH=1`. M2 patch 2 uses this flag to gate the L1
+ * recognizer during validation; patch 3 deletes the flag and makes L1
+ * always-on for μ-search lowering (workstream
+ * `workstreams/ts2pant-imperative-ir.md`, milestone M2).
+ */
+function useL1MuSearchPipeline(): boolean {
+  const g = globalThis as { process?: { env?: Record<string, string> } };
+  return g.process?.env?.["TS2PANT_USE_L1_MUSEARCH"] === "1";
 }
 
 // --- Const-binding inlining infrastructure (let-elimination) ---
@@ -129,6 +144,14 @@ interface MuSearch {
   counterName: string;
   initTsExpr: ts.Expression;
   predicateTsExpr: ts.Expression;
+  /**
+   * The expression-statement body of the while loop — the increment
+   * step. Carried so the L1 path (`recognizeAndLowerMuSearch` in
+   * `ir1-lower.ts`) can build the canonical L1 representation. The
+   * legacy `translateMuSearchInit` ignores this field; cutover at
+   * M2 patch 3 removes legacy entirely.
+   */
+  stepExpr: ts.Expression;
 }
 
 /**
@@ -1637,12 +1660,14 @@ function recognizeMuSearch(
     return null;
   }
 
-  // Body must be exactly one `counter++` or `++counter`, either as the
-  // direct child of the while (unbraced) or as the sole statement of a
-  // single-statement block. Side-effect purity of init and predicate is
-  // not pre-screened here: the recognizer identifies the syntactic shape;
-  // the downstream translation surfaces any unsupported expressions with
-  // their natural error message.
+  // Body must be exactly one expression-statement whose expression is a
+  // recognized `+1` increment on the counter — `i++`, `++i`, `i += 1`,
+  // `i = i + 1`, or `i = 1 + i`. All five spellings are accepted (the
+  // L1 builder collapses them to one canonical Assign at lowering).
+  // Side-effect purity of init and predicate is not pre-screened here:
+  // the recognizer identifies the syntactic shape; the downstream
+  // translation surfaces any unsupported expressions with their natural
+  // error message.
   const body = whileStmt.statement;
   const bodyStmt: ts.Statement | null = ts.isBlock(body)
     ? body.statements.length === 1
@@ -1653,16 +1678,7 @@ function recognizeMuSearch(
     return null;
   }
   const update = bodyStmt.expression;
-  if (
-    !ts.isPostfixUnaryExpression(update) &&
-    !ts.isPrefixUnaryExpression(update)
-  ) {
-    return null;
-  }
-  if (update.operator !== ts.SyntaxKind.PlusPlusToken) {
-    return null;
-  }
-  if (!ts.isIdentifier(update.operand) || update.operand.text !== counterName) {
+  if (!isPlusOneStep(update, counterName)) {
     return null;
   }
   // Predicate must reference the counter; otherwise the loop is either a
@@ -1679,7 +1695,62 @@ function recognizeMuSearch(
     counterName,
     initTsExpr: decl.initializer,
     predicateTsExpr: whileStmt.expression,
+    stepExpr: update,
   };
+}
+
+/**
+ * Recognize a `+1` increment-step expression on the named counter. The
+ * five spellings — `i++`, `++i`, `i += 1`, `i = i + 1`, `i = 1 + i` —
+ * all return true. Anything else returns false; in particular, `i--`,
+ * `i += 2`, and `i = i + k` for non-literal `k` reject. The L1
+ * `buildL1IncrementStep` accepts a broader set of increment forms; this
+ * predicate is the narrower `+1` filter the μ-search recognizer uses.
+ */
+function isPlusOneStep(expr: ts.Expression, counterName: string): boolean {
+  // `i++` / `++i`
+  if (ts.isPostfixUnaryExpression(expr) || ts.isPrefixUnaryExpression(expr)) {
+    return (
+      expr.operator === ts.SyntaxKind.PlusPlusToken &&
+      ts.isIdentifier(expr.operand) &&
+      expr.operand.text === counterName
+    );
+  }
+  if (!ts.isBinaryExpression(expr)) {
+    return false;
+  }
+  const opKind = expr.operatorToken.kind;
+  // `i += 1`
+  if (opKind === ts.SyntaxKind.PlusEqualsToken) {
+    return (
+      ts.isIdentifier(expr.left) &&
+      expr.left.text === counterName &&
+      isLiteralOne(expr.right)
+    );
+  }
+  // `i = i + 1` / `i = 1 + i`
+  if (opKind === ts.SyntaxKind.EqualsToken) {
+    if (!ts.isIdentifier(expr.left) || expr.left.text !== counterName) {
+      return false;
+    }
+    if (
+      !ts.isBinaryExpression(expr.right) ||
+      expr.right.operatorToken.kind !== ts.SyntaxKind.PlusToken
+    ) {
+      return false;
+    }
+    const a = expr.right.left;
+    const b = expr.right.right;
+    return (
+      (ts.isIdentifier(a) && a.text === counterName && isLiteralOne(b)) ||
+      (ts.isIdentifier(b) && b.text === counterName && isLiteralOne(a))
+    );
+  }
+  return false;
+}
+
+function isLiteralOne(expr: ts.Expression): boolean {
+  return ts.isNumericLiteral(expr) && Number(expr.text) === 1;
 }
 
 /**
@@ -2119,6 +2190,86 @@ function translateBindingInit(
  * legal identifier character.
  */
 function translateMuSearchInit(
+  mu: MuSearch,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  scopedParams: ReadonlyMap<string, string>,
+  state: SymbolicState | undefined,
+  supply: UniqueSupply,
+): BindingInitResult {
+  if (useL1MuSearchPipeline()) {
+    return translateMuSearchInitViaL1(
+      mu,
+      checker,
+      strategy,
+      scopedParams,
+      state,
+      supply,
+    );
+  }
+  return translateMuSearchInitLegacy(
+    mu,
+    checker,
+    strategy,
+    scopedParams,
+    state,
+    supply,
+  );
+}
+
+/**
+ * L1 imperative-IR path for μ-search lowering (workstream M2 patch 2).
+ * Builds the canonical L1 form `Block([Let(c, init), While(p, Assign(c,
+ * BinOp(add, c, Lit(1))))])` and validates it via the L1 recognizer
+ * (`isCanonicalMuSearchForm` in `ir1-lower.ts`). On successful
+ * validation, lowers to the same OpaqueExpr the legacy path produces —
+ * byte-equality is the cutover gate. Patch 3 deletes the legacy path
+ * and inlines this function as the sole μ-search lowering.
+ */
+function translateMuSearchInitViaL1(
+  mu: MuSearch,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  scopedParams: ReadonlyMap<string, string>,
+  state: SymbolicState | undefined,
+  supply: UniqueSupply,
+): BindingInitResult {
+  const l1Ctx = {
+    checker,
+    strategy,
+    paramNames: scopedParams,
+    state,
+    supply,
+  };
+  const form = buildL1LetWhile(
+    mu.counterName,
+    mu.initTsExpr,
+    mu.predicateTsExpr,
+    mu.stepExpr,
+    l1Ctx,
+  );
+  if (isL1StmtUnsupported(form)) {
+    return { error: form.unsupported };
+  }
+  const recognized = isCanonicalMuSearchForm(form, mu.counterName);
+  if (!recognized.ok) {
+    return { error: recognized.unsupported };
+  }
+  // Canonical-shape validation passed. Use the same OpaqueExpr-building
+  // mechanics as legacy — same scopedParams, same binder allocation,
+  // same eachComb construction. Byte-equality with legacy is the
+  // cutover gate.
+  return translateMuSearchInitLegacy(
+    mu,
+    checker,
+    strategy,
+    scopedParams,
+    state,
+    supply,
+  );
+}
+
+function translateMuSearchInitLegacy(
   mu: MuSearch,
   checker: ts.TypeChecker,
   strategy: NumericStrategy,

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -13,7 +13,7 @@ import {
   isL1Unsupported,
   lowerL1ToOpaque,
 } from "./ir1-build.js";
-import { isCanonicalMuSearchForm } from "./ir1-lower.js";
+import { lowerL1MuSearch, type MuSearchLowerCtx } from "./ir1-lower.js";
 import type {
   OpaqueCombiner,
   OpaqueExpr,
@@ -2104,14 +2104,18 @@ function translateBindingInit(
 }
 
 /**
- * Emit a `min over each j: Int, j >= init, ~P(j) | j` expression for a
- * recognized μ-search binding (binder type follows `strategy.mapNumber()`).
- * A fresh comprehension binder takes the place of the loop counter inside
- * the predicate. The binder is allocated through the document-wide name
- * registry (when present) so it never collides with the function's own
- * params or with type-derived rule binders; the `$N` `freshHygienicBinder`
- * form would not round-trip through Pantagruel's parser since `$` isn't a
- * legal identifier character.
+ * Translate a recognized μ-search prelude binding to an OpaqueExpr.
+ * Pure orchestrator — builds the canonical L1 form, hands off to
+ * `lowerL1MuSearch` for the L1 → L2 lowering (which carries all
+ * μ-search semantics), and lowers the L2 result to OpaqueExpr.
+ *
+ * Per the layering principle (workstream `ts2pant-imperative-ir.md`):
+ * `translate-body.ts` has no Pantagruel-target awareness for μ-search.
+ * The canonical-shape check, strategy validation, binder allocation,
+ * predicate substitution, and `comb-typed` construction all live in
+ * `ir1-lower.ts:lowerL1MuSearch`. This function only wires the
+ * lowering context — including the synthCell-aware binder allocator
+ * that needs translate-body's internal supply / scopedParams state.
  */
 function translateMuSearchInit(
   mu: MuSearch,
@@ -2121,112 +2125,47 @@ function translateMuSearchInit(
   state: SymbolicState | undefined,
   supply: UniqueSupply,
 ): BindingInitResult {
-  const ast = getAst();
-
-  // L1 imperative-IR path. Build the canonical L1 form
-  // `Block([Let(c, init), While(p, Assign(c, BinOp(add, c, Lit(1))))])`
-  // and validate via the L1 recognizer. The recognizer is the canonical
-  // home for the canonical-shape check (step is `+1`); the TS-AST
-  // `recognizeLetWhilePair` is purely structural. Predicate-references-
-  // counter and discrete-strategy checks live below as semantic gates.
-  const l1Ctx = {
+  const buildCtx = {
     checker,
     strategy,
     paramNames: scopedParams,
     state,
     supply,
   };
-  const form = buildL1LetWhile(mu, l1Ctx);
+  const form = buildL1LetWhile(mu, buildCtx);
   if (isL1StmtUnsupported(form)) {
     return { error: form.unsupported };
   }
-  const rejection = isCanonicalMuSearchForm(form, mu.counterName);
-  if (rejection !== null) {
-    return { error: rejection.unsupported };
-  }
-
-  // Predicate must reference the counter; otherwise the loop is either
-  // a no-op or a divergence, neither of which is a μ-search. Translating
-  // such a shape as `min over each j: Int, j >= INIT, ~Q | j` (with Q
-  // free of j) changes behavior at the non-terminating case.
-  if (
-    !expressionReferencesNames(mu.predicateTsExpr, new Set([mu.counterName]))
-  ) {
-    return {
-      error: "μ-search predicate does not reference the counter",
-    };
-  }
-
-  // Binder type follows the active NumericStrategy so the comprehension
-  // stays consistent with how `number` is emitted elsewhere. A hardcoded
-  // `Nat` would exclude negative INITs from the search domain and
-  // diverge from the containing body's numeric type. Real is rejected:
-  // μ-search enumerates the discrete sequence `INIT, INIT+1, …` from
-  // `counter++`, whereas `min over each j: Real, j >= INIT, ~P(j) | j`
-  // ranges over a dense domain — e.g. `while (i * i < 2) i++` would
-  // return √2 instead of 2.
-  const counterType = strategy.mapNumber();
-  if (counterType === "Real") {
-    return {
-      error:
-        "μ-search is only supported for discrete numeric strategies (got Real)",
-    };
-  }
-
-  // Translate the init expression for the comprehension's `j >= INIT` guard.
-  const initResult = translateBodyExpr(
-    mu.initTsExpr,
-    checker,
+  const lowerCtx: MuSearchLowerCtx = {
     strategy,
-    scopedParams,
-    state,
-    supply,
-  );
-  if (isBodyUnsupported(initResult)) {
-    return { error: initResult.unsupported };
-  }
-  const initExpr = bodyExpr(initResult);
-
-  // `synthCell` path uses the document-wide NameRegistry (kebab-cased,
-  // numeric-suffixed) and is inherently collision-safe against other
-  // registered names. The standalone fallback has to guard itself against
-  // the current frame's Pant names — `scopedParams.values()` is the set
-  // the comprehension binder must avoid so predicate translation cannot
-  // alias a param to the fresh binder.
-  let jName: string;
-  if (supply.synthCell) {
-    jName = cellRegisterName(supply.synthCell, "j");
-  } else {
-    const usedNames = new Set(scopedParams.values());
-    do {
-      jName = `j${nextSupply(supply)}`;
-    } while (usedNames.has(jName));
-  }
-  const predicateScope = withParam(scopedParams, mu.counterName, jName);
-  const predResult = translateBodyExpr(
-    mu.predicateTsExpr,
-    checker,
-    strategy,
-    predicateScope,
-    state,
-    supply,
-  );
-  if (isBodyUnsupported(predResult)) {
-    return { error: predResult.unsupported };
-  }
-  const predExpr = bodyExpr(predResult);
-
-  return {
-    value: ast.eachComb(
-      [ast.param(jName, ast.tName(counterType))],
-      [
-        ast.gExpr(ast.binop(ast.opGe(), ast.var(jName), initExpr)),
-        ast.gExpr(ast.unop(ast.opNot(), predExpr)),
-      ],
-      ast.combMin(),
-      ast.var(jName),
-    ),
+    counterPantName: scopedParams.get(mu.counterName) ?? mu.counterName,
+    allocateBinder: (hint) => {
+      // synthCell path: document-wide NameRegistry (kebab-cased,
+      // numeric-suffixed) — collision-safe across the document.
+      if (supply.synthCell) {
+        return cellRegisterName(supply.synthCell, hint);
+      }
+      // Standalone fallback: avoid colliding with the current frame's
+      // Pant names so predicate substitution can't alias a param.
+      const usedNames = new Set(scopedParams.values());
+      let name: string;
+      do {
+        name = `${hint}${nextSupply(supply)}`;
+      } while (usedNames.has(name));
+      return name;
+    },
   };
+  const lowered = lowerL1MuSearch(form, mu.counterName, lowerCtx);
+  if (isLowerUnsupported(lowered)) {
+    return { error: lowered.unsupported };
+  }
+  return { value: lowerExpr(lowered) };
+}
+
+function isLowerUnsupported(
+  r: IRExpr | { unsupported: string },
+): r is { unsupported: string } {
+  return typeof r === "object" && r !== null && "unsupported" in r;
 }
 
 function isGuardStatement(

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -59,18 +59,6 @@ function useIRPipeline(): boolean {
   return g.process?.env?.["TS2PANT_USE_IR"] === "1";
 }
 
-/**
- * True if the imperative-IR (Layer 1) μ-search pipeline is enabled via
- * `TS2PANT_USE_L1_MUSEARCH=1`. M2 patch 2 uses this flag to gate the L1
- * recognizer during validation; patch 3 deletes the flag and makes L1
- * always-on for μ-search lowering (workstream
- * `workstreams/ts2pant-imperative-ir.md`, milestone M2).
- */
-function useL1MuSearchPipeline(): boolean {
-  const g = globalThis as { process?: { env?: Record<string, string> } };
-  return g.process?.env?.["TS2PANT_USE_L1_MUSEARCH"] === "1";
-}
-
 // --- Const-binding inlining infrastructure (let-elimination) ---
 
 /**
@@ -124,7 +112,7 @@ export function isNullableTsType(type: ts.Type): boolean {
  *   - `muSearch`: the `let counter = init; while (P(counter)) counter++;`
  *     pair, recognized as Kleene μ-minimization and emitted as a synthetic
  *     binding whose value is `min over each $j: Nat, $j >= init, ~P($j) | $j`.
- *     See `recognizeMuSearch` and `emitMuSearch`.
+ *     See `recognizeLetWhilePair` and `emitMuSearch`.
  */
 type ConstBinding =
   | { kind: "const"; tsName: string; initializer: ts.Expression }
@@ -1630,7 +1618,16 @@ function isInterfaceFieldAccess(
  * Reference: Kleene, *General Recursive Functions of Natural Numbers*,
  * Math. Ann. 112 (1936); Kroening & Strichman, *Decision Procedures* Ch. 4.
  */
-function recognizeMuSearch(
+/**
+ * Recognize a `let + while` pair as one prelude unit. Purely structural:
+ * the let must have a single identifier declarator with an initializer,
+ * the while body must be a single expression-statement (or a single-stmt
+ * block thereof). No μ-search-specific semantics here — those live at
+ * `ir1-lower.ts:isCanonicalMuSearchForm` and the L1 path in
+ * `translateMuSearchInit`. This recognizer's only job is to consume
+ * the pair structurally so `extractReturnExpression` can keep walking.
+ */
+function recognizeLetWhilePair(
   stmts: readonly ts.Statement[],
   idx: number,
   _checker: ts.TypeChecker,
@@ -1660,14 +1657,9 @@ function recognizeMuSearch(
     return null;
   }
 
-  // Body must be exactly one expression-statement whose expression is a
-  // recognized `+1` increment on the counter — `i++`, `++i`, `i += 1`,
-  // `i = i + 1`, or `i = 1 + i`. All five spellings are accepted (the
-  // L1 builder collapses them to one canonical Assign at lowering).
-  // Side-effect purity of init and predicate is not pre-screened here:
-  // the recognizer identifies the syntactic shape; the downstream
-  // translation surfaces any unsupported expressions with their natural
-  // error message.
+  // Body must be a single expression-statement (unbraced or single-stmt
+  // block). No semantic check on the step — that's the L1 recognizer's
+  // job.
   const body = whileStmt.statement;
   const bodyStmt: ts.Statement | null = ts.isBlock(body)
     ? body.statements.length === 1
@@ -1677,80 +1669,13 @@ function recognizeMuSearch(
   if (!bodyStmt || !ts.isExpressionStatement(bodyStmt)) {
     return null;
   }
-  const update = bodyStmt.expression;
-  if (!isPlusOneStep(update, counterName)) {
-    return null;
-  }
-  // Predicate must reference the counter; otherwise the loop is either a
-  // no-op or a divergence, neither of which is a μ-search. Translating
-  // such a shape as `min over each j: Int, j >= INIT, ~Q | j` (with Q
-  // free of j) changes behavior at the non-terminating case.
-  if (
-    !expressionReferencesNames(whileStmt.expression, new Set([counterName]))
-  ) {
-    return null;
-  }
 
   return {
     counterName,
     initTsExpr: decl.initializer,
     predicateTsExpr: whileStmt.expression,
-    stepExpr: update,
+    stepExpr: bodyStmt.expression,
   };
-}
-
-/**
- * Recognize a `+1` increment-step expression on the named counter. The
- * five spellings — `i++`, `++i`, `i += 1`, `i = i + 1`, `i = 1 + i` —
- * all return true. Anything else returns false; in particular, `i--`,
- * `i += 2`, and `i = i + k` for non-literal `k` reject. The L1
- * `buildL1IncrementStep` accepts a broader set of increment forms; this
- * predicate is the narrower `+1` filter the μ-search recognizer uses.
- */
-function isPlusOneStep(expr: ts.Expression, counterName: string): boolean {
-  // `i++` / `++i`
-  if (ts.isPostfixUnaryExpression(expr) || ts.isPrefixUnaryExpression(expr)) {
-    return (
-      expr.operator === ts.SyntaxKind.PlusPlusToken &&
-      ts.isIdentifier(expr.operand) &&
-      expr.operand.text === counterName
-    );
-  }
-  if (!ts.isBinaryExpression(expr)) {
-    return false;
-  }
-  const opKind = expr.operatorToken.kind;
-  // `i += 1`
-  if (opKind === ts.SyntaxKind.PlusEqualsToken) {
-    return (
-      ts.isIdentifier(expr.left) &&
-      expr.left.text === counterName &&
-      isLiteralOne(expr.right)
-    );
-  }
-  // `i = i + 1` / `i = 1 + i`
-  if (opKind === ts.SyntaxKind.EqualsToken) {
-    if (!ts.isIdentifier(expr.left) || expr.left.text !== counterName) {
-      return false;
-    }
-    if (
-      !ts.isBinaryExpression(expr.right) ||
-      expr.right.operatorToken.kind !== ts.SyntaxKind.PlusToken
-    ) {
-      return false;
-    }
-    const a = expr.right.left;
-    const b = expr.right.right;
-    return (
-      (ts.isIdentifier(a) && a.text === counterName && isLiteralOne(b)) ||
-      (ts.isIdentifier(b) && b.text === counterName && isLiteralOne(a))
-    );
-  }
-  return false;
-}
-
-function isLiteralOne(expr: ts.Expression): boolean {
-  return ts.isNumericLiteral(expr) && Number(expr.text) === 1;
 }
 
 /**
@@ -1811,7 +1736,7 @@ function extractReturnExpression(
   const lastIdx = stmts.length - 1;
   let i = 0;
   while (i < lastIdx) {
-    const mu = recognizeMuSearch(stmts, i, checker);
+    const mu = recognizeLetWhilePair(stmts, i, checker);
     if (mu) {
       bindings.push({ kind: "muSearch", tsName: mu.counterName, mu });
       i += 2;
@@ -1880,7 +1805,7 @@ function describeRejectedBody(body: ts.Block, checker: ts.TypeChecker): string {
     // failed rather than a heuristic guess.
     let i = 0;
     while (i < lastIdx) {
-      if (recognizeMuSearch(stmts, i, checker)) {
+      if (recognizeLetWhilePair(stmts, i, checker)) {
         i += 2;
         continue;
       }
@@ -1897,7 +1822,7 @@ function describeRejectedBody(body: ts.Block, checker: ts.TypeChecker): string {
         }
         return "if-with-return body must be a single return statement";
       }
-      // A let; while pair where recognizeMuSearch failed — probably a
+      // A let; while pair where recognizeLetWhilePair failed — probably a
       // compound while body or non-`i++` body.
       if (
         ts.isVariableStatement(stmt) &&
@@ -2197,43 +2122,14 @@ function translateMuSearchInit(
   state: SymbolicState | undefined,
   supply: UniqueSupply,
 ): BindingInitResult {
-  if (useL1MuSearchPipeline()) {
-    return translateMuSearchInitViaL1(
-      mu,
-      checker,
-      strategy,
-      scopedParams,
-      state,
-      supply,
-    );
-  }
-  return translateMuSearchInitLegacy(
-    mu,
-    checker,
-    strategy,
-    scopedParams,
-    state,
-    supply,
-  );
-}
+  const ast = getAst();
 
-/**
- * L1 imperative-IR path for μ-search lowering (workstream M2 patch 2).
- * Builds the canonical L1 form `Block([Let(c, init), While(p, Assign(c,
- * BinOp(add, c, Lit(1))))])` and validates it via the L1 recognizer
- * (`isCanonicalMuSearchForm` in `ir1-lower.ts`). On successful
- * validation, lowers to the same OpaqueExpr the legacy path produces —
- * byte-equality is the cutover gate. Patch 3 deletes the legacy path
- * and inlines this function as the sole μ-search lowering.
- */
-function translateMuSearchInitViaL1(
-  mu: MuSearch,
-  checker: ts.TypeChecker,
-  strategy: NumericStrategy,
-  scopedParams: ReadonlyMap<string, string>,
-  state: SymbolicState | undefined,
-  supply: UniqueSupply,
-): BindingInitResult {
+  // L1 imperative-IR path. Build the canonical L1 form
+  // `Block([Let(c, init), While(p, Assign(c, BinOp(add, c, Lit(1))))])`
+  // and validate via the L1 recognizer. The recognizer is the canonical
+  // home for the canonical-shape check (step is `+1`); the TS-AST
+  // `recognizeLetWhilePair` is purely structural. Predicate-references-
+  // counter and discrete-strategy checks live below as semantic gates.
   const l1Ctx = {
     checker,
     strategy,
@@ -2255,30 +2151,36 @@ function translateMuSearchInitViaL1(
   if (!recognized.ok) {
     return { error: recognized.unsupported };
   }
-  // Canonical-shape validation passed. Use the same OpaqueExpr-building
-  // mechanics as legacy — same scopedParams, same binder allocation,
-  // same eachComb construction. Byte-equality with legacy is the
-  // cutover gate.
-  return translateMuSearchInitLegacy(
-    mu,
-    checker,
-    strategy,
-    scopedParams,
-    state,
-    supply,
-  );
-}
 
-function translateMuSearchInitLegacy(
-  mu: MuSearch,
-  checker: ts.TypeChecker,
-  strategy: NumericStrategy,
-  scopedParams: ReadonlyMap<string, string>,
-  state: SymbolicState | undefined,
-  supply: UniqueSupply,
-): BindingInitResult {
-  const ast = getAst();
+  // Predicate must reference the counter; otherwise the loop is either
+  // a no-op or a divergence, neither of which is a μ-search. Translating
+  // such a shape as `min over each j: Int, j >= INIT, ~Q | j` (with Q
+  // free of j) changes behavior at the non-terminating case.
+  if (
+    !expressionReferencesNames(mu.predicateTsExpr, new Set([mu.counterName]))
+  ) {
+    return {
+      error: "μ-search predicate does not reference the counter",
+    };
+  }
 
+  // Binder type follows the active NumericStrategy so the comprehension
+  // stays consistent with how `number` is emitted elsewhere. A hardcoded
+  // `Nat` would exclude negative INITs from the search domain and
+  // diverge from the containing body's numeric type. Real is rejected:
+  // μ-search enumerates the discrete sequence `INIT, INIT+1, …` from
+  // `counter++`, whereas `min over each j: Real, j >= INIT, ~P(j) | j`
+  // ranges over a dense domain — e.g. `while (i * i < 2) i++` would
+  // return √2 instead of 2.
+  const counterType = strategy.mapNumber();
+  if (counterType === "Real") {
+    return {
+      error:
+        "μ-search is only supported for discrete numeric strategies (got Real)",
+    };
+  }
+
+  // Translate the init expression for the comprehension's `j >= INIT` guard.
   const initResult = translateBodyExpr(
     mu.initTsExpr,
     checker,
@@ -2321,21 +2223,6 @@ function translateMuSearchInitLegacy(
   }
   const predExpr = bodyExpr(predResult);
 
-  // Binder type follows the active NumericStrategy so the comprehension
-  // stays consistent with how `number` is emitted elsewhere. A hardcoded
-  // `Nat` would exclude negative INITs from the search domain and
-  // diverge from the containing body's numeric type. Real is rejected:
-  // μ-search enumerates the discrete sequence `INIT, INIT+1, …` from
-  // `counter++`, whereas `min over each j: Real, j >= INIT, ~P(j) | j`
-  // ranges over a dense domain — e.g. `while (i * i < 2) i++` would
-  // return √2 instead of 2.
-  const counterType = strategy.mapNumber();
-  if (counterType === "Real") {
-    return {
-      error:
-        "μ-search is only supported for discrete numeric strategies (got Real)",
-    };
-  }
   return {
     value: ast.eachComb(
       [ast.param(jName, ast.tName(counterType))],

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -538,8 +538,20 @@ exports[`expressions-set.ts > contains 1`] = `
 "module Contains.\\n\\ncontains xs: [String], x: String => Bool.\\n\\n---\\n\\ncontains xs x = (x in xs).\\n"
 `;
 
+exports[`expressions-while-mu-search.ts > compoundIncrementStep 1`] = `
+"module CompoundIncrementStep.\\n\\ncompound-increment-step used: [Int] => Int.\\n\\n---\\n\\ncompound-increment-step used = (min over each j: Int, j >= 1, ~(j in used) | j).\\n"
+`;
+
 exports[`expressions-while-mu-search.ts > compoundWhileBody 1`] = `
 "module CompoundWhileBody.\\n\\ncompound-while-body used: [Int] => Int.\\n\\n---\\n\\n> UNSUPPORTED: compound-while-body — unsupported while-loop shape (not a recognized μ-search).\\n"
+`;
+
+exports[`expressions-while-mu-search.ts > explicitIncrementStep 1`] = `
+"module ExplicitIncrementStep.\\n\\nexplicit-increment-step used: [Int] => Int.\\n\\n---\\n\\nexplicit-increment-step used = (min over each j: Int, j >= 1, ~(j in used) | j).\\n"
+`;
+
+exports[`expressions-while-mu-search.ts > explicitIncrementStepFlipped 1`] = `
+"module ExplicitIncrementStepFlipped.\\n\\nexplicit-increment-step-flipped used: [Int] => Int.\\n\\n---\\n\\nexplicit-increment-step-flipped used = (min over each j: Int, j >= 1, ~(j in used) | j).\\n"
 `;
 
 exports[`expressions-while-mu-search.ts > firstUnusedSuffix 1`] = `

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-while-mu-search.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-while-mu-search.ts
@@ -60,3 +60,36 @@ export function unbracedWhileBody(used: ReadonlySet<number>): number {
   while (used.has(i)) i++;
   return i;
 }
+
+/** Compound-assignment increment step (`i += 1`). M2's L1 normalizer
+ *  collapses this to the same canonical Assign as `i++` — same Pant
+ *  output. */
+export function compoundIncrementStep(used: ReadonlySet<number>): number {
+  let i = 1;
+  while (used.has(i)) {
+    i += 1;
+  }
+  return i;
+}
+
+/** Explicit-assignment increment step (`i = i + 1`). M2 collapses to
+ *  the canonical Assign. */
+export function explicitIncrementStep(used: ReadonlySet<number>): number {
+  let i = 1;
+  while (used.has(i)) {
+    i = i + 1;
+  }
+  return i;
+}
+
+/** Counter on the right of the explicit `+` (`i = 1 + i`) —
+ *  commutative-rewrite gives the same canonical Assign. */
+export function explicitIncrementStepFlipped(
+  used: ReadonlySet<number>,
+): number {
+  let i = 1;
+  while (used.has(i)) {
+    i = 1 + i;
+  }
+  return i;
+}

--- a/tools/ts2pant/tests/ir1-build-increment.test.mts
+++ b/tools/ts2pant/tests/ir1-build-increment.test.mts
@@ -1,0 +1,234 @@
+/**
+ * Unit tests for `buildL1IncrementStep` (workstream M2).
+ *
+ * Exercises the increment surface-form normalizer in isolation: takes a
+ * TS expression-statement body, recognizes one of the increment shapes
+ * on the named counter, and produces canonical L1 `Assign(Var(c),
+ * BinOp(<op>, Var(c), <k>))`.
+ *
+ * The five `+1` spellings (`i++`, `++i`, `i += 1`, `i = i + 1`,
+ * `i = 1 + i`) MUST produce identical L1 output. Other increment shapes
+ * (compound, non-commutative, unary `--`) build to non-canonical Assign
+ * variants; the L1 μ-search recognizer at lowering time rejects those.
+ */
+
+import assert from "node:assert/strict";
+import { before, describe, it } from "node:test";
+import { createSourceFileFromSource, getChecker } from "../src/extract.js";
+import {
+  buildL1IncrementStep,
+  isL1StmtUnsupported,
+} from "../src/ir1-build.js";
+import {
+  ir1Assign,
+  ir1Binop,
+  ir1LitNat,
+  ir1Var,
+} from "../src/ir1.js";
+import { loadAst } from "../src/pant-wasm.js";
+import {
+  type UniqueSupply,
+  freshHygienicBinder,
+} from "../src/translate-body.js";
+import { IntStrategy } from "../src/translate-types.js";
+import ts from "typescript";
+
+before(async () => {
+  await loadAst();
+});
+
+/**
+ * Build a minimal `L1BuildContext` and pull the body of `function f(i:
+ * number) { <step>; }` so we can run `buildL1IncrementStep` directly on
+ * the underlying expression. Returns the increment expression and a
+ * context suitable for building it.
+ */
+function setup(stepSource: string) {
+  const source = `function f(i: number) { ${stepSource}; }`;
+  const sourceFile = createSourceFileFromSource(source);
+  const checker = getChecker(sourceFile);
+  const fn = sourceFile.compilerNode.statements[0]!;
+  if (!ts.isFunctionDeclaration(fn) || !fn.body) {
+    throw new Error("test helper: expected a function declaration");
+  }
+  const stmt = fn.body.statements[0]!;
+  if (!ts.isExpressionStatement(stmt)) {
+    throw new Error("test helper: expected an expression-statement body");
+  }
+  const supply: UniqueSupply = { n: 0 };
+  // freshHygienicBinder is a no-op here; we just want a valid supply.
+  void freshHygienicBinder;
+  const ctx = {
+    checker,
+    strategy: IntStrategy,
+    paramNames: new Map<string, string>([["i", "i"]]),
+    state: undefined,
+    supply,
+  };
+  return { expr: stmt.expression, ctx };
+}
+
+const CANONICAL_PLUS_ONE = ir1Assign(
+  ir1Var("i"),
+  ir1Binop("add", ir1Var("i"), ir1LitNat(1)),
+);
+
+// ---------------------------------------------------------------------------
+// The five canonical `+1` spellings — all produce identical Assign
+// ---------------------------------------------------------------------------
+
+describe("buildL1IncrementStep: +1 spellings collapse to one canonical Assign", () => {
+  it("`i++` → Assign(i, i + 1)", () => {
+    const { expr, ctx } = setup("i++");
+    const result = buildL1IncrementStep(expr, "i", ctx);
+    if (isL1StmtUnsupported(result)) {
+      assert.fail(`expected L1 statement, got: ${result.unsupported}`);
+    }
+    assert.deepEqual(result, CANONICAL_PLUS_ONE);
+  });
+
+  it("`++i` → Assign(i, i + 1)", () => {
+    const { expr, ctx } = setup("++i");
+    const result = buildL1IncrementStep(expr, "i", ctx);
+    if (isL1StmtUnsupported(result)) {
+      assert.fail(`expected L1 statement, got: ${result.unsupported}`);
+    }
+    assert.deepEqual(result, CANONICAL_PLUS_ONE);
+  });
+
+  it("`i += 1` → Assign(i, i + 1)", () => {
+    const { expr, ctx } = setup("i += 1");
+    const result = buildL1IncrementStep(expr, "i", ctx);
+    if (isL1StmtUnsupported(result)) {
+      assert.fail(`expected L1 statement, got: ${result.unsupported}`);
+    }
+    assert.deepEqual(result, CANONICAL_PLUS_ONE);
+  });
+
+  it("`i = i + 1` → Assign(i, i + 1)", () => {
+    const { expr, ctx } = setup("i = i + 1");
+    const result = buildL1IncrementStep(expr, "i", ctx);
+    if (isL1StmtUnsupported(result)) {
+      assert.fail(`expected L1 statement, got: ${result.unsupported}`);
+    }
+    assert.deepEqual(result, CANONICAL_PLUS_ONE);
+  });
+
+  it("`i = 1 + i` → Assign(i, i + 1)  (commutative-rewrite)", () => {
+    const { expr, ctx } = setup("i = 1 + i");
+    const result = buildL1IncrementStep(expr, "i", ctx);
+    if (isL1StmtUnsupported(result)) {
+      assert.fail(`expected L1 statement, got: ${result.unsupported}`);
+    }
+    assert.deepEqual(result, CANONICAL_PLUS_ONE);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Non-`+1` increments build successfully (L1 recognizer rejects later)
+// ---------------------------------------------------------------------------
+
+describe("buildL1IncrementStep: non-+1 increments build to L1", () => {
+  it("`i--` → Assign(i, i - 1)", () => {
+    const { expr, ctx } = setup("i--");
+    const result = buildL1IncrementStep(expr, "i", ctx);
+    if (isL1StmtUnsupported(result)) {
+      assert.fail(`expected L1 statement, got: ${result.unsupported}`);
+    }
+    assert.deepEqual(
+      result,
+      ir1Assign(ir1Var("i"), ir1Binop("sub", ir1Var("i"), ir1LitNat(1))),
+    );
+  });
+
+  it("`i += 2` → Assign(i, i + 2)", () => {
+    const { expr, ctx } = setup("i += 2");
+    const result = buildL1IncrementStep(expr, "i", ctx);
+    if (isL1StmtUnsupported(result)) {
+      assert.fail(`expected L1 statement, got: ${result.unsupported}`);
+    }
+    if (!isL1StmtUnsupported(result) && result.kind === "assign") {
+      assert.equal(result.value.kind, "binop");
+    }
+  });
+
+  it("`i = i * 2` → Assign(i, i * 2)", () => {
+    const { expr, ctx } = setup("i = i * 2");
+    const result = buildL1IncrementStep(expr, "i", ctx);
+    if (isL1StmtUnsupported(result)) {
+      assert.fail(`expected L1 statement, got: ${result.unsupported}`);
+    }
+    if (!isL1StmtUnsupported(result) && result.kind === "assign") {
+      assert.equal(result.value.kind, "binop");
+      if (result.value.kind === "binop") {
+        assert.equal(result.value.op, "mul");
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rejection cases
+// ---------------------------------------------------------------------------
+
+describe("buildL1IncrementStep: rejection cases", () => {
+  it("rejects assignment to a non-counter variable", () => {
+    const { expr, ctx } = setup("j = j + 1");
+    const result = buildL1IncrementStep(expr, "i", ctx);
+    if (!isL1StmtUnsupported(result)) {
+      assert.fail("expected unsupported, got an L1 statement");
+    }
+    assert.match(result.unsupported, /not the counter/);
+  });
+
+  it("rejects compound-assignment to a non-counter variable", () => {
+    const { expr, ctx } = setup("j += 1");
+    const result = buildL1IncrementStep(expr, "i", ctx);
+    if (!isL1StmtUnsupported(result)) {
+      assert.fail("expected unsupported, got an L1 statement");
+    }
+  });
+
+  it("rejects unary increment on a non-counter variable", () => {
+    const { expr, ctx } = setup("j++");
+    const result = buildL1IncrementStep(expr, "i", ctx);
+    if (!isL1StmtUnsupported(result)) {
+      assert.fail("expected unsupported, got an L1 statement");
+    }
+  });
+
+  it("rejects RHS that does not reference counter (`i = 5`)", () => {
+    const { expr, ctx } = setup("i = 5");
+    const result = buildL1IncrementStep(expr, "i", ctx);
+    if (!isL1StmtUnsupported(result)) {
+      assert.fail("expected unsupported, got an L1 statement");
+    }
+    assert.match(result.unsupported, /not a binary expression/);
+  });
+
+  it("rejects `i = k - i` (counter on right of non-commutative op)", () => {
+    const { expr, ctx } = setup("i = 5 - i");
+    const result = buildL1IncrementStep(expr, "i", ctx);
+    if (!isL1StmtUnsupported(result)) {
+      assert.fail("expected unsupported, got an L1 statement");
+    }
+    assert.match(result.unsupported, /non-commutative/);
+  });
+
+  it("rejects RHS without counter (`i = j + 1`)", () => {
+    const { expr, ctx } = setup("i = j + 1");
+    const result = buildL1IncrementStep(expr, "i", ctx);
+    if (!isL1StmtUnsupported(result)) {
+      assert.fail("expected unsupported, got an L1 statement");
+    }
+    assert.match(result.unsupported, /reference counter/);
+  });
+
+  it("rejects bare expression that's not an assignment or increment", () => {
+    const { expr, ctx } = setup("i + 1");
+    const result = buildL1IncrementStep(expr, "i", ctx);
+    if (!isL1StmtUnsupported(result)) {
+      assert.fail("expected unsupported, got an L1 statement");
+    }
+  });
+});

--- a/tools/ts2pant/tests/ir1-lower.test.mts
+++ b/tools/ts2pant/tests/ir1-lower.test.mts
@@ -391,3 +391,68 @@ describe("active statement constructors (block, let, return)", () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// L2 `comb-typed` form (M2 cleanup) — typed-comprehension with no source
+// ---------------------------------------------------------------------------
+
+describe("L2 comb-typed form (typed comprehension)", () => {
+  it("min over each j: Int, j >= 1, ¬p(j) | j → eachComb with typed param", async () => {
+    const { irBinop, irLitNat, irUnop, irVar, irAppName, irCombTyped } =
+      await import("../src/ir.js");
+    const ast = getAst();
+    const l2 = irCombTyped(
+      "min",
+      "j",
+      "Int",
+      [
+        irBinop("ge", irVar("j"), irLitNat(1)),
+        irUnop("not", irAppName("p", [irVar("j")])),
+      ],
+      irVar("j"),
+    );
+    const lowered = lowerExpr(l2);
+    assert.equal(
+      ast.strExpr(lowered),
+      "min over each j: Int, j >= 1, ~(p j) | j",
+    );
+  });
+
+  it("byte-equality with a hand-built legacy eachComb", async () => {
+    const { irBinop, irLitNat, irUnop, irVar, irAppName, irCombTyped } =
+      await import("../src/ir.js");
+    const ast = getAst();
+    // Hand-built legacy form — what today's translateMuSearchInit emits.
+    const legacy = ast.eachComb(
+      [ast.param("j", ast.tName("Int"))],
+      [
+        ast.gExpr(ast.binop(ast.opGe(), ast.var("j"), ast.litNat(1))),
+        ast.gExpr(ast.unop(ast.opNot(), ast.app(ast.var("p"), [ast.var("j")]))),
+      ],
+      ast.combMin(),
+      ast.var("j"),
+    );
+    const l2 = irCombTyped(
+      "min",
+      "j",
+      "Int",
+      [
+        irBinop("ge", irVar("j"), irLitNat(1)),
+        irUnop("not", irAppName("p", [irVar("j")])),
+      ],
+      irVar("j"),
+    );
+    assert.equal(ast.strExpr(lowerExpr(l2)), ast.strExpr(legacy));
+  });
+
+  it("max combiner accepted (forbids init at type level)", async () => {
+    const { irLitNat, irVar, irCombTyped } = await import("../src/ir.js");
+    const ast = getAst();
+    const l2 = irCombTyped("max", "k", "Nat", [], irVar("k"));
+    const lowered = lowerExpr(l2);
+    // No guards beyond the typed binder.
+    assert.match(ast.strExpr(lowered), /max over each k: Nat \| k/);
+    // Suppress unused var warning.
+    void irLitNat;
+  });
+});

--- a/tools/ts2pant/tests/ir1-lower.test.mts
+++ b/tools/ts2pant/tests/ir1-lower.test.mts
@@ -281,11 +281,41 @@ describe("L1 → L2 → OpaqueExpr — full pipeline byte-equality with legacy",
 // Vocabulary-locked stubs throw not-implemented
 // ---------------------------------------------------------------------------
 
-describe("vocabulary-locked stubs (M2/M3 forms)", () => {
-  it("ir1Assign throws not-implemented (M2)", () => {
-    assert.throws(() => ir1Assign(ir1Var("x"), ir1LitNat(1)), /M2/);
+describe("M2: ir1Assign and ir1While constructors are active", () => {
+  it("ir1Assign builds an `assign` statement", () => {
+    const stmt = ir1Assign(ir1Var("i"), ir1LitNat(1));
+    assert.equal(stmt.kind, "assign");
+    if (stmt.kind === "assign") {
+      assert.deepEqual(stmt.target, ir1Var("i"));
+      assert.deepEqual(stmt.value, ir1LitNat(1));
+    }
   });
 
+  it("ir1Assign target may be a Member expression", () => {
+    const stmt = ir1Assign(
+      ir1Member(ir1Var("a"), "balance"),
+      ir1LitNat(0),
+    );
+    assert.equal(stmt.kind, "assign");
+    if (stmt.kind === "assign") {
+      assert.equal(stmt.target.kind, "member");
+    }
+  });
+
+  it("ir1While builds a `while` statement with body", () => {
+    const stmt = ir1While(
+      ir1Var("p"),
+      ir1Assign(ir1Var("i"), ir1LitNat(0)),
+    );
+    assert.equal(stmt.kind, "while");
+    if (stmt.kind === "while") {
+      assert.deepEqual(stmt.cond, ir1Var("p"));
+      assert.equal(stmt.body.kind, "assign");
+    }
+  });
+});
+
+describe("vocabulary-locked stubs (M3 forms)", () => {
   it("ir1CondStmt throws not-implemented (M3)", () => {
     assert.throws(
       () => ir1CondStmt([[ir1Var("g"), ir1Return(ir1Var("v"))]], null),
@@ -301,17 +331,7 @@ describe("vocabulary-locked stubs (M2/M3 forms)", () => {
   });
 
   it("ir1For throws not-implemented (M3)", () => {
-    assert.throws(
-      () => ir1For(null, null, null, ir1Return(null)),
-      /M3/,
-    );
-  });
-
-  it("ir1While throws not-implemented (M3)", () => {
-    assert.throws(
-      () => ir1While(ir1Var("g"), ir1Return(null)),
-      /M3/,
-    );
+    assert.throws(() => ir1For(null, null, null, ir1Return(null)), /M3/);
   });
 
   it("ir1Throw throws not-implemented (M3)", () => {

--- a/tools/ts2pant/tests/ir1-lower.test.mts
+++ b/tools/ts2pant/tests/ir1-lower.test.mts
@@ -3,6 +3,7 @@ import { before, describe, it } from "node:test";
 import {
   irAppName,
   irBinop,
+  irCombTyped,
   irCond,
   irLitBool,
   irLitNat,
@@ -397,9 +398,7 @@ describe("active statement constructors (block, let, return)", () => {
 // ---------------------------------------------------------------------------
 
 describe("L2 comb-typed form (typed comprehension)", () => {
-  it("min over each j: Int, j >= 1, ¬p(j) | j → eachComb with typed param", async () => {
-    const { irBinop, irLitNat, irUnop, irVar, irAppName, irCombTyped } =
-      await import("../src/ir.js");
+  it("min over each j: Int, j >= 1, ¬p(j) | j → eachComb with typed param", () => {
     const ast = getAst();
     const l2 = irCombTyped(
       "min",
@@ -418,9 +417,7 @@ describe("L2 comb-typed form (typed comprehension)", () => {
     );
   });
 
-  it("byte-equality with a hand-built legacy eachComb", async () => {
-    const { irBinop, irLitNat, irUnop, irVar, irAppName, irCombTyped } =
-      await import("../src/ir.js");
+  it("byte-equality with a hand-built legacy eachComb", () => {
     const ast = getAst();
     // Hand-built legacy form — what today's translateMuSearchInit emits.
     const legacy = ast.eachComb(
@@ -445,14 +442,11 @@ describe("L2 comb-typed form (typed comprehension)", () => {
     assert.equal(ast.strExpr(lowerExpr(l2)), ast.strExpr(legacy));
   });
 
-  it("max combiner accepted (forbids init at type level)", async () => {
-    const { irLitNat, irVar, irCombTyped } = await import("../src/ir.js");
+  it("max combiner accepted (forbids init at type level)", () => {
     const ast = getAst();
     const l2 = irCombTyped("max", "k", "Nat", [], irVar("k"));
     const lowered = lowerExpr(l2);
     // No guards beyond the typed binder.
     assert.match(ast.strExpr(lowered), /max over each k: Nat \| k/);
-    // Suppress unused var warning.
-    void irLitNat;
   });
 });

--- a/tools/ts2pant/tests/m2-musearch-l1.test.mts
+++ b/tools/ts2pant/tests/m2-musearch-l1.test.mts
@@ -1,0 +1,245 @@
+/**
+ * Integration tests for the M2 L1 μ-search pipeline (workstream M2
+ * patch 2).
+ *
+ * Sets `TS2PANT_USE_L1_MUSEARCH=1` so the L1 path is exercised
+ * end-to-end. Asserts:
+ *
+ * 1. **Byte-equality with legacy** for the existing μ-search shapes
+ *    (`i++`, `++i`, unbraced body, post-loop counter use, +const-binding
+ *    interleave). Translating the same source under flag-off vs flag-on
+ *    produces identical Pant. This is the cutover gate for M2 patch 3.
+ *
+ * 2. **L1 path accepts the broader `+1` spellings** (`i += 1`,
+ *    `i = i + 1`, `i = 1 + i`) and produces the same canonical
+ *    `min over each j: Int, j >= 1, ~(j in used) | j` form.
+ *
+ * 3. **L1 recognizer rejection** for non-canonical shapes that the
+ *    TS-AST recognizer accepts (none today; the TS recognizer is
+ *    narrower than L1 in M2 patch 2 — patch 3 will widen TS-AST and
+ *    rely on the L1 recognizer for canonical-shape rejection).
+ */
+
+import assert from "node:assert/strict";
+import { before, describe, it } from "node:test";
+import { createSourceFileFromSource } from "../src/extract.js";
+import { getAst, loadAst } from "../src/pant-wasm.js";
+import { translateBody } from "../src/translate-body.js";
+import { IntStrategy } from "../src/translate-types.js";
+
+before(async () => {
+  await loadAst();
+});
+
+function withFlag<T>(flag: string, value: string, fn: () => T): T {
+  const prev = process.env[flag];
+  process.env[flag] = value;
+  try {
+    return fn();
+  } finally {
+    if (prev === undefined) {
+      delete process.env[flag];
+    } else {
+      process.env[flag] = prev;
+    }
+  }
+}
+
+function withoutFlag<T>(flag: string, fn: () => T): T {
+  const prev = process.env[flag];
+  delete process.env[flag];
+  try {
+    return fn();
+  } finally {
+    if (prev !== undefined) {
+      process.env[flag] = prev;
+    }
+  }
+}
+
+function translate(
+  source: string,
+  name: string,
+): { unsupported: string | null; pant: string | null } {
+  const sourceFile = createSourceFileFromSource(source);
+  const props = translateBody({
+    sourceFile,
+    functionName: name,
+    strategy: IntStrategy,
+  });
+  if (props.length === 0) {
+    return { unsupported: "no propositions", pant: null };
+  }
+  const p = props[0]!;
+  if (p.kind === "unsupported") {
+    return { unsupported: p.reason, pant: null };
+  }
+  if (p.kind !== "equation") {
+    return { unsupported: `non-equation: ${p.kind}`, pant: null };
+  }
+  return { unsupported: null, pant: getAst().strExpr(p.rhs) };
+}
+
+function translateBoth(source: string, name: string) {
+  const legacy = withoutFlag("TS2PANT_USE_L1_MUSEARCH", () =>
+    translate(source, name),
+  );
+  const l1 = withFlag("TS2PANT_USE_L1_MUSEARCH", "1", () =>
+    translate(source, name),
+  );
+  return { legacy, l1 };
+}
+
+// ---------------------------------------------------------------------------
+// 1. Byte-equality with legacy on existing shapes (cutover gate)
+// ---------------------------------------------------------------------------
+
+describe("M2 μ-search L1: byte-equality with legacy", () => {
+  it("`i++` step produces identical output", () => {
+    const source = `
+      function firstUnused(used: ReadonlySet<number>): number {
+        let i = 1;
+        while (used.has(i)) i++;
+        return i;
+      }
+    `;
+    const { legacy, l1 } = translateBoth(source, "firstUnused");
+    assert.equal(legacy.unsupported, null);
+    assert.equal(l1.unsupported, null);
+    assert.equal(legacy.pant, l1.pant);
+    assert.match(l1.pant!, /min over each j\d*: Int/);
+  });
+
+  it("`++i` step produces identical output", () => {
+    const source = `
+      function firstUnused(used: ReadonlySet<number>): number {
+        let i = 0;
+        while (used.has(i)) ++i;
+        return i;
+      }
+    `;
+    const { legacy, l1 } = translateBoth(source, "firstUnused");
+    assert.equal(legacy.unsupported, null);
+    assert.equal(l1.unsupported, null);
+    assert.equal(legacy.pant, l1.pant);
+  });
+
+  it("μ-search counter referenced post-loop", () => {
+    const source = `
+      function nextSlotPlusOne(used: ReadonlySet<number>): number {
+        let i = 0;
+        while (used.has(i)) i++;
+        return i + 1;
+      }
+    `;
+    const { legacy, l1 } = translateBoth(source, "nextSlotPlusOne");
+    assert.equal(legacy.unsupported, null);
+    assert.equal(l1.unsupported, null);
+    assert.equal(legacy.pant, l1.pant);
+  });
+
+  it("μ-search interleaved with const binding", () => {
+    const source = `
+      function offset(used: ReadonlySet<number>, base: number): number {
+        const n = base * 2;
+        let i = 1;
+        while (used.has(i)) i++;
+        return n + i;
+      }
+    `;
+    const { legacy, l1 } = translateBoth(source, "offset");
+    assert.equal(legacy.unsupported, null);
+    assert.equal(l1.unsupported, null);
+    assert.equal(legacy.pant, l1.pant);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. L1 accepts broader +1 spellings; all produce the canonical form
+// ---------------------------------------------------------------------------
+
+describe("M2 μ-search L1: all five +1 spellings produce identical Pant", () => {
+  function translateForm(stepSource: string): string {
+    const source = `
+      function findSuffix(used: ReadonlySet<number>): number {
+        let i = 1;
+        while (used.has(i)) { ${stepSource}; }
+        return i;
+      }
+    `;
+    const { l1 } = translateBoth(source, "findSuffix");
+    if (l1.unsupported) {
+      throw new Error(`unsupported: ${l1.unsupported}`);
+    }
+    return l1.pant!;
+  }
+
+  it("all five spellings produce identical L1 output", () => {
+    // Each translation gets a fresh `UniqueSupply` and a fresh
+    // `SourceFile`, so binder allocation is deterministic per call.
+    // The five spellings must produce byte-identical Pant — that's the
+    // M2 architectural promise.
+    const baseline = translateForm("i++");
+    assert.match(baseline, /min over each j\d*: Int/);
+    assert.match(baseline, /~\(j\d* in used\)/);
+
+    assert.equal(translateForm("++i"), baseline);
+    assert.equal(translateForm("i += 1"), baseline);
+    assert.equal(translateForm("i = i + 1"), baseline);
+    assert.equal(translateForm("i = 1 + i"), baseline);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Existing rejection cases remain rejected
+// ---------------------------------------------------------------------------
+
+describe("M2 μ-search L1: rejection cases", () => {
+  it("compound while body still rejects", () => {
+    const source = `
+      function compound(used: ReadonlySet<number>): number {
+        let i = 0;
+        while (used.has(i)) {
+          i++;
+          i++;
+        }
+        return i;
+      }
+    `;
+    const { legacy, l1 } = translateBoth(source, "compound");
+    assert.notEqual(legacy.unsupported, null);
+    assert.notEqual(l1.unsupported, null);
+  });
+
+  it("`i += 2` step rejects under both modes", () => {
+    const source = `
+      function nonUnit(used: ReadonlySet<number>): number {
+        let i = 0;
+        while (used.has(i)) {
+          i += 2;
+        }
+        return i;
+      }
+    `;
+    const { legacy, l1 } = translateBoth(source, "nonUnit");
+    // Legacy (with the broadened isPlusOneStep at TS-AST recognizer)
+    // also rejects this — `i += 2` is not a +1 step.
+    assert.notEqual(legacy.unsupported, null);
+    assert.notEqual(l1.unsupported, null);
+  });
+
+  it("predicate not referencing counter rejects", () => {
+    const source = `
+      function noRef(used: ReadonlySet<number>, flag: boolean): number {
+        let i = 0;
+        while (flag) {
+          i++;
+        }
+        return i;
+      }
+    `;
+    const { legacy, l1 } = translateBoth(source, "noRef");
+    assert.notEqual(legacy.unsupported, null);
+    assert.notEqual(l1.unsupported, null);
+  });
+});

--- a/tools/ts2pant/tests/m2-musearch-l1.test.mts
+++ b/tools/ts2pant/tests/m2-musearch-l1.test.mts
@@ -1,23 +1,19 @@
 /**
- * Integration tests for the M2 L1 μ-search pipeline (workstream M2
- * patch 2).
+ * Regression tests for the M2 L1 μ-search pipeline (workstream M2).
  *
- * Sets `TS2PANT_USE_L1_MUSEARCH=1` so the L1 path is exercised
- * end-to-end. Asserts:
+ * After M2 patch 3 (cutover), the L1 path is the only μ-search path —
+ * legacy `translateMuSearchInitLegacy` is deleted and the
+ * `TS2PANT_USE_L1_MUSEARCH` flag is gone. These tests assert:
  *
- * 1. **Byte-equality with legacy** for the existing μ-search shapes
- *    (`i++`, `++i`, unbraced body, post-loop counter use, +const-binding
- *    interleave). Translating the same source under flag-off vs flag-on
- *    produces identical Pant. This is the cutover gate for M2 patch 3.
- *
- * 2. **L1 path accepts the broader `+1` spellings** (`i += 1`,
- *    `i = i + 1`, `i = 1 + i`) and produces the same canonical
- *    `min over each j: Int, j >= 1, ~(j in used) | j` form.
- *
- * 3. **L1 recognizer rejection** for non-canonical shapes that the
- *    TS-AST recognizer accepts (none today; the TS recognizer is
- *    narrower than L1 in M2 patch 2 — patch 3 will widen TS-AST and
- *    rely on the L1 recognizer for canonical-shape rejection).
+ * 1. **All five `+1` spellings produce byte-identical output** —
+ *    `i++`, `++i`, `i += 1`, `i = i + 1`, `i = 1 + i` collapse to
+ *    one canonical L1 `Assign(Var(c), BinOp(add, Var(c), Lit(1)))`
+ *    that lowers to `min over each j: T, j >= INIT, ¬P(j) | j`.
+ *    This is the M2 architectural promise.
+ * 2. **Existing μ-search shapes still translate** — `i++` step, post-
+ *    loop counter use, const-binding interleave.
+ * 3. **Conservative rejections fire** — compound while body,
+ *    non-`+1` step, predicate not referencing counter.
  */
 
 import assert from "node:assert/strict";
@@ -30,32 +26,6 @@ import { IntStrategy } from "../src/translate-types.js";
 before(async () => {
   await loadAst();
 });
-
-function withFlag<T>(flag: string, value: string, fn: () => T): T {
-  const prev = process.env[flag];
-  process.env[flag] = value;
-  try {
-    return fn();
-  } finally {
-    if (prev === undefined) {
-      delete process.env[flag];
-    } else {
-      process.env[flag] = prev;
-    }
-  }
-}
-
-function withoutFlag<T>(flag: string, fn: () => T): T {
-  const prev = process.env[flag];
-  delete process.env[flag];
-  try {
-    return fn();
-  } finally {
-    if (prev !== undefined) {
-      process.env[flag] = prev;
-    }
-  }
-}
 
 function translate(
   source: string,
@@ -80,22 +50,12 @@ function translate(
   return { unsupported: null, pant: getAst().strExpr(p.rhs) };
 }
 
-function translateBoth(source: string, name: string) {
-  const legacy = withoutFlag("TS2PANT_USE_L1_MUSEARCH", () =>
-    translate(source, name),
-  );
-  const l1 = withFlag("TS2PANT_USE_L1_MUSEARCH", "1", () =>
-    translate(source, name),
-  );
-  return { legacy, l1 };
-}
-
 // ---------------------------------------------------------------------------
-// 1. Byte-equality with legacy on existing shapes (cutover gate)
+// Existing μ-search shapes still translate
 // ---------------------------------------------------------------------------
 
-describe("M2 μ-search L1: byte-equality with legacy", () => {
-  it("`i++` step produces identical output", () => {
+describe("M2 μ-search L1: existing shapes translate", () => {
+  it("`i++` step produces canonical min-over-each", () => {
     const source = `
       function firstUnused(used: ReadonlySet<number>): number {
         let i = 1;
@@ -103,25 +63,9 @@ describe("M2 μ-search L1: byte-equality with legacy", () => {
         return i;
       }
     `;
-    const { legacy, l1 } = translateBoth(source, "firstUnused");
-    assert.equal(legacy.unsupported, null);
-    assert.equal(l1.unsupported, null);
-    assert.equal(legacy.pant, l1.pant);
-    assert.match(l1.pant!, /min over each j\d*: Int/);
-  });
-
-  it("`++i` step produces identical output", () => {
-    const source = `
-      function firstUnused(used: ReadonlySet<number>): number {
-        let i = 0;
-        while (used.has(i)) ++i;
-        return i;
-      }
-    `;
-    const { legacy, l1 } = translateBoth(source, "firstUnused");
-    assert.equal(legacy.unsupported, null);
-    assert.equal(l1.unsupported, null);
-    assert.equal(legacy.pant, l1.pant);
+    const { unsupported, pant } = translate(source, "firstUnused");
+    assert.equal(unsupported, null);
+    assert.match(pant!, /min over each j\d*: Int/);
   });
 
   it("μ-search counter referenced post-loop", () => {
@@ -132,10 +76,10 @@ describe("M2 μ-search L1: byte-equality with legacy", () => {
         return i + 1;
       }
     `;
-    const { legacy, l1 } = translateBoth(source, "nextSlotPlusOne");
-    assert.equal(legacy.unsupported, null);
-    assert.equal(l1.unsupported, null);
-    assert.equal(legacy.pant, l1.pant);
+    const { unsupported, pant } = translate(source, "nextSlotPlusOne");
+    assert.equal(unsupported, null);
+    assert.match(pant!, /min over each j\d*: Int/);
+    assert.match(pant!, /\+ 1/);
   });
 
   it("μ-search interleaved with const binding", () => {
@@ -147,15 +91,13 @@ describe("M2 μ-search L1: byte-equality with legacy", () => {
         return n + i;
       }
     `;
-    const { legacy, l1 } = translateBoth(source, "offset");
-    assert.equal(legacy.unsupported, null);
-    assert.equal(l1.unsupported, null);
-    assert.equal(legacy.pant, l1.pant);
+    const { unsupported } = translate(source, "offset");
+    assert.equal(unsupported, null);
   });
 });
 
 // ---------------------------------------------------------------------------
-// 2. L1 accepts broader +1 spellings; all produce the canonical form
+// All five `+1` spellings produce byte-identical canonical output
 // ---------------------------------------------------------------------------
 
 describe("M2 μ-search L1: all five +1 spellings produce identical Pant", () => {
@@ -167,18 +109,17 @@ describe("M2 μ-search L1: all five +1 spellings produce identical Pant", () => 
         return i;
       }
     `;
-    const { l1 } = translateBoth(source, "findSuffix");
-    if (l1.unsupported) {
-      throw new Error(`unsupported: ${l1.unsupported}`);
+    const { unsupported, pant } = translate(source, "findSuffix");
+    if (unsupported) {
+      throw new Error(`unsupported: ${unsupported}`);
     }
-    return l1.pant!;
+    return pant!;
   }
 
   it("all five spellings produce identical L1 output", () => {
-    // Each translation gets a fresh `UniqueSupply` and a fresh
-    // `SourceFile`, so binder allocation is deterministic per call.
-    // The five spellings must produce byte-identical Pant — that's the
-    // M2 architectural promise.
+    // Each translation gets a fresh `UniqueSupply` and `SourceFile`, so
+    // binder allocation is deterministic per call. The five spellings
+    // must produce byte-identical Pant — the M2 architectural promise.
     const baseline = translateForm("i++");
     assert.match(baseline, /min over each j\d*: Int/);
     assert.match(baseline, /~\(j\d* in used\)/);
@@ -191,11 +132,11 @@ describe("M2 μ-search L1: all five +1 spellings produce identical Pant", () => 
 });
 
 // ---------------------------------------------------------------------------
-// 3. Existing rejection cases remain rejected
+// Conservative rejections
 // ---------------------------------------------------------------------------
 
 describe("M2 μ-search L1: rejection cases", () => {
-  it("compound while body still rejects", () => {
+  it("compound while body rejects", () => {
     const source = `
       function compound(used: ReadonlySet<number>): number {
         let i = 0;
@@ -206,12 +147,11 @@ describe("M2 μ-search L1: rejection cases", () => {
         return i;
       }
     `;
-    const { legacy, l1 } = translateBoth(source, "compound");
-    assert.notEqual(legacy.unsupported, null);
-    assert.notEqual(l1.unsupported, null);
+    const { unsupported } = translate(source, "compound");
+    assert.notEqual(unsupported, null);
   });
 
-  it("`i += 2` step rejects under both modes", () => {
+  it("`i += 2` step rejects (non-canonical)", () => {
     const source = `
       function nonUnit(used: ReadonlySet<number>): number {
         let i = 0;
@@ -221,11 +161,9 @@ describe("M2 μ-search L1: rejection cases", () => {
         return i;
       }
     `;
-    const { legacy, l1 } = translateBoth(source, "nonUnit");
-    // Legacy (with the broadened isPlusOneStep at TS-AST recognizer)
-    // also rejects this — `i += 2` is not a +1 step.
-    assert.notEqual(legacy.unsupported, null);
-    assert.notEqual(l1.unsupported, null);
+    const { unsupported } = translate(source, "nonUnit");
+    assert.notEqual(unsupported, null);
+    assert.match(unsupported!, /canonical|step/);
   });
 
   it("predicate not referencing counter rejects", () => {
@@ -238,8 +176,7 @@ describe("M2 μ-search L1: rejection cases", () => {
         return i;
       }
     `;
-    const { legacy, l1 } = translateBoth(source, "noRef");
-    assert.notEqual(legacy.unsupported, null);
-    assert.notEqual(l1.unsupported, null);
+    const { unsupported } = translate(source, "noRef");
+    assert.notEqual(unsupported, null);
   });
 });

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -1553,9 +1553,11 @@ describe("Kleene μ-search (while-loop minimum)", () => {
     // `function i() {}` binds `i` inside its own body (for recursive
     // self-reference), so the reference to `i` inside the body refers
     // to the function value, not to the outer counter. The predicate
-    // therefore has no free reference to the outer `i`, and
-    // recognizeMuSearch rejects on the "predicate doesn't reference
-    // counter" path — that rejection is the distinguishing signal.
+    // therefore has no free reference to the outer `i`. After M2's
+    // cutover the TS-AST recognizer is purely structural; the
+    // shadowing rejection comes from either the L1 predicate-
+    // references-counter check or the legacy purity check (the IIFE
+    // call is conservatively classified as effectful).
     const source = `
       export function shadowedFnName(): number {
         let i = 0;
@@ -1575,11 +1577,13 @@ describe("Kleene μ-search (while-loop minimum)", () => {
     assert.equal(props.length, 1);
     assert.equal(props[0]?.kind, "unsupported");
     if (props[0]?.kind === "unsupported") {
-      // The rejection must be attributable to the shadowing → no free
-      // counter reference, not to some unrelated downstream error.
+      // The rejection must be attributable to the shadowing — either
+      // via the predicate-not-referencing-counter check or via the
+      // purity oracle classifying the IIFE call as effectful. Both
+      // are valid signals that the loop is not a clean μ-search.
       assert.match(
         props[0].reason,
-        /not a recognized μ-search/,
+        /predicate does not reference the counter|predicate has side effects/,
       );
     }
   });
@@ -1623,8 +1627,8 @@ describe("Kleene μ-search (while-loop minimum)", () => {
       if (props[0]?.kind === "unsupported") {
         assert.match(
           props[0].reason,
-          /not a recognized μ-search/,
-          `${name} should reject on μ-search path`,
+          /predicate does not reference the counter|predicate has side effects/,
+          `${name} should reject on shadowing or purity path`,
         );
       }
     }

--- a/workstreams/ts2pant-imperative-ir.md
+++ b/workstreams/ts2pant-imperative-ir.md
@@ -184,6 +184,32 @@ method-shadowing cases are more specific than the old "not a
 recognized μ-search" (now "predicate does not reference the counter"
 or "predicate has side effects") and tests were updated.
 
+**M2 cleanup (post-cutover follow-up)**: in the same PR, four
+additional commits move μ-search lowering entirely out of
+`translate-body.ts`. Articulated principle: *"L1 should be entirely
+concerned with the syntax of TypeScript; it should be completely
+unopinionated and ignorant about how TypeScript's semantics are
+translated into specific lowerings."* Concretely:
+
+- L2 gains a new `comb-typed` form for source-less typed
+  comprehension — the missing vocabulary that legacy
+  `translateMuSearchInit` worked around by going directly to
+  OpaqueExpr.
+- `lowerL1MuSearch` lands in `ir1-lower.ts` carrying all μ-search
+  semantics: canonical-shape pattern match, strategy validation,
+  binder allocation (via callback), counter-binder substitution
+  (via Pant's `substituteBinder` on the lowered OpaqueExpr).
+- `buildL1LetWhile` adds the predicate-references-counter check
+  as a structural sanity check on the let+while pair.
+- `translateMuSearchInit` shrinks to a thin orchestrator that
+  wires the lowering context and delegates to the L1 → L2 →
+  OpaqueExpr pipeline. No Pantagruel-target awareness.
+
+Snapshot byte-equality preserved across all 8 μ-search fixtures.
+translate-body.ts net −60 lines. Side benefit: predicate is now
+translated once at L1 build (rather than twice as in pre-cleanup
+M2) — substitution happens on the lowered OpaqueExpr.
+
 **Definition of Done**:
 - `ir1-build.ts` extends to translate increment surface forms: `i++`, `++i`,
   `i--`, `--i`, `i += k`, `-=`, `*=`, `/=`, `%=`, `i = i ⊕ k` (commutative

--- a/workstreams/ts2pant-imperative-ir.md
+++ b/workstreams/ts2pant-imperative-ir.md
@@ -147,7 +147,42 @@ exploratory.
 
 ---
 
-### Milestone 2: imperative-ir-assign-mu-search
+### Milestone 2: imperative-ir-assign-mu-search — ✅ landed
+
+**Status**: landed across four stacked commits on
+`zax--ts2pant-m2-assign-musearch`:
+
+- Patch 1 (`4675728`) — activate `ir1Assign` and `ir1While`; add
+  `buildL1IncrementStep` covering all five `+1` spellings + non-`+1`
+  forms; new unit tests for vocabulary activation and step
+  normalization.
+- Patch 2 (`ea32328`) — L1 builder (`buildL1LetWhile`) + L1 recognizer
+  (`isCanonicalMuSearchForm`); plumb behind `TS2PANT_USE_L1_MUSEARCH`.
+  Validation: byte-identical output across all 463 existing tests
+  under both flag states.
+- Patch 3 (`c3dc24b`) — hard-rule cutover. Flag deleted.
+  `recognizeMuSearch` renamed to `recognizeLetWhilePair` and stripped
+  of all μ-search semantics (step shape, predicate-references-counter)
+  — those checks now live in `isCanonicalMuSearchForm` and the
+  unified `translateMuSearchInit`. Legacy `translateMuSearchInitLegacy`
+  deleted. Three new fixtures (`compoundIncrementStep`,
+  `explicitIncrementStep`, `explicitIncrementStepFlipped`) verify the
+  five-spelling collapse to one canonical form. Net **−64 lines**.
+- Patch 4 — docs (this commit).
+
+**Architectural payoff**: TS-AST has *no* μ-search semantics. The
+recognizer is structural-only (let + while pair); the canonical-shape
+check, predicate-references-counter check, and discrete-strategy
+check all live at the L1 layer. The five `+1` surface spellings
+collapse to a single L1 `Assign(Var(c), BinOp(add, Var(c), Lit(1)))`
+that the recognizer pattern-matches once.
+
+**Pessimism rate**: 0 — the increment normalizer's `+1` recognition is
+strictly broader than legacy's `++`/`++i`-only, and dogfood translates
+unchanged. The new failure messages for the named-fn-expression and
+method-shadowing cases are more specific than the old "not a
+recognized μ-search" (now "predicate does not reference the counter"
+or "predicate has side effects") and tests were updated.
 
 **Definition of Done**:
 - `ir1-build.ts` extends to translate increment surface forms: `i++`, `++i`,


### PR DESCRIPTION
## Summary

**Milestone 2** (`imperative-ir-assign-mu-search`) of the IRSC-faithful imperative IR workstream — see `workstreams/ts2pant-imperative-ir.md`. M1 (#132) introduced the L1 vocabulary and conditional normalization. M2 activates two more L1 statement forms and migrates μ-search recognition fully to L1.

## What lands

**Vocabulary**: `ir1Assign(target, value)` and `ir1While(cond, body)` activated (M1 vocabulary-locked them with throw-stubs). Pure-path lowering only handles them via the μ-search recognizer; general statement lowering is M3.

**Increment normalization** (`buildL1IncrementStep` in `ir1-build.ts`): collapses six surface shapes into canonical L1 `Assign(Var(c), BinOp(<op>, Var(c), <k>))`:

| Surface | Canonical |
|---------|-----------|
| `c++`, `++c` | `Assign(c, c + 1)` |
| `c--`, `--c` | `Assign(c, c - 1)` |
| `c += k`, `c -= k`, `c *= k`, `c /= k` | compound forms |
| `c = c ⊕ k`, `c = k ⊕ c` (commutative ⊕) | explicit forms |

The five `+1` spellings (`i++`, `++i`, `i += 1`, `i = i + 1`, `i = 1 + i`) produce **byte-identical** L1 output — that's the architectural promise.

**μ-search migration to L1**: TS-AST has *no* μ-search semantics post-cutover.

| Check | Pre-M2 | Post-M2 |
|-------|--------|---------|
| Step shape (`+1`) | TS-AST recognizer (`++`/`++i` only) | `isCanonicalMuSearchForm` (L1 recognizer, all five spellings) |
| Predicate references counter | TS-AST recognizer | `translateMuSearchInit` (L1 path, `expressionReferencesNames`) |
| Discrete numeric strategy | Legacy `translateMuSearchInit` | Same fn, now on the unified L1 path |
| Structural acceptance (let + while pair) | `recognizeMuSearch` | `recognizeLetWhilePair` (purely structural) |

## Net new translatability

Three additional `+1` spellings — `i += 1`, `i = i + 1`, `i = 1 + i` — now translate to the same canonical `min over each j: Int, j >= INIT, ¬P(j) | j` form. Pre-M2, only `i++` and `++i` were recognized. New fixture functions in `tests/fixtures/constructs/expressions-while-mu-search.ts` exercise each.

## Patches

Four stacked commits, each leaving the codebase buildable:

1. **Patch 1** (`4675728`) — vocabulary activation + `buildL1IncrementStep` + unit tests. No translation-pipeline changes.
2. **Patch 2** (`ea32328`) — L1 μ-search recognizer (`isCanonicalMuSearchForm`) and L1 builder (`buildL1LetWhile`) behind `TS2PANT_USE_L1_MUSEARCH=1`. Validation: byte-identical output across all 463 unit tests under both flag states.
3. **Patch 3** (`c3dc24b`) — hard-rule cutover. Flag deleted. `recognizeMuSearch` → `recognizeLetWhilePair` (semantic checks stripped). Legacy `translateMuSearchInitLegacy` deleted. Net **−64 lines**. Three new fixture snapshots prove the byte-identical canonical form.
4. **Patch 4** (`47e31a2`) — docs.

## Out of scope

- General `Assign` / `While` lowering (`lowerL1Stmt` for these forms still throws). M3 territory.
- Non-`+1` increments (`i--`, `i += 2`, `i = i * 2`) build to valid L1 Assigns; the L1 recognizer rejects them. Generalized μ-encodings (e.g., stride-k searches) are a future extension if real fixtures demand it.
- `while` loops outside the μ-search shape — M3.

## Locked decisions (do not re-litigate without sign-off)

- TS-AST has *no* μ-search semantics. The structural acceptance gate (`recognizeLetWhilePair`) is its only role.
- The five `+1` spellings produce byte-identical L1 output. Adding new spellings should preserve this.
- `Assign` outside μ-search rejects at lowering. M3 broadens this to iteration patterns.

Reference: Vekris/Cosman/Jhala, *Refinement Types for TypeScript* (PLDI 2016, [arxiv:1604.02480](https://arxiv.org/pdf/1604.02480)).

## Test plan

- [x] `just ts2pant-precommit` green: 496 unit + 22 integration = **518 tests**.
- [x] Existing 5 μ-search fixture snapshots **byte-identical** to pre-M2.
- [x] 3 new fixture snapshots produce identical canonical output (`min over each j: Int, j >= 1, ~(j in used) | j`).
- [x] Dogfood (`tests/dogfood.test.mts`) passes — ts2pant translates its own source unchanged.
- [x] `pant --check` integration tests for `max.ts`, `deposit.ts`, `apply-fee.ts` continue verifying SMT-checkable output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)