### PR TITLE
ts2pant: M3 cutover Patch CO-0 — IR guard ADT (architectural prerequisite)

### DIFF
--- a/tools/ts2pant/src/ir-emit.ts
+++ b/tools/ts2pant/src/ir-emit.ts
@@ -21,6 +21,7 @@ import {
   type IREquation,
   type IRExpr,
   type IRFoldCombiner,
+  type IRGuard,
   type IRHead,
   type IRStmt,
   type IRUnop,
@@ -352,6 +353,21 @@ function isIdentityFor(c: IRFoldCombiner, init: IRExpr): boolean {
  * Lower an `IREquation` to a `PropResult`-shaped object suitable for
  * pushing into the propositions array. Caller wraps in `kind: "equation"`.
  */
+function lowerGuard(g: IRGuard): OpaqueGuard {
+  const ast = getAst();
+  switch (g.kind) {
+    case "expr":
+      return ast.gExpr(lowerExpr(g.expr));
+    case "in":
+      return ast.gIn(g.binder, lowerExpr(g.src));
+    default: {
+      const _exhaustive: never = g;
+      void _exhaustive;
+      throw new Error("unreachable: IRGuard");
+    }
+  }
+}
+
 export function lowerEquation(eq: IREquation): {
   quantifiers: OpaqueParam[];
   guards: OpaqueGuard[];
@@ -363,7 +379,7 @@ export function lowerEquation(eq: IREquation): {
     quantifiers: eq.quantifiers.map((q) =>
       ast.param(q.name, ast.tName(q.type)),
     ),
-    guards: (eq.guards ?? []).map((g) => ast.gExpr(lowerExpr(g))),
+    guards: (eq.guards ?? []).map(lowerGuard),
     lhs: lowerExpr(eq.lhs),
     rhs: lowerExpr(eq.rhs),
   };
@@ -377,7 +393,7 @@ export function lowerAssert(a: IRAssertExit): {
   const ast = getAst();
   return {
     quantifiers: a.quantifiers.map((q) => ast.param(q.name, ast.tName(q.type))),
-    guards: (a.guards ?? []).map((g) => ast.gExpr(lowerExpr(g))),
+    guards: (a.guards ?? []).map(lowerGuard),
     body: lowerExpr(a.body),
   };
 }

--- a/tools/ts2pant/src/ir.ts
+++ b/tools/ts2pant/src/ir.ts
@@ -327,7 +327,7 @@ export type IRStmt =
   | {
       kind: "quantified-stmt";
       quantifiers: Array<{ name: string; type: string }>;
-      guards: IRExpr[];
+      guards: IRGuard[];
       body: IRStmt;
     };
 
@@ -363,16 +363,50 @@ export interface IRBody {
  * non-empty for the `all m, k | R' m k = ...` shape from Map/Set
  * mutation.
  */
+/**
+ * Guards on quantified equations and assertions. Two flavors that
+ * Pantagruel distinguishes structurally:
+ *
+ * - `expr`: a Bool predicate guard that lowers via `ast.gExpr`. The
+ *   binder must already be in scope (typically from a quantifier or a
+ *   sibling `in` guard).
+ * - `in`: a binder-introducing guard that lowers via `ast.gIn`. The
+ *   binder enters scope here, with the quantification ranging over the
+ *   `src` collection. Canonical for Shape A iteration emission, where
+ *   the iterator binder is introduced through the iteration source
+ *   rather than via a typed quantifier.
+ *
+ * Distinct guard kinds matter because legacy iteration emission relies
+ * on `gIn` to produce `all x in src | …` (no typed quantifier on `x`),
+ * while predicate guards produce `all p1: T | <pred> => …`. The IR
+ * layer needs both forms to round-trip the legacy output shape
+ * exactly.
+ */
+export type IRGuard =
+  | { kind: "expr"; expr: IRExpr }
+  | { kind: "in"; binder: string; src: IRExpr };
+
+export const irGuardExpr = (expr: IRExpr): IRGuard => ({
+  kind: "expr",
+  expr,
+});
+
+export const irGuardIn = (binder: string, src: IRExpr): IRGuard => ({
+  kind: "in",
+  binder,
+  src,
+});
+
 export interface IREquation {
   quantifiers: Array<{ name: string; type: string }>;
-  guards?: IRExpr[];
+  guards?: IRGuard[];
   lhs: IRExpr;
   rhs: IRExpr;
 }
 
 export interface IRAssertExit {
   quantifiers: Array<{ name: string; type: string }>;
-  guards?: IRExpr[];
+  guards?: IRGuard[];
   body: IRExpr;
 }
 
@@ -570,7 +604,7 @@ export const irStmtAssert = (
 
 export const irStmtQuantified = (
   quantifiers: Array<{ name: string; type: string }>,
-  guards: IRExpr[],
+  guards: IRGuard[],
   body: IRStmt,
 ): IRStmt => ({ kind: "quantified-stmt", quantifiers, guards, body });
 

--- a/tools/ts2pant/src/ir1-lower.ts
+++ b/tools/ts2pant/src/ir1-lower.ts
@@ -24,12 +24,15 @@
 
 import {
   type IRExpr,
+  type IRGuard,
   type IRStmt,
   irAppExpr,
   irAppName,
   irBinop,
   irCombTyped,
   irCond,
+  irGuardExpr,
+  irGuardIn,
   irLitBool,
   irStmtSeq,
   irStmtWrite,
@@ -236,13 +239,15 @@ export function lowerL1Stmt(s: IR1Stmt): IRStmt[] {
 // ---------------------------------------------------------------------------
 
 function lowerL1Foreach(s: Extract<IR1Stmt, { kind: "foreach" }>): IRStmt[] {
-  const inGuard = irBinop("in", irVar(s.binder), lowerL1Expr(s.source));
+  // The iteration source becomes a binder-introducing `gIn` guard,
+  // matching legacy emission `all x in src | …` (no typed quantifier
+  // on x — Pantagruel infers x's type from the source).
+  const guards: IRGuard[] = [irGuardIn(s.binder, lowerL1Expr(s.source))];
   // Strip a single-armed guard cond-stmt at the top of the body
   // (Shape A with guard). Multi-armed cond inside a foreach is
   // structurally suspicious — reject for now (workstream open
   // question).
   let body = s.body;
-  const extraGuards: IRExpr[] = [inGuard];
   if (body.kind === "cond-stmt") {
     if (body.arms.length !== 1 || body.otherwise !== null) {
       throw new Error(
@@ -252,15 +257,13 @@ function lowerL1Foreach(s: Extract<IR1Stmt, { kind: "foreach" }>): IRStmt[] {
       );
     }
     const [g, innerBody] = body.arms[0]!;
-    extraGuards.push(lowerL1Expr(g));
+    guards.push(irGuardExpr(lowerL1Expr(g)));
     body = innerBody;
   }
   // Body must be either a single member-target assign or a block of
   // such assigns.
   validateShapeABody(body);
   const loweredBody = lowerL1Stmt(body);
-  // Wrap the (possibly multi-statement) body in a `seq` if needed,
-  // then wrap that in `quantified-stmt`.
   const innerStmt: IRStmt =
     loweredBody.length === 1
       ? loweredBody[0]!
@@ -268,8 +271,11 @@ function lowerL1Foreach(s: Extract<IR1Stmt, { kind: "foreach" }>): IRStmt[] {
   return [
     {
       kind: "quantified-stmt",
-      quantifiers: [{ name: s.binder, type: s.binderType }],
-      guards: extraGuards,
+      // Empty quantifiers: the binder enters scope through the gIn
+      // guard, not through a typed quantifier. Matches legacy
+      // emission shape exactly.
+      quantifiers: [],
+      guards,
       body: innerStmt,
     },
   ];

--- a/tools/ts2pant/tests/ir-emit-stmt.test.mts
+++ b/tools/ts2pant/tests/ir-emit-stmt.test.mts
@@ -4,6 +4,7 @@ import {
   type IRStmt,
   type IRWriteTarget,
   irBinop,
+  irGuardIn,
   irLitNat,
   irLitString,
   irStmtAssert,
@@ -630,7 +631,7 @@ describe("emitStmt — quantified-stmt envelope (Shape A target)", () => {
     const body = irStmtWrite(target, irBinop("eq", irLitNat(1), irLitNat(1))); // dummy expr
     const wrapped = irStmtQuantified(
       [{ name: "x", type: "User" }],
-      [irBinop("in", irVar("x"), irVar("users"))],
+      [irGuardIn("x", irVar("users"))],
       body,
     );
     const result = emitStmt(wrapped, ctx());
@@ -651,7 +652,7 @@ describe("emitStmt — quantified-stmt envelope (Shape A target)", () => {
     };
     const wrapped = irStmtQuantified(
       [{ name: "x", type: "User" }],
-      [irBinop("in", irVar("x"), irVar("users"))],
+      [irGuardIn("x", irVar("users"))],
       irStmtWrite(target, irLitString("on")),
     );
     const result = emitStmt(wrapped, ctx());
@@ -680,12 +681,12 @@ describe("emitStmt — quantified-stmt envelope (Shape A target)", () => {
     };
     const inner = irStmtQuantified(
       [{ name: "y", type: "Item" }],
-      [irBinop("in", irVar("y"), irVar("items"))],
+      [irGuardIn("y", irVar("items"))],
       irStmtWrite(target, irLitNat(1)),
     );
     const outer = irStmtQuantified(
       [{ name: "x", type: "User" }],
-      [irBinop("in", irVar("x"), irVar("users"))],
+      [irGuardIn("x", irVar("users"))],
       inner,
     );
     const result = emitStmt(outer, ctx());
@@ -711,7 +712,7 @@ describe("emitStmt — quantified-stmt envelope (Shape A target)", () => {
     };
     const wrapped = irStmtQuantified(
       [{ name: "x", type: "T" }],
-      [irBinop("in", irVar("x"), irVar("xs"))],
+      [irGuardIn("x", irVar("xs"))],
       irStmtSeq([irStmtWrite(tA, irLitNat(1)), irStmtWrite(tB, irLitNat(2))]),
     );
     const result = emitStmt(wrapped, ctx());
@@ -737,7 +738,7 @@ describe("emitStmt — quantified-stmt envelope (Shape A target)", () => {
     };
     const wrapped = irStmtQuantified(
       [{ name: "x", type: "Card" }],
-      [irBinop("in", irVar("x"), irVar("cards"))],
+      [irGuardIn("x", irVar("cards"))],
       irStmtWrite(target, null),
     );
     const result = emitStmt(wrapped, ctx());

--- a/tools/ts2pant/tests/ir1-lower.test.mts
+++ b/tools/ts2pant/tests/ir1-lower.test.mts
@@ -554,10 +554,10 @@ describe("lowerL1Foreach — Shape A (M3 Patch 5)", () => {
     const q = stmts[0]!;
     assert.equal(q.kind, "quantified-stmt");
     if (q.kind === "quantified-stmt") {
-      assert.equal(q.quantifiers.length, 1);
-      assert.equal(q.quantifiers[0]!.name, "x");
-      assert.equal(q.quantifiers[0]!.type, "User");
-      assert.equal(q.guards.length, 1); // in(x, users)
+      // Empty quantifiers — binder enters scope through gIn guard.
+      assert.equal(q.quantifiers.length, 0);
+      assert.equal(q.guards.length, 1);
+      assert.equal(q.guards[0]!.kind, "in");
     }
     const result = emitStmt(stmts, { allocBinder: makeAlloc() });
     assert.equal(result.equations.length, 1);
@@ -571,7 +571,7 @@ describe("lowerL1Foreach — Shape A (M3 Patch 5)", () => {
           ast.binop(ast.opEq(), eq.lhs, eq.rhs),
         ),
       ),
-      "all x: User, x in users | active' x = true",
+      "all x in users | active' x = true",
     );
   });
 

--- a/workstreams/m3-cutover-analysis.md
+++ b/workstreams/m3-cutover-analysis.md
@@ -1,0 +1,120 @@
+# M3 Cutover — Analysis & Blocker
+
+## Summary
+
+I branched off `zax--ts2pant-m3-iteration-mutation` to perform the
+deferred cutover work but hit an architectural blocker in the very first
+case I attempted (for-of Shape A, the simplest cutover candidate).
+Documenting it here so the next session can pick up cleanly.
+
+## What needed to land
+
+Per the M3 PR (#134) description, the deferred work is:
+1. L1 build pass: `buildL1ForOf`, `buildL1ForEachCall`,
+   `buildL1ReduceCall`, `buildL1CondStmt` translating TS AST → L1
+   statements.
+2. Cutover: replace legacy `translateForOfLoop`,
+   `translateForEachStmt`, `translateReduceCall` and the
+   branched-mutation arm of `symbolicExecute` with the L1 path; delete
+   `mergeOverrides` / `combineCond` / `classifyLoopStmt` / etc.
+3. Shape B (accumulator fold) and Shape C (.reduce as expression)
+   recognition at the L1 build site.
+
+## The blocker: IR guard semantics for Shape A
+
+Legacy emits Shape A as a quantified equation with **no typed
+quantifier**, just a `gIn` (binder-introducing) guard:
+
+  ```
+  forall(
+    params=[],
+    guards=[gIn(iterName, arrExpr)],
+    body=<equation>,
+  )
+  ```
+
+This prints as `all x in arr | p' x = e.`
+
+My Patch 5 `lowerL1Foreach` produces a `quantified-stmt([{x, T}],
+[in(x, src)], …)` which lowers to **typed quantifier + gExpr guard**:
+
+  ```
+  forall(
+    params=[param(x, T)],
+    guards=[gExpr(in(x, src))],
+    body=<equation>,
+  )
+  ```
+
+This prints as `all x: T, x in src | p' x = e.` — a **superfluous type
+annotation** vs the legacy form. The discrepancy is because:
+
+1. `IREquation.guards` is `IRExpr[]`, lowered uniformly via `gExpr`.
+2. There is no IR-level representation of `gIn` (the binder-introducing
+   guard form Pantagruel uses for `x in src` quantification).
+3. To match legacy output, the L1 → L2 lowering would need to either:
+   - Add an IR guard ADT distinguishing `gExpr`-style from
+     `gIn`-style guards, OR
+   - Emit the equation by constructing OpaqueExpr quantifier+guard
+     directly (bypassing IR for this specific case), OR
+   - Accept the regression (typed quantifier appears in every iteration
+     fixture's output)
+
+## Why it matters
+
+`pant --check` *probably* accepts both forms equivalently — Pantagruel
+infers types from the iteration source. But the snapshot regression
+would touch every iteration fixture (~10 files) and produce a noisier
+output. Given snapshot policy says regressions are acceptable for
+cleaner output, this regression is *uglier*, not cleaner.
+
+The right architectural fix is option 1: extend the IR guard
+representation. That's a structural change to `IREquation` and
+`lowerEquation` that should land before the cutover, otherwise every
+iteration use-site bakes in the suboptimal output shape.
+
+## Proposed path forward
+
+1. **Patch CO-0**: Extend IR guard types — add an `IRGuard` ADT (or
+   tagged union of IRExpr + gIn-style) and update `IREquation.guards` /
+   `IRAssertExit.guards` / `lowerEquation` / `lowerAssert`. Update
+   Patch 5's `lowerL1Foreach` to emit `gIn`-style guards. Snapshot test
+   verifies output matches legacy `all x in src | ...`.
+
+2. **Patch CO-1**: Cutover `translateForOfLoop` Shape A bodies to
+   `buildL1ForOfShapeA` → `lowerL1Stmt` → `emitStmt`. Delete
+   Shape A logic from `classifyLoopStmt`/`translateForOfLoopBody`.
+
+3. **Patch CO-2**: Cutover `translateForEachStmt` similarly.
+
+4. **Patch CO-3**: Implement Shape B build pass + cutover. Shape B
+   produces `write{property-field}` with a `comb`-RHS, not a quantified
+   envelope, so the IR guard issue doesn't apply.
+
+5. **Patch CO-4**: Cutover `translateReduceCall`. Shape C is
+   expression-position — produces L2 `comb`, no IR guard issue.
+
+6. **Patch CO-5**: Cutover branched-mutation arm of `symbolicExecute`.
+   Requires `buildL1IfMutation` covering all mutation kinds (property,
+   Map, Set) inside branches. The state-merge integration is the
+   subtle piece — `emitStmt` finalizes equations immediately, which
+   means a later if-statement on the same write-key would conflict.
+   Solution: thread the merged WriteAccs back into outer
+   `state.writes` rather than finalizing inside emitStmt. Requires a
+   "merge-only, don't finalize" entry point on emitStmt.
+
+7. **Patch CO-6**: Cleanup — delete `classifyLoopStmt`,
+   `translateForOfLoopBody`, `translateForOfLoop`,
+   `translateForEachStmt`, `translateReduceCall`, `mergeOverrides`,
+   `combineCond`, `ShapeBLeaf`, `COMPOUND_ASSIGN_TO_FOLD`, etc.
+
+## Recommendation
+
+The cutover is structurally sound and the M3 plumbing PR (#134)
+provides the foundation. The IR guard fix (Patch CO-0) is the
+prerequisite — it's a small focused patch (~50 lines) that resolves
+the output-shape mismatch.
+
+I haven't attempted CO-0 in this session because the analysis was
+already substantial; doing the architectural fix correctly deserves
+its own focused effort with proper test coverage.


### PR DESCRIPTION
## Summary

Branched off the M3 plumbing PR (#134) to perform the deferred cutover work. Rather than dive directly into legacy-deletion patches, this PR lands the architectural prerequisite identified during cutover analysis, plus the analysis document that proposes the remaining 6-patch sequence.

## What lands

### Patch CO-0 — IR guard ADT (`587cc04`)

Pantagruel distinguishes two guard flavors structurally:
- **`gExpr`** — predicate guards (binder must already be in scope)
- **`gIn`** — binder-introducing guards (`x in src` style; binder enters scope through the source collection)

The IR layer prior to this PR represented guards uniformly as `IRExpr[]` lowered via `gExpr`, so `lowerL1Foreach` (Patch 5) emitted Shape A as `all x: T, x in src | …` (typed quantifier + gExpr guard). Legacy emits `all x in src | …` (empty quantifier + gIn guard). Without this fix, every iteration cutover would bake the noisier output into snapshots.

Changes:
- New `IRGuard` ADT in `ir.ts` — tagged union of `expr`-style and `in`-style.
- `IREquation.guards` / `IRAssertExit.guards` / `quantified-stmt.guards` change from `IRExpr[]` to `IRGuard[]`.
- `lowerEquation` / `lowerAssert` dispatch on guard kind.
- `lowerL1Foreach` updated to emit empty quantifiers + gIn guard for the iteration source. Now produces `all x in src | …` exactly matching legacy.
- Tests updated.

### Analysis doc (`5013b40`)

`workstreams/m3-cutover-analysis.md` proposes the 7-patch cutover sequence (CO-0 through CO-6):

1. **CO-0** (this PR) — IR guard ADT
2. **CO-1** — Cut over `translateForOfLoop` Shape A → L1 path
3. **CO-2** — Cut over `translateForEachStmt` Shape A
4. **CO-3** — Implement Shape B (accumulator fold) build pass + cutover
5. **CO-4** — Cut over `translateReduceCall` (Shape C, expression-position)
6. **CO-5** — Cut over branched-mutation arm of `symbolicExecute`. Requires `emitStmt` to expose a merge-only/don't-finalize entry point so cond-merged WriteAccs thread back into outer `state.writes` rather than producing pre-finalized equations. Subtle.
7. **CO-6** — Cleanup; delete `classifyLoopStmt`, `translateForOfLoopBody`, `translateForOfLoop`, `translateForEachStmt`, `translateReduceCall`, `mergeOverrides`, `combineCond`, `ShapeBLeaf`, `COMPOUND_ASSIGN_TO_FOLD`.

## Why split this way

The cutover work is structurally sound — the M3 plumbing PR (#134) gives all the L1/L2 infrastructure needed. But each cutover step carries snapshot-regression and state-merge integration risk. CO-0 is the only patch that's purely architectural / no-cutover, and it's a clear prerequisite: without it, every iteration cutover would change snapshot output unnecessarily. Landing CO-0 alone keeps the PR focused.

The remaining cutovers (CO-1 through CO-6) are best done as separate PRs each with its own snapshot review.

## Test plan

- [x] All 520 existing unit tests pass; precommit green.
- [x] `lowerL1Foreach` test updated to assert the new empty-quantifier emission shape (`all x in users | active' x = true`).
- [x] Existing `quantified-stmt` tests use `irGuardIn(...)` constructor, confirming the new ADT works for the canonical Shape A input shape.

## Stack

- Base: `zax--ts2pant-m3-iteration-mutation` (PR #134, M3 plumbing)
- This PR: `zax--ts2pant-m3-cutover` (CO-0)
- Follow-up: separate PR per CO-1 through CO-6 against this branch (or master once #134 merges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)