### PR TITLE
[ts2pant-m4-equality-nullish] Patch 2: Recognize nullish surface forms via L1 IsNullish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,14 +97,6 @@ jobs:
             | tar -xz -C /usr/local/bin just
           just --version
 
-      - name: Install OCaml dependencies
-        run: |
-          opam install . --deps-only
-          opam install js_of_ocaml js_of_ocaml-ppx wasm_of_ocaml-compiler
-
-      - name: Build pant
-        run: opam exec -- just build-pant
-
       - uses: actions/setup-node@v6
         with:
           node-version: "22"
@@ -112,8 +104,18 @@ jobs:
           cache-dependency-path: tools/ts2pant/package-lock.json
 
       - name: Install binaryen
-        # Needed at link time by wasm_of_ocaml; install after Node is set up.
+        # `conf-binaryen` (pulled in by `wasm_of_ocaml-compiler`) probes for
+        # `wasm-opt` at opam install time, so binaryen must be on PATH before
+        # the next step. Also needed at link time by wasm_of_ocaml.
         run: npm install -g binaryen
+
+      - name: Install OCaml dependencies
+        run: |
+          opam install . --deps-only
+          opam install js_of_ocaml js_of_ocaml-ppx wasm_of_ocaml-compiler
+
+      - name: Build pant
+        run: opam exec -- just build-pant
 
       - name: Build wasm for ts2pant
         run: opam exec -- just ts2pant-build-wasm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,8 +76,10 @@ jobs:
           # Pin a specific version so the action doesn't have to resolve
           # the latest release via the GitHub API on each run — that
           # resolution is intermittently flaky ("no release for just
-          # matching version specifier"). Bump as needed.
-          just-version: "1.50.0"
+          # matching version specifier"). 1.50.0 (April 19) was rejected
+          # by the action's manifest; use 1.49.0 which has been out long
+          # enough to be reliably cached. Bump as needed.
+          just-version: "1.49.0"
 
       - name: Install OCaml dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,16 +13,15 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up OCaml
-        uses: ocaml/setup-ocaml@v3
+        # Pinned to v3.6.0 — v3.6.1 (current `@v3` head) added a
+        # fallback-to-older-opam-release codepath that itself fails
+        # with "Failed to find any opam release that matches the
+        # specified version constraint." `allow-prerelease-opam: true`
+        # is not enough; the lookup itself is broken. Drop the pin
+        # once `@v3` is healthy again.
+        uses: ocaml/setup-ocaml@v3.6.0
         with:
           ocaml-compiler: "5.4.1"
-          # The action's default opam version constraint sometimes
-          # excludes the latest stable opam release ("Failed to find
-          # any opam release that matches the specified version
-          # constraint" — the error message itself suggests this
-          # toggle). Allowing prereleases lets the action pick a
-          # matching opam build instead of failing the setup step.
-          allow-prerelease-opam: true
 
       - name: Use opam.ocaml.org archive cache
         # erratique.ch (upstream for cmdliner, mtime, fpath, logs, uutf, ...)
@@ -67,16 +66,10 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up OCaml
-        uses: ocaml/setup-ocaml@v3
+        # Pinned to v3.6.0 — see rationale in the build job above.
+        uses: ocaml/setup-ocaml@v3.6.0
         with:
           ocaml-compiler: "5.4.1"
-          # The action's default opam version constraint sometimes
-          # excludes the latest stable opam release ("Failed to find
-          # any opam release that matches the specified version
-          # constraint" — the error message itself suggests this
-          # toggle). Allowing prereleases lets the action pick a
-          # matching opam build instead of failing the setup step.
-          allow-prerelease-opam: true
 
       - name: Use opam.ocaml.org archive cache
         run: opam option archive-mirrors='["https://opam.ocaml.org/cache"]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,12 @@ jobs:
 
       - name: Install just
         uses: extractions/setup-just@v3
+        with:
+          # Pin a specific version so the action doesn't have to resolve
+          # the latest release via the GitHub API on each run — that
+          # resolution is intermittently flaky ("no release for just
+          # matching version specifier"). Bump as needed.
+          just-version: "1.50.0"
 
       - name: Install OCaml dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,11 @@ jobs:
         # ownership root doesn't recognize.
         run: git config --global --add safe.directory '*'
 
-      - name: Use opam.ocaml.org archive cache
-        # erratique.ch (upstream for cmdliner, mtime, fpath, logs, uutf, ...)
-        # is frequently flaky; the community cache mirrors opam-repository
-        # archives behind a CDN, so opam only falls back to upstream on a miss.
-        run: opam option archive-mirrors='["https://opam.ocaml.org/cache"]'
+      - name: Diagnose opam
+        run: |
+          opam --version
+          opam switch list
+          opam config list
 
       - name: Install dependencies
         run: |
@@ -87,9 +87,6 @@ jobs:
 
       - name: Trust workspace
         run: git config --global --add safe.directory '*'
-
-      - name: Use opam.ocaml.org archive cache
-        run: opam option archive-mirrors='["https://opam.ocaml.org/cache"]'
 
       - name: Install just
         # Install directly from the GitHub release tarball so we don't depend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,24 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ocaml/opam:ubuntu-24.04-ocaml-5.4
+      # Override the image's default `opam` (uid 1000) user — GHA mounts the
+      # workspace with ownership the in-image opam user can't write to, so
+      # `actions/checkout@v6` fails before any of our steps run.
+      options: --user root
+    env:
+      # Reuse the switch baked into the image (which lives under the opam
+      # user's home) instead of letting opam create a fresh one under /root.
+      OPAMROOT: /home/opam/.opam
+      # opam refuses to run as root by default; this overrides that check.
+      OPAMROOTISOK: "1"
+      OPAMYES: "1"
     steps:
       - uses: actions/checkout@v6
 
       - name: Trust workspace
-        # GHA mounts the workspace into the container with ownership that git
-        # sees as foreign; without this, `git` invocations inside dune/opam
-        # subprocesses fail with "dubious ownership".
+        # Without this, `git` invocations inside dune/opam subprocesses fail
+        # with "dubious ownership" because the workspace is mounted with
+        # ownership root doesn't recognize.
         run: git config --global --add safe.directory '*'
 
       - name: Use opam.ocaml.org archive cache
@@ -66,6 +77,11 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ocaml/opam:ubuntu-24.04-ocaml-5.4
+      options: --user root
+    env:
+      OPAMROOT: /home/opam/.opam
+      OPAMROOTISOK: "1"
+      OPAMYES: "1"
     steps:
       - uses: actions/checkout@v6
 
@@ -81,7 +97,7 @@ jobs:
         # reproducibility; bump as needed.
         run: |
           curl -fsSL https://github.com/casey/just/releases/download/1.50.0/just-1.50.0-x86_64-unknown-linux-musl.tar.gz \
-            | sudo tar -xz -C /usr/local/bin just
+            | tar -xz -C /usr/local/bin just
           just --version
 
       - name: Install OCaml dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,26 +6,24 @@ on:
   pull_request:
     branches: [master]
 
+# Both jobs run inside the official `ocaml/opam` Docker image, which has opam
+# and the OCaml 5.4 switch baked in. This bypasses `ocaml/setup-ocaml` (which
+# does a live GitHub release lookup at job start) — that lookup has been
+# repeatedly broken by upstream opam release naming changes (see git log for
+# the chain of pin commits this replaces). Bump the image tag to upgrade OCaml.
 jobs:
   build:
     runs-on: ubuntu-latest
+    container:
+      image: ocaml/opam:ubuntu-24.04-ocaml-5.4
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set up OCaml
-        # Pinned to v3.6.0 + allow-prerelease-opam — v3.6.1 (current
-        # `@v3` head) added a broken fallback-to-older-opam-release
-        # codepath. v3.6.0 alone now also fails the lookup with
-        # "Failed to find any opam release that matches the specified
-        # version constraint" because the latest stable opam release
-        # falls outside the action's default version constraint.
-        # Allowing prereleases lets the lookup pick a matching opam
-        # build instead of failing the setup step. Drop the pin once
-        # `@v3` is healthy again.
-        uses: ocaml/setup-ocaml@v3.6.0
-        with:
-          ocaml-compiler: "5.4.1"
-          allow-prerelease-opam: true
+      - name: Trust workspace
+        # GHA mounts the workspace into the container with ownership that git
+        # sees as foreign; without this, `git` invocations inside dune/opam
+        # subprocesses fail with "dubious ownership".
+        run: git config --global --add safe.directory '*'
 
       - name: Use opam.ocaml.org archive cache
         # erratique.ch (upstream for cmdliner, mtime, fpath, logs, uutf, ...)
@@ -66,30 +64,25 @@ jobs:
 
   ts2pant:
     runs-on: ubuntu-latest
+    container:
+      image: ocaml/opam:ubuntu-24.04-ocaml-5.4
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set up OCaml
-        # Pinned to v3.6.0 + allow-prerelease-opam — see rationale in the build job above.
-        uses: ocaml/setup-ocaml@v3.6.0
-        with:
-          ocaml-compiler: "5.4.1"
-          allow-prerelease-opam: true
+      - name: Trust workspace
+        run: git config --global --add safe.directory '*'
 
       - name: Use opam.ocaml.org archive cache
         run: opam option archive-mirrors='["https://opam.ocaml.org/cache"]'
 
-      - name: Install binaryen
-        run: npm install -g binaryen
-
       - name: Install just
-        uses: extractions/setup-just@v3
-        with:
-          # Pin a specific version so the action doesn't have to resolve
-          # the latest release via the GitHub API on each run — that
-          # resolution is intermittently flaky ("no release for just
-          # matching version specifier"). Bump as needed.
-          just-version: "1.50.0"
+        # Install directly from the GitHub release tarball so we don't depend
+        # on `extractions/setup-just`'s release-lookup logic. Pinned for
+        # reproducibility; bump as needed.
+        run: |
+          curl -fsSL https://github.com/casey/just/releases/download/1.50.0/just-1.50.0-x86_64-unknown-linux-musl.tar.gz \
+            | sudo tar -xz -C /usr/local/bin just
+          just --version
 
       - name: Install OCaml dependencies
         run: |
@@ -99,14 +92,18 @@ jobs:
       - name: Build pant
         run: opam exec -- just build-pant
 
-      - name: Build wasm for ts2pant
-        run: opam exec -- just ts2pant-build-wasm
-
       - uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: npm
           cache-dependency-path: tools/ts2pant/package-lock.json
+
+      - name: Install binaryen
+        # Needed at link time by wasm_of_ocaml; install after Node is set up.
+        run: npm install -g binaryen
+
+      - name: Build wasm for ts2pant
+        run: opam exec -- just ts2pant-build-wasm
 
       - name: Install ts2pant dependencies
         run: just ts2pant-install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,13 @@ jobs:
         uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: "5.4.1"
+          # The action's default opam version constraint sometimes
+          # excludes the latest stable opam release ("Failed to find
+          # any opam release that matches the specified version
+          # constraint" — the error message itself suggests this
+          # toggle). Allowing prereleases lets the action pick a
+          # matching opam build instead of failing the setup step.
+          allow-prerelease-opam: true
 
       - name: Use opam.ocaml.org archive cache
         # erratique.ch (upstream for cmdliner, mtime, fpath, logs, uutf, ...)
@@ -63,6 +70,13 @@ jobs:
         uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: "5.4.1"
+          # The action's default opam version constraint sometimes
+          # excludes the latest stable opam release ("Failed to find
+          # any opam release that matches the specified version
+          # constraint" — the error message itself suggests this
+          # toggle). Allowing prereleases lets the action pick a
+          # matching opam build instead of failing the setup step.
+          allow-prerelease-opam: true
 
       - name: Use opam.ocaml.org archive cache
         run: opam option archive-mirrors='["https://opam.ocaml.org/cache"]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,16 +13,16 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up OCaml
-        # Pinned to v3.6.0 — v3.6.1 (current `@v3` head) added a
-        # fallback-to-older-opam-release codepath that itself fails
-        # with "Failed to find any opam release that matches the
-        # specified version constraint." Same workflow ran fine on
-        # v3.6.1 around 15:23 today, then started failing at ~16:25,
-        # so something at the action's runtime release-lookup
-        # interface broke. Drop the pin once `@v3` is healthy again.
-        uses: ocaml/setup-ocaml@v3.6.0
+        uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: "5.4.1"
+          # The action's default opam version constraint sometimes
+          # excludes the latest stable opam release ("Failed to find
+          # any opam release that matches the specified version
+          # constraint" — the error message itself suggests this
+          # toggle). Allowing prereleases lets the action pick a
+          # matching opam build instead of failing the setup step.
+          allow-prerelease-opam: true
 
       - name: Use opam.ocaml.org archive cache
         # erratique.ch (upstream for cmdliner, mtime, fpath, logs, uutf, ...)
@@ -67,16 +67,16 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up OCaml
-        # Pinned to v3.6.0 — v3.6.1 (current `@v3` head) added a
-        # fallback-to-older-opam-release codepath that itself fails
-        # with "Failed to find any opam release that matches the
-        # specified version constraint." Same workflow ran fine on
-        # v3.6.1 around 15:23 today, then started failing at ~16:25,
-        # so something at the action's runtime release-lookup
-        # interface broke. Drop the pin once `@v3` is healthy again.
-        uses: ocaml/setup-ocaml@v3.6.0
+        uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: "5.4.1"
+          # The action's default opam version constraint sometimes
+          # excludes the latest stable opam release ("Failed to find
+          # any opam release that matches the specified version
+          # constraint" — the error message itself suggests this
+          # toggle). Allowing prereleases lets the action pick a
+          # matching opam build instead of failing the setup step.
+          allow-prerelease-opam: true
 
       - name: Use opam.ocaml.org archive cache
         run: opam option archive-mirrors='["https://opam.ocaml.org/cache"]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,15 +13,19 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up OCaml
-        # Pinned to v3.6.0 — v3.6.1 (current `@v3` head) added a
-        # fallback-to-older-opam-release codepath that itself fails
-        # with "Failed to find any opam release that matches the
-        # specified version constraint." `allow-prerelease-opam: true`
-        # is not enough; the lookup itself is broken. Drop the pin
-        # once `@v3` is healthy again.
+        # Pinned to v3.6.0 + allow-prerelease-opam — v3.6.1 (current
+        # `@v3` head) added a broken fallback-to-older-opam-release
+        # codepath. v3.6.0 alone now also fails the lookup with
+        # "Failed to find any opam release that matches the specified
+        # version constraint" because the latest stable opam release
+        # falls outside the action's default version constraint.
+        # Allowing prereleases lets the lookup pick a matching opam
+        # build instead of failing the setup step. Drop the pin once
+        # `@v3` is healthy again.
         uses: ocaml/setup-ocaml@v3.6.0
         with:
           ocaml-compiler: "5.4.1"
+          allow-prerelease-opam: true
 
       - name: Use opam.ocaml.org archive cache
         # erratique.ch (upstream for cmdliner, mtime, fpath, logs, uutf, ...)
@@ -66,10 +70,11 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up OCaml
-        # Pinned to v3.6.0 — see rationale in the build job above.
+        # Pinned to v3.6.0 + allow-prerelease-opam — see rationale in the build job above.
         uses: ocaml/setup-ocaml@v3.6.0
         with:
           ocaml-compiler: "5.4.1"
+          allow-prerelease-opam: true
 
       - name: Use opam.ocaml.org archive cache
         run: opam option archive-mirrors='["https://opam.ocaml.org/cache"]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,16 +13,16 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up OCaml
-        uses: ocaml/setup-ocaml@v3
+        # Pinned to v3.6.0 — v3.6.1 (current `@v3` head) added a
+        # fallback-to-older-opam-release codepath that itself fails
+        # with "Failed to find any opam release that matches the
+        # specified version constraint." Same workflow ran fine on
+        # v3.6.1 around 15:23 today, then started failing at ~16:25,
+        # so something at the action's runtime release-lookup
+        # interface broke. Drop the pin once `@v3` is healthy again.
+        uses: ocaml/setup-ocaml@v3.6.0
         with:
           ocaml-compiler: "5.4.1"
-          # The action's default opam version constraint sometimes
-          # excludes the latest stable opam release ("Failed to find
-          # any opam release that matches the specified version
-          # constraint" — the error message itself suggests this
-          # toggle). Allowing prereleases lets the action pick a
-          # matching opam build instead of failing the setup step.
-          allow-prerelease-opam: true
 
       - name: Use opam.ocaml.org archive cache
         # erratique.ch (upstream for cmdliner, mtime, fpath, logs, uutf, ...)
@@ -67,16 +67,16 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up OCaml
-        uses: ocaml/setup-ocaml@v3
+        # Pinned to v3.6.0 — v3.6.1 (current `@v3` head) added a
+        # fallback-to-older-opam-release codepath that itself fails
+        # with "Failed to find any opam release that matches the
+        # specified version constraint." Same workflow ran fine on
+        # v3.6.1 around 15:23 today, then started failing at ~16:25,
+        # so something at the action's runtime release-lookup
+        # interface broke. Drop the pin once `@v3` is healthy again.
+        uses: ocaml/setup-ocaml@v3.6.0
         with:
           ocaml-compiler: "5.4.1"
