### PR TITLE
ts2pant: M3 — Imperative IR statement-lowering plumbing (Patches 1-5)

### DIFF
--- a/tools/ts2pant/CLAUDE.md
+++ b/tools/ts2pant/CLAUDE.md
@@ -696,6 +696,50 @@ and last, and case labels must be literal. `&&`/`||` Bool-type detection
 is in `purity.ts:isStaticallyBoolTyped` (apparent-type walk requiring
 every union/intersection constituent to satisfy `BooleanLike`).
 
+**M3 (imperative-ir-iteration-mutation): partial — Patches 1–5 landed.**
+The L1/L2 statement-lowering plumbing is in place but the L1 build
+side and legacy cutover are deferred. What landed:
+
+- **`emitStmt`** in `ir-emit.ts` — walks L2 IRStmt[]
+  (`seq`/`write`/`let-if`/`quantified-stmt`/`assert`) and produces
+  `{equations, assertions, modifiedProps}`. Coalesces multi-writes
+  to the same write-key (property: last-write-wins; map-entry +
+  set-member: append override). `let-if` branches are merged via
+  per-write-key cond(g => vT, true => vE), with missing-branch
+  fallback to the appropriate pre-state read. Mirrors legacy
+  `mergeOverrides`/`combineCond` semantics at the IR layer.
+- **L2 `quantified-stmt`** form — new IRStmt variant for Shape A's
+  `all x in src | …` envelope. Mirrors M2's `comb-typed` pattern
+  (declare + emit + subst + tests; introduced before the L1 path
+  needs it).
+- **L1 statement vocabulary unblocked** — `cond-stmt`, `expr-stmt`,
+  `foreach`, `for`, `throw` constructors no longer throw NOT_IMPL.
+  `IR1Foreach` gains `binderType: string`.
+- **`lowerL1Stmt`** in `ir1-lower.ts` for `block` (→ `seq`),
+  member-target `assign` (→ `write{property-field}`), `cond-stmt`
+  (→ nested `let-if`), and `foreach` Shape A (→ `quantified-stmt`
+  with single-armed guard folding into the comprehension).
+  Var-target assigns reject (μ-search counter only). Other kinds
+  (let / return / expr-stmt / while / for / throw / Shape B / Shape
+  C) defer to follow-up.
+
+What's deferred (originally M3 DoD; tracked in
+`workstreams/ts2pant-imperative-ir.md`):
+
+- L1 build pass: `buildL1ForOf`, `buildL1ForEachCall`,
+  `buildL1ReduceCall`, `buildL1CondStmt` translating TS AST → L1
+  statements.
+- Cutover: replace legacy `translateForOfLoop` /
+  `translateForEachStmt` / `translateReduceCall` and the
+  branched-mutation arm of `symbolicExecute` with the L1 path,
+  delete the legacy `mergeOverrides` / `combineCond`.
+- Shape B (accumulator fold) + Shape C (.reduce as expression)
+  recognition at L1 build site.
+
+The deferred work is a follow-up PR. Current state is plumbing-only
+— production iteration / branched-mutation paths are still the
+legacy `symbolicExecute` machinery.
+
 **M2 (imperative-ir-assign-mu-search): landed.** `ir1Assign` and
 `ir1While` activated. Increment surface forms (`i++`, `++i`, `i--`,
 `--i`, `i += k`, `i -= k`, `i = i ⊕ k`, `i = k ⊕ i` for commutative

--- a/tools/ts2pant/src/ir-emit.ts
+++ b/tools/ts2pant/src/ir-emit.ts
@@ -472,14 +472,25 @@ interface EmitStmtState {
   // is the order in which writes were first encountered, which feeds
   // deterministic emission and frame-ordering.
   writes: Map<string, WriteAcc>;
-  // Assertions accumulated in textual order (Set membership writes).
+  // Pre-finalized equations from quantified-stmt envelopes (these
+  // have their quantifier prefix already applied and bypass the
+  // writes-coalescing path).
+  equations: IREquation[];
+  // Assertions accumulated in textual order (Set membership writes
+  // via finalize, plus quantified-stmt assertions and direct asserts).
   assertions: IRAssertExit[];
+  // Modified rule names produced by quantified-stmt sub-states or
+  // direct emissions; merged with finalize-time modifiedProps in the
+  // final result.
+  modifiedProps: Set<string>;
 }
 
 function makeEmitState(): EmitStmtState {
   return {
     writes: new Map(),
+    equations: [],
     assertions: [],
+    modifiedProps: new Set(),
   };
 }
 
@@ -586,11 +597,11 @@ function headKey(head: IRHead): string {
   }
 }
 
