### PR TITLE
ts2pant: M3 R1 — drop NOT_IMPL throws on L1 statement constructors

### DIFF
--- a/tools/ts2pant/src/ir1.ts
+++ b/tools/ts2pant/src/ir1.ts
@@ -320,18 +320,15 @@ export const ir1Return = (expr: IR1Expr | null): IR1Stmt => ({
 });
 
 // --------------------------------------------------------------------------
-// Vocabulary-locked stubs (constructors throw until the milestone that
-// introduces them lands). Forms are declared in IR1Stmt at the type level
-// so consumers can pattern-match without runtime branch errors; the
-// constructors here surface premature use.
+// Statement constructors for forms beyond M1's active set.
+//
+// All constructors are now active; the consumer side (lowering or build
+// pipeline) is responsible for handling each form or rejecting with a
+// specific reason. Adding a constructor that builds a vocabulary-locked
+// IR1Stmt without a corresponding lowering arm is allowed during
+// staged work — the lowering throws on first use, surfacing the gap
+// rather than letting it silently miscompile.
 // --------------------------------------------------------------------------
-
-const NOT_IMPL = (form: string, milestone: string): never => {
-  throw new Error(
-    `IR1 form '${form}' is vocabulary-locked but not implemented until ${milestone}; ` +
-      `see workstreams/ts2pant-imperative-ir.md`,
-  );
-};
 
 /**
  * Assignment / read-modify-write. Canonical form for all increment and
@@ -352,25 +349,25 @@ export const ir1Assign = (target: IR1Expr, value: IR1Expr): IR1Stmt => ({
 });
 
 export const ir1CondStmt = (
-  _arms: readonly [
+  arms: readonly [
     readonly [IR1Expr, IR1Stmt],
     ...ReadonlyArray<readonly [IR1Expr, IR1Stmt]>,
   ],
-  _otherwise: IR1Stmt | null,
-): IR1Stmt => NOT_IMPL("cond-stmt", "M3 (iteration + mutation)");
+  otherwise: IR1Stmt | null,
+): IR1Stmt => ({ kind: "cond-stmt", arms, otherwise });
 
 export const ir1Foreach = (
-  _binder: string,
-  _source: IR1Expr,
-  _body: IR1Stmt,
-): IR1Stmt => NOT_IMPL("foreach", "M3 (iteration + mutation)");
+  binder: string,
+  source: IR1Expr,
+  body: IR1Stmt,
+): IR1Stmt => ({ kind: "foreach", binder, source, body });
 
 export const ir1For = (
-  _init: IR1Stmt | null,
-  _cond: IR1Expr | null,
-  _step: IR1Stmt | null,
-  _body: IR1Stmt,
-): IR1Stmt => NOT_IMPL("for", "M3 (iteration + mutation)");
+  init: IR1Stmt | null,
+  cond: IR1Expr | null,
+  step: IR1Stmt | null,
+  body: IR1Stmt,
+): IR1Stmt => ({ kind: "for", init, cond, step, body });
 
 /**
  * Bounded while loop. M2 activates this form to faithfully represent
@@ -387,8 +384,9 @@ export const ir1While = (cond: IR1Expr, body: IR1Stmt): IR1Stmt => ({
   body,
 });
 
-export const ir1Throw = (_expr: IR1Expr): IR1Stmt =>
-  NOT_IMPL("throw", "M3 (iteration + mutation)");
+export const ir1Throw = (expr: IR1Expr): IR1Stmt => ({ kind: "throw", expr });
 
-export const ir1ExprStmt = (_expr: IR1Expr): IR1Stmt =>
-  NOT_IMPL("expr-stmt", "M3 (iteration + mutation)");
+export const ir1ExprStmt = (expr: IR1Expr): IR1Stmt => ({
+  kind: "expr-stmt",
+  expr,
+});

--- a/tools/ts2pant/tests/ir1-lower.test.mts
+++ b/tools/ts2pant/tests/ir1-lower.test.mts
@@ -316,34 +316,42 @@ describe("M2: ir1Assign and ir1While constructors are active", () => {
   });
 });
 
-describe("vocabulary-locked stubs (M3 forms)", () => {
-  it("ir1CondStmt throws not-implemented (M3)", () => {
-    assert.throws(
-      () => ir1CondStmt([[ir1Var("g"), ir1Return(ir1Var("v"))]], null),
-      /M3/,
+describe("M3 statement constructors are active (no longer NOT_IMPL)", () => {
+  // Constructors return IR1Stmt values of the appropriate kind.
+  // Lowering for these forms is provided by the new `lowerL1Body` fold
+  // (Patch R2) that operates on L1 statements. Until R2 lands,
+  // `lowerL1Stmt` (the M1/M2 expression-only entry point) still throws
+  // — the new fold has its own entry point.
+
+  it("ir1CondStmt builds a cond-stmt", () => {
+    const stmt = ir1CondStmt(
+      [[ir1Var("g"), ir1Return(ir1Var("v"))]],
+      null,
     );
+    assert.equal(stmt.kind, "cond-stmt");
   });
 
-  it("ir1Foreach throws not-implemented (M3)", () => {
-    assert.throws(
-      () => ir1Foreach("x", ir1Var("xs"), ir1Return(ir1Var("x"))),
-      /M3/,
-    );
+  it("ir1Foreach builds a foreach", () => {
+    const stmt = ir1Foreach("x", ir1Var("xs"), ir1Return(ir1Var("x")));
+    assert.equal(stmt.kind, "foreach");
   });
 
-  it("ir1For throws not-implemented (M3)", () => {
-    assert.throws(() => ir1For(null, null, null, ir1Return(null)), /M3/);
+  it("ir1For builds a for", () => {
+    const stmt = ir1For(null, null, null, ir1Return(null));
+    assert.equal(stmt.kind, "for");
   });
 
-  it("ir1Throw throws not-implemented (M3)", () => {
-    assert.throws(() => ir1Throw(ir1Var("err")), /M3/);
+  it("ir1Throw builds a throw", () => {
+    const stmt = ir1Throw(ir1Var("err"));
+    assert.equal(stmt.kind, "throw");
   });
 
-  it("ir1ExprStmt throws not-implemented (M3)", () => {
-    assert.throws(() => ir1ExprStmt(ir1Var("e")), /M3/);
+  it("ir1ExprStmt builds an expr-stmt", () => {
+    const stmt = ir1ExprStmt(ir1Var("e"));
+    assert.equal(stmt.kind, "expr-stmt");
   });
 
-  it("lowerL1Stmt throws — statement lowering is M3", () => {
+  it("lowerL1Stmt — statement lowering still throws (replaced by lowerL1Body)", () => {
     const stmt = ir1Return(ir1Var("x"));
     assert.throws(() => lowerL1Stmt(stmt), /M3/);
   });


### PR DESCRIPTION
## Summary

First commit of the M3 reset (after closing #134 and #135 — see those PRs' close comments for the architecture-mistake diagnosis).

This PR salvages the **only** piece worth saving from the closed PRs: dropping the NOT_IMPL throws on the L1 statement constructors so they actually build IR1Stmt values. Everything else from #134/#135 (the L2 IRStmt vocabulary, `emitStmt` machinery, IRGuard ADT, `lowerL1Stmt` for non-iteration kinds, `lowerL1Foreach`, all related tests) is discarded. The reset starts fresh from master.

## What lands

- `ir1.ts`: `ir1CondStmt`, `ir1Foreach`, `ir1For`, `ir1Throw`, `ir1ExprStmt` constructors return `IR1Stmt` values of the appropriate kind instead of throwing. `NOT_IMPL` helper deleted.
- `tests/ir1-lower.test.mts`: M3 vocabulary-locked-stub tests replaced with structural sanity checks (each constructor produces an IR1Stmt of the expected kind). The `lowerL1Stmt throws — M3` test stays since `lowerL1Stmt` (the M1/M2 expression-only entry point) doesn't yet handle these kinds.
- All 476 existing unit tests pass.

No production behavior change.

## Plan for follow-ups

The full reset plan is at `~/.claude/plans/plan-it-snug-tulip.md`. Architecture summary:

> **One IR (L1), one fold (`lowerL1Body`), no L2 statement vocabulary.** The fold operates on canonicalized L1 statements and threads the existing legacy `SymbolicState` from `translate-body.ts`, identical in shape to `symbolicExecute` but operating on canonicalized L1 input rather than raw TS AST. The benefit of L1 over TS AST is canonicalization — `if`-with-mutation, `for-of`, `forEach`, increment spellings, etc. all collapse to one L1 shape so the fold has one case per construct, not many. **Mutation primitives (`installMapWrite` / `installSetWrite` / `mergeOverrides` / etc.) are reused as-is** — they're the existing legacy infrastructure, just dispatched from L1 instead of TS AST.

Follow-up PRs against this branch (or master once this merges):

- **R2**: `lowerL1Body` — single fold over L1 statements that reuses legacy mutation primitives. No production callers yet.
- **R3**: `buildL1Body` — TS AST → L1 statements. Recognizes if-with-mutation, for-of, forEach, property assigns, Map/Set effect calls.
- **R4**: Cutover — replace `symbolicExecute`'s if/for-of/forEach arms with `buildL1Body` + `lowerL1Body`. Delete `classifyLoopStmt`, `translateForOfLoopBody`, `translateForOfLoop`, `translateForEachStmt`. Snapshots regenerate.
- **R5**: Shape B (accumulator fold) + `.reduce` (Shape C, expression-position).
- **R6**: Cleanup + docs.

## Why the reset

PR #134 built a parallel L2 IRStmt vocabulary (`write`/`let-if`/`seq`/`quantified-stmt`/`assert`) and `emitStmt` machinery that mirrored legacy `symbolicExecute` one layer up. The `WriteAcc` types were renamed copies of `WriteEntry`; `processLetIf` was a port of `mergeOverrides`/`combineCond`. Same fold, two passes instead of one — zero abstraction value. Every architectural blocker we hit (IR guard distinction in #135, finalize-vs-merge timing) came from trying to make the parallel IR match legacy emission exactly.

User (2026-04-26): "We have no users; if we need to fundamentally restructure things in order to create a sustainable and well-ordered architecture, we can [do] that."

The right architecture is the single fold described above. The closed PRs documented the journey but the destination is wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)