### PR TITLE
[ts2pant-m4-equality-nullish] Patch 6: M4 docs and dogfood verification

### DIFF
--- a/tools/ts2pant/CLAUDE.md
+++ b/tools/ts2pant/CLAUDE.md
@@ -193,9 +193,11 @@ indexing `(x 1)` replaces singleton extraction. Post-M4, the `#x = 0`
 shape is the lowering of an L1 `IsNullish(x)` primitive — see § "Imperative
 IR Workstream" / "M4". The OpaqueExpr is identical pre- and post-M4; only
 the construction route changed (legacy `??` builder → L1 IsNullish →
-mechanical lower). Other null/undefined surface forms (`x == null`,
-`x === null`, `x === undefined`, the long disjunction, `typeof
-x === 'undefined'`) all flow through the same primitive.
+mechanical lower). On the body/L1 expression-translation path, other
+null/undefined surface forms (`x == null`, `x === null`, `x === undefined`,
+the long disjunction, `typeof x === 'undefined'`) all flow through the
+same primitive. The signature/guard-classification path is stricter —
+see § "Imperative IR Workstream" / "M4" for the asymmetry.
 
 - `x ?? y` with `x: [T]`:
   - `y: T` (non-nullable default) → `cond #x = 0 => y, true => (x 1)`
@@ -928,9 +930,27 @@ is no type-based "safe loose-eq" exception. The rejection is the rule-1
 case of § "Developer Steering Principles": loose equality is ambiguous
 in TS itself between value-equality and JS-coercion semantics, and
 ts2pant steers the programmer toward `===`/`!==` where intent is
-unambiguous rather than guess. The one exception — `x == null` — is
-universally idiomatic for null-or-undefined and is consumed by the
-nullish recognizer before the dispatcher is reached.
+unambiguous rather than guess.
+
+The `x == null` carve-out is **path-scoped**, not global:
+
+- *Body / L1 expression-translation path* (`translateBodyExpr` and
+  `translateExpr` in `translate-signature.ts`) — the nullish recognizer
+  fires *before* the loose-eq rejection dispatcher, so `x == null` and
+  `x != null` are folded to `IsNullish` (or its negation) and translate
+  successfully.
+- *Signature / guard-classification path* (`containsUnsupportedOperator`
+  in `translate-signature.ts`, used by `classifyGuardIf` and
+  helper-followability checks) — strict: ALL loose equality (`==` /
+  `!=`), including `x == null` and `x != null`, returns
+  `containsUnsupportedOperator = true` and the guard is **not**
+  classified as a guard. The if-statement stays in the body, where the
+  body translator then folds it via the recognizer — so the runtime
+  check survives, but it's no longer factored out as a precondition.
+
+The asymmetry is deliberate: a guard is a *factored-out* runtime check
+with no body, so misclassifying one would silently drop the check on
+both sides; classifying conservatively keeps the if-statement intact.
 
 *from-l2 shrinkage scope.* Sub-expressions of nullish and equality
 forms now build natively on L1: the `IsNullish` operand is an