-function processStmt(s: IRStmt, st: EmitStmtState): void {
+function processStmt(s: IRStmt, st: EmitStmtState, ctx: EmitStmtCtx): void {
   switch (s.kind) {
     case "seq":
       for (const child of s.stmts) {
-        processStmt(child, st);
+        processStmt(child, st, ctx);
       }
       return;
 
@@ -599,7 +610,7 @@ function processStmt(s: IRStmt, st: EmitStmtState): void {
       return;
 
     case "let-if":
-      processLetIf(s, st);
+      processLetIf(s, st, ctx);
       return;
 
     case "assert":
@@ -609,11 +620,61 @@ function processStmt(s: IRStmt, st: EmitStmtState): void {
       });
       return;
 
+    case "quantified-stmt":
+      processQuantified(s, st, ctx);
+      return;
+
     default: {
       const _exhaustive: never = s;
       void _exhaustive;
       throw new Error("unreachable: IRStmt");
     }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// `quantified-stmt` envelope (M3 Patch 3)
+//
+// The envelope carries `quantifiers` and `guards` that prepend onto every
+// equation and assertion the body produces. Used canonically for Shape A
+// iteration: `Foreach(x, src, Assign(Member(x, p), e))` lowers to
+// `quantified-stmt([{x, T}], [in(x, src)], write{property-field})`,
+// emitting as `all x: T, x in src | p' x = e`.
+//
+// Implementation: process the body in a sub-EmitStmtState; finalize that
+// sub-state to recover its equations/assertions; prepend the envelope's
+// quants/guards to each; push the wrapped equations/assertions into the
+// outer state's pre-finalized buckets (NOT the writes accumulator —
+// quantified writes don't coalesce with non-quantified writes to the
+// same write-key).
+// ---------------------------------------------------------------------------
+
+function processQuantified(
+  s: Extract<IRStmt, { kind: "quantified-stmt" }>,
+  st: EmitStmtState,
+  ctx: EmitStmtCtx,
+): void {
+  const subSt = makeEmitState();
+  processStmt(s.body, subSt, ctx);
+  const sub = finalizeEmit(subSt, ctx);
+
+  for (const eq of sub.equations) {
+    st.equations.push({
+      quantifiers: [...s.quantifiers, ...eq.quantifiers],
+      guards: [...s.guards, ...(eq.guards ?? [])],
+      lhs: eq.lhs,
+      rhs: eq.rhs,
+    });
+  }
+  for (const a of sub.assertions) {
+    st.assertions.push({
+      quantifiers: [...s.quantifiers, ...a.quantifiers],
+      guards: [...s.guards, ...(a.guards ?? [])],
+      body: a.body,
+    });
+  }
+  for (const r of sub.modifiedProps) {
+    st.modifiedProps.add(r);
   }
 }
 
@@ -647,6 +708,7 @@ function processStmt(s: IRStmt, st: EmitStmtState): void {
 function processLetIf(
   s: Extract<IRStmt, { kind: "let-if" }>,
   st: EmitStmtState,
+  ctx: EmitStmtCtx,
 ): void {
   // Direct `assert` inside a let-if branch lacks a clear φ-merge story
   // (assertions are unconditionally quantified bool formulas; conditioning
@@ -657,7 +719,7 @@ function processLetIf(
   // an iff-with-guard, but defer until a fixture demands it.
   const stT = makeEmitState();
   for (const child of s.then) {
-    processStmt(child, stT);
+    processStmt(child, stT, ctx);
   }
   if (stT.assertions.length > 0) {
     throw new Error(
@@ -668,7 +730,7 @@ function processLetIf(
 
   const stE = makeEmitState();
   for (const child of s.else) {
-    processStmt(child, stE);
+    processStmt(child, stE, ctx);
   }
   if (stE.assertions.length > 0) {
     throw new Error(
@@ -686,7 +748,7 @@ function processLetIf(
   }
 
   for (const child of s.continuation) {
-    processStmt(child, st);
+    processStmt(child, st, ctx);
   }
 }
 
@@ -977,14 +1039,18 @@ export function emitStmt(
   const st = makeEmitState();
   const items = Array.isArray(stmts) ? stmts : [stmts];
   for (const s of items) {
-    processStmt(s, st);
+    processStmt(s, st, ctx);
   }
   return finalizeEmit(st, ctx);
 }
 
 function finalizeEmit(st: EmitStmtState, ctx: EmitStmtCtx): EmitStmtResult {
-  const equations: IREquation[] = [];
-  const modifiedProps = new Set<string>();
+  // Start with any pre-finalized equations / assertions / modifiedProps
+  // pulled in by quantified-stmt envelopes during processing. These
+  // bypassed the writes accumulator because their quantifier prefix
+  // would not be commutative with same-write-key coalescing.
+  const equations: IREquation[] = [...st.equations];
+  const modifiedProps = new Set<string>(st.modifiedProps);
 
   for (const acc of st.writes.values()) {
     switch (acc.kind) {

--- a/tools/ts2pant/src/ir-emit.ts
+++ b/tools/ts2pant/src/ir-emit.ts
@@ -599,10 +599,8 @@ function processStmt(s: IRStmt, st: EmitStmtState): void {
       return;
 
     case "let-if":
-      throw new Error(
-        "emitStmt: `let-if` lowering is M3 Patch 2 (φ-merged IREquation[]); " +
-          "see plan at /Users/zax/.claude/plans/plan-it-snug-tulip.md",
-      );
+      processLetIf(s, st);
+      return;
 
     case "assert":
       st.assertions.push({
@@ -617,6 +615,243 @@ function processStmt(s: IRStmt, st: EmitStmtState): void {
       throw new Error("unreachable: IRStmt");
     }
   }
+}
+
+// ---------------------------------------------------------------------------
+// φ-merge for `let-if` (M3 Patch 2)
+//
+// L1 `cond-stmt(arms, else)` lowers to L2 `let-if(phiVars, cond, then,
+// else, continuation)`. The lowering pass forks two sub-EmitStmtStates
+// for the then/else branches, processes their statements independently,
+// then merges the per-write-key accumulators via cond(g => vT, true =>
+// vE) — the same merge discipline as legacy `mergeOverrides` /
+// `combineCond` in translate-body.ts:5018-5170, ported into the IR
+// layer.
+//
+// Branches that don't write a given key fall back to the *pre-state*
+// expression for that key:
+//   - property: app(ruleName, [objExpr]) — pre-state read
+//   - map override: app(ruleName, [objExpr, keyExpr]) — pre-state lookup
+//   - set override: in(elemExpr, app(ruleName, [objExpr])) — pre-state membership
+//
+// The φ-merged write goes into the outer state; the let-if's
+// `continuation` then runs against the outer state with merged values
+// observable.
+//
+// `phiVars` on the IRStmt is informational at the IR level — the merge
+// computes the union of touched keys from the actual sub-state writes.
+// The field exists for type-level non-emptiness invariants (per ir.ts
+// §"Hybrid SSA scope") but isn't validated against the merge result.
+// ---------------------------------------------------------------------------
+
+function processLetIf(
+  s: Extract<IRStmt, { kind: "let-if" }>,
+  st: EmitStmtState,
+): void {
+  // Direct `assert` inside a let-if branch lacks a clear φ-merge story
+  // (assertions are unconditionally quantified bool formulas; conditioning
+  // the body on the let-if guard would change the proposition shape). In
+  // practice, ts2pant emits `assert` only at function entry for empty-
+  // Set/empty-Map initializers, never inside conditional branches. Any
+  // case that arises can be plumbed through later by wrapping the body in
+  // an iff-with-guard, but defer until a fixture demands it.
+  const stT = makeEmitState();
+  for (const child of s.then) {
+    processStmt(child, stT);
+  }
+  if (stT.assertions.length > 0) {
+    throw new Error(
+      "emitStmt: assertions inside a let-if `then` branch are not yet " +
+        "supported (would require iff-with-guard wrap; no fixture currently demands it)",
+    );
+  }
+
+  const stE = makeEmitState();
+  for (const child of s.else) {
+    processStmt(child, stE);
+  }
+  if (stE.assertions.length > 0) {
+    throw new Error(
+      "emitStmt: assertions inside a let-if `else` branch are not yet " +
+        "supported (would require iff-with-guard wrap; no fixture currently demands it)",
+    );
+  }
+
+  const touched = new Set<string>([...stT.writes.keys(), ...stE.writes.keys()]);
+  for (const key of touched) {
+    const accT = stT.writes.get(key);
+    const accE = stE.writes.get(key);
+    const merged = mergeWriteAccs(accT, accE, s.cond);
+    st.writes.set(key, merged);
+  }
+
+  for (const child of s.continuation) {
+    processStmt(child, st);
+  }
+}
+
+function mergeWriteAccs(
+  accT: WriteAcc | undefined,
+  accE: WriteAcc | undefined,
+  guard: IRExpr,
+): WriteAcc {
+  if (accT === undefined && accE === undefined) {
+    throw new Error("emitStmt: mergeWriteAccs called with no input");
+  }
+  if (accT !== undefined && accE !== undefined && accT.kind !== accE.kind) {
+    throw new Error(
+      `emitStmt: branches wrote the same key with different kinds (${accT.kind} vs ${accE.kind})`,
+    );
+  }
+  const pick = (accT ?? accE)!;
+  switch (pick.kind) {
+    case "property":
+      return mergePropertyAcc(
+        accT as PropertyWriteAcc | undefined,
+        accE as PropertyWriteAcc | undefined,
+        pick,
+        guard,
+      );
+    case "map":
+      return mergeMapAcc(
+        accT as MapWriteAcc | undefined,
+        accE as MapWriteAcc | undefined,
+        pick,
+        guard,
+      );
+    case "set":
+      return mergeSetAcc(
+        accT as SetWriteAcc | undefined,
+        accE as SetWriteAcc | undefined,
+        pick,
+        guard,
+      );
+    default: {
+      const _exhaustive: never = pick;
+      void _exhaustive;
+      throw new Error("unreachable: WriteAcc");
+    }
+  }
+}
+
+function combineCond(g: IRExpr, vA: IRExpr, vB: IRExpr): IRExpr {
+  return irCond([
+    [g, vA],
+    [irLitBool(true), vB],
+  ]);
+}
+
+function mergePropertyAcc(
+  accT: PropertyWriteAcc | undefined,
+  accE: PropertyWriteAcc | undefined,
+  pick: PropertyWriteAcc,
+  guard: IRExpr,
+): PropertyWriteAcc {
+  const identity = irAppName(pick.ruleName, [pick.objExpr]);
+  const vT = accT?.value ?? identity;
+  const vE = accE?.value ?? identity;
+  return {
+    kind: "property",
+    ruleName: pick.ruleName,
+    objExpr: pick.objExpr,
+    value: combineCond(guard, vT, vE),
+  };
+}
+
+function mergeMapAcc(
+  accT: MapWriteAcc | undefined,
+  accE: MapWriteAcc | undefined,
+  pick: MapWriteAcc,
+  guard: IRExpr,
+): MapWriteAcc {
+  const valueFallback = (o: MapOverrideAcc): IRExpr =>
+    irAppName(pick.ruleName, [pick.objExpr, o.keyExpr]);
+  const memberFallback = (o: MapOverrideAcc): IRExpr =>
+    irAppName(pick.keyPredName, [pick.objExpr, o.keyExpr]);
+  return {
+    kind: "map",
+    ruleName: pick.ruleName,
+    keyPredName: pick.keyPredName,
+    ownerType: pick.ownerType,
+    keyType: pick.keyType,
+    objExpr: pick.objExpr,
+    valueOverrides: mergeIROverrides(
+      accT?.valueOverrides ?? [],
+      accE?.valueOverrides ?? [],
+      (o) => o.keyExpr,
+      valueFallback,
+      guard,
+    ),
+    membershipOverrides: mergeIROverrides(
+      accT?.membershipOverrides ?? [],
+      accE?.membershipOverrides ?? [],
+      (o) => o.keyExpr,
+      memberFallback,
+      guard,
+    ),
+  };
+}
+
+function mergeSetAcc(
+  accT: SetWriteAcc | undefined,
+  accE: SetWriteAcc | undefined,
+  pick: SetWriteAcc,
+  guard: IRExpr,
+): SetWriteAcc {
+  const fallback = (o: SetOverrideAcc): IRExpr =>
+    irBinop("in", o.elemExpr, irAppName(pick.ruleName, [pick.objExpr]));
+  return {
+    kind: "set",
+    ruleName: pick.ruleName,
+    ownerType: pick.ownerType,
+    elemType: pick.elemType,
+    objExpr: pick.objExpr,
+    memberOverrides: mergeIROverrides(
+      accT?.memberOverrides ?? [],
+      accE?.memberOverrides ?? [],
+      (o) => o.elemExpr,
+      fallback,
+      guard,
+    ),
+    cleared: (accT?.cleared ?? false) || (accE?.cleared ?? false),
+  };
+}
+
+/**
+ * Merge two override lists by key. Mirrors legacy `mergeOverrides` at
+ * translate-body.ts:460. For each key present in either side, produce
+ * an output override with the same key shape and a cond-merged value;
+ * keys missing from a branch get the per-branch fallback (pre-state
+ * lookup).
+ */
+function mergeIROverrides<O extends { value: IRExpr }>(
+  aSide: ReadonlyArray<O>,
+  bSide: ReadonlyArray<O>,
+  keyOf: (o: O) => IRExpr,
+  fallback: (o: O) => IRExpr,
+  guard: IRExpr,
+): O[] {
+  const bByKey = new Map<string, IRExpr>();
+  for (const o of bSide) {
+    bByKey.set(irExprKey(keyOf(o)), o.value);
+  }
+  const seen = new Set<string>();
+  const out: O[] = [];
+  for (const o of aSide) {
+    const k = irExprKey(keyOf(o));
+    seen.add(k);
+    const vB = bByKey.get(k) ?? fallback(o);
+    out.push({ ...o, value: combineCond(guard, o.value, vB) });
+  }
+  for (const o of bSide) {
+    const k = irExprKey(keyOf(o));
+    if (seen.has(k)) {
+      continue;
+    }
+    const vA = fallback(o);
+    out.push({ ...o, value: combineCond(guard, vA, o.value) });
+  }
+  return out;
 }
 
 function processWrite(

--- a/tools/ts2pant/src/ir-emit.ts
+++ b/tools/ts2pant/src/ir-emit.ts
@@ -22,7 +22,16 @@ import {
   type IRExpr,
   type IRFoldCombiner,
   type IRHead,
+  type IRStmt,
   type IRUnop,
+  type IRWriteTarget,
+  irAppName,
+  irAppPrimed,
+  irBinop,
+  irCond,
+  irLitBool,
+  irVar,
+  irWrap,
   isFoldComb,
 } from "./ir.js";
 import type {
@@ -370,5 +379,505 @@ export function lowerAssert(a: IRAssertExit): {
     quantifiers: a.quantifiers.map((q) => ast.param(q.name, ast.tName(q.type))),
     guards: (a.guards ?? []).map((g) => ast.gExpr(lowerExpr(g))),
     body: lowerExpr(a.body),
+  };
+}
+
+// --------------------------------------------------------------------------
+// IRStmt → IREquation[] / IRAssertExit[] (M3 Patch 1)
+// --------------------------------------------------------------------------
+//
+// `emitStmt` walks a sequence of L2 IRStmts and accumulates their effects
+// into a structured result: equations (one per modified rule, with
+// per-rule overrides coalesced into a single override expression),
+// assertions (Set membership writes), and the deterministic insertion-
+// ordered set of modified rule names used by callers to drive frame-
+// condition synthesis.
+//
+// Coalescing discipline mirrors the legacy `state.writes` Map in
+// `translate-body.ts`: multiple `.set` calls on the same Map rule
+// produce a single equation with multiple key-tuple overrides;
+// repeated property-field writes overwrite (last-write-wins);
+// `.clear()` on a Set drops the pre-state membership fallthrough.
+//
+// **Patch 1 scope**: `seq` (recurse + concat into a single
+// accumulator) and `write` (all three target kinds). `let-if` and
+// `quantified-stmt` arms throw NOT_IMPL — Patches 2 and 3 land them.
+
+/**
+ * Caller-supplied allocator for fresh quantifier binders. Used for the
+ * `m1`/`k1`/`y` binders introduced by Map and Set write equations. The
+ * production caller wires this to the document-wide `NameRegistry` (via
+ * `cellRegisterName`) so binders don't collide with the function's
+ * params or other emitted binders. Standalone tests can pass any
+ * collision-safe allocator.
+ */
+export interface EmitStmtCtx {
+  allocBinder: (hint: string) => string;
+}
+
+export interface EmitStmtResult {
+  equations: IREquation[];
+  assertions: IRAssertExit[];
+  /**
+   * Names of primed rules emitted by this statement sequence, in
+   * insertion order. Threaded into `state.modifiedProps` by the
+   * caller so `generateFrameConditions` produces frames for
+   * unmodified rules only.
+   */
+  modifiedProps: Set<string>;
+}
+
+interface PropertyWriteAcc {
+  kind: "property";
+  ruleName: string;
+  objExpr: IRExpr;
+  value: IRExpr;
+}
+
+interface MapOverrideAcc {
+  keyExpr: IRExpr;
+  value: IRExpr;
+}
+
+interface MapWriteAcc {
+  kind: "map";
+  ruleName: string;
+  keyPredName: string;
+  ownerType: string;
+  keyType: string;
+  objExpr: IRExpr;
+  valueOverrides: MapOverrideAcc[];
+  membershipOverrides: MapOverrideAcc[];
+}
+
+interface SetOverrideAcc {
+  elemExpr: IRExpr;
+  value: IRExpr;
+}
+
+interface SetWriteAcc {
+  kind: "set";
+  ruleName: string;
+  ownerType: string;
+  elemType: string;
+  objExpr: IRExpr;
+  memberOverrides: SetOverrideAcc[];
+  cleared: boolean;
+}
+
+type WriteAcc = PropertyWriteAcc | MapWriteAcc | SetWriteAcc;
+
+interface EmitStmtState {
+  // Insertion-ordered Map keyed by write-key string. Iteration order
+  // is the order in which writes were first encountered, which feeds
+  // deterministic emission and frame-ordering.
+  writes: Map<string, WriteAcc>;
+  // Assertions accumulated in textual order (Set membership writes).
+  assertions: IRAssertExit[];
+}
+
+function makeEmitState(): EmitStmtState {
+  return {
+    writes: new Map(),
+    assertions: [],
+  };
+}
+
+/**
+ * Compute a stable string key for a write target. Different writes to
+ * the same rule + canonical receiver coalesce; writes to different
+ * receivers stay separate.
+ *
+ * Patch 1 uses a structural string of the IRExpr; semantic
+ * canonicalization (e.g., resolving `applyConst` substitutions) is the
+ * caller's responsibility before emitting (mirrors how legacy
+ * `installMapWrite` runs `applyConst` on the receiver before keying).
+ */
+function writeKey(target: IRWriteTarget): string {
+  const objKey = irExprKey(target.objExpr);
+  switch (target.kind) {
+    case "property-field":
+      return `prop:${target.ruleName}:${objKey}`;
+    case "map-entry":
+      return `map:${target.ruleName}:${objKey}`;
+    case "set-member":
+      return `set:${target.ruleName}:${objKey}`;
+    default: {
+      const _exhaustive: never = target;
+      void _exhaustive;
+      throw new Error("unreachable: IRWriteTarget");
+    }
+  }
+}
+
+/**
+ * Structural string key for an IRExpr. Used only for write-coalescing
+ * — the strings are not stable across IR refactors, but they are
+ * stable within a single translation pass, which is all we need.
+ * `ir-wrap` falls back to the OpaqueExpr identity (best-effort:
+ * `OpaqueExpr` is opaque from TS, so two structurally-equal wraps
+ * may produce different keys; in practice, callers pass the same
+ * canonicalized OpaqueExpr instance for matching receivers).
+ */
+function irExprKey(e: IRExpr): string {
+  switch (e.kind) {
+    case "var":
+      return `v:${e.primed ? "'" : ""}${e.name}`;
+    case "lit":
+      return litKey(e.value);
+    case "app":
+      return `a:${headKey(e.head)}(${e.args.map(irExprKey).join(",")})`;
+    case "cond":
+      return `c:${e.arms.map(([g, v]) => `${irExprKey(g)}=>${irExprKey(v)}`).join("|")}`;
+    case "let":
+      return `l:${e.name}=${irExprKey(e.value)};${irExprKey(e.body)}`;
+    case "each":
+      return `ea:${e.binder}@${irExprKey(e.src)}|${e.guards.map(irExprKey).join(",")}|${irExprKey(e.proj)}`;
+    case "comb":
+      return `cb:${e.combiner}|${irExprKey(e.each)}`;
+    case "comb-typed":
+      return `ct:${e.combiner}|${e.binder}:${e.binderType}|${e.guards.map(irExprKey).join(",")}|${irExprKey(e.proj)}`;
+    case "forall":
+      return `fa:${e.binder}:${e.binderType}|${e.guard ? irExprKey(e.guard) : ""}|${irExprKey(e.body)}`;
+    case "exists":
+      return `ex:${e.binder}:${e.binderType}|${e.guard ? irExprKey(e.guard) : ""}|${irExprKey(e.body)}`;
+    case "ir-wrap":
+      // OpaqueExpr is opaque from TS — best-effort identity.
+      return `w:${String(e.expr)}`;
+    default: {
+      const _exhaustive: never = e;
+      void _exhaustive;
+      throw new Error("unreachable: IRExpr");
+    }
+  }
+}
+
+function litKey(v: Extract<IRExpr, { kind: "lit" }>["value"]): string {
+  switch (v.kind) {
+    case "nat":
+      return `n:${v.value}`;
+    case "bool":
+      return `b:${v.value}`;
+    case "string":
+      return `s:${v.value}`;
+    default: {
+      const _exhaustive: never = v;
+      void _exhaustive;
+      throw new Error("unreachable: IRLiteral");
+    }
+  }
+}
+
+function headKey(head: IRHead): string {
+  switch (head.kind) {
+    case "name":
+      return `${head.primed ? "'" : ""}${head.name}`;
+    case "binop":
+      return `bo:${head.op}`;
+    case "unop":
+      return `uo:${head.op}`;
+    case "expr":
+      return `e:${irExprKey(head.expr)}`;
+    default: {
+      const _exhaustive: never = head;
+      void _exhaustive;
+      throw new Error("unreachable: IRHead");
+    }
+  }
+}
+
+function processStmt(s: IRStmt, st: EmitStmtState): void {
+  switch (s.kind) {
+    case "seq":
+      for (const child of s.stmts) {
+        processStmt(child, st);
+      }
+      return;
+
+    case "write":
+      processWrite(s.target, s.value, st);
+      return;
+
+    case "let-if":
+      throw new Error(
+        "emitStmt: `let-if` lowering is M3 Patch 2 (φ-merged IREquation[]); " +
+          "see plan at /Users/zax/.claude/plans/plan-it-snug-tulip.md",
+      );
+
+    case "assert":
+      st.assertions.push({
+        quantifiers: s.quantifiers,
+        body: s.body,
+      });
+      return;
+
+    default: {
+      const _exhaustive: never = s;
+      void _exhaustive;
+      throw new Error("unreachable: IRStmt");
+    }
+  }
+}
+
+function processWrite(
+  target: IRWriteTarget,
+  value: IRExpr | null,
+  st: EmitStmtState,
+): void {
+  const key = writeKey(target);
+  switch (target.kind) {
+    case "property-field": {
+      if (value === null) {
+        throw new Error(
+          "emitStmt: property-field write requires a non-null value",
+        );
+      }
+      // Last-write-wins: legacy `putWrite` overwrites prior entries
+      // for the same write-key. Sequential writes to the same property
+      // produce a single equation with the latest value.
+      st.writes.set(key, {
+        kind: "property",
+        ruleName: target.ruleName,
+        objExpr: target.objExpr,
+        value,
+      });
+      return;
+    }
+
+    case "map-entry": {
+      const prior = st.writes.get(key);
+      const existing: MapWriteAcc =
+        prior !== undefined && prior.kind === "map"
+          ? prior
+          : {
+              kind: "map",
+              ruleName: target.ruleName,
+              keyPredName: target.keyPredName,
+              ownerType: target.ownerType,
+              keyType: target.keyType,
+              objExpr: target.objExpr,
+              valueOverrides: [],
+              membershipOverrides: [],
+            };
+      const op = target.op;
+      const keyExpr = target.keyExpr;
+      if (op === "set") {
+        if (value === null) {
+          throw new Error("emitStmt: map-entry set requires a non-null value");
+        }
+        existing.valueOverrides.push({ keyExpr, value });
+        existing.membershipOverrides.push({ keyExpr, value: irLitBool(true) });
+      } else {
+        // delete: drop any previous value override at the same key
+        // and append a `false` membership override. Pantagruel's
+        // declaration-guard discipline makes the value-rule body
+        // vacuous under false membership, so we don't restate the
+        // value for delete (matches legacy `installMapWrite`).
+        existing.membershipOverrides.push({ keyExpr, value: irLitBool(false) });
+      }
+      st.writes.set(key, existing);
+      return;
+    }
+
+    case "set-member": {
+      const prior = st.writes.get(key);
+      const existing: SetWriteAcc =
+        prior !== undefined && prior.kind === "set"
+          ? prior
+          : {
+              kind: "set",
+              ruleName: target.ruleName,
+              ownerType: target.ownerType,
+              elemType: target.elemType,
+              objExpr: target.objExpr,
+              memberOverrides: [],
+              cleared: false,
+            };
+      switch (target.op) {
+        case "add":
+          if (target.elemExpr === null) {
+            throw new Error("emitStmt: set-member add requires elemExpr");
+          }
+          existing.memberOverrides.push({
+            elemExpr: target.elemExpr,
+            value: irLitBool(true),
+          });
+          break;
+        case "delete":
+          if (target.elemExpr === null) {
+            throw new Error("emitStmt: set-member delete requires elemExpr");
+          }
+          existing.memberOverrides.push({
+            elemExpr: target.elemExpr,
+            value: irLitBool(false),
+          });
+          break;
+        case "clear":
+          existing.cleared = true;
+          existing.memberOverrides = [];
+          break;
+        default:
+          throw new Error("unreachable: set-member op");
+      }
+      st.writes.set(key, existing);
+      return;
+    }
+    default: {
+      const _exhaustive: never = target;
+      void _exhaustive;
+      throw new Error("unreachable: IRWriteTarget");
+    }
+  }
+}
+
+/**
+ * Walk an IRStmt (or array of IRStmts) and produce the L2 emission
+ * result: per-rule equations (with overrides coalesced), assertions,
+ * and the insertion-order set of modified rule names.
+ */
+export function emitStmt(
+  stmts: IRStmt | IRStmt[],
+  ctx: EmitStmtCtx,
+): EmitStmtResult {
+  const st = makeEmitState();
+  const items = Array.isArray(stmts) ? stmts : [stmts];
+  for (const s of items) {
+    processStmt(s, st);
+  }
+  return finalizeEmit(st, ctx);
+}
+
+function finalizeEmit(st: EmitStmtState, ctx: EmitStmtCtx): EmitStmtResult {
+  const equations: IREquation[] = [];
+  const modifiedProps = new Set<string>();
+
+  for (const acc of st.writes.values()) {
+    switch (acc.kind) {
+      case "property":
+        equations.push(emitPropertyEquation(acc));
+        modifiedProps.add(acc.ruleName);
+        break;
+      case "map": {
+        const eqs = emitMapEquations(acc, ctx);
+        equations.push(...eqs);
+        if (acc.valueOverrides.length > 0) {
+          modifiedProps.add(acc.ruleName);
+        }
+        if (acc.membershipOverrides.length > 0) {
+          modifiedProps.add(acc.keyPredName);
+        }
+        break;
+      }
+      case "set": {
+        const a = emitSetMembershipAssertion(acc, ctx);
+        if (a !== null) {
+          st.assertions.push(a);
+          modifiedProps.add(acc.ruleName);
+        }
+        break;
+      }
+      default: {
+        const _exhaustive: never = acc;
+        void _exhaustive;
+        throw new Error("unreachable: WriteAcc");
+      }
+    }
+  }
+
+  return {
+    equations,
+    assertions: st.assertions,
+    modifiedProps,
+  };
+}
+
+function emitPropertyEquation(acc: PropertyWriteAcc): IREquation {
+  return {
+    quantifiers: [],
+    lhs: irAppPrimed(acc.ruleName, [acc.objExpr]),
+    rhs: acc.value,
+  };
+}
+
+function emitMapEquations(acc: MapWriteAcc, ctx: EmitStmtCtx): IREquation[] {
+  const ast = getAst();
+  const eqs: IREquation[] = [];
+  if (acc.valueOverrides.length > 0) {
+    const m1 = ctx.allocBinder("m");
+    const k1 = ctx.allocBinder("k");
+    const overrides = acc.valueOverrides.map(
+      (o) =>
+        [
+          ast.tuple([lowerExpr(acc.objExpr), lowerExpr(o.keyExpr)]),
+          lowerExpr(o.value),
+        ] as [OpaqueExpr, OpaqueExpr],
+    );
+    const rhs = irWrap(
+      ast.app(ast.override(acc.ruleName, overrides), [
+        ast.var(m1),
+        ast.var(k1),
+      ]),
+    );
+    eqs.push({
+      quantifiers: [
+        { name: m1, type: acc.ownerType },
+        { name: k1, type: acc.keyType },
+      ],
+      lhs: irAppPrimed(acc.ruleName, [irVar(m1), irVar(k1)]),
+      rhs,
+    });
+  }
+  if (acc.membershipOverrides.length > 0) {
+    const m1 = ctx.allocBinder("m");
+    const k1 = ctx.allocBinder("k");
+    const overrides = acc.membershipOverrides.map(
+      (o) =>
+        [
+          ast.tuple([lowerExpr(acc.objExpr), lowerExpr(o.keyExpr)]),
+          lowerExpr(o.value),
+        ] as [OpaqueExpr, OpaqueExpr],
+    );
+    const rhs = irWrap(
+      ast.app(ast.override(acc.keyPredName, overrides), [
+        ast.var(m1),
+        ast.var(k1),
+      ]),
+    );
+    eqs.push({
+      quantifiers: [
+        { name: m1, type: acc.ownerType },
+        { name: k1, type: acc.keyType },
+      ],
+      lhs: irAppPrimed(acc.keyPredName, [irVar(m1), irVar(k1)]),
+      rhs,
+    });
+  }
+  return eqs;
+}
+
+function emitSetMembershipAssertion(
+  acc: SetWriteAcc,
+  ctx: EmitStmtCtx,
+): IRAssertExit | null {
+  if (acc.memberOverrides.length === 0 && !acc.cleared) {
+    return null;
+  }
+  const y = ctx.allocBinder("y");
+  const yVar = irVar(y);
+  const memberIn = (rule: IRExpr) => irBinop("in", yVar, rule);
+  const primedApp = irAppPrimed(acc.ruleName, [acc.objExpr]);
+  const preApp = irAppName(acc.ruleName, [acc.objExpr]);
+  const fallback: [IRExpr, IRExpr] = acc.cleared
+    ? [irLitBool(true), irLitBool(false)]
+    : [irLitBool(true), memberIn(preApp)];
+  const condArms: Array<[IRExpr, IRExpr]> = acc.memberOverrides.map((o) => [
+    irBinop("eq", yVar, o.elemExpr),
+    o.value,
+  ]);
+  const rhs =
+    condArms.length === 0 ? fallback[1] : irCond([...condArms, fallback]);
+  return {
+    quantifiers: [{ name: y, type: acc.elemType }],
+    body: irBinop("iff", memberIn(primedApp), rhs),
   };
 }

--- a/tools/ts2pant/src/ir.ts
+++ b/tools/ts2pant/src/ir.ts
@@ -309,6 +309,26 @@ export type IRStmt =
       kind: "assert";
       quantifiers: Array<{ name: string; type: string }>;
       body: IRExpr;
+    }
+  /**
+   * Universal-quantification envelope around a statement body. Each
+   * equation/assertion produced by `body` gets `quantifiers` prepended
+   * to its quantifier list and `guards` prepended to its guard list.
+   *
+   * Canonical use: Shape A iteration. `Foreach(x, src,
+   * Assign(Member(x, p), e))` lowers to
+   * `quantified-stmt([{x, T}], [in(x, src)], write{property-field}(p, x,
+   * e))`, which emits as `all x: T, x in src | p' x = e`.
+   *
+   * M3 Patch 3 introduces this form. The body is a single IRStmt; nested
+   * quantifications compose via nested envelopes (each layer prepends
+   * its own quants).
+   */
+  | {
+      kind: "quantified-stmt";
+      quantifiers: Array<{ name: string; type: string }>;
+      guards: IRExpr[];
+      body: IRStmt;
     };
 
 // --------------------------------------------------------------------------
@@ -547,6 +567,12 @@ export const irStmtAssert = (
   quantifiers: Array<{ name: string; type: string }>,
   body: IRExpr,
 ): IRStmt => ({ kind: "assert", quantifiers, body });
+
+export const irStmtQuantified = (
+  quantifiers: Array<{ name: string; type: string }>,
+  guards: IRExpr[],
+  body: IRStmt,
+): IRStmt => ({ kind: "quantified-stmt", quantifiers, guards, body });
 
 // Type guards (small, useful for migration code)
 

--- a/tools/ts2pant/src/ir1-lower.ts
+++ b/tools/ts2pant/src/ir1-lower.ts
@@ -188,15 +188,17 @@ export function lowerL1Stmt(s: IR1Stmt): IRStmt[] {
       return acc;
     }
 
+    case "foreach":
+      return lowerL1Foreach(s);
+
     case "let":
     case "return":
     case "expr-stmt":
     case "while":
-    case "foreach":
     case "for":
     case "throw":
       throw new Error(
-        `lowerL1Stmt: lowering for L1 form '${s.kind}' is M3 Patch 5 ` +
+        `lowerL1Stmt: lowering for L1 form '${s.kind}' is deferred ` +
           "(L1 build + iteration cutover); see plan",
       );
 
@@ -205,6 +207,94 @@ export function lowerL1Stmt(s: IR1Stmt): IRStmt[] {
       void _exhaustive;
       throw new Error("unreachable: IR1Stmt");
     }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// L1 foreach lowering (M3 Patch 5)
+//
+// `foreach(x: T, src, body)` lowers to one of:
+//   - Shape A: body is `Assign(Member(x, p), e)` (or block of such writes)
+//     → `quantified-stmt([{x, T}], [in(x, src)], lower(body))`
+//   - Shape A with guard: body is `CondStmt([(g, body')], None)`
+//     → `quantified-stmt([{x, T}], [in(x, src), g], lower(body'))`
+//
+// Shape B (accumulator fold) and Shape C (.reduce as expression) are
+// recognized at the L1 build site (`ir1-build.ts`) and lowered there to
+// L2 IRExpr forms (`comb`, `comb-typed`); they do not flow through this
+// statement-level lowering. Mixed Shape A + Shape B bodies: each Shape
+// B accumulator becomes its own L2 fold expression at build time and
+// is wired into the surrounding equation; the residual Shape A writes
+// pass through this lowering.
+//
+// **Implementation discipline (M3 Patch 5)**: this lowering recognizes
+// the canonical Shape A (and guarded Shape A) shape only. Other body
+// shapes (multiple statements, mutation through receivers other than
+// the iterator, nested foreach) are rejected with a specific error.
+// The build pass is responsible for either canonicalizing into one of
+// these shapes at L1 construction time or rejecting up-front.
+// ---------------------------------------------------------------------------
+
+function lowerL1Foreach(s: Extract<IR1Stmt, { kind: "foreach" }>): IRStmt[] {
+  const inGuard = irBinop("in", irVar(s.binder), lowerL1Expr(s.source));
+  // Strip a single-armed guard cond-stmt at the top of the body
+  // (Shape A with guard). Multi-armed cond inside a foreach is
+  // structurally suspicious — reject for now (workstream open
+  // question).
+  let body = s.body;
+  const extraGuards: IRExpr[] = [inGuard];
+  if (body.kind === "cond-stmt") {
+    if (body.arms.length !== 1 || body.otherwise !== null) {
+      throw new Error(
+        "lowerL1Foreach: only single-armed cond-stmt (no else) is " +
+          "supported as a foreach body guard (Shape B with guard); " +
+          "got multi-armed or with-else cond-stmt",
+      );
+    }
+    const [g, innerBody] = body.arms[0]!;
+    extraGuards.push(lowerL1Expr(g));
+    body = innerBody;
+  }
+  // Body must be either a single member-target assign or a block of
+  // such assigns.
+  validateShapeABody(body);
+  const loweredBody = lowerL1Stmt(body);
+  // Wrap the (possibly multi-statement) body in a `seq` if needed,
+  // then wrap that in `quantified-stmt`.
+  const innerStmt: IRStmt =
+    loweredBody.length === 1
+      ? loweredBody[0]!
+      : { kind: "seq", stmts: loweredBody };
+  return [
+    {
+      kind: "quantified-stmt",
+      quantifiers: [{ name: s.binder, type: s.binderType }],
+      guards: extraGuards,
+      body: innerStmt,
+    },
+  ];
+}
+
+function validateShapeABody(body: IR1Stmt): void {
+  if (body.kind === "block") {
+    for (const child of body.stmts) {
+      validateShapeABody(child);
+    }
+    return;
+  }
+  if (body.kind !== "assign") {
+    throw new Error(
+      `lowerL1Foreach: foreach body must be Assign(Member, e) (Shape A); ` +
+        `got '${body.kind}' — Shape B (accumulator fold) and other ` +
+        "iteration shapes are recognized at the L1 build pass and lowered " +
+        "to L2 IRExpr (comb), not via this statement-level path",
+    );
+  }
+  if (body.target.kind !== "member") {
+    throw new Error(
+      `lowerL1Foreach: Shape A assign must target a Member; got ` +
+        `'${body.target.kind}'`,
+    );
   }
 }
 

--- a/tools/ts2pant/src/ir1-lower.ts
+++ b/tools/ts2pant/src/ir1-lower.ts
@@ -31,6 +31,8 @@ import {
   irCombTyped,
   irCond,
   irLitBool,
+  irStmtSeq,
+  irStmtWrite,
   irUnop,
   irVar,
   irWrap,
@@ -103,22 +105,107 @@ export function lowerL1Expr(e: IR1Expr): IRExpr {
 }
 
 /**
- * Lower a Layer 1 statement to a list of L2 `IRStmt`. **Not implemented
- * in M1** — statement lowering lands in M3 alongside iteration + mutation
- * normalization, where L2's `Write` / `LetIf` / `Seq` forms become the
- * targets. Until then, calling this function on any L1 statement is a
- * bug; M1 only constructs and lowers L1 *expressions*.
+ * Lower a Layer 1 statement to a list of L2 `IRStmt`.
  *
- * The signature returns the eventual M3 type (`IRStmt[]`) so adding the
- * real implementation in M3 is not a public type break — the body throws
- * unconditionally until then.
+ * **M3 Patch 4 scope**: handles `block` (→ `seq`) and `cond-stmt` (→
+ * `let-if`) and `assign` with a `member` target (→ `write{property-field}`).
+ * Iteration kinds (`foreach`, `for`, `while`, `throw`) and the more
+ * complex non-iteration kinds (`let` substitution, `return` packaging,
+ * `expr-stmt` Map/Set effect detection) throw `not-implemented` pointing
+ * at Patch 5, where the L1 build side gets wired up alongside the
+ * branched-mutation cutover.
+ *
+ * Callers feed the resulting `IRStmt[]` to `emitStmt` (Patch 1) which
+ * produces `{ equations, assertions, modifiedProps }` for installation
+ * into the propositions array.
  */
 export function lowerL1Stmt(s: IR1Stmt): IRStmt[] {
-  void s;
-  throw new Error(
-    "lowerL1Stmt: Layer 1 statement lowering is M3 (iteration + mutation); " +
-      "see workstreams/ts2pant-imperative-ir.md",
-  );
+  switch (s.kind) {
+    case "block": {
+      const lowered: IRStmt[] = [];
+      for (const child of s.stmts) {
+        lowered.push(...lowerL1Stmt(child));
+      }
+      // Single-element `seq` collapses to its child at L2; >1 wraps in
+      // `seq` so the emit pass sees a uniform sequence.
+      if (lowered.length === 1) {
+        return lowered;
+      }
+      return [irStmtSeq(lowered)];
+    }
+
+    case "assign": {
+      // M3 Patch 4 supports member-target assigns (property writes).
+      // Var-target assigns are reserved for μ-search counter steps and
+      // are handled by `lowerL1MuSearch`, not by general statement
+      // lowering.
+      if (s.target.kind !== "member") {
+        throw new Error(
+          `lowerL1Stmt: assign with target kind '${s.target.kind}' is not ` +
+            "supported by general statement lowering (var-target is " +
+            "μ-search-only via lowerL1MuSearch)",
+        );
+      }
+      return [
+        irStmtWrite(
+          {
+            kind: "property-field",
+            ruleName: s.target.name,
+            objExpr: lowerL1Expr(s.target.receiver),
+          },
+          lowerL1Expr(s.value),
+        ),
+      ];
+    }
+
+    case "cond-stmt": {
+      // Multi-armed cond-stmt folds right-to-left into nested `let-if`.
+      // Each arm `(g, body)` becomes a `let-if(cond=g, then=lower(body),
+      // else=<rest>)`. The final `otherwise` (or empty stmts) is the
+      // innermost else-branch.
+      const otherwiseStmts: IRStmt[] =
+        s.otherwise === null ? [] : lowerL1Stmt(s.otherwise);
+      let acc: IRStmt[] = otherwiseStmts;
+      for (let i = s.arms.length - 1; i >= 0; i--) {
+        const [guard, body] = s.arms[i]!;
+        const thenStmts = lowerL1Stmt(body);
+        // phiVars is informational at this lowering layer — emitStmt's
+        // let-if processor computes touched keys from the actual
+        // sub-state writes. Use a placeholder `["__phi__"]` to satisfy
+        // the IRStmt type's non-empty invariant.
+        acc = [
+          {
+            kind: "let-if",
+            phiVars: ["__phi__"],
+            cond: lowerL1Expr(guard),
+            // biome-ignore lint/suspicious/noThenProperty: IRStmt ADT shape uses `then`/`else` for branching mutation merge.
+            then: thenStmts,
+            else: acc,
+            continuation: [],
+          },
+        ];
+      }
+      return acc;
+    }
+
+    case "let":
+    case "return":
+    case "expr-stmt":
+    case "while":
+    case "foreach":
+    case "for":
+    case "throw":
+      throw new Error(
+        `lowerL1Stmt: lowering for L1 form '${s.kind}' is M3 Patch 5 ` +
+          "(L1 build + iteration cutover); see plan",
+      );
+
+    default: {
+      const _exhaustive: never = s;
+      void _exhaustive;
+      throw new Error("unreachable: IR1Stmt");
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/tools/ts2pant/src/ir1.ts
+++ b/tools/ts2pant/src/ir1.ts
@@ -159,10 +159,19 @@ export type IR1Stmt =
       ];
       otherwise: IR1Stmt | null;
     }
-  /** Uniform iteration. Introduced in M3. */
+  /**
+   * Uniform iteration over a typed source. The `binderType` field carries
+   * the iterator's element type (Pant name) so the L1 → L2 lowering can
+   * synthesize the `all x: T, x in src | …` envelope without re-running TS
+   * type inference. Build-side is responsible for populating it from
+   * `checker.getTypeAtLocation`.
+   *
+   * Introduced (vocabulary) in M1; lowering active in M3.
+   */
   | {
       kind: "foreach";
       binder: string;
+      binderType: string;
       source: IR1Expr;
       body: IR1Stmt;
     }
@@ -353,9 +362,10 @@ export const ir1CondStmt = (
 
 export const ir1Foreach = (
   binder: string,
+  binderType: string,
   source: IR1Expr,
   body: IR1Stmt,
-): IR1Stmt => ({ kind: "foreach", binder, source, body });
+): IR1Stmt => ({ kind: "foreach", binder, binderType, source, body });
 
 export const ir1For = (
   init: IR1Stmt | null,

--- a/tools/ts2pant/src/ir1.ts
+++ b/tools/ts2pant/src/ir1.ts
@@ -320,18 +320,10 @@ export const ir1Return = (expr: IR1Expr | null): IR1Stmt => ({
 });
 
 // --------------------------------------------------------------------------
-// Vocabulary-locked stubs (constructors throw until the milestone that
-// introduces them lands). Forms are declared in IR1Stmt at the type level
-// so consumers can pattern-match without runtime branch errors; the
-// constructors here surface premature use.
+// Statement constructors for forms beyond the M1 active set.
+// All forms are now active as of M3 Patch 4; lowering for the iteration
+// kinds (foreach / for / throw / while-outside-μ-search) lands in Patch 5.
 // --------------------------------------------------------------------------
-
-const NOT_IMPL = (form: string, milestone: string): never => {
-  throw new Error(
-    `IR1 form '${form}' is vocabulary-locked but not implemented until ${milestone}; ` +
-      `see workstreams/ts2pant-imperative-ir.md`,
-  );
-};
 
 /**
  * Assignment / read-modify-write. Canonical form for all increment and
@@ -352,25 +344,25 @@ export const ir1Assign = (target: IR1Expr, value: IR1Expr): IR1Stmt => ({
 });
 
 export const ir1CondStmt = (
-  _arms: readonly [
+  arms: readonly [
     readonly [IR1Expr, IR1Stmt],
     ...ReadonlyArray<readonly [IR1Expr, IR1Stmt]>,
   ],
-  _otherwise: IR1Stmt | null,
-): IR1Stmt => NOT_IMPL("cond-stmt", "M3 (iteration + mutation)");
+  otherwise: IR1Stmt | null,
+): IR1Stmt => ({ kind: "cond-stmt", arms, otherwise });
 
 export const ir1Foreach = (
-  _binder: string,
-  _source: IR1Expr,
-  _body: IR1Stmt,
-): IR1Stmt => NOT_IMPL("foreach", "M3 (iteration + mutation)");
+  binder: string,
+  source: IR1Expr,
+  body: IR1Stmt,
+): IR1Stmt => ({ kind: "foreach", binder, source, body });
 
 export const ir1For = (
-  _init: IR1Stmt | null,
-  _cond: IR1Expr | null,
-  _step: IR1Stmt | null,
-  _body: IR1Stmt,
-): IR1Stmt => NOT_IMPL("for", "M3 (iteration + mutation)");
+  init: IR1Stmt | null,
+  cond: IR1Expr | null,
+  step: IR1Stmt | null,
+  body: IR1Stmt,
+): IR1Stmt => ({ kind: "for", init, cond, step, body });
 
 /**
  * Bounded while loop. M2 activates this form to faithfully represent
@@ -387,8 +379,9 @@ export const ir1While = (cond: IR1Expr, body: IR1Stmt): IR1Stmt => ({
   body,
 });
 
-export const ir1Throw = (_expr: IR1Expr): IR1Stmt =>
-  NOT_IMPL("throw", "M3 (iteration + mutation)");
+export const ir1Throw = (expr: IR1Expr): IR1Stmt => ({ kind: "throw", expr });
 
-export const ir1ExprStmt = (_expr: IR1Expr): IR1Stmt =>
-  NOT_IMPL("expr-stmt", "M3 (iteration + mutation)");
+export const ir1ExprStmt = (expr: IR1Expr): IR1Stmt => ({
+  kind: "expr-stmt",
+  expr,
+});

--- a/tools/ts2pant/tests/ir-emit-stmt.test.mts
+++ b/tools/ts2pant/tests/ir-emit-stmt.test.mts
@@ -1,0 +1,371 @@
+import assert from "node:assert/strict";
+import { before, describe, it } from "node:test";
+import {
+  type IRStmt,
+  type IRWriteTarget,
+  irBinop,
+  irLitNat,
+  irLitString,
+  irStmtAssert,
+  irStmtSeq,
+  irStmtWrite,
+  irVar,
+} from "../src/ir.js";
+import { emitStmt, lowerAssert, lowerEquation } from "../src/ir-emit.js";
+import { getAst, loadAst } from "../src/pant-wasm.js";
+
+before(async () => {
+  await loadAst();
+});
+
+// Deterministic allocator for tests — produces hint, hint1, hint2, …
+// independent of the document-wide NameRegistry so tests are
+// hermetic.
+function makeTestAllocator(): (hint: string) => string {
+  const counts = new Map<string, number>();
+  return (hint: string): string => {
+    const n = counts.get(hint) ?? 0;
+    counts.set(hint, n + 1);
+    return n === 0 ? hint : `${hint}${n}`;
+  };
+}
+
+function ctx() {
+  return { allocBinder: makeTestAllocator() };
+}
+
+// Render an IREquation to a Pantagruel string for snapshot-style checks.
+function renderEquation(eq: ReturnType<typeof lowerEquation>): string {
+  const ast = getAst();
+  const lhs = ast.strExpr(eq.lhs);
+  const rhs = ast.strExpr(eq.rhs);
+  return `${lhs} = ${rhs}`;
+}
+
+// Render a lowered assertion by reconstructing it as a `forall` expression
+// and stringifying that. The Pant printer for `forall` produces
+// `all p1: T1, ... | body`, which is exactly the form a quantified
+// assertion takes — except a `forall` is a Bool expression, not a
+// proposition, so the textual rendering is what we want for diff checks.
+function renderAssert(a: ReturnType<typeof lowerAssert>): string {
+  const ast = getAst();
+  return ast.strExpr(ast.forall(a.quantifiers, a.guards, a.body));
+}
+
+// ---------------------------------------------------------------------------
+// Patch 1: seq + write → IREquation[] / IRAssertExit[]
+// ---------------------------------------------------------------------------
+
+describe("emitStmt — empty + atoms", () => {
+  it("empty seq produces no equations and no modified rules", () => {
+    const result = emitStmt(irStmtSeq([]), ctx());
+    assert.deepEqual(result.equations, []);
+    assert.deepEqual(result.assertions, []);
+    assert.equal(result.modifiedProps.size, 0);
+  });
+
+  it("empty IRStmt array produces no equations", () => {
+    const result = emitStmt([], ctx());
+    assert.deepEqual(result.equations, []);
+    assert.equal(result.modifiedProps.size, 0);
+  });
+
+  it("nested seq flattens transparently", () => {
+    const target: IRWriteTarget = {
+      kind: "property-field",
+      ruleName: "balance",
+      objExpr: irVar("acct"),
+    };
+    const w = irStmtWrite(target, irLitNat(100));
+    const result = emitStmt(irStmtSeq([irStmtSeq([w])]), ctx());
+    assert.equal(result.equations.length, 1);
+    assert.deepEqual([...result.modifiedProps], ["balance"]);
+  });
+});
+
+describe("emitStmt — property-field writes", () => {
+  it("single property write emits one equation `prop' obj = value`", () => {
+    const target: IRWriteTarget = {
+      kind: "property-field",
+      ruleName: "balance",
+      objExpr: irVar("acct"),
+    };
+    const result = emitStmt(irStmtWrite(target, irLitNat(100)), ctx());
+    assert.equal(result.equations.length, 1);
+    const rendered = renderEquation(lowerEquation(result.equations[0]!));
+    assert.equal(rendered, "balance' acct = 100");
+    assert.deepEqual([...result.modifiedProps], ["balance"]);
+  });
+
+  it("two writes to same prop+obj coalesce (last wins)", () => {
+    const target: IRWriteTarget = {
+      kind: "property-field",
+      ruleName: "balance",
+      objExpr: irVar("acct"),
+    };
+    const result = emitStmt(
+      irStmtSeq([
+        irStmtWrite(target, irLitNat(100)),
+        irStmtWrite(target, irLitNat(200)),
+      ]),
+      ctx(),
+    );
+    assert.equal(result.equations.length, 1);
+    const rendered = renderEquation(lowerEquation(result.equations[0]!));
+    assert.equal(rendered, "balance' acct = 200");
+  });
+
+  it("two writes to same prop, different objects, emit two equations", () => {
+    const t1: IRWriteTarget = {
+      kind: "property-field",
+      ruleName: "balance",
+      objExpr: irVar("a1"),
+    };
+    const t2: IRWriteTarget = {
+      kind: "property-field",
+      ruleName: "balance",
+      objExpr: irVar("a2"),
+    };
+    const result = emitStmt(
+      irStmtSeq([irStmtWrite(t1, irLitNat(1)), irStmtWrite(t2, irLitNat(2))]),
+      ctx(),
+    );
+    assert.equal(result.equations.length, 2);
+    // Both target the same rule — modifiedProps still carries one entry.
+    assert.deepEqual([...result.modifiedProps], ["balance"]);
+  });
+
+  it("writes to two different rules produce two equations and two modified rules", () => {
+    const t1: IRWriteTarget = {
+      kind: "property-field",
+      ruleName: "balance",
+      objExpr: irVar("a"),
+    };
+    const t2: IRWriteTarget = {
+      kind: "property-field",
+      ruleName: "name",
+      objExpr: irVar("a"),
+    };
+    const result = emitStmt(
+      irStmtSeq([irStmtWrite(t1, irLitNat(0)), irStmtWrite(t2, irLitString("x"))]),
+      ctx(),
+    );
+    assert.equal(result.equations.length, 2);
+    assert.deepEqual([...result.modifiedProps], ["balance", "name"]);
+  });
+});
+
+describe("emitStmt — map-entry writes", () => {
+  function mapTarget(op: "set" | "delete", keyExpr = irVar("k")): IRWriteTarget {
+    return {
+      kind: "map-entry",
+      ruleName: "entries",
+      keyPredName: "entriesKey",
+      ownerType: "Cache",
+      keyType: "String",
+      objExpr: irVar("c"),
+      keyExpr,
+      op,
+    };
+  }
+
+  it("Map.set emits two equations: value override + membership override", () => {
+    const result = emitStmt(
+      irStmtWrite(mapTarget("set"), irLitNat(42)),
+      ctx(),
+    );
+    assert.equal(result.equations.length, 2);
+    const valueEq = renderEquation(lowerEquation(result.equations[0]!));
+    const memberEq = renderEquation(lowerEquation(result.equations[1]!));
+    assert.equal(
+      valueEq,
+      "entries' m k = entries[(c, k) |-> 42] m k",
+    );
+    assert.equal(
+      memberEq,
+      "entriesKey' m1 k1 = entriesKey[(c, k) |-> true] m1 k1",
+    );
+    assert.deepEqual([...result.modifiedProps], ["entries", "entriesKey"]);
+  });
+
+  it("Map.delete emits only membership override (value rule untouched)", () => {
+    const result = emitStmt(irStmtWrite(mapTarget("delete"), null), ctx());
+    assert.equal(result.equations.length, 1);
+    const memberEq = renderEquation(lowerEquation(result.equations[0]!));
+    assert.equal(
+      memberEq,
+      "entriesKey' m k = entriesKey[(c, k) |-> false] m k",
+    );
+    assert.deepEqual([...result.modifiedProps], ["entriesKey"]);
+  });
+
+  it("two Map.set on same map coalesce into one value + one membership equation", () => {
+    const result = emitStmt(
+      irStmtSeq([
+        irStmtWrite(mapTarget("set", irVar("k1")), irLitNat(1)),
+        irStmtWrite(mapTarget("set", irVar("k2")), irLitNat(2)),
+      ]),
+      ctx(),
+    );
+    assert.equal(result.equations.length, 2);
+    const valueEq = renderEquation(lowerEquation(result.equations[0]!));
+    assert.equal(
+      valueEq,
+      "entries' m k = entries[(c, k1) |-> 1, (c, k2) |-> 2] m k",
+    );
+  });
+
+  it("Map.set then Map.delete produce a value override + two membership overrides", () => {
+    const result = emitStmt(
+      irStmtSeq([
+        irStmtWrite(mapTarget("set", irVar("k1")), irLitNat(1)),
+        irStmtWrite(mapTarget("delete", irVar("k2")), null),
+      ]),
+      ctx(),
+    );
+    assert.equal(result.equations.length, 2);
+    const valueEq = renderEquation(lowerEquation(result.equations[0]!));
+    const memberEq = renderEquation(lowerEquation(result.equations[1]!));
+    assert.equal(valueEq, "entries' m k = entries[(c, k1) |-> 1] m k");
+    assert.equal(
+      memberEq,
+      "entriesKey' m1 k1 = entriesKey[(c, k1) |-> true, (c, k2) |-> false] m1 k1",
+    );
+  });
+});
+
+describe("emitStmt — set-member writes", () => {
+  function setTarget(
+    op: "add" | "delete" | "clear",
+    elemExpr: ReturnType<typeof irVar> | null = null,
+  ): IRWriteTarget {
+    return {
+      kind: "set-member",
+      ruleName: "tags",
+      ownerType: "Card",
+      elemType: "String",
+      objExpr: irVar("c"),
+      elemExpr,
+      op,
+    };
+  }
+
+  it("Set.add emits one assertion `all y | y in tags' c <-> (cond y = e ...)`", () => {
+    const result = emitStmt(
+      irStmtWrite(setTarget("add", irVar("e")), null),
+      ctx(),
+    );
+    assert.equal(result.assertions.length, 1);
+    const rendered = renderAssert(lowerAssert(result.assertions[0]!));
+    assert.equal(
+      rendered,
+      "all y: String | y in tags' c <-> (cond y = e => true, true => y in tags c)",
+    );
+    assert.deepEqual([...result.modifiedProps], ["tags"]);
+  });
+
+  it("Set.delete emits assertion with `false` arm", () => {
+    const result = emitStmt(
+      irStmtWrite(setTarget("delete", irVar("e")), null),
+      ctx(),
+    );
+    assert.equal(result.assertions.length, 1);
+    const rendered = renderAssert(lowerAssert(result.assertions[0]!));
+    assert.equal(
+      rendered,
+      "all y: String | y in tags' c <-> (cond y = e => false, true => y in tags c)",
+    );
+  });
+
+  it("Set.clear emits assertion `all y | ~(y in tags' c)`", () => {
+    const result = emitStmt(irStmtWrite(setTarget("clear"), null), ctx());
+    assert.equal(result.assertions.length, 1);
+    const rendered = renderAssert(lowerAssert(result.assertions[0]!));
+    assert.equal(rendered, "all y: String | y in tags' c <-> false");
+  });
+
+  it("Set.add then Set.delete produce an assertion with two cond arms", () => {
+    const result = emitStmt(
+      irStmtSeq([
+        irStmtWrite(setTarget("add", irVar("e1")), null),
+        irStmtWrite(setTarget("delete", irVar("e2")), null),
+      ]),
+      ctx(),
+    );
+    assert.equal(result.assertions.length, 1);
+    const rendered = renderAssert(lowerAssert(result.assertions[0]!));
+    assert.equal(
+      rendered,
+      "all y: String | y in tags' c <-> (cond y = e1 => true, y = e2 => false, true => y in tags c)",
+    );
+  });
+
+  it("Set.add then Set.clear drops the prior overrides; tail becomes `false`", () => {
+    const result = emitStmt(
+      irStmtSeq([
+        irStmtWrite(setTarget("add", irVar("e1")), null),
+        irStmtWrite(setTarget("clear"), null),
+      ]),
+      ctx(),
+    );
+    assert.equal(result.assertions.length, 1);
+    const rendered = renderAssert(lowerAssert(result.assertions[0]!));
+    assert.equal(rendered, "all y: String | y in tags' c <-> false");
+  });
+});
+
+describe("emitStmt — assertions pass through", () => {
+  it("irStmtAssert produces an IRAssertExit verbatim", () => {
+    const stmt = irStmtAssert(
+      [{ name: "x", type: "Int" }],
+      irBinop("eq", irVar("x"), irLitNat(0)),
+    );
+    const result = emitStmt(stmt, ctx());
+    assert.equal(result.assertions.length, 1);
+    const rendered = renderAssert(lowerAssert(result.assertions[0]!));
+    assert.equal(rendered, "all x: Int | x = 0");
+  });
+});
+
+describe("emitStmt — let-if defers to Patch 2", () => {
+  it("let-if throws NOT_IMPL pointing at M3 Patch 2", () => {
+    const stmt: IRStmt = {
+      kind: "let-if",
+      phiVars: ["balance:acct"],
+      cond: irVar("g"),
+      then: [],
+      else: [],
+      continuation: [],
+    };
+    assert.throws(() => emitStmt(stmt, ctx()), /Patch 2/);
+  });
+});
+
+describe("emitStmt — modifiedProps insertion order", () => {
+  it("preserves insertion order across writes", () => {
+    const tA: IRWriteTarget = {
+      kind: "property-field",
+      ruleName: "alpha",
+      objExpr: irVar("o"),
+    };
+    const tB: IRWriteTarget = {
+      kind: "property-field",
+      ruleName: "beta",
+      objExpr: irVar("o"),
+    };
+    const tC: IRWriteTarget = {
+      kind: "property-field",
+      ruleName: "gamma",
+      objExpr: irVar("o"),
+    };
+    const result = emitStmt(
+      irStmtSeq([
+        irStmtWrite(tB, irLitNat(2)),
+        irStmtWrite(tA, irLitNat(1)),
+        irStmtWrite(tC, irLitNat(3)),
+      ]),
+      ctx(),
+    );
+    assert.deepEqual([...result.modifiedProps], ["beta", "alpha", "gamma"]);
+  });
+});

--- a/tools/ts2pant/tests/ir-emit-stmt.test.mts
+++ b/tools/ts2pant/tests/ir-emit-stmt.test.mts
@@ -148,7 +148,10 @@ describe("emitStmt — property-field writes", () => {
       objExpr: irVar("a"),
     };
     const result = emitStmt(
-      irStmtSeq([irStmtWrite(t1, irLitNat(0)), irStmtWrite(t2, irLitString("x"))]),
+      irStmtSeq([
+        irStmtWrite(t1, irLitNat(0)),
+        irStmtWrite(t2, irLitString("x")),
+      ]),
       ctx(),
     );
     assert.equal(result.equations.length, 2);
@@ -157,7 +160,10 @@ describe("emitStmt — property-field writes", () => {
 });
 
 describe("emitStmt — map-entry writes", () => {
-  function mapTarget(op: "set" | "delete", keyExpr = irVar("k")): IRWriteTarget {
+  function mapTarget(
+    op: "set" | "delete",
+    keyExpr = irVar("k"),
+  ): IRWriteTarget {
     return {
       kind: "map-entry",
       ruleName: "entries",
@@ -171,17 +177,11 @@ describe("emitStmt — map-entry writes", () => {
   }
 
   it("Map.set emits two equations: value override + membership override", () => {
-    const result = emitStmt(
-      irStmtWrite(mapTarget("set"), irLitNat(42)),
-      ctx(),
-    );
+    const result = emitStmt(irStmtWrite(mapTarget("set"), irLitNat(42)), ctx());
     assert.equal(result.equations.length, 2);
     const valueEq = renderEquation(lowerEquation(result.equations[0]!));
     const memberEq = renderEquation(lowerEquation(result.equations[1]!));
-    assert.equal(
-      valueEq,
-      "entries' m k = entries[(c, k) |-> 42] m k",
-    );
+    assert.equal(valueEq, "entries' m k = entries[(c, k) |-> 42] m k");
     assert.equal(
       memberEq,
       "entriesKey' m1 k1 = entriesKey[(c, k) |-> true] m1 k1",
@@ -369,10 +369,7 @@ describe("emitStmt — let-if φ-merge (property writes)", () => {
     );
     assert.equal(result.equations.length, 1);
     const rendered = renderEquation(lowerEquation(result.equations[0]!));
-    assert.equal(
-      rendered,
-      "balance' acct = cond g => 100, true => 50",
-    );
+    assert.equal(rendered, "balance' acct = cond g => 100, true => 50");
     assert.deepEqual([...result.modifiedProps], ["balance"]);
   });
 
@@ -671,7 +668,7 @@ describe("emitStmt — quantified-stmt envelope (Shape A target)", () => {
     );
     assert.equal(
       ast.strExpr(envelope),
-      "all x: User, x in users | active' x = \"on\"",
+      'all x: User, x in users | active\' x = "on"',
     );
   });
 
@@ -715,10 +712,7 @@ describe("emitStmt — quantified-stmt envelope (Shape A target)", () => {
     const wrapped = irStmtQuantified(
       [{ name: "x", type: "T" }],
       [irBinop("in", irVar("x"), irVar("xs"))],
-      irStmtSeq([
-        irStmtWrite(tA, irLitNat(1)),
-        irStmtWrite(tB, irLitNat(2)),
-      ]),
+      irStmtSeq([irStmtWrite(tA, irLitNat(1)), irStmtWrite(tB, irLitNat(2))]),
     );
     const result = emitStmt(wrapped, ctx());
     assert.equal(result.equations.length, 2);

--- a/tools/ts2pant/tests/ir-emit-stmt.test.mts
+++ b/tools/ts2pant/tests/ir-emit-stmt.test.mts
@@ -327,17 +327,291 @@ describe("emitStmt — assertions pass through", () => {
   });
 });
 
-describe("emitStmt — let-if defers to Patch 2", () => {
-  it("let-if throws NOT_IMPL pointing at M3 Patch 2", () => {
-    const stmt: IRStmt = {
+// ---------------------------------------------------------------------------
+// Patch 2: let-if φ-merge
+// ---------------------------------------------------------------------------
+
+describe("emitStmt — let-if φ-merge (property writes)", () => {
+  function propTarget(rule: string, obj = "acct"): IRWriteTarget {
+    return {
+      kind: "property-field",
+      ruleName: rule,
+      objExpr: irVar(obj),
+    };
+  }
+
+  function letIf(
+    cond: ReturnType<typeof irVar>,
+    thenStmts: IRStmt[],
+    elseStmts: IRStmt[],
+    cont: IRStmt[] = [],
+  ): IRStmt {
+    return {
       kind: "let-if",
-      phiVars: ["balance:acct"],
-      cond: irVar("g"),
-      then: [],
-      else: [],
+      phiVars: ["__phi__"],
+      cond,
+      then: thenStmts,
+      else: elseStmts,
+      continuation: cont,
+    };
+  }
+
+  it("both branches write same property → cond(g => vT, true => vE)", () => {
+    const t = propTarget("balance");
+    const result = emitStmt(
+      letIf(
+        irVar("g"),
+        [irStmtWrite(t, irLitNat(100))],
+        [irStmtWrite(t, irLitNat(50))],
+      ),
+      ctx(),
+    );
+    assert.equal(result.equations.length, 1);
+    const rendered = renderEquation(lowerEquation(result.equations[0]!));
+    assert.equal(
+      rendered,
+      "balance' acct = cond g => 100, true => 50",
+    );
+    assert.deepEqual([...result.modifiedProps], ["balance"]);
+  });
+
+  it("only then-branch writes → cond(g => vT, true => identity)", () => {
+    const t = propTarget("balance");
+    const result = emitStmt(
+      letIf(irVar("g"), [irStmtWrite(t, irLitNat(100))], []),
+      ctx(),
+    );
+    assert.equal(result.equations.length, 1);
+    const rendered = renderEquation(lowerEquation(result.equations[0]!));
+    assert.equal(
+      rendered,
+      "balance' acct = cond g => 100, true => balance acct",
+    );
+  });
+
+  it("only else-branch writes → cond(g => identity, true => vE)", () => {
+    const t = propTarget("balance");
+    const result = emitStmt(
+      letIf(irVar("g"), [], [irStmtWrite(t, irLitNat(50))]),
+      ctx(),
+    );
+    assert.equal(result.equations.length, 1);
+    const rendered = renderEquation(lowerEquation(result.equations[0]!));
+    assert.equal(
+      rendered,
+      "balance' acct = cond g => balance acct, true => 50",
+    );
+  });
+
+  it("disjoint property writes (different rules) merge independently", () => {
+    const tA = propTarget("alpha");
+    const tB = propTarget("beta");
+    const result = emitStmt(
+      letIf(
+        irVar("g"),
+        [irStmtWrite(tA, irLitNat(1))],
+        [irStmtWrite(tB, irLitNat(2))],
+      ),
+      ctx(),
+    );
+    assert.equal(result.equations.length, 2);
+    const rA = renderEquation(lowerEquation(result.equations[0]!));
+    const rB = renderEquation(lowerEquation(result.equations[1]!));
+    assert.equal(rA, "alpha' acct = cond g => 1, true => alpha acct");
+    assert.equal(rB, "beta' acct = cond g => beta acct, true => 2");
+    assert.deepEqual([...result.modifiedProps], ["alpha", "beta"]);
+  });
+
+  it("continuation runs after let-if and observes merged writes", () => {
+    const t = propTarget("balance");
+    const t2 = propTarget("name");
+    // if (g) balance = 100; balance = balance * 2;
+    // After the let-if, the merged balance value is cond(g => 100, true =>
+    // identity); the continuation does NOT directly observe that since
+    // emitStmt's read side doesn't currently re-thread cond writes back
+    // through the next write — but a sequential write to the same key
+    // overwrites the prior cond-merged value (last-write-wins).
+    const result = emitStmt(
+      irStmtSeq([
+        letIf(irVar("g"), [irStmtWrite(t, irLitNat(100))], []),
+        irStmtWrite(t2, irLitString("post")),
+      ]),
+      ctx(),
+    );
+    assert.equal(result.equations.length, 2);
+    assert.deepEqual([...result.modifiedProps], ["balance", "name"]);
+  });
+
+  it("nested let-if produces nested cond expression", () => {
+    const t = propTarget("balance");
+    const result = emitStmt(
+      letIf(
+        irVar("g1"),
+        [
+          letIf(
+            irVar("g2"),
+            [irStmtWrite(t, irLitNat(1))],
+            [irStmtWrite(t, irLitNat(2))],
+          ),
+        ],
+        [irStmtWrite(t, irLitNat(3))],
+      ),
+      ctx(),
+    );
+    assert.equal(result.equations.length, 1);
+    const rendered = renderEquation(lowerEquation(result.equations[0]!));
+    assert.equal(
+      rendered,
+      "balance' acct = cond g1 => (cond g2 => 1, true => 2), true => 3",
+    );
+  });
+
+  // Note: branches writing the same TARGET KIND but different rules cannot
+  // collide on a write-key because `writeKey` namespaces per-kind
+  // (`prop:rule:obj`, `map:rule:obj`, `set:rule:obj`), so the kind-mismatch
+  // check in `mergeWriteAccs` is structurally unreachable from the IR
+  // builder. Defensive only — kept to prevent silently corrupting state if
+  // a future write-key scheme allows collision.
+});
+
+describe("emitStmt — let-if φ-merge (Map writes)", () => {
+  function mapTarget(
+    op: "set" | "delete",
+    keyExpr = irVar("k"),
+  ): IRWriteTarget {
+    return {
+      kind: "map-entry",
+      ruleName: "entries",
+      keyPredName: "entriesKey",
+      ownerType: "Cache",
+      keyType: "String",
+      objExpr: irVar("c"),
+      keyExpr,
+      op,
+    };
+  }
+  function letIf(
+    cond: ReturnType<typeof irVar>,
+    thenStmts: IRStmt[],
+    elseStmts: IRStmt[],
+  ): IRStmt {
+    return {
+      kind: "let-if",
+      phiVars: ["__phi__"],
+      cond,
+      then: thenStmts,
+      else: elseStmts,
       continuation: [],
     };
-    assert.throws(() => emitStmt(stmt, ctx()), /Patch 2/);
+  }
+
+  it("both branches Map.set same key with different values → cond per override", () => {
+    const result = emitStmt(
+      letIf(
+        irVar("g"),
+        [irStmtWrite(mapTarget("set", irVar("k")), irLitNat(1))],
+        [irStmtWrite(mapTarget("set", irVar("k")), irLitNat(2))],
+      ),
+      ctx(),
+    );
+    assert.equal(result.equations.length, 2);
+    const valueEq = renderEquation(lowerEquation(result.equations[0]!));
+    assert.equal(
+      valueEq,
+      "entries' m k = entries[(c, k) |-> cond g => 1, true => 2] m k",
+    );
+  });
+
+  it("only then-branch Map.set → cond with pre-state fallback", () => {
+    const result = emitStmt(
+      letIf(
+        irVar("g"),
+        [irStmtWrite(mapTarget("set", irVar("k")), irLitNat(1))],
+        [],
+      ),
+      ctx(),
+    );
+    assert.equal(result.equations.length, 2);
+    const valueEq = renderEquation(lowerEquation(result.equations[0]!));
+    assert.equal(
+      valueEq,
+      "entries' m k = entries[(c, k) |-> cond g => 1, true => entries c k] m k",
+    );
+  });
+
+  it("disjoint keys across branches produce two overrides", () => {
+    const result = emitStmt(
+      letIf(
+        irVar("g"),
+        [irStmtWrite(mapTarget("set", irVar("k1")), irLitNat(1))],
+        [irStmtWrite(mapTarget("set", irVar("k2")), irLitNat(2))],
+      ),
+      ctx(),
+    );
+    assert.equal(result.equations.length, 2);
+    const valueEq = renderEquation(lowerEquation(result.equations[0]!));
+    assert.equal(
+      valueEq,
+      "entries' m k = entries[(c, k1) |-> cond g => 1, true => entries c k1, (c, k2) |-> cond g => entries c k2, true => 2] m k",
+    );
+  });
+});
+
+describe("emitStmt — let-if φ-merge (Set writes)", () => {
+  function setTarget(op: "add" | "delete", elem: string): IRWriteTarget {
+    return {
+      kind: "set-member",
+      ruleName: "tags",
+      ownerType: "Card",
+      elemType: "String",
+      objExpr: irVar("c"),
+      elemExpr: irVar(elem),
+      op,
+    };
+  }
+  function letIf(
+    cond: ReturnType<typeof irVar>,
+    thenStmts: IRStmt[],
+    elseStmts: IRStmt[],
+  ): IRStmt {
+    return {
+      kind: "let-if",
+      phiVars: ["__phi__"],
+      cond,
+      then: thenStmts,
+      else: elseStmts,
+      continuation: [],
+    };
+  }
+
+  it("then-only Set.add merges with pre-state fallback", () => {
+    const result = emitStmt(
+      letIf(irVar("g"), [irStmtWrite(setTarget("add", "e"), null)], []),
+      ctx(),
+    );
+    assert.equal(result.assertions.length, 1);
+    const rendered = renderAssert(lowerAssert(result.assertions[0]!));
+    assert.equal(
+      rendered,
+      "all y: String | y in tags' c <-> (cond y = e => (cond g => true, true => e in tags c), true => y in tags c)",
+    );
+  });
+
+  it("both branches Set.add different elements → two cond-merged overrides", () => {
+    const result = emitStmt(
+      letIf(
+        irVar("g"),
+        [irStmtWrite(setTarget("add", "e1"), null)],
+        [irStmtWrite(setTarget("add", "e2"), null)],
+      ),
+      ctx(),
+    );
+    assert.equal(result.assertions.length, 1);
+    const rendered = renderAssert(lowerAssert(result.assertions[0]!));
+    assert.equal(
+      rendered,
+      "all y: String | y in tags' c <-> (cond y = e1 => (cond g => true, true => e1 in tags c), y = e2 => (cond g => e2 in tags c, true => true), true => y in tags c)",
+    );
   });
 });
 

--- a/tools/ts2pant/tests/ir-emit-stmt.test.mts
+++ b/tools/ts2pant/tests/ir-emit-stmt.test.mts
@@ -7,6 +7,7 @@ import {
   irLitNat,
   irLitString,
   irStmtAssert,
+  irStmtQuantified,
   irStmtSeq,
   irStmtWrite,
   irVar,
@@ -611,6 +612,148 @@ describe("emitStmt — let-if φ-merge (Set writes)", () => {
     assert.equal(
       rendered,
       "all y: String | y in tags' c <-> (cond y = e1 => (cond g => true, true => e1 in tags c), y = e2 => (cond g => e2 in tags c, true => true), true => y in tags c)",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Patch 3: quantified-stmt envelope
+// ---------------------------------------------------------------------------
+
+describe("emitStmt — quantified-stmt envelope (Shape A target)", () => {
+  it("wraps a property-field write in `all x in src | p' x = e`", () => {
+    // Foreach(x, src, Assign(Member(x, "active"), true)) lowers to
+    // quantified-stmt([{x, User}], [in(x, users)],
+    //   write{property-field, "active", x, true}).
+    const target: IRWriteTarget = {
+      kind: "property-field",
+      ruleName: "active",
+      objExpr: irVar("x"),
+    };
+    const body = irStmtWrite(target, irBinop("eq", irLitNat(1), irLitNat(1))); // dummy expr
+    const wrapped = irStmtQuantified(
+      [{ name: "x", type: "User" }],
+      [irBinop("in", irVar("x"), irVar("users"))],
+      body,
+    );
+    const result = emitStmt(wrapped, ctx());
+    assert.equal(result.equations.length, 1);
+    const rendered = renderEquation(lowerEquation(result.equations[0]!));
+    assert.equal(rendered, "active' x = 1 = 1");
+    assert.equal(result.equations[0]!.quantifiers.length, 1);
+    assert.equal(result.equations[0]!.quantifiers[0]!.name, "x");
+    assert.equal(result.equations[0]!.guards?.length, 1);
+    assert.deepEqual([...result.modifiedProps], ["active"]);
+  });
+
+  it("simple Shape A: assigning a constant value", () => {
+    const target: IRWriteTarget = {
+      kind: "property-field",
+      ruleName: "active",
+      objExpr: irVar("x"),
+    };
+    const wrapped = irStmtQuantified(
+      [{ name: "x", type: "User" }],
+      [irBinop("in", irVar("x"), irVar("users"))],
+      irStmtWrite(target, irLitString("on")),
+    );
+    const result = emitStmt(wrapped, ctx());
+    assert.equal(result.equations.length, 1);
+    const eq = result.equations[0]!;
+    const lowered = lowerEquation(eq);
+    const ast = getAst();
+    // The forall envelope assembles via Pant's forall constructor with our
+    // params + guards; the body is the equation expression `lhs = rhs`.
+    const envelope = ast.forall(
+      lowered.quantifiers,
+      lowered.guards,
+      ast.binop(ast.opEq(), lowered.lhs, lowered.rhs),
+    );
+    assert.equal(
+      ast.strExpr(envelope),
+      "all x: User, x in users | active' x = \"on\"",
+    );
+  });
+
+  it("composes nested quantified-stmt envelopes (concats quants/guards)", () => {
+    const target: IRWriteTarget = {
+      kind: "property-field",
+      ruleName: "joint",
+      objExpr: irVar("y"),
+    };
+    const inner = irStmtQuantified(
+      [{ name: "y", type: "Item" }],
+      [irBinop("in", irVar("y"), irVar("items"))],
+      irStmtWrite(target, irLitNat(1)),
+    );
+    const outer = irStmtQuantified(
+      [{ name: "x", type: "User" }],
+      [irBinop("in", irVar("x"), irVar("users"))],
+      inner,
+    );
+    const result = emitStmt(outer, ctx());
+    assert.equal(result.equations.length, 1);
+    const eq = result.equations[0]!;
+    assert.deepEqual(
+      eq.quantifiers.map((q) => q.name),
+      ["x", "y"],
+    );
+    assert.equal(eq.guards?.length, 2);
+  });
+
+  it("seq inside quantified-stmt wraps each emitted equation independently", () => {
+    const tA: IRWriteTarget = {
+      kind: "property-field",
+      ruleName: "alpha",
+      objExpr: irVar("x"),
+    };
+    const tB: IRWriteTarget = {
+      kind: "property-field",
+      ruleName: "beta",
+      objExpr: irVar("x"),
+    };
+    const wrapped = irStmtQuantified(
+      [{ name: "x", type: "T" }],
+      [irBinop("in", irVar("x"), irVar("xs"))],
+      irStmtSeq([
+        irStmtWrite(tA, irLitNat(1)),
+        irStmtWrite(tB, irLitNat(2)),
+      ]),
+    );
+    const result = emitStmt(wrapped, ctx());
+    assert.equal(result.equations.length, 2);
+    for (const eq of result.equations) {
+      assert.deepEqual(
+        eq.quantifiers.map((q) => q.name),
+        ["x"],
+      );
+    }
+    assert.deepEqual([...result.modifiedProps], ["alpha", "beta"]);
+  });
+
+  it("quantified-stmt over a Set assertion prepends quants to the assertion", () => {
+    const target: IRWriteTarget = {
+      kind: "set-member",
+      ruleName: "tags",
+      ownerType: "Card",
+      elemType: "String",
+      objExpr: irVar("c"),
+      elemExpr: irVar("e"),
+      op: "add",
+    };
+    const wrapped = irStmtQuantified(
+      [{ name: "x", type: "Card" }],
+      [irBinop("in", irVar("x"), irVar("cards"))],
+      irStmtWrite(target, null),
+    );
+    const result = emitStmt(wrapped, ctx());
+    assert.equal(result.assertions.length, 1);
+    const a = result.assertions[0]!;
+    // Outer x quantifier is prepended; inner y quantifier (allocated by
+    // emitSetMembershipAssertion) follows.
+    assert.deepEqual(
+      a.quantifiers.map((q) => q.name),
+      ["x", "y"],
     );
   });
 });

--- a/tools/ts2pant/tests/ir1-lower.test.mts
+++ b/tools/ts2pant/tests/ir1-lower.test.mts
@@ -10,7 +10,7 @@ import {
   irUnop,
   irVar,
 } from "../src/ir.js";
-import { lowerExpr } from "../src/ir-emit.js";
+import { emitStmt, lowerEquation, lowerExpr } from "../src/ir-emit.js";
 import {
   ir1App,
   ir1Assign,
@@ -120,10 +120,9 @@ describe("lowerL1Expr — applications", () => {
 
   it("non-var-headed app lowers via L2 expr-headed application", () => {
     // (cond ? f : g)(x) — pathological but syntactically valid
-    const l1 = ir1App(
-      ir1Cond([[ir1Var("c"), ir1Var("f")]], ir1Var("g")),
-      [ir1Var("x")],
-    );
+    const l1 = ir1App(ir1Cond([[ir1Var("c"), ir1Var("f")]], ir1Var("g")), [
+      ir1Var("x"),
+    ]);
     const l2 = lowerL1Expr(l1);
     // Just check the shape: head is expression-kind, args has one var.
     assert.equal(l2.kind, "app");
@@ -220,10 +219,7 @@ describe("lowerL1Expr — from-l2 transitional adapter", () => {
     assert.deepEqual(
       l2,
       irCond([
-        [
-          irVar("g", false),
-          irBinop("add", irVar("a", false), irLitNat(1)),
-        ],
+        [irVar("g", false), irBinop("add", irVar("a", false), irLitNat(1))],
         [irLitBool(true), irLitNat(0)],
       ]),
     );
@@ -293,10 +289,7 @@ describe("M2: ir1Assign and ir1While constructors are active", () => {
   });
 
   it("ir1Assign target may be a Member expression", () => {
-    const stmt = ir1Assign(
-      ir1Member(ir1Var("a"), "balance"),
-      ir1LitNat(0),
-    );
+    const stmt = ir1Assign(ir1Member(ir1Var("a"), "balance"), ir1LitNat(0));
     assert.equal(stmt.kind, "assign");
     if (stmt.kind === "assign") {
       assert.equal(stmt.target.kind, "member");
@@ -304,10 +297,7 @@ describe("M2: ir1Assign and ir1While constructors are active", () => {
   });
 
   it("ir1While builds a `while` statement with body", () => {
-    const stmt = ir1While(
-      ir1Var("p"),
-      ir1Assign(ir1Var("i"), ir1LitNat(0)),
-    );
+    const stmt = ir1While(ir1Var("p"), ir1Assign(ir1Var("i"), ir1LitNat(0)));
     assert.equal(stmt.kind, "while");
     if (stmt.kind === "while") {
       assert.deepEqual(stmt.cond, ir1Var("p"));
@@ -316,36 +306,30 @@ describe("M2: ir1Assign and ir1While constructors are active", () => {
   });
 });
 
-describe("vocabulary-locked stubs (M3 forms)", () => {
-  it("ir1CondStmt throws not-implemented (M3)", () => {
-    assert.throws(
-      () => ir1CondStmt([[ir1Var("g"), ir1Return(ir1Var("v"))]], null),
-      /M3/,
-    );
+describe("M3 statement constructors (Patch 4 — no longer NOT_IMPL)", () => {
+  it("ir1CondStmt builds a cond-stmt", () => {
+    const stmt = ir1CondStmt([[ir1Var("g"), ir1Return(ir1Var("v"))]], null);
+    assert.equal(stmt.kind, "cond-stmt");
   });
 
-  it("ir1Foreach throws not-implemented (M3)", () => {
-    assert.throws(
-      () => ir1Foreach("x", ir1Var("xs"), ir1Return(ir1Var("x"))),
-      /M3/,
-    );
+  it("ir1Foreach builds a foreach", () => {
+    const stmt = ir1Foreach("x", ir1Var("xs"), ir1Return(ir1Var("x")));
+    assert.equal(stmt.kind, "foreach");
   });
 
-  it("ir1For throws not-implemented (M3)", () => {
-    assert.throws(() => ir1For(null, null, null, ir1Return(null)), /M3/);
+  it("ir1For builds a for", () => {
+    const stmt = ir1For(null, null, null, ir1Return(null));
+    assert.equal(stmt.kind, "for");
   });
 
-  it("ir1Throw throws not-implemented (M3)", () => {
-    assert.throws(() => ir1Throw(ir1Var("err")), /M3/);
+  it("ir1Throw builds a throw", () => {
+    const stmt = ir1Throw(ir1Var("err"));
+    assert.equal(stmt.kind, "throw");
   });
 
-  it("ir1ExprStmt throws not-implemented (M3)", () => {
-    assert.throws(() => ir1ExprStmt(ir1Var("e")), /M3/);
-  });
-
-  it("lowerL1Stmt throws — statement lowering is M3", () => {
-    const stmt = ir1Return(ir1Var("x"));
-    assert.throws(() => lowerL1Stmt(stmt), /M3/);
+  it("ir1ExprStmt builds an expr-stmt", () => {
+    const stmt = ir1ExprStmt(ir1Var("e"));
+    assert.equal(stmt.kind, "expr-stmt");
   });
 });
 
@@ -355,10 +339,7 @@ describe("vocabulary-locked stubs (M3 forms)", () => {
 
 describe("active statement constructors (block, let, return)", () => {
   it("ir1Block constructs a block of two statements", () => {
-    const block = ir1Block([
-      ir1Let("x", ir1LitNat(1)),
-      ir1Return(ir1Var("x")),
-    ]);
+    const block = ir1Block([ir1Let("x", ir1LitNat(1)), ir1Return(ir1Var("x"))]);
     assert.equal(block.kind, "block");
   });
 
@@ -447,6 +428,113 @@ describe("L2 comb-typed form (typed comprehension)", () => {
     const l2 = irCombTyped("max", "k", "Nat", [], irVar("k"));
     const lowered = lowerExpr(l2);
     // No guards beyond the typed binder.
-    assert.match(ast.strExpr(lowered), /max over each k: Nat \| k/);
+    assert.match(ast.strExpr(lowered), /max over each k: Nat \| k/u);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// M3 Patch 4: lowerL1Stmt for non-iteration kinds
+// ---------------------------------------------------------------------------
+
+function makeAlloc(): (hint: string) => string {
+  const counts = new Map<string, number>();
+  return (hint: string): string => {
+    const n = counts.get(hint) ?? 0;
+    counts.set(hint, n + 1);
+    return n === 0 ? hint : `${hint}${n}`;
+  };
+}
+
+describe("lowerL1Stmt — block + assign + cond-stmt (M3 Patch 4)", () => {
+  it("block of one assign lowers to a single L2 write", () => {
+    const block = ir1Block([
+      ir1Assign(ir1Member(ir1Var("acct"), "balance"), ir1LitNat(100)),
+    ]);
+    const stmts = lowerL1Stmt(block);
+    assert.equal(stmts.length, 1);
+    assert.equal(stmts[0]!.kind, "write");
+  });
+
+  it("assign with member target produces write{property-field}", () => {
+    const stmt = ir1Assign(
+      ir1Member(ir1Var("acct"), "balance"),
+      ir1LitNat(100),
+    );
+    const stmts = lowerL1Stmt(stmt);
+    assert.equal(stmts.length, 1);
+    const w = stmts[0]!;
+    assert.equal(w.kind, "write");
+    if (w.kind === "write") {
+      assert.equal(w.target.kind, "property-field");
+      if (w.target.kind === "property-field") {
+        assert.equal(w.target.ruleName, "balance");
+      }
+    }
+  });
+
+  it("assign with var target rejects (μ-search territory)", () => {
+    const stmt = ir1Assign(ir1Var("c"), ir1LitNat(1));
+    assert.throws(() => lowerL1Stmt(stmt), /var-target/u);
+  });
+
+  it("end-to-end: cond-stmt lowers and emits a φ-merged equation", () => {
+    // if (g) acct.balance = 100; else acct.balance = 50;
+    const stmt = ir1CondStmt(
+      [
+        [
+          ir1Var("g"),
+          ir1Assign(ir1Member(ir1Var("acct"), "balance"), ir1LitNat(100)),
+        ],
+      ],
+      ir1Assign(ir1Member(ir1Var("acct"), "balance"), ir1LitNat(50)),
+    );
+    const lowered = lowerL1Stmt(stmt);
+    const result = emitStmt(lowered, { allocBinder: makeAlloc() });
+    assert.equal(result.equations.length, 1);
+    const ast = getAst();
+    const eq = lowerEquation(result.equations[0]!);
+    assert.equal(
+      `${ast.strExpr(eq.lhs)} = ${ast.strExpr(eq.rhs)}`,
+      "balance' acct = cond g => 100, true => 50",
+    );
+  });
+
+  it("multi-armed cond-stmt folds right-to-left into nested let-if", () => {
+    // if (g1) p = 1 else if (g2) p = 2 else p = 3
+    const stmt = ir1CondStmt(
+      [
+        [ir1Var("g1"), ir1Assign(ir1Member(ir1Var("o"), "p"), ir1LitNat(1))],
+        [ir1Var("g2"), ir1Assign(ir1Member(ir1Var("o"), "p"), ir1LitNat(2))],
+      ],
+      ir1Assign(ir1Member(ir1Var("o"), "p"), ir1LitNat(3)),
+    );
+    const lowered = lowerL1Stmt(stmt);
+    const result = emitStmt(lowered, { allocBinder: makeAlloc() });
+    assert.equal(result.equations.length, 1);
+    const ast = getAst();
+    const eq = lowerEquation(result.equations[0]!);
+    assert.equal(
+      `${ast.strExpr(eq.lhs)} = ${ast.strExpr(eq.rhs)}`,
+      "p' o = cond g1 => 1, true => (cond g2 => 2, true => 3)",
+    );
+  });
+
+  it("iteration kinds throw with pointer to Patch 5", () => {
+    assert.throws(
+      () => lowerL1Stmt(ir1Foreach("x", ir1Var("xs"), ir1Return(null))),
+      /Patch 5/u,
+    );
+    assert.throws(
+      () => lowerL1Stmt(ir1For(null, null, null, ir1Return(null))),
+      /Patch 5/u,
+    );
+    assert.throws(() => lowerL1Stmt(ir1Throw(ir1Var("e"))), /Patch 5/u);
+    assert.throws(() => lowerL1Stmt(ir1ExprStmt(ir1Var("e"))), /Patch 5/u);
+    assert.throws(() => lowerL1Stmt(ir1Let("x", ir1LitNat(0))), /Patch 5/u);
+    assert.throws(() => lowerL1Stmt(ir1Return(null)), /Patch 5/u);
+    assert.throws(
+      () => lowerL1Stmt(ir1While(ir1Var("g"), ir1Return(null))),
+      /Patch 5/u,
+    );
   });
 });

--- a/tools/ts2pant/tests/ir1-lower.test.mts
+++ b/tools/ts2pant/tests/ir1-lower.test.mts
@@ -313,7 +313,7 @@ describe("M3 statement constructors (Patch 4 — no longer NOT_IMPL)", () => {
   });
 
   it("ir1Foreach builds a foreach", () => {
-    const stmt = ir1Foreach("x", ir1Var("xs"), ir1Return(ir1Var("x")));
+    const stmt = ir1Foreach("x", "T", ir1Var("xs"), ir1Return(ir1Var("x")));
     assert.equal(stmt.kind, "foreach");
   });
 
@@ -519,22 +519,124 @@ describe("lowerL1Stmt — block + assign + cond-stmt (M3 Patch 4)", () => {
     );
   });
 
-  it("iteration kinds throw with pointer to Patch 5", () => {
-    assert.throws(
-      () => lowerL1Stmt(ir1Foreach("x", ir1Var("xs"), ir1Return(null))),
-      /Patch 5/u,
-    );
+  it("deferred kinds (let/return/expr-stmt/while/for/throw) throw", () => {
+    // Patch 5 added foreach lowering; the remaining kinds defer to a
+    // follow-up patch (build-side + cutover work).
     assert.throws(
       () => lowerL1Stmt(ir1For(null, null, null, ir1Return(null))),
-      /Patch 5/u,
+      /deferred/u,
     );
-    assert.throws(() => lowerL1Stmt(ir1Throw(ir1Var("e"))), /Patch 5/u);
-    assert.throws(() => lowerL1Stmt(ir1ExprStmt(ir1Var("e"))), /Patch 5/u);
-    assert.throws(() => lowerL1Stmt(ir1Let("x", ir1LitNat(0))), /Patch 5/u);
-    assert.throws(() => lowerL1Stmt(ir1Return(null)), /Patch 5/u);
+    assert.throws(() => lowerL1Stmt(ir1Throw(ir1Var("e"))), /deferred/u);
+    assert.throws(() => lowerL1Stmt(ir1ExprStmt(ir1Var("e"))), /deferred/u);
+    assert.throws(() => lowerL1Stmt(ir1Let("x", ir1LitNat(0))), /deferred/u);
+    assert.throws(() => lowerL1Stmt(ir1Return(null)), /deferred/u);
     assert.throws(
       () => lowerL1Stmt(ir1While(ir1Var("g"), ir1Return(null))),
-      /Patch 5/u,
+      /deferred/u,
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// M3 Patch 5: lowerL1Foreach for Shape A
+// ---------------------------------------------------------------------------
+
+describe("lowerL1Foreach — Shape A (M3 Patch 5)", () => {
+  it("simple uniform write: for x in users { x.active = true }", () => {
+    const stmt = ir1Foreach(
+      "x",
+      "User",
+      ir1Var("users"),
+      ir1Assign(ir1Member(ir1Var("x"), "active"), ir1LitBool(true)),
+    );
+    const stmts = lowerL1Stmt(stmt);
+    assert.equal(stmts.length, 1);
+    const q = stmts[0]!;
+    assert.equal(q.kind, "quantified-stmt");
+    if (q.kind === "quantified-stmt") {
+      assert.equal(q.quantifiers.length, 1);
+      assert.equal(q.quantifiers[0]!.name, "x");
+      assert.equal(q.quantifiers[0]!.type, "User");
+      assert.equal(q.guards.length, 1); // in(x, users)
+    }
+    const result = emitStmt(stmts, { allocBinder: makeAlloc() });
+    assert.equal(result.equations.length, 1);
+    const ast = getAst();
+    const eq = lowerEquation(result.equations[0]!);
+    assert.equal(
+      ast.strExpr(
+        ast.forall(
+          eq.quantifiers,
+          eq.guards,
+          ast.binop(ast.opEq(), eq.lhs, eq.rhs),
+        ),
+      ),
+      "all x: User, x in users | active' x = true",
+    );
+  });
+
+  it("Shape A with guard: for x in users { if (g(x)) { x.active = true } }", () => {
+    const stmt = ir1Foreach(
+      "x",
+      "User",
+      ir1Var("users"),
+      ir1CondStmt(
+        [
+          [
+            ir1App(ir1Var("g"), [ir1Var("x")]),
+            ir1Assign(ir1Member(ir1Var("x"), "active"), ir1LitBool(true)),
+          ],
+        ],
+        null,
+      ),
+    );
+    const stmts = lowerL1Stmt(stmt);
+    assert.equal(stmts.length, 1);
+    const q = stmts[0]!;
+    if (q.kind === "quantified-stmt") {
+      assert.equal(q.guards.length, 2); // in(x, users) + g(x)
+    }
+  });
+
+  it("rejects multi-armed cond inside foreach body", () => {
+    const stmt = ir1Foreach(
+      "x",
+      "User",
+      ir1Var("users"),
+      ir1CondStmt(
+        [
+          [
+            ir1Var("g"),
+            ir1Assign(ir1Member(ir1Var("x"), "p"), ir1LitNat(1)),
+          ],
+        ],
+        ir1Assign(ir1Member(ir1Var("x"), "p"), ir1LitNat(2)),
+      ),
+    );
+    assert.throws(() => lowerL1Stmt(stmt), /multi-armed or with-else/);
+  });
+
+  it("rejects body that isn't Shape A", () => {
+    const stmt = ir1Foreach("x", "T", ir1Var("xs"), ir1Return(null));
+    assert.throws(() => lowerL1Stmt(stmt), /Shape A|return/);
+  });
+
+  it("multi-statement Shape A body: block of writes", () => {
+    const stmt = ir1Foreach(
+      "x",
+      "User",
+      ir1Var("users"),
+      ir1Block([
+        ir1Assign(ir1Member(ir1Var("x"), "active"), ir1LitBool(true)),
+        ir1Assign(
+          ir1Member(ir1Var("x"), "checkedAt"),
+          ir1LitNat(0),
+        ),
+      ]),
+    );
+    const stmts = lowerL1Stmt(stmt);
+    const result = emitStmt(stmts, { allocBinder: makeAlloc() });
+    assert.equal(result.equations.length, 2);
+    assert.deepEqual([...result.modifiedProps], ["active", "checkedAt"]);
   });
 });

--- a/workstreams/ts2pant-imperative-ir.md
+++ b/workstreams/ts2pant-imperative-ir.md
@@ -253,9 +253,56 @@ re-forms on top of `Assign`.
 
 ---
 
-### Milestone 3: imperative-ir-iteration-mutation
+### Milestone 3: imperative-ir-iteration-mutation — 🟡 partial (Patches 1–5 landed)
 
-**Definition of Done**:
+**Status (2026-04-26)**: M3 split into 7 patches; Patches 1–5 + docs
+landed on `zax--ts2pant-m3-iteration-mutation`. The plumbing side
+(L1 statement vocabulary, L1→L2 lowering, L2 IRStmt→IREquation
+emit) is complete and exercised by 26 hand-built tests across
+`tests/ir-emit-stmt.test.mts` and `tests/ir1-lower.test.mts`. The
+**L1 build pass** (`buildL1ForOf` / `buildL1ForEachCall` /
+`buildL1ReduceCall` / `buildL1CondStmt` translating TS AST → L1
+statements) and the **legacy-iteration / branched-mutation
+cutover** (replacing `translateForOfLoop` /
+`translateForEachStmt` / `translateReduceCall` and the
+branched-mutation arm of `symbolicExecute`) are deferred to a
+follow-up milestone (M3.5 or M3 follow-up PR).
+
+What landed:
+- **emitStmt** in `tools/ts2pant/src/ir-emit.ts` — walks L2 `IRStmt[]`
+  (seq / write / let-if / quantified-stmt / assert) and produces
+  `{ equations: IREquation[], assertions: IRAssertExit[],
+    modifiedProps: Set<string> }`. Coalesces multiple writes to the
+  same write-key (property-field last-write-wins; map-entry +
+  set-member append into override lists). φ-merge for let-if
+  follows the same discipline as legacy `mergeOverrides` /
+  `combineCond` but at the IR layer.
+- **L2 quantified-stmt form** for Shape A's `all x in src | …`
+  envelope — new IRStmt variant + emit + ir-subst handling. Mirrors
+  M2's `comb-typed` pattern.
+- **L1 statement vocabulary unblocked** — `cond-stmt`, `expr-stmt`,
+  `foreach`, `for`, `throw` constructors no longer throw `NOT_IMPL`;
+  `IR1Foreach` carries `binderType: string` so the L1 → L2 lowering
+  can emit the typed quantifier without re-running TS type
+  inference.
+- **lowerL1Stmt** in `ir1-lower.ts` for non-iteration kinds (block,
+  member-target assign, multi-armed cond-stmt → nested let-if) and
+  for `foreach` Shape A (with optional single-armed guard fold).
+  Iteration kinds beyond Shape A (Shape B, Shape C, classic for,
+  while-outside-μ-search) defer to follow-up.
+
+What's deferred to follow-up (was originally part of M3 DoD):
+- L1 build pass for iteration surface forms (`for-of`, `forEach`,
+  `.reduce`).
+- Cutover from legacy `translateForOfLoop` / `translateForEachStmt`
+  / `translateReduceCall` to the L1 path.
+- Cutover from legacy branched-mutation arm of `symbolicExecute`
+  (the `mergeOverrides` / `combineCond` machinery).
+- Shape B (accumulator fold) and Shape C (.reduce-as-expression)
+  recognition at L1 build time.
+
+**Original Definition of Done** (preserved below for reference; not
+all DoD items landed in this PR):
 - `ir1-build.ts` extends to translate iteration surface forms:
   `for (const x of arr) {body}`, `arr.forEach(x => {body})`,
   `for (let i = 0; i < arr.length; i++) {body using arr[i]}` (when `arr[i]`


### PR DESCRIPTION
## Summary

Milestone 3 of the IRSC-faithful imperative IR workstream — see `workstreams/ts2pant-imperative-ir.md`. **Plumbing-only**: the L1/L2 statement-lowering infrastructure lands here so the L1 build pass and legacy cutover can be done as a follow-up PR.

This PR was originally scoped to be the full M3 (L1 build + foreach lowering + cutover). It got split mid-implementation when the architectural finding surfaced: the L2 `IRStmt` vocabulary (`write`/`let-if`/`seq`/`assert`) was declared in `ir.ts` but had **zero callers and zero lowering** — Stage 9 wiring that never migrated. The user directed full-scope: wire it up, introduce new constructs as needed, snapshot regressions are acceptable. The 7-patch sequence makes this incremental.

## What lands (Patches 1-5)

**Patches 1-3 — L2 IRStmt → IREquation[] / IRAssertExit[]:**

- `emitStmt(s: IRStmt | IRStmt[], ctx)` in `ir-emit.ts` walks L2 IRStmts and produces `{ equations, assertions, modifiedProps }`.
- `seq` recurses + concats. `write{property-field|map-entry|set-member}` accumulates per write-key into an internal Map (insertion-ordered for deterministic frame emission); finalize coalesces overrides into a single equation per rule. Mirrors legacy `state.writes` discipline at the IR layer.
- `let-if` φ-merges per write-key via cond(g => vT, true => vE), with missing-branch fallback to pre-state read (`app(ruleName, [objExpr])` for property; `app(ruleName, [objExpr, keyExpr])` for map; `in(elemExpr, app(ruleName, [objExpr]))` for set). Mirrors legacy `mergeOverrides` / `combineCond` exactly, but at the IR layer with pure IRExpr fallbacks (no `irWrap`).
- New L2 `quantified-stmt(quants, guards, body: IRStmt)` form for Shape A's `all x in src | …` envelope. Mirrors M2 cleanup patch A's `comb-typed` pattern.

**Patch 4 — L1 statement scaffolding:**

- Drops NOT_IMPL throws on `cond-stmt`, `expr-stmt`, `foreach`, `for`, `throw` constructors.
- `lowerL1Stmt` in `ir1-lower.ts` for non-iteration kinds: `block` (→ `seq`), member-target `assign` (→ `write{property-field}`), multi-armed `cond-stmt` (→ nested `let-if` chains via right-fold). Var-target assigns reject (μ-search counter only). Other kinds throw with helpful pointers.

**Patch 5 — L1 foreach lowering (Shape A):**

- `lowerL1Foreach` recognizes Shape A: `Foreach(x: T, src, Assign(Member(x, p), e))` → `quantified-stmt([{x, T}], [in(x, src)], write{property-field})` → emits `all x: T, x in src | p' x = e`.
- Single-armed guard-cond inside foreach folds into the comprehension's guard list. Multi-armed cond and non-Shape-A bodies reject with specific errors.
- Vocabulary change: `IR1Foreach` gains `binderType: string` so the L1 → L2 lowering can synthesize the typed quantifier without re-running TS type inference.

**Patch 7 — Docs:**

Marks M3 partial in `tools/ts2pant/CLAUDE.md` and `workstreams/ts2pant-imperative-ir.md`. Documents what landed vs what's deferred.

## What's deferred (follow-up PR)

- **L1 build pass** — `buildL1ForOf`, `buildL1ForEachCall`, `buildL1ReduceCall`, `buildL1CondStmt` translating TS AST → L1 statements.
- **Cutover** — replacing `translateForOfLoop` / `translateForEachStmt` / `translateReduceCall` and the branched-mutation arm of `symbolicExecute` with the L1 path; deleting `mergeOverrides` / `combineCond` / `classifyLoopStmt` / `translateForOfLoopBody`.
- **Shape B** (accumulator fold, `for x { a.total += x.value }`) and **Shape C** (.reduce as expression) recognition at the L1 build site, lowered to L2 `comb` / `comb-typed` IRExpr.

The deferred work is what flips production iteration / branched-mutation paths onto the L1 substrate. Production translation is unchanged in this PR.

## Architecture

```
TS-AST  →  L1 (ir1.ts)   →  L2 IRStmt (ir.ts)            →  IREquation[]
       (build deferred)     (lowerL1Stmt — Patches 4-5)     (emitStmt — Patches 1-3)
                                                              ↓
                                                              lowerEquation/lowerAssert
                                                              (existing)
                                                              ↓
                                                              PropResult / OpaqueExpr
```

## Test plan

- [x] `just ts2pant-precommit` green: 520 unit + 22 integration = **542 tests**.
- [x] 26 new hand-built unit tests across `tests/ir-emit-stmt.test.mts` (17) and `tests/ir1-lower.test.mts` (9 for Patches 4-5) cover each L2 form, override coalescing, φ-merge cases, Shape A variants, and rejection paths.
- [x] Existing `pant --check` integration tests for `max.ts`, `deposit.ts`, `apply-fee.ts` continue verifying SMT-checkable output.
- [x] Existing 5 μ-search fixture snapshots and all iteration/mutation snapshots **byte-identical** to pre-M3 (this PR doesn't touch production paths).

## Locked decisions (do not re-litigate without sign-off)

- L2 IRStmt is the M3 statement-lowering target (not bypassed). `quantified-stmt` is the only new L2 form needed.
- φ-merge semantics: cond(g => vT, true => vE) per write-key, missing-branch fallback is the pre-state lookup at the appropriate kind. Matches legacy mergeOverrides exactly.
- `lowerL1Stmt` returns `IRStmt[]` (not `IREquation[]` directly); the L2 emit step finalizes per-rule coalescing.
- Snapshot policy (per user 2026-04-26): byte-equality is **not** required. Cleaner Pantagruel output is welcomed, regressions acceptable along the way as long as `pant --check` still verifies.

## Plan revisions during the PR

The plan went through three structural revisions during execution:

1. Original 5-patch plan assumed L2 IRStmt was already wired.
2. Discovered L2 IRStmt was vocabulary-only; user chose full-scope (wire it up rather than skip). Plan grew to 9 patches.
3. Snapshot policy revised — no byte-equality requirement — collapsed to 7 patches by dropping the dual-flag staging.
4. Mid-Patch-4: deferred branched-mutation cutover to keep the patch tractable. Mid-Patch-5: deferred L1 build side + iteration cutover for the same reason. The PR shipped is now plumbing-only; cutover is its own follow-up PR.

The plan file at `~/.claude/plans/plan-it-snug-tulip.md` records the journey.

🤖 Generated with [Claude Code](https://claude.com/claude-code)