### PR TITLE
[ts2pant-m4-equality-nullish] Patch 1: Add L1 IsNullish form and mechanical lowering

### DIFF
--- a/tools/ts2pant/src/ir1-lower.ts
+++ b/tools/ts2pant/src/ir1-lower.ts
@@ -31,6 +31,7 @@ import {
   irCombTyped,
   irCond,
   irLitBool,
+  irLitNat,
   irUnop,
   irVar,
   irWrap,
@@ -90,6 +91,11 @@ export function lowerL1Expr(e: IR1Expr): IRExpr {
       armPairs.push([irLitBool(true), lowerL1Expr(e.otherwise)]);
       return irCond(armPairs);
     }
+
+    case "is-nullish":
+      // Mechanical lowering under list-lift: `T | null` → `[T]`, so
+      // "is nullish" is "list is empty", i.e. `#operand = 0`.
+      return irBinop("eq", irUnop("card", lowerL1Expr(e.operand)), irLitNat(0));
 
     case "from-l2":
       return e.expr;

--- a/tools/ts2pant/src/ir1.ts
+++ b/tools/ts2pant/src/ir1.ts
@@ -16,13 +16,13 @@
  * pure expressions).
  *
  * **Vocabulary lock at M1.** The forms declared here are the locked Layer
- * 1 vocabulary. Forms can be *added* in later milestones (e.g.,
- * `IsNullish` primitive at M4) but the existing forms cannot be changed.
- * Forms not yet active (`foreach`, `for`, `throw`, `expr-stmt`,
- * statement-position `cond-stmt`) are declared at the type level; their
- * constructors throw `not-implemented` until the milestone that
- * introduces them lands. M1 activated `block`, `let`, `return`, and
- * expression-position `cond`; M2 adds `assign` and `while`.
+ * 1 vocabulary. Forms can be *added* in later milestones — the
+ * `is-nullish` primitive landed at M4 — but existing forms cannot be
+ * changed. Forms not yet active (`foreach`, `for`, `throw`,
+ * `expr-stmt`, statement-position `cond-stmt`) are declared at the type
+ * level; their constructors throw `not-implemented` until the milestone
+ * that introduces them lands. M1 activated `block`, `let`, `return`,
+ * and expression-position `cond`; M2 adds `assign` and `while`.
  *
  * **No `IR1Wrap` form.** Layer 1 is *not* an escape-hatch layer — the
  * build pass either produces L1 or rejects with `unsupported`. An L1
