### PR TITLE
[ts2pant-m4-equality-nullish] Patch 4: Refactor `??` builder to construct guard via IsNullish

### DIFF
--- a/tools/ts2pant/src/ir-build.ts
+++ b/tools/ts2pant/src/ir-build.ts
@@ -19,7 +19,6 @@ import {
   type IRExpr,
   irAppExpr,
   irAppName,
-  irBinop,
   irCond,
   irEach,
   irLitBool,
@@ -29,6 +28,8 @@ import {
   irVar,
   irWrap,
 } from "./ir.js";
+import { ir1FromL2, ir1IsNullish } from "./ir1.js";
+import { lowerL1Expr } from "./ir1-lower.js";
 import {
   ambiguousFieldMsg,
   bodyExpr,
@@ -194,7 +195,11 @@ export function buildIR(
       return rightIR;
     }
     const rightTsType = checker.getTypeAtLocation(expr.right);
-    const cardZero = irBinop("eq", irUnop("card", leftIR), irLitNat(0));
+    // Construct the cardinality-zero null test through L1 IsNullish so
+    // every nullish-shape lowering shares one source of truth (M4).
+    // The lowering chain `from-l2 → IsNullish → eq(card(_), 0)` is
+    // byte-identical to the inlined form, which is the cutover gate.
+    const cardZero = lowerL1Expr(ir1IsNullish(ir1FromL2(leftIR)));
     const presentBranch: IRExpr = isNullableTsType(rightTsType)
       ? leftIR
       : irAppExpr(leftIR, [irLitNat(1)]);

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -3,7 +3,7 @@ import ts from "typescript";
 import { type IRExpr, irLet, irWrap } from "./ir.js";
 import { buildIR, isBuildUnsupported } from "./ir-build.js";
 import { lowerExpr } from "./ir-emit.js";
-import { type IR1Expr, ir1Binop, ir1FromL2 } from "./ir1.js";
+import { type IR1Expr, ir1Binop, ir1FromL2, ir1IsNullish } from "./ir1.js";
 import {
   buildL1Conditional,
   buildL1ConditionalFromArms,
@@ -2898,11 +2898,11 @@ export function translateBodyExpr(
       const xExpr = bodyExpr(leftResult);
       const yExpr = bodyExpr(rightResult);
       const rightTsType = checker.getTypeAtLocation(expr.right);
-      const cardZero = ast.binop(
-        ast.opEq(),
-        ast.unop(ast.opCard(), xExpr),
-        ast.litNat(0),
-      );
+      // Construct the cardinality-zero null test through L1 IsNullish so
+      // every nullish-shape lowering shares one source of truth (M4).
+      // The lowering chain `from-l2 → IsNullish → eq(card(_), 0)` is
+      // byte-identical to the inlined form, which is the cutover gate.
+      const cardZero = lowerL1ToOpaque(ir1IsNullish(ir1FromL2(irWrap(xExpr))));
       const presentBranch = isNullableTsType(rightTsType)
         ? xExpr
         : ast.app(xExpr, [ast.litNat(1)]);


### PR DESCRIPTION
## Patch 4: Refactor `??` builder to construct guard via IsNullish

- In `translate-body.ts:2813-2857`, replace the `ast.binop(ast.opEq(), ast.unop(ast.opCard(), xExpr), ast.litNat(0))` construction at line 2844 with `lowerL1Expr(ir1IsNullish(ir1FromL2(xExpr)))`
- In `src/ir-build.ts:188-198` (pure-path `??` builder), do the same refactor — use `ir1IsNullish` for the cardinality test, then lower
- No changes to the surrounding `cond #x = 0 => y, true => (x 1)` shape — only the guard is restructured. The lowered OpaqueExpr is byte-identical because Patch 1's lowering produces the same `binop(eq, unop(card, x), litNat(0))` shape
- Run `just ts2pant-test` — every `expressions-nullish.ts` snapshot must remain byte-equal. This is the cutover gate
- If any snapshot diverges: investigate. The likely cause is a missed unwrap of `ir1FromL2(x)` somewhere in the chain. Patch 4 must NOT be merged without snapshot byte-equality
- Verify `?.` is unchanged — it does not refactor in M4 (per explicitOpinion above). The `?.` lowering still uses `ast.each(...)` directly

## Changes
- In `translate-body.ts:2813-2857`, replace the `ast.binop(ast.opEq(), ast.unop(ast.opCard(), xExpr), ast.litNat(0))` construction at line 2844 with `lowerL1Expr(ir1IsNullish(ir1FromL2(xExpr)))`
- In `src/ir-build.ts:188-198` (pure-path `??` builder), do the same refactor — use `ir1IsNullish` for the cardinality test, then lower
- No changes to the surrounding `cond #x = 0 => y, true => (x 1)` shape — only the guard is restructured. The lowered OpaqueExpr is byte-identical because Patch 1's lowering produces the same `binop(eq, unop(card, x), litNat(0))` shape
- Run `just ts2pant-test` — every `expressions-nullish.ts` snapshot must remain byte-equal. This is the cutover gate
- If any snapshot diverges: investigate. The likely cause is a missed unwrap of `ir1FromL2(x)` somewhere in the chain. Patch 4 must NOT be merged without snapshot byte-equality
- Verify `?.` is unchanged — it does not refactor in M4 (per explicitOpinion above). The `?.` lowering still uses `ast.each(...)` directly

## Files to Modify
- tools/ts2pant/src/translate-body.ts (modify): Replace inline `ast.binop(opEq, unop(card, x), litNat(0))` in the `??` handler with `lowerL1Expr(ir1IsNullish(ir1FromL2(xOpaque)))`
- tools/ts2pant/src/ir-build.ts (modify): Mirror the same refactor in the pure-path `??` builder

## Gameplan Specification

```
module TS2PANT_M4.

> ════════════════════════════════════════════════════════════
> M4: equality and nullish normalization
> ════════════════════════════════════════════════════════════
>
> After M4, every TS-AST expression in the equality/nullish
> equivalence class flows through Layer 1. The class is
> normalized into three canonical paths plus an unconditional
> rejection on surviving loose equality:
>
>   - `IsNullish(x)` — the canonical Bool null/undefined test.
>     Recognized from x==null, x===null, x===undefined, the
>     ||-long form, and typeof-undefined. Negated forms wrap as
>     `not(IsNullish(x))`.
>   - `BinOp(eq | neq, lhs, rhs)` — canonical equality, only
>     produced from `===` / `!==`.
>   - Functor-lift `each $n in x | f $n` — the canonical lowering
>     for null-guarded list-lifted conditionals. Pant has no list
>     literal, so cardinality-dispatch is not a viable alternative;
>     this path makes idiomatic null-guard-then-list-return TS
>     functions translate.
>   - Any `==` / `!=` not consumed by the nullish recognizer is
>     rejected. ts2pant steers the programmer toward `===`/`!==`
>     rather than guess loose-equality intent.

TSExpr.
TSType.
L1Expr.
L2Expr.
OpaqueExpr.

> ─── L1 form predicates ───────────────────────────────────────

is-nullish? e: L1Expr => Bool.
is-not? e: L1Expr => Bool.
is-binop-eq? e: L1Expr => Bool.
is-binop-neq? e: L1Expr => Bool.
is-each? e: L1Expr => Bool.
is-cond? e: L1Expr => Bool.

operand e: L1Expr, is-nullish? e => L1Expr.
inner e: L1Expr, is-not? e => L1Expr.

> ─── TS-side classification ───────────────────────────────────

is-positive-nullish? t: TSExpr => Bool.
is-negative-nullish? t: TSExpr => Bool.
is-strict-eq? t: TSExpr => Bool.
is-strict-neq? t: TSExpr => Bool.
is-loose-eq? t: TSExpr => Bool.
is-loose-neq? t: TSExpr => Bool.

is-conditional? t: TSExpr => Bool.
functor-lift-eligible? t: TSExpr, is-conditional? t => Bool.

> ─── Build / lower pipeline ───────────────────────────────────

build-l1 t: TSExpr => L1Expr.
lower-l1 e: L1Expr => L2Expr.
emit l: L2Expr => OpaqueExpr.
unsupported? e: L1Expr => Bool.

> ─── L2 / OpaqueExpr shape predicate ─────────────────────────

card-zero? l: L2Expr => Bool.

---

> ─── Canonical form: every nullish surface form maps to one
>     L1 IsNullish (or its negation). ───────────────────────────

all t: TSExpr, is-positive-nullish? t |
  is-nullish? (build-l1 t).

all t: TSExpr, is-negative-nullish? t |
  is-not? (build-l1 t)
  and is-nullish? (inner (build-l1 t)).

> ─── Lowering: IsNullish becomes the cardinality-zero shape. ──

all e: L1Expr, is-nullish? e | card-zero? (lower-l1 e).

> ─── Strict equality canonicalizes unconditionally. ──────────

all t: TSExpr, is-strict-eq? t | is-binop-eq? (build-l1 t).
all t: TSExpr, is-strict-neq? t | is-binop-neq? (build-l1 t).

> ─── Surviving loose equality is rejected unconditionally.
>     The nullish family is consumed before this rule fires. ───

all t: TSExpr, is-loose-eq? t | unsupported? (build-l1 t).
all t: TSExpr, is-loose-neq? t | unsupported? (build-l1 t).

> ─── Functor-lift recognizer: eligible conditionals lower to
>     `each`; ineligible conditionals fall through to L1 Cond
>     (which then rejects at the no-list-literal wall). ────────

all t: TSExpr, is-conditional? t, functor-lift-eligible? t |
  is-each? (build-l1 t).

all t: TSExpr, is-conditional? t, ~ functor-lift-eligible? t |
  is-cond? (build-l1 t).

```

## Patch Specification

```
module TS2PANT_M4_PATCH_4.

> Patch 4 refactors the `??` builder to construct its cardinality
> guard via IsNullish, instead of inlining `binop(eq, unop(card, x),
> litNat(0))` directly.
>
> Snapshot byte-equality is the cutover gate: the lowered OpaqueExpr
> shape must be identical pre- and post-refactor.
>
> `?.` does not change here — its lowering uses `each x in src | ...`,
> which carries the cardinality test implicitly and has no direct
> IsNullish refactor opportunity.

L1Expr.
OpaqueExpr.

is-nullish-coalesce? e: L1Expr => Bool.
guard-of-coalesce e: L1Expr, is-nullish-coalesce? e => L1Expr.

is-nullish? e: L1Expr => Bool.

lower-to-opaque e: L1Expr => OpaqueExpr.

---

> Every nullish-coalesce build site uses an IsNullish guard.
all e: L1Expr, is-nullish-coalesce? e |
  is-nullish? (guard-of-coalesce e).

> The lowered output is determined solely by the L1 form: lowering
> is a function. Snapshot byte-equality follows from this and from
> Patch 1's mechanical IsNullish lowering rule.
all a: L1Expr, b: L1Expr, a = b |
  lower-to-opaque a = lower-to-opaque b.

```


## Implementation Notes

- The plan's `lowerL1Expr(ir1IsNullish(ir1FromL2(xExpr)))` shorthand glosses over a type mismatch at each site, which the implementation resolves differently per caller:
  - In `translate-body.ts`, `xExpr` is an `OpaqueExpr` and the consumer (`ast.cond`) needs an `OpaqueExpr` back. Lifting required `irWrap(xExpr)` (L2 escape hatch around the opaque) inside `ir1FromL2(...)`, and the final lowering uses `lowerL1ToOpaque` (L1→L2→OpaqueExpr) rather than just `lowerL1Expr`. Net shape: `lowerL1ToOpaque(ir1IsNullish(ir1FromL2(irWrap(xExpr))))`.
  - In `ir-build.ts`, `leftIR` is already an L2 `IRExpr` and the consumer (`irCond`) wants L2 back, so plain `lowerL1Expr(ir1IsNullish(ir1FromL2(leftIR)))` suffices — no `irWrap` needed.
- The two `from-l2` uses are tagged with the existing `@deprecated` warning on `ir1FromL2` (transitional adapter, lifetime bounded by the workstream — slated for deletion at M6). The deprecation lints surface but match the documented use case (scoped sub-expression delegation in the build pipeline).
- `irBinop` was removed from `ir-build.ts`'s import list because the refactor eliminated the only call site — kept the diff tight rather than leaving an unused import.
- Cutover gate verified: `just ts2pant-test` passes 541 unit + 22 integration tests with zero snapshot diffs. `expressions-nullish.ts` snapshots are byte-identical, as are the `??`-touching dogfood and e2e tests.
- `?.` audited and confirmed unchanged at both sites (`translate-body.ts:2762` still emits `ast.each(...)` directly; `ir-build.ts:163` still emits `irEach(...)` directly).