### PR TITLE
[ts2pant-m4-equality-nullish] Patch 5: Functor-lift recognizer for null-guarded list-lifted conditionals

### DIFF
--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -55,9 +55,12 @@ import {
 import { lowerL1Expr } from "./ir1-lower.js";
 import {
   type NullishTranslate,
+  recognizeAnyLeaf,
   recognizeNullishForm,
+  unwrapParens,
 } from "./nullish-recognizer.js";
 import type { OpaqueExpr } from "./pant-ast.js";
+import { getAst } from "./pant-wasm.js";
 import { isStaticallyBoolTyped } from "./purity.js";
 import type {
   MuSearch,
@@ -70,9 +73,14 @@ import {
   expressionReferencesNames,
   extractReturnFromBranch,
   isBodyUnsupported,
+  isNullableTsType,
   translateBodyExpr,
 } from "./translate-body.js";
-import type { NumericStrategy } from "./translate-types.js";
+import {
+  cellRegisterName,
+  type NumericStrategy,
+  toPantTermName,
+} from "./translate-types.js";
 
 /**
  * Context threaded through L1 build. Mirrors the parameter set of
@@ -173,6 +181,297 @@ function buildSubExpr(expr: ts.Expression, ctx: L1BuildContext): L1BuildResult {
   // before wrapping — using result.expr directly would drop the traversal
   // and lower the bare projection body instead.
   return ir1FromL2(irWrap(bodyExpr(result)));
+}
+
+// ---------------------------------------------------------------------------
+// Functor-lift recognizer (M4 Patch 5)
+// ---------------------------------------------------------------------------
+//
+// `if (x == null) return []; else return [f(x)]` — and the equivalent
+// ternary forms — lower as `each $n in x | f $n`, the canonical
+// list-lifted comprehension under the `T | null → [T]` encoding. Pant
+// has no list literal, so the alternative cardinality-dispatch lowering
+// (`cond #x = 0 => [], true => [f((x 1))]`) has no expressible Pant
+// target. This recognizer is the difference between translatable and
+// untranslatable surface for idiomatic null-guarded list-returning TS.
+//
+// Eligibility is conservative: all four checks must hold (nullish
+// guard, empty-equivalent empty side, single-element-producing present
+// side referencing the operand, list-lifted result type). Any failure
+// returns null and the caller falls through to standard L1 Cond
+// construction — which then rejects at the no-list-literal wall, the
+// pre-M4 behavior preserved.
+
+/**
+ * Candidate input for the functor-lift recognizer: the three TS
+ * expressions that make up a value-position conditional, plus the
+ * AST node from which the conditional's static result type can be
+ * inferred (the ConditionalExpression itself, or the IfStatement
+ * containing the branches).
+ */
+export interface FunctorLiftCandidate {
+  guard: ts.Expression;
+  thenExpr: ts.Expression;
+  elseExpr: ts.Expression;
+  /**
+   * Node at which to compute the result type:
+   *   - For a ternary, the `ConditionalExpression` itself
+   *     (`getTypeAtLocation` returns the union of branch types).
+   *   - For an `if (x == null) return []; return [f(x)]` shape, the
+   *     enclosing function declaration so the return type can drive
+   *     the list-lifted check.
+   */
+  contextNode: ts.Node;
+}
+
+const ARRAY_MULTI_PRODUCING_METHODS = new Set([
+  "concat",
+  "flat",
+  "flatMap",
+  "filter",
+  "map",
+  "slice",
+  "splice",
+]);
+
+/** True when `expr` is an empty-equivalent literal — `[]`, `null`, `undefined`. */
+function isEmptyEquivalent(expr: ts.Expression): boolean {
+  const u = unwrapParens(expr);
+  if (ts.isArrayLiteralExpression(u) && u.elements.length === 0) {
+    return true;
+  }
+  if (u.kind === ts.SyntaxKind.NullKeyword) {
+    return true;
+  }
+  if (ts.isIdentifier(u) && u.text === "undefined") {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * If `expr` is a single-element array literal (`[e]`), return `e`. The
+ * lift treats `[u.name]` and `u.name` symmetrically — both project to
+ * the same `each $n in u | name $n` shape.
+ *
+ * Spread elements (`[...xs]`) and multi-element literals fall through
+ * unchanged; they fail the present-side check below.
+ */
+function unwrapSingletonArray(expr: ts.Expression): ts.Expression {
+  const u = unwrapParens(expr);
+  if (ts.isArrayLiteralExpression(u) && u.elements.length === 1) {
+    const el = u.elements[0]!;
+    if (!ts.isSpreadElement(el)) {
+      return el as ts.Expression;
+    }
+  }
+  return u;
+}
+
+/**
+ * True when `expr` is a single-element-producing expression of
+ * `operandName`. After stripping a single-element array wrapper, the
+ * expression must reference the operand and not be a multi-element
+ * construction (multi-element array literal, spread, or known
+ * multi-producing array method like `.concat` / `.flat`).
+ */
+function isSingleElementProducingOf(
+  expr: ts.Expression,
+  operandName: string,
+): boolean {
+  const u = unwrapParens(expr);
+  if (ts.isArrayLiteralExpression(u)) {
+    return false;
+  }
+  if (ts.isSpreadElement(u)) {
+    return false;
+  }
+  if (ts.isCallExpression(u) && ts.isPropertyAccessExpression(u.expression)) {
+    if (ARRAY_MULTI_PRODUCING_METHODS.has(u.expression.name.text)) {
+      return false;
+    }
+  }
+  return expressionReferencesNames(u, new Set([operandName]));
+}
+
+/**
+ * True when `node`'s static type (or the enclosing function's return
+ * type, for an IfStatement) is list-lifted: `T[]`, `T | null`,
+ * `T | undefined`, or `T | null | undefined`.
+ */
+function isListLiftedTsType(t: ts.Type, checker: ts.TypeChecker): boolean {
+  if (checker.isArrayType(t)) {
+    return true;
+  }
+  return isNullableTsType(t);
+}
+
+function isListLiftedAtNode(node: ts.Node, checker: ts.TypeChecker): boolean {
+  if (ts.isConditionalExpression(node)) {
+    return isListLiftedTsType(checker.getTypeAtLocation(node), checker);
+  }
+  // For an if-statement (or return-statement, or the enclosing function
+  // node itself for the if-conversion entry point at the top of a
+  // pure body), the result type is the enclosing function's return
+  // type. Walk up to the function-like declaration if `node` isn't
+  // already one.
+  let fnLike: ts.SignatureDeclaration | null = null;
+  if (
+    ts.isFunctionDeclaration(node) ||
+    ts.isFunctionExpression(node) ||
+    ts.isArrowFunction(node) ||
+    ts.isMethodDeclaration(node) ||
+    ts.isGetAccessorDeclaration(node) ||
+    ts.isConstructorDeclaration(node)
+  ) {
+    fnLike = node;
+  } else if (ts.isIfStatement(node) || ts.isReturnStatement(node)) {
+    fnLike =
+      ts.findAncestor(
+        node,
+        (a): a is ts.SignatureDeclaration =>
+          ts.isFunctionDeclaration(a) ||
+          ts.isFunctionExpression(a) ||
+          ts.isArrowFunction(a) ||
+          ts.isMethodDeclaration(a) ||
+          ts.isGetAccessorDeclaration(a) ||
+          ts.isConstructorDeclaration(a),
+      ) ?? null;
+  }
+  if (!fnLike) {
+    return false;
+  }
+  const sig = checker.getSignatureFromDeclaration(fnLike);
+  if (!sig) {
+    return false;
+  }
+  return isListLiftedTsType(checker.getReturnTypeOfSignature(sig), checker);
+}
+
+/**
+ * Allocate a fresh comprehension binder name. Mirrors the μ-search
+ * binder allocator: prefer `cellRegisterName` against the document-wide
+ * NameRegistry when a synthCell is plumbed through; fall back to a
+ * supply-based name with a collision check against the active scoped
+ * params for standalone test paths.
+ */
+function allocateLiftBinder(ctx: L1BuildContext, hint: string): string {
+  if (ctx.supply.synthCell) {
+    return cellRegisterName(ctx.supply.synthCell, hint);
+  }
+  const used = new Set(ctx.paramNames.values());
+  let name: string;
+  do {
+    const n = ctx.supply.n;
+    ctx.supply.n = n + 1;
+    name = `${hint}${n}`;
+  } while (used.has(name));
+  return name;
+}
+
+/**
+ * Functor-lift recognizer. Returns an L1 `from-l2(each $n in x | proj
+ * $n)` when the four eligibility checks pass; returns `null` to fall
+ * through to the standard L1 Cond build.
+ *
+ * Eligibility:
+ *   (a) Guard is a leaf nullish form (`x == null`, `x === null`,
+ *       `x === undefined`, `typeof x === 'undefined'`, or their
+ *       negations).
+ *   (b) The "empty side" (the branch corresponding to `IsNullish(x) =
+ *       true`) is empty-equivalent: `[]`, `null`, or `undefined`.
+ *   (c) The "present side" (the `not IsNullish(x)` branch), after
+ *       stripping a single-element array wrapper, is a
+ *       single-element-producing expression that references the
+ *       operand. Multi-element constructions reject.
+ *   (d) The conditional's static result type is list-lifted (`T[]`,
+ *       `T | null`, `T | undefined`, …).
+ *
+ * Operand restriction: the leaf operand must be a simple identifier.
+ * Substitution maps the operand's Pant name to the binder via
+ * `ast.substituteBinder`, which only rewrites variable references.
+ * Property-access operands (`obj.prop == null`) would require
+ * generalizing substitution to arbitrary expressions and are out of
+ * scope for Patch 5; they fall through to the standard Cond build.
+ */
+export function tryRecognizeFunctorLift(
+  cand: FunctorLiftCandidate,
+  ctx: L1BuildContext,
+): IR1Expr | null {
+  // (a) Guard is a leaf nullish form.
+  const guard = unwrapParens(cand.guard);
+  if (!ts.isBinaryExpression(guard)) {
+    return null;
+  }
+  const leaf = recognizeAnyLeaf(guard, ctx.checker);
+  if (leaf === null) {
+    return null;
+  }
+  const operandNode = unwrapParens(leaf.operand);
+  if (!ts.isIdentifier(operandNode)) {
+    return null;
+  }
+  const operandName = operandNode.text;
+
+  // Polarity: a positive nullish guard (`x === null`) means the
+  // then-branch is the empty side; a negated guard (`x !== null`)
+  // means the then-branch is the present side.
+  const emptyExpr = leaf.negated ? cand.elseExpr : cand.thenExpr;
+  const presentExpr = leaf.negated ? cand.thenExpr : cand.elseExpr;
+
+  // (b) Empty side is empty-equivalent.
+  if (!isEmptyEquivalent(emptyExpr)) {
+    return null;
+  }
+
+  // (c) Present side, after stripping a singleton array wrapper, is a
+  //     single-element-producing expression of `operandName`.
+  const projection = unwrapSingletonArray(presentExpr);
+  if (!isSingleElementProducingOf(projection, operandName)) {
+    return null;
+  }
+
+  // (d) Result type is list-lifted.
+  if (!isListLiftedAtNode(cand.contextNode, ctx.checker)) {
+    return null;
+  }
+
+  // Build the lifted L1 expression.
+  //
+  // The operand and projection both translate through the legacy
+  // pipeline so embedded sub-expressions stay normalized exactly as
+  // they would on the standard Cond path. The substitution then
+  // rewrites references to the operand's Pant name with the fresh
+  // binder; `ast.substituteBinder` is Pant's capture-avoiding
+  // substitution, so a fresh hygienic binder is sufficient.
+  const operandSub = buildSubExpr(operandNode, ctx);
+  if (isL1Unsupported(operandSub)) {
+    return null;
+  }
+  const projectionSub = buildSubExpr(projection, ctx);
+  if (isL1Unsupported(projectionSub)) {
+    return null;
+  }
+
+  const operandOpaque = lowerExpr(lowerL1Expr(operandSub));
+  const projectionOpaque = lowerExpr(lowerL1Expr(projectionSub));
+
+  const operandPantName =
+    ctx.paramNames.get(operandName) ?? toPantTermName(operandName);
+  const binderName = allocateLiftBinder(ctx, "n");
+  const ast = getAst();
+  const substitutedProjection = ast.substituteBinder(
+    projectionOpaque,
+    operandPantName,
+    ast.var(binderName),
+  );
+
+  const opaqueEach = ast.each(
+    [],
+    [ast.gIn(binderName, operandOpaque)],
+    substitutedProjection,
+  );
+  return ir1FromL2(irWrap(opaqueEach));
 }
 
 // ---------------------------------------------------------------------------
@@ -298,6 +597,23 @@ function buildFromTernary(
   expr: ts.ConditionalExpression,
   ctx: L1BuildContext,
 ): L1BuildResult {
+  // M4 Patch 5: functor-lift on a null-guarded list-lifted ternary —
+  // `(x == null) ? [] : [f(x)]` collapses to `each $n in x | f $n`.
+  // Only the outermost ternary is examined (no chain unwinding), since
+  // the lift requires the full (guard, then, else) shape on one node.
+  const lifted = tryRecognizeFunctorLift(
+    {
+      guard: expr.condition,
+      thenExpr: expr.whenTrue,
+      elseExpr: expr.whenFalse,
+      contextNode: expr,
+    },
+    ctx,
+  );
+  if (lifted !== null) {
+    return lifted;
+  }
+
   const arms: Array<readonly [IR1Expr, IR1Expr]> = [];
   let current: ts.Expression = expr;
   // Right-leaning chain: a ? x : (b ? y : (c ? z : w)) → flatten.
@@ -336,6 +652,29 @@ function buildFromIfStatement(
   stmt: ts.IfStatement,
   ctx: L1BuildContext,
 ): L1BuildResult {
+  // M4 Patch 5: functor-lift on the simple two-branch shape
+  // `if (x == null) return []; else return [f(x)]`. Only attempts the
+  // lift when there is no else-if chain — multi-arm if-with-returns
+  // can't be uniformly lifted to one comprehension.
+  if (stmt.elseStatement && !ts.isIfStatement(stmt.elseStatement)) {
+    const thenExpr = extractReturnFromBranch(stmt.thenStatement, ctx.checker);
+    const elseExpr = extractReturnFromBranch(stmt.elseStatement, ctx.checker);
+    if (thenExpr !== null && elseExpr !== null) {
+      const lifted = tryRecognizeFunctorLift(
+        {
+          guard: stmt.expression,
+          thenExpr,
+          elseExpr,
+          contextNode: stmt,
+        },
+        ctx,
+      );
+      if (lifted !== null) {
+        return lifted;
+      }
+    }
+  }
+
   const arms: Array<readonly [IR1Expr, IR1Expr]> = [];
   let current: ts.IfStatement = stmt;
   while (true) {

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -57,7 +57,7 @@ import {
   type NullishTranslate,
   recognizeAnyLeaf,
   recognizeNullishForm,
-  unwrapParens,
+  unwrapTransparentExpression,
 } from "./nullish-recognizer.js";
 import type { OpaqueExpr } from "./pant-ast.js";
 import { getAst } from "./pant-wasm.js";
@@ -236,7 +236,7 @@ const ARRAY_MULTI_PRODUCING_METHODS = new Set([
 
 /** True when `expr` is an empty-equivalent literal — `[]`, `null`, `undefined`. */
 function isEmptyEquivalent(expr: ts.Expression): boolean {
-  const u = unwrapParens(expr);
+  const u = unwrapTransparentExpression(expr);
   if (ts.isArrayLiteralExpression(u) && u.elements.length === 0) {
     return true;
   }
@@ -258,7 +258,7 @@ function isEmptyEquivalent(expr: ts.Expression): boolean {
  * unchanged; they fail the present-side check below.
  */
 function unwrapSingletonArray(expr: ts.Expression): ts.Expression {
-  const u = unwrapParens(expr);
+  const u = unwrapTransparentExpression(expr);
   if (ts.isArrayLiteralExpression(u) && u.elements.length === 1) {
     const el = u.elements[0]!;
     if (!ts.isSpreadElement(el)) {
@@ -279,7 +279,7 @@ function isSingleElementProducingOf(
   expr: ts.Expression,
   operandName: string,
 ): boolean {
-  const u = unwrapParens(expr);
+  const u = unwrapTransparentExpression(expr);
   if (ts.isArrayLiteralExpression(u)) {
     return false;
   }
@@ -399,7 +399,7 @@ export function tryRecognizeFunctorLift(
   ctx: L1BuildContext,
 ): IR1Expr | null {
   // (a) Guard is a leaf nullish form.
-  const guard = unwrapParens(cand.guard);
+  const guard = unwrapTransparentExpression(cand.guard);
   if (!ts.isBinaryExpression(guard)) {
     return null;
   }
@@ -407,7 +407,7 @@ export function tryRecognizeFunctorLift(
   if (leaf === null) {
     return null;
   }
-  const operandNode = unwrapParens(leaf.operand);
+  const operandNode = unwrapTransparentExpression(leaf.operand);
   if (!ts.isIdentifier(operandNode)) {
     return null;
   }
@@ -444,12 +444,23 @@ export function tryRecognizeFunctorLift(
   // rewrites references to the operand's Pant name with the fresh
   // binder; `ast.substituteBinder` is Pant's capture-avoiding
   // substitution, so a fresh hygienic binder is sufficient.
+  //
+  // Snapshot the hygienic supply counter so that a `buildSubExpr`
+  // failure (which can advance `supply.n` via deferred-comprehension
+  // allocations before returning unsupported) doesn't perturb the
+  // fallback Cond path's binder sequencing. The synthCell registration
+  // via `cellRegisterName` runs only after the last failure point, so
+  // it needs no rollback. Counter increments past the last failure
+  // point are the lift's real allocations and stay committed.
+  const supplyCounterSnapshot = ctx.supply.n;
   const operandSub = buildSubExpr(operandNode, ctx);
   if (isL1Unsupported(operandSub)) {
+    ctx.supply.n = supplyCounterSnapshot;
     return null;
   }
   const projectionSub = buildSubExpr(projection, ctx);
   if (isL1Unsupported(projectionSub)) {
+    ctx.supply.n = supplyCounterSnapshot;
     return null;
   }
 

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -184,7 +184,7 @@ function buildSubExpr(expr: ts.Expression, ctx: L1BuildContext): L1BuildResult {
 // ---------------------------------------------------------------------------
 //
 // `if (x == null) return []; else return [f(x)]` — and the equivalent
-// ternary forms — lower as `each $n in x | f $n`, the canonical
+// ternary forms — lower as `each n in x | f n`, the canonical
 // list-lifted comprehension under the `T | null → [T]` encoding. Pant
 // has no list literal, so the alternative cardinality-dispatch lowering
 // (`cond #x = 0 => [], true => [f((x 1))]`) has no expressible Pant
@@ -262,7 +262,7 @@ function isEmptyEquivalent(
 /**
  * If `expr` is a single-element array literal (`[e]`), return `e`. The
  * lift treats `[u.name]` and `u.name` symmetrically — both project to
- * the same `each $n in u | name $n` shape.
+ * the same `each n in u | name n` shape.
  *
  * Spread elements (`[...xs]`) and multi-element literals fall through
  * unchanged; they fail the present-side check below.
@@ -380,8 +380,8 @@ function allocateLiftBinder(ctx: L1BuildContext, hint: string): string {
 }
 
 /**
- * Functor-lift recognizer. Returns an L1 `from-l2(each $n in x | proj
- * $n)` when the four eligibility checks pass; returns `null` to fall
+ * Functor-lift recognizer. Returns an L1 `from-l2(each n in x | proj
+ * n)` when the four eligibility checks pass; returns `null` to fall
  * through to the standard L1 Cond build.
  *
  * Eligibility:
@@ -626,7 +626,7 @@ function buildFromTernary(
   ctx: L1BuildContext,
 ): L1BuildResult {
   // M4 Patch 5: functor-lift on a null-guarded list-lifted ternary —
-  // `(x == null) ? [] : [f(x)]` collapses to `each $n in x | f $n`.
+  // `(x == null) ? [] : [f(x)]` collapses to `each n in x | f n`.
   // Only the outermost ternary is examined (no chain unwinding), since
   // the lift requires the full (guard, then, else) shape on one node.
   const lifted = tryRecognizeFunctorLift(

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -76,11 +76,7 @@ import {
   isNullableTsType,
   translateBodyExpr,
 } from "./translate-body.js";
-import {
-  cellRegisterName,
-  type NumericStrategy,
-  toPantTermName,
-} from "./translate-types.js";
+import { cellRegisterName, type NumericStrategy } from "./translate-types.js";
 
 /**
  * Context threaded through L1 build. Mirrors the parameter set of
@@ -234,8 +230,21 @@ const ARRAY_MULTI_PRODUCING_METHODS = new Set([
   "splice",
 ]);
 
-/** True when `expr` is an empty-equivalent literal — `[]`, `null`, `undefined`. */
-function isEmptyEquivalent(expr: ts.Expression): boolean {
+/**
+ * True when `expr` is an empty-equivalent literal — `[]`, `null`, or
+ * the global `undefined`. The `undefined` check is checker-aware
+ * because `undefined` is not a reserved word in JS: a parameter,
+ * local, or import named `undefined` is a legal binding that shadows
+ * the global. The resolved type's flags must include `Undefined`; a
+ * shadowed `undefined: number` resolves to `number` (no Undefined
+ * flag) and is rejected — falling through to the standard Cond
+ * build rather than silently rewriting semantics. Mirrors the
+ * shadowing gate in nullish-recognizer.ts.
+ */
+function isEmptyEquivalent(
+  expr: ts.Expression,
+  checker: ts.TypeChecker,
+): boolean {
   const u = unwrapTransparentExpression(expr);
   if (ts.isArrayLiteralExpression(u) && u.elements.length === 0) {
     return true;
@@ -244,7 +253,8 @@ function isEmptyEquivalent(expr: ts.Expression): boolean {
     return true;
   }
   if (ts.isIdentifier(u) && u.text === "undefined") {
-    return true;
+    const type = checker.getTypeAtLocation(u);
+    return (type.flags & ts.TypeFlags.Undefined) !== 0;
   }
   return false;
 }
@@ -420,7 +430,7 @@ export function tryRecognizeFunctorLift(
   const presentExpr = leaf.negated ? cand.thenExpr : cand.elseExpr;
 
   // (b) Empty side is empty-equivalent.
-  if (!isEmptyEquivalent(emptyExpr)) {
+  if (!isEmptyEquivalent(emptyExpr, ctx.checker)) {
     return null;
   }
 
@@ -467,8 +477,15 @@ export function tryRecognizeFunctorLift(
   const operandOpaque = lowerExpr(lowerL1Expr(operandSub));
   const projectionOpaque = lowerExpr(lowerL1Expr(projectionSub));
 
-  const operandPantName =
-    ctx.paramNames.get(operandName) ?? toPantTermName(operandName);
+  // Mirror `translateExpr`'s identifier handling
+  // (`translate-signature.ts:1122` — `paramNames.get(expr.text) ?? expr.text`).
+  // Only *parameters* go through name sanitization on translation;
+  // bare identifiers (locals, captures from outer scope) are emitted
+  // as their raw TS text. Sanitizing here would produce
+  // `toPantTermName("maybeUser") = "maybe-user"`, which the lowered
+  // projection — which still references `maybeUser` — would never
+  // match, leaving the binder unsubstituted and the lift broken.
+  const operandPantName = ctx.paramNames.get(operandName) ?? operandName;
   const binderName = allocateLiftBinder(ctx, "n");
   const ast = getAst();
   const substitutedProjection = ast.substituteBinder(

--- a/tools/ts2pant/src/nullish-recognizer.ts
+++ b/tools/ts2pant/src/nullish-recognizer.ts
@@ -596,3 +596,32 @@ export function recognizeNullishForm(
 // which needs to peek through parenthesized wrappers on guard / branch
 // expressions before classifying their shape.
 export { unwrapParens };
+
+/**
+ * Peel transparent TypeScript wrappers — parens, `as` casts, non-null
+ * assertions (`!`), and `satisfies` expressions — to expose the
+ * inner expression. These wrappers carry no runtime semantics and
+ * must not block recognizer matches: a guard like
+ * `(x as User | null) == null` and a present-side projection like
+ * `[u.name] satisfies string[]` should be recognized just as their
+ * unwrapped forms would be.
+ *
+ * Mirrors the symmetric `unwrapExpression` handling in
+ * `translate-body.ts` (see CodeRabbit review thread on cross-recognizer
+ * symmetry). The narrower `unwrapParens` is preserved for internal
+ * nullish-recognizer use because long-form chain detection
+ * (`flattenChain`, `recognizeLongForm`) only walks `||`/`&&` shapes
+ * and does not need to thread through `as`/`!`/`satisfies`.
+ */
+export function unwrapTransparentExpression(e: ts.Expression): ts.Expression {
+  let cur = e;
+  while (
+    ts.isParenthesizedExpression(cur) ||
+    ts.isAsExpression(cur) ||
+    ts.isNonNullExpression(cur) ||
+    ts.isSatisfiesExpression(cur)
+  ) {
+    cur = cur.expression;
+  }
+  return cur;
+}

--- a/tools/ts2pant/src/nullish-recognizer.ts
+++ b/tools/ts2pant/src/nullish-recognizer.ts
@@ -319,8 +319,13 @@ export function recognizeTypeofUndefined(
 /**
  * Combined leaf matcher: tries `recognizeNullishLeaf` first, then
  * `recognizeTypeofUndefined`. Returns `null` if neither matches.
+ *
+ * Exported for the M4 functor-lift recognizer (`tryRecognizeFunctorLift`
+ * in `ir1-build.ts`), which needs to inspect a conditional's guard for
+ * a leaf nullish form before deciding whether to lift the conditional
+ * to a functor `each` over the operand.
  */
-function recognizeAnyLeaf(
+export function recognizeAnyLeaf(
   expr: ts.BinaryExpression,
   checker: ts.TypeChecker,
 ): NullishLeafMatch | null {
@@ -586,3 +591,8 @@ export function recognizeNullishForm(
   }
   return null;
 }
+
+// Re-export the parens-unwrap helper for the functor-lift recognizer,
+// which needs to peek through parenthesized wrappers on guard / branch
+// expressions before classifying their shape.
+export { unwrapParens };

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -12,6 +12,7 @@ import {
   isL1StmtUnsupported,
   isL1Unsupported,
   lowerL1ToOpaque,
+  tryRecognizeFunctorLift,
 } from "./ir1-build.js";
 import {
   buildL1ForEachCall,
@@ -1447,6 +1448,51 @@ function translatePureBody(
   }
 
   const supply = makeUniqueSupply(synthCell);
+
+  // M4 Patch 5: functor-lift on the if-conversion shape
+  //   `if (x == null) return []; return [f(x)];`
+  // Detected at the prelude level (one earlyReturn arm + an
+  // expression terminal) so the lift can produce one comprehension
+  // instead of an `unsupported`-rejecting cardinality-dispatch Cond.
+  if (
+    extracted.bindings.length === 1 &&
+    extracted.bindings[0]!.kind === "earlyReturn" &&
+    ts.isExpression(extracted.returnExpr)
+  ) {
+    const arm = extracted.bindings[0] as Extract<
+      ConstBinding,
+      { kind: "earlyReturn" }
+    >;
+    const lifted = tryRecognizeFunctorLift(
+      {
+        guard: arm.predicateExpr,
+        thenExpr: arm.valueExpr,
+        elseExpr: extracted.returnExpr,
+        contextNode: node,
+      },
+      {
+        checker,
+        strategy,
+        paramNames,
+        state: undefined,
+        supply,
+      },
+    );
+    if (lifted !== null) {
+      const liftedRhs = lowerL1ToOpaque(lifted);
+      const argExprs = params.map((p) => ast.var(p.name));
+      const lhs = ast.app(ast.var(functionName), argExprs);
+      return [
+        {
+          kind: "equation",
+          quantifiers: [] as OpaqueParam[],
+          lhs,
+          rhs: liftedRhs,
+        },
+      ];
+    }
+  }
+
   const inlined = inlineConstBindings(
     extracted.bindings,
     checker,

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -270,6 +270,34 @@ exports[`expressions-equality-nullish.ts > typeofUndefinedNeq 1`] = `
 "module TypeofUndefinedNeq.\\n\\ntypeof-undefined-neq x: [Int] => Bool.\\n\\n---\\n\\ntypeof-undefined-neq x = (~(#x = 0)).\\n"
 `;
 
+exports[`expressions-functor-lift.ts > ifConversion 1`] = `
+"module IfConversion.\\n\\nUser.\\nuser--name u1: User => String.\\nuser--age u1: User => Int.\\nif-conversion u: [User] => [String].\\n\\n---\\n\\nif-conversion u = (each n in u | user--name n).\\n"
+`;
+
+exports[`expressions-functor-lift.ts > looseGuardLift 1`] = `
+"module LooseGuardLift.\\n\\nUser.\\nuser--name u1: User => String.\\nuser--age u1: User => Int.\\nloose-guard-lift u: [User] => [String].\\n\\n---\\n\\nloose-guard-lift u = (each n in u | user--name n).\\n"
+`;
+
+exports[`expressions-functor-lift.ts > negatedIfConversion 1`] = `
+"module NegatedIfConversion.\\n\\nUser.\\nuser--name u1: User => String.\\nuser--age u1: User => Int.\\nnegated-if-conversion u: [User] => [String].\\n\\n---\\n\\nnegated-if-conversion u = (each n in u | user--name n).\\n"
+`;
+
+exports[`expressions-functor-lift.ts > negatedTernary 1`] = `
+"module NegatedTernary.\\n\\nUser.\\nuser--name u1: User => String.\\nuser--age u1: User => Int.\\nnegated-ternary u: [User] => [Int].\\n\\n---\\n\\nnegated-ternary u = (each n in u | user--age n).\\n"
+`;
+
+exports[`expressions-functor-lift.ts > optionalChain 1`] = `
+"module OptionalChain.\\n\\nUser.\\nuser--name u1: User => String.\\nuser--age u1: User => Int.\\noptional-chain u: [User] => [String].\\n\\n---\\n\\noptional-chain u = (each n in u | user--name n).\\n"
+`;
+
+exports[`expressions-functor-lift.ts > optionalNames 1`] = `
+"module OptionalNames.\\n\\nUser.\\nuser--name u1: User => String.\\nuser--age u1: User => Int.\\noptional-names u: [User] => [String].\\n\\n---\\n\\noptional-names u = (each n in u | user--name n).\\n"
+`;
+
+exports[`expressions-functor-lift.ts > typeofGuardLift 1`] = `
+"module TypeofGuardLift.\\n\\nUser.\\nuser--name u1: User => String.\\nuser--age u1: User => Int.\\ntypeof-guard-lift u: [User] => [String].\\n\\n---\\n\\ntypeof-guard-lift u = (each n in u | user--name n).\\n"
+`;
+
 exports[`expressions-if-early-return.ts > armBetweenBindings 1`] = `
 "module ArmBetweenBindings.\\n\\narm-between-bindings n: Int => Int.\\n\\n---\\n\\narm-between-bindings n = (cond n + 1 < 0 => 0, true => n + 1 + (n + 1)).\\n"
 `;

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-functor-lift.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-functor-lift.ts
@@ -1,0 +1,67 @@
+// Functor-lift recognizer (M4 Patch 5).
+//
+// `if (x == null) return []; return [f(x)];` and the equivalent
+// ternary forms lower to `each $n in x | f $n`. Pant has no list
+// literal, so the alternative cardinality-dispatch lowering for these
+// shapes is untranslatable — without the recognizer these functions
+// reject. See `tools/ts2pant/CLAUDE.md` "Option-Type Elimination" and
+// `workstreams/ts2pant-imperative-ir.md` § "M4".
+
+interface User {
+  readonly name: string;
+  readonly age: number;
+}
+
+/** Ternary, positive guard, single-element array on the present side.
+ *  `optionalNames(u)` returns `[]` when u is null and `[u.name]` when
+ *  it isn't. Lifts to `each $n in u | name $n`. */
+export function optionalNames(u: User | null): string[] {
+  return u == null ? [] : [u.name];
+}
+
+/** Ternary, positive guard, bare projection on the present side. The
+ *  result type `string | null` is itself list-lifted (`[String]`), so
+ *  the bare `u.name` projects through the comprehension without an
+ *  array wrapper. */
+export function optionalChain(u: User | null): string | null {
+  return u == null ? null : u.name;
+}
+
+/** Negated guard: `(x !== null) ? f(x) : null` — present side on the
+ *  then-branch, empty side on the else-branch. */
+export function negatedTernary(u: User | null): number | null {
+  return u !== null ? u.age : null;
+}
+
+/** If-conversion: early return for the empty side, terminal return
+ *  for the present side. The recognizer fires at the prelude level. */
+export function ifConversion(u: User | null): string[] {
+  if (u === null) {
+    return [];
+  }
+  return [u.name];
+}
+
+/** Negated if-conversion: early return for the present side. */
+export function negatedIfConversion(u: User | null): string[] {
+  if (u !== null) {
+    return [u.name];
+  }
+  return [];
+}
+
+/** Long-form positive guard: `x === null || x === undefined` folds to
+ *  `IsNullish(x)` first, then the lift fires. The functor-lift
+ *  recognizer requires a *leaf* nullish form on the guard, so the
+ *  caller cannot use the long-form here — but the simpler `== null`
+ *  form covers both null and undefined and so it suffices. This
+ *  function exercises the loose-eq leaf form on a `T | null |
+ *  undefined` operand. */
+export function looseGuardLift(u: User | null | undefined): string[] {
+  return u == null ? [] : [u.name];
+}
+
+/** typeof-undefined leaf form on the guard. */
+export function typeofGuardLift(u: User | undefined): string[] {
+  return typeof u === "undefined" ? [] : [u.name];
+}

--- a/tools/ts2pant/tests/ir1-build-functor-lift.test.mts
+++ b/tools/ts2pant/tests/ir1-build-functor-lift.test.mts
@@ -258,12 +258,19 @@ describe("ir1-build-functor-lift", () => {
   // ------------------------------------------------------------------
 
   it("non-list-lifted result type does not lift (`number`)", () => {
+    // Use `null as number` for the empty branch so check (b)
+    // (`isEmptyEquivalent`) passes: the `null` keyword survives the
+    // transparent unwrap. Without the cast, `0` is not empty-equivalent
+    // and (b) would reject before (d) is consulted, masking a regression
+    // in `isListLiftedAtNode`. With this isolation, (a)/(b)/(c) all pass
+    // and only the result-type gate decides — function returns `number`,
+    // which is neither array-typed nor nullable-union, so (d) fails and
+    // the lift returns null.
     const { candidate, ctx } = setup(
       `function f(u: number | null): number {
-         return u == null ? 0 : u;
+         return u == null ? (null as number) : u;
        }`,
     );
-    // Return type `number` is not list-lifted — falls through.
     assert.equal(tryRecognizeFunctorLift(candidate, ctx), null);
   });
 
@@ -365,30 +372,44 @@ describe("ir1-build-functor-lift", () => {
 
   it("binder substitution avoids capture: param named `n` does not collide", () => {
     // The lift wants binder hint `n`. With a parameter also named `n`,
-    // `cellRegisterName` should pick a non-colliding suffix (`n1`) so
-    // the comprehension binder doesn't shadow the param. Building the
-    // L1 form succeeds; the resulting `from-l2`-wrapped each carries
-    // a non-`n` binder name.
+    // the production-style `setup()` already registers `n` against the
+    // shared `synthCell` (mirroring `translateSignature`'s parameter
+    // allocation). When the lift then calls `cellRegisterName(synthCell,
+    // "n")` for the comprehension binder, the registry must emit a
+    // suffixed alternative (`n1`) so the binder doesn't shadow the
+    // param.
+    //
+    // Inspect the lowered output to confirm the binder name actually
+    // rotated — proving the lift succeeded isn't sufficient because a
+    // collision regression could still produce a working `each` whose
+    // binder happens to alias the param at the Pant level (visible
+    // only if you read the output string).
     const { candidate, ctx } = setup(
       `interface Box { readonly v: number; }
        function f(n: Box | null, m: number): number[] {
          return n == null ? [] : [n.v];
        }`,
     );
-    // Pre-claim `n` in the synth cell registry to model the
-    // document-wide name conflict — `cellRegisterName` will see `n` is
-    // taken and yield `n1`.
     if (!ctx.supply.synthCell) {
-      assert.fail("test setup error: expected a synthCell");
+      throw new Error("test setup error: expected a synthCell");
     }
-    // Pre-register a few names to force a collision-free fresh binder.
-    // `cellRegisterName` is monotonic, so any name we register stays
-    // claimed for the rest of the test.
-    // (No explicit pre-register call needed: the lift will be the
-    // first to allocate via the cell, and the snapshot test elsewhere
-    // verifies the binder name is fresh against ts2pant's
-    // document-wide registry.)
-    expectLifted(tryRecognizeFunctorLift(candidate, ctx));
+    const lifted = expectLifted(tryRecognizeFunctorLift(candidate, ctx));
+    const out = getAst().strExpr(lowerL1ToOpaque(lifted));
+    // Match `each <binder> in ...`, extract the binder name.
+    const m = out.match(/\beach\s+(\S+)\s+in\b/);
+    if (!m) {
+      throw new Error(`could not parse binder from output: ${out}`);
+    }
+    const binder = m[1] as string;
+    const paramPantName = ctx.paramNames.get("n");
+    if (paramPantName === undefined) {
+      throw new Error("test setup error: paramNames missing `n`");
+    }
+    assert.notEqual(
+      binder,
+      paramPantName,
+      `binder ${binder} collides with param ${paramPantName} in: ${out}`,
+    );
   });
 
   it("camelCase parameter substitution doesn't kebab-mangle the binder target", () => {

--- a/tools/ts2pant/tests/ir1-build-functor-lift.test.mts
+++ b/tools/ts2pant/tests/ir1-build-functor-lift.test.mts
@@ -167,7 +167,17 @@ function expectLifted(result: IR1Expr | null): IR1Expr {
     throw new Error("expected a lifted L1 expression, got null (fall-through)");
   }
   // The lift wraps an opaque each via `from-l2(irWrap(opaqueEach))`.
+  // Verify the kind discriminator AND the lowered shape — a regression
+  // that returned a different wrapped L2 form (e.g., a `cond`) would
+  // still have `kind === "from-l2"`, so lower the expression and
+  // assert the emitted text contains an `each` comprehension.
   assert.equal(result.kind, "from-l2");
+  const out = getAst().strExpr(lowerL1ToOpaque(result));
+  assert.match(
+    out,
+    /\beach\s+\S+\s+in\b/,
+    `expected functor-lift lowering to emit an each-comprehension, got: ${out}`,
+  );
   return result;
 }
 
@@ -460,12 +470,34 @@ describe("ir1-build-functor-lift", () => {
     // branch — the standard sub-expression translation pipeline (which
     // the lift recurses through for the projection) handles the inner
     // ternary, lifting it independently.
+    //
+    // Both inner and outer need a simple-identifier operand: the outer
+    // is on `u`, the inner is on `v` (passed as an argument to a call
+    // that also references `u`, so the outer's present-side check (c)
+    // is satisfied via `u.combine(...)`). The inner's empty branch is
+    // `null`, present branch is `v.label` referencing the operand —
+    // all four eligibility checks fire on the inner and it lifts too.
+    //
+    // Verify by counting `each` occurrences in the lowered output:
+    // exactly 2 (one per lift). A regression that broke recursive
+    // recognition would produce 1 (outer-only) and the assertion
+    // would fail.
     const { candidate, ctx } = setup(
-      `interface User { readonly name: string | null; }
-       function f(u: User | null): string | null {
-         return u == null ? null : (u.name == null ? null : u.name);
+      `interface User {
+         combine(arg: string | null): string;
+       }
+       interface Box { readonly label: string; }
+       function f(u: User | null, v: Box | null): string | null {
+         return u == null ? null : u.combine(v == null ? null : v.label);
        }`,
     );
-    expectLifted(tryRecognizeFunctorLift(candidate, ctx));
+    const lifted = expectLifted(tryRecognizeFunctorLift(candidate, ctx));
+    const out = getAst().strExpr(lowerL1ToOpaque(lifted));
+    const matches = out.match(/\beach\s+\S+\s+in\b/g) ?? [];
+    assert.equal(
+      matches.length,
+      2,
+      `expected both outer and inner null-guards to lower as lifts, got: ${out}`,
+    );
   });
 });

--- a/tools/ts2pant/tests/ir1-build-functor-lift.test.mts
+++ b/tools/ts2pant/tests/ir1-build-functor-lift.test.mts
@@ -221,6 +221,22 @@ describe("ir1-build-functor-lift", () => {
     expectLifted(tryRecognizeFunctorLift(candidate, ctx));
   });
 
+  it("lifts through transparent wrappers (`as`, `!`, `satisfies`)", () => {
+    // Each of `as` / `!` / `satisfies` is runtime-transparent and must
+    // not block recognition. A guard wrapped in `as boolean`, an
+    // operand widened with `as`, or a present-side projection asserted
+    // with `!` or `satisfies` should still recognize.
+    const { candidate, ctx } = setup(
+      `interface User { readonly name: string; }
+       function f(u: User | null): string[] {
+         return ((u as User | null) == null) as boolean
+           ? ([] satisfies string[])
+           : [u!.name];
+       }`,
+    );
+    expectLifted(tryRecognizeFunctorLift(candidate, ctx));
+  });
+
   // ------------------------------------------------------------------
   // Eligibility-failure cases (each check fails in isolation)
   // ------------------------------------------------------------------

--- a/tools/ts2pant/tests/ir1-build-functor-lift.test.mts
+++ b/tools/ts2pant/tests/ir1-build-functor-lift.test.mts
@@ -25,7 +25,12 @@ import {
 import type { IR1Expr } from "../src/ir1.js";
 import { getAst, loadAst } from "../src/pant-wasm.js";
 import type { UniqueSupply } from "../src/translate-body.js";
-import { IntStrategy, newSynthCell } from "../src/translate-types.js";
+import {
+  cellRegisterName,
+  IntStrategy,
+  newSynthCell,
+  toPantTermName,
+} from "../src/translate-types.js";
 
 before(async () => {
   await loadAst();
@@ -55,13 +60,23 @@ function setup(source: string): SetupResult {
   if (!fn || !fn.body) {
     throw new Error("setup: expected a function declaration with a body");
   }
+  // Build paramNames the same way production does: each TS parameter
+  // name is sanitized through `toPantTermName` and registered against
+  // the document-wide NameRegistry via `cellRegisterName`. Keeping the
+  // test's allocation path in lockstep with `translateSignature`'s
+  // `paramNameMap` (translate-signature.ts:1241–1244) means the test
+  // exercises the real substitution path — `maybeUser` parameter
+  // canonicalizes to `maybe-user` in the lowered Pant, so the lift
+  // must look up the same Pant name when targeting `substituteBinder`.
+  const synthCell = newSynthCell();
   const paramNames = new Map<string, string>();
   for (const p of fn.parameters) {
     if (ts.isIdentifier(p.name)) {
-      paramNames.set(p.name.text, p.name.text);
+      const pantName = cellRegisterName(synthCell, toPantTermName(p.name.text));
+      paramNames.set(p.name.text, pantName);
     }
   }
-  const supply: UniqueSupply = { n: 0, synthCell: newSynthCell() };
+  const supply: UniqueSupply = { n: 0, synthCell };
   const ctx = {
     checker,
     strategy: IntStrategy,
@@ -320,13 +335,24 @@ describe("ir1-build-functor-lift", () => {
     // `undefined` is not a reserved word — a parameter named
     // `undefined` is a legal binding that shadows the global. If
     // `isEmptyEquivalent` matched the identifier text alone, the
-    // lift would silently rewrite `u == null ? undefined : [u.v]`
-    // (where `undefined` resolves to a `string` parameter) to an
-    // each comprehension, dropping the shadowed value. Reject.
+    // lift would silently rewrite the conditional to a comprehension,
+    // dropping the shadowed value. To make the empty-branch check
+    // (b) the deciding gate, the other three eligibility checks must
+    // all pass:
+    //   (a) guard `u == null` is a leaf nullish form on `u`
+    //   (c) present branch `[u]` (after singleton unwrap) is `u`,
+    //       which references the operand
+    //   (d) the conditional's static result type is list-lifted —
+    //       both branches type as `Box[]` (the shadowed `undefined`
+    //       parameter has type `Box[]`), so the conditional itself
+    //       is `Box[]` and `isListLiftedTsType` accepts it
+    // Pre-fix this test would have green-lit the lift on the text
+    // match alone; post-fix the checker resolves the `undefined`
+    // identifier to `Box[]` (no Undefined flag) and (b) rejects.
     const { candidate, ctx } = setup(
       `interface Box { readonly v: number; }
-       function f(u: Box | null, undefined: string): string {
-         return u == null ? undefined : "x";
+       function f(u: Box | null, undefined: Box[]): Box[] {
+         return u == null ? undefined : [u];
        }`,
     );
     assert.equal(tryRecognizeFunctorLift(candidate, ctx), null);
@@ -366,15 +392,22 @@ describe("ir1-build-functor-lift", () => {
   });
 
   it("camelCase parameter substitution doesn't kebab-mangle the binder target", () => {
-    // The operand's substitution name must match the spelling
+    // The operand's substitution name must match the spelling that
     // `translateBodyExpr` emits for the identifier — for parameters,
-    // that's `paramNames.get(text)` (already canonicalized at signature
-    // translation), and for bare references it's the raw text. Running
-    // `toPantTermName` here would target `maybe-user` while the lowered
-    // projection still references `maybeUser`, leaving the binder
-    // unsubstituted and the lift broken. Verify by stringifying the
-    // lowered output: the original identifier must NOT appear (replaced
-    // by the binder), and the binder name MUST appear.
+    // that's `paramNames.get(text)` (sanitized at signature translation
+    // via `toPantTermName` + `cellRegisterName`); for bare references
+    // it's the raw text. `setup()` mirrors production's allocation,
+    // so `maybeUser` is registered as `maybe-user` in `paramNames`.
+    // The lowered projection references `maybe-user`, and the lift's
+    // substitution target must too — both paths look up
+    // `paramNames.get(operandName)`, so any divergence between body
+    // and lift lookup logic (e.g., body uses raw text but lift
+    // sanitizes) would leave the projection's reference unsubstituted.
+    //
+    // Verify by counting occurrences of the sanitized operand name
+    // `maybe-user` in the lowered output: exactly 1 (the iter source).
+    // If substitution failed, the projection's reference would
+    // persist, giving 2.
     const { candidate, ctx } = setup(
       `interface User { readonly name: string; }
        function f(maybeUser: User | null): string[] {
@@ -384,16 +417,20 @@ describe("ir1-build-functor-lift", () => {
     const lifted = expectLifted(tryRecognizeFunctorLift(candidate, ctx));
     const ast = getAst();
     const out = ast.strExpr(lowerL1ToOpaque(lifted));
-    // The lifted form is `each <binder> in maybeUser | <accessor> <binder>`,
-    // so `maybeUser` appears once in the source position; the projection
-    // has no remaining `maybeUser` reference (substituted by the binder).
-    // If the bug were live, `maybeUser` would appear twice — once as
-    // the iter source and once unsubstituted in the projection.
-    const occurrences = out.split("maybeUser").length - 1;
+    const sanitizedName = ctx.paramNames.get("maybeUser");
+    if (sanitizedName === undefined) {
+      throw new Error("test setup error: paramNames missing maybeUser");
+    }
+    assert.equal(
+      sanitizedName,
+      "maybe-user",
+      `expected setup to sanitize maybeUser → maybe-user, got ${sanitizedName}`,
+    );
+    const occurrences = out.split(sanitizedName).length - 1;
     assert.equal(
       occurrences,
       1,
-      `expected exactly one occurrence of 'maybeUser' (as iter source), got ${occurrences} in: ${out}`,
+      `expected exactly one occurrence of '${sanitizedName}' (as iter source), got ${occurrences} in: ${out}`,
     );
   });
 

--- a/tools/ts2pant/tests/ir1-build-functor-lift.test.mts
+++ b/tools/ts2pant/tests/ir1-build-functor-lift.test.mts
@@ -19,10 +19,11 @@ import ts from "typescript";
 import { createSourceFileFromSource, getChecker } from "../src/extract.js";
 import {
   type FunctorLiftCandidate,
+  lowerL1ToOpaque,
   tryRecognizeFunctorLift,
 } from "../src/ir1-build.js";
 import type { IR1Expr } from "../src/ir1.js";
-import { loadAst } from "../src/pant-wasm.js";
+import { getAst, loadAst } from "../src/pant-wasm.js";
 import type { UniqueSupply } from "../src/translate-body.js";
 import { IntStrategy, newSynthCell } from "../src/translate-types.js";
 
@@ -315,6 +316,23 @@ describe("ir1-build-functor-lift", () => {
     assert.equal(tryRecognizeFunctorLift(candidate, ctx), null);
   });
 
+  it("shadowed `undefined` empty branch falls through", () => {
+    // `undefined` is not a reserved word — a parameter named
+    // `undefined` is a legal binding that shadows the global. If
+    // `isEmptyEquivalent` matched the identifier text alone, the
+    // lift would silently rewrite `u == null ? undefined : [u.v]`
+    // (where `undefined` resolves to a `string` parameter) to an
+    // each comprehension, dropping the shadowed value. Reject.
+    const { candidate, ctx } = setup(
+      `interface Box { readonly v: number; }
+       function f(u: Box | null, undefined: string): string {
+         return u == null ? undefined : "x";
+       }`,
+    );
+    assert.equal(tryRecognizeFunctorLift(candidate, ctx), null);
+  });
+
+
   // ------------------------------------------------------------------
   // Substitution / capture avoidance / nesting
   // ------------------------------------------------------------------
@@ -345,6 +363,38 @@ describe("ir1-build-functor-lift", () => {
     // verifies the binder name is fresh against ts2pant's
     // document-wide registry.)
     expectLifted(tryRecognizeFunctorLift(candidate, ctx));
+  });
+
+  it("camelCase parameter substitution doesn't kebab-mangle the binder target", () => {
+    // The operand's substitution name must match the spelling
+    // `translateBodyExpr` emits for the identifier — for parameters,
+    // that's `paramNames.get(text)` (already canonicalized at signature
+    // translation), and for bare references it's the raw text. Running
+    // `toPantTermName` here would target `maybe-user` while the lowered
+    // projection still references `maybeUser`, leaving the binder
+    // unsubstituted and the lift broken. Verify by stringifying the
+    // lowered output: the original identifier must NOT appear (replaced
+    // by the binder), and the binder name MUST appear.
+    const { candidate, ctx } = setup(
+      `interface User { readonly name: string; }
+       function f(maybeUser: User | null): string[] {
+         return maybeUser == null ? [] : [maybeUser.name];
+       }`,
+    );
+    const lifted = expectLifted(tryRecognizeFunctorLift(candidate, ctx));
+    const ast = getAst();
+    const out = ast.strExpr(lowerL1ToOpaque(lifted));
+    // The lifted form is `each <binder> in maybeUser | <accessor> <binder>`,
+    // so `maybeUser` appears once in the source position; the projection
+    // has no remaining `maybeUser` reference (substituted by the binder).
+    // If the bug were live, `maybeUser` would appear twice — once as
+    // the iter source and once unsubstituted in the projection.
+    const occurrences = out.split("maybeUser").length - 1;
+    assert.equal(
+      occurrences,
+      1,
+      `expected exactly one occurrence of 'maybeUser' (as iter source), got ${occurrences} in: ${out}`,
+    );
   });
 
   it("nested null-guards: inner ternary inside outer present-side", () => {

--- a/tools/ts2pant/tests/ir1-build-functor-lift.test.mts
+++ b/tools/ts2pant/tests/ir1-build-functor-lift.test.mts
@@ -1,0 +1,347 @@
+/**
+ * Unit tests for the M4 Patch 5 functor-lift recognizer
+ * (`tryRecognizeFunctorLift` in `src/ir1-build.ts`).
+ *
+ * The recognizer collapses null-guarded list-lifted conditionals like
+ * `(x == null) ? [] : [f(x)]` into `each $n in x | f $n` — Pant has
+ * no list literal, so this is the canonical (and only translatable)
+ * lowering for these shapes.
+ *
+ * Each test parses a function declaration containing a single ternary
+ * or if-statement, runs the recognizer on the (guard, then, else)
+ * triple, and asserts whether the result is a lifted `each` (via
+ * `from-l2`) or a fall-through (`null`).
+ */
+
+import assert from "node:assert/strict";
+import { before, describe, it } from "node:test";
+import ts from "typescript";
+import { createSourceFileFromSource, getChecker } from "../src/extract.js";
+import {
+  type FunctorLiftCandidate,
+  tryRecognizeFunctorLift,
+} from "../src/ir1-build.js";
+import type { IR1Expr } from "../src/ir1.js";
+import { loadAst } from "../src/pant-wasm.js";
+import type { UniqueSupply } from "../src/translate-body.js";
+import { IntStrategy, newSynthCell } from "../src/translate-types.js";
+
+before(async () => {
+  await loadAst();
+});
+
+interface SetupResult {
+  candidate: FunctorLiftCandidate;
+  ctx: {
+    checker: ts.TypeChecker;
+    strategy: typeof IntStrategy;
+    paramNames: ReadonlyMap<string, string>;
+    state: undefined;
+    supply: UniqueSupply;
+  };
+}
+
+/**
+ * Parse a function declaration and extract the single ternary or
+ * if-statement at the top of its body. Builds a `FunctorLiftCandidate`
+ * pointing at the appropriate (guard, then, else) triple plus a build
+ * context with the parameter scope.
+ */
+function setup(source: string): SetupResult {
+  const sourceFile = createSourceFileFromSource(source);
+  const checker = getChecker(sourceFile);
+  const fn = sourceFile.compilerNode.statements.find(ts.isFunctionDeclaration);
+  if (!fn || !fn.body) {
+    throw new Error("setup: expected a function declaration with a body");
+  }
+  const paramNames = new Map<string, string>();
+  for (const p of fn.parameters) {
+    if (ts.isIdentifier(p.name)) {
+      paramNames.set(p.name.text, p.name.text);
+    }
+  }
+  const supply: UniqueSupply = { n: 0, synthCell: newSynthCell() };
+  const ctx = {
+    checker,
+    strategy: IntStrategy,
+    paramNames,
+    state: undefined,
+    supply,
+  };
+
+  // Locate the conditional shape inside the body. Three accepted
+  // top-of-body shapes:
+  //   1. `return (cond) ? then : else;`
+  //   2. `if (cond) return E1; else return E2;`
+  //   3. `if (cond) return E1; return E2;`
+  const stmts = fn.body.statements;
+  const first = stmts[0];
+  if (!first) {
+    throw new Error("setup: empty body");
+  }
+  if (
+    ts.isReturnStatement(first) &&
+    first.expression &&
+    ts.isConditionalExpression(first.expression)
+  ) {
+    const cond = first.expression;
+    return {
+      candidate: {
+        guard: cond.condition,
+        thenExpr: cond.whenTrue,
+        elseExpr: cond.whenFalse,
+        contextNode: cond,
+      },
+      ctx,
+    };
+  }
+  if (ts.isIfStatement(first)) {
+    const thenRet = unwrapReturn(first.thenStatement);
+    if (first.elseStatement) {
+      const elseRet = unwrapReturn(first.elseStatement);
+      if (thenRet && elseRet) {
+        return {
+          candidate: {
+            guard: first.expression,
+            thenExpr: thenRet,
+            elseExpr: elseRet,
+            contextNode: first,
+          },
+          ctx,
+        };
+      }
+    }
+    // if-conversion form: `if (g) return E1; return E2;`
+    const second = stmts[1];
+    if (
+      thenRet &&
+      second &&
+      ts.isReturnStatement(second) &&
+      second.expression
+    ) {
+      return {
+        candidate: {
+          guard: first.expression,
+          thenExpr: thenRet,
+          elseExpr: second.expression,
+          contextNode: fn,
+        },
+        ctx,
+      };
+    }
+  }
+  throw new Error("setup: no conditional shape found at top of body");
+}
+
+function unwrapReturn(stmt: ts.Statement): ts.Expression | null {
+  if (ts.isReturnStatement(stmt) && stmt.expression) {
+    return stmt.expression;
+  }
+  if (ts.isBlock(stmt) && stmt.statements.length === 1) {
+    const inner = stmt.statements[0]!;
+    if (ts.isReturnStatement(inner) && inner.expression) {
+      return inner.expression;
+    }
+  }
+  return null;
+}
+
+function expectLifted(result: IR1Expr | null): IR1Expr {
+  if (result === null) {
+    throw new Error("expected a lifted L1 expression, got null (fall-through)");
+  }
+  // The lift wraps an opaque each via `from-l2(irWrap(opaqueEach))`.
+  assert.equal(result.kind, "from-l2");
+  return result;
+}
+
+describe("ir1-build-functor-lift", () => {
+  // ------------------------------------------------------------------
+  // Positive lifts
+  // ------------------------------------------------------------------
+
+  it("positive ternary lifts (`u == null ? [] : [u.name]`)", () => {
+    const { candidate, ctx } = setup(
+      `interface User { readonly name: string; }
+       function f(u: User | null): string[] {
+         return u == null ? [] : [u.name];
+       }`,
+    );
+    expectLifted(tryRecognizeFunctorLift(candidate, ctx));
+  });
+
+  it("positive ternary lifts with bare projection (`u == null ? null : u.name`)", () => {
+    const { candidate, ctx } = setup(
+      `interface User { readonly name: string; }
+       function f(u: User | null): string | null {
+         return u == null ? null : u.name;
+       }`,
+    );
+    expectLifted(tryRecognizeFunctorLift(candidate, ctx));
+  });
+
+  it("negated ternary lifts (`u != null ? u.name : null`)", () => {
+    const { candidate, ctx } = setup(
+      `interface User { readonly name: string; }
+       function f(u: User | null): string | null {
+         return u != null ? u.name : null;
+       }`,
+    );
+    expectLifted(tryRecognizeFunctorLift(candidate, ctx));
+  });
+
+  it("if-conversion lifts (`if (u === null) return []; return [u.name];`)", () => {
+    const { candidate, ctx } = setup(
+      `interface User { readonly name: string; }
+       function f(u: User | null): string[] {
+         if (u === null) return [];
+         return [u.name];
+       }`,
+    );
+    expectLifted(tryRecognizeFunctorLift(candidate, ctx));
+  });
+
+  it("if-else lifts (`if (u === null) { return []; } else { return [u.name]; }`)", () => {
+    const { candidate, ctx } = setup(
+      `interface User { readonly name: string; }
+       function f(u: User | null): string[] {
+         if (u === null) { return []; } else { return [u.name]; }
+       }`,
+    );
+    expectLifted(tryRecognizeFunctorLift(candidate, ctx));
+  });
+
+  it("typeof-undefined guard lifts", () => {
+    const { candidate, ctx } = setup(
+      `interface User { readonly name: string; }
+       function f(u: User | undefined): string[] {
+         return typeof u === "undefined" ? [] : [u.name];
+       }`,
+    );
+    expectLifted(tryRecognizeFunctorLift(candidate, ctx));
+  });
+
+  // ------------------------------------------------------------------
+  // Eligibility-failure cases (each check fails in isolation)
+  // ------------------------------------------------------------------
+
+  it("non-list-lifted result type does not lift (`number`)", () => {
+    const { candidate, ctx } = setup(
+      `function f(u: number | null): number {
+         return u == null ? 0 : u;
+       }`,
+    );
+    // Return type `number` is not list-lifted — falls through.
+    assert.equal(tryRecognizeFunctorLift(candidate, ctx), null);
+  });
+
+  it("multi-element non-empty branch does not lift (`[u.name, u.name]`)", () => {
+    const { candidate, ctx } = setup(
+      `interface User { readonly name: string; }
+       function f(u: User | null): string[] {
+         return u == null ? [] : [u.name, u.name];
+       }`,
+    );
+    assert.equal(tryRecognizeFunctorLift(candidate, ctx), null);
+  });
+
+  it("non-empty-equivalent empty branch does not lift (`[42]`)", () => {
+    const { candidate, ctx } = setup(
+      `interface User { readonly age: number; }
+       function f(u: User | null): number[] {
+         return u == null ? [42] : [u.age];
+       }`,
+    );
+    assert.equal(tryRecognizeFunctorLift(candidate, ctx), null);
+  });
+
+  it("non-nullish guard does not lift (`u.age > 18`)", () => {
+    const { candidate, ctx } = setup(
+      `interface User { readonly age: number; readonly name: string; }
+       function f(u: User): string[] {
+         return u.age > 18 ? [] : [u.name];
+       }`,
+    );
+    assert.equal(tryRecognizeFunctorLift(candidate, ctx), null);
+  });
+
+  it("non-identifier operand falls through (`u.next == null`)", () => {
+    const { candidate, ctx } = setup(
+      `interface User { readonly name: string; readonly next: User | null; }
+       function f(u: User): string[] {
+         return u.next == null ? [] : [u.next.name];
+       }`,
+    );
+    // Operand restriction: only simple identifiers participate in the
+    // lift; property-access operands fall through.
+    assert.equal(tryRecognizeFunctorLift(candidate, ctx), null);
+  });
+
+  it("present side does not reference the operand falls through", () => {
+    const { candidate, ctx } = setup(
+      `interface User { readonly name: string; }
+       function f(u: User | null, fallback: string): string[] {
+         return u == null ? [] : [fallback];
+       }`,
+    );
+    // `[fallback]` does not reference the nullish operand `u` —
+    // the lift would erase the conditional dependence on `u`. Reject.
+    assert.equal(tryRecognizeFunctorLift(candidate, ctx), null);
+  });
+
+  it("loose-eq with non-null literal falls through (`x == 5`)", () => {
+    const { candidate, ctx } = setup(
+      `function f(x: number): number[] {
+         return x == 5 ? [] : [x];
+       }`,
+    );
+    // `x == 5` is not a leaf nullish form; recognizer falls through.
+    assert.equal(tryRecognizeFunctorLift(candidate, ctx), null);
+  });
+
+  // ------------------------------------------------------------------
+  // Substitution / capture avoidance / nesting
+  // ------------------------------------------------------------------
+
+  it("binder substitution avoids capture: param named `n` does not collide", () => {
+    // The lift wants binder hint `n`. With a parameter also named `n`,
+    // `cellRegisterName` should pick a non-colliding suffix (`n1`) so
+    // the comprehension binder doesn't shadow the param. Building the
+    // L1 form succeeds; the resulting `from-l2`-wrapped each carries
+    // a non-`n` binder name.
+    const { candidate, ctx } = setup(
+      `interface Box { readonly v: number; }
+       function f(n: Box | null, m: number): number[] {
+         return n == null ? [] : [n.v];
+       }`,
+    );
+    // Pre-claim `n` in the synth cell registry to model the
+    // document-wide name conflict — `cellRegisterName` will see `n` is
+    // taken and yield `n1`.
+    if (!ctx.supply.synthCell) {
+      assert.fail("test setup error: expected a synthCell");
+    }
+    // Pre-register a few names to force a collision-free fresh binder.
+    // `cellRegisterName` is monotonic, so any name we register stays
+    // claimed for the rest of the test.
+    // (No explicit pre-register call needed: the lift will be the
+    // first to allocate via the cell, and the snapshot test elsewhere
+    // verifies the binder name is fresh against ts2pant's
+    // document-wide registry.)
+    expectLifted(tryRecognizeFunctorLift(candidate, ctx));
+  });
+
+  it("nested null-guards: inner ternary inside outer present-side", () => {
+    // The outer lift's recognizer accepts an inner lift in the present
+    // branch — the standard sub-expression translation pipeline (which
+    // the lift recurses through for the projection) handles the inner
+    // ternary, lifting it independently.
+    const { candidate, ctx } = setup(
+      `interface User { readonly name: string | null; }
+       function f(u: User | null): string | null {
+         return u == null ? null : (u.name == null ? null : u.name);
+       }`,
+    );
+    expectLifted(tryRecognizeFunctorLift(candidate, ctx));
+  });
+});

--- a/tools/ts2pant/tests/ir1-build-functor-lift.test.mts
+++ b/tools/ts2pant/tests/ir1-build-functor-lift.test.mts
@@ -3,9 +3,11 @@
  * (`tryRecognizeFunctorLift` in `src/ir1-build.ts`).
  *
  * The recognizer collapses null-guarded list-lifted conditionals like
- * `(x == null) ? [] : [f(x)]` into `each $n in x | f $n` — Pant has
+ * `(x == null) ? [] : [f(x)]` into `each n in x | f n` — Pant has
  * no list literal, so this is the canonical (and only translatable)
- * lowering for these shapes.
+ * lowering for these shapes. (The binder is plain `n` / `n1` /
+ * etc., not the internal `$N` hygienic class — comprehension binders
+ * must round-trip through Pant's parser, which rejects `$`.)
  *
  * Each test parses a function declaration containing a single ternary
  * or if-statement, runs the recognizer on the (guard, then, else)
@@ -457,7 +459,18 @@ describe("ir1-build-functor-lift", () => {
       "maybe-user",
       `expected setup to sanitize maybeUser → maybe-user, got ${sanitizedName}`,
     );
-    const occurrences = out.split(sanitizedName).length - 1;
+    // Token-bounded match instead of `out.split(sanitizedName)` so a
+    // hypothetical longer token like `maybe-user-suffix` doesn't double-
+    // count `maybe-user`. The negative-lookbehind/lookahead asserts the
+    // surrounding chars aren't valid Pant identifier continuations
+    // (alphanumerics, `_`, `-`, plus the trailing-`?`/`!` shapes Pant
+    // accepts in identifiers).
+    const escaped = sanitizedName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const tokenRx = new RegExp(
+      `(?<![A-Za-z0-9?!_-])${escaped}(?![A-Za-z0-9?!_-])`,
+      "g",
+    );
+    const occurrences = (out.match(tokenRx) ?? []).length;
     assert.equal(
       occurrences,
       1,


### PR DESCRIPTION
## Patch 5: Functor-lift recognizer for null-guarded list-lifted conditionals

- Implement `tryRecognizeFunctorLift(node, checker, paramNames, supply): IR1Expr | null` in `src/ir1-build.ts`. Inputs: a TS conditional shape (`ConditionalExpression`, or an `IfStatement` whose body and else are both single-return forms after M1's if-conversion screen).
- Eligibility checks (all must hold; otherwise return null and fall through to standard Cond build):
-   (a) Guard is nullish-shaped per Patch 2's recognizer. Extract `operand` and `negated` flag.
-   (b) The 'empty side' (whichever branch corresponds to `IsNullish(x) = true`) is empty-equivalent: TS empty array literal (`[]` with zero elements), `null` literal, or `undefined` literal. Anything else: not eligible.
-   (c) The 'present side' (the `not IsNullish(x)` branch) translates as a single-element-producing expression of `x` — an identifier `x`, a property access `x.foo`, a call `f(x)` or `x.method(...)`, or an arithmetic/logical combination thereof. Multi-element constructions (array literals with multiple elements, spread expressions, concat calls) fail this check.
-   (d) The conditional's static result type is list-lifted: TS array (`U[]`), `T | null`, `T | undefined`, or `T | null | undefined`. Use `checker.getContextualType` or the contextual return type. Non-list-lifted result types (`number`, `string`, plain objects) fail this check.
- When all four hold: translate the operand `x` via the legacy pipeline (wrap in `ir1FromL2`); allocate a fresh binder name `$n` via `cellRegisterName(supply.synthCell, 'n')`; translate the present side under a scope where `x` substitutes for `$n` (use `ast.substituteBinder` on the lowered OpaqueExpr to replace `x`'s Pant name with `$n`); construct the L2 each via `ast.each([], [ast.gIn(binderName, operandOpaque)], substitutedPresentOpaque)`; wrap as `ir1FromL2(opaqueEach)` and return.
- When any check fails: return null. The caller falls through to the standard L1 Cond build (Patch 2's nullish recognizer + M1 Cond), which then lowers via cardinality-dispatch — but for empty-list-typed branches that translation hits the no-list-literal wall and rejects with `unsupported`. That rejection IS the pre-M4 behavior, deliberately preserved.
- Mirror the recognizer entry point in `translate-body.ts` for early-return / ternary expression-position uses inside mutating bodies. Share the eligibility logic with `ir1-build.ts` via an exported helper.
- Create `tests/fixtures/constructs/expressions-functor-lift.ts`: `optionalNames(u: User | null): string[]` (returns `[]` or `[u.name]`); `optionalChain(u: User | null): string | null` (returns `null` or `u.name`); `negatedTernary(x: T | null)` (`(x != null) ? f(x) : null`); `ifConversion(x: T | null)` (`if (x === null) return []; return [g(x)]`); plus deliberate-reject cases that still translate via fall-through (currently: end up as `unsupported`).
- Add unit tests in `tests/ir1-build-functor-lift.test.mts`: each eligibility check fails independently → recognizer returns null; all checks pass → recognizer returns `ir1FromL2(L2 each)` with correct binder substitution; substitution preserves capture-avoidance (binder name doesn't clash with parameters); handle nested null-guards (inner lift inside outer lift) — recursive recognition works via build-time recursion.
- Run `just ts2pant-test-integration` — every fixture in `expressions-functor-lift.ts` must pant-check successfully (the lift produces well-typed `[U]` results matching the declared return type)
- Run `just ts2pant-test` and dogfood — verify no existing snapshot regresses. Pre-M4, no fixture exercised this shape (because they all fail at the empty-list literal); the new fixture is the first to hit this code path

## Changes
- Implement `tryRecognizeFunctorLift(node, checker, paramNames, supply): IR1Expr | null` in `src/ir1-build.ts`. Inputs: a TS conditional shape (`ConditionalExpression`, or an `IfStatement` whose body and else are both single-return forms after M1's if-conversion screen).
- Eligibility checks (all must hold; otherwise return null and fall through to standard Cond build):
-   (a) Guard is nullish-shaped per Patch 2's recognizer. Extract `operand` and `negated` flag.
-   (b) The 'empty side' (whichever branch corresponds to `IsNullish(x) = true`) is empty-equivalent: TS empty array literal (`[]` with zero elements), `null` literal, or `undefined` literal. Anything else: not eligible.
-   (c) The 'present side' (the `not IsNullish(x)` branch) translates as a single-element-producing expression of `x` — an identifier `x`, a property access `x.foo`, a call `f(x)` or `x.method(...)`, or an arithmetic/logical combination thereof. Multi-element constructions (array literals with multiple elements, spread expressions, concat calls) fail this check.
-   (d) The conditional's static result type is list-lifted: TS array (`U[]`), `T | null`, `T | undefined`, or `T | null | undefined`. Use `checker.getContextualType` or the contextual return type. Non-list-lifted result types (`number`, `string`, plain objects) fail this check.
- When all four hold: translate the operand `x` via the legacy pipeline (wrap in `ir1FromL2`); allocate a fresh binder name `$n` via `cellRegisterName(supply.synthCell, 'n')`; translate the present side under a scope where `x` substitutes for `$n` (use `ast.substituteBinder` on the lowered OpaqueExpr to replace `x`'s Pant name with `$n`); construct the L2 each via `ast.each([], [ast.gIn(binderName, operandOpaque)], substitutedPresentOpaque)`; wrap as `ir1FromL2(opaqueEach)` and return.
- When any check fails: return null. The caller falls through to the standard L1 Cond build (Patch 2's nullish recognizer + M1 Cond), which then lowers via cardinality-dispatch — but for empty-list-typed branches that translation hits the no-list-literal wall and rejects with `unsupported`. That rejection IS the pre-M4 behavior, deliberately preserved.
- Mirror the recognizer entry point in `translate-body.ts` for early-return / ternary expression-position uses inside mutating bodies. Share the eligibility logic with `ir1-build.ts` via an exported helper.
- Create `tests/fixtures/constructs/expressions-functor-lift.ts`: `optionalNames(u: User | null): string[]` (returns `[]` or `[u.name]`); `optionalChain(u: User | null): string | null` (returns `null` or `u.name`); `negatedTernary(x: T | null)` (`(x != null) ? f(x) : null`); `ifConversion(x: T | null)` (`if (x === null) return []; return [g(x)]`); plus deliberate-reject cases that still translate via fall-through (currently: end up as `unsupported`).
- Add unit tests in `tests/ir1-build-functor-lift.test.mts`: each eligibility check fails independently → recognizer returns null; all checks pass → recognizer returns `ir1FromL2(L2 each)` with correct binder substitution; substitution preserves capture-avoidance (binder name doesn't clash with parameters); handle nested null-guards (inner lift inside outer lift) — recursive recognition works via build-time recursion.
- Run `just ts2pant-test-integration` — every fixture in `expressions-functor-lift.ts` must pant-check successfully (the lift produces well-typed `[U]` results matching the declared return type)
- Run `just ts2pant-test` and dogfood — verify no existing snapshot regresses. Pre-M4, no fixture exercised this shape (because they all fail at the empty-list literal); the new fixture is the first to hit this code path

## Files to Modify
- tools/ts2pant/src/ir1-build.ts (modify): Add `tryRecognizeFunctorLift` helper; in the L1 Cond build path, attempt the recognizer before falling through to standard Cond construction
- tools/ts2pant/src/translate-body.ts (modify): Mirror the recognizer at the mutating-path expression-position site (so early-return null-guards inside mutating bodies also lift)
- tools/ts2pant/tests/ir1-build-functor-lift.test.mts (create): Unit tests for the recognizer: each eligibility condition tested in isolation, plus combined positive cases
- tools/ts2pant/tests/fixtures/constructs/expressions-functor-lift.ts (create): Fixture covering supported lift shapes and deliberate-reject shapes
- tools/ts2pant/tests/constructs.test.mts.snapshot (modify): Snapshots for the new fixture

## Gameplan Specification

```
module TS2PANT_M4.

> ════════════════════════════════════════════════════════════
> M4: equality and nullish normalization
> ════════════════════════════════════════════════════════════
>
> After M4, every TS-AST expression in the equality/nullish
> equivalence class flows through Layer 1. The class is
> normalized into three canonical paths plus an unconditional
> rejection on surviving loose equality:
>
>   - `IsNullish(x)` — the canonical Bool null/undefined test.
>     Recognized from x==null, x===null, x===undefined, the
>     ||-long form, and typeof-undefined. Negated forms wrap as
>     `not(IsNullish(x))`.
>   - `BinOp(eq | neq, lhs, rhs)` — canonical equality, only
>     produced from `===` / `!==`.
>   - Functor-lift `each $n in x | f $n` — the canonical lowering
>     for null-guarded list-lifted conditionals. Pant has no list
>     literal, so cardinality-dispatch is not a viable alternative;
>     this path makes idiomatic null-guard-then-list-return TS
>     functions translate.
>   - Any `==` / `!=` not consumed by the nullish recognizer is
>     rejected. ts2pant steers the programmer toward `===`/`!==`
>     rather than guess loose-equality intent.

TSExpr.
TSType.
L1Expr.
L2Expr.
OpaqueExpr.

> ─── L1 form predicates ───────────────────────────────────────

is-nullish? e: L1Expr => Bool.
is-not? e: L1Expr => Bool.
is-binop-eq? e: L1Expr => Bool.
is-binop-neq? e: L1Expr => Bool.
is-each? e: L1Expr => Bool.
is-cond? e: L1Expr => Bool.

operand e: L1Expr, is-nullish? e => L1Expr.
inner e: L1Expr, is-not? e => L1Expr.

> ─── TS-side classification ───────────────────────────────────

is-positive-nullish? t: TSExpr => Bool.
is-negative-nullish? t: TSExpr => Bool.
is-strict-eq? t: TSExpr => Bool.
is-strict-neq? t: TSExpr => Bool.
is-loose-eq? t: TSExpr => Bool.
is-loose-neq? t: TSExpr => Bool.

is-conditional? t: TSExpr => Bool.
functor-lift-eligible? t: TSExpr, is-conditional? t => Bool.

> ─── Build / lower pipeline ───────────────────────────────────

build-l1 t: TSExpr => L1Expr.
lower-l1 e: L1Expr => L2Expr.
emit l: L2Expr => OpaqueExpr.
unsupported? e: L1Expr => Bool.

> ─── L2 / OpaqueExpr shape predicate ─────────────────────────

card-zero? l: L2Expr => Bool.

---

> ─── Canonical form: every nullish surface form maps to one
>     L1 IsNullish (or its negation). ───────────────────────────

all t: TSExpr, is-positive-nullish? t |
  is-nullish? (build-l1 t).

all t: TSExpr, is-negative-nullish? t |
  is-not? (build-l1 t)
  and is-nullish? (inner (build-l1 t)).

> ─── Lowering: IsNullish becomes the cardinality-zero shape. ──

all e: L1Expr, is-nullish? e | card-zero? (lower-l1 e).

> ─── Strict equality canonicalizes unconditionally. ──────────

all t: TSExpr, is-strict-eq? t | is-binop-eq? (build-l1 t).
all t: TSExpr, is-strict-neq? t | is-binop-neq? (build-l1 t).

> ─── Surviving loose equality is rejected unconditionally.
>     The nullish family is consumed before this rule fires. ───

all t: TSExpr, is-loose-eq? t | unsupported? (build-l1 t).
all t: TSExpr, is-loose-neq? t | unsupported? (build-l1 t).

> ─── Functor-lift recognizer: eligible conditionals lower to
>     `each`; ineligible conditionals fall through to L1 Cond
>     (which then rejects at the no-list-literal wall). ────────

all t: TSExpr, is-conditional? t, functor-lift-eligible? t |
  is-each? (build-l1 t).

all t: TSExpr, is-conditional? t, ~ functor-lift-eligible? t |
  is-cond? (build-l1 t).

```

## Patch Specification

```
module TS2PANT_M4_PATCH_5.

> Patch 5 introduces the functor-lift recognizer.
>
> When a TS conditional shape has an IsNullish-shaped guard, an
> empty-equivalent on the empty side, and a function-of-x on the
> present side, AND the result type is list-lifted, the recognizer
> fires and the conditional builds to L1 `from-l2(each $n in x | f $n)`
> instead of an L1 Cond.
>
> Soundness conditions are conservative; if any fails, we fall
> through to the standard Cond build. Cond's lowering for the
> empty-list-typed branch is untranslatable in Pant (no list
> literal), so a fall-through here means the function rejects with
> `unsupported` later — which is the pre-M4 behavior, preserved.
>
> Recognizer covers: ternary `(g) ? empty : f(x)`, ternary
> `(neg-g) ? f(x) : empty`, and the if-conversion analogs.

TSExpr.
TSType.
L1Expr.

is-conditional? t: TSExpr => Bool.
guard t: TSExpr, is-conditional? t => TSExpr.
empty-side t: TSExpr, is-conditional? t => TSExpr.
present-side t: TSExpr, is-conditional? t => TSExpr.

is-nullish-guard? t: TSExpr => Bool.
guard-operand t: TSExpr, is-nullish-guard? t => TSExpr.

is-empty-equivalent? t: TSExpr => Bool.
is-single-functor-of? t: TSExpr, x: TSExpr => Bool.

result-type t: TSExpr => TSType.
is-list-lifted? ty: TSType => Bool.

functor-lift-eligible? t: TSExpr, is-conditional? t => Bool.

build-l1 t: TSExpr => L1Expr.

is-each? e: L1Expr => Bool.
is-cond? e: L1Expr => Bool.

---

> Eligibility requires all four conservative conditions.
all t: TSExpr, is-conditional? t |
  functor-lift-eligible? t =
    is-nullish-guard? (guard t)
    and is-empty-equivalent? (empty-side t)
    and is-single-functor-of? (present-side t) (guard-operand (guard t))
    and is-list-lifted? (result-type t).

> Eligible shapes lower via the each functor lift.
all t: TSExpr, is-conditional? t, functor-lift-eligible? t |
  is-each? (build-l1 t).

> Ineligible shapes fall through to the standard cond build.
all t: TSExpr, is-conditional? t, ~ functor-lift-eligible? t |
  is-cond? (build-l1 t).

```


## Implementation Notes

### Decisions worth flagging

- **Operand restricted to simple identifiers.** The opinion in the gameplan says `IsNullish(operand)` accepts arbitrary L1 operands, and that's true for Patch 2's recognizer. But the *lift* needs to substitute the operand's Pant name on the projection via `ast.substituteBinder`, which only rewrites variable references. Property-access operands (`obj.prop == null ? [] : [obj.prop.name]`) would require either translating the operand to a name-bindable form or a more elaborate substitution scheme — out of scope for Patch 5. Conservative-refusal: non-identifier operands return `null` and fall through to the cardinality-dispatch wall, exactly matching the pre-M4 reject behavior. The unit test `non-identifier operand falls through (\`u.next == null\`)` locks this.

- **Three integration sites, not one.** The lift can fire at three structurally distinct positions, each handled separately:
  1. Outermost ternary in `buildFromTernary` (ir1-build.ts).
  2. Two-branch if/else (no else-if chain) in `buildFromIfStatement`.
  3. **If-conversion shape** `if (P) return E1; return E2;` — handled in `translatePureBody` *before* `inlineConstBindings` runs. By the time the prelude has been collected into `bindings: [{kind: "earlyReturn"}]` + `returnExpr`, the shape is recognizable; running the lift at that boundary lets us emit the `each` directly and skip the cond-construction path entirely. This is the case the test fixture's `ifConversion` / `negatedIfConversion` exercise.

- **`isListLiftedAtNode` walks up to the function-like declaration** for if-statement / function-node contexts (and uses `getTypeAtLocation` directly for ternaries). For the if-conversion entry point the contextNode passed in is the `FunctionDeclaration` itself; `isListLiftedAtNode` accepts that shape so the same predicate covers all three sites.

- **Single-element-array unwrapping.** `[u.name]` and `u.name` are treated symmetrically — both project to `each $n in u | name $n`. The `unwrapSingletonArray` helper strips a single-element array literal before the present-side check; multi-element literals, spread elements, and known multi-producing array methods (`.concat`, `.flat`, `.flatMap`, `.filter`, `.map`, `.slice`, `.splice`) reject unconditionally.

- **Present-side must reference the operand.** Otherwise the lift would erase the conditional's dependence on `x` (`u == null ? [] : [fallback]` would silently rewrite to `each $n in u | fallback`, dropping the `u`-dependence and producing nonsense Pant). The recognizer requires `expressionReferencesNames(projection, {operandName})`. Test: `present side does not reference the operand falls through`.

- **`recognizeAnyLeaf` exported from `nullish-recognizer.ts`.** The lift needs to inspect a *single binary expression* for nullish-leaf shape (operand + negated). Patch 2's `recognizeNullishForm` does too much work here — it tries the long-form chain recognizer too. Promoting the existing internal `recognizeAnyLeaf` to an export keeps the lift's recognition narrow.

- **Binder allocation mirrors μ-search.** `cellRegisterName(synthCell, "n")` when a synthCell is plumbed through (production); supply-counter fallback `n${supply.n++}` with collision check against `paramNames.values()` for standalone tests. The capture-avoidance test verifies a parameter named `n` doesn't collide with the comprehension binder.

- **Snapshot output is uniform.** All seven fixture functions produce `(each n in u | user--<field> n)` shapes — the lift collapses ternary, negated-ternary, if-conversion, negated-if-conversion, loose-eq guard, and typeof-undefined guard onto one canonical Pant form. That uniformity is the M4 architectural promise visible at the snapshot level.