### PR TITLE
[ts2pant-m4-equality-nullish] Patch 3: Canonicalize strict equality; reject all surviving loose-eq

### DIFF
--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -36,6 +36,7 @@ import {
   isAssertionCall,
   isFollowableGuardCall,
   isPureExpression,
+  isTranslateExprUnsupported,
   shortParamName,
   translateExpr,
   translateOperator,
@@ -2939,15 +2940,17 @@ export function translateBodyExpr(
 
   // Fall through to base translateExpr for identifiers, literals, this, etc.
   if (ts.isExpression(expr)) {
-    return {
-      expr: translateExpr(
-        expr,
-        checker,
-        strategy,
-        paramNames,
-        supply.synthCell,
-      ),
-    };
+    const result = translateExpr(
+      expr,
+      checker,
+      strategy,
+      paramNames,
+      supply.synthCell,
+    );
+    if (isTranslateExprUnsupported(result)) {
+      return { unsupported: result.unsupported };
+    }
+    return { expr: result };
   }
 
   return { unsupported: "non-expression statement" };

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -3,7 +3,7 @@ import ts from "typescript";
 import { type IRExpr, irLet, irWrap } from "./ir.js";
 import { buildIR, isBuildUnsupported } from "./ir-build.js";
 import { lowerExpr } from "./ir-emit.js";
-import { type IR1Expr, ir1FromL2 } from "./ir1.js";
+import { type IR1Expr, ir1Binop, ir1FromL2 } from "./ir1.js";
 import {
   buildL1Conditional,
   buildL1ConditionalFromArms,
@@ -2855,6 +2855,56 @@ export function translateBodyExpr(
           [ast.litBool(true), presentBranch],
         ]),
       };
+    }
+    // M4 P3: reject loose equality unconditionally. Patch 2's nullish
+    // recognizer consumes `x == null` / `x != null` family before we
+    // reach this point; everything else is `==`/`!=` whose intent is
+    // ambiguous between value-equality and JS coercion semantics — we
+    // steer the programmer toward `===`/`!==` rather than guess.
+    if (
+      expr.operatorToken.kind === ts.SyntaxKind.EqualsEqualsToken ||
+      expr.operatorToken.kind === ts.SyntaxKind.ExclamationEqualsToken
+    ) {
+      return {
+        unsupported: "loose equality (== / !=) is unsupported; use === / !==",
+      };
+    }
+    // M4 P3: canonicalize strict equality through Layer 1
+    // `BinOp(eq | neq, ...)`. Sub-expressions wrap via `ir1FromL2`
+    // (M5 territory — sub-expressions reach L1 natively then).
+    if (
+      expr.operatorToken.kind === ts.SyntaxKind.EqualsEqualsEqualsToken ||
+      expr.operatorToken.kind === ts.SyntaxKind.ExclamationEqualsEqualsToken
+    ) {
+      const left = translateBodyExpr(
+        expr.left,
+        checker,
+        strategy,
+        paramNames,
+        state,
+        supply,
+      );
+      if (isBodyUnsupported(left)) {
+        return left;
+      }
+      const right = translateBodyExpr(
+        expr.right,
+        checker,
+        strategy,
+        paramNames,
+        state,
+        supply,
+      );
+      if (isBodyUnsupported(right)) {
+        return right;
+      }
+      const l1Op =
+        expr.operatorToken.kind === ts.SyntaxKind.EqualsEqualsEqualsToken
+          ? "eq"
+          : "neq";
+      const lhsL1 = ir1FromL2(irWrap(bodyExpr(left)));
+      const rhsL1 = ir1FromL2(irWrap(bodyExpr(right)));
+      return { expr: lowerL1ToOpaque(ir1Binop(l1Op, lhsL1, rhsL1)) };
     }
     const op = translateOperator(expr.operatorToken.kind);
     if (op === null) {

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -32,6 +32,7 @@ import { isKnownPureCall } from "./purity.js";
 import { translateRecordReturn } from "./translate-record.js";
 import {
   classifyFunction,
+  containsUnsupportedOperator,
   findFunction,
   isAssertionCall,
   isFollowableGuardCall,
@@ -2313,6 +2314,13 @@ export function isGuardStatement(
     if (!call.arguments.every(isPureExpression)) {
       return false;
     }
+    // M4 P3: an assertion arg containing loose equality cannot translate.
+    // Filtering the call out of the body would silently drop the runtime
+    // check on both sides; keep it so the body translator surfaces the
+    // rejection.
+    if (call.arguments.some(containsUnsupportedOperator)) {
+      return false;
+    }
     if (isAssertionCall(checker, call) !== null) {
       return true;
     }
@@ -2326,6 +2334,13 @@ export function isGuardStatement(
   }
   // Condition must be pure (aligned with classifyGuardIf's isPureExpression check)
   if (!isPureExpression(stmt.expression)) {
+    return false;
+  }
+  // M4 P3: same as classifyGuardIf — refuse to classify an if-throw guard
+  // whose condition contains an explicitly-unsupported operator. The body
+  // translator will then handle the if-statement on the regular path,
+  // where it will surface a specific `unsupported` reason.
+  if (containsUnsupportedOperator(stmt.expression)) {
     return false;
   }
   // if (...) { throw } without else

--- a/tools/ts2pant/src/translate-signature.ts
+++ b/tools/ts2pant/src/translate-signature.ts
@@ -424,6 +424,68 @@ const ASSIGNMENT_OPERATORS = new Set([
 ]);
 
 /**
+ * Walk an expression looking for operators that `translateExpr` /
+ * `translateBodyExpr` explicitly reject (today: loose equality `==` and
+ * `!=`). Used by guard-detection predicates to keep them aligned with
+ * the actual translator — a guard whose condition contains a forbidden
+ * operator must NOT be classified as a guard, otherwise the body filter
+ * would silently drop the statement while signature extraction would
+ * separately drop the guard, losing the runtime check on both sides.
+ *
+ * Mirrors the rejection list in `translateExpr`'s binary-expression
+ * branch (translate-signature.ts) and `translateBodyExpr`'s
+ * binary-expression branch (translate-body.ts). Adding a new operator
+ * to those rejection lists must also add it here.
+ */
+export function containsUnsupportedOperator(expr: ts.Expression): boolean {
+  if (ts.isBinaryExpression(expr)) {
+    if (
+      expr.operatorToken.kind === ts.SyntaxKind.EqualsEqualsToken ||
+      expr.operatorToken.kind === ts.SyntaxKind.ExclamationEqualsToken
+    ) {
+      return true;
+    }
+    return (
+      containsUnsupportedOperator(expr.left) ||
+      containsUnsupportedOperator(expr.right)
+    );
+  }
+  if (
+    ts.isParenthesizedExpression(expr) ||
+    ts.isAsExpression(expr) ||
+    ts.isNonNullExpression(expr)
+  ) {
+    return containsUnsupportedOperator(expr.expression);
+  }
+  if (ts.isPrefixUnaryExpression(expr) || ts.isPostfixUnaryExpression(expr)) {
+    return containsUnsupportedOperator(expr.operand);
+  }
+  if (ts.isPropertyAccessExpression(expr)) {
+    return containsUnsupportedOperator(expr.expression);
+  }
+  if (ts.isElementAccessExpression(expr)) {
+    return (
+      containsUnsupportedOperator(expr.expression) ||
+      containsUnsupportedOperator(expr.argumentExpression)
+    );
+  }
+  if (ts.isCallExpression(expr)) {
+    return (
+      containsUnsupportedOperator(expr.expression) ||
+      expr.arguments.some(containsUnsupportedOperator)
+    );
+  }
+  if (ts.isConditionalExpression(expr)) {
+    return (
+      containsUnsupportedOperator(expr.condition) ||
+      containsUnsupportedOperator(expr.whenTrue) ||
+      containsUnsupportedOperator(expr.whenFalse)
+    );
+  }
+  return false;
+}
+
+/**
  * Check whether an expression is side-effect-free (identifiers, literals,
  * property access, operators — no calls, assignments, or increments).
  */
@@ -522,6 +584,15 @@ function guardBranchHasNoSideEffects(node: ts.Statement): boolean {
  */
 function classifyGuardIf(stmt: ts.IfStatement): "positive" | "negative" | null {
   if (!isPureExpression(stmt.expression)) {
+    return null;
+  }
+  // M4 P3: a guard whose condition contains a forbidden operator (loose
+  // equality) cannot be translated. If we classified it as a guard, the
+  // body filter would drop the statement and signature extraction would
+  // separately drop the guard — losing the runtime check on both sides.
+  // Refuse the classification so the statement stays in the body, where
+  // the body translator will surface a specific `unsupported` reason.
+  if (containsUnsupportedOperator(stmt.expression)) {
     return null;
   }
   if (
@@ -730,6 +801,14 @@ export function isFollowableGuardCall(
       if (!stmt.expression.arguments.every(isPureExpression)) {
         return false;
       }
+      // M4 P3: an assertion call whose argument contains a forbidden
+      // operator (loose equality) cannot be translated. Reject the
+      // whole helper rather than silently dropping the guard during
+      // signature extraction. The body translator will then surface
+      // the rejection on the helper call itself.
+      if (stmt.expression.arguments.some(containsUnsupportedOperator)) {
+        return false;
+      }
       return (
         isAssertionCall(checker, stmt.expression) !== null ||
         isFollowableGuardCall(stmt.expression, checker, visited)
@@ -746,6 +825,8 @@ export function isFollowableGuardCall(
     if (!ts.isIfStatement(stmt)) {
       return false;
     }
+    // classifyGuardIf already rejects untranslatable conditions —
+    // this is the same check scanBodyForGuards relies on.
     return classifyGuardIf(stmt) !== null;
   });
   visited.delete(target.body);

--- a/tools/ts2pant/src/translate-signature.ts
+++ b/tools/ts2pant/src/translate-signature.ts
@@ -453,7 +453,8 @@ export function containsUnsupportedOperator(expr: ts.Expression): boolean {
   if (
     ts.isParenthesizedExpression(expr) ||
     ts.isAsExpression(expr) ||
-    ts.isNonNullExpression(expr)
+    ts.isNonNullExpression(expr) ||
+    ts.isSatisfiesExpression(expr)
   ) {
     return containsUnsupportedOperator(expr.expression);
   }
@@ -1044,8 +1045,19 @@ export function translateExpr(
     }
   }
 
-  // Parenthesized — unwrap (parens are a rendering concern)
-  if (ts.isParenthesizedExpression(expr)) {
+  // Transparent wrappers — unwrap before any translation, including
+  // before falling through to the raw-text fallback at the end of this
+  // function. Without this, `(x == 0) as boolean` and `(x == 0)!` would
+  // bypass the loose-equality rejection above and emit raw source text
+  // as a Pant variable name. Mirrors `unwrapExpression` in
+  // translate-body.ts and the wrapper handling in `isPureExpression` /
+  // `containsUnsupportedOperator`.
+  if (
+    ts.isParenthesizedExpression(expr) ||
+    ts.isAsExpression(expr) ||
+    ts.isNonNullExpression(expr) ||
+    ts.isSatisfiesExpression(expr)
+  ) {
     return translateExpr(
       expr.expression,
       checker,

--- a/tools/ts2pant/src/translate-signature.ts
+++ b/tools/ts2pant/src/translate-signature.ts
@@ -903,11 +903,17 @@ export function translateOperator(kind: ts.SyntaxKind): OpaqueBinop | null {
     case ts.SyntaxKind.LessThanToken:
       return ast.opLt();
     case ts.SyntaxKind.EqualsEqualsEqualsToken:
-    case ts.SyntaxKind.EqualsEqualsToken:
       return ast.opEq();
     case ts.SyntaxKind.ExclamationEqualsEqualsToken:
-    case ts.SyntaxKind.ExclamationEqualsToken:
       return ast.opNeq();
+    // M4 P3: loose equality (`==` / `!=`) is unsupported. Patch 2's
+    // nullish recognizer consumes `x == null` / `x != null` before
+    // this dispatcher is reached on the pure path; any `==`/`!=`
+    // here has ambiguous intent and we reject (return null) to steer
+    // the programmer toward `===`/`!==`.
+    case ts.SyntaxKind.EqualsEqualsToken:
+    case ts.SyntaxKind.ExclamationEqualsToken:
+      return null;
     case ts.SyntaxKind.AmpersandAmpersandToken:
       return ast.opAnd();
     case ts.SyntaxKind.BarBarToken:

--- a/tools/ts2pant/src/translate-signature.ts
+++ b/tools/ts2pant/src/translate-signature.ts
@@ -18,20 +18,27 @@ import type { PantAction, PantDeclaration, PantRule } from "./types.js";
 export type Classification = "pure" | "mutating";
 
 /**
- * Thrown by `translateExpr` when it encounters an operator that the
- * conservative-refusal policy explicitly rejects (today: loose equality
- * `==` / `!=`). Distinct from `translateOperator`'s `null` return — that
- * signals "operator not handled" and falls through to a raw-text
- * fallback (acceptable for genuinely-unknown operators that pant will
- * fail to parse downstream). This error signals "operator forbidden",
- * and entry-point callers in the signature/guard path catch it and bail
- * cleanly rather than emitting raw source text as a Pant variable.
+ * Result of translating a TS expression to a Pant `OpaqueExpr`.
+ * Either the translated expression, or an explicit `{ unsupported }`
+ * marker for operators the conservative-refusal policy rejects (today:
+ * loose equality `==` / `!=`). Distinct from `translateOperator`'s
+ * `null` return — that signals "operator not handled" and falls through
+ * to a raw-text fallback (acceptable for genuinely-unknown operators
+ * that pant will fail to parse downstream). This `{ unsupported }`
+ * signals "operator forbidden"; callers must check and bail cleanly
+ * rather than emit raw source text as a Pant variable.
+ *
+ * Mirrors the `L1BuildResult` shape in `ir1-build.ts` (and the
+ * `BodyResult` union in `translate-body.ts`) — the codebase convention
+ * for unsupported translations is an explicit discriminated-union
+ * result, never an exception.
  */
-export class UnsupportedOperatorError extends Error {
-  constructor(reason: string) {
-    super(reason);
-    this.name = "UnsupportedOperatorError";
-  }
+export type TranslateExprResult = OpaqueExpr | { unsupported: string };
+
+export function isTranslateExprUnsupported(
+  r: TranslateExprResult,
+): r is { unsupported: string } {
+  return typeof r === "object" && r !== null && "unsupported" in r;
 }
 
 export interface TranslatedSignature {
@@ -231,16 +238,13 @@ export function extractAssertionGuard(
     return undefined;
   }
   const arg = call.arguments[paramIndex]!;
-  try {
-    return translateExpr(arg, checker, strategy, paramNames, synthCell);
-  } catch (e) {
-    if (e instanceof UnsupportedOperatorError) {
-      // Assertion contains an explicitly-unsupported operator (loose
-      // equality). Skip the guard rather than emit raw text.
-      return undefined;
-    }
-    throw e;
+  const result = translateExpr(arg, checker, strategy, paramNames, synthCell);
+  if (isTranslateExprUnsupported(result)) {
+    // Assertion contains an explicitly-unsupported operator (loose
+    // equality). Skip the guard rather than emit raw text.
+    return undefined;
   }
+  return result;
 }
 
 /**
@@ -330,24 +334,20 @@ function buildSubstitutionMap(
       return null;
     }
 
-    let actual: OpaqueExpr;
-    try {
-      actual = translateExpr(
-        call.arguments[i]!,
-        checker,
-        strategy,
-        callerParamNames,
-        synthCell,
-      );
-    } catch (e) {
-      if (e instanceof UnsupportedOperatorError) {
-        // Argument contains an explicitly-unsupported operator. Bail
-        // the entire substitution rather than emit a partial map that
-        // would inline raw source text into a guard.
-        return null;
-      }
-      throw e;
+    const actualResult = translateExpr(
+      call.arguments[i]!,
+      checker,
+      strategy,
+      callerParamNames,
+      synthCell,
+    );
+    if (isTranslateExprUnsupported(actualResult)) {
+      // Argument contains an explicitly-unsupported operator. Bail the
+      // entire substitution rather than emit a partial map that would
+      // inline raw source text into a guard.
+      return null;
     }
+    const actual = actualResult;
     const rendered = ast.strExpr(actual);
     // Heuristic: if the rendered string contains spaces, it's compound and needs parens
     const safeRendered = /\s/u.test(rendered) ? `(${rendered})` : rendered;
@@ -665,8 +665,8 @@ function scanBodyForGuards(
  * Translate a guard expression, returning `null` when the expression
  * contains an explicitly-unsupported operator (today: loose equality).
  * Mirrors the bail behavior in `extractAssertionGuard` and
- * `buildSubstitutionMap` — a single helper centralizes the catch site so
- * all three guard-extraction paths reject identically.
+ * `buildSubstitutionMap` — one helper unifies the union check so all
+ * three guard-extraction paths reject identically.
  */
 function tryTranslateGuardExpr(
   expr: ts.Expression,
@@ -675,14 +675,11 @@ function tryTranslateGuardExpr(
   paramNames: ReadonlyMap<string, string>,
   synthCell: SynthCell | undefined,
 ): OpaqueExpr | null {
-  try {
-    return translateExpr(expr, checker, strategy, paramNames, synthCell);
-  } catch (e) {
-    if (e instanceof UnsupportedOperatorError) {
-      return null;
-    }
-    throw e;
+  const result = translateExpr(expr, checker, strategy, paramNames, synthCell);
+  if (isTranslateExprUnsupported(result)) {
+    return null;
   }
+  return result;
 }
 
 /**
@@ -853,7 +850,14 @@ function blockThrows(node: ts.Statement): boolean {
 }
 
 /**
- * Translate a TypeScript expression to an opaque Pantagruel AST node (best-effort).
+ * Translate a TypeScript expression to an opaque Pantagruel AST node
+ * (best-effort), or return `{ unsupported: reason }` for operators the
+ * conservative-refusal policy rejects (today: loose `==`/`!=`).
+ *
+ * Callers must check the result via `isTranslateExprUnsupported` and
+ * bail cleanly. This mirrors the `BodyResult` / `L1BuildResult`
+ * convention — the codebase signals unsupported translations through
+ * explicit discriminated-union results, never exceptions.
  */
 export function translateExpr(
   expr: ts.Expression,
@@ -861,7 +865,7 @@ export function translateExpr(
   _strategy: NumericStrategy,
   paramNames: ReadonlyMap<string, string>,
   synthCell?: SynthCell,
-): OpaqueExpr {
+): TranslateExprResult {
   const ast = getAst();
 
   // Property access: a.balance -> app(var("account-balance"), [obj])
@@ -873,6 +877,9 @@ export function translateExpr(
       paramNames,
       synthCell,
     );
+    if (isTranslateExprUnsupported(obj)) {
+      return obj;
+    }
     const ruleName = qualifyFieldAccess(
       checker.getTypeAtLocation(expr.expression),
       expr.name.text,
@@ -885,18 +892,19 @@ export function translateExpr(
 
   // Binary expression: a >= b -> binop(opGe(), a, b)
   if (ts.isBinaryExpression(expr)) {
-    // M4 P3: reject loose equality (== / !=) explicitly. Falling through
-    // to the `ast.var(expr.getText())` path below would emit raw source
-    // text as a Pant variable name, which violates conservative-refusal
-    // policy 3(b). Entry-point callers (extractAssertionGuard,
-    // buildSubstitutionMap, scanBodyForGuards) catch this error and bail.
+    // M4 P3: reject loose equality (== / !=) explicitly. Falling
+    // through to the `ast.var(expr.getText())` path below would emit
+    // raw source text as a Pant variable name, violating
+    // conservative-refusal policy 3(b). Return an explicit `unsupported`
+    // marker — entry-point callers (extractAssertionGuard,
+    // buildSubstitutionMap, scanBodyForGuards) propagate it and bail.
     if (
       expr.operatorToken.kind === ts.SyntaxKind.EqualsEqualsToken ||
       expr.operatorToken.kind === ts.SyntaxKind.ExclamationEqualsToken
     ) {
-      throw new UnsupportedOperatorError(
-        "loose equality (== / !=) is unsupported; use === / !==",
-      );
+      return {
+        unsupported: "loose equality (== / !=) is unsupported; use === / !==",
+      };
     }
     const left = translateExpr(
       expr.left,
@@ -905,6 +913,9 @@ export function translateExpr(
       paramNames,
       synthCell,
     );
+    if (isTranslateExprUnsupported(left)) {
+      return left;
+    }
     const right = translateExpr(
       expr.right,
       checker,
@@ -912,6 +923,9 @@ export function translateExpr(
       paramNames,
       synthCell,
     );
+    if (isTranslateExprUnsupported(right)) {
+      return right;
+    }
     const op = translateOperator(expr.operatorToken.kind);
     if (op === null) {
       return ast.var(expr.getText());
@@ -922,16 +936,30 @@ export function translateExpr(
   // Prefix unary: !x -> unop(opNot(), x), -x -> unop(opNeg(), x)
   if (ts.isPrefixUnaryExpression(expr)) {
     if (expr.operator === ts.SyntaxKind.ExclamationToken) {
-      return ast.unop(
-        ast.opNot(),
-        translateExpr(expr.operand, checker, _strategy, paramNames, synthCell),
+      const operand = translateExpr(
+        expr.operand,
+        checker,
+        _strategy,
+        paramNames,
+        synthCell,
       );
+      if (isTranslateExprUnsupported(operand)) {
+        return operand;
+      }
+      return ast.unop(ast.opNot(), operand);
     }
     if (expr.operator === ts.SyntaxKind.MinusToken) {
-      return ast.unop(
-        ast.opNeg(),
-        translateExpr(expr.operand, checker, _strategy, paramNames, synthCell),
+      const operand = translateExpr(
+        expr.operand,
+        checker,
+        _strategy,
+        paramNames,
+        synthCell,
       );
+      if (isTranslateExprUnsupported(operand)) {
+        return operand;
+      }
+      return ast.unop(ast.opNeg(), operand);
     }
   }
 

--- a/tools/ts2pant/src/translate-signature.ts
+++ b/tools/ts2pant/src/translate-signature.ts
@@ -17,6 +17,23 @@ import type { PantAction, PantDeclaration, PantRule } from "./types.js";
 
 export type Classification = "pure" | "mutating";
 
+/**
+ * Thrown by `translateExpr` when it encounters an operator that the
+ * conservative-refusal policy explicitly rejects (today: loose equality
+ * `==` / `!=`). Distinct from `translateOperator`'s `null` return — that
+ * signals "operator not handled" and falls through to a raw-text
+ * fallback (acceptable for genuinely-unknown operators that pant will
+ * fail to parse downstream). This error signals "operator forbidden",
+ * and entry-point callers in the signature/guard path catch it and bail
+ * cleanly rather than emitting raw source text as a Pant variable.
+ */
+export class UnsupportedOperatorError extends Error {
+  constructor(reason: string) {
+    super(reason);
+    this.name = "UnsupportedOperatorError";
+  }
+}
+
 export interface TranslatedSignature {
   declaration: PantDeclaration;
   classification: Classification;
@@ -214,7 +231,16 @@ export function extractAssertionGuard(
     return undefined;
   }
   const arg = call.arguments[paramIndex]!;
-  return translateExpr(arg, checker, strategy, paramNames, synthCell);
+  try {
+    return translateExpr(arg, checker, strategy, paramNames, synthCell);
+  } catch (e) {
+    if (e instanceof UnsupportedOperatorError) {
+      // Assertion contains an explicitly-unsupported operator (loose
+      // equality). Skip the guard rather than emit raw text.
+      return undefined;
+    }
+    throw e;
+  }
 }
 
 /**
@@ -304,13 +330,24 @@ function buildSubstitutionMap(
       return null;
     }
 
-    const actual = translateExpr(
-      call.arguments[i]!,
-      checker,
-      strategy,
-      callerParamNames,
-      synthCell,
-    );
+    let actual: OpaqueExpr;
+    try {
+      actual = translateExpr(
+        call.arguments[i]!,
+        checker,
+        strategy,
+        callerParamNames,
+        synthCell,
+      );
+    } catch (e) {
+      if (e instanceof UnsupportedOperatorError) {
+        // Argument contains an explicitly-unsupported operator. Bail
+        // the entire substitution rather than emit a partial map that
+        // would inline raw source text into a guard.
+        return null;
+      }
+      throw e;
+    }
     const rendered = ast.strExpr(actual);
     // Heuristic: if the rendered string contains spaces, it's compound and needs parens
     const safeRendered = /\s/u.test(rendered) ? `(${rendered})` : rendered;
@@ -570,15 +607,19 @@ function scanBodyForGuards(
 
     const guardKind = classifyGuardIf(stmt);
     if (guardKind === "positive") {
-      guards.push(
-        translateExpr(
-          stmt.expression,
-          checker,
-          strategy,
-          paramNames,
-          synthCell,
-        ),
+      const g = tryTranslateGuardExpr(
+        stmt.expression,
+        checker,
+        strategy,
+        paramNames,
+        synthCell,
       );
+      if (g === null) {
+        // Guard contains explicitly-unsupported operator — stop scanning
+        // rather than emit a partial guard set with raw source text.
+        break;
+      }
+      guards.push(g);
       continue;
     }
     if (guardKind === "negative") {
@@ -586,29 +627,30 @@ function scanBodyForGuards(
         ts.isPrefixUnaryExpression(stmt.expression) &&
         stmt.expression.operator === ts.SyntaxKind.ExclamationToken
       ) {
-        guards.push(
-          translateExpr(
-            stmt.expression.operand,
-            checker,
-            strategy,
-            paramNames,
-            synthCell,
-          ),
+        const g = tryTranslateGuardExpr(
+          stmt.expression.operand,
+          checker,
+          strategy,
+          paramNames,
+          synthCell,
         );
+        if (g === null) {
+          break;
+        }
+        guards.push(g);
         continue;
       }
-      guards.push(
-        ast.unop(
-          ast.opNot(),
-          translateExpr(
-            stmt.expression,
-            checker,
-            strategy,
-            paramNames,
-            synthCell,
-          ),
-        ),
+      const g = tryTranslateGuardExpr(
+        stmt.expression,
+        checker,
+        strategy,
+        paramNames,
+        synthCell,
       );
+      if (g === null) {
+        break;
+      }
+      guards.push(ast.unop(ast.opNot(), g));
       continue;
     }
 
@@ -617,6 +659,30 @@ function scanBodyForGuards(
   }
 
   return guards;
+}
+
+/**
+ * Translate a guard expression, returning `null` when the expression
+ * contains an explicitly-unsupported operator (today: loose equality).
+ * Mirrors the bail behavior in `extractAssertionGuard` and
+ * `buildSubstitutionMap` — a single helper centralizes the catch site so
+ * all three guard-extraction paths reject identically.
+ */
+function tryTranslateGuardExpr(
+  expr: ts.Expression,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  paramNames: ReadonlyMap<string, string>,
+  synthCell: SynthCell | undefined,
+): OpaqueExpr | null {
+  try {
+    return translateExpr(expr, checker, strategy, paramNames, synthCell);
+  } catch (e) {
+    if (e instanceof UnsupportedOperatorError) {
+      return null;
+    }
+    throw e;
+  }
 }
 
 /**
@@ -819,6 +885,19 @@ export function translateExpr(
 
   // Binary expression: a >= b -> binop(opGe(), a, b)
   if (ts.isBinaryExpression(expr)) {
+    // M4 P3: reject loose equality (== / !=) explicitly. Falling through
+    // to the `ast.var(expr.getText())` path below would emit raw source
+    // text as a Pant variable name, which violates conservative-refusal
+    // policy 3(b). Entry-point callers (extractAssertionGuard,
+    // buildSubstitutionMap, scanBodyForGuards) catch this error and bail.
+    if (
+      expr.operatorToken.kind === ts.SyntaxKind.EqualsEqualsToken ||
+      expr.operatorToken.kind === ts.SyntaxKind.ExclamationEqualsToken
+    ) {
+      throw new UnsupportedOperatorError(
+        "loose equality (== / !=) is unsupported; use === / !==",
+      );
+    }
     const left = translateExpr(
       expr.left,
       checker,

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -206,6 +206,26 @@ exports[`expressions-const-pure-calls.ts > constStringMethod 1`] = `
 "module ConstStringMethod.\\n\\nconst-string-method s: String => Int.\\n\\n---\\n\\nconst-string-method s = index-of s \\"x\\".\\n"
 `;
 
+exports[`expressions-equality-nullish.ts > strictEqAgainstLit 1`] = `
+"module StrictEqAgainstLit.\\n\\nstrict-eq-against-lit n: Int => Bool.\\n\\n---\\n\\nstrict-eq-against-lit n = (n = 0).\\n"
+`;
+
+exports[`expressions-equality-nullish.ts > strictEqExprOperands 1`] = `
+"module StrictEqExprOperands.\\n\\nstrict-eq-expr-operands a: Int, b: Int => Bool.\\n\\n---\\n\\nstrict-eq-expr-operands a b = (a + 1 = b * 2).\\n"
+`;
+
+exports[`expressions-equality-nullish.ts > strictEqNumbers 1`] = `
+"module StrictEqNumbers.\\n\\nstrict-eq-numbers a: Int, b: Int => Bool.\\n\\n---\\n\\nstrict-eq-numbers a b = (a = b).\\n"
+`;
+
+exports[`expressions-equality-nullish.ts > strictNeqInArm 1`] = `
+"module StrictNeqInArm.\\n\\nstrict-neq-in-arm a: Int, b: Int => Bool.\\n\\n---\\n\\nstrict-neq-in-arm a b = (cond a < 0 => a ~= b, true => a = b).\\n"
+`;
+
+exports[`expressions-equality-nullish.ts > strictNeqStrings 1`] = `
+"module StrictNeqStrings.\\n\\nstrict-neq-strings a: String, b: String => Bool.\\n\\n---\\n\\nstrict-neq-strings a b = (a ~= b).\\n"
+`;
+
 exports[`expressions-if-early-return.ts > armBetweenBindings 1`] = `
 "module ArmBetweenBindings.\\n\\narm-between-bindings n: Int => Int.\\n\\n---\\n\\narm-between-bindings n = (cond n + 1 < 0 => 0, true => n + 1 + (n + 1)).\\n"
 `;

--- a/tools/ts2pant/tests/equality-canonicalization.test.mts
+++ b/tools/ts2pant/tests/equality-canonicalization.test.mts
@@ -13,6 +13,7 @@ import { before, describe, it } from "node:test";
 import { createSourceFileFromSource } from "../src/extract.js";
 import { getAst, loadAst } from "../src/pant-wasm.js";
 import { translateBody } from "../src/translate-body.js";
+import { translateSignature } from "../src/translate-signature.js";
 import { IntStrategy } from "../src/translate-types.js";
 import type { PropResult } from "../src/types.js";
 
@@ -121,5 +122,92 @@ describe("equality-canonicalization", () => {
       expectEquationStr(props),
       "cond a < 0 => a ~= b, true => a = b",
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Signature / guard path: loose equality must reject cleanly rather than
+// fall through to `ast.var(expr.getText())`, which would emit raw source
+// text as a Pant variable name (conservative-refusal policy 3(b)).
+// ---------------------------------------------------------------------------
+
+describe("equality-canonicalization (signature/guard path)", () => {
+  it("assertion guard with == drops the guard rather than emit raw text", () => {
+    const source = `
+      function assert(condition: unknown, msg?: string): asserts condition {
+        if (!condition) throw new Error(msg ?? "Assertion failed");
+      }
+      interface Account { balance: number; }
+      function deposit(account: Account, amount: number): void {
+        assert(amount == 0, "must be zero");
+        account.balance = account.balance + amount;
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const result = translateSignature(sourceFile, "deposit", IntStrategy);
+    assert.equal(result.declaration.kind, "action");
+    if (result.declaration.kind !== "action") {
+      return;
+    }
+    // The guard must NOT be the raw text `amount == 0` — bail cleanly.
+    assert.equal(result.declaration.guard, undefined);
+  });
+
+  it("if-throw guard with != drops the guard rather than emit raw text", () => {
+    const source = `
+      interface Account { balance: number; }
+      function deposit(account: Account, amount: number): void {
+        if (amount != 0) { throw new Error("nonzero"); }
+        account.balance = account.balance + amount;
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const result = translateSignature(sourceFile, "deposit", IntStrategy);
+    assert.equal(result.declaration.kind, "action");
+    if (result.declaration.kind !== "action") {
+      return;
+    }
+    assert.equal(result.declaration.guard, undefined);
+  });
+
+  it("if-throw guard with strict !== still produces a guard", () => {
+    // Sanity check that the bail logic is operator-specific — strict
+    // inequality continues to work in guard extraction.
+    const source = `
+      interface Account { balance: number; }
+      function deposit(account: Account, amount: number): void {
+        if (amount !== 0) { throw new Error("nonzero"); }
+        account.balance = account.balance + amount;
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const result = translateSignature(sourceFile, "deposit", IntStrategy);
+    assert.equal(result.declaration.kind, "action");
+    if (result.declaration.kind !== "action") {
+      return;
+    }
+    assert.equal(
+      getAst().strExpr(result.declaration.guard!),
+      "~(amount ~= 0)",
+    );
+  });
+
+  it("nested == inside a strict-eq guard also bails", () => {
+    // The throw is inside translateExpr's recursion; outer translateExpr
+    // catches it through the wrapped entry-point caller.
+    const source = `
+      interface Account { balance: number; }
+      function deposit(account: Account, amount: number): void {
+        if ((amount == 0) === false) { throw new Error("guarded"); }
+        account.balance = account.balance + amount;
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const result = translateSignature(sourceFile, "deposit", IntStrategy);
+    assert.equal(result.declaration.kind, "action");
+    if (result.declaration.kind !== "action") {
+      return;
+    }
+    assert.equal(result.declaration.guard, undefined);
   });
 });

--- a/tools/ts2pant/tests/equality-canonicalization.test.mts
+++ b/tools/ts2pant/tests/equality-canonicalization.test.mts
@@ -196,6 +196,49 @@ describe("equality-canonicalization (signature/guard path)", () => {
     );
   });
 
+  it("== wrapped in `as`/non-null assertion still rejects (no raw-text fallback)", () => {
+    // Without wrapper-unwrapping in translateExpr, `(amount == 0) as boolean`
+    // would bypass the loose-equality rejection in the binary branch and
+    // fall through to `ast.var(expr.getText())` — emitting raw source as
+    // a Pant variable name. Verify the wrappers route back through the
+    // binary-expression rejection.
+    const sourceAs = `
+      function assert(condition: unknown): asserts condition {
+        if (!condition) throw new Error();
+      }
+      interface Account { balance: number; }
+      function deposit(account: Account, amount: number): void {
+        assert((amount == 0) as boolean);
+        account.balance = account.balance + amount;
+      }
+    `;
+    const sf1 = createSourceFileFromSource(sourceAs);
+    const r1 = translateSignature(sf1, "deposit", IntStrategy);
+    assert.equal(r1.declaration.kind, "action");
+    if (r1.declaration.kind !== "action") {
+      return;
+    }
+    assert.equal(r1.declaration.guard, undefined);
+
+    const sourceBang = `
+      function assert(condition: unknown): asserts condition {
+        if (!condition) throw new Error();
+      }
+      interface Account { value: number | null; }
+      function setIfPresent(account: Account, amount: number | null): void {
+        assert((amount != null)!);
+        account.value = amount;
+      }
+    `;
+    const sf2 = createSourceFileFromSource(sourceBang);
+    const r2 = translateSignature(sf2, "setIfPresent", IntStrategy);
+    assert.equal(r2.declaration.kind, "action");
+    if (r2.declaration.kind !== "action") {
+      return;
+    }
+    assert.equal(r2.declaration.guard, undefined);
+  });
+
   it("nested == inside a strict-eq guard also bails", () => {
     // The unsupported result propagates through translateExpr's
     // internal recursion (binop branch) up to the entry-point caller.

--- a/tools/ts2pant/tests/equality-canonicalization.test.mts
+++ b/tools/ts2pant/tests/equality-canonicalization.test.mts
@@ -1,0 +1,125 @@
+/**
+ * M4 P3 — strict equality canonicalizes through L1; loose equality rejects.
+ *
+ * The dispatcher in `translate-body.ts` routes `===`/`!==` through Layer 1
+ * `BinOp(eq | neq, ...)` (then `lowerL1Expr` → `lowerExpr`); any
+ * `==`/`!=` returns an `unsupported` `BodyResult`. Patch 2's nullish
+ * recognizer consumes `x == null` / `x != null` before this dispatcher
+ * fires; the rejection here covers everything else.
+ */
+
+import assert from "node:assert/strict";
+import { before, describe, it } from "node:test";
+import { createSourceFileFromSource } from "../src/extract.js";
+import { getAst, loadAst } from "../src/pant-wasm.js";
+import { translateBody } from "../src/translate-body.js";
+import { IntStrategy } from "../src/translate-types.js";
+import type { PropResult } from "../src/types.js";
+
+before(async () => {
+  await loadAst();
+});
+
+const LOOSE_EQ_REASON =
+  "loose equality (== / !=) is unsupported; use === / !==";
+
+function translateOne(source: string, functionName: string): PropResult[] {
+  const sourceFile = createSourceFileFromSource(source);
+  return translateBody({
+    sourceFile,
+    functionName,
+    strategy: IntStrategy,
+  });
+}
+
+function expectEquationStr(props: PropResult[]): string {
+  assert.equal(props.length, 1);
+  const prop = props[0]!;
+  assert.equal(prop.kind, "equation");
+  if (prop.kind !== "equation") {
+    throw new Error("unreachable");
+  }
+  return getAst().strExpr(prop.rhs);
+}
+
+function expectUnsupported(props: PropResult[]): string {
+  assert.equal(props.length, 1);
+  const prop = props[0]!;
+  assert.equal(prop.kind, "unsupported");
+  if (prop.kind !== "unsupported") {
+    throw new Error("unreachable");
+  }
+  return prop.reason;
+}
+
+describe("equality-canonicalization", () => {
+  it("=== builds binop(eq) via L1", () => {
+    const props = translateOne(
+      `export function f(a: number, b: number): boolean {
+        return a === b;
+      }`,
+      "f",
+    );
+    assert.equal(expectEquationStr(props), "a = b");
+  });
+
+  it("!== builds binop(neq) via L1", () => {
+    const props = translateOne(
+      `export function f(a: number, b: number): boolean {
+        return a !== b;
+      }`,
+      "f",
+    );
+    assert.equal(expectEquationStr(props), "a ~= b");
+  });
+
+  it("== (non-nullish) rejects with unsupported reason", () => {
+    const props = translateOne(
+      `export function f(a: number, b: number): boolean {
+        return a == b;
+      }`,
+      "f",
+    );
+    assert.equal(expectUnsupported(props), LOOSE_EQ_REASON);
+  });
+
+  it("!= (non-nullish) rejects with unsupported reason", () => {
+    const props = translateOne(
+      `export function f(a: number, b: number): boolean {
+        return a != b;
+      }`,
+      "f",
+    );
+    assert.equal(expectUnsupported(props), LOOSE_EQ_REASON);
+  });
+
+  it("=== preserves operand sub-expression translation", () => {
+    // The LHS `a + 1` and RHS `b * 2` must reach the L1 binop as their
+    // already-translated forms — the from-l2 wrap is the M5 territory
+    // mentioned in the workstream.
+    const props = translateOne(
+      `export function f(a: number, b: number): boolean {
+        return a + 1 === b * 2;
+      }`,
+      "f",
+    );
+    assert.equal(expectEquationStr(props), "a + 1 = b * 2");
+  });
+
+  it("!== inside a return expression composes with cond", () => {
+    // The if-with-return prelude builds a cond whose first arm's
+    // value is the translated `a !== b`. Verifies that the L1
+    // canonicalization integrates with the M1 cond pipeline.
+    const props = translateOne(
+      `export function f(a: number, b: number): boolean {
+        if (a < 0) return a !== b;
+        return a === b;
+      }`,
+      "f",
+    );
+    assert.equal(
+      expectEquationStr(props),
+      "cond a < 0 => a ~= b, true => a = b",
+    );
+  });
+});

--- a/tools/ts2pant/tests/equality-canonicalization.test.mts
+++ b/tools/ts2pant/tests/equality-canonicalization.test.mts
@@ -13,7 +13,11 @@ import { before, describe, it } from "node:test";
 import { createSourceFileFromSource } from "../src/extract.js";
 import { getAst, loadAst } from "../src/pant-wasm.js";
 import { translateBody } from "../src/translate-body.js";
-import { translateSignature } from "../src/translate-signature.js";
+import {
+  containsUnsupportedOperator,
+  translateSignature,
+} from "../src/translate-signature.js";
+import ts from "typescript";
 import { IntStrategy } from "../src/translate-types.js";
 import type { PropResult } from "../src/types.js";
 
@@ -209,5 +213,135 @@ describe("equality-canonicalization (signature/guard path)", () => {
       return;
     }
     assert.equal(result.declaration.guard, undefined);
+  });
+
+  // ------------------------------------------------------------------
+  // Predicate alignment: isFollowableGuardCall / isGuardStatement must
+  // match scanBodyForGuards on translatability. If they diverge, the
+  // body filter silently drops a guard statement that signature
+  // extraction also fails to translate — losing the runtime check on
+  // both sides.
+  // ------------------------------------------------------------------
+
+  it("followable helper with == in if-throw guard isn't silently dropped", () => {
+    // The helper's `if (amount == 0) throw` cannot translate; the
+    // helper must NOT be classified as followable, so the call stays
+    // in the body where the body translator surfaces the rejection.
+    const source = `
+      function ensureValid(amount: number): void {
+        if (amount == 0) { throw new Error("zero"); }
+      }
+      interface Account { balance: number; }
+      function deposit(account: Account, amount: number): void {
+        ensureValid(amount);
+        account.balance = account.balance + amount;
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const result = translateSignature(sourceFile, "deposit", IntStrategy);
+    assert.equal(result.declaration.kind, "action");
+    if (result.declaration.kind !== "action") {
+      return;
+    }
+    // No guard inlined from the helper.
+    assert.equal(result.declaration.guard, undefined);
+    // Body translation must reject (statement preserved + non-guard
+    // call rejected) rather than silently dropping the helper call.
+    const props = translateBody({
+      sourceFile,
+      functionName: "deposit",
+      strategy: IntStrategy,
+    });
+    assert.ok(
+      props.some((p) => p.kind === "unsupported"),
+      `expected an unsupported prop; saw: ${JSON.stringify(props.map((p) => p.kind))}`,
+    );
+  });
+
+  it("followable helper with == in assertion arg isn't silently dropped", () => {
+    const source = `
+      function assert(condition: unknown): asserts condition {
+        if (!condition) throw new Error();
+      }
+      function ensureValid(amount: number): void {
+        assert(amount == 0);
+      }
+      interface Account { balance: number; }
+      function deposit(account: Account, amount: number): void {
+        ensureValid(amount);
+        account.balance = account.balance + amount;
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const result = translateSignature(sourceFile, "deposit", IntStrategy);
+    assert.equal(result.declaration.kind, "action");
+    if (result.declaration.kind !== "action") {
+      return;
+    }
+    assert.equal(result.declaration.guard, undefined);
+    const props = translateBody({
+      sourceFile,
+      functionName: "deposit",
+      strategy: IntStrategy,
+    });
+    assert.ok(
+      props.some((p) => p.kind === "unsupported"),
+      `expected an unsupported prop; saw: ${JSON.stringify(props.map((p) => p.kind))}`,
+    );
+  });
+
+  // ------------------------------------------------------------------
+  // containsUnsupportedOperator — the syntactic walk that aligns the
+  // predicate side (classifyGuardIf, isGuardStatement, isFollowableGuardCall)
+  // with translateExpr's actual rejection list.
+  // ------------------------------------------------------------------
+
+  it("containsUnsupportedOperator detects loose equality at any depth", () => {
+    function exprOf(src: string): ts.Expression {
+      const sf = createSourceFileFromSource(`const _x = ${src};`);
+      const stmt = sf.compilerNode.statements[0] as ts.VariableStatement;
+      const decl = stmt.declarationList.declarations[0]!;
+      return decl.initializer!;
+    }
+    assert.equal(containsUnsupportedOperator(exprOf("a == b")), true);
+    assert.equal(containsUnsupportedOperator(exprOf("a != b")), true);
+    assert.equal(containsUnsupportedOperator(exprOf("(a == b)")), true);
+    assert.equal(containsUnsupportedOperator(exprOf("!(a == b)")), true);
+    assert.equal(containsUnsupportedOperator(exprOf("a + (b == c)")), true);
+    assert.equal(containsUnsupportedOperator(exprOf("f(a == b)")), true);
+    assert.equal(
+      containsUnsupportedOperator(exprOf("a === b ? a == b : false")),
+      true,
+    );
+    // Negative cases — strict equality and other operators are accepted.
+    assert.equal(containsUnsupportedOperator(exprOf("a === b")), false);
+    assert.equal(containsUnsupportedOperator(exprOf("a !== b")), false);
+    assert.equal(containsUnsupportedOperator(exprOf("a + b")), false);
+    assert.equal(containsUnsupportedOperator(exprOf("a.b.c")), false);
+  });
+
+  it("followable helper with translatable guards still works", () => {
+    // Sanity: the predicate gating only rejects untranslatable guards.
+    // A standard helper continues to follow.
+    const source = `
+      function ensureValid(amount: number): void {
+        if (amount <= 0) { throw new Error("nonpositive"); }
+      }
+      interface Account { balance: number; }
+      function deposit(account: Account, amount: number): void {
+        ensureValid(amount);
+        account.balance = account.balance + amount;
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const result = translateSignature(sourceFile, "deposit", IntStrategy);
+    assert.equal(result.declaration.kind, "action");
+    if (result.declaration.kind !== "action") {
+      return;
+    }
+    assert.equal(
+      getAst().strExpr(result.declaration.guard!),
+      "~(amount <= 0)",
+    );
   });
 });

--- a/tools/ts2pant/tests/equality-canonicalization.test.mts
+++ b/tools/ts2pant/tests/equality-canonicalization.test.mts
@@ -193,8 +193,8 @@ describe("equality-canonicalization (signature/guard path)", () => {
   });
 
   it("nested == inside a strict-eq guard also bails", () => {
-    // The throw is inside translateExpr's recursion; outer translateExpr
-    // catches it through the wrapped entry-point caller.
+    // The unsupported result propagates through translateExpr's
+    // internal recursion (binop branch) up to the entry-point caller.
     const source = `
       interface Account { balance: number; }
       function deposit(account: Account, amount: number): void {

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-equality-nullish.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-equality-nullish.ts
@@ -1,0 +1,35 @@
+// M4 — equality and nullish normalization. This fixture exercises the
+// strict-eq / strict-neq canonicalization through Layer 1. Loose-eq
+// rejection is exercised in `tests/equality-canonicalization.test.mts`
+// (rejection isn't snapshot-tested; the constructs runner skips
+// functions that fail to translate).
+//
+// See `workstreams/ts2pant-m4-equality-nullish.md` for the full
+// equivalence-class lock and lowering rules.
+
+/** `===` on numbers → canonical L1 binop(eq) → Pant `=`. */
+export function strictEqNumbers(a: number, b: number): boolean {
+  return a === b;
+}
+
+/** `!==` on strings → canonical L1 binop(neq) → Pant `~=`. */
+export function strictNeqStrings(a: string, b: string): boolean {
+  return a !== b;
+}
+
+/** `===` against a literal — sub-expression is a literal lit, not a var. */
+export function strictEqAgainstLit(n: number): boolean {
+  return n === 0;
+}
+
+/** `===` with arithmetic operands — verifies sub-expressions reach the
+ *  L1 binop as already-translated forms. */
+export function strictEqExprOperands(a: number, b: number): boolean {
+  return a + 1 === b * 2;
+}
+
+/** `!==` inside an early-return arm composes with the surrounding cond. */
+export function strictNeqInArm(a: number, b: number): boolean {
+  if (a < 0) return a !== b;
+  return a === b;
+}


### PR DESCRIPTION
## Patch 3: Canonicalize strict equality; reject all surviving loose-eq

- In `translate-body.ts:2859` (after the `??` branch and Patch 2's nullish recognizer), dispatch on operator kind: for `===`/`!==`, build via L1 `ir1Binop("eq" | "neq", lhsL1, rhsL1)` then `lowerL1Expr`; for `==`/`!=`, return `{ unsupported: "loose equality (== / !=) is unsupported; use === / !==" }`
- Operand sub-expressions wrap via `ir1FromL2(translateBodyExpr(...))` (M5 territory — sub-expressions reach L1 natively then)
- In `translate-signature.ts:905-910` `translateOperator`: leave `===`/`!==` mapped to `ast.opEq()` / `ast.opNeq()` (unchanged); change `==` / `!=` to return null (the existing convention for unsupported operators). Verify that the `||`/long-form recognizer in Patch 2 has already consumed `x == null` and `x != null` before `translateOperator` is reached on the pure path
- Add a new test file `tools/ts2pant/tests/equality-canonicalization.test.mts` with assertions: `===` builds L1 `binop(eq)`; `!==` builds L1 `binop(neq)`; `==` (non-nullish) rejects with the expected reason string; `!=` (non-nullish) rejects
- Extend the M4 fixture with strict-eq passthrough functions (`strictEqNumbers`, `strictNeqStrings`, etc.) — these are the snapshot-tested side. The `==` reject case lives only in the unit test (rejection isn't snapshot-tested; the constructs runner skips functions that fail to translate)
- Run `just ts2pant-test` — verify dogfood still passes. ts2pant's own source uses `===` exclusively, so dogfood pessimism is expected to be 0
- Measure pessimism: grep fixtures and dogfood for `==` / `!=` sites surviving Patch 2's nullish consumption. Expected count: 0. Record the result in the workstream document via Patch 5

## Changes
- In `translate-body.ts:2859` (after the `??` branch and Patch 2's nullish recognizer), dispatch on operator kind: for `===`/`!==`, build via L1 `ir1Binop("eq" | "neq", lhsL1, rhsL1)` then `lowerL1Expr`; for `==`/`!=`, return `{ unsupported: "loose equality (== / !=) is unsupported; use === / !==" }`
- Operand sub-expressions wrap via `ir1FromL2(translateBodyExpr(...))` (M5 territory — sub-expressions reach L1 natively then)
- In `translate-signature.ts:905-910` `translateOperator`: leave `===`/`!==` mapped to `ast.opEq()` / `ast.opNeq()` (unchanged); change `==` / `!=` to return null (the existing convention for unsupported operators). Verify that the `||`/long-form recognizer in Patch 2 has already consumed `x == null` and `x != null` before `translateOperator` is reached on the pure path
- Add a new test file `tools/ts2pant/tests/equality-canonicalization.test.mts` with assertions: `===` builds L1 `binop(eq)`; `!==` builds L1 `binop(neq)`; `==` (non-nullish) rejects with the expected reason string; `!=` (non-nullish) rejects
- Extend the M4 fixture with strict-eq passthrough functions (`strictEqNumbers`, `strictNeqStrings`, etc.) — these are the snapshot-tested side. The `==` reject case lives only in the unit test (rejection isn't snapshot-tested; the constructs runner skips functions that fail to translate)
- Run `just ts2pant-test` — verify dogfood still passes. ts2pant's own source uses `===` exclusively, so dogfood pessimism is expected to be 0
- Measure pessimism: grep fixtures and dogfood for `==` / `!=` sites surviving Patch 2's nullish consumption. Expected count: 0. Record the result in the workstream document via Patch 5

## Files to Modify
- tools/ts2pant/src/translate-body.ts (modify): Canonicalize `===`/`!==` through L1 `BinOp(eq|neq, ...)`; reject any `==`/`!=` that reaches this point (Patch 2's nullish recognizer has already consumed the `x == null` family)
- tools/ts2pant/src/translate-signature.ts (modify): Mirror the equality rejection in the pure-path operator dispatcher (line 894-926): return null for `==`/`!=`, route `===`/`!==` through L1
- tools/ts2pant/tests/fixtures/constructs/expressions-equality-nullish.ts (modify): Extend the M4 fixture with strict-eq passthrough cases; deliberate `==` reject cases live in the unit test (not the snapshot fixture)
- tools/ts2pant/tests/constructs.test.mts.snapshot (modify): Snapshot updates

## Gameplan Specification

```
module TS2PANT_M4.

> ════════════════════════════════════════════════════════════
> M4: equality and nullish normalization
> ════════════════════════════════════════════════════════════
>
> After M4, every TS-AST expression in the equality/nullish
> equivalence class flows through Layer 1. The class is
> normalized into three canonical paths plus an unconditional
> rejection on surviving loose equality:
>
>   - `IsNullish(x)` — the canonical Bool null/undefined test.
>     Recognized from x==null, x===null, x===undefined, the
>     ||-long form, and typeof-undefined. Negated forms wrap as
>     `not(IsNullish(x))`.
>   - `BinOp(eq | neq, lhs, rhs)` — canonical equality, only
>     produced from `===` / `!==`.
>   - Functor-lift `each $n in x | f $n` — the canonical lowering
>     for null-guarded list-lifted conditionals. Pant has no list
>     literal, so cardinality-dispatch is not a viable alternative;
>     this path makes idiomatic null-guard-then-list-return TS
>     functions translate.
>   - Any `==` / `!=` not consumed by the nullish recognizer is
>     rejected. ts2pant steers the programmer toward `===`/`!==`
>     rather than guess loose-equality intent.

TSExpr.
TSType.
L1Expr.
L2Expr.
OpaqueExpr.

> ─── L1 form predicates ───────────────────────────────────────

is-nullish? e: L1Expr => Bool.
is-not? e: L1Expr => Bool.
is-binop-eq? e: L1Expr => Bool.
is-binop-neq? e: L1Expr => Bool.
is-each? e: L1Expr => Bool.
is-cond? e: L1Expr => Bool.

operand e: L1Expr, is-nullish? e => L1Expr.
inner e: L1Expr, is-not? e => L1Expr.

> ─── TS-side classification ───────────────────────────────────

is-positive-nullish? t: TSExpr => Bool.
is-negative-nullish? t: TSExpr => Bool.
is-strict-eq? t: TSExpr => Bool.
is-strict-neq? t: TSExpr => Bool.
is-loose-eq? t: TSExpr => Bool.
is-loose-neq? t: TSExpr => Bool.

is-conditional? t: TSExpr => Bool.
functor-lift-eligible? t: TSExpr, is-conditional? t => Bool.

> ─── Build / lower pipeline ───────────────────────────────────

build-l1 t: TSExpr => L1Expr.
lower-l1 e: L1Expr => L2Expr.
emit l: L2Expr => OpaqueExpr.
unsupported? e: L1Expr => Bool.

> ─── L2 / OpaqueExpr shape predicate ─────────────────────────

card-zero? l: L2Expr => Bool.

---

> ─── Canonical form: every nullish surface form maps to one
>     L1 IsNullish (or its negation). ───────────────────────────

all t: TSExpr, is-positive-nullish? t |
  is-nullish? (build-l1 t).

all t: TSExpr, is-negative-nullish? t |
  is-not? (build-l1 t)
  and is-nullish? (inner (build-l1 t)).

> ─── Lowering: IsNullish becomes the cardinality-zero shape. ──

all e: L1Expr, is-nullish? e | card-zero? (lower-l1 e).

> ─── Strict equality canonicalizes unconditionally. ──────────

all t: TSExpr, is-strict-eq? t | is-binop-eq? (build-l1 t).
all t: TSExpr, is-strict-neq? t | is-binop-neq? (build-l1 t).

> ─── Surviving loose equality is rejected unconditionally.
>     The nullish family is consumed before this rule fires. ───

all t: TSExpr, is-loose-eq? t | unsupported? (build-l1 t).
all t: TSExpr, is-loose-neq? t | unsupported? (build-l1 t).

> ─── Functor-lift recognizer: eligible conditionals lower to
>     `each`; ineligible conditionals fall through to L1 Cond
>     (which then rejects at the no-list-literal wall). ────────

all t: TSExpr, is-conditional? t, functor-lift-eligible? t |
  is-each? (build-l1 t).

all t: TSExpr, is-conditional? t, ~ functor-lift-eligible? t |
  is-cond? (build-l1 t).

```

## Patch Specification

```
module TS2PANT_M4_PATCH_3.

> Patch 3 canonicalizes strict equality and rejects surviving loose
> equality.
>
> Both `===` and `!==` build to L1 BinOp with op = "eq" / "neq".
> Any `==` / `!=` that reaches this point is rejected unconditionally
> with `unsupported: "loose equality (== / !=) is unsupported; use
> === / !=="`. Patch 2's nullish recognizer has already consumed the
> idiomatic `x == null` family before this rule fires; everything else
> is `==` whose intent is ambiguous and should be steered to `===`.

TSBinaryExpr.
L1Expr.

binary-op b: TSBinaryExpr => Op.
Op.
loose-eq => Op.
loose-neq => Op.
strict-eq => Op.
strict-neq => Op.

build-l1 b: TSBinaryExpr => L1Expr.
unsupported? e: L1Expr => Bool.

is-binop? e: L1Expr => Bool.
binop-op e: L1Expr, is-binop? e => Op.

---

> Strict equality always canonicalizes.
all b: TSBinaryExpr, binary-op b = strict-eq |
  is-binop? (build-l1 b)
  and binop-op (build-l1 b) = strict-eq.

all b: TSBinaryExpr, binary-op b = strict-neq |
  is-binop? (build-l1 b)
  and binop-op (build-l1 b) = strict-neq.

> Loose equality is rejected unconditionally (the nullish family is
> consumed earlier and never reaches this rule).
all b: TSBinaryExpr, binary-op b = loose-eq | unsupported? (build-l1 b).
all b: TSBinaryExpr, binary-op b = loose-neq | unsupported? (build-l1 b).

```


## Implementation Notes

- **Patch 2 ordering.** Patch 3 landed independently (Patch 2 not yet merged), so on the standalone path *every* `==`/`!=` reaches this dispatcher and rejects — no nullish-recognized cases exist yet. Once Patch 2 lands, the `x == null` family will be consumed earlier and the rejection here narrows to the truly-ambiguous remainder. The behavior is correct in both orderings.
- **Sub-expression wrapping.** `ir1FromL2` takes an L2 `IRExpr`, not an `OpaqueExpr`, so the wrap is `ir1FromL2(irWrap(bodyExpr(left)))` (mirroring existing `from-l2` call sites in `ir1-build-body.ts`). The `irWrap` step is implicit in the gameplan's `ir1FromL2(translateBodyExpr(...))` shorthand.
- **Rejection reason format.** `translateBody` at line 1611 returns `body.unsupported` verbatim (no `${functionName} —` prefix), unlike the early-return paths above it. The unit test asserts the bare reason string accordingly.
- **Signature-path rejection convention.** `translateOperator` returns `null` for `==`/`!=` to mirror existing unsupported-operator handling. In `translateExpr` (translate-signature.ts:837), `null` falls back to `ast.var(expr.getText())` — i.e. emits the raw source as a Pant variable name. Loose equality in a *pure-path signature expression* would render as a literal-text var, which is then nonsense Pant. In practice this path is unreachable because `translateBodyExpr` rejects first; the signature dispatcher is consulted only for declaration-time expressions where `==`/`!=` doesn't appear in the supported fixtures.
- **Pessimism = 0.** Confirmed by grep: ts2pant's own source uses `===` exclusively; no fixture uses `==`/`!=`. Dogfood passes unchanged. Workstream document update is deferred to Patch 5 per the gameplan.
- **Biome formatting.** Pre-commit `biome ci` required the rejection return to be a single-line `unsupported:` string (the formatter rejects the wrapped-string spelling I tried first). The pre-existing nursery warning in `ir1-lower.ts:214` (from P1) is non-fatal.
- **Snapshot fixture.** The new `expressions-equality-nullish.ts` is M4-owned (P3 created it; P2 and later patches will extend). Five strict-eq passthrough functions cover: bare `===`/`!==`, literal RHS, arithmetic operands, and arm composition with `cond`.