@@ -58,7 +58,7 @@ export type IR1Unop = IRUnop;
 // --------------------------------------------------------------------------
 
 /**
- * Layer 1 expressions. Seven forms preserve TS-shape canonicalization:
+ * Layer 1 expressions. Eight forms preserve TS-shape canonicalization:
  *
  * - `var`, `lit` — literal references
  * - `binop`, `unop` — arithmetic/logical/comparison operators
@@ -69,6 +69,10 @@ export type IR1Unop = IRUnop;
  * - `cond` — multi-arm value-position conditional (M1 canonical form for
  *   if-with-returns, ternary chains, switch w/o fall-through, &&/||
  *   when Bool-typed)
+ * - `is-nullish` — canonical Bool null/undefined test (M4 canonical form
+ *   for `x == null`, `x === null`, `x === undefined`, the long
+ *   `||`-form, and `typeof x === "undefined"`). Lowers to the
+ *   cardinality-zero shape `#x = 0` under list-lift.
  *
  * Plus one transitional form:
  *
@@ -104,6 +108,16 @@ export type IR1Expr =
       arms: ReadonlyArray<readonly [IR1Expr, IR1Expr]>;
       otherwise: IR1Expr;
     }
+  /**
+   * Canonical Bool test for null/undefined. Lowers mechanically to the
+   * cardinality-zero shape `#x = 0`, which is the same shape `??` and
+   * `?.` already use under the list-lift encoding (`T | null` → `[T]`).
+   * `operand` is an arbitrary L1 expression — receiver chains
+   * (`obj.prop`) and other non-`Var` shapes are accepted; the build pass
+   * is responsible for verifying operand-identity in long-form
+   * recognition (`x === null || x === undefined`).
+   */
+  | { kind: "is-nullish"; operand: IR1Expr }
   /**
    * Transitional delegation to a pre-built Layer 2 IRExpr. Used for
    * sub-expressions whose internal structure is outside the current
@@ -415,6 +429,20 @@ export const ir1Cond = (
   ],
   otherwise: IR1Expr,
 ): IR1Expr => ({ kind: "cond", arms, otherwise });
+
+/**
+ * Canonical L1 nullish test. The M4 build pass routes all nullish
+ * surface forms (`x == null`, `x === null`, `x === undefined`, the
+ * long `||`-form, and `typeof x === "undefined"`) through this
+ * constructor; negated forms wrap as `unop("not", isNullish(x))`.
+ * Lowers mechanically to `#x = 0` (cardinality-zero under list-lift),
+ * the same shape `??` and `?.` already use. Operand may be any L1
+ * expression — receiver chains and other non-`Var` shapes are accepted.
+ */
+export const ir1IsNullish = (operand: IR1Expr): IR1Expr => ({
+  kind: "is-nullish",
+  operand,
+});
 
 /**
  * Transitional delegation to a pre-built Layer 2 IRExpr. Use only inside

--- a/tools/ts2pant/tests/ir1-lower.test.mts
+++ b/tools/ts2pant/tests/ir1-lower.test.mts
@@ -22,6 +22,7 @@ import {
   ir1For,
   ir1Foreach,
   ir1FromL2,
+  ir1IsNullish,
   ir1Let,
   ir1LitBool,
   ir1LitNat,
@@ -196,6 +197,46 @@ describe("lowerL1Expr — cond (byte-equality with legacy ast.cond)", () => {
         [irLitBool(true), irVar("z", false)],
       ]),
     );
+  });
+});
+
+describe("lowerL1Expr — is-nullish (M4 canonical nullish test)", () => {
+  it("IsNullish lowers to binop(eq, unop(card, x), litNat(0))", () => {
+    const l1 = ir1IsNullish(ir1Var("x"));
+    const l2 = lowerL1Expr(l1);
+    assert.deepEqual(
+      l2,
+      irBinop("eq", irUnop("card", irVar("x", false)), irLitNat(0)),
+    );
+  });
+
+  it("IsNullish operand can be a member expression", () => {
+    // is-nullish(receiver.prop)
+    const l1 = ir1IsNullish(ir1Member(ir1Var("receiver"), "prop"));
+    const l2 = lowerL1Expr(l1);
+    assert.deepEqual(
+      l2,
+      irBinop(
+        "eq",
+        irUnop("card", irAppName("prop", [irVar("receiver", false)])),
+        irLitNat(0),
+      ),
+    );
+  });
+
+  it("IsNullish lowered shape matches manual ast.binop construction", () => {
+    const ast = getAst();
+
+    // Manual: ast.binop(opEq, unop(opCard, var "x"), litNat 0)
+    const manual = ast.binop(
+      ast.opEq(),
+      ast.unop(ast.opCard(), ast.var("x")),
+      ast.litNat(0),
+    );
+
+    const l1Lowered = lowerExpr(lowerL1Expr(ir1IsNullish(ir1Var("x"))));
+
+    assert.equal(ast.strExpr(l1Lowered), ast.strExpr(manual));
   });
 });
 


### PR DESCRIPTION
## Patch 1: Add L1 IsNullish form and mechanical lowering

- Extend `IR1Expr` union in `src/ir1.ts` with `| { kind: "is-nullish"; operand: IR1Expr }`
- Add `export const ir1IsNullish = (operand: IR1Expr): IR1Expr => ({ kind: "is-nullish", operand });` near other expression constructors (around line 396)
- Update the IR1Expr jsdoc block (lines 60-78) to list `is-nullish` and remove the 'M4' future-tense note from line 20
- In `src/ir1-lower.ts:46-103` `lowerL1Expr`, add `case "is-nullish": return irBinop("eq", irUnop("card", lowerL1Expr(e.operand)), { kind: "lit", value: { kind: "nat", value: 0 } });` (use `irLitNat` if exported; otherwise the inline literal shape)
- Verify the existing exhaustiveness `_exhaustive: never = e` check at the bottom of `lowerL1Expr` still holds with the new variant
- Add tests in `tests/ir1-lower.test.mts`: (a) `lowerL1Expr(ir1IsNullish(ir1Var("x")))` returns an L2 binop with op="eq", lhs is a unop("card", var("x")), rhs is litNat(0); (b) lowering composes — `is-nullish(member(receiver, "prop"))` works; (c) emit-to-OpaqueExpr produces the same shape as a manually-constructed `ast.binop(ast.opEq(), ast.unop(ast.opCard(), ast.var("x")), ast.litNat(0))`
- Run `just ts2pant-test-unit` — should pass without touching translate-body.ts

## Changes
- Extend `IR1Expr` union in `src/ir1.ts` with `| { kind: "is-nullish"; operand: IR1Expr }`
- Add `export const ir1IsNullish = (operand: IR1Expr): IR1Expr => ({ kind: "is-nullish", operand });` near other expression constructors (around line 396)
- Update the IR1Expr jsdoc block (lines 60-78) to list `is-nullish` and remove the 'M4' future-tense note from line 20
- In `src/ir1-lower.ts:46-103` `lowerL1Expr`, add `case "is-nullish": return irBinop("eq", irUnop("card", lowerL1Expr(e.operand)), { kind: "lit", value: { kind: "nat", value: 0 } });` (use `irLitNat` if exported; otherwise the inline literal shape)
- Verify the existing exhaustiveness `_exhaustive: never = e` check at the bottom of `lowerL1Expr` still holds with the new variant
- Add tests in `tests/ir1-lower.test.mts`: (a) `lowerL1Expr(ir1IsNullish(ir1Var("x")))` returns an L2 binop with op="eq", lhs is a unop("card", var("x")), rhs is litNat(0); (b) lowering composes — `is-nullish(member(receiver, "prop"))` works; (c) emit-to-OpaqueExpr produces the same shape as a manually-constructed `ast.binop(ast.opEq(), ast.unop(ast.opCard(), ast.var("x")), ast.litNat(0))`
- Run `just ts2pant-test-unit` — should pass without touching translate-body.ts

## Files to Modify
- tools/ts2pant/src/ir1.ts (modify): Add `is-nullish` variant to `IR1Expr` union; add constructor `ir1IsNullish`; update jsdoc to remove the 'M4' future-tense annotation
- tools/ts2pant/src/ir1-lower.ts (modify): Add `is-nullish` case to `lowerL1Expr` switch: lower to `irBinop("eq", irUnop("card", lowerL1Expr(operand)), irLitNat(0))`
- tools/ts2pant/tests/ir1-lower.test.mts (modify): Add lowering tests for `is-nullish`: assert structural shape of lowered L2 IR and OpaqueExpr

## Gameplan Specification

```
module TS2PANT_M4.

> ════════════════════════════════════════════════════════════
> M4: equality and nullish normalization
> ════════════════════════════════════════════════════════════
>
> After M4, every TS-AST expression in the equality/nullish
> equivalence class flows through Layer 1. The class is
> normalized into three canonical paths plus an unconditional
> rejection on surviving loose equality:
>
>   - `IsNullish(x)` — the canonical Bool null/undefined test.
>     Recognized from x==null, x===null, x===undefined, the
>     ||-long form, and typeof-undefined. Negated forms wrap as
>     `not(IsNullish(x))`.
>   - `BinOp(eq | neq, lhs, rhs)` — canonical equality, only
>     produced from `===` / `!==`.
>   - Functor-lift `each $n in x | f $n` — the canonical lowering
>     for null-guarded list-lifted conditionals. Pant has no list
>     literal, so cardinality-dispatch is not a viable alternative;
>     this path makes idiomatic null-guard-then-list-return TS
>     functions translate.
>   - Any `==` / `!=` not consumed by the nullish recognizer is
>     rejected. ts2pant steers the programmer toward `===`/`!==`
>     rather than guess loose-equality intent.

TSExpr.
TSType.
L1Expr.
L2Expr.
OpaqueExpr.

> ─── L1 form predicates ───────────────────────────────────────

is-nullish? e: L1Expr => Bool.
is-not? e: L1Expr => Bool.
is-binop-eq? e: L1Expr => Bool.
is-binop-neq? e: L1Expr => Bool.
is-each? e: L1Expr => Bool.
is-cond? e: L1Expr => Bool.

operand e: L1Expr, is-nullish? e => L1Expr.
inner e: L1Expr, is-not? e => L1Expr.

> ─── TS-side classification ───────────────────────────────────

is-positive-nullish? t: TSExpr => Bool.
is-negative-nullish? t: TSExpr => Bool.
is-strict-eq? t: TSExpr => Bool.
is-strict-neq? t: TSExpr => Bool.
is-loose-eq? t: TSExpr => Bool.
is-loose-neq? t: TSExpr => Bool.

is-conditional? t: TSExpr => Bool.
functor-lift-eligible? t: TSExpr, is-conditional? t => Bool.

> ─── Build / lower pipeline ───────────────────────────────────

build-l1 t: TSExpr => L1Expr.
lower-l1 e: L1Expr => L2Expr.
emit l: L2Expr => OpaqueExpr.
unsupported? e: L1Expr => Bool.

> ─── L2 / OpaqueExpr shape predicate ─────────────────────────

card-zero? l: L2Expr => Bool.

---

> ─── Canonical form: every nullish surface form maps to one
>     L1 IsNullish (or its negation). ───────────────────────────

all t: TSExpr, is-positive-nullish? t |
  is-nullish? (build-l1 t).

all t: TSExpr, is-negative-nullish? t |
  is-not? (build-l1 t)
  and is-nullish? (inner (build-l1 t)).

> ─── Lowering: IsNullish becomes the cardinality-zero shape. ──

all e: L1Expr, is-nullish? e | card-zero? (lower-l1 e).

> ─── Strict equality canonicalizes unconditionally. ──────────

all t: TSExpr, is-strict-eq? t | is-binop-eq? (build-l1 t).
all t: TSExpr, is-strict-neq? t | is-binop-neq? (build-l1 t).

> ─── Surviving loose equality is rejected unconditionally.
>     The nullish family is consumed before this rule fires. ───

all t: TSExpr, is-loose-eq? t | unsupported? (build-l1 t).
all t: TSExpr, is-loose-neq? t | unsupported? (build-l1 t).

> ─── Functor-lift recognizer: eligible conditionals lower to
>     `each`; ineligible conditionals fall through to L1 Cond
>     (which then rejects at the no-list-literal wall). ────────

all t: TSExpr, is-conditional? t, functor-lift-eligible? t |
  is-each? (build-l1 t).

all t: TSExpr, is-conditional? t, ~ functor-lift-eligible? t |
  is-cond? (build-l1 t).

```

## Patch Specification

```
module TS2PANT_M4_PATCH_1.

> Patch 1 adds the L1 `IsNullish` expression form and its mechanical
> lowering to L2.
>
> The vocabulary lock is preserved: forms can be added in later
> milestones (this is what M1 promised at workstream commit time).

L1Expr.
L2Expr.

is-nullish? e: L1Expr => Bool.
operand e: L1Expr, is-nullish? e => L1Expr.

lower-l1 e: L1Expr => L2Expr.

> An L2 cardinality-zero test: shape `#x = 0`.
card-zero? l: L2Expr => Bool.

---

> Lowering of an IsNullish form yields the cardinality-zero shape.
> Downstream emitters never see the IsNullish form directly — only its
> lowered card-zero shape.
all e: L1Expr, is-nullish? e | card-zero? (lower-l1 e).

```


## Implementation Notes

- Used the exported `irLitNat` constructor (already in `ir.ts`) rather than the inline literal shape — the plan listed the inline shape as a fallback only.
- The exhaustiveness `_exhaustive: never = e` check at the bottom of `lowerL1Expr` continues to hold: TypeScript narrows the new `is-nullish` variant to `never` after its case clause, same as the other arms.
- Jsdoc updates went a little further than "remove M4 future-tense": the `IR1Expr` block now lists eight forms (was seven) and the constructor docstring describes the M4 build-pass routing so the form's purpose is discoverable from the constructor itself. The module-level vocabulary-lock paragraph was also rephrased to record `is-nullish` as a landed addition (not a future one), keeping the lock-with-allowed-additions narrative coherent.
- Pre-commit hook surfaced one biome `useConsistentMethodSignatures` warning at `ir1-lower.ts:214` (`allocateBinder(hint): string` on `MuSearchLowerCtx`) — that's pre-existing code untouched by this patch; the hook reports it as a non-blocking warning and the commit landed clean.
- All 503 unit tests pass, including the three new `lowerL1Expr — is-nullish` cases.