--- a/tools/ts2pant/CLAUDE.md
+++ b/tools/ts2pant/CLAUDE.md
@@ -42,6 +42,47 @@ These cover the full scope of ts2pant's translation work:
 | Partial functions / option types | [Dafny Reference Manual](https://dafny.org/dafny/DafnyRef/DafnyRef) | Nullable types, preconditions, `modifies` clauses — practical verification language patterns |
 | IRSC / SSA-based IR | Vekris, Cosman, Jhala, ["Refinement Types for TypeScript"](https://arxiv.org/pdf/1604.02480), PLDI 2016 | Lifting surface-syntax recognizers into a typed intermediate representation via SSA-style translation; precedent for the IR introduced in §"Intermediate Representation" |
 
+## Developer Steering Principles
+
+ts2pant is a translator, not a style guide. But it does have to make a
+decision when a TS surface form doesn't unambiguously map to a Pantagruel
+target — and the decision is the same in both directions: **be honest
+about which side owes the work**.
+
+The two-sided rule:
+
+1. **When TS itself is ambiguous, ts2pant rejects and steers the
+   programmer to an unambiguous TS form.** The rewrite is owed to the
+   *TS* program, not to Pantagruel — TS would be clearer code if it said
+   what it meant. Example: `==` is rejected unconditionally outside the
+   nullish recognizer (M4 Patch 3). `a == b` between two arbitrary
+   operands is ambiguous in TS regardless of where it ends up — does
+   the author want value equality, or do they want JS coercion
+   semantics? ts2pant doesn't guess; it asks the programmer to say
+   `===` (or `!==`) and move on.
+
+2. **When TS is unambiguous but doesn't fit a pantagruel-shaped
+   recognizer, ts2pant adapts to recognize it.** The programmer should
+   not be taxed by the tool's preferred input shape — refusing
+   idiomatic, unambiguous TS purely to fit ts2pant's recognizer
+   internals is the same kind of guesswork-tax in reverse. Example:
+   `(a === null) || (a === undefined) || other` is unambiguous,
+   idiomatic TS. The nullish recognizer recurses on `||`/`&&`
+   operands and extracts nullish pairs opportunistically rather than
+   forcing the programmer to rewrite into a recognizer-shaped subset.
+
+**The test:** does the TS code's intent read clearly to a TS reader?
+If yes, ts2pant adapts to recognize it. If no, ts2pant rejects with a
+specific reason explaining the rewrite the programmer should make to
+*their TS*. The principle is structural: the burden of clarity lives
+with whichever side of the translation introduced the ambiguity.
+
+**Precedent:** M4 (equality and nullish normalization) is where this
+principle was articulated. `==` rejection (rule 1) sits alongside
+partial-match disjunction recognition (rule 2) inside the same
+milestone — they're two halves of one steering posture, not in
+tension. Future milestones inherit this principle.
+
 ## Architecture
 
 ts2pant translates TypeScript function bodies into Pantagruel propositions. The main
@@ -148,7 +189,13 @@ unions fold the null marker into the list wrapper: `A | B | null` → `[A + B]`.
 
 Under list-lift, `??` and `?.` have a universal lowering — the empty-list
 cardinality test `#x = 0` replaces the absent `~= Nothing` check, and list
-indexing `(x 1)` replaces singleton extraction:
+indexing `(x 1)` replaces singleton extraction. Post-M4, the `#x = 0`
+shape is the lowering of an L1 `IsNullish(x)` primitive — see § "Imperative
+IR Workstream" / "M4". The OpaqueExpr is identical pre- and post-M4; only
+the construction route changed (legacy `??` builder → L1 IsNullish →
+mechanical lower). Other null/undefined surface forms (`x == null`,
+`x === null`, `x === undefined`, the long disjunction, `typeof
+x === 'undefined'`) all flow through the same primitive.
 
 - `x ?? y` with `x: [T]`:
   - `y: T` (non-nullable default) → `cond #x = 0 => y, true => (x 1)`
@@ -173,6 +220,17 @@ cardinality case-split above, giving one list-lifted signature rather than
 multiple arity overloads. This preserves one-source-one-target for
 everything reached through the general lowering — no special-case
 detection at the signature level.
+
+**Null-guarded list-lifted conditionals** — TS code that pattern-matches
+on a nullable receiver and returns a list-lifted projection
+(`u == null ? [] : [u.name]`, `if (u === null) return []; return [u.name]`,
+and the negated polarity variants) is a Pantagruel-untranslatable shape
+without a recognizer: Pant has no list literal, so the alternative
+cardinality-dispatch lowering `cond #u = 0 => [], true => [name (u 1)]`
+has no expressible target. The functor-lift recognizer (M4 Patch 5) is
+the canonical handling for this family — see § "Functor-Lift Recognizer"
+below. The four supported TS shapes lower uniformly to `each $n in u |
+name $n`, the same comprehension shape `?.` already uses.
 
 ### Partial Rules (Map<K, V>)
 
@@ -419,6 +477,93 @@ ops require acc on the left.
 - `state.modifiedProps` (shared across state clones) tracks which primed rules were emitted,
   including Shape A equations that bypass `state.writes`; used to compute frame conditions
   correctly when Shape A and Shape B appear in the same body.
+
+### Functor-Lift Recognizer
+
+**Standard name:** Functor lift / `Maybe` (option) `fmap`. The list-lift
+encoding makes `T | null` into `[T]` (length 0 or 1); the recognizer is
+exactly `fmap : (a -> b) -> Maybe a -> Maybe b` specialized to the
+list-as-Maybe representation.
+**Reference:** Wadler, ["The Essence of Functional Programming"](https://homepages.inf.ed.ac.uk/wadler/papers/essence/essence.ps),
+POPL 1992, §2 (the Maybe monad and `fmap`); Hutton & Meijer,
+["Monadic Parsing in Haskell"](https://www.cs.nott.ac.uk/~pszgmh/pearl.pdf), JFP 1998
+(structural lift over `Maybe` as the canonical idiom for null-guarded
+projections).
+
+`if (x == null) return []; return [f(x)];` and the equivalent ternary /
+negated forms lower to `each $n in x | f $n`. This is *not* an
+optimization — Pantagruel has no list literal, so the alternative
+cardinality-dispatch lowering `cond #x = 0 => [], true => [f (x 1)]`
+has no expressible Pant target. Without the recognizer these
+idiomatic null-guards reject; with it they translate uniformly through
+the same comprehension shape `?.` already produces.
+
+**Why this lives here.** The recognizer is itself an instance of the
+"recognize idiomatic TS" side of the Developer Steering Principles
+(§ above). Idiomatic null-guard-then-list-return is unambiguous TS;
+forcing the programmer to rewrite as `?.`-chains or comprehensions
+would tax the user for a Pant-vocabulary gap that the translator can
+absorb structurally. Combined-shape recognizers crossing milestone
+boundaries (this one straddles M1 Cond + M4 IsNullish) are sometimes
+load-bearing; see `workstreams/ts2pant-imperative-ir.md`
+§ "Architectural Lesson 5".
+
+**Soundness conditions** (`tryRecognizeFunctorLift` in `ir1-build.ts`):
+
+1. **Guard is a leaf nullish form** — `x == null`, `x === null`,
+   `x === undefined`, `typeof x === 'undefined'`, or any of their
+   negations. Composite guards (long-form disjunction, parenthesized
+   chains, `&&`-conjuncts) fall through; only the leaves of M4's
+   nullish recognizer are eligible here.
+2. **The "empty side" branch is empty-equivalent** — `[]`, `null`, or
+   `undefined`. (Polarity follows the guard: a positive guard puts the
+   empty side on the then-branch; a negated guard puts it on the
+   else-branch.)
+3. **The "present side" branch is single-element-producing of the
+   operand** — after stripping a single-element array wrapper (`[u.name]`
+   → `u.name`), the expression must reference the operand and not be a
+   multi-element construction. Multi-element array literals, spreads,
+   and known multi-producing array methods (`.concat`, `.flat`,
+   `.flatMap`, `.filter`, `.map`, `.slice`, `.splice`) are
+   deliberately rejected — `each` over a length-≤1 list cannot soundly
+   produce multiple output elements per input.
+4. **The conditional's static result type is list-lifted** — `T[]`,
+   `T | null`, `T | undefined`, or `T | null | undefined`. Computed
+   from the `ConditionalExpression` for ternaries; from the enclosing
+   function's return type for if-conversion entry points.
+
+**Supported TS shapes** (operand restricted to a simple identifier;
+property-access operands defer to M5):
+
+```ts
+// (a) Positive ternary, with array wrapper or bare projection.
+u == null ? [] : [u.name]
+u == null ? null : u.name
+
+// (b) Negated ternary.
+u !== null ? u.age : null
+
+// (c) Positive if-conversion (early return = empty side).
+if (u === null) { return []; }
+return [u.name];
+
+// (d) Negated if-conversion (early return = present side).
+if (u !== null) { return [u.name]; }
+return [];
+```
+
+All four lower to `each $n in u | name $n` (or `age $n`, etc.). The
+fixture is `tests/fixtures/constructs/expressions-functor-lift.ts`.
+
+**Deliberate rejection of multi-element non-empty branches.** A shape
+like `if (xs == null) return []; return [xs[0], xs[1]];` would require
+the lift to multiply elements per input — `each x in xs | …` over a
+length-≤1 list cannot produce two output elements. The recognizer
+refuses, and these forms fall through to the standard L1 Cond build
+(which then rejects at the no-list-literal wall — there is no
+translatable target). This is intentional under the steering principle's
+rule 1: the TS itself is fine, but ts2pant cannot translate
+"sometimes-multi-element" pattern-matching without misrepresenting it.
 
 ### Chain Fusion (.filter / .map / .reduce)
 
@@ -745,6 +890,77 @@ deleted — `symbolicExecute`'s if-statement / for-of / forEach arms are
 thin dispatchers to the L1 path. Pure-path `.reduce` (chain fusion via
 `BodyResult.pendingComprehension`) is expression-position and
 architecturally separate; it stays on `translateReduceCall`.
+
+**M4 (equality-nullish-normalization): landed.** Every TS expression
+in the equality / nullish equivalence class flows through Layer 1.
+
+*Canonical forms:*
+
+- `IsNullish(operand)` — the canonical Bool null/undefined test.
+  Recognized from `x == null`, `x != null`, `x === null`,
+  `x === undefined` (and the `!==` negations), the long disjunction
+  `x === null || x === undefined`, the conjunction-negated long form
+  `x !== null && x !== undefined`, and `typeof x === 'undefined'` (and
+  `!==`). Negated forms wrap as `unop(not, IsNullish(operand))`.
+  Lowers mechanically to the cardinality-zero shape `#x = 0` —
+  byte-identical to the pre-M4 hand-emitted shape `??` and `?.`
+  already used. The operand may be any L1 expression (not just a
+  `Var`). Long-form recognition uses a structural `structurallyEqualExpression`
+  walk, not `node.getText()`, so whitespace/comment/quote-style
+  variation in the source doesn't break recognition. Partial-match
+  disjunctions (`(a === null) || (a === undefined) || other`) recurse
+  on the `||`/`&&` operands and extract nullish prefixes
+  opportunistically — see § "Developer Steering Principles" rule 2.
+- `BinOp(eq | neq, lhs, rhs)` — canonical strict equality. Produced
+  unconditionally from `===` / `!==`. The L1 form admits arbitrary
+  operands; sub-expressions wrap via `from-l2` until M5 brings property
+  access onto L1 natively.
+- Functor-lift `each $n in x | f $n` — the canonical lowering for
+  null-guarded list-lifted conditionals (see § "Functor-Lift
+  Recognizer" above for the four soundness conditions). Combined-shape
+  match crossing M1 (Cond) + M4 (IsNullish); load-bearing because
+  Pant has no list literal — the alternative cardinality-dispatch
+  lowering has no expressible target.
+
+*Equality rule:* `===` / `!==` always canonicalize through L1; `==` /
+`!=` is rejected unconditionally outside the nullish recognizer. There
+is no type-based "safe loose-eq" exception. The rejection is the rule-1
+case of § "Developer Steering Principles": loose equality is ambiguous
+in TS itself between value-equality and JS-coercion semantics, and
+ts2pant steers the programmer toward `===`/`!==` where intent is
+unambiguous rather than guess. The one exception — `x == null` — is
+universally idiomatic for null-or-undefined and is consumed by the
+nullish recognizer before the dispatcher is reached.
+
+*from-l2 shrinkage scope.* Sub-expressions of nullish and equality
+forms now build natively on L1: the `IsNullish` operand is an
+arbitrary L1 expression, and `BinOp(eq | neq, …)` operands are L1.
+The `from-l2` adapter still wraps internal sub-expressions where
+those operands themselves come from `translateBodyExpr` (property
+access in particular) — full elimination is M5 territory.
+
+*Out of scope by design* (candidates for future milestones if real
+fixtures demand them):
+
+- `.indexOf(x) === -1` array-absence idioms — these are EUF equality
+  on a sentinel value, not nullish testing. They translate correctly
+  today via `===` canonicalization; they just don't route through
+  `IsNullish`.
+- `x === SomeEnum.NONE` enum-sentinel patterns — typed equality on a
+  named constant. Works as-is via `===` canonicalization; absorption
+  into `IsNullish` would require a notion of user-declared "absence"
+  values that ts2pant doesn't have.
+- `Boolean(x)` / `!!x` truthiness coercion — semantically distinct
+  from nullish testing (truthy includes `0`, `""`, `false`). Tests
+  presence in JS's truthy-coercion sense, not absence in the nullish
+  sense. May stay UNSUPPORTED indefinitely or become its own
+  milestone.
+
+*Pessimism rate (loose-eq rejection):* N=5 loose-equality sites across
+fixtures + dogfood, all consumed by the nullish recognizer. 0 rejected.
+**0%.** No fixture or dogfood site exercises a non-nullish loose-eq
+that would surface the rejection path; rejection is exercised by
+synthetic cases in `tests/equality-canonicalization.test.mts`.
 
 **Layering principle.** This is the architectural commitment that
 M2 ratifies and the M2 cleanup completes:

--- a/workstreams/ts2pant-imperative-ir.md
+++ b/workstreams/ts2pant-imperative-ir.md
@@ -534,9 +534,18 @@ surviving loose `==` / `!=`.
 - Patch 3 — Canonicalize strict equality; reject all surviving loose-eq.
   `===` / `!==` route through L1 `BinOp(eq | neq, …)` unconditionally.
   `==` / `!=` are rejected with a specific reason ("loose equality
-  (== / !=) is unsupported; use === / !==") in both `translate-body.ts`
-  and `translate-signature.ts`. No type-based exception — the principle
-  is rule-1 of § "Developer Steering Principles" in `tools/ts2pant/CLAUDE.md`.
+  (== / !=) is unsupported; use === / !==") on the body / L1
+  expression-translation paths in `translate-body.ts` and
+  `translate-signature.ts`'s `translateExpr`, *after* the nullish
+  recognizer has had a chance to fold `x == null`. The signature
+  guard-classification path (`containsUnsupportedOperator` in
+  `translate-signature.ts`, used by `classifyGuardIf` and
+  helper-followability) is stricter — it rejects ALL loose equality
+  including `x == null`, so an `if (x == null) throw` is *not*
+  classified as a guard and stays in the body where the body
+  translator's nullish recognizer handles it. No type-based exception
+  on either path — the principle is rule-1 of § "Developer Steering
+  Principles" in `tools/ts2pant/CLAUDE.md`.
 - Patch 4 — Refactor the `??` builder to construct its guard via L1
   `IsNullish`. Snapshot byte-equality is the cutover gate; the
   OpaqueExpr is identical pre- and post-M4.
@@ -582,7 +591,7 @@ is covered by synthetic cases in `tests/equality-canonicalization.test.mts`.
 | Question | Resolution |
 |----------|------------|
 | M4 standalone vs absorbed into M3 | Landed standalone. M3 was absorbed enough by iteration + mutation; equality/nullish is expression-only and a clean six-patch slice. |
-| Loose-eq policy: type-based accept exception, or unconditional reject? | Reject all surviving loose-eq. Per § "Developer Steering Principles" rule 1, `==` is ambiguous in TS regardless of operand type — defining a "safe-loose-eq" subset would be exactly the guesswork the IRSC discipline rejects. The `x == null` exception survives because Patch 2's nullish recognizer consumes it before the dispatcher is reached. |
+| Loose-eq policy: type-based accept exception, or unconditional reject? | Reject all surviving loose-eq. Per § "Developer Steering Principles" rule 1, `==` is ambiguous in TS regardless of operand type — defining a "safe-loose-eq" subset would be exactly the guesswork the IRSC discipline rejects. The `x == null` carve-out is path-scoped: on the body / L1 expression-translation paths, Patch 2's nullish recognizer consumes it before the loose-eq dispatcher fires; on the signature guard-classification path (`containsUnsupportedOperator`), all loose equality is rejected unconditionally including `x == null`, so a guard with `x == null` falls through to the body where the body translator handles it. |
 | Combined-shape recognizer scope (functor-lift crossing M1 + M4) | Included as Patch 5. Pant has no list literal — without the recognizer, idiomatic null-guards over list-lifted return types are untranslatable. Sets the precedent recorded in Lesson 5. |
 
 **Why this is a safe pause point**: Equality and nullish are

--- a/workstreams/ts2pant-imperative-ir.md
+++ b/workstreams/ts2pant-imperative-ir.md
@@ -29,18 +29,20 @@ differ by program position:
 This asymmetry is intentional and was hard-won — see § "Architectural
 Lessons" below.
 
-## Current State (post-M3)
+## Current State (post-M4)
 
-M1 (conditionals), M2 (assign + μ-search), and M3 (iteration + mutation)
-have landed. Layer 1 IR is the canonical input shape for every
-mutating-body construct ts2pant supports plus the conditional /
-assign / iteration expression forms.
+M1 (conditionals), M2 (assign + μ-search), M3 (iteration + mutation),
+and M4 (equality + nullish) have landed. Layer 1 IR is the canonical
+input shape for every mutating-body construct ts2pant supports, plus
+the conditional / assign / iteration expression forms, plus the
+equality / nullish equivalence class.
 
 **What's on Layer 1**:
 
-- Expression forms: `var`, `lit`, `binop`, `unop`, `app`, `member`, `cond`,
-  `from-l2` (transitional adapter for sub-expressions outside the current
-  milestone's normalization concern).
+- Expression forms: `var`, `lit`, `binop`, `unop`, `app`, `member`,
+  `cond`, `is-nullish` (M4 canonical Bool null/undefined test),
+  `from-l2` (transitional adapter for sub-expressions outside the
+  current milestone's normalization concern).
 - Statement forms: `block`, `let`, `assign`, `cond-stmt`, `foreach`
   (with optional `body` and `foldLeaves` for Shape A + Shape B), `for`
   (declared, unused), `while` (μ-search only), `return`, `throw`
@@ -53,16 +55,24 @@ companion `src/ir-subst.ts` were the speculative target of the
 parallel-build PRs (#134/#135/#137) that got closed; PR #138 deleted
 them once M3 confirmed nothing built or lowered them.
 
-**What's still on the legacy path** (pre-M4/M5/M6):
+**What's still on the legacy path** (pre-M5/M6):
 
 - Property access (`obj.f` / `obj["f"]`) — qualified at build time via
   `qualifyFieldAccess`; no L1 `Member` normalization yet.
-- Equality / nullish (`==` vs `===`, `x == null` family) — no
-  `IsNullish` primitive yet.
 - Pure-path `.reduce` chain fusion — `translateReduceCall` builds an
   L2 `eachComb` directly. Architecturally separate from M3's
   mutating-body foreach.
 - `IRWrap` escape hatch in L2 — survives until M6.
+
+**Combined-shape recognizer precedent (M4 Patch 5).** The functor-lift
+recognizer (`tryRecognizeFunctorLift` in `ir1-build.ts`) is the first
+combined-shape recognizer crossing milestone boundaries — it matches
+M1 Cond + M4 IsNullish in a single rewrite. The motivation is
+load-bearing: Pant has no list literal, so the alternative
+cardinality-dispatch lowering for null-guarded list-lifted conditionals
+has no expressible target. Future milestones may need to follow this
+pattern when Pant's expression vocabulary forces a multi-form match;
+see "Architectural Lesson 5" below.
 
 ## Key Challenges
 
@@ -188,6 +198,45 @@ expression-level normalization (M4 / M5 territory) without blocking
 statement-level normalization (M1 / M2 / M3). Its lifetime is bounded
 by M4 + M5 landing — at that point sub-expressions reach L1 natively
 and `from-l2` shrinks for real, then deletes at M6.
+
+### Lesson 5: combined-shape recognizers are sometimes load-bearing
+
+**The setup at M4**: the equality / nullish equivalence class has three
+canonical L1 forms (`IsNullish`, `BinOp(eq | neq, …)`, and the
+loose-eq rejection). Each one is the canonical lowering for one
+syntactic class. So far, so milestone-shaped.
+
+**The forcing function**: idiomatic null-guard-then-list-return TS —
+`if (x == null) return []; return [f(x)];` and the equivalent ternaries
+— would map naturally to a cardinality-dispatch lowering `cond
+IsNullish(x) => [], true => [f((x 1))]`. But Pantagruel has no list
+literal. There is no expressible Pant target for `[f((x 1))]`. Without
+some other recognition path, idiomatic TS code in this shape simply
+doesn't translate.
+
+**The fix**: M4 Patch 5's functor-lift recognizer matches a *combined*
+shape — M1's Cond on the outside, M4's IsNullish (or any nullish leaf
+form) on the guard, with empty/single-element-projection branch
+checks — and lowers to `each $n in x | f $n`. The recognizer crosses
+two milestone boundaries by construction.
+
+**Generalizable principle**: when Pant's expression vocabulary lacks
+a target for a specific TS shape, a recognizer crossing milestone
+boundaries can be the only translatable path. This isn't a violation
+of the "hard rule per equivalence class" discipline — the equivalence
+class is normalized correctly inside its own milestone (M4 still
+canonicalizes nullish testing onto `IsNullish`); the combined recognizer
+is a *secondary* lowering that fires for a specific cross-class shape
+where the primary path would emit untranslatable Pant.
+
+The litmus test: would the alternative lowering produce valid Pant?
+If no, a combined recognizer is structurally necessary. If yes, the
+combined match is an optimization that should be deferred until the
+optimization is genuinely worth carrying.
+
+M4's functor-lift recognizer is the precedent. Future milestones may
+need to follow it; M5 (property access) doesn't obviously need one,
+but the general principle is now on the table.
 
 ## Milestones
 
@@ -455,30 +504,94 @@ remains in `translate-body.ts`.
 
 ---
 
-### Milestone 4 (deferred): equality-nullish-normalization
+### Milestone 4: equality-nullish-normalization — ✅ landed
+
+**Status**: landed across six stacked patches on
+`ts2pant-m4-equality-nullish`.
+
+The equality / nullish equivalence class flows through Layer 1.
+Every TS expression in the class normalizes to one of three canonical
+shapes — `IsNullish(operand)`, `BinOp(eq | neq, …)`, or the functor-lift
+`each $n in x | f $n` — plus an unconditional rejection of any
+surviving loose `==` / `!=`.
+
+**Slice breakdown:**
+
+- Patch 1 — Add L1 `IsNullish` form and mechanical lowering. Lowers to
+  `binop(eq, unop(card, x), litNat(0))` — byte-identical to the shape
+  `??` and `?.` already emit. No call sites yet; build-pass cutover
+  follows in P2.
+- Patch 2 — Recognize nullish surface forms via L1 `IsNullish`. The
+  build pass intercepts `x == null`, `x != null`, `x === null`,
+  `x === undefined`, the `!==` negations, the long disjunction
+  `x === null || x === undefined`, the conjunction-negated long form,
+  and `typeof x === 'undefined'` (and `!==`) before the generic
+  binop dispatcher fires. Long-form recognition uses
+  `structurallyEqualExpression` (not `node.getText()`) for
+  whitespace-tolerant operand identity. Negative forms wrap as
+  `unop(not, IsNullish(operand))`. Partial-match disjunctions recurse
+  on `||`/`&&` operands.
+- Patch 3 — Canonicalize strict equality; reject all surviving loose-eq.
+  `===` / `!==` route through L1 `BinOp(eq | neq, …)` unconditionally.
+  `==` / `!=` are rejected with a specific reason ("loose equality
+  (== / !=) is unsupported; use === / !==") in both `translate-body.ts`
+  and `translate-signature.ts`. No type-based exception — the principle
+  is rule-1 of § "Developer Steering Principles" in `tools/ts2pant/CLAUDE.md`.
+- Patch 4 — Refactor the `??` builder to construct its guard via L1
+  `IsNullish`. Snapshot byte-equality is the cutover gate; the
+  OpaqueExpr is identical pre- and post-M4.
+- Patch 5 — Functor-lift recognizer for null-guarded list-lifted
+  conditionals. `if (x == null) return []; return [f(x)];` and the
+  three other supported shapes lower to `each $n in x | f $n`. Crosses
+  M1 (Cond) + M4 (IsNullish) by design — see Lesson 5 below.
+- Patch 6 — Docs + dogfood verification (this commit).
+
+**Pessimism rate (loose-eq rejection)**: N=5 loose-equality sites
+across fixtures + dogfood, all consumed by the nullish recognizer.
+0 rejected. **0%.** No real-fixture or dogfood site exercises a
+non-nullish loose-eq that would surface the rejection path; rejection
+is covered by synthetic cases in `tests/equality-canonicalization.test.mts`.
 
 **Definition of Done**:
-- New Layer 1 primitive `IsNullish(expr)`. Surface forms `x == null`,
-  `x === null || x === undefined`, `x === undefined`, `typeof x === 'undefined'`
-  all collapse to `IsNullish(Var(x))`.
-- `BinOp(===, …)` is the canonical equality form; `BinOp(==, …)` rejected
-  unless we can prove operand types Bool/numeric/string-literal-equivalent.
-- Existing `??` and `?.` lowerings (currently on Layer 2 since Stages 2–3)
-  are revisited if their interaction with `IsNullish` simplifies — but no
-  redesign required; the goal is M4 absorbs the equality/nullish equivalence
-  class without disturbing existing forms.
-- Hard rule honored for the equality/nullish class.
+
+- [x] New Layer 1 primitive `IsNullish(expr)`. Surface forms
+  `x == null`, `x === null`, `x === undefined`, the long-form
+  disjunction, `typeof x === 'undefined'` and their negations all
+  collapse to `IsNullish(operand)` (or `unop(not, IsNullish(…))`
+  for negative polarity).
+- [x] `BinOp(eq | neq, …)` is the canonical strict-equality form;
+  `===` / `!==` always canonicalize.
+- [x] Loose `==` / `!=` rejected unconditionally outside the nullish
+  recognizer (no type-based exception).
+- [x] `??` builder refactored to construct its guard via L1
+  `IsNullish`; snapshot byte-equal pre/post.
+- [x] Functor-lift recognizer (combined M1 Cond + M4 IsNullish shape)
+  lowers null-guarded list-lifted conditionals to `each $n in x |
+  f $n`. Four supported TS shapes (positive ternary, negated ternary,
+  positive if-conversion, negated if-conversion); operand restricted
+  to a simple identifier; multi-element non-empty branches
+  deliberately rejected.
+- [x] All 598 unit tests + 22 integration tests pass; `pant --check`
+  passes for every M4 fixture function (equality-nullish + functor-lift).
+- [x] Hard rule honored for the equality/nullish class — every
+  nullish-shaped TS expression flows through L1; legacy direct
+  equality-to-null path retired.
+
+**Resolved open questions**:
+
+| Question | Resolution |
+|----------|------------|
+| M4 standalone vs absorbed into M3 | Landed standalone. M3 was absorbed enough by iteration + mutation; equality/nullish is expression-only and a clean six-patch slice. |
+| Loose-eq policy: type-based accept exception, or unconditional reject? | Reject all surviving loose-eq. Per § "Developer Steering Principles" rule 1, `==` is ambiguous in TS regardless of operand type — defining a "safe-loose-eq" subset would be exactly the guesswork the IRSC discipline rejects. The `x == null` exception survives because Patch 2's nullish recognizer consumes it before the dispatcher is reached. |
+| Combined-shape recognizer scope (functor-lift crossing M1 + M4) | Included as Patch 5. Pant has no list literal — without the recognizer, idiomatic null-guards over list-lifted return types are untranslatable. Sets the precedent recorded in Lesson 5. |
 
 **Why this is a safe pause point**: Equality and nullish are
-expression-only; no statement-level forms touched. All other classes
-already on Layer 1 from M1–M3.
+expression-only; no statement-level forms touched. M5 (property
+access) and M6 (cleanup) can land independently.
 
-**Unlocks**: M6 cleanup can delete more legacy expression-handling code.
-
-**Open Questions**:
-- Whether to land at all. Decided post-M3 based on real-fixture pressure
-  from M1's conservative-refusal measurements. May absorb into M3 if
-  pressure is high.
+**Unlocks**: M6 cleanup can shrink `from-l2` further (sub-expressions
+of nullish and equality forms now build natively on L1; property
+access defers to M5).
 
 ---
 
@@ -558,15 +671,15 @@ clear the L2 statement vocabulary was free to delete):
 1 (imperative-ir-conditionals)        → []
 2 (imperative-ir-assign-mu-search)    → [1]
 3 (imperative-ir-iteration-mutation)  → [2]
-4 (equality-nullish-normalization)    → [3]   (deferred; may absorb into 3)
+4 (equality-nullish-normalization)    → [3]   (✅ landed standalone)
 5 (property-access-normalization)     → [3]   (deferred; may absorb into 3)
 6 (legacy-recognizer-cleanup)         → [3, 4, 5]
 ```
 
-PR #128 must merge before M1 begins. M1–M3 are strictly sequential because
+PR #128 must merge before M1 begins. M1–M4 are strictly sequential because
 each adds a class to the same Layer 1 vocabulary and the hard-rule
-constraint forbids partial migration of a class. M4 and M5 can run in
-parallel if both are needed.
+constraint forbids partial migration of a class. M5 can run independently
+of M4 once M3 has landed.
 
 ## Open Questions
 
@@ -574,16 +687,21 @@ parallel if both are needed.
 |----------|-------|------------|
 | Decrement μ-search (`i--`) SMT encoding | Layer 1 admits it; SMT lowering for `max over each j: Int, j <= INIT, ~P(j) \| j` (the *greatest* `j ≤ INIT` satisfying `¬P` — dual of the increment case's `min over j ≥ INIT`) needs verification on a fixture. | When a fixture demands it |
 | Index-for with mutating `arr[i] = …` writes | Aliasing semantics non-trivial. Deferred unless a fixture demands it. | When a fixture demands it |
-| M4 standalone vs absorbed | Depends on real-fixture pressure on equality/nullish forms inside iteration bodies. | Pre-M4 |
 | M5 standalone vs absorbed | Property access likely absorbs into whichever earlier milestone first needs uniform `Member` shape. | Pre-M5 |
+| `.indexOf(x) === -1` array-absence recognition | Currently translates correctly via `===` canonicalization (EUF equality on the sentinel `-1`). Routing through `IsNullish` would be a stricter modeling of "absence" but isn't required for correctness. | When a fixture demands it |
+| Enum-sentinel-as-nullish absorption (`x === SomeEnum.NONE`) | Typed equality on a named constant; works as-is via `===` canonicalization. Absorption into `IsNullish` would require user-declared "absence" values that ts2pant doesn't model today. | When a fixture demands it |
+| Truthiness coercion (`Boolean(x)`, `!!x`) | Semantically distinct from nullish testing (truthy excludes `0`, `""`, `false`). May stay UNSUPPORTED indefinitely or become its own milestone. | Defer; revisit if a fixture demands it |
 
 Resolved questions (kept for history):
 
 | Resolved | Resolution |
 |----------|------------|
-| Conservative-refusal pessimism rate | M1, M2, M3 all measured 0% pessimism on existing fixtures. Policy 3(b) holds. |
+| Conservative-refusal pessimism rate | M1, M2, M3, M4 all measured 0% pessimism on existing fixtures. Policy 3(b) holds. |
 | `Reduce` as own L1 form vs desugared | Pure-path `.reduce` stays on `translateReduceCall` (chain-fusion via `BodyResult.pendingComprehension`); not absorbed into L1. The "desugared into `Let + Foreach + Assign`" framing in the original plan was wrong — chain fusion is expression-position, architecturally separate from M3's mutating foreach. |
 | Frame-condition emission ordering | Frames flow through `state.modifiedProps` (Set with insertion-order iteration) — same path as legacy. No L1 → L2 lowering pass for frames; M3's `lowerL1Body` reuses the existing primitive. |
+| M4 standalone vs absorbed into M3 | Landed standalone post-M3. M3 was absorbed enough by iteration + mutation; equality/nullish was a clean six-patch slice on its own. |
+| Loose-eq policy at M4 | Reject all surviving loose-eq unconditionally. Per § "Developer Steering Principles" rule 1 in `tools/ts2pant/CLAUDE.md` — `==` is ambiguous in TS regardless of operand type, so steering the programmer to `===`/`!==` is the right move. |
+| Combined-shape recognizer scope at M4 | Included as Patch 5 (functor-lift). Pant has no list literal; without the recognizer, idiomatic null-guarded list-lifted conditionals are untranslatable. Sets the precedent recorded in Architectural Lesson 5. |
 
 ## Decisions Made
 


### PR DESCRIPTION
## Patch 6: M4 docs and dogfood verification

- Add a new top-level § 'Developer Steering Principles' to `tools/ts2pant/CLAUDE.md`, immediately after § 'First Principles: This Is Program Translation, Not Novel Research'. Articulate the two-sided rule: (1) When TS itself is ambiguous, ts2pant rejects and steers the programmer to an unambiguous TS form — the rewrite is owed to the *TS* program, not to pantagruel. Example: `==` rejected, programmer rewrites as `===`. (2) When TS is unambiguous but doesn't match a pantagruel-shaped recognizer, ts2pant adapts to recognize it — the programmer should not be taxed by the tool's preferred input shape. Example: `(a === null) || (a === undefined) || other` is unambiguous TS; ts2pant recognizes the nullish prefix opportunistically rather than forcing rewrites. The test: does the TS code's intent read clearly to a TS reader? If yes, recognize. If no, reject and explain. Future milestones inherit this principle. Reference M4 (equality vs. partial-match disjunction) as the precedent
- In `tools/ts2pant/CLAUDE.md` § 'Imperative IR Workstream', add a new subsection 'M4 (equality-nullish-normalization): landed.' mirroring the M2/M3 status blocks: canonical form (`IsNullish(operand)` lowering to `#x = 0`), equality rule (`===`/`!==` always canonicalize; `==`/`!=` rejected unconditionally outside the nullish recognizer — cross-reference the Developer Steering principle), functor-lift recognizer (null-guarded list-lifted conditionals → `each $n in x | f $n`, soundness conditions enumerated), `from-l2` shrinkage scope (sub-expressions of nullish/equality forms now build natively on L1)
- In `tools/ts2pant/CLAUDE.md` § 'Option-Type Elimination', add a forward reference to the new IsNullish primitive — note that the encoding (`#x = 0`) is unchanged but is now produced by lowering an L1 IsNullish rather than emitted directly. Document the new functor-lift recognizer as the canonical handling for null-guarded list-lifted conditionals
- Add a new § 'Functor-Lift Recognizer' to CLAUDE.md (alongside the existing structured-iteration section): standard name (functor lift / Maybe-monad fmap), reference to Wadler 'The Essence of Functional Programming' or equivalent, the four soundness conditions, the four supported TS shapes, and the deliberate rejection of multi-element non-empty branches. Note that this recognizer is itself an instance of the 'recognize idiomatic TS' side of the Developer Steering principle
- In `workstreams/ts2pant-imperative-ir.md` § 'Milestone 4 (deferred)': change heading to 'Milestone 4: equality-nullish-normalization — ✅ landed', add the same status block format used by M1-M3 (slice breakdown, pessimism rate, definition-of-done checkboxes). Record three resolved open questions: 'M4 standalone vs absorbed' (resolved: landed standalone), 'loose-eq policy' (resolved: reject all surviving loose-eq), 'combined-shape recognizer scope' (resolved: included as Patch 5)
- Update workstream § 'Current State (post-M3)' → § 'Current State (post-M4)': move equality / nullish out of 'What's still on the legacy path'; update the 'What's on Layer 1' list to include `IsNullish`; note the precedent set by Patch 5's combined-shape recognizer (M1 Cond + M4 IsNullish) for future cross-milestone normalization needs
- Add a new § 'Architectural Lesson 5: combined-shape recognizers are sometimes load-bearing' to the workstream doc, articulating: when Pant's expression vocabulary lacks a target for a TS shape, a combined recognizer crossing milestone boundaries can be the only translatable path. M4's functor-lift recognizer is the precedent
- Run `just ts2pant-test` and `just ts2pant-test-integration` end-to-end. All tests + dogfood pass byte-equal. `pant --check` passes for every M4-fixture function (equality-nullish + functor-lift)
- Compute and record the loose-equality pessimism count. Workstream document records: 'Pessimism rate (loose-eq rejection): N=X across fixtures+dogfood. Y%.'
- In `tools/ts2pant/CLAUDE.md` § 'Imperative IR Workstream', M4 status block: explicitly enumerate what M4 does NOT cover (out-of-scope by design): `.indexOf(x) === -1` array-absence idioms (these are EUF equality on a sentinel — they translate correctly today, just not via IsNullish); `x === SomeEnum.NONE` enum-sentinel patterns (typed equality, works as-is via `===` canonicalization); `Boolean(x)` / `!!x` truthiness coercion (tests presence, not equality — semantically distinct from nullish testing). These remain candidates for future milestones if real fixtures demand them
- In `workstreams/ts2pant-imperative-ir.md` § 'Open Questions' table, add three deferred-to-future-milestone rows: (1) `.indexOf(x) === -1` recognition — resolve when a fixture demands it; (2) enum-sentinel-as-nullish absorption — resolve when a fixture demands it; (3) truthiness coercion (`Boolean(x)` / `!!x`) handling — may stay UNSUPPORTED indefinitely or become its own milestone
- Final review: skim `translate-body.ts:2780-2900` and `ir1-build.ts` to verify no leftover direct OpaqueExpr emission for nullish, equality, or functor-lift-eligible forms outside the L1 path

## Changes
- Add a new top-level § 'Developer Steering Principles' to `tools/ts2pant/CLAUDE.md`, immediately after § 'First Principles: This Is Program Translation, Not Novel Research'. Articulate the two-sided rule: (1) When TS itself is ambiguous, ts2pant rejects and steers the programmer to an unambiguous TS form — the rewrite is owed to the *TS* program, not to pantagruel. Example: `==` rejected, programmer rewrites as `===`. (2) When TS is unambiguous but doesn't match a pantagruel-shaped recognizer, ts2pant adapts to recognize it — the programmer should not be taxed by the tool's preferred input shape. Example: `(a === null) || (a === undefined) || other` is unambiguous TS; ts2pant recognizes the nullish prefix opportunistically rather than forcing rewrites. The test: does the TS code's intent read clearly to a TS reader? If yes, recognize. If no, reject and explain. Future milestones inherit this principle. Reference M4 (equality vs. partial-match disjunction) as the precedent
- In `tools/ts2pant/CLAUDE.md` § 'Imperative IR Workstream', add a new subsection 'M4 (equality-nullish-normalization): landed.' mirroring the M2/M3 status blocks: canonical form (`IsNullish(operand)` lowering to `#x = 0`), equality rule (`===`/`!==` always canonicalize; `==`/`!=` rejected unconditionally outside the nullish recognizer — cross-reference the Developer Steering principle), functor-lift recognizer (null-guarded list-lifted conditionals → `each $n in x | f $n`, soundness conditions enumerated), `from-l2` shrinkage scope (sub-expressions of nullish/equality forms now build natively on L1)
- In `tools/ts2pant/CLAUDE.md` § 'Option-Type Elimination', add a forward reference to the new IsNullish primitive — note that the encoding (`#x = 0`) is unchanged but is now produced by lowering an L1 IsNullish rather than emitted directly. Document the new functor-lift recognizer as the canonical handling for null-guarded list-lifted conditionals
- Add a new § 'Functor-Lift Recognizer' to CLAUDE.md (alongside the existing structured-iteration section): standard name (functor lift / Maybe-monad fmap), reference to Wadler 'The Essence of Functional Programming' or equivalent, the four soundness conditions, the four supported TS shapes, and the deliberate rejection of multi-element non-empty branches. Note that this recognizer is itself an instance of the 'recognize idiomatic TS' side of the Developer Steering principle
- In `workstreams/ts2pant-imperative-ir.md` § 'Milestone 4 (deferred)': change heading to 'Milestone 4: equality-nullish-normalization — ✅ landed', add the same status block format used by M1-M3 (slice breakdown, pessimism rate, definition-of-done checkboxes). Record three resolved open questions: 'M4 standalone vs absorbed' (resolved: landed standalone), 'loose-eq policy' (resolved: reject all surviving loose-eq), 'combined-shape recognizer scope' (resolved: included as Patch 5)
- Update workstream § 'Current State (post-M3)' → § 'Current State (post-M4)': move equality / nullish out of 'What's still on the legacy path'; update the 'What's on Layer 1' list to include `IsNullish`; note the precedent set by Patch 5's combined-shape recognizer (M1 Cond + M4 IsNullish) for future cross-milestone normalization needs
- Add a new § 'Architectural Lesson 5: combined-shape recognizers are sometimes load-bearing' to the workstream doc, articulating: when Pant's expression vocabulary lacks a target for a TS shape, a combined recognizer crossing milestone boundaries can be the only translatable path. M4's functor-lift recognizer is the precedent
- Run `just ts2pant-test` and `just ts2pant-test-integration` end-to-end. All tests + dogfood pass byte-equal. `pant --check` passes for every M4-fixture function (equality-nullish + functor-lift)
- Compute and record the loose-equality pessimism count. Workstream document records: 'Pessimism rate (loose-eq rejection): N=X across fixtures+dogfood. Y%.'
- In `tools/ts2pant/CLAUDE.md` § 'Imperative IR Workstream', M4 status block: explicitly enumerate what M4 does NOT cover (out-of-scope by design): `.indexOf(x) === -1` array-absence idioms (these are EUF equality on a sentinel — they translate correctly today, just not via IsNullish); `x === SomeEnum.NONE` enum-sentinel patterns (typed equality, works as-is via `===` canonicalization); `Boolean(x)` / `!!x` truthiness coercion (tests presence, not equality — semantically distinct from nullish testing). These remain candidates for future milestones if real fixtures demand them
- In `workstreams/ts2pant-imperative-ir.md` § 'Open Questions' table, add three deferred-to-future-milestone rows: (1) `.indexOf(x) === -1` recognition — resolve when a fixture demands it; (2) enum-sentinel-as-nullish absorption — resolve when a fixture demands it; (3) truthiness coercion (`Boolean(x)` / `!!x`) handling — may stay UNSUPPORTED indefinitely or become its own milestone
- Final review: skim `translate-body.ts:2780-2900` and `ir1-build.ts` to verify no leftover direct OpaqueExpr emission for nullish, equality, or functor-lift-eligible forms outside the L1 path

## Files to Modify
- tools/ts2pant/CLAUDE.md (modify): Add an M4 status block to the IR Workstream section: canonical IsNullish form, equality canonicalization rules, `from-l2` shrinkage notes
- workstreams/ts2pant-imperative-ir.md (modify): Mark M4 ✅ landed; record pessimism rate; resolve the 'M4 standalone vs absorbed' open question

## Gameplan Specification

```
module TS2PANT_M4.

> ════════════════════════════════════════════════════════════
> M4: equality and nullish normalization
> ════════════════════════════════════════════════════════════
>
> After M4, every TS-AST expression in the equality/nullish
> equivalence class flows through Layer 1. The class is
> normalized into three canonical paths plus an unconditional
> rejection on surviving loose equality:
>
>   - `IsNullish(x)` — the canonical Bool null/undefined test.
>     Recognized from x==null, x===null, x===undefined, the
>     ||-long form, and typeof-undefined. Negated forms wrap as
>     `not(IsNullish(x))`.
>   - `BinOp(eq | neq, lhs, rhs)` — canonical equality, only
>     produced from `===` / `!==`.
>   - Functor-lift `each $n in x | f $n` — the canonical lowering
>     for null-guarded list-lifted conditionals. Pant has no list
>     literal, so cardinality-dispatch is not a viable alternative;
>     this path makes idiomatic null-guard-then-list-return TS
>     functions translate.
>   - Any `==` / `!=` not consumed by the nullish recognizer is
>     rejected. ts2pant steers the programmer toward `===`/`!==`
>     rather than guess loose-equality intent.

TSExpr.
TSType.
L1Expr.
L2Expr.
OpaqueExpr.

> ─── L1 form predicates ───────────────────────────────────────

is-nullish? e: L1Expr => Bool.
is-not? e: L1Expr => Bool.
is-binop-eq? e: L1Expr => Bool.
is-binop-neq? e: L1Expr => Bool.
is-each? e: L1Expr => Bool.
is-cond? e: L1Expr => Bool.

operand e: L1Expr, is-nullish? e => L1Expr.
inner e: L1Expr, is-not? e => L1Expr.

> ─── TS-side classification ───────────────────────────────────

is-positive-nullish? t: TSExpr => Bool.
is-negative-nullish? t: TSExpr => Bool.
is-strict-eq? t: TSExpr => Bool.
is-strict-neq? t: TSExpr => Bool.
is-loose-eq? t: TSExpr => Bool.
is-loose-neq? t: TSExpr => Bool.

is-conditional? t: TSExpr => Bool.
functor-lift-eligible? t: TSExpr, is-conditional? t => Bool.

> ─── Build / lower pipeline ───────────────────────────────────

build-l1 t: TSExpr => L1Expr.
lower-l1 e: L1Expr => L2Expr.
emit l: L2Expr => OpaqueExpr.
unsupported? e: L1Expr => Bool.

> ─── L2 / OpaqueExpr shape predicate ─────────────────────────

card-zero? l: L2Expr => Bool.

---

> ─── Canonical form: every nullish surface form maps to one
>     L1 IsNullish (or its negation). ───────────────────────────

all t: TSExpr, is-positive-nullish? t |
  is-nullish? (build-l1 t).

all t: TSExpr, is-negative-nullish? t |
  is-not? (build-l1 t)
  and is-nullish? (inner (build-l1 t)).

> ─── Lowering: IsNullish becomes the cardinality-zero shape. ──

all e: L1Expr, is-nullish? e | card-zero? (lower-l1 e).

> ─── Strict equality canonicalizes unconditionally. ──────────

all t: TSExpr, is-strict-eq? t | is-binop-eq? (build-l1 t).
all t: TSExpr, is-strict-neq? t | is-binop-neq? (build-l1 t).

> ─── Surviving loose equality is rejected unconditionally.
>     The nullish family is consumed before this rule fires. ───

all t: TSExpr, is-loose-eq? t | unsupported? (build-l1 t).
all t: TSExpr, is-loose-neq? t | unsupported? (build-l1 t).

> ─── Functor-lift recognizer: eligible conditionals lower to
>     `each`; ineligible conditionals fall through to L1 Cond
>     (which then rejects at the no-list-literal wall). ────────

all t: TSExpr, is-conditional? t, functor-lift-eligible? t |
  is-each? (build-l1 t).

all t: TSExpr, is-conditional? t, ~ functor-lift-eligible? t |
  is-cond? (build-l1 t).

```

## Patch Specification

```
module TS2PANT_M4_PATCH_5.

> Patch 5 — documentation + dogfood verification. No new code paths.
>
> Updates `tools/ts2pant/CLAUDE.md` and
> `workstreams/ts2pant-imperative-ir.md` to reflect M4 landed status.
> Adds a fixture covering all supported equality/nullish surface
> shapes. Confirms `pant --check` and dogfood remain green.

Doc.
Fixture.

m4-status-recorded? d: Doc => Bool.
fixture-covers-equality-nullish? f: Fixture => Bool.

---

true.

```



## Implementation Notes

- **Doc-only patch.** Two files changed: `tools/ts2pant/CLAUDE.md` (+218) and `workstreams/ts2pant-imperative-ir.md` (+190 net). No source files modified.

- **Pessimism rate methodology.** Counted real `==`/`!=` use sites (excluding comments, error-message string literals, and JSDoc) across `tools/ts2pant/src/**` (dogfood) and `tools/ts2pant/tests/fixtures/**`. Total N=5: two in `expressions-equality-nullish.ts` (`x == null`, `x != null`) and three in `expressions-functor-lift.ts` (`u == null` ternary guards). All five are consumed by Patch 2's nullish recognizer; 0 rejected. Dogfood contains zero loose-eq sites. Synthetic rejection coverage lives in `tests/equality-canonicalization.test.mts`.

- **`pant --check` verification.** The existing integration suite (`tests/integration/e2e.test.mts`) only `--check`s a small set of named fixtures (`max.ts`, `deposit.ts`, `apply-fee.ts`); it does not iterate `expressions-equality-nullish.ts` or `expressions-functor-lift.ts`. To honor the gameplan's "`pant --check` passes for every M4-fixture function" requirement, I wrote a small ad-hoc translator script that emits each of the 23 M4 fixture functions (16 equality-nullish + 7 functor-lift) as standalone `.pant` documents and ran `pant --check` against each. All 23 passed. Script was deleted post-verification — adding a permanent integration-test loop over fixture-by-fixture `--check` is plausible follow-up work but out of scope for a docs patch.

- **Patch 4 landed mid-Patch-6.** When this PR was first authored, P4 (the `??` builder refactor through L1 `IsNullish`) was not in the branch — the docs were written describing the post-M4 architectural state in terms of what `IsNullish` *means* (canonical Bool null/undefined test, lowers to `#x = 0`), and the `??` site was the one outstanding hand-emitted exception. Post-rebase onto master, P4 is now in (`translate-body.ts:2951` constructs `cardZero` via `lowerL1ToOpaque(ir1IsNullish(ir1FromL2(irWrap(xExpr))))`), so the docs are now fully accurate. Tests reconfirmed: 601 unit (up from 598 pre-rebase — P4 added 3) + 22 integration pass.

- **Spec module name.** The "Patch Specification" embedded in the PR body is labeled `TS2PANT_M4_PATCH_5` even though this is Patch 6 — appears to be a copy-paste artifact in the gameplan tooling. The patch number and the work itself are unambiguous from the branch name and commit; flagging in case the spec-numbering machinery should round-trip the correction.

- **Open Questions table is now strictly future-fixture-driven.** The three new rows (`.indexOf(x) === -1`, enum-sentinel-as-nullish, truthiness coercion) all resolve "when a fixture demands it" — none are blocking M5/M6. The truthiness row notes it may stay UNSUPPORTED indefinitely; that's the principled stance under § "Developer Steering Principles" rule 1, since `Boolean(x)` semantically tests truthy-coercion (excluding `0`, `""`, `false`) rather than absence.