-          # The action's default opam version constraint sometimes
-          # excludes the latest stable opam release ("Failed to find
-          # any opam release that matches the specified version
-          # constraint" — the error message itself suggests this
-          # toggle). Allowing prereleases lets the action pick a
-          # matching opam build instead of failing the setup step.
-          allow-prerelease-opam: true
 
       - name: Use opam.ocaml.org archive cache
         run: opam option archive-mirrors='["https://opam.ocaml.org/cache"]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,10 +90,8 @@ jobs:
           # Pin a specific version so the action doesn't have to resolve
           # the latest release via the GitHub API on each run — that
           # resolution is intermittently flaky ("no release for just
-          # matching version specifier"). 1.50.0 (April 19) was rejected
-          # by the action's manifest; use 1.49.0 which has been out long
-          # enough to be reliably cached. Bump as needed.
-          just-version: "1.49.0"
+          # matching version specifier"). Bump as needed.
+          just-version: "1.50.0"
 
       - name: Install OCaml dependencies
         run: |

--- a/tools/ts2pant/src/ast-equal.ts
+++ b/tools/ts2pant/src/ast-equal.ts
@@ -79,6 +79,23 @@ export function structurallyEqualExpression(
   }
 
   if (ts.isPropertyAccessExpression(ua) && ts.isPropertyAccessExpression(ub)) {
+    // `a?.b` vs `a.b` must compare unequal — otherwise the nullish
+    // recognizer's operand-identity dedup would fold a pair like
+    // `a?.b === null || a.b === undefined` into a single `IsNullish`,
+    // which is unsound (the optional chain short-circuits when `a` is
+    // nullish; the plain access throws). Check both `questionDotToken`
+    // (the `?.` itself, on the head of a chain) and `NodeFlags.OptionalChain`
+    // (on the *tail* members of a chain like the outer `.b` in `x?.a.b`,
+    // which carry the flag but no token).
+    if (Boolean(ua.questionDotToken) !== Boolean(ub.questionDotToken)) {
+      return false;
+    }
+    if (
+      (ua.flags & ts.NodeFlags.OptionalChain) !==
+      (ub.flags & ts.NodeFlags.OptionalChain)
+    ) {
+      return false;
+    }
     return (
       ua.name.text === ub.name.text &&
       structurallyEqualExpression(ua.expression, ub.expression)

--- a/tools/ts2pant/src/ast-equal.ts
+++ b/tools/ts2pant/src/ast-equal.ts
@@ -73,6 +73,22 @@ export function structurallyEqualExpression(
   }
 
   if (ts.isCallExpression(ua) && ts.isCallExpression(ub)) {
+    // Bail on spread arguments — `f(...arr)` and `f(a, b)` may have
+    // matching `.arguments.length` (1 vs 1) but the spread expands at
+    // runtime to an unknown number of values, so structural equality
+    // here would be unsound. Pairwise comparison alone happens to
+    // catch most cases (a SpreadElement compares unequal to a non-
+    // spread Expression because the kind check fails), but be
+    // explicit so a future SpreadElement match doesn't silently
+    // accept `f(...a)` ≡ `f(...a)` as if the runtime expansions
+    // matched — the operand identity needed for nullish folding is
+    // about value identity, which spread expansions cannot guarantee.
+    if (
+      ua.arguments.some(ts.isSpreadElement) ||
+      ub.arguments.some(ts.isSpreadElement)
+    ) {
+      return false;
+    }
     if (!structurallyEqualExpression(ua.expression, ub.expression)) {
       return false;
     }

--- a/tools/ts2pant/src/ast-equal.ts
+++ b/tools/ts2pant/src/ast-equal.ts
@@ -22,7 +22,12 @@
  * - `PropertyAccessExpression` — recurse on `.expression`, compare `.name.text`
  * - `ElementAccessExpression` — recurse on `.expression` and `.argumentExpression`
  * - `CallExpression` — recurse on `.expression`, recurse pairwise on `.arguments`
- * - `ParenthesizedExpression` — unwrap and recurse
+ *   (spread arguments cause the comparison to bail conservatively)
+ * - `ParenthesizedExpression`, `AsExpression`, `NonNullExpression`,
+ *   `SatisfiesExpression` — unwrapped via `unwrapTransparentExpression`
+ *   to mirror `translate-body.ts`'s `unwrapExpression`. So
+ *   `(x as T) === null || x === undefined` matches operand identity
+ *   and folds to a single `IsNullish(x)`.
  * - `ThisExpression` — always equal
  * - `StringLiteral` — compare `.text` (so quote-style differences don't matter)
  * - `NumericLiteral` — compare `.text`
@@ -35,9 +40,24 @@
 
 import ts from "typescript";
 
-function unwrapParens(e: ts.Expression): ts.Expression {
+/**
+ * Strip transparent wrappers — parentheses, `as` casts, non-null
+ * assertions, and `satisfies` — to expose the underlying expression
+ * for structural comparison. Mirrors `unwrapExpression` in
+ * `translate-body.ts`: those wrappers don't change runtime value, so
+ * `(x as T) === null || x === undefined` should fold to one
+ * `IsNullish(x)` rather than miss the operand-identity match. The
+ * helper is recursive, peeling nested wrappers in any order
+ * (`(x as T)!`, `(x!) as T`, etc.).
+ */
+function unwrapTransparentExpression(e: ts.Expression): ts.Expression {
   let cur = e;
-  while (ts.isParenthesizedExpression(cur)) {
+  while (
+    ts.isParenthesizedExpression(cur) ||
+    ts.isAsExpression(cur) ||
+    ts.isNonNullExpression(cur) ||
+    ts.isSatisfiesExpression(cur)
+  ) {
     cur = cur.expression;
   }
   return cur;
@@ -47,8 +67,8 @@ export function structurallyEqualExpression(
   a: ts.Expression,
   b: ts.Expression,
 ): boolean {
-  const ua = unwrapParens(a);
-  const ub = unwrapParens(b);
+  const ua = unwrapTransparentExpression(a);
+  const ub = unwrapTransparentExpression(b);
 
   if (ua.kind !== ub.kind) {
     return false;

--- a/tools/ts2pant/src/ast-equal.ts
+++ b/tools/ts2pant/src/ast-equal.ts
@@ -1,0 +1,111 @@
+/**
+ * Structural equality for TypeScript expression nodes.
+ *
+ * Compares two `ts.Expression` ASTs node-by-node by `kind` plus the
+ * structural children that participate in identity (identifier text,
+ * call arguments, etc.). The comparison is intentionally narrower than
+ * a general AST equality — only the shapes that arise as nullish-test
+ * operands in M4 are handled. Anything outside the supported shape
+ * returns `false` (conservative).
+ *
+ * **Why not `node.getText()`?** Surface-text equality is sensitive to
+ * whitespace, comments, quote style, and parenthesization (`a.b` vs
+ * `a /* note *​/.b` would compare unequal). Those false non-matches
+ * would let the long-form nullish recognizer drop a perfectly good
+ * pair, falling through to a generic `||`/`&&` translation that emits
+ * broken Pant for the surrounding shape. Walking the AST avoids the
+ * trap. Pays forward into M5's `Member`-path normalization, which
+ * needs the same predicate.
+ *
+ * **Supported node kinds:**
+ * - `Identifier` — compare `.text`
+ * - `PropertyAccessExpression` — recurse on `.expression`, compare `.name.text`
+ * - `ElementAccessExpression` — recurse on `.expression` and `.argumentExpression`
+ * - `CallExpression` — recurse on `.expression`, recurse pairwise on `.arguments`
+ * - `ParenthesizedExpression` — unwrap and recurse
+ * - `ThisExpression` — always equal
+ * - `StringLiteral` — compare `.text` (so quote-style differences don't matter)
+ * - `NumericLiteral` — compare `.text`
+ *
+ * Anything else returns `false`. There is no fallback to `getText` —
+ * conservative-refusal here means "not provably equal, treat as
+ * different and don't fold" which preserves the legacy translation
+ * for the surrounding shape.
+ */
+
+import ts from "typescript";
+
+function unwrapParens(e: ts.Expression): ts.Expression {
+  let cur = e;
+  while (ts.isParenthesizedExpression(cur)) {
+    cur = cur.expression;
+  }
+  return cur;
+}
+
+export function structurallyEqualExpression(
+  a: ts.Expression,
+  b: ts.Expression,
+): boolean {
+  const ua = unwrapParens(a);
+  const ub = unwrapParens(b);
+
+  if (ua.kind !== ub.kind) {
+    return false;
+  }
+
+  if (ts.isIdentifier(ua) && ts.isIdentifier(ub)) {
+    return ua.text === ub.text;
+  }
+
+  if (ts.isPropertyAccessExpression(ua) && ts.isPropertyAccessExpression(ub)) {
+    return (
+      ua.name.text === ub.name.text &&
+      structurallyEqualExpression(ua.expression, ub.expression)
+    );
+  }
+
+  if (ts.isElementAccessExpression(ua) && ts.isElementAccessExpression(ub)) {
+    return (
+      structurallyEqualExpression(ua.expression, ub.expression) &&
+      structurallyEqualExpression(ua.argumentExpression, ub.argumentExpression)
+    );
+  }
+
+  if (ts.isCallExpression(ua) && ts.isCallExpression(ub)) {
+    if (!structurallyEqualExpression(ua.expression, ub.expression)) {
+      return false;
+    }
+    if (ua.arguments.length !== ub.arguments.length) {
+      return false;
+    }
+    for (let i = 0; i < ua.arguments.length; i++) {
+      if (
+        !structurallyEqualExpression(
+          ua.arguments[i] as ts.Expression,
+          ub.arguments[i] as ts.Expression,
+        )
+      ) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  if (
+    ua.kind === ts.SyntaxKind.ThisKeyword &&
+    ub.kind === ts.SyntaxKind.ThisKeyword
+  ) {
+    return true;
+  }
+
+  if (ts.isStringLiteral(ua) && ts.isStringLiteral(ub)) {
+    return ua.text === ub.text;
+  }
+
+  if (ts.isNumericLiteral(ua) && ts.isNumericLiteral(ub)) {
+    return ua.text === ub.text;
+  }
+
+  return false;
+}

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -596,7 +596,7 @@ function buildFromShortCircuit(
     }
     return result;
   };
-  const recognized = recognizeNullishForm(expr, nullishTranslate);
+  const recognized = recognizeNullishForm(expr, ctx.checker, nullishTranslate);
   if (recognized !== null) {
     if ("unsupported" in recognized) {
       return { unsupported: recognized.unsupported };

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -53,6 +53,10 @@ import {
   ir1While,
 } from "./ir1.js";
 import { lowerL1Expr } from "./ir1-lower.js";
+import {
+  type NullishTranslate,
+  recognizeNullishForm,
+} from "./nullish-recognizer.js";
 import type { OpaqueExpr } from "./pant-ast.js";
 import { isStaticallyBoolTyped } from "./purity.js";
 import type {
@@ -580,6 +584,26 @@ function buildFromShortCircuit(
   expr: ts.BinaryExpression,
   ctx: L1BuildContext,
 ): L1BuildResult {
+  // M4: try the long-form nullish recognizer first. The recognizer
+  // collapses `x === null || x === undefined` (and the negated `&&`
+  // variant) into a single `IsNullish(x)` rather than two equality
+  // tests joined by `or`. Operand-mismatch falls through and the
+  // chain is handled by the regular Bool-typed short-circuit below.
+  const nullishTranslate: NullishTranslate = (sub) => {
+    const result = buildSubExpr(sub, ctx);
+    if (isL1Unsupported(result)) {
+      return { unsupported: result.unsupported };
+    }
+    return result;
+  };
+  const recognized = recognizeNullishForm(expr, nullishTranslate);
+  if (recognized !== null) {
+    if ("unsupported" in recognized) {
+      return { unsupported: recognized.unsupported };
+    }
+    return recognized;
+  }
+
   if (
     !isStaticallyBoolTyped(expr.left, ctx.checker) ||
     !isStaticallyBoolTyped(expr.right, ctx.checker)

--- a/tools/ts2pant/src/nullish-recognizer.ts
+++ b/tools/ts2pant/src/nullish-recognizer.ts
@@ -73,11 +73,38 @@ function isNullableType(type: ts.Type): boolean {
   return (type.flags & mask) !== 0;
 }
 
+/**
+ * Resolve `operand`'s type for the nullability gate, ignoring TS
+ * flow-narrowing. The plain `getTypeAtLocation(operand)` would return
+ * the narrowed type — and inside a long-form chain
+ * (`x === null || x === undefined || x === null`) TypeScript narrows
+ * `x` to non-nullable in later clauses based on prior negative
+ * comparisons. The recognizer is operating syntactically, so we want
+ * the *declared* type at each occurrence: `x: number | null | undefined`
+ * stays nullable in every leaf of the chain.
+ *
+ * For Identifiers and PropertyAccess we resolve the symbol and ask
+ * for `getTypeOfSymbolAtLocation(symbol, declaration)`, which is
+ * narrowing-free. For shapes without a clear symbol (call results,
+ * etc.) we fall back to `getTypeAtLocation` — those are rarely
+ * repeated in a chain, so the narrowing risk is low.
+ */
+function getOperandDeclaredType(
+  operand: ts.Expression,
+  checker: ts.TypeChecker,
+): ts.Type {
+  const symbol = checker.getSymbolAtLocation(operand);
+  if (symbol?.valueDeclaration) {
+    return checker.getTypeOfSymbolAtLocation(symbol, symbol.valueDeclaration);
+  }
+  return checker.getTypeAtLocation(operand);
+}
+
 function isOperandNullable(
   operand: ts.Expression,
   checker: ts.TypeChecker,
 ): boolean {
-  return isNullableType(checker.getTypeAtLocation(operand));
+  return isNullableType(getOperandDeclaredType(operand, checker));
 }
 
 /**
@@ -126,6 +153,19 @@ function isUndefinedIdentifier(
 function isUndefinedStringLiteral(e: ts.Expression): boolean {
   const u = unwrapParens(e);
   return ts.isStringLiteral(u) && u.text === "undefined";
+}
+
+/**
+ * True when `e` is itself one of the nullish sentinels — either the
+ * `null` keyword or a checker-resolved global `undefined`. Used to
+ * reject sentinel-vs-sentinel comparisons (`null === undefined`,
+ * `undefined !== null`, even `null === null`) where the proposed
+ * "operand" is itself a sentinel — folding such a comparison to
+ * `IsNullish(sentinel)` lowers to `#null = 0` or `#undefined = 0`,
+ * which is meaningless and ill-typed in Pant.
+ */
+function isNullishSentinel(e: ts.Expression, checker: ts.TypeChecker): boolean {
+  return isNullKeyword(e) || isUndefinedIdentifier(e, checker);
 }
 
 function isTypeofExpression(e: ts.Expression): ts.Expression | null {
@@ -185,25 +225,35 @@ export function recognizeNullishLeaf(
       return null;
   }
 
-  const matchIfNullable = (operand: ts.Expression): NullishLeafMatch | null =>
-    isOperandNullable(operand, checker) ? { operand, negated } : null;
+  // Refuse the fold when the candidate operand is itself a nullish
+  // sentinel — `null === undefined`, `undefined !== null`, even
+  // `null === null` and `undefined === undefined`. Such comparisons
+  // are constants in TS, and folding them to `IsNullish(null)` /
+  // `IsNullish(undefined)` lowers to `#null = 0` (cardinality of a
+  // literal sentinel), which is ill-typed in Pant.
+  const matchIfValid = (operand: ts.Expression): NullishLeafMatch | null => {
+    if (isNullishSentinel(operand, checker)) {
+      return null;
+    }
+    return isOperandNullable(operand, checker) ? { operand, negated } : null;
+  };
 
   const leftIsNull = isNullKeyword(expr.left);
   const rightIsNull = isNullKeyword(expr.right);
   if (rightIsNull) {
-    return matchIfNullable(expr.left);
+    return matchIfValid(expr.left);
   }
   if (leftIsNull) {
-    return matchIfNullable(expr.right);
+    return matchIfValid(expr.right);
   }
   if (strict) {
     const leftIsUndef = isUndefinedIdentifier(expr.left, checker);
     const rightIsUndef = isUndefinedIdentifier(expr.right, checker);
     if (rightIsUndef) {
-      return matchIfNullable(expr.left);
+      return matchIfValid(expr.left);
     }
     if (leftIsUndef) {
-      return matchIfNullable(expr.right);
+      return matchIfValid(expr.right);
     }
   }
   return null;
@@ -245,14 +295,23 @@ export function recognizeTypeofUndefined(
   const leftTypeofOperand = isTypeofExpression(expr.left);
   const rightTypeofOperand = isTypeofExpression(expr.right);
 
-  const matchIfNullable = (operand: ts.Expression): NullishLeafMatch | null =>
-    isOperandNullable(operand, checker) ? { operand, negated } : null;
+  // Same sentinel-rejection as `recognizeNullishLeaf`: `typeof null
+  // === 'undefined'` is `false` (typeof null is "object"), so folding
+  // to `IsNullish(null)` is wrong both semantically and as Pant
+  // shape. Refuse if the operand inside `typeof` is itself a
+  // nullish sentinel.
+  const matchIfValid = (operand: ts.Expression): NullishLeafMatch | null => {
+    if (isNullishSentinel(operand, checker)) {
+      return null;
+    }
+    return isOperandNullable(operand, checker) ? { operand, negated } : null;
+  };
 
   if (leftTypeofOperand !== null && isUndefinedStringLiteral(expr.right)) {
-    return matchIfNullable(leftTypeofOperand);
+    return matchIfValid(leftTypeofOperand);
   }
   if (rightTypeofOperand !== null && isUndefinedStringLiteral(expr.left)) {
-    return matchIfNullable(rightTypeofOperand);
+    return matchIfValid(rightTypeofOperand);
   }
   return null;
 }
@@ -406,9 +465,39 @@ function recognizeLongForm(
     return null;
   }
 
-  const skipIndices = new Set<number>(folds.map((f) => f.secondIndex));
+  // Post-process: dedupe folds whose operands are structurally equal
+  // to an earlier fold's operand. `(P or P) ≡ P` and `(P and P) ≡ P`,
+  // so a chain like `x === null || x === undefined || x === null ||
+  // x === undefined` should produce a single `IsNullish(x)`, not two
+  // structurally-equivalent ones joined by `or`. Absorbing the
+  // duplicate fold also avoids translating the same operand twice
+  // through the shared `UniqueSupply` — fresh-binder counters would
+  // otherwise diverge between the two translations of a chain-typed
+  // operand (e.g., `arr.filter(p)`), producing redundant L1 with
+  // different binder names per `IsNullish`.
+  const dedupedFolds: Fold[] = [];
+  const absorbedSkip = new Set<number>();
+  for (const f of folds) {
+    const equiv = dedupedFolds.find((d) =>
+      structurallyEqualExpression(d.operand, f.operand),
+    );
+    if (equiv === undefined) {
+      dedupedFolds.push(f);
+    } else {
+      // Both positions of the duplicate fold are absorbed by the
+      // earlier fold's IsNullish. They produce no items in
+      // reconstruction.
+      absorbedSkip.add(f.firstIndex);
+      absorbedSkip.add(f.secondIndex);
+    }
+  }
+
+  const skipIndices = new Set<number>([
+    ...dedupedFolds.map((f) => f.secondIndex),
+    ...absorbedSkip,
+  ]);
   const foldByFirst = new Map<number, ts.Expression>(
-    folds.map((f) => [f.firstIndex, f.operand]),
+    dedupedFolds.map((f) => [f.firstIndex, f.operand]),
   );
 
   // Bool-type gate on leftover operands. After folding, the result

--- a/tools/ts2pant/src/nullish-recognizer.ts
+++ b/tools/ts2pant/src/nullish-recognizer.ts
@@ -14,6 +14,25 @@
  *
  * Negated leaves wrap as `unop(not, IsNullish(x))`.
  *
+ * **Nullability gate.** A leaf only folds when the matched operand's
+ * TS type at the AST location actually includes `null`, `undefined`,
+ * or `void`. This guards the list-lift encoding (`T | null → [T]`):
+ * if `x: number` is non-nullable, `#x = 0` would be ill-typed
+ * (cardinality applies to lists, not scalars). Non-nullable
+ * occurrences fall through and the surrounding TS-AST handler
+ * either rejects or emits the legacy shape. See
+ * `tools/ts2pant/CLAUDE.md` § "Option-Type Elimination" for the
+ * encoding rationale.
+ *
+ * **`undefined` shadowing.** `undefined` is not a reserved word in
+ * JavaScript — a parameter, local, or import named `undefined` is
+ * a legal binding that shadows the global. Identifier-only matching
+ * would fold `x === undefined` even when `undefined` resolves to a
+ * shadowed local of unrelated type. The leaf recognizer guards by
+ * asking the checker for the resolved type at the identifier's
+ * location and only matching when that type's flags include
+ * `Undefined`.
+ *
  * **Long-form recognizer is flat-aware.** For a chain
  * `a || b || c || …`, all `||` operands at the same level are
  * collected into a flat list. The recognizer scans for two operands
@@ -39,6 +58,28 @@ import { structurallyEqualExpression } from "./ast-equal.js";
 import { type IR1Expr, ir1Binop, ir1IsNullish, ir1Unop } from "./ir1.js";
 
 /**
+ * True when the TS type at this AST location includes `null`,
+ * `undefined`, or `void` — i.e., when the operand is list-lifted to
+ * `[T]` on the Pant side and `#operand = 0` is a well-typed nullish
+ * test. Mirrors `isNullableTsType` in `translate-body.ts`; defined
+ * locally to keep this module dependency-light.
+ */
+function isNullableType(type: ts.Type): boolean {
+  const mask = ts.TypeFlags.Null | ts.TypeFlags.Undefined | ts.TypeFlags.Void;
+  if (type.isUnion()) {
+    return type.types.some((t) => (t.flags & mask) !== 0);
+  }
+  return (type.flags & mask) !== 0;
+}
+
+function isOperandNullable(
+  operand: ts.Expression,
+  checker: ts.TypeChecker,
+): boolean {
+  return isNullableType(checker.getTypeAtLocation(operand));
+}
+
+/**
  * A nullish leaf match — one of the short-form binary expressions
  * (`x == null`, `x === undefined`, `typeof x === 'undefined'`, etc.).
  * `negated` is `true` for `!=` / `!==` forms.
@@ -60,9 +101,25 @@ function isNullKeyword(e: ts.Expression): boolean {
   return unwrapParens(e).kind === ts.SyntaxKind.NullKeyword;
 }
 
-function isUndefinedIdentifier(e: ts.Expression): boolean {
+/**
+ * True when `e` is a reference to the global `undefined` value (not a
+ * shadowed local with that name). Verifies via the checker because
+ * `undefined` is not a reserved word — a parameter, local variable,
+ * or import named `undefined` is a legal binding that hides the
+ * global. The resolved type's flags must include `Undefined`; a
+ * shadowed `undefined: number` resolves to `number` (no Undefined
+ * flag) and is rejected.
+ */
+function isUndefinedIdentifier(
+  e: ts.Expression,
+  checker: ts.TypeChecker,
+): boolean {
   const u = unwrapParens(e);
-  return ts.isIdentifier(u) && u.text === "undefined";
+  if (!ts.isIdentifier(u) || u.text !== "undefined") {
+    return false;
+  }
+  const type = checker.getTypeAtLocation(u);
+  return (type.flags & ts.TypeFlags.Undefined) !== 0;
 }
 
 function isUndefinedStringLiteral(e: ts.Expression): boolean {
@@ -89,11 +146,20 @@ function isTypeofExpression(e: ts.Expression): ts.Expression | null {
  * the `null` literal — `x == undefined` is unusual idiomatically and
  * is not part of the recognized leaf shapes.
  *
+ * The match also requires that `operand` has a nullable TS type at
+ * the AST location (includes `null`, `undefined`, or `void`). A
+ * non-nullable operand like `x: number` doesn't list-lift to `[T]`,
+ * so `#x = 0` would be ill-typed in Pant. Mismatched cases fall
+ * through (return `null`) and the surrounding handler decides what
+ * to do — typically reject as unsupported.
+ *
  * Returns `null` if the binary expression is not a nullish-equality
- * leaf (e.g., `x === 0`, `x + null`, `==` against a non-null literal).
+ * leaf (e.g., `x === 0`, `x + null`, `==` against a non-null literal,
+ * or operand whose TS type isn't nullable).
  */
 export function recognizeNullishLeaf(
   expr: ts.BinaryExpression,
+  checker: ts.TypeChecker,
 ): NullishLeafMatch | null {
   let negated: boolean;
   let strict: boolean;
@@ -118,22 +184,25 @@ export function recognizeNullishLeaf(
       return null;
   }
 
+  const matchIfNullable = (operand: ts.Expression): NullishLeafMatch | null =>
+    isOperandNullable(operand, checker) ? { operand, negated } : null;
+
   const leftIsNull = isNullKeyword(expr.left);
   const rightIsNull = isNullKeyword(expr.right);
   if (rightIsNull) {
-    return { operand: expr.left, negated };
+    return matchIfNullable(expr.left);
   }
   if (leftIsNull) {
-    return { operand: expr.right, negated };
+    return matchIfNullable(expr.right);
   }
   if (strict) {
-    const leftIsUndef = isUndefinedIdentifier(expr.left);
-    const rightIsUndef = isUndefinedIdentifier(expr.right);
+    const leftIsUndef = isUndefinedIdentifier(expr.left, checker);
+    const rightIsUndef = isUndefinedIdentifier(expr.right, checker);
     if (rightIsUndef) {
-      return { operand: expr.left, negated };
+      return matchIfNullable(expr.left);
     }
     if (leftIsUndef) {
-      return { operand: expr.right, negated };
+      return matchIfNullable(expr.right);
     }
   }
   return null;
@@ -146,11 +215,17 @@ export function recognizeNullishLeaf(
  * is also accepted because the legal TS coercion semantics for
  * `typeof x` are well-defined.
  *
+ * Like `recognizeNullishLeaf`, requires the operand inside `typeof`
+ * to have a nullable TS type — otherwise `#x = 0` would be ill-typed
+ * even though the surface syntax `typeof x === 'undefined'` is
+ * always-false-but-legal in TypeScript.
+ *
  * Returns `null` if the binary expression is not a typeof-undefined
- * leaf.
+ * leaf or the operand isn't nullable.
  */
 export function recognizeTypeofUndefined(
   expr: ts.BinaryExpression,
+  checker: ts.TypeChecker,
 ): NullishLeafMatch | null {
   let negated: boolean;
   switch (expr.operatorToken.kind) {
@@ -169,11 +244,14 @@ export function recognizeTypeofUndefined(
   const leftTypeofOperand = isTypeofExpression(expr.left);
   const rightTypeofOperand = isTypeofExpression(expr.right);
 
+  const matchIfNullable = (operand: ts.Expression): NullishLeafMatch | null =>
+    isOperandNullable(operand, checker) ? { operand, negated } : null;
+
   if (leftTypeofOperand !== null && isUndefinedStringLiteral(expr.right)) {
-    return { operand: leftTypeofOperand, negated };
+    return matchIfNullable(leftTypeofOperand);
   }
   if (rightTypeofOperand !== null && isUndefinedStringLiteral(expr.left)) {
-    return { operand: rightTypeofOperand, negated };
+    return matchIfNullable(rightTypeofOperand);
   }
   return null;
 }
@@ -182,8 +260,14 @@ export function recognizeTypeofUndefined(
  * Combined leaf matcher: tries `recognizeNullishLeaf` first, then
  * `recognizeTypeofUndefined`. Returns `null` if neither matches.
  */
-function recognizeAnyLeaf(expr: ts.BinaryExpression): NullishLeafMatch | null {
-  return recognizeNullishLeaf(expr) ?? recognizeTypeofUndefined(expr);
+function recognizeAnyLeaf(
+  expr: ts.BinaryExpression,
+  checker: ts.TypeChecker,
+): NullishLeafMatch | null {
+  return (
+    recognizeNullishLeaf(expr, checker) ??
+    recognizeTypeofUndefined(expr, checker)
+  );
 }
 
 /**
@@ -255,6 +339,7 @@ function flattenChain(
 function recognizeLongForm(
   expr: ts.BinaryExpression,
   combinator: "or" | "and",
+  checker: ts.TypeChecker,
   translate: NullishTranslate,
 ): IR1Expr | { unsupported: string } | null {
   const targetOp =
@@ -275,7 +360,7 @@ function recognizeLongForm(
     if (!ts.isBinaryExpression(u)) {
       return null;
     }
-    const leaf = recognizeAnyLeaf(u);
+    const leaf = recognizeAnyLeaf(u, checker);
     if (leaf === null || leaf.negated !== targetNegated) {
       return null;
     }
@@ -364,6 +449,10 @@ function recognizeLongForm(
  * `typeof x === 'undefined'`, etc.), then long-form chains
  * (`x === null || x === undefined`).
  *
+ * The checker is required for the nullability gate (see module
+ * doc) and for verifying that an `undefined` identifier resolves
+ * to the global value rather than a shadowed local.
+ *
  * Returns:
  * - An `IR1Expr` if recognized — the caller should lower it and use
  *   the result instead of the legacy translation path.
@@ -374,18 +463,19 @@ function recognizeLongForm(
  */
 export function recognizeNullishForm(
   expr: ts.BinaryExpression,
+  checker: ts.TypeChecker,
   translate: NullishTranslate,
 ): IR1Expr | { unsupported: string } | null {
-  const leaf = recognizeAnyLeaf(expr);
+  const leaf = recognizeAnyLeaf(expr, checker);
   if (leaf !== null) {
     return buildLeafL1(leaf, translate);
   }
 
   if (expr.operatorToken.kind === ts.SyntaxKind.BarBarToken) {
-    return recognizeLongForm(expr, "or", translate);
+    return recognizeLongForm(expr, "or", checker, translate);
   }
   if (expr.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken) {
-    return recognizeLongForm(expr, "and", translate);
+    return recognizeLongForm(expr, "and", checker, translate);
   }
   return null;
 }

--- a/tools/ts2pant/src/nullish-recognizer.ts
+++ b/tools/ts2pant/src/nullish-recognizer.ts
@@ -56,6 +56,7 @@
 import ts from "typescript";
 import { structurallyEqualExpression } from "./ast-equal.js";
 import { type IR1Expr, ir1Binop, ir1IsNullish, ir1Unop } from "./ir1.js";
+import { isStaticallyBoolTyped } from "./purity.js";
 
 /**
  * True when the TS type at this AST location includes `null`,
@@ -409,6 +410,23 @@ function recognizeLongForm(
   const foldByFirst = new Map<number, ts.Expression>(
     folds.map((f) => [f.firstIndex, f.operand]),
   );
+
+  // Bool-type gate on leftover operands. After folding, the result
+  // becomes `IsNullish(...) <combinator> <leftover...>`. `IsNullish`
+  // is Bool by construction, but the leftover clauses must also be
+  // statically Bool — otherwise the rebuilt `or`/`and` would mix a
+  // Bool with a value-typed clause, changing JS's truthy-coercion
+  // short-circuit semantics. Refuse to fold rather than emit
+  // potentially-incorrect IR (workstream conservative-refusal 3(b));
+  // the caller falls through to its normal binop path.
+  for (let i = 0; i < operands.length; i++) {
+    if (skipIndices.has(i) || foldByFirst.has(i)) {
+      continue;
+    }
+    if (!isStaticallyBoolTyped(operands[i] as ts.Expression, checker)) {
+      return null;
+    }
+  }
 
   const items: IR1Expr[] = [];
   for (let i = 0; i < operands.length; i++) {

--- a/tools/ts2pant/src/nullish-recognizer.ts
+++ b/tools/ts2pant/src/nullish-recognizer.ts
@@ -1,0 +1,391 @@
+/**
+ * M4 nullish recognizer (workstream M4: equality and nullish).
+ *
+ * Routes the equality/nullish equivalence class onto Layer 1's
+ * canonical `is-nullish` form. Five surface forms collapse to one
+ * shape:
+ *
+ *   - `x == null` / `x != null`            (loose-eq variant)
+ *   - `x === null` / `x !== null`          (strict, null literal)
+ *   - `x === undefined` / `x !== undefined`  (strict, undefined literal)
+ *   - `x === null || x === undefined`       (long form, positive)
+ *   - `x !== null && x !== undefined`       (long form, negated)
+ *   - `typeof x === 'undefined'` / `!==`    (typeof-undefined family)
+ *
+ * Negated leaves wrap as `unop(not, IsNullish(x))`.
+ *
+ * **Long-form recognizer is flat-aware.** For a chain
+ * `a || b || c || …`, all `||` operands at the same level are
+ * collected into a flat list. The recognizer scans for two operands
+ * that are nullish-shaped against the *same operand expression*
+ * (structurally — see `ast-equal.ts`), folds the pair into one
+ * `IsNullish` node, and rebuilds the disjunction with the remaining
+ * clauses around the fold. Same for `&&` chains using the negated
+ * form. This means
+ * `(a === null) || (a === undefined) || other`
+ * recognizes as `IsNullish(a) || other` rather than forcing the
+ * programmer to rewrite their TS to fit a strict pattern.
+ *
+ * **Operand mismatch falls through.** If no two leaves in a
+ * chain share an operand structurally, the long-form recognizer
+ * returns `null` — the surrounding `||`/`&&` flows through the
+ * normal Bool-typed short-circuit path. Each leaf, on its own
+ * recursive translation, is still a leaf-level nullish form and
+ * recognized individually.
+ */
+
+import ts from "typescript";
+import { structurallyEqualExpression } from "./ast-equal.js";
+import { type IR1Expr, ir1Binop, ir1IsNullish, ir1Unop } from "./ir1.js";
+
+/**
+ * A nullish leaf match — one of the short-form binary expressions
+ * (`x == null`, `x === undefined`, `typeof x === 'undefined'`, etc.).
+ * `negated` is `true` for `!=` / `!==` forms.
+ */
+export interface NullishLeafMatch {
+  operand: ts.Expression;
+  negated: boolean;
+}
+
+function unwrapParens(e: ts.Expression): ts.Expression {
+  let cur = e;
+  while (ts.isParenthesizedExpression(cur)) {
+    cur = cur.expression;
+  }
+  return cur;
+}
+
+function isNullKeyword(e: ts.Expression): boolean {
+  return unwrapParens(e).kind === ts.SyntaxKind.NullKeyword;
+}
+
+function isUndefinedIdentifier(e: ts.Expression): boolean {
+  const u = unwrapParens(e);
+  return ts.isIdentifier(u) && u.text === "undefined";
+}
+
+function isUndefinedStringLiteral(e: ts.Expression): boolean {
+  const u = unwrapParens(e);
+  return ts.isStringLiteral(u) && u.text === "undefined";
+}
+
+function isTypeofExpression(e: ts.Expression): ts.Expression | null {
+  const u = unwrapParens(e);
+  if (ts.isTypeOfExpression(u)) {
+    return u.expression;
+  }
+  return null;
+}
+
+/**
+ * Recognize the leaf nullish-equality forms:
+ *   - `x == null` / `x != null`
+ *   - `x === null` / `x !== null`
+ *   - `x === undefined` / `x !== undefined`
+ *
+ * The `null`/`undefined` literal can appear on either side; the
+ * other side is `operand`. Loose equality (`==`/`!=`) accepts only
+ * the `null` literal — `x == undefined` is unusual idiomatically and
+ * is not part of the recognized leaf shapes.
+ *
+ * Returns `null` if the binary expression is not a nullish-equality
+ * leaf (e.g., `x === 0`, `x + null`, `==` against a non-null literal).
+ */
+export function recognizeNullishLeaf(
+  expr: ts.BinaryExpression,
+): NullishLeafMatch | null {
+  let negated: boolean;
+  let strict: boolean;
+  switch (expr.operatorToken.kind) {
+    case ts.SyntaxKind.EqualsEqualsToken:
+      negated = false;
+      strict = false;
+      break;
+    case ts.SyntaxKind.EqualsEqualsEqualsToken:
+      negated = false;
+      strict = true;
+      break;
+    case ts.SyntaxKind.ExclamationEqualsToken:
+      negated = true;
+      strict = false;
+      break;
+    case ts.SyntaxKind.ExclamationEqualsEqualsToken:
+      negated = true;
+      strict = true;
+      break;
+    default:
+      return null;
+  }
+
+  const leftIsNull = isNullKeyword(expr.left);
+  const rightIsNull = isNullKeyword(expr.right);
+  if (rightIsNull) {
+    return { operand: expr.left, negated };
+  }
+  if (leftIsNull) {
+    return { operand: expr.right, negated };
+  }
+  if (strict) {
+    const leftIsUndef = isUndefinedIdentifier(expr.left);
+    const rightIsUndef = isUndefinedIdentifier(expr.right);
+    if (rightIsUndef) {
+      return { operand: expr.left, negated };
+    }
+    if (leftIsUndef) {
+      return { operand: expr.right, negated };
+    }
+  }
+  return null;
+}
+
+/**
+ * Recognize the `typeof x === 'undefined'` / `typeof x !== 'undefined'`
+ * family. The `typeof` operand can appear on either side; the other
+ * side is the string literal `'undefined'`. Loose equality (`==`/`!=`)
+ * is also accepted because the legal TS coercion semantics for
+ * `typeof x` are well-defined.
+ *
+ * Returns `null` if the binary expression is not a typeof-undefined
+ * leaf.
+ */
+export function recognizeTypeofUndefined(
+  expr: ts.BinaryExpression,
+): NullishLeafMatch | null {
+  let negated: boolean;
+  switch (expr.operatorToken.kind) {
+    case ts.SyntaxKind.EqualsEqualsToken:
+    case ts.SyntaxKind.EqualsEqualsEqualsToken:
+      negated = false;
+      break;
+    case ts.SyntaxKind.ExclamationEqualsToken:
+    case ts.SyntaxKind.ExclamationEqualsEqualsToken:
+      negated = true;
+      break;
+    default:
+      return null;
+  }
+
+  const leftTypeofOperand = isTypeofExpression(expr.left);
+  const rightTypeofOperand = isTypeofExpression(expr.right);
+
+  if (leftTypeofOperand !== null && isUndefinedStringLiteral(expr.right)) {
+    return { operand: leftTypeofOperand, negated };
+  }
+  if (rightTypeofOperand !== null && isUndefinedStringLiteral(expr.left)) {
+    return { operand: rightTypeofOperand, negated };
+  }
+  return null;
+}
+
+/**
+ * Combined leaf matcher: tries `recognizeNullishLeaf` first, then
+ * `recognizeTypeofUndefined`. Returns `null` if neither matches.
+ */
+function recognizeAnyLeaf(expr: ts.BinaryExpression): NullishLeafMatch | null {
+  return recognizeNullishLeaf(expr) ?? recognizeTypeofUndefined(expr);
+}
+
+/**
+ * Translation callback shape expected by the nullish recognizer. The
+ * recognizer drives translation of operands (the `x` in `x == null`)
+ * and any non-nullish residue from a long-form chain. The caller
+ * threads the appropriate `translateBodyExpr` / `translateExpr` into
+ * this callback.
+ *
+ * Returning `{ unsupported }` propagates the rejection up through the
+ * recognizer's result, so the caller can surface the same reason as
+ * if the recognizer had not fired.
+ */
+export type NullishTranslate = (
+  expr: ts.Expression,
+) => IR1Expr | { unsupported: string };
+
+const isUnsupported = (
+  r: IR1Expr | { unsupported: string },
+): r is { unsupported: string } => "unsupported" in r;
+
+/**
+ * Build an L1 expression for a single recognized leaf — `IsNullish(x)`,
+ * wrapped in `unop(not, …)` if negated.
+ */
+function buildLeafL1(
+  leaf: NullishLeafMatch,
+  translate: NullishTranslate,
+): IR1Expr | { unsupported: string } {
+  const operandL1 = translate(leaf.operand);
+  if (isUnsupported(operandL1)) {
+    return operandL1;
+  }
+  const isNull = ir1IsNullish(operandL1);
+  return leaf.negated ? ir1Unop("not", isNull) : isNull;
+}
+
+/**
+ * Flatten a chain of binary expressions joined by `targetOp` into the
+ * list of leaf operands. Parenthesized wrappers around a chain
+ * connector are unwrapped so nesting structure doesn't hide a
+ * fold-eligible pair.
+ */
+function flattenChain(
+  expr: ts.Expression,
+  targetOp: ts.SyntaxKind,
+  out: ts.Expression[],
+): void {
+  const u = unwrapParens(expr);
+  if (ts.isBinaryExpression(u) && u.operatorToken.kind === targetOp) {
+    flattenChain(u.left, targetOp, out);
+    flattenChain(u.right, targetOp, out);
+    return;
+  }
+  out.push(expr);
+}
+
+/**
+ * Recognize a long-form chain of `||` (positive) or `&&` (negated).
+ * Looks for two operands that are nullish-shaped against the same
+ * operand expression and folds them into one `IsNullish` node.
+ *
+ * Returns `null` if no fold-eligible pair was found — the caller
+ * falls through to the normal short-circuit translation path. If a
+ * pair is found, the result is the chain rebuilt with the fold in
+ * place of the two consumed operands and any remaining clauses
+ * translated through the callback.
+ */
+function recognizeLongForm(
+  expr: ts.BinaryExpression,
+  combinator: "or" | "and",
+  translate: NullishTranslate,
+): IR1Expr | { unsupported: string } | null {
+  const targetOp =
+    combinator === "or"
+      ? ts.SyntaxKind.BarBarToken
+      : ts.SyntaxKind.AmpersandAmpersandToken;
+  const targetNegated = combinator === "and";
+
+  const operands: ts.Expression[] = [];
+  flattenChain(expr.left, targetOp, operands);
+  flattenChain(expr.right, targetOp, operands);
+
+  // Classify each operand: is it a nullish leaf with negated matching
+  // the chain's polarity? If so, remember its operand expression for
+  // pair-matching against the same operand.
+  const leafOperands: Array<ts.Expression | null> = operands.map((op) => {
+    const u = unwrapParens(op);
+    if (!ts.isBinaryExpression(u)) {
+      return null;
+    }
+    const leaf = recognizeAnyLeaf(u);
+    if (leaf === null || leaf.negated !== targetNegated) {
+      return null;
+    }
+    return leaf.operand;
+  });
+
+  // Greedy pairing: walk left-to-right, pair each unconsumed nullish
+  // leaf with the next unconsumed nullish leaf that shares an operand.
+  const consumed = new Set<number>();
+  type Fold = {
+    firstIndex: number;
+    secondIndex: number;
+    operand: ts.Expression;
+  };
+  const folds: Fold[] = [];
+  for (let i = 0; i < leafOperands.length; i++) {
+    if (consumed.has(i)) {
+      continue;
+    }
+    const opA = leafOperands[i];
+    if (opA === null || opA === undefined) {
+      continue;
+    }
+    for (let j = i + 1; j < leafOperands.length; j++) {
+      if (consumed.has(j)) {
+        continue;
+      }
+      const opB = leafOperands[j];
+      if (opB === null || opB === undefined) {
+        continue;
+      }
+      if (structurallyEqualExpression(opA, opB)) {
+        consumed.add(i);
+        consumed.add(j);
+        folds.push({ firstIndex: i, secondIndex: j, operand: opA });
+        break;
+      }
+    }
+  }
+
+  if (folds.length === 0) {
+    return null;
+  }
+
+  const skipIndices = new Set<number>(folds.map((f) => f.secondIndex));
+  const foldByFirst = new Map<number, ts.Expression>(
+    folds.map((f) => [f.firstIndex, f.operand]),
+  );
+
+  const items: IR1Expr[] = [];
+  for (let i = 0; i < operands.length; i++) {
+    if (skipIndices.has(i)) {
+      continue;
+    }
+    const foldedOperand = foldByFirst.get(i);
+    if (foldedOperand !== undefined) {
+      const operandL1 = translate(foldedOperand);
+      if (isUnsupported(operandL1)) {
+        return operandL1;
+      }
+      const isNull = ir1IsNullish(operandL1);
+      items.push(targetNegated ? ir1Unop("not", isNull) : isNull);
+    } else {
+      const otherL1 = translate(operands[i] as ts.Expression);
+      if (isUnsupported(otherL1)) {
+        return otherL1;
+      }
+      items.push(otherL1);
+    }
+  }
+
+  if (items.length === 0) {
+    // Should be unreachable — a fold consumed two leaves but produced
+    // no items, meaning the chain had length < 2. Defense in depth.
+    return null;
+  }
+  let result = items[0] as IR1Expr;
+  for (let i = 1; i < items.length; i++) {
+    result = ir1Binop(combinator, result, items[i] as IR1Expr);
+  }
+  return result;
+}
+
+/**
+ * Top-level recognizer. Tries leaf forms first (`x == null`,
+ * `typeof x === 'undefined'`, etc.), then long-form chains
+ * (`x === null || x === undefined`).
+ *
+ * Returns:
+ * - An `IR1Expr` if recognized — the caller should lower it and use
+ *   the result instead of the legacy translation path.
+ * - `{ unsupported }` if recognized but the operand failed to
+ *   translate — the caller should surface the same rejection.
+ * - `null` if not recognized — the caller should fall through to its
+ *   normal binary-expression handling.
+ */
+export function recognizeNullishForm(
+  expr: ts.BinaryExpression,
+  translate: NullishTranslate,
+): IR1Expr | { unsupported: string } | null {
+  const leaf = recognizeAnyLeaf(expr);
+  if (leaf !== null) {
+    return buildLeafL1(leaf, translate);
+  }
+
+  if (expr.operatorToken.kind === ts.SyntaxKind.BarBarToken) {
+    return recognizeLongForm(expr, "or", translate);
+  }
+  if (expr.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken) {
+    return recognizeLongForm(expr, "and", translate);
+  }
+  return null;
+}

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -21,6 +21,10 @@ import {
 } from "./ir1-build-body.js";
 import { lowerL1MuSearch, type MuSearchLowerCtx } from "./ir1-lower.js";
 import { lowerL1Body } from "./ir1-lower-body.js";
+import {
+  type NullishTranslate,
+  recognizeNullishForm,
+} from "./nullish-recognizer.js";
 import type {
   OpaqueCombiner,
   OpaqueExpr,
@@ -2661,6 +2665,43 @@ export function translateBodyExpr(
 
   if (ts.isExpression(expr)) {
     expr = unwrapExpression(expr);
+  }
+
+  // M4: nullish surface forms (`x == null`, `x === undefined`, the
+  // `||`-long form, `typeof x === 'undefined'`, etc.) collapse to a
+  // canonical L1 `IsNullish` (with `unop(not, …)` for negated forms).
+  // Runs *before* the L1 conditional dispatch so a Bool-typed
+  // `||`/`&&` chain that's actually a long-form nullish test does not
+  // get consumed by `buildFromShortCircuit`. Operand mismatch (e.g.,
+  // `a === null || b === undefined`) returns `null` and falls through
+  // to the normal Bool-typed short-circuit path.
+  if (ts.isBinaryExpression(expr)) {
+    const translate: NullishTranslate = (sub) => {
+      const subResult = translateBodyExpr(
+        sub,
+        checker,
+        strategy,
+        paramNames,
+        state,
+        supply,
+      );
+      if (isBodyUnsupported(subResult)) {
+        return subResult;
+      }
+      if (isBodyEffect(subResult)) {
+        return {
+          unsupported: "collection mutation cannot appear in a nullish operand",
+        };
+      }
+      return ir1FromL2(irWrap(bodyExpr(subResult)));
+    };
+    const recognized = recognizeNullishForm(expr, translate);
+    if (recognized !== null) {
+      if ("unsupported" in recognized) {
+        return { unsupported: recognized.unsupported };
+      }
+      return { expr: lowerL1ToOpaque(recognized) };
+    }
   }
 
   // Layer 1 imperative-IR conditional pipeline (workstream M1).

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -2676,6 +2676,11 @@ export function translateBodyExpr(
   // `a === null || b === undefined`) returns `null` and falls through
   // to the normal Bool-typed short-circuit path.
   if (ts.isBinaryExpression(expr)) {
+    // `translateBodyExpr` itself converts effectful call expressions
+    // into `{ unsupported }` via `rejectEffect` (the CallExpression
+    // arm below), so the effect variant of `BodyResult` never
+    // reaches us here — the surfaced rejection carries the upstream
+    // "collection mutation outside statement position" message.
     const translate: NullishTranslate = (sub) => {
       const subResult = translateBodyExpr(
         sub,
@@ -2687,11 +2692,6 @@ export function translateBodyExpr(
       );
       if (isBodyUnsupported(subResult)) {
         return subResult;
-      }
-      if (isBodyEffect(subResult)) {
-        return {
-          unsupported: "collection mutation cannot appear in a nullish operand",
-        };
       }
       return ir1FromL2(irWrap(bodyExpr(subResult)));
     };

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -2695,7 +2695,7 @@ export function translateBodyExpr(
       }
       return ir1FromL2(irWrap(bodyExpr(subResult)));
     };
-    const recognized = recognizeNullishForm(expr, translate);
+    const recognized = recognizeNullishForm(expr, checker, translate);
     if (recognized !== null) {
       if ("unsupported" in recognized) {
         return { unsupported: recognized.unsupported };

--- a/tools/ts2pant/src/translate-signature.ts
+++ b/tools/ts2pant/src/translate-signature.ts
@@ -1,5 +1,13 @@
 import type { SourceFile } from "ts-morph";
 import ts from "typescript";
+import { irWrap } from "./ir.js";
+import { lowerExpr } from "./ir-emit.js";
+import { ir1FromL2 } from "./ir1.js";
+import { lowerL1Expr } from "./ir1-lower.js";
+import {
+  type NullishTranslate,
+  recognizeNullishForm,
+} from "./nullish-recognizer.js";
 import type { OpaqueBinop, OpaqueExpr } from "./pant-ast.js";
 import { getAst } from "./pant-wasm.js";
 import {
@@ -974,7 +982,37 @@ export function translateExpr(
 
   // Binary expression: a >= b -> binop(opGe(), a, b)
   if (ts.isBinaryExpression(expr)) {
-    // M4 P3: reject loose equality (== / !=) explicitly. Falling
+    // M4 P2: recognize nullish surface forms (`x == null`,
+    // `x === undefined`, the long form, `typeof x === 'undefined'`,
+    // …) and collapse them to L1 `IsNullish`. Runs *before* the
+    // loose-eq rejection below so `x == null` (a loose-eq nullish)
+    // gets folded, not rejected. Mirrors the body-side recognition
+    // site in `translate-body.ts`.
+    //
+    // The translate callback unwraps `translateExpr`'s discriminated-
+    // union result; an upstream `{ unsupported }` propagates through
+    // the recognizer.
+    const translate: NullishTranslate = (sub) => {
+      const subResult = translateExpr(
+        sub,
+        checker,
+        _strategy,
+        paramNames,
+        synthCell,
+      );
+      if (isTranslateExprUnsupported(subResult)) {
+        return subResult;
+      }
+      return ir1FromL2(irWrap(subResult));
+    };
+    const recognized = recognizeNullishForm(expr, translate);
+    if (recognized !== null && !("unsupported" in recognized)) {
+      return lowerExpr(lowerL1Expr(recognized));
+    }
+    // M4 P3: reject any surviving loose equality (== / !=). The
+    // nullish recognizer above consumes loose-eq nullish forms; what
+    // reaches here is `==` / `!=` against non-nullish operands, which
+    // is inherently ambiguous in TS coercion semantics. Falling
     // through to the `ast.var(expr.getText())` path below would emit
     // raw source text as a Pant variable name, violating
     // conservative-refusal policy 3(b). Return an explicit `unsupported`

--- a/tools/ts2pant/src/translate-signature.ts
+++ b/tools/ts2pant/src/translate-signature.ts
@@ -990,8 +990,15 @@ export function translateExpr(
     // site in `translate-body.ts`.
     //
     // The translate callback unwraps `translateExpr`'s discriminated-
-    // union result; an upstream `{ unsupported }` propagates through
-    // the recognizer.
+    // union result (post-P3 `TranslateExprResult`); an upstream
+    // `{ unsupported }` propagates through the recognizer and is
+    // surfaced by the entry-point caller.
+    //
+    // The recognizer takes the checker for two soundness gates:
+    // (1) TS-type nullability — only fold when the operand's
+    // declared type includes `null`/`undefined`/`void`; (2)
+    // resolved-`undefined` — verify the `undefined` identifier
+    // resolves to the global symbol, not a shadowed local.
     const translate: NullishTranslate = (sub) => {
       const subResult = translateExpr(
         sub,
@@ -1005,7 +1012,7 @@ export function translateExpr(
       }
       return ir1FromL2(irWrap(subResult));
     };
-    const recognized = recognizeNullishForm(expr, translate);
+    const recognized = recognizeNullishForm(expr, checker, translate);
     if (recognized !== null && !("unsupported" in recognized)) {
       return lowerExpr(lowerL1Expr(recognized));
     }

--- a/tools/ts2pant/tests/ast-equal.test.mts
+++ b/tools/ts2pant/tests/ast-equal.test.mts
@@ -124,6 +124,36 @@ describe("ast-equal", () => {
     );
   });
 
+  it("transparent wrappers (as / !  / satisfies) are unwrapped", () => {
+    // Match `unwrapExpression` in translate-body.ts — these wrappers
+    // don't change runtime value, so two operands wrapped differently
+    // should still match for the long-form nullish recognizer to
+    // fold them.
+    assert.equal(
+      structurallyEqualExpression(parseExpr("(x as number)"), parseExpr("x")),
+      true,
+    );
+    assert.equal(
+      structurallyEqualExpression(parseExpr("x!"), parseExpr("x")),
+      true,
+    );
+    assert.equal(
+      structurallyEqualExpression(
+        parseExpr("x satisfies number"),
+        parseExpr("x"),
+      ),
+      true,
+    );
+    // Composed wrappers (paren around as, etc.).
+    assert.equal(
+      structurallyEqualExpression(
+        parseExpr("((x as number)!)"),
+        parseExpr("x"),
+      ),
+      true,
+    );
+  });
+
   it("parenthesized wrappers are unwrapped", () => {
     assert.equal(
       structurallyEqualExpression(parseExpr("(a.b)"), parseExpr("a.b")),

--- a/tools/ts2pant/tests/ast-equal.test.mts
+++ b/tools/ts2pant/tests/ast-equal.test.mts
@@ -81,6 +81,20 @@ describe("ast-equal", () => {
     );
   });
 
+  it("spread arguments cause calls to compare unequal (conservative)", () => {
+    // f(...arr) vs f(...arr) — same source text but spread expansion
+    // is runtime-determined; we cannot assert operand identity.
+    assert.equal(
+      structurallyEqualExpression(parseExpr("f(...a)"), parseExpr("f(...a)")),
+      false,
+    );
+    // f(...arr) vs f(a, b) — different argument shapes.
+    assert.equal(
+      structurallyEqualExpression(parseExpr("f(...a)"), parseExpr("f(a, b)")),
+      false,
+    );
+  });
+
   it("calls compare structurally including arguments", () => {
     assert.equal(
       structurallyEqualExpression(parseExpr("f(x)"), parseExpr("f(x)")),

--- a/tools/ts2pant/tests/ast-equal.test.mts
+++ b/tools/ts2pant/tests/ast-equal.test.mts
@@ -1,0 +1,200 @@
+/**
+ * Unit tests for `structurallyEqualExpression` (M4 helper).
+ *
+ * Verifies that equality is structural — same kind, same identifier
+ * texts, same recursive children — and that surface-text differences
+ * (whitespace, comments, quote style, parenthesization) don't change
+ * the verdict. The latter is exactly what `getText`-based comparison
+ * would get wrong.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import ts from "typescript";
+import { structurallyEqualExpression } from "../src/ast-equal.js";
+import { createSourceFileFromSource } from "../src/extract.js";
+
+/**
+ * Parse a TS expression. Wraps the source in `const _ = (<expr>);`
+ * so we can pull a single typed Expression node back out without
+ * fighting the statement-level parser.
+ */
+function parseExpr(source: string): ts.Expression {
+  const sf = createSourceFileFromSource(`const _ = (${source});`);
+  const stmt = sf.compilerNode.statements[0];
+  if (!stmt || !ts.isVariableStatement(stmt)) {
+    throw new Error("test helper: expected a variable statement");
+  }
+  const decl = stmt.declarationList.declarations[0];
+  if (!decl || !decl.initializer) {
+    throw new Error("test helper: expected an initializer");
+  }
+  // Unwrap the outer parens we added.
+  let expr: ts.Expression = decl.initializer;
+  while (ts.isParenthesizedExpression(expr)) {
+    expr = expr.expression;
+  }
+  return expr;
+}
+
+describe("ast-equal", () => {
+  it("identifiers compare structurally", () => {
+    assert.equal(structurallyEqualExpression(parseExpr("a"), parseExpr("a")), true);
+    assert.equal(
+      structurallyEqualExpression(parseExpr("a"), parseExpr("b")),
+      false,
+    );
+  });
+
+  it("dotted paths compare structurally", () => {
+    assert.equal(
+      structurallyEqualExpression(parseExpr("a.b"), parseExpr("a.b")),
+      true,
+    );
+    assert.equal(
+      structurallyEqualExpression(parseExpr("a.b"), parseExpr("a.c")),
+      false,
+    );
+    assert.equal(
+      structurallyEqualExpression(parseExpr("a.b.c"), parseExpr("a.b.c")),
+      true,
+    );
+    assert.equal(
+      structurallyEqualExpression(parseExpr("a.b.c"), parseExpr("a.x.c")),
+      false,
+    );
+  });
+
+  it("indexed access compares structurally", () => {
+    assert.equal(
+      structurallyEqualExpression(parseExpr('a["k"]'), parseExpr('a["k"]')),
+      true,
+    );
+    assert.equal(
+      structurallyEqualExpression(parseExpr('a["k"]'), parseExpr('a["j"]')),
+      false,
+    );
+    // Mixed dotted-and-indexed paths
+    assert.equal(
+      structurallyEqualExpression(parseExpr('a.b["k"]'), parseExpr('a.b["k"]')),
+      true,
+    );
+  });
+
+  it("calls compare structurally including arguments", () => {
+    assert.equal(
+      structurallyEqualExpression(parseExpr("f(x)"), parseExpr("f(x)")),
+      true,
+    );
+    assert.equal(
+      structurallyEqualExpression(parseExpr("f(x)"), parseExpr("f(y)")),
+      false,
+    );
+    assert.equal(
+      structurallyEqualExpression(parseExpr("f(x, y)"), parseExpr("f(x, y)")),
+      true,
+    );
+    assert.equal(
+      structurallyEqualExpression(parseExpr("f(x, y)"), parseExpr("f(x, z)")),
+      false,
+    );
+    // Arity differs
+    assert.equal(
+      structurallyEqualExpression(parseExpr("f(x)"), parseExpr("f(x, y)")),
+      false,
+    );
+    // Different callee
+    assert.equal(
+      structurallyEqualExpression(parseExpr("f(x)"), parseExpr("g(x)")),
+      false,
+    );
+  });
+
+  it("parenthesized wrappers are unwrapped", () => {
+    assert.equal(
+      structurallyEqualExpression(parseExpr("(a.b)"), parseExpr("a.b")),
+      true,
+    );
+    assert.equal(
+      structurallyEqualExpression(
+        parseExpr("((a.b))"),
+        parseExpr("a.b"),
+      ),
+      true,
+    );
+    assert.equal(
+      structurallyEqualExpression(
+        parseExpr("(f(x))"),
+        parseExpr("f((x))"),
+      ),
+      true,
+    );
+  });
+
+  it("comments inside nodes are ignored", () => {
+    // Comments live as trivia, not as AST children — structural equality
+    // walks AST children only, so a comment between nodes is naturally
+    // invisible. `getText`-based comparison would see them.
+    assert.equal(
+      structurallyEqualExpression(
+        parseExpr("a /* note */.b"),
+        parseExpr("a.b"),
+      ),
+      true,
+    );
+    assert.equal(
+      structurallyEqualExpression(
+        parseExpr("f(/*1*/ x /*2*/)"),
+        parseExpr("f(x)"),
+      ),
+      true,
+    );
+  });
+
+  it("quote-style differences ignored on string element-access keys", () => {
+    // `obj['k']` and `obj["k"]` parse to identical ElementAccess+StringLiteral
+    // structure (the literal's `.text` strips the surrounding quotes).
+    assert.equal(
+      structurallyEqualExpression(parseExpr("a['k']"), parseExpr('a["k"]')),
+      true,
+    );
+  });
+
+  it("different operand shapes return false", () => {
+    // Identifier vs PropertyAccess
+    assert.equal(
+      structurallyEqualExpression(parseExpr("a"), parseExpr("a.b")),
+      false,
+    );
+    // Call vs PropertyAccess
+    assert.equal(
+      structurallyEqualExpression(parseExpr("f(x)"), parseExpr("f.x")),
+      false,
+    );
+    // ElementAccess vs PropertyAccess (even with same effective key)
+    assert.equal(
+      structurallyEqualExpression(parseExpr('a["b"]'), parseExpr("a.b")),
+      false,
+    );
+  });
+
+  it("`this` always equal to `this`", () => {
+    assert.equal(
+      structurallyEqualExpression(parseExpr("this"), parseExpr("this")),
+      true,
+    );
+    assert.equal(
+      structurallyEqualExpression(parseExpr("this.x"), parseExpr("this.x")),
+      true,
+    );
+  });
+
+  it("unsupported node kinds (e.g., binary expressions) return false", () => {
+    // `a + b` is not in the supported shape vocabulary; conservative-refusal
+    // returns false rather than recursively comparing.
+    assert.equal(
+      structurallyEqualExpression(parseExpr("a + b"), parseExpr("a + b")),
+      false,
+    );
+  });
+});

--- a/tools/ts2pant/tests/ast-equal.test.mts
+++ b/tools/ts2pant/tests/ast-equal.test.mts
@@ -222,6 +222,32 @@ describe("ast-equal", () => {
     );
   });
 
+  it("optional-chain access is distinct from plain access", () => {
+    // `a?.b` vs `a.b` must compare unequal so the nullish recognizer's
+    // operand-identity dedup doesn't fold a pair like
+    // `a?.b === null || a.b === undefined` into one `IsNullish`.
+    assert.equal(
+      structurallyEqualExpression(parseExpr("a?.b"), parseExpr("a.b")),
+      false,
+    );
+    assert.equal(
+      structurallyEqualExpression(parseExpr("a.b"), parseExpr("a?.b")),
+      false,
+    );
+    // Tail members of a chain (`a?.b.c`'s outer `.c`) carry
+    // NodeFlags.OptionalChain even without a `?.` token; that flag must
+    // also distinguish them from plain `.c` accesses.
+    assert.equal(
+      structurallyEqualExpression(parseExpr("a?.b.c"), parseExpr("a.b.c")),
+      false,
+    );
+    // Same-shape optional chains compare equal.
+    assert.equal(
+      structurallyEqualExpression(parseExpr("a?.b"), parseExpr("a?.b")),
+      true,
+    );
+  });
+
   it("`this` always equal to `this`", () => {
     assert.equal(
       structurallyEqualExpression(parseExpr("this"), parseExpr("this")),

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -206,6 +206,26 @@ exports[`expressions-const-pure-calls.ts > constStringMethod 1`] = `
 "module ConstStringMethod.\\n\\nconst-string-method s: String => Int.\\n\\n---\\n\\nconst-string-method s = index-of s \\"x\\".\\n"
 `;
 
+exports[`expressions-equality-nullish.ts > disjunctionDifferentOperands 1`] = `
+"module DisjunctionDifferentOperands.\\n\\ndisjunction-different-operands a: [Int], b: [Int] => Bool.\\n\\n---\\n\\ndisjunction-different-operands a b = (#a = 0 or #b = 0).\\n"
+`;
+
+exports[`expressions-equality-nullish.ts > longFormNegated 1`] = `
+"module LongFormNegated.\\n\\nlong-form-negated x: [Int] => Bool.\\n\\n---\\n\\nlong-form-negated x = (~(#x = 0)).\\n"
+`;
+
+exports[`expressions-equality-nullish.ts > longFormPositive 1`] = `
+"module LongFormPositive.\\n\\nlong-form-positive x: [Int] => Bool.\\n\\n---\\n\\nlong-form-positive x = (#x = 0).\\n"
+`;
+
+exports[`expressions-equality-nullish.ts > looseNullEq 1`] = `
+"module LooseNullEq.\\n\\nloose-null-eq x: [Int] => Bool.\\n\\n---\\n\\nloose-null-eq x = (#x = 0).\\n"
+`;
+
+exports[`expressions-equality-nullish.ts > looseNullNeq 1`] = `
+"module LooseNullNeq.\\n\\nloose-null-neq x: [Int] => Bool.\\n\\n---\\n\\nloose-null-neq x = (~(#x = 0)).\\n"
+`;
+
 exports[`expressions-equality-nullish.ts > strictEqAgainstLit 1`] = `
 "module StrictEqAgainstLit.\\n\\nstrict-eq-against-lit n: Int => Bool.\\n\\n---\\n\\nstrict-eq-against-lit n = (n = 0).\\n"
 `;
@@ -224,6 +244,30 @@ exports[`expressions-equality-nullish.ts > strictNeqInArm 1`] = `
 
 exports[`expressions-equality-nullish.ts > strictNeqStrings 1`] = `
 "module StrictNeqStrings.\\n\\nstrict-neq-strings a: String, b: String => Bool.\\n\\n---\\n\\nstrict-neq-strings a b = (a ~= b).\\n"
+`;
+
+exports[`expressions-equality-nullish.ts > strictNullEq 1`] = `
+"module StrictNullEq.\\n\\nstrict-null-eq x: [Int] => Bool.\\n\\n---\\n\\nstrict-null-eq x = (#x = 0).\\n"
+`;
+
+exports[`expressions-equality-nullish.ts > strictNullNeq 1`] = `
+"module StrictNullNeq.\\n\\nstrict-null-neq x: [Int] => Bool.\\n\\n---\\n\\nstrict-null-neq x = (~(#x = 0)).\\n"
+`;
+
+exports[`expressions-equality-nullish.ts > strictUndefinedEq 1`] = `
+"module StrictUndefinedEq.\\n\\nstrict-undefined-eq x: [Int] => Bool.\\n\\n---\\n\\nstrict-undefined-eq x = (#x = 0).\\n"
+`;
+
+exports[`expressions-equality-nullish.ts > strictUndefinedNeq 1`] = `
+"module StrictUndefinedNeq.\\n\\nstrict-undefined-neq x: [Int] => Bool.\\n\\n---\\n\\nstrict-undefined-neq x = (~(#x = 0)).\\n"
+`;
+
+exports[`expressions-equality-nullish.ts > typeofUndefinedEq 1`] = `
+"module TypeofUndefinedEq.\\n\\ntypeof-undefined-eq x: [Int] => Bool.\\n\\n---\\n\\ntypeof-undefined-eq x = (#x = 0).\\n"
+`;
+
+exports[`expressions-equality-nullish.ts > typeofUndefinedNeq 1`] = `
+"module TypeofUndefinedNeq.\\n\\ntypeof-undefined-neq x: [Int] => Bool.\\n\\n---\\n\\ntypeof-undefined-neq x = (~(#x = 0)).\\n"
 `;
 
 exports[`expressions-if-early-return.ts > armBetweenBindings 1`] = `

--- a/tools/ts2pant/tests/equality-canonicalization.test.mts
+++ b/tools/ts2pant/tests/equality-canonicalization.test.mts
@@ -220,18 +220,23 @@ describe("equality-canonicalization (signature/guard path)", () => {
     }
     assert.equal(r1.declaration.guard, undefined);
 
+    // The non-null assertion variant uses a non-nullish loose-eq
+    // (`amount != 0`) so Patch 2's nullish recognizer doesn't consume
+    // it — the test still verifies that the `!` wrapper routes the
+    // rejection back to the binary-expression handler instead of
+    // falling through to a raw-text fallback.
     const sourceBang = `
       function assert(condition: unknown): asserts condition {
         if (!condition) throw new Error();
       }
-      interface Account { value: number | null; }
-      function setIfPresent(account: Account, amount: number | null): void {
-        assert((amount != null)!);
+      interface Account { value: number; }
+      function setIfNonZero(account: Account, amount: number): void {
+        assert((amount != 0)!);
         account.value = amount;
       }
     `;
     const sf2 = createSourceFileFromSource(sourceBang);
-    const r2 = translateSignature(sf2, "setIfPresent", IntStrategy);
+    const r2 = translateSignature(sf2, "setIfNonZero", IntStrategy);
     assert.equal(r2.declaration.kind, "action");
     if (r2.declaration.kind !== "action") {
       return;

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-equality-nullish.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-equality-nullish.ts
@@ -1,11 +1,21 @@
-// M4 — equality and nullish normalization. This fixture exercises the
-// strict-eq / strict-neq canonicalization through Layer 1. Loose-eq
-// rejection is exercised in `tests/equality-canonicalization.test.mts`
-// (rejection isn't snapshot-tested; the constructs runner skips
-// functions that fail to translate).
+// M4 — equality and nullish normalization. Every TS expression in the
+// equality/nullish equivalence class flows through one of three
+// canonical Layer 1 forms:
+//   - `IsNullish(x)` — null/undefined tests; positive forms here, with
+//     `unop(not, IsNullish(...))` for negated. Lowers to `#x = 0`
+//     under the list-lift encoding.
+//   - `BinOp(eq | neq, …)` — strict equality `===` / `!==`. Lowers to
+//     Pant `=` / `~=`.
+//   - Loose equality `==` / `!=` is rejected unless consumed by the
+//     nullish recognizer. Rejection is exercised in
+//     `tests/equality-canonicalization.test.mts` — the constructs
+//     runner skips functions that fail to translate, so rejected
+//     forms can't be snapshot-tested here.
 //
-// See `workstreams/ts2pant-m4-equality-nullish.md` for the full
-// equivalence-class lock and lowering rules.
+// See `workstreams/ts2pant-m4-equality-nullish.md` and CLAUDE.md
+// "Option-Type Elimination" for the encoding rationale.
+
+// ─── Strict equality canonicalization (M4 Patch 3) ─────────────────
 
 /** `===` on numbers → canonical L1 binop(eq) → Pant `=`. */
 export function strictEqNumbers(a: number, b: number): boolean {
@@ -32,4 +42,66 @@ export function strictEqExprOperands(a: number, b: number): boolean {
 export function strictNeqInArm(a: number, b: number): boolean {
   if (a < 0) return a !== b;
   return a === b;
+}
+
+// ─── Nullish surface forms (M4 Patch 2) ────────────────────────────
+
+/** `x == null` — loose-eq nullish. Recognized; folds to IsNullish(x). */
+export function looseNullEq(x: number | null): boolean {
+  return x == null;
+}
+
+/** `x != null` — loose-neq nullish. Recognized; folds to not(IsNullish(x)). */
+export function looseNullNeq(x: number | null): boolean {
+  return x != null;
+}
+
+/** `x === null` — strict-eq null. Recognized; folds to IsNullish(x). */
+export function strictNullEq(x: number | null): boolean {
+  return x === null;
+}
+
+/** `x === undefined` — strict-eq undefined. Recognized; folds to IsNullish(x). */
+export function strictUndefinedEq(x: number | undefined): boolean {
+  return x === undefined;
+}
+
+/** `x !== null` — strict-neq null. Recognized; folds to not(IsNullish(x)). */
+export function strictNullNeq(x: number | null): boolean {
+  return x !== null;
+}
+
+/** `x !== undefined` — strict-neq undefined. Recognized; folds to not(IsNullish(x)). */
+export function strictUndefinedNeq(x: number | undefined): boolean {
+  return x !== undefined;
+}
+
+/** Long form `x === null || x === undefined` — folds to IsNullish(x). */
+export function longFormPositive(x: number | null | undefined): boolean {
+  return x === null || x === undefined;
+}
+
+/** Negated long form `x !== null && x !== undefined` — folds to not(IsNullish(x)). */
+export function longFormNegated(x: number | null | undefined): boolean {
+  return x !== null && x !== undefined;
+}
+
+/** `typeof x === 'undefined'` — recognized; folds to IsNullish(x). */
+export function typeofUndefinedEq(x: number | undefined): boolean {
+  return typeof x === "undefined";
+}
+
+/** `typeof x !== 'undefined'` — recognized; folds to not(IsNullish(x)). */
+export function typeofUndefinedNeq(x: number | undefined): boolean {
+  return typeof x !== "undefined";
+}
+
+/** Operand mismatch: `a === null || b === undefined` — long-form recognizer
+ *  doesn't fire (different operands), but each leaf is still recognized
+ *  recursively as a per-side IsNullish, then OR'd. */
+export function disjunctionDifferentOperands(
+  a: number | null,
+  b: number | undefined,
+): boolean {
+  return a === null || b === undefined;
 }

--- a/tools/ts2pant/tests/ir1-build-nullish.test.mts
+++ b/tools/ts2pant/tests/ir1-build-nullish.test.mts
@@ -1,0 +1,226 @@
+/**
+ * Unit tests for the M4 nullish recognizer (`recognizeNullishForm`).
+ *
+ * Each test parses a TS expression and asserts the recognizer
+ * produces the expected L1 shape:
+ *
+ * - `IsNullish(operand)` for positive forms
+ * - `Unop(not, IsNullish(operand))` for negated forms
+ * - `BinOp(or | and, IsNullish(...), other)` when a long-form chain
+ *   has residue
+ * - `null` when no nullish form is recognized (fall-through)
+ *
+ * The recognizer is invoked through a synthetic translation callback
+ * that builds opaque `var` references so we can compare structure
+ * without translating actual TS bindings.
+ */
+
+import assert from "node:assert/strict";
+import { before, describe, it } from "node:test";
+import ts from "typescript";
+import { irWrap } from "../src/ir.js";
+import { type IR1Expr, ir1FromL2 } from "../src/ir1.js";
+import { createSourceFileFromSource } from "../src/extract.js";
+import {
+  type NullishTranslate,
+  recognizeNullishForm,
+} from "../src/nullish-recognizer.js";
+import { getAst, loadAst } from "../src/pant-wasm.js";
+
+before(async () => {
+  await loadAst();
+});
+
+/**
+ * Parse `expr` as a single binary expression. Wraps in `const _ = (<expr>);`
+ * to give the parser a statement context, then unwraps the outer parens.
+ */
+function parseBinExpr(source: string): ts.BinaryExpression {
+  const sf = createSourceFileFromSource(`const _ = (${source});`);
+  const stmt = sf.compilerNode.statements[0];
+  if (!stmt || !ts.isVariableStatement(stmt)) {
+    throw new Error("test helper: expected a variable statement");
+  }
+  const decl = stmt.declarationList.declarations[0];
+  if (!decl || !decl.initializer) {
+    throw new Error("test helper: expected an initializer");
+  }
+  let expr: ts.Expression = decl.initializer;
+  while (ts.isParenthesizedExpression(expr)) {
+    expr = expr.expression;
+  }
+  if (!ts.isBinaryExpression(expr)) {
+    throw new Error(
+      `test helper: expected a binary expression, got ${ts.SyntaxKind[expr.kind]}`,
+    );
+  }
+  return expr;
+}
+
+/**
+ * Synthetic translator: turns each TS expression into a `from-l2` that
+ * wraps an opaque `var` named after the expression's source text. This
+ * makes the structural assertions readable without a real binding
+ * environment.
+ */
+function makeTranslate(): NullishTranslate {
+  const ast = getAst();
+  return (e) => ir1FromL2(irWrap(ast.var(e.getText())));
+}
+
+function asL1(
+  result: IR1Expr | { unsupported: string } | null,
+): IR1Expr {
+  if (result === null) {
+    throw new Error("expected an L1 expression, got null (no match)");
+  }
+  if ("unsupported" in result) {
+    throw new Error(`expected an L1 expression, got unsupported: ${result.unsupported}`);
+  }
+  return result;
+}
+
+function expectIsNullish(l1: IR1Expr): IR1Expr {
+  if (l1.kind !== "is-nullish") {
+    throw new Error(
+      `expected is-nullish at top level, got ${l1.kind}`,
+    );
+  }
+  return l1.operand;
+}
+
+function expectNotIsNullish(l1: IR1Expr): IR1Expr {
+  if (l1.kind !== "unop" || l1.op !== "not") {
+    throw new Error(`expected unop(not, …) at top level, got ${l1.kind}`);
+  }
+  return expectIsNullish(l1.arg);
+}
+
+describe("ir1-build-nullish", () => {
+  it("x == null builds is-nullish", () => {
+    const expr = parseBinExpr("x == null");
+    const l1 = asL1(recognizeNullishForm(expr, makeTranslate()));
+    expectIsNullish(l1);
+  });
+
+  it("x === null builds is-nullish", () => {
+    const expr = parseBinExpr("x === null");
+    const l1 = asL1(recognizeNullishForm(expr, makeTranslate()));
+    expectIsNullish(l1);
+  });
+
+  it("x === undefined builds is-nullish", () => {
+    const expr = parseBinExpr("x === undefined");
+    const l1 = asL1(recognizeNullishForm(expr, makeTranslate()));
+    expectIsNullish(l1);
+  });
+
+  it("x === null || x === undefined builds is-nullish (operand identity)", () => {
+    const expr = parseBinExpr("x === null || x === undefined");
+    const l1 = asL1(recognizeNullishForm(expr, makeTranslate()));
+    // The recognizer folds the pair into one `is-nullish` (not nested
+    // inside `or` — that's the point of the long-form recognizer).
+    expectIsNullish(l1);
+  });
+
+  it("typeof x === 'undefined' builds is-nullish", () => {
+    const expr = parseBinExpr("typeof x === 'undefined'");
+    const l1 = asL1(recognizeNullishForm(expr, makeTranslate()));
+    expectIsNullish(l1);
+  });
+
+  it("x != null builds not(is-nullish)", () => {
+    const expr = parseBinExpr("x != null");
+    const l1 = asL1(recognizeNullishForm(expr, makeTranslate()));
+    expectNotIsNullish(l1);
+  });
+
+  it("x !== null builds not(is-nullish)", () => {
+    const expr = parseBinExpr("x !== null");
+    const l1 = asL1(recognizeNullishForm(expr, makeTranslate()));
+    expectNotIsNullish(l1);
+  });
+
+  it("x !== null && x !== undefined builds not(is-nullish)", () => {
+    const expr = parseBinExpr("x !== null && x !== undefined");
+    const l1 = asL1(recognizeNullishForm(expr, makeTranslate()));
+    expectNotIsNullish(l1);
+  });
+
+  it("typeof x !== 'undefined' builds not(is-nullish)", () => {
+    const expr = parseBinExpr("typeof x !== 'undefined'");
+    const l1 = asL1(recognizeNullishForm(expr, makeTranslate()));
+    expectNotIsNullish(l1);
+  });
+
+  it("a === null || b === undefined falls through (operand mismatch)", () => {
+    const expr = parseBinExpr("a === null || b === undefined");
+    const l1 = recognizeNullishForm(expr, makeTranslate());
+    // No fold-eligible pair (different operands), so the long-form
+    // recognizer returns null and the caller falls through to its
+    // normal `||` handling. Each leaf would still be recognized
+    // individually if the caller re-translates them.
+    assert.equal(l1, null);
+  });
+
+  it("x === null || x === undefined || other extracts is-nullish prefix", () => {
+    const expr = parseBinExpr("x === null || x === undefined || other");
+    const l1 = asL1(recognizeNullishForm(expr, makeTranslate()));
+    // Expect: or(is-nullish(x), other)
+    assert.equal(l1.kind, "binop");
+    if (l1.kind === "binop") {
+      assert.equal(l1.op, "or");
+      assert.equal(l1.lhs.kind, "is-nullish");
+    }
+  });
+
+  it("other || x === null || x === undefined extracts is-nullish suffix", () => {
+    const expr = parseBinExpr("other || x === null || x === undefined");
+    const l1 = asL1(recognizeNullishForm(expr, makeTranslate()));
+    // Expect: or(other, is-nullish(x))
+    assert.equal(l1.kind, "binop");
+    if (l1.kind === "binop") {
+      assert.equal(l1.op, "or");
+      assert.equal(l1.rhs.kind, "is-nullish");
+    }
+  });
+
+  it("other && x !== null && x !== undefined extracts not-is-nullish", () => {
+    const expr = parseBinExpr("other && x !== null && x !== undefined");
+    const l1 = asL1(recognizeNullishForm(expr, makeTranslate()));
+    // Expect: and(other, not(is-nullish(x)))
+    assert.equal(l1.kind, "binop");
+    if (l1.kind === "binop") {
+      assert.equal(l1.op, "and");
+      assert.equal(l1.rhs.kind, "unop");
+      if (l1.rhs.kind === "unop") {
+        assert.equal(l1.rhs.op, "not");
+        assert.equal(l1.rhs.arg.kind, "is-nullish");
+      }
+    }
+  });
+
+  it("non-nullish equality (x === 5) falls through", () => {
+    const expr = parseBinExpr("x === 5");
+    const l1 = recognizeNullishForm(expr, makeTranslate());
+    assert.equal(l1, null);
+  });
+
+  it("non-nullish disjunction (x > 0 || y < 0) falls through", () => {
+    const expr = parseBinExpr("x > 0 || y < 0");
+    const l1 = recognizeNullishForm(expr, makeTranslate());
+    assert.equal(l1, null);
+  });
+
+  it("loose-eq with non-null literal (x == 5) falls through", () => {
+    const expr = parseBinExpr("x == 5");
+    const l1 = recognizeNullishForm(expr, makeTranslate());
+    assert.equal(l1, null);
+  });
+
+  it("loose-eq with undefined (x == undefined) falls through (only null is recognized for ==)", () => {
+    const expr = parseBinExpr("x == undefined");
+    const l1 = recognizeNullishForm(expr, makeTranslate());
+    assert.equal(l1, null);
+  });
+});

--- a/tools/ts2pant/tests/ir1-build-nullish.test.mts
+++ b/tools/ts2pant/tests/ir1-build-nullish.test.mts
@@ -20,7 +20,7 @@ import { before, describe, it } from "node:test";
 import ts from "typescript";
 import { irWrap } from "../src/ir.js";
 import { type IR1Expr, ir1FromL2 } from "../src/ir1.js";
-import { createSourceFileFromSource } from "../src/extract.js";
+import { createSourceFileFromSource, getChecker } from "../src/extract.js";
 import {
   type NullishTranslate,
   recognizeNullishForm,
@@ -32,16 +32,41 @@ before(async () => {
 });
 
 /**
- * Parse `expr` as a single binary expression. Wraps in `const _ = (<expr>);`
- * to give the parser a statement context, then unwraps the outer parens.
+ * Parse `expr` as a single binary expression. Declares ambient
+ * bindings for the names commonly used in tests (`x`, `y`, `a`, `b`,
+ * `other`) so the type checker has a real type at each operand
+ * location — the recognizer's nullability gate consults
+ * `checker.getTypeAtLocation` and would reject an operand whose type
+ * resolves to error/`any`.
+ *
+ * Pass an `overrides` map to override types for specific names — used
+ * by the negative tests (e.g. `x: number` to assert non-nullable
+ * operands fall through).
  */
-function parseBinExpr(source: string): ts.BinaryExpression {
-  const sf = createSourceFileFromSource(`const _ = (${source});`);
-  const stmt = sf.compilerNode.statements[0];
-  if (!stmt || !ts.isVariableStatement(stmt)) {
-    throw new Error("test helper: expected a variable statement");
+function parseBinExpr(
+  source: string,
+  overrides: Record<string, string> = {},
+): { expr: ts.BinaryExpression; checker: ts.TypeChecker } {
+  const types: Record<string, string> = {
+    x: "number | null | undefined",
+    y: "number | null | undefined",
+    a: "number | null | undefined",
+    b: "number | null | undefined",
+    other: "boolean",
+    ...overrides,
+  };
+  const decls = Object.entries(types)
+    .map(([name, ty]) => `declare const ${name}: ${ty};`)
+    .join("\n");
+  const wrapper = `${decls}\nconst _ = (${source});`;
+  const sf = createSourceFileFromSource(wrapper);
+  const checker = getChecker(sf);
+  const stmts = sf.compilerNode.statements;
+  const last = stmts[stmts.length - 1];
+  if (!last || !ts.isVariableStatement(last)) {
+    throw new Error("test helper: expected a trailing variable statement");
   }
-  const decl = stmt.declarationList.declarations[0];
+  const decl = last.declarationList.declarations[0];
   if (!decl || !decl.initializer) {
     throw new Error("test helper: expected an initializer");
   }
@@ -54,7 +79,7 @@ function parseBinExpr(source: string): ts.BinaryExpression {
       `test helper: expected a binary expression, got ${ts.SyntaxKind[expr.kind]}`,
     );
   }
-  return expr;
+  return { expr, checker };
 }
 
 /**
@@ -96,66 +121,96 @@ function expectNotIsNullish(l1: IR1Expr): IR1Expr {
   return expectIsNullish(l1.arg);
 }
 
+/**
+ * Verify that `operand` is the result of translating a TS expression
+ * with text `expectedText`. The synthetic translator builds
+ * `ir1FromL2(irWrap(ast.var(e.getText())))`, so the operand should be
+ * a `from-l2` wrapping a `var`-headed OpaqueExpr of that text.
+ */
+function expectOperandText(operand: IR1Expr, expectedText: string): void {
+  assert.equal(operand.kind, "from-l2");
+  if (operand.kind === "from-l2") {
+    assert.equal(operand.expr.kind, "ir-wrap");
+    if (operand.expr.kind === "ir-wrap") {
+      const ast = getAst();
+      assert.equal(ast.strExpr(operand.expr.expr), expectedText);
+    }
+  }
+}
+
 describe("ir1-build-nullish", () => {
   it("x == null builds is-nullish", () => {
-    const expr = parseBinExpr("x == null");
-    const l1 = asL1(recognizeNullishForm(expr, makeTranslate()));
-    expectIsNullish(l1);
+    const { expr, checker } = parseBinExpr("x == null");
+    const l1 = asL1(recognizeNullishForm(expr, checker, makeTranslate()));
+    const operand = expectIsNullish(l1);
+    expectOperandText(operand, "x");
   });
 
   it("x === null builds is-nullish", () => {
-    const expr = parseBinExpr("x === null");
-    const l1 = asL1(recognizeNullishForm(expr, makeTranslate()));
-    expectIsNullish(l1);
+    const { expr, checker } = parseBinExpr("x === null");
+    const l1 = asL1(recognizeNullishForm(expr, checker, makeTranslate()));
+    const operand = expectIsNullish(l1);
+    expectOperandText(operand, "x");
   });
 
   it("x === undefined builds is-nullish", () => {
-    const expr = parseBinExpr("x === undefined");
-    const l1 = asL1(recognizeNullishForm(expr, makeTranslate()));
-    expectIsNullish(l1);
+    const { expr, checker } = parseBinExpr("x === undefined");
+    const l1 = asL1(recognizeNullishForm(expr, checker, makeTranslate()));
+    const operand = expectIsNullish(l1);
+    expectOperandText(operand, "x");
   });
 
   it("x === null || x === undefined builds is-nullish (operand identity)", () => {
-    const expr = parseBinExpr("x === null || x === undefined");
-    const l1 = asL1(recognizeNullishForm(expr, makeTranslate()));
+    const { expr, checker } = parseBinExpr(
+      "x === null || x === undefined",
+    );
+    const l1 = asL1(recognizeNullishForm(expr, checker, makeTranslate()));
     // The recognizer folds the pair into one `is-nullish` (not nested
     // inside `or` — that's the point of the long-form recognizer).
-    expectIsNullish(l1);
+    const operand = expectIsNullish(l1);
+    expectOperandText(operand, "x");
   });
 
   it("typeof x === 'undefined' builds is-nullish", () => {
-    const expr = parseBinExpr("typeof x === 'undefined'");
-    const l1 = asL1(recognizeNullishForm(expr, makeTranslate()));
-    expectIsNullish(l1);
+    const { expr, checker } = parseBinExpr("typeof x === 'undefined'");
+    const l1 = asL1(recognizeNullishForm(expr, checker, makeTranslate()));
+    const operand = expectIsNullish(l1);
+    expectOperandText(operand, "x");
   });
 
   it("x != null builds not(is-nullish)", () => {
-    const expr = parseBinExpr("x != null");
-    const l1 = asL1(recognizeNullishForm(expr, makeTranslate()));
-    expectNotIsNullish(l1);
+    const { expr, checker } = parseBinExpr("x != null");
+    const l1 = asL1(recognizeNullishForm(expr, checker, makeTranslate()));
+    const operand = expectNotIsNullish(l1);
+    expectOperandText(operand, "x");
   });
 
   it("x !== null builds not(is-nullish)", () => {
-    const expr = parseBinExpr("x !== null");
-    const l1 = asL1(recognizeNullishForm(expr, makeTranslate()));
-    expectNotIsNullish(l1);
+    const { expr, checker } = parseBinExpr("x !== null");
+    const l1 = asL1(recognizeNullishForm(expr, checker, makeTranslate()));
+    const operand = expectNotIsNullish(l1);
+    expectOperandText(operand, "x");
   });
 
   it("x !== null && x !== undefined builds not(is-nullish)", () => {
-    const expr = parseBinExpr("x !== null && x !== undefined");
-    const l1 = asL1(recognizeNullishForm(expr, makeTranslate()));
-    expectNotIsNullish(l1);
+    const { expr, checker } = parseBinExpr(
+      "x !== null && x !== undefined",
+    );
+    const l1 = asL1(recognizeNullishForm(expr, checker, makeTranslate()));
+    const operand = expectNotIsNullish(l1);
+    expectOperandText(operand, "x");
   });
 
   it("typeof x !== 'undefined' builds not(is-nullish)", () => {
-    const expr = parseBinExpr("typeof x !== 'undefined'");
-    const l1 = asL1(recognizeNullishForm(expr, makeTranslate()));
-    expectNotIsNullish(l1);
+    const { expr, checker } = parseBinExpr("typeof x !== 'undefined'");
+    const l1 = asL1(recognizeNullishForm(expr, checker, makeTranslate()));
+    const operand = expectNotIsNullish(l1);
+    expectOperandText(operand, "x");
   });
 
   it("a === null || b === undefined falls through (operand mismatch)", () => {
-    const expr = parseBinExpr("a === null || b === undefined");
-    const l1 = recognizeNullishForm(expr, makeTranslate());
+    const { expr, checker } = parseBinExpr("a === null || b === undefined");
+    const l1 = recognizeNullishForm(expr, checker, makeTranslate());
     // No fold-eligible pair (different operands), so the long-form
     // recognizer returns null and the caller falls through to its
     // normal `||` handling. Each leaf would still be recognized
@@ -164,30 +219,44 @@ describe("ir1-build-nullish", () => {
   });
 
   it("x === null || x === undefined || other extracts is-nullish prefix", () => {
-    const expr = parseBinExpr("x === null || x === undefined || other");
-    const l1 = asL1(recognizeNullishForm(expr, makeTranslate()));
+    const { expr, checker } = parseBinExpr(
+      "x === null || x === undefined || other",
+    );
+    const l1 = asL1(recognizeNullishForm(expr, checker, makeTranslate()));
     // Expect: or(is-nullish(x), other)
     assert.equal(l1.kind, "binop");
     if (l1.kind === "binop") {
       assert.equal(l1.op, "or");
       assert.equal(l1.lhs.kind, "is-nullish");
+      if (l1.lhs.kind === "is-nullish") {
+        // Verify the folded operand is the translated `x`, not e.g.
+        // the `other` clause that incidentally has the right kind.
+        expectOperandText(l1.lhs.operand, "x");
+      }
     }
   });
 
   it("other || x === null || x === undefined extracts is-nullish suffix", () => {
-    const expr = parseBinExpr("other || x === null || x === undefined");
-    const l1 = asL1(recognizeNullishForm(expr, makeTranslate()));
+    const { expr, checker } = parseBinExpr(
+      "other || x === null || x === undefined",
+    );
+    const l1 = asL1(recognizeNullishForm(expr, checker, makeTranslate()));
     // Expect: or(other, is-nullish(x))
     assert.equal(l1.kind, "binop");
     if (l1.kind === "binop") {
       assert.equal(l1.op, "or");
       assert.equal(l1.rhs.kind, "is-nullish");
+      if (l1.rhs.kind === "is-nullish") {
+        expectOperandText(l1.rhs.operand, "x");
+      }
     }
   });
 
   it("other && x !== null && x !== undefined extracts not-is-nullish", () => {
-    const expr = parseBinExpr("other && x !== null && x !== undefined");
-    const l1 = asL1(recognizeNullishForm(expr, makeTranslate()));
+    const { expr, checker } = parseBinExpr(
+      "other && x !== null && x !== undefined",
+    );
+    const l1 = asL1(recognizeNullishForm(expr, checker, makeTranslate()));
     // Expect: and(other, not(is-nullish(x)))
     assert.equal(l1.kind, "binop");
     if (l1.kind === "binop") {
@@ -196,31 +265,55 @@ describe("ir1-build-nullish", () => {
       if (l1.rhs.kind === "unop") {
         assert.equal(l1.rhs.op, "not");
         assert.equal(l1.rhs.arg.kind, "is-nullish");
+        if (l1.rhs.arg.kind === "is-nullish") {
+          expectOperandText(l1.rhs.arg.operand, "x");
+        }
       }
     }
   });
 
   it("non-nullish equality (x === 5) falls through", () => {
-    const expr = parseBinExpr("x === 5");
-    const l1 = recognizeNullishForm(expr, makeTranslate());
+    const { expr, checker } = parseBinExpr("x === 5");
+    const l1 = recognizeNullishForm(expr, checker, makeTranslate());
     assert.equal(l1, null);
   });
 
   it("non-nullish disjunction (x > 0 || y < 0) falls through", () => {
-    const expr = parseBinExpr("x > 0 || y < 0");
-    const l1 = recognizeNullishForm(expr, makeTranslate());
+    const { expr, checker } = parseBinExpr("x > 0 || y < 0");
+    const l1 = recognizeNullishForm(expr, checker, makeTranslate());
     assert.equal(l1, null);
   });
 
   it("loose-eq with non-null literal (x == 5) falls through", () => {
-    const expr = parseBinExpr("x == 5");
-    const l1 = recognizeNullishForm(expr, makeTranslate());
+    const { expr, checker } = parseBinExpr("x == 5");
+    const l1 = recognizeNullishForm(expr, checker, makeTranslate());
     assert.equal(l1, null);
   });
 
   it("loose-eq with undefined (x == undefined) falls through (only null is recognized for ==)", () => {
-    const expr = parseBinExpr("x == undefined");
-    const l1 = recognizeNullishForm(expr, makeTranslate());
+    const { expr, checker } = parseBinExpr("x == undefined");
+    const l1 = recognizeNullishForm(expr, checker, makeTranslate());
+    assert.equal(l1, null);
+  });
+
+  it("non-nullable operand (n: number) falls through (nullability gate)", () => {
+    // Non-nullable `n` would lower to a scalar, not `[T]`, so `#n = 0`
+    // would be ill-typed. The recognizer must refuse to fold here.
+    const { expr, checker } = parseBinExpr("n === null", {
+      n: "number",
+    });
+    const l1 = recognizeNullishForm(expr, checker, makeTranslate());
+    assert.equal(l1, null);
+  });
+
+  it("shadowed `undefined` falls through (shadowing gate)", () => {
+    // A locally bound `undefined: number` doesn't resolve to the
+    // global undefined value. The recognizer's symbol-resolution
+    // gate keeps `x === undefined` from matching here.
+    const { expr, checker } = parseBinExpr("x === undefined", {
+      undefined: "number",
+    });
+    const l1 = recognizeNullishForm(expr, checker, makeTranslate());
     assert.equal(l1, null);
   });
 });

--- a/tools/ts2pant/tests/ir1-build-nullish.test.mts
+++ b/tools/ts2pant/tests/ir1-build-nullish.test.mts
@@ -35,9 +35,13 @@ before(async () => {
  * Parse `expr` as a single binary expression. Declares ambient
  * bindings for the names commonly used in tests (`x`, `y`, `a`, `b`,
  * `other`) so the type checker has a real type at each operand
- * location — the recognizer's nullability gate consults
- * `checker.getTypeAtLocation` and would reject an operand whose type
- * resolves to error/`any`.
+ * location — the recognizer's nullability gate uses the *declared*
+ * type from the symbol's declaration (via
+ * `getOperandDeclaredType` / `checker.getTypeOfSymbolAtLocation`),
+ * not the flow-narrowed type at the use site, so leaves later in a
+ * long-form chain still see the parameter's full nullable union.
+ * Without ambient bindings the operand's symbol resolution would
+ * fall back to error/`any` and reject the fold.
  *
  * Pass an `overrides` map to override types for specific names — used
  * by the negative tests (e.g. `x: number` to assert non-nullable
@@ -167,6 +171,26 @@ describe("ir1-build-nullish", () => {
     const l1 = asL1(recognizeNullishForm(expr, checker, makeTranslate()));
     // The recognizer folds the pair into one `is-nullish` (not nested
     // inside `or` — that's the point of the long-form recognizer).
+    const operand = expectIsNullish(l1);
+    expectOperandText(operand, "x");
+  });
+
+  it("x: number | null still folds long-form nullish pair (declared-type gate)", () => {
+    // Regression for the declared-type vs location-type distinction:
+    // TS narrows `x` to non-nullable in later clauses of a long-form
+    // chain after prior negative comparisons. Without using
+    // `getOperandDeclaredType`, the third leaf would see `x: never`
+    // and the gate would reject the fold. Even when the declared
+    // type only includes `null` (no `undefined`), the recognizer
+    // should still fold the pair — comparing a `number | null` value
+    // against `undefined` is an always-false comparison in TS, but
+    // syntactically it's still part of the nullish pattern, and
+    // collapsing to `IsNullish(x)` lowers to a sound `#x = 0` test.
+    const { expr, checker } = parseBinExpr(
+      "x === null || x === undefined",
+      { x: "number | null" },
+    );
+    const l1 = asL1(recognizeNullishForm(expr, checker, makeTranslate()));
     const operand = expectIsNullish(l1);
     expectOperandText(operand, "x");
   });

--- a/tools/ts2pant/tests/ir1-build-nullish.test.mts
+++ b/tools/ts2pant/tests/ir1-build-nullish.test.mts
@@ -343,4 +343,80 @@ describe("ir1-build-nullish", () => {
     const l1 = recognizeNullishForm(expr, checker, makeTranslate());
     assert.equal(l1, null);
   });
+
+  // ─── Sentinel-vs-sentinel rejection ─────────────────────────────────
+
+  it("`null === undefined` falls through (sentinel-vs-sentinel)", () => {
+    // The "operand" would itself be a nullish sentinel — folding to
+    // `IsNullish(undefined)` lowers to `#undefined = 0`, ill-typed.
+    const { expr, checker } = parseBinExpr("null === undefined");
+    const l1 = recognizeNullishForm(expr, checker, makeTranslate());
+    assert.equal(l1, null);
+  });
+
+  it("`undefined !== null` falls through (sentinel-vs-sentinel, negated)", () => {
+    const { expr, checker } = parseBinExpr("undefined !== null");
+    const l1 = recognizeNullishForm(expr, checker, makeTranslate());
+    assert.equal(l1, null);
+  });
+
+  it("`null === null` falls through (same-kind sentinel)", () => {
+    // Always-true; folding to `IsNullish(null)` is ill-typed.
+    const { expr, checker } = parseBinExpr("null === null");
+    const l1 = recognizeNullishForm(expr, checker, makeTranslate());
+    assert.equal(l1, null);
+  });
+
+  it("`undefined === undefined` falls through (same-kind sentinel)", () => {
+    const { expr, checker } = parseBinExpr("undefined === undefined");
+    const l1 = recognizeNullishForm(expr, checker, makeTranslate());
+    assert.equal(l1, null);
+  });
+
+  it("`typeof null === 'undefined'` falls through (sentinel inside typeof)", () => {
+    // `typeof null` is "object", so this is always false. Folding to
+    // `IsNullish(null)` is wrong both semantically and as Pant shape.
+    const { expr, checker } = parseBinExpr("typeof null === 'undefined'");
+    const l1 = recognizeNullishForm(expr, checker, makeTranslate());
+    assert.equal(l1, null);
+  });
+
+  // ─── Duplicate-fold dedup ───────────────────────────────────────────
+
+  it("duplicate-operand long form collapses to a single is-nullish", () => {
+    // `(P or P) ≡ P`: chains with multiple fold pairs sharing the
+    // same operand should produce ONE IsNullish, not two joined by
+    // `or`. Also avoids translating the same operand twice through
+    // the shared UniqueSupply (which could diverge fresh-binder
+    // counters for chain-typed operands).
+    const { expr, checker } = parseBinExpr(
+      "x === null || x === undefined || x === null || x === undefined",
+    );
+    const l1 = asL1(recognizeNullishForm(expr, checker, makeTranslate()));
+    // Top-level should be a single `is-nullish`, not `binop(or, …)`.
+    const operand = expectIsNullish(l1);
+    expectOperandText(operand, "x");
+  });
+
+  it("two distinct duplicate folds keep both is-nullish (different operands)", () => {
+    // Sanity: dedup is by operand identity, not by fold count.
+    // `x..., x..., y..., y...` should produce
+    // `IsNullish(x) or IsNullish(y)`, not collapse to one.
+    const { expr, checker } = parseBinExpr(
+      "x === null || x === undefined || y === null || y === undefined",
+    );
+    const l1 = asL1(recognizeNullishForm(expr, checker, makeTranslate()));
+    assert.equal(l1.kind, "binop");
+    if (l1.kind === "binop") {
+      assert.equal(l1.op, "or");
+      assert.equal(l1.lhs.kind, "is-nullish");
+      assert.equal(l1.rhs.kind, "is-nullish");
+      if (l1.lhs.kind === "is-nullish") {
+        expectOperandText(l1.lhs.operand, "x");
+      }
+      if (l1.rhs.kind === "is-nullish") {
+        expectOperandText(l1.rhs.operand, "y");
+      }
+    }
+  });
 });

--- a/tools/ts2pant/tests/ir1-build-nullish.test.mts
+++ b/tools/ts2pant/tests/ir1-build-nullish.test.mts
@@ -306,6 +306,33 @@ describe("ir1-build-nullish", () => {
     assert.equal(l1, null);
   });
 
+  it("non-Bool leftover clause falls through (Bool-typed gate)", () => {
+    // Mixed-type long form: `x === null || x === undefined || n` where
+    // `n: number` is not Bool. Folding would rebuild as
+    // `IsNullish(x) or n`, mixing a Bool with a number — changes JS's
+    // truthy short-circuit semantics. Refuse to fold.
+    const { expr, checker } = parseBinExpr(
+      "x === null || x === undefined || n",
+      { n: "number" },
+    );
+    const l1 = recognizeNullishForm(expr, checker, makeTranslate());
+    assert.equal(l1, null);
+  });
+
+  it("Bool leftover clause still folds (Bool-typed gate)", () => {
+    // Sanity: the Bool gate doesn't reject the legitimate residue
+    // case where `other: boolean` — same shape as the existing
+    // prefix-extraction test, but tests the gate path explicitly.
+    const { expr, checker } = parseBinExpr(
+      "x === null || x === undefined || other",
+    );
+    const l1 = asL1(recognizeNullishForm(expr, checker, makeTranslate()));
+    assert.equal(l1.kind, "binop");
+    if (l1.kind === "binop") {
+      assert.equal(l1.lhs.kind, "is-nullish");
+    }
+  });
+
   it("shadowed `undefined` falls through (shadowing gate)", () => {
     // A locally bound `undefined: number` doesn't resolve to the
     // global undefined value. The recognizer's symbol-resolution


### PR DESCRIPTION
## Patch 2: Recognize nullish surface forms via L1 IsNullish

- Add `recognizeNullishForm(expr: ts.BinaryExpression, checker, …): { l1: IR1Expr; negated: boolean } | null` near the top of `translate-body.ts`'s binop dispatcher (around line 2801)
- Match `x == null`, `x != null`, `x === null`, `x === undefined`, `x !== null`, `x !== undefined` by inspecting `expr.left`, `expr.right`, and `expr.operatorToken.kind`. Operand `x` is whichever side is non-null/non-undefined
- Match the long form `x === null || x === undefined` (and `&&`-negated form) by recursing on `BinaryExpression` with `BarBarToken` / `AmpersandAmpersandToken`. The recognizer is flat-aware: for a chain `a || b || c || …`, collect all operands at the same `||` level into a flat list, scan for any two operands that are nullish-shaped against the *same operand expression*, fold those two into a single `IsNullish` node, and rebuild the disjunction with the remaining clauses around it. Same for `&&` chains using the negated form. This means `(a === null) || (a === undefined) || other` recognizes as `IsNullish(a) || other`
- Add `structurallyEqualExpression(a: ts.Expression, b: ts.Expression): boolean` in a new helper module `tools/ts2pant/src/ast-equal.ts` (or co-located with the recognizer if more convenient). Walks the AST node-by-node comparing kinds and child structure. Initial coverage: `Identifier` (compare `.text`), `PropertyAccessExpression` (recurse on `.expression`, compare `.name.text`), `ElementAccessExpression` (recurse on `.expression` and `.argumentExpression`), `CallExpression` (recurse on `.expression`, recurse pairwise on `.arguments`), `ParenthesizedExpression` (unwrap and recurse), `ThisExpression` (always equal). Anything else: return false (conservative). This avoids `node.getText()` whitespace/comment/quote-style/parenthesization sensitivity. The same helper will be reused in M5 for `Member`-path normalization, so building it generically here pays forward
- Add `recognizeTypeofUndefined(expr): { operand: ts.Expression; negated: boolean } | null` to handle `typeof x === 'undefined'` and `typeof x !== 'undefined'`
- In the binop dispatcher (translate-body.ts:2801), call recognizers before falling through to `translateOperator`. On match: translate the operand via `translateBodyExpr`, wrap as `ir1FromL2(operandOpaque)` (shrinks at M5/M6), build `ir1IsNullish(operandL1)`, optionally wrap with `ir1Unop("not", …)` for negation, and lower via `lowerL1Expr` to OpaqueExpr
- On long-form operand-mismatch (e.g., `(a === null) || (b === undefined)` — different operands): do not fold those two into IsNullish; fall through to generic `||`/`&&` handling (preserves current behavior for non-nullish disjunctions)
- Mirror the same recognizers in `translate-signature.ts` (pure path, around line 821-841) — keep both paths consistent
- Create new fixture `tests/fixtures/constructs/expressions-equality-nullish.ts` with one exported function per surface form: `looseNullEq`, `looseNullNeq`, `strictNullEq`, `strictUndefinedEq`, `strictNullNeq`, `strictUndefinedNeq`, `longFormPositive`, `longFormNegated`, `typeofUndefinedEq`, `typeofUndefinedNeq`, plus the operand-mismatch fall-through case `disjunctionDifferentOperands`
- Create `tests/ir1-build-nullish.test.mts`: assert the build pass produces the expected L1 shape for each surface form (positive form yields `ir1IsNullish(...)`; negated yields `ir1Unop('not', ir1IsNullish(...))`); operand-mismatch in long form does NOT match the recognizer
- Run `just ts2pant-test-update-snapshots` once to capture the new snapshot, then verify the snapshot matches expectations by hand-inspection
- Run `just ts2pant-test-integration` — `pant --check` should accept all the new fixture functions as well-typed (they now produce valid `[T]`-typed cardinality tests instead of broken `(x = null)`)

## Changes
- Add `recognizeNullishForm(expr: ts.BinaryExpression, checker, …): { l1: IR1Expr; negated: boolean } | null` near the top of `translate-body.ts`'s binop dispatcher (around line 2801)
- Match `x == null`, `x != null`, `x === null`, `x === undefined`, `x !== null`, `x !== undefined` by inspecting `expr.left`, `expr.right`, and `expr.operatorToken.kind`. Operand `x` is whichever side is non-null/non-undefined
- Match the long form `x === null || x === undefined` (and `&&`-negated form) by recursing on `BinaryExpression` with `BarBarToken` / `AmpersandAmpersandToken`. The recognizer is flat-aware: for a chain `a || b || c || …`, collect all operands at the same `||` level into a flat list, scan for any two operands that are nullish-shaped against the *same operand expression*, fold those two into a single `IsNullish` node, and rebuild the disjunction with the remaining clauses around it. Same for `&&` chains using the negated form. This means `(a === null) || (a === undefined) || other` recognizes as `IsNullish(a) || other`
- Add `structurallyEqualExpression(a: ts.Expression, b: ts.Expression): boolean` in a new helper module `tools/ts2pant/src/ast-equal.ts` (or co-located with the recognizer if more convenient). Walks the AST node-by-node comparing kinds and child structure. Initial coverage: `Identifier` (compare `.text`), `PropertyAccessExpression` (recurse on `.expression`, compare `.name.text`), `ElementAccessExpression` (recurse on `.expression` and `.argumentExpression`), `CallExpression` (recurse on `.expression`, recurse pairwise on `.arguments`), `ParenthesizedExpression` (unwrap and recurse), `ThisExpression` (always equal). Anything else: return false (conservative). This avoids `node.getText()` whitespace/comment/quote-style/parenthesization sensitivity. The same helper will be reused in M5 for `Member`-path normalization, so building it generically here pays forward
- Add `recognizeTypeofUndefined(expr): { operand: ts.Expression; negated: boolean } | null` to handle `typeof x === 'undefined'` and `typeof x !== 'undefined'`
- In the binop dispatcher (translate-body.ts:2801), call recognizers before falling through to `translateOperator`. On match: translate the operand via `translateBodyExpr`, wrap as `ir1FromL2(operandOpaque)` (shrinks at M5/M6), build `ir1IsNullish(operandL1)`, optionally wrap with `ir1Unop("not", …)` for negation, and lower via `lowerL1Expr` to OpaqueExpr
- On long-form operand-mismatch (e.g., `(a === null) || (b === undefined)` — different operands): do not fold those two into IsNullish; fall through to generic `||`/`&&` handling (preserves current behavior for non-nullish disjunctions)
- Mirror the same recognizers in `translate-signature.ts` (pure path, around line 821-841) — keep both paths consistent
- Create new fixture `tests/fixtures/constructs/expressions-equality-nullish.ts` with one exported function per surface form: `looseNullEq`, `looseNullNeq`, `strictNullEq`, `strictUndefinedEq`, `strictNullNeq`, `strictUndefinedNeq`, `longFormPositive`, `longFormNegated`, `typeofUndefinedEq`, `typeofUndefinedNeq`, plus the operand-mismatch fall-through case `disjunctionDifferentOperands`
- Create `tests/ir1-build-nullish.test.mts`: assert the build pass produces the expected L1 shape for each surface form (positive form yields `ir1IsNullish(...)`; negated yields `ir1Unop('not', ir1IsNullish(...))`); operand-mismatch in long form does NOT match the recognizer
- Run `just ts2pant-test-update-snapshots` once to capture the new snapshot, then verify the snapshot matches expectations by hand-inspection
- Run `just ts2pant-test-integration` — `pant --check` should accept all the new fixture functions as well-typed (they now produce valid `[T]`-typed cardinality tests instead of broken `(x = null)`)

## Files to Modify
- tools/ts2pant/src/translate-body.ts (modify): Recognize the five nullish surface forms in the `BinaryExpression` dispatcher; build via `ir1IsNullish` and lower; handle negation
- tools/ts2pant/src/ast-equal.ts (create): Structural AST equality helper for comparing TS expression operands (Identifier, PropertyAccess, ElementAccess, Call, Parenthesized, This). Reused in M5 for Member-path comparison
- tools/ts2pant/tests/ast-equal.test.mts (create): Unit tests for `structurallyEqualExpression` covering each supported node kind plus formatting variants (whitespace, comments, quote style, parenthesization) that getText would falsely distinguish
- tools/ts2pant/tests/ir1-build-nullish.test.mts (create): Unit tests for the new recognizer: positive forms, negated forms, long-form operand-identity check, typeof handling, fall-through cases
- tools/ts2pant/tests/fixtures/constructs/expressions-equality-nullish.ts (create): Fixture covering all positive and negated nullish surface forms
- tools/ts2pant/tests/constructs.test.mts.snapshot (modify): Snapshot updates from the new fixture

## Gameplan Specification

```
module TS2PANT_M4.

> ════════════════════════════════════════════════════════════
> M4: equality and nullish normalization
> ════════════════════════════════════════════════════════════
>
> After M4, every TS-AST expression in the equality/nullish
> equivalence class flows through Layer 1. The class is
> normalized into three canonical paths plus an unconditional
> rejection on surviving loose equality:
>
>   - `IsNullish(x)` — the canonical Bool null/undefined test.
>     Recognized from x==null, x===null, x===undefined, the
>     ||-long form, and typeof-undefined. Negated forms wrap as
>     `not(IsNullish(x))`.
>   - `BinOp(eq | neq, lhs, rhs)` — canonical equality, only
>     produced from `===` / `!==`.
>   - Functor-lift `each $n in x | f $n` — the canonical lowering
>     for null-guarded list-lifted conditionals. Pant has no list
>     literal, so cardinality-dispatch is not a viable alternative;
>     this path makes idiomatic null-guard-then-list-return TS
>     functions translate.
>   - Any `==` / `!=` not consumed by the nullish recognizer is
>     rejected. ts2pant steers the programmer toward `===`/`!==`
>     rather than guess loose-equality intent.

TSExpr.
TSType.
L1Expr.
L2Expr.
OpaqueExpr.

> ─── L1 form predicates ───────────────────────────────────────

is-nullish? e: L1Expr => Bool.
is-not? e: L1Expr => Bool.
is-binop-eq? e: L1Expr => Bool.
is-binop-neq? e: L1Expr => Bool.
is-each? e: L1Expr => Bool.
is-cond? e: L1Expr => Bool.

operand e: L1Expr, is-nullish? e => L1Expr.
inner e: L1Expr, is-not? e => L1Expr.

> ─── TS-side classification ───────────────────────────────────

is-positive-nullish? t: TSExpr => Bool.
is-negative-nullish? t: TSExpr => Bool.
is-strict-eq? t: TSExpr => Bool.
is-strict-neq? t: TSExpr => Bool.
is-loose-eq? t: TSExpr => Bool.
is-loose-neq? t: TSExpr => Bool.

is-conditional? t: TSExpr => Bool.
functor-lift-eligible? t: TSExpr, is-conditional? t => Bool.

> ─── Build / lower pipeline ───────────────────────────────────

build-l1 t: TSExpr => L1Expr.
lower-l1 e: L1Expr => L2Expr.
emit l: L2Expr => OpaqueExpr.
unsupported? e: L1Expr => Bool.

> ─── L2 / OpaqueExpr shape predicate ─────────────────────────

card-zero? l: L2Expr => Bool.

---

> ─── Canonical form: every nullish surface form maps to one
>     L1 IsNullish (or its negation). ───────────────────────────

all t: TSExpr, is-positive-nullish? t |
  is-nullish? (build-l1 t).

all t: TSExpr, is-negative-nullish? t |
  is-not? (build-l1 t)
  and is-nullish? (inner (build-l1 t)).

> ─── Lowering: IsNullish becomes the cardinality-zero shape. ──

all e: L1Expr, is-nullish? e | card-zero? (lower-l1 e).

> ─── Strict equality canonicalizes unconditionally. ──────────

all t: TSExpr, is-strict-eq? t | is-binop-eq? (build-l1 t).
all t: TSExpr, is-strict-neq? t | is-binop-neq? (build-l1 t).

> ─── Surviving loose equality is rejected unconditionally.
>     The nullish family is consumed before this rule fires. ───

all t: TSExpr, is-loose-eq? t | unsupported? (build-l1 t).
all t: TSExpr, is-loose-neq? t | unsupported? (build-l1 t).

> ─── Functor-lift recognizer: eligible conditionals lower to
>     `each`; ineligible conditionals fall through to L1 Cond
>     (which then rejects at the no-list-literal wall). ────────

all t: TSExpr, is-conditional? t, functor-lift-eligible? t |
  is-each? (build-l1 t).

all t: TSExpr, is-conditional? t, ~ functor-lift-eligible? t |
  is-cond? (build-l1 t).

```

## Patch Specification

```
module TS2PANT_M4_PATCH_2.

> Patch 2 routes every nullish surface form through L1 IsNullish.
>
> Surface forms in scope (operand `x`):
>   - x == null
>   - x != null         (negated)
>   - x === null
>   - x === undefined
>   - x !== null        (negated)
>   - x !== undefined   (negated)
>   - x === null || x === undefined        (long form)
>   - x !== null && x !== undefined        (negated long form)
>   - typeof x === 'undefined'
>   - typeof x !== 'undefined'              (negated)

TSExpr.
L1Expr.

is-nullish-form? t: TSExpr => Bool.
is-negated-nullish-form? t: TSExpr => Bool.
nullish-operand t: TSExpr, is-nullish-form? t => TSExpr.
nullish-operand-of-neg t: TSExpr, is-negated-nullish-form? t => TSExpr.

build-l1 t: TSExpr => L1Expr.

is-nullish? e: L1Expr => Bool.
is-not? e: L1Expr => Bool.
operand e: L1Expr, is-nullish? e => L1Expr.
inner e: L1Expr, is-not? e => L1Expr.

build-l1-of-tsexpr t: TSExpr, is-nullish-form? t => L1Expr.

---

> Positive nullish forms build to a single L1 IsNullish.
all t: TSExpr, is-nullish-form? t | is-nullish? (build-l1 t).

> Negated nullish forms build to `not (IsNullish ...)`.
all t: TSExpr, is-negated-nullish-form? t |
  is-not? (build-l1 t)
  and is-nullish? (inner (build-l1 t)).

```


## Implementation Notes

### Three wiring sites, not two

The plan called for wiring in `translate-body.ts` and `translate-signature.ts`. A third site was needed: `ir1-build.ts:buildFromShortCircuit`. The pure-body path (`translatePureBody`) calls `isL1ConditionalForm` directly and routes Bool-typed `||`/`&&` chains through `buildL1ConditionalFromArms` → `buildFromShortCircuit`, *bypassing* `translateBodyExpr`. Without the third site, `x === null || x === undefined` fell through to the regular short-circuit path, which translated each leaf via `buildSubExpr` (giving per-leaf `IsNullish` from the body-side recognizer) and joined with `or`, producing `(#x = 0 or #x = 0)` instead of the folded `#x = 0`. The first snapshot run caught this; adding the recognizer call at the top of `buildFromShortCircuit` fixed it without touching the L1 dispatch ordering.

### Recognizer signature deviated from the plan

Plan: `recognizeNullishForm(...): { l1: IR1Expr; negated: boolean } | null`.
Shipped: `recognizeNullishForm(expr, translate): IR1Expr | { unsupported: string } | null`.

The plan's separate `negated` flag would only carry information for leaf forms — long-form `||`/`&&` chains with partial-fold residue produce a top-level binop, not a leaf. The recognizer needs a translation callback anyway (to translate operand expressions and any non-nullish residue), so the flag becomes redundant: negation is wrapped into `unop("not", IsNullish(...))` inside the recognizer. Returning `IR1Expr` directly also lets the long-form path return a `BinOp(or, IsNullish(x), residue)` tree when only some operands fold.

### Loose-eq with `undefined` does not match

`x == undefined` *would* be a coercion-equivalent nullish test, but it's not part of the recognized leaf shapes. The leaf recognizer's loose-eq branch only matches when one side is the literal `null` keyword. Patch 3 will reject any surviving loose-eq, so the choice here is between "consume `x == undefined`" (collapse to IsNullish) and "leave for Patch 3" (reject as ambiguous loose-eq). Per the gameplan's explicit-opinion `OPINION: Loose equality is rejected unconditionally outside the nullish-recognizer path; no type-based accept exception`, idiomatic-`null`-only is the conservative read of the spec — `x == undefined` is not idiomatic in TypeScript. If reviewers want it accepted, two extra lines in `recognizeNullishLeaf` would do it.

### `structurallyEqualExpression` covers more than the plan listed

Plan listed: Identifier, PropertyAccess, ElementAccess, Call, Parenthesized, This.
Added: StringLiteral and NumericLiteral (compared by `.text`).

StringLiteral support is required by the `quote-style differences ignored on string element-access keys` test — `obj["k"]` vs `obj['k']` recurses through ElementAccess into a StringLiteral comparison. NumericLiteral support is symmetric and pays forward into M5. Anything outside this set still returns `false` (the conservative-refusal contract holds).

### `disjunctionDifferentOperands` fixture emits a sound result

The fixture exercises the operand-mismatch fall-through. The long-form recognizer returns `null` for `a === null || b === undefined` (different operands), so the L1 short-circuit path fires; each leaf, when re-translated, hits the leaf-level recognizer and produces `IsNullish`. The output is `(#a = 0 or #b = 0)` — sound, type-checks under `pant`, and demonstrates that "fall-through" doesn't mean "untranslated".