### PR TITLE
[ts2pant-m5-property-access] Patch 1: Add buildL1MemberAccess helper; cut over pure-path PropertyAccess sites

### DIFF
--- a/tools/ts2pant/src/ir-build.ts
+++ b/tools/ts2pant/src/ir-build.ts
@@ -24,11 +24,16 @@ import {
   irLitBool,
   irLitNat,
   irLitString,
-  irUnop,
   irVar,
   irWrap,
 } from "./ir.js";
 import { ir1FromL2, ir1IsNullish } from "./ir1.js";
+import {
+  buildL1MemberAccess,
+  type L1BuildContext,
+  tryBuildL1Cardinality,
+  unwrapParens,
+} from "./ir1-build.js";
 import { lowerL1Expr } from "./ir1-lower.js";
 import {
   ambiguousFieldMsg,
@@ -40,7 +45,7 @@ import {
   translateBodyExpr,
   type UniqueSupply,
 } from "./translate-body.js";
-import { isSetType, type NumericStrategy } from "./translate-types.js";
+import type { NumericStrategy } from "./translate-types.js";
 
 /**
  * Translate a TypeScript expression to IR.
@@ -59,6 +64,23 @@ export function buildIR(
   paramNames: ReadonlyMap<string, string>,
   supply: UniqueSupply,
 ): IRExpr | { unsupported: string } {
+  // Universal L1-layering: strip `(…)` wrappers at the build dispatch
+  // entry so downstream recognizers see canonical shapes. Type-erasure
+  // wrappers (`as T`, `!`, `<T>x`, `satisfies`) are NOT stripped — they
+  // change the TS-checker type of the inner node and are load-bearing
+  // for type-dependent dispatch like `qualifyFieldAccess`.
+  expr = unwrapParens(expr) as ts.Expression;
+
+  // L1 build context for sub-dispatchers (cardinality / Member). Pure
+  // path has no symbolic state.
+  const l1Ctx: L1BuildContext = {
+    checker,
+    strategy,
+    paramNames,
+    state: undefined,
+    supply,
+  };
+
   // Boolean keywords
   if (expr.kind === ts.SyntaxKind.TrueKeyword) {
     return irLitBool(true);
@@ -91,32 +113,15 @@ export function buildIR(
     return irVar(renamed);
   }
 
-  // Stage 5: `.length` (Array) / `.size` (Set) → `Unop(card, x)`. Plain
-  // property access on a non-optional, non-effectful receiver where the
-  // property is the cardinality slot. Falls through (to legacy / qualified
-  // field access) for property names other than `length`/`size`, and for
-  // receivers that are neither Array nor Set.
-  if (
-    ts.isPropertyAccessExpression(expr) &&
-    !(expr.flags & ts.NodeFlags.OptionalChain) &&
-    (expr.name.text === "length" || expr.name.text === "size")
-  ) {
-    const receiverTsType = checker.getTypeAtLocation(expr.expression);
-    const isArray =
-      expr.name.text === "length" && checker.isArrayType(receiverTsType);
-    const isSet = expr.name.text === "size" && isSetType(receiverTsType);
-    if (isArray || isSet) {
-      const objIR = buildIR(
-        expr.expression,
-        checker,
-        strategy,
-        paramNames,
-        supply,
-      );
-      if (isBuildUnsupported(objIR)) {
-        return objIR;
-      }
-      return irUnop("card", objIR);
+  // M5: cardinality dispatch (`.length` / `.size` → `Unop(card, x)`).
+  // Pant's primitive for list cardinality is `#x`, not a `length` / `size`
+  // rule application — routing through Member would produce a dangling
+  // EUF function distinct from the actual cardinality. Fires before the
+  // Member dispatch below for the six list-shaped TS types.
+  if (ts.isPropertyAccessExpression(expr)) {
+    const card = tryBuildL1Cardinality(expr, l1Ctx);
+    if (card !== null) {
+      return lowerL1Expr(card);
     }
   }
 
@@ -169,6 +174,22 @@ export function buildIR(
         );
       }
     }
+  }
+
+  // M5: plain (non-optional) property access → canonical L1 Member.
+  // The lowering at `ir1-lower.ts` produces `App(qualifiedName,
+  // [receiver])` — byte-equal to the legacy direct construction.
+  // Cardinality dispatch above already handled the `.length` / `.size`
+  // path, so anything reaching here is a genuine field accessor.
+  if (
+    ts.isPropertyAccessExpression(expr) &&
+    (expr.flags & ts.NodeFlags.OptionalChain) === 0
+  ) {
+    const member = buildL1MemberAccess(expr, l1Ctx);
+    if ("unsupported" in member) {
+      return member;
+    }
+    return lowerL1Expr(member);
   }
 
   // Stage 3: Nullish coalescing `x ?? y` under list-lift. With `x: [T]`

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -157,10 +157,18 @@ function isSizeCardinalityType(t: ts.Type): boolean {
  * shaped TS type and whose property is the cardinality slot for that
  * type. Returns null when the node is not a cardinality form — caller
  * falls through to `buildL1MemberAccess`.
+ *
+ * `options` propagate through to the inner Member dispatch when the
+ * cardinality receiver is itself a property access (e.g.,
+ * `a.items.length`) and to the leaf-translator hook for non-property
+ * receivers. Signature-path callers pass the same options here that
+ * they pass to `buildL1MemberAccess` so cardinality and Member share
+ * the signature-style receiver leaf and ambiguous-owner fallback.
  */
 export function tryBuildL1Cardinality(
   node: ts.Expression,
   ctx: L1BuildContext,
+  options: BuildL1MemberAccessOptions = {},
 ): IR1Expr | null {
   const stripped = unwrapParens(node);
   if (!ts.isPropertyAccessExpression(stripped)) {
@@ -192,21 +200,29 @@ export function tryBuildL1Cardinality(
   // entire chain stays on the L1 path — no half-migration where the
   // outer `card` is L1 but the inner `.items` round-trips through L2
   // via `from-l2`. Other receiver shapes (Identifier, call, binop,
-  // etc.) translate through the legacy pipeline; those aren't
-  // property-access and are out of M5's equivalence class.
+  // etc.) translate through the supplied leaf translator (default
+  // `translateBodyExpr`); those aren't property-access and are out of
+  // M5's equivalence class.
   if (
     ts.isPropertyAccessExpression(receiverNode) &&
     (receiverNode.flags & ts.NodeFlags.OptionalChain) === 0
   ) {
-    const innerCard = tryBuildL1Cardinality(receiverNode, ctx);
+    const innerCard = tryBuildL1Cardinality(receiverNode, ctx, options);
     if (innerCard !== null) {
       return ir1Unop("card", innerCard);
     }
-    const inner = buildL1MemberAccess(receiverNode, ctx);
+    const inner = buildL1MemberAccess(receiverNode, ctx, options);
     if (isL1Unsupported(inner)) {
       return null;
     }
     return ir1Unop("card", inner);
+  }
+  if (options.translateReceiverLeaf !== undefined) {
+    const r = options.translateReceiverLeaf(receiverNode as ts.Expression, ctx);
+    if (r.kind === "unsupported") {
+      return null;
+    }
+    return ir1Unop("card", ir1FromL2(irWrap(r.expr)));
   }
   const r = translateBodyExpr(
     receiverNode as ts.Expression,

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -238,6 +238,17 @@ export function tryBuildL1Cardinality(
 // matching the legacy `App(qualified-rule, [receiver])` byte-for-byte.
 
 /**
+ * Receiver translation result — either an opaque expression or an
+ * upstream-rejection marker. Mirrors the convention of
+ * `TranslateExprResult` and the body-side `BodyResult` so signature
+ * and body translators can plug into `buildL1MemberAccess` through a
+ * single callback shape.
+ */
+export type MemberReceiverResult =
+  | { kind: "expr"; expr: OpaqueExpr }
+  | { kind: "unsupported"; reason: string };
+
+/**
  * Options threaded through `buildL1MemberAccess`.
  *
  * - `ambiguousOwnerFallback: "reject"` — body-side default. Ambiguous
@@ -254,9 +265,26 @@ export function tryBuildL1Cardinality(
  *   without preventing other guards in the same function from
  *   extracting cleanly. Mirrors the asymmetry the deleted local
  *   `qualifyFieldAccess` in `translate-signature.ts` carried.
+ *
+ * - `translateReceiverLeaf` — translator for the non-property leaf at
+ *   the bottom of the receiver chain (e.g., the `a` in `a.b.c.field`).
+ *   Defaults to `translateBodyExpr`, which is what body-position and
+ *   pure-path call sites want. The signature path passes a callback
+ *   that routes through `translateExpr` (signature) so the leaf gets
+ *   the same transparent-wrapper handling and signature-only operator
+ *   surface (loose-eq rejection, no body-only chain fusion or
+ *   Map/Set effect handling) as the rest of guard analysis.
+ *
+ *   The callback's input is already paren-stripped via `unwrapParens`;
+ *   it is responsible for any further unwrapping (`as T`, `!`, etc.)
+ *   that its respective layer applies.
  */
 export interface BuildL1MemberAccessOptions {
   ambiguousOwnerFallback?: "reject" | "bare-kebab";
+  translateReceiverLeaf?: (
+    expr: ts.Expression,
+    ctx: L1BuildContext,
+  ) => MemberReceiverResult;
 }
 
 /**
@@ -354,6 +382,18 @@ export function buildL1MemberAccess(
       }
       receiverL1 = inner;
     }
+  } else if (options.translateReceiverLeaf !== undefined) {
+    // Caller-supplied leaf translator (used by the signature path so
+    // the non-property leaf goes through `translateExpr` instead of
+    // `translateBodyExpr` — preserves signature-only operator surface
+    // like loose-eq rejection and avoids body-only branches like
+    // chain fusion / Map-Set effect handling that aren't appropriate
+    // in guard analysis).
+    const r = options.translateReceiverLeaf(receiverNode as ts.Expression, ctx);
+    if (r.kind === "unsupported") {
+      return { unsupported: r.reason };
+    }
+    receiverL1 = ir1FromL2(irWrap(r.expr));
   } else {
     const r = translateBodyExpr(
       receiverNode as ts.Expression,

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -388,7 +388,7 @@ export function buildL1MemberAccess(
     // Pure path: prefer canonical nested Member trees. Cardinality
     // dispatch fires first so a chain like `arr.length.foo` wouldn't
     // silently route `arr.length` through Member.
-    const card = tryBuildL1Cardinality(receiverNode, ctx);
+    const card = tryBuildL1Cardinality(receiverNode, ctx, options);
     if (card !== null) {
       receiverL1 = card;
     } else {

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -48,6 +48,7 @@ import {
   ir1LitBool,
   ir1LitNat,
   ir1LitString,
+  ir1Member,
   ir1Unop,
   ir1Var,
   ir1While,
@@ -74,9 +75,16 @@ import {
   extractReturnFromBranch,
   isBodyUnsupported,
   isNullableTsType,
+  qualifyFieldAccess,
+  symbolicKey,
   translateBodyExpr,
 } from "./translate-body.js";
-import { cellRegisterName, type NumericStrategy } from "./translate-types.js";
+import {
+  cellRegisterName,
+  isMapType,
+  isSetType,
+  type NumericStrategy,
+} from "./translate-types.js";
 
 /**
  * Context threaded through L1 build. Mirrors the parameter set of
@@ -96,6 +104,240 @@ export const isL1Unsupported = (
   r: L1BuildResult,
 ): r is { unsupported: string } =>
   typeof r === "object" && r !== null && "unsupported" in r;
+
+/**
+ * L1-layering primitive: strip operationally-equivalent syntactic
+ * wrappers at the L1 build boundary so downstream recognizers see
+ * canonical shapes without re-implementing the strip themselves.
+ *
+ * Only `ParenthesizedExpression` is normalized away — type-erasure
+ * wrappers (`as T`, `!`, `<T>x`, `satisfies`) change the TS-checker
+ * type of the inner node and are load-bearing for type-dependent
+ * dispatch (`qualifyFieldAccess`, nullability gates, etc.). They stay
+ * on the standard build path that consults the type-checker.
+ */
+export function unwrapParens(n: ts.Node): ts.Node {
+  while (ts.isParenthesizedExpression(n)) {
+    n = n.expression;
+  }
+  return n;
+}
+
+// ---------------------------------------------------------------------------
+// Cardinality dispatch (`.length` / `.size` → `Unop(card, x)`)
+// ---------------------------------------------------------------------------
+//
+// Pant's primitive for list cardinality is `#x` (`Unop(card, x)`), not a
+// `length` / `size` rule application. Routing `arr.length` through Member
+// would lower to `length arr` — an EUF uninterpreted function distinct
+// from `#arr`. Specs reasoning about list sizes would silently fail. So
+// the build pass attempts cardinality recognition before Member dispatch
+// for property access on the six list-shaped TS types: `Array`,
+// `ReadonlyArray`, `Set`, `ReadonlySet`, `Map`, `ReadonlyMap`. This is
+// a deliberate non-Member dispatch driven by the target language; see
+// `tools/ts2pant/CLAUDE.md` § "Divergence from IRSC".
+
+/**
+ * True when `t` is a TS type whose cardinality is exposed via `length`
+ * (arrays) or `size` (sets, maps). Centralizes the predicate so the
+ * cardinality dispatch and the Member fallback agree on coverage.
+ */
+function isLengthCardinalityType(t: ts.Type, checker: ts.TypeChecker): boolean {
+  return checker.isArrayType(t);
+}
+
+function isSizeCardinalityType(t: ts.Type): boolean {
+  return isSetType(t) || isMapType(t);
+}
+
+/**
+ * Try to build an L1 `Unop(card, receiver)` for `node` if it is a
+ * non-optional `PropertyAccessExpression` whose receiver is a list-
+ * shaped TS type and whose property is the cardinality slot for that
+ * type. Returns null when the node is not a cardinality form — caller
+ * falls through to `buildL1MemberAccess`.
+ */
+export function tryBuildL1Cardinality(
+  node: ts.Expression,
+  ctx: L1BuildContext,
+): IR1Expr | null {
+  const stripped = unwrapParens(node);
+  if (!ts.isPropertyAccessExpression(stripped)) {
+    return null;
+  }
+  // Optional-chain `.length` / `.size` (i.e., `xs?.length`) preserves
+  // `?.` semantics — when `xs` is null the chain short-circuits to
+  // `undefined`, which `#xs` would not encode. Defer to the optional-
+  // chain handler in legacy `translateBodyExpr` rather than collapsing
+  // to a cardinality.
+  if ((stripped.flags & ts.NodeFlags.OptionalChain) !== 0) {
+    return null;
+  }
+  const propName = stripped.name.text;
+  if (propName !== "length" && propName !== "size") {
+    return null;
+  }
+  const receiverNode = unwrapParens(stripped.expression);
+  const receiverType = ctx.checker.getTypeAtLocation(receiverNode);
+  const matches =
+    (propName === "length" &&
+      isLengthCardinalityType(receiverType, ctx.checker)) ||
+    (propName === "size" && isSizeCardinalityType(receiverType));
+  if (!matches) {
+    return null;
+  }
+  // Receiver translates through the legacy pipeline so it picks up
+  // const-binding inlining, symbolic-state lookup, and any other
+  // body-level normalization. Wrap as `from-l2` for embedding under
+  // L1 `Unop`.
+  const r = translateBodyExpr(
+    receiverNode as ts.Expression,
+    ctx.checker,
+    ctx.strategy,
+    ctx.paramNames,
+    ctx.state,
+    ctx.supply,
+  );
+  if (isBodyUnsupported(r)) {
+    return null;
+  }
+  if ("effect" in r) {
+    return null;
+  }
+  return ir1Unop("card", ir1FromL2(irWrap(bodyExpr(r))));
+}
+
+// ---------------------------------------------------------------------------
+// Property access → L1 Member
+// ---------------------------------------------------------------------------
+//
+// Build the canonical L1 `Member(receiver, qualified-name)` form for a TS
+// `PropertyAccessExpression` (and, in M5 Patch 3, string-literal
+// `ElementAccessExpression`). The qualified name is resolved at build
+// time via `qualifyFieldAccess` — IRSC discipline preserves the
+// pre-qualification: L1 `Member` is a *normalization* form whose lowering
+// at `ir1-lower.ts` is mechanical (`Member(r, n) → App(n, [lower r])`),
+// matching the legacy `App(qualified-rule, [receiver])` byte-for-byte.
+
+/**
+ * Build an L1 `Member(receiverL1, qualifiedName)` for a TS property
+ * access. Returns an `{ unsupported }` descriptor on ambiguous owner,
+ * unsupported access shape, or a sub-expression that itself rejects.
+ *
+ * Receiver translation:
+ *   - State-free contexts (pure path, unit tests) recurse on
+ *     `PropertyAccessExpression` receivers, producing nested L1
+ *     `Member` trees. The recursion bottoms out at a non-property
+ *     receiver translated through the legacy pipeline and wrapped as
+ *     `from-l2`.
+ *   - State-bearing contexts (mutating-body path) translate the
+ *     receiver via the legacy pipeline so symbolic-state lookup at
+ *     each nested level fires identically to the pre-M5 path. This
+ *     preserves byte-equality with the legacy snapshots while still
+ *     routing the outer access through L1 `Member`.
+ *
+ * Patch 1 handles `PropertyAccessExpression` only; the
+ * `ElementAccessExpression` arm (string-literal element access lands
+ * on the same canonical Member; computed access rejects) is M5
+ * Patch 3.
+ */
+export function buildL1MemberAccess(
+  node: ts.PropertyAccessExpression | ts.ElementAccessExpression,
+  ctx: L1BuildContext,
+): L1BuildResult {
+  const stripped = unwrapParens(node);
+  if (!ts.isPropertyAccessExpression(stripped)) {
+    // Patch 1 scope: ElementAccess lands in Patch 3 (string-literal key
+    // canonicalizes to the same Member; computed key rejects).
+    return {
+      unsupported:
+        "element access not yet routed through L1 Member (M5 Patch 3)",
+    };
+  }
+  // Optional-chain `.f` (`x?.f` and the chain tail) routes through the
+  // optional-chain functor-lift recognizer, not Member. Caller is
+  // expected to filter optional chains before invoking this helper.
+  if ((stripped.flags & ts.NodeFlags.OptionalChain) !== 0) {
+    return {
+      unsupported:
+        "optional-chain property access uses functor-lift, not Member",
+    };
+  }
+  const receiverNode = unwrapParens(stripped.expression);
+  const fieldName = stripped.name.text;
+  const receiverType = ctx.checker.getTypeAtLocation(receiverNode);
+  const qualified = qualifyFieldAccess(
+    receiverType,
+    fieldName,
+    ctx.checker,
+    ctx.strategy,
+    ctx.supply.synthCell,
+  );
+  if (qualified === null) {
+    // Ambiguous owner — union/intersection members declare this field
+    // on multiple distinct types.
+    return {
+      unsupported:
+        `property access .${fieldName}: ambiguous owner — ` +
+        `union/intersection members declare this field on multiple distinct ` +
+        `types, so no single qualified accessor rule applies`,
+    };
+  }
+
+  let receiverL1: IR1Expr;
+  if (
+    ctx.state === undefined &&
+    ts.isPropertyAccessExpression(receiverNode) &&
+    (receiverNode.flags & ts.NodeFlags.OptionalChain) === 0
+  ) {
+    // Pure path: prefer canonical nested Member trees. Cardinality
+    // dispatch fires first so a chain like `arr.length.foo` wouldn't
+    // silently route `arr.length` through Member.
+    const card = tryBuildL1Cardinality(receiverNode, ctx);
+    if (card !== null) {
+      receiverL1 = card;
+    } else {
+      const inner = buildL1MemberAccess(receiverNode, ctx);
+      if (isL1Unsupported(inner)) {
+        return inner;
+      }
+      receiverL1 = inner;
+    }
+  } else {
+    const r = translateBodyExpr(
+      receiverNode as ts.Expression,
+      ctx.checker,
+      ctx.strategy,
+      ctx.paramNames,
+      ctx.state,
+      ctx.supply,
+    );
+    if (isBodyUnsupported(r)) {
+      return { unsupported: r.unsupported };
+    }
+    if ("effect" in r) {
+      return {
+        unsupported: "collection mutation as property-access receiver",
+      };
+    }
+    receiverL1 = ir1FromL2(irWrap(bodyExpr(r)));
+  }
+
+  // Symbolic-state lookup at the outer level (mirrors
+  // `translate-body.ts:2861`). When a prior write to this exact
+  // property exists at this canonicalized receiver, return the prior
+  // value rather than re-emitting the rule application.
+  if (ctx.state !== undefined) {
+    const objOpaque = lowerExpr(lowerL1Expr(receiverL1));
+    const key = symbolicKey(qualified, ctx.state.canonicalize(objOpaque));
+    const entry = ctx.state.writes.get(key);
+    if (entry !== undefined && entry.kind === "property") {
+      return ir1FromL2(irWrap(entry.value));
+    }
+  }
+
+  return ir1Member(receiverL1, qualified);
+}
 
 // ---------------------------------------------------------------------------
 // Recognizer entry — is this TS node a conditional shape M1 handles?
@@ -150,6 +392,7 @@ export function isL1ConditionalForm(
  * statement position; an L1 expression cannot host one).
  */
 function buildSubExpr(expr: ts.Expression, ctx: L1BuildContext): L1BuildResult {
+  expr = unwrapParens(expr) as ts.Expression;
   // Object literals don't lower to a Pantagruel value — Pant has no
   // record-constructor expression syntax. Reject *before* translating
   // so the error message is precise (legacy translateBodyExpr would
@@ -515,6 +758,10 @@ export function buildL1Conditional(
   expr: ts.Expression | ts.IfStatement | ts.SwitchStatement,
   ctx: L1BuildContext,
 ): L1BuildResult {
+  expr = unwrapParens(expr) as
+    | ts.Expression
+    | ts.IfStatement
+    | ts.SwitchStatement;
   if (ts.isConditionalExpression(expr)) {
     return buildFromTernary(expr, ctx);
   }
@@ -555,6 +802,10 @@ export function buildL1ConditionalFromArms(
   terminal: ts.Expression | ts.IfStatement | ts.SwitchStatement,
   ctx: L1BuildContext,
 ): L1BuildResult {
+  terminal = unwrapParens(terminal) as
+    | ts.Expression
+    | ts.IfStatement
+    | ts.SwitchStatement;
   const builtArms: Array<readonly [IR1Expr, IR1Expr]> = [...preludeArms];
 
   const terminalIsConditional =
@@ -1044,6 +1295,7 @@ export function buildL1IncrementStep(
   counterName: string,
   ctx: L1BuildContext,
 ): L1StmtBuildResult {
+  expr = unwrapParens(expr) as ts.Expression;
   // `c++` / `++c` / `c--` / `--c`
   if (ts.isPostfixUnaryExpression(expr) || ts.isPrefixUnaryExpression(expr)) {
     if (!ts.isIdentifier(expr.operand) || expr.operand.text !== counterName) {

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -84,6 +84,7 @@ import {
   isMapType,
   isSetType,
   type NumericStrategy,
+  toPantTermName,
 } from "./translate-types.js";
 
 /**
@@ -186,10 +187,27 @@ export function tryBuildL1Cardinality(
   if (!matches) {
     return null;
   }
-  // Receiver translates through the legacy pipeline so it picks up
-  // const-binding inlining, symbolic-state lookup, and any other
-  // body-level normalization. Wrap as `from-l2` for embedding under
-  // L1 `Unop`.
+  // Receiver translation. Property-access receivers (e.g.,
+  // `a.items.length`) route through `buildL1MemberAccess` so the
+  // entire chain stays on the L1 path — no half-migration where the
+  // outer `card` is L1 but the inner `.items` round-trips through L2
+  // via `from-l2`. Other receiver shapes (Identifier, call, binop,
+  // etc.) translate through the legacy pipeline; those aren't
+  // property-access and are out of M5's equivalence class.
+  if (
+    ts.isPropertyAccessExpression(receiverNode) &&
+    (receiverNode.flags & ts.NodeFlags.OptionalChain) === 0
+  ) {
+    const innerCard = tryBuildL1Cardinality(receiverNode, ctx);
+    if (innerCard !== null) {
+      return ir1Unop("card", innerCard);
+    }
+    const inner = buildL1MemberAccess(receiverNode, ctx);
+    if (isL1Unsupported(inner)) {
+      return null;
+    }
+    return ir1Unop("card", inner);
+  }
   const r = translateBodyExpr(
     receiverNode as ts.Expression,
     ctx.checker,
@@ -220,9 +238,32 @@ export function tryBuildL1Cardinality(
 // matching the legacy `App(qualified-rule, [receiver])` byte-for-byte.
 
 /**
+ * Options threaded through `buildL1MemberAccess`.
+ *
+ * - `ambiguousOwnerFallback: "reject"` — body-side default. Ambiguous
+ *   union/intersection owners surface as `{ unsupported }` because
+ *   the resulting accessor rule is load-bearing in emitted
+ *   propositions.
+ * - `ambiguousOwnerFallback: "bare-kebab"` — signature-side
+ *   best-effort. Ambiguous owners produce a Member with the bare
+ *   kebab'd field name. The signature path uses this in
+ *   `extractAssertionGuard` / `buildSubstitutionMap` /
+ *   `tryTranslateGuardExpr` where `translateExpr` failures bail the
+ *   *optional* analysis (the would-be guard never fires) — so a bare
+ *   fallback yields the same observable behavior as a hard reject
+ *   without preventing other guards in the same function from
+ *   extracting cleanly. Mirrors the asymmetry the deleted local
+ *   `qualifyFieldAccess` in `translate-signature.ts` carried.
+ */
+export interface BuildL1MemberAccessOptions {
+  ambiguousOwnerFallback?: "reject" | "bare-kebab";
+}
+
+/**
  * Build an L1 `Member(receiverL1, qualifiedName)` for a TS property
- * access. Returns an `{ unsupported }` descriptor on ambiguous owner,
- * unsupported access shape, or a sub-expression that itself rejects.
+ * access. Returns an `{ unsupported }` descriptor on ambiguous owner
+ * (under the body-side default), unsupported access shape, or a
+ * sub-expression that itself rejects.
  *
  * Receiver translation:
  *   - State-free contexts (pure path, unit tests) recurse on
@@ -244,7 +285,9 @@ export function tryBuildL1Cardinality(
 export function buildL1MemberAccess(
   node: ts.PropertyAccessExpression | ts.ElementAccessExpression,
   ctx: L1BuildContext,
+  options: BuildL1MemberAccessOptions = {},
 ): L1BuildResult {
+  const ambiguousMode = options.ambiguousOwnerFallback ?? "reject";
   const stripped = unwrapParens(node);
   if (!ts.isPropertyAccessExpression(stripped)) {
     // Patch 1 scope: ElementAccess lands in Patch 3 (string-literal key
@@ -266,16 +309,24 @@ export function buildL1MemberAccess(
   const receiverNode = unwrapParens(stripped.expression);
   const fieldName = stripped.name.text;
   const receiverType = ctx.checker.getTypeAtLocation(receiverNode);
-  const qualified = qualifyFieldAccess(
+  const qualifiedStrict = qualifyFieldAccess(
     receiverType,
     fieldName,
     ctx.checker,
     ctx.strategy,
     ctx.supply.synthCell,
   );
-  if (qualified === null) {
-    // Ambiguous owner — union/intersection members declare this field
-    // on multiple distinct types.
+  let qualified: string;
+  if (qualifiedStrict !== null) {
+    qualified = qualifiedStrict;
+  } else if (ambiguousMode === "bare-kebab") {
+    // Signature-side best-effort: ambiguous union/intersection
+    // owners fall back to the bare kebab'd field name so optional
+    // analyses (guard extraction, call-following) can continue past
+    // an inherently-ambiguous accessor instead of bailing the whole
+    // analysis on a single ambiguous read.
+    qualified = toPantTermName(fieldName);
+  } else {
     return {
       unsupported:
         `property access .${fieldName}: ambiguous owner — ` +
@@ -297,7 +348,7 @@ export function buildL1MemberAccess(
     if (card !== null) {
       receiverL1 = card;
     } else {
-      const inner = buildL1MemberAccess(receiverNode, ctx);
+      const inner = buildL1MemberAccess(receiverNode, ctx, options);
       if (isL1Unsupported(inner)) {
         return inner;
       }

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -464,6 +464,12 @@ export function isL1ConditionalForm(
   node: ts.Node,
   checker: ts.TypeChecker,
 ): boolean {
+  // Mirror `buildL1Conditional`'s entry-point paren-strip so a
+  // parenthesized conditional (`(c ? a : b)`, `(g && h)`) classifies
+  // identically to its unwrapped form. Body-side callers already
+  // pre-strip via `unwrapExpression`, but defensive normalization
+  // keeps the recognizer self-contained for any future caller.
+  node = unwrapParens(node);
   if (
     ts.isConditionalExpression(node) ||
     ts.isIfStatement(node) ||

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -8,10 +8,12 @@ import {
   buildL1Conditional,
   buildL1ConditionalFromArms,
   buildL1LetWhile,
+  buildL1MemberAccess,
   isL1ConditionalForm,
   isL1StmtUnsupported,
   isL1Unsupported,
   lowerL1ToOpaque,
+  tryBuildL1Cardinality,
   tryRecognizeFunctorLift,
 } from "./ir1-build.js";
 import {
@@ -2771,30 +2773,19 @@ export function translateBodyExpr(
     return { expr: lowerL1ToOpaque(l1) };
   }
 
-  // Property access with special array operations
+  // Property access. Dispatch order:
+  //   (1) Optional chain → functor-lift via comprehension (legacy path;
+  //       M5 doesn't touch ?.).
+  //   (2) Cardinality (`.length` / `.size` on list-shaped types) →
+  //       L1 `Unop(card, x)`. Pant's primitive for cardinality is
+  //       `#x`, not a `length` / `size` rule application — routing
+  //       through Member would emit a dangling EUF rule. Fires before
+  //       Member dispatch.
+  //   (3) Plain (non-optional) property access → canonical L1 Member.
+  //       The lowering at `ir1-lower.ts` produces `App(qualifiedRule,
+  //       [receiver])` — byte-equal to the legacy direct construction.
   if (ts.isPropertyAccessExpression(expr)) {
     const prop = expr.name.text;
-    const obj = translateBodyExpr(
-      expr.expression,
-      checker,
-      strategy,
-      paramNames,
-      state,
-      supply,
-    );
-    if (isBodyUnsupported(obj)) {
-      return obj;
-    }
-    // Optional chain `x?.prop` under list-lift. With `x: [T]` on the Pant
-    // side, the functor-lift encoding is `each $n in x | prop $n`, giving
-    // `[U]` — empty when x is null/empty, singleton when x is present.
-    // Chains compose as nested comprehensions: TS parses `x?.a.b` as outer
-    // `.b` (no questionDotToken) wrapping inner `x?.a` (questionDotToken),
-    // with the outer tail marked by `NodeFlags.OptionalChain`. Lift at the
-    // tail too, so `x?.a.b` becomes `each $n' in (each $n in x | a $n) | b $n'`
-    // rather than falling through to a plain property access on the list-
-    // lifted receiver. When the receiver is not nullable in TS, `?.`
-    // degenerates to `.` and falls through.
     const inOptionalChain = (expr.flags & ts.NodeFlags.OptionalChain) !== 0;
     if (inOptionalChain) {
       let shouldLift = false;
@@ -2805,10 +2796,17 @@ export function translateBodyExpr(
         shouldLift = true;
       }
       if (shouldLift) {
-        // Qualify the accessor by the receiver's element type so the
-        // comprehension body matches the declaration-site rule emitted by
-        // translateTypes. `resolveFieldOwner` walks union members, so a
-        // nullable receiver like `Account | null` resolves to `Account`.
+        const obj = translateBodyExpr(
+          expr.expression,
+          checker,
+          strategy,
+          paramNames,
+          state,
+          supply,
+        );
+        if (isBodyUnsupported(obj)) {
+          return obj;
+        }
         const receiverTsType = checker.getTypeAtLocation(expr.expression);
         const ruleName = qualifyFieldAccess(
           receiverTsType,
@@ -2829,43 +2827,25 @@ export function translateBodyExpr(
           ),
         };
       }
+      // Receiver isn't actually nullable in TS — `?.` degenerates to
+      // `.`; fall through to cardinality / Member dispatch.
     }
-    // .length (array) / .size (Set) -> #obj
-    if (prop === "length" || prop === "size") {
-      const receiverType = checker.getTypeAtLocation(expr.expression);
-      const isArray = prop === "length" && checker.isArrayType(receiverType);
-      const isSet = prop === "size" && isSetType(receiverType);
-      if (isArray || isSet) {
-        return { expr: ast.unop(ast.opCard(), bodyExpr(obj)) };
-      }
-    }
-    // Qualify the rule symbol by the receiver's interface, matching the
-    // declaration-site emission in translateTypes. Symbolic-state keys use
-    // the qualified form too so writes and reads hash under the same key.
-    const receiverType = checker.getTypeAtLocation(expr.expression);
-    const ruleName = qualifyFieldAccess(
-      receiverType,
-      prop,
+    const l1Ctx = {
       checker,
       strategy,
-      supply.synthCell,
-    );
-    if (ruleName === null) {
-      return { unsupported: ambiguousFieldMsg(prop) };
+      paramNames,
+      state,
+      supply,
+    };
+    const card = tryBuildL1Cardinality(expr, l1Ctx);
+    if (card !== null) {
+      return { expr: lowerL1ToOpaque(card) };
     }
-    // Consult symbolic state for a prior write at this location. Apply the
-    // same canonicalization as the write site (see SymbolicState) so that
-    // reads through const aliases hit the prior write — e.g.,
-    // `const x = a; x.balance = 1; x.balance += 2` must see the `= 1` write
-    // under a key that matches both the read and the write.
-    if (state !== undefined) {
-      const key = symbolicKey(ruleName, state.canonicalize(bodyExpr(obj)));
-      const entry = state.writes.get(key);
-      if (entry !== undefined && entry.kind === "property") {
-        return { expr: entry.value };
-      }
+    const member = buildL1MemberAccess(expr, l1Ctx);
+    if ("unsupported" in member) {
+      return member;
     }
-    return { expr: ast.app(ast.var(ruleName), [bodyExpr(obj)]) };
+    return { expr: lowerL1ToOpaque(member) };
   }
 
   // Call expression: handle .includes(), .filter().map(), etc.

--- a/tools/ts2pant/src/translate-signature.ts
+++ b/tools/ts2pant/src/translate-signature.ts
@@ -953,8 +953,23 @@ export function translateExpr(
     // of the *optional* analysis — so a strict reject here would
     // unnecessarily skip surrounding guards that translate fine. The
     // body-side path keeps the strict default.
+    //
+    // Receiver leaf (the non-property bottom of the chain) goes
+    // through `translateExpr` (signature-side) instead of
+    // `translateBodyExpr` so the receiver inherits signature-only
+    // operator surface — loose-eq rejection, transparent
+    // `as`/`!`/`satisfies` unwrapping — and skips body-only branches
+    // (chain fusion, Map/Set effects, optional-chain functor lift)
+    // that aren't appropriate inside guard analysis.
     const member = buildL1MemberAccess(expr, l1Ctx, {
       ambiguousOwnerFallback: "bare-kebab",
+      translateReceiverLeaf: (e) => {
+        const r = translateExpr(e, checker, _strategy, paramNames, synthCell);
+        if (isTranslateExprUnsupported(r)) {
+          return { kind: "unsupported", reason: r.unsupported };
+        }
+        return { kind: "expr", expr: r };
+      },
     });
     if ("unsupported" in member) {
       return member;

--- a/tools/ts2pant/src/translate-signature.ts
+++ b/tools/ts2pant/src/translate-signature.ts
@@ -4,8 +4,10 @@ import { irWrap } from "./ir.js";
 import { lowerExpr } from "./ir-emit.js";
 import { ir1FromL2 } from "./ir1.js";
 import {
+  type BuildL1MemberAccessOptions,
   buildL1MemberAccess,
   type L1BuildContext,
+  tryBuildL1Cardinality,
   unwrapParens,
 } from "./ir1-build.js";
 import { lowerL1Expr } from "./ir1-lower.js";
@@ -929,11 +931,16 @@ export function translateExpr(
 ): TranslateExprResult {
   const ast = getAst();
 
-  // M5: plain (non-optional) property access routes through L1 Member.
-  // The lowered shape is byte-equal to the legacy
-  // `app(var(qualifiedRule), [obj])` construction; this cutover
-  // canonicalizes the build path. Optional-chain access and
-  // ElementAccess fall through to the rest of the dispatch.
+  // M5: plain (non-optional) property access dispatches cardinality
+  // first (`xs.length` / `m.size` on list-shaped TS types → L1
+  // `Unop(card, x)`, lowered to `#x`), then falls through to L1
+  // Member. Pre-cutover the signature path emitted `length xs` /
+  // `size m` as opaque EUF rule applications — solver couldn't see
+  // them as cardinality. Routing through `tryBuildL1Cardinality`
+  // makes signature guards see the same `#x` primitive that body and
+  // pure paths now produce, satisfying spec invariant 8 universally.
+  // Optional-chain access and ElementAccess fall through to the rest
+  // of the dispatch.
   if (
     ts.isPropertyAccessExpression(expr) &&
     (expr.flags & ts.NodeFlags.OptionalChain) === 0
@@ -945,23 +952,18 @@ export function translateExpr(
       state: undefined,
       supply: { n: 0, synthCell },
     };
-    // Signature-side best-effort: ambiguous union/intersection owners
-    // fall back to the bare kebab'd field name rather than rejecting
-    // the entire translation. `translateExpr`'s callers
-    // (`extractAssertionGuard`, `buildSubstitutionMap`,
-    // `tryTranslateGuardExpr`) treat any `unsupported` as a hard bail
-    // of the *optional* analysis — so a strict reject here would
-    // unnecessarily skip surrounding guards that translate fine. The
-    // body-side path keeps the strict default.
-    //
-    // Receiver leaf (the non-property bottom of the chain) goes
-    // through `translateExpr` (signature-side) instead of
-    // `translateBodyExpr` so the receiver inherits signature-only
-    // operator surface — loose-eq rejection, transparent
-    // `as`/`!`/`satisfies` unwrapping — and skips body-only branches
-    // (chain fusion, Map/Set effects, optional-chain functor lift)
-    // that aren't appropriate inside guard analysis.
-    const member = buildL1MemberAccess(expr, l1Ctx, {
+    // Signature-side options shared between cardinality and Member:
+    // - `ambiguousOwnerFallback: "bare-kebab"` keeps optional analyses
+    //   (guard extraction, call-following) from bailing on a single
+    //   ambiguous union/intersection accessor; `translateExpr`'s
+    //   callers treat unsupported as a hard bail.
+    // - `translateReceiverLeaf` routes the non-property leaf through
+    //   `translateExpr` (signature-side) so the receiver inherits
+    //   signature-only operator surface — loose-eq rejection,
+    //   transparent `as`/`!`/`satisfies` unwrapping — and skips
+    //   body-only branches (chain fusion, Map/Set effects,
+    //   optional-chain functor lift) inappropriate inside guards.
+    const sigOptions: BuildL1MemberAccessOptions = {
       ambiguousOwnerFallback: "bare-kebab",
       translateReceiverLeaf: (e) => {
         const r = translateExpr(e, checker, _strategy, paramNames, synthCell);
@@ -970,7 +972,12 @@ export function translateExpr(
         }
         return { kind: "expr", expr: r };
       },
-    });
+    };
+    const card = tryBuildL1Cardinality(expr, l1Ctx, sigOptions);
+    if (card !== null) {
+      return lowerExpr(lowerL1Expr(card));
+    }
+    const member = buildL1MemberAccess(expr, l1Ctx, sigOptions);
     if ("unsupported" in member) {
       return member;
     }

--- a/tools/ts2pant/src/translate-signature.ts
+++ b/tools/ts2pant/src/translate-signature.ts
@@ -945,7 +945,17 @@ export function translateExpr(
       state: undefined,
       supply: { n: 0, synthCell },
     };
-    const member = buildL1MemberAccess(expr, l1Ctx);
+    // Signature-side best-effort: ambiguous union/intersection owners
+    // fall back to the bare kebab'd field name rather than rejecting
+    // the entire translation. `translateExpr`'s callers
+    // (`extractAssertionGuard`, `buildSubstitutionMap`,
+    // `tryTranslateGuardExpr`) treat any `unsupported` as a hard bail
+    // of the *optional* analysis — so a strict reject here would
+    // unnecessarily skip surrounding guards that translate fine. The
+    // body-side path keeps the strict default.
+    const member = buildL1MemberAccess(expr, l1Ctx, {
+      ambiguousOwnerFallback: "bare-kebab",
+    });
     if ("unsupported" in member) {
       return member;
     }

--- a/tools/ts2pant/src/translate-signature.ts
+++ b/tools/ts2pant/src/translate-signature.ts
@@ -3,6 +3,11 @@ import ts from "typescript";
 import { irWrap } from "./ir.js";
 import { lowerExpr } from "./ir-emit.js";
 import { ir1FromL2 } from "./ir1.js";
+import {
+  buildL1MemberAccess,
+  type L1BuildContext,
+  unwrapParens,
+} from "./ir1-build.js";
 import { lowerL1Expr } from "./ir1-lower.js";
 import {
   type NullishTranslate,
@@ -13,11 +18,9 @@ import { getAst } from "./pant-wasm.js";
 import {
   cellIsUsed,
   cellRegisterName,
-  fieldRuleName,
   isMapType,
   mapTsType,
   type NumericStrategy,
-  resolveFieldOwner,
   type SynthCell,
   toPantTermName,
 } from "./translate-types.js";
@@ -880,38 +883,6 @@ export function detectGuard(
   return guards.reduce((acc, g) => ast.binop(ast.opAnd(), acc, g));
 }
 
-/** Resolve a receiver type to the owner name that declares [fieldName],
- *  then qualify via [fieldRuleName]. Delegates to `resolveFieldOwner`,
- *  which walks the property-declaration chain (handles inheritance) and
- *  aggregates distinct owners across union/intersection members. When
- *  ambiguous (>1 distinct owner), falls back to the bare kebab'd field
- *  name — the guard-extraction path here is an *optional* analysis
- *  (`detectGuard` returns `undefined` if no guard is extractable), so a
- *  bare fallback simply means the would-be guard never fires instead
- *  of producing a silently wrong qualified symbol. The body-side
- *  `qualifyFieldAccess` is stricter (returns null for ambiguous) because
- *  its output is an identifier in emitted propositions, not a hint for
- *  an optional analysis. */
-function qualifyFieldAccess(
-  receiverType: ts.Type,
-  fieldName: string,
-  checker: ts.TypeChecker,
-  strategy: NumericStrategy,
-  synthCell?: SynthCell,
-): string {
-  const r = resolveFieldOwner(
-    receiverType,
-    fieldName,
-    checker,
-    strategy,
-    synthCell,
-  );
-  if (r.kind === "resolved") {
-    return fieldRuleName(r.owner, fieldName);
-  }
-  return toPantTermName(fieldName);
-}
-
 function blockThrows(node: ts.Statement): boolean {
   if (ts.isThrowStatement(node)) {
     return true;
@@ -958,26 +929,38 @@ export function translateExpr(
 ): TranslateExprResult {
   const ast = getAst();
 
-  // Property access: a.balance -> app(var("account-balance"), [obj])
-  if (ts.isPropertyAccessExpression(expr)) {
-    const obj = translateExpr(
-      expr.expression,
+  // M5: plain (non-optional) property access routes through L1 Member.
+  // The lowered shape is byte-equal to the legacy
+  // `app(var(qualifiedRule), [obj])` construction; this cutover
+  // canonicalizes the build path. Optional-chain access and
+  // ElementAccess fall through to the rest of the dispatch.
+  if (
+    ts.isPropertyAccessExpression(expr) &&
+    (expr.flags & ts.NodeFlags.OptionalChain) === 0
+  ) {
+    const l1Ctx: L1BuildContext = {
       checker,
-      _strategy,
+      strategy: _strategy,
       paramNames,
-      synthCell,
-    );
-    if (isTranslateExprUnsupported(obj)) {
-      return obj;
+      state: undefined,
+      supply: { n: 0, synthCell },
+    };
+    const member = buildL1MemberAccess(expr, l1Ctx);
+    if ("unsupported" in member) {
+      return member;
     }
-    const ruleName = qualifyFieldAccess(
-      checker.getTypeAtLocation(expr.expression),
-      expr.name.text,
-      checker,
-      _strategy,
-      synthCell,
-    );
-    return ast.app(ast.var(ruleName), [obj]);
+    return lowerExpr(lowerL1Expr(member));
+  }
+  // Defensively unwrap parens for the paren-stripping invariant — a
+  // paren-wrapped property access (`(a).b`) routes through the same
+  // Member dispatch as `a.b`.
+  const stripped = unwrapParens(expr) as ts.Expression;
+  if (
+    stripped !== expr &&
+    ts.isPropertyAccessExpression(stripped) &&
+    (stripped.flags & ts.NodeFlags.OptionalChain) === 0
+  ) {
+    return translateExpr(stripped, checker, _strategy, paramNames, synthCell);
   }
 
   // Binary expression: a >= b -> binop(opGe(), a, b)

--- a/tools/ts2pant/tests/ir1-build-cardinality.test.mts
+++ b/tools/ts2pant/tests/ir1-build-cardinality.test.mts
@@ -1,0 +1,163 @@
+/**
+ * Unit tests for the M5 Patch 1 cardinality dispatch
+ * (`tryBuildL1Cardinality` in `src/ir1-build.ts`).
+ *
+ * Cardinality is a deliberate non-Member dispatch: Pant's primitive for
+ * list cardinality is `#x` (`Unop(card, x)`), not a `length` / `size`
+ * rule application. Routing through Member would emit `length arr` —
+ * an EUF rule application distinct from `#arr`. The build pass tries
+ * cardinality recognition before Member dispatch for the six
+ * list-shaped TS types.
+ *
+ * Coverage list: `Array.length`, `ReadonlyArray.length`, `Set.size`,
+ * `ReadonlySet.size`, `Map.size`, `ReadonlyMap.size`. User-typed
+ * `.length` on a non-list interface and optional-chain `.length`
+ * fall through to Member.
+ */
+
+import assert from "node:assert/strict";
+import { before, describe, it } from "node:test";
+import ts from "typescript";
+import { createSourceFileFromSource, getChecker } from "../src/extract.js";
+import {
+  type L1BuildContext,
+  tryBuildL1Cardinality,
+} from "../src/ir1-build.js";
+import type { IR1Expr } from "../src/ir1.js";
+import { loadAst } from "../src/pant-wasm.js";
+import {
+  type UniqueSupply,
+} from "../src/translate-body.js";
+import {
+  cellRegisterName,
+  IntStrategy,
+  newSynthCell,
+  toPantTermName,
+} from "../src/translate-types.js";
+
+before(async () => {
+  await loadAst();
+});
+
+interface AccessSetup {
+  node: ts.PropertyAccessExpression;
+  ctx: L1BuildContext;
+}
+
+/**
+ * Parse a function declaration whose body is a single
+ * `return EXPR;` where `EXPR` is the property access we want to
+ * exercise. Builds the production-style param scope.
+ */
+function setup(source: string): AccessSetup {
+  const sourceFile = createSourceFileFromSource(source);
+  const checker = getChecker(sourceFile);
+  const fn = sourceFile.compilerNode.statements.find(ts.isFunctionDeclaration);
+  if (!fn || !fn.body) {
+    throw new Error("setup: expected function declaration with a body");
+  }
+  const synthCell = newSynthCell();
+  const paramNames = new Map<string, string>();
+  for (const p of fn.parameters) {
+    if (ts.isIdentifier(p.name)) {
+      paramNames.set(
+        p.name.text,
+        cellRegisterName(synthCell, toPantTermName(p.name.text)),
+      );
+    }
+  }
+  const supply: UniqueSupply = { n: 0, synthCell };
+  const ctx: L1BuildContext = {
+    checker,
+    strategy: IntStrategy,
+    paramNames,
+    state: undefined,
+    supply,
+  };
+  const stmt = fn.body.statements[0];
+  if (!stmt || !ts.isReturnStatement(stmt) || !stmt.expression) {
+    throw new Error("setup: expected return statement");
+  }
+  if (!ts.isPropertyAccessExpression(stmt.expression)) {
+    throw new Error(
+      `setup: expected PropertyAccess, got ${ts.SyntaxKind[stmt.expression.kind]}`,
+    );
+  }
+  return { node: stmt.expression, ctx };
+}
+
+function expectCardUnop(result: IR1Expr | null): void {
+  assert.notEqual(result, null, "expected Unop(card, _), got null");
+  if (result === null) return;
+  assert.equal(result.kind, "unop");
+  if (result.kind === "unop") {
+    assert.equal(result.op, "card");
+  }
+}
+
+describe("ir1-build-cardinality", () => {
+  it("Array.length builds Unop(card)", () => {
+    const { node, ctx } = setup(
+      `function f(xs: number[]): number { return xs.length; }`,
+    );
+    expectCardUnop(tryBuildL1Cardinality(node, ctx));
+  });
+
+  it("ReadonlyArray.length builds Unop(card)", () => {
+    const { node, ctx } = setup(
+      `function f(xs: ReadonlyArray<number>): number { return xs.length; }`,
+    );
+    expectCardUnop(tryBuildL1Cardinality(node, ctx));
+  });
+
+  it("Set.size builds Unop(card)", () => {
+    const { node, ctx } = setup(
+      `function f(xs: Set<number>): number { return xs.size; }`,
+    );
+    expectCardUnop(tryBuildL1Cardinality(node, ctx));
+  });
+
+  it("ReadonlySet.size builds Unop(card)", () => {
+    const { node, ctx } = setup(
+      `function f(xs: ReadonlySet<number>): number { return xs.size; }`,
+    );
+    expectCardUnop(tryBuildL1Cardinality(node, ctx));
+  });
+
+  it("Map.size builds Unop(card)", () => {
+    const { node, ctx } = setup(
+      `function f(m: Map<string, number>): number { return m.size; }`,
+    );
+    expectCardUnop(tryBuildL1Cardinality(node, ctx));
+  });
+
+  it("ReadonlyMap.size builds Unop(card)", () => {
+    const { node, ctx } = setup(
+      `function f(m: ReadonlyMap<string, number>): number { return m.size; }`,
+    );
+    expectCardUnop(tryBuildL1Cardinality(node, ctx));
+  });
+
+  it("user-typed .length on a non-list interface falls through to Member", () => {
+    // `User.length` is a regular field, not array cardinality.
+    // `tryBuildL1Cardinality` must return null here so the Member
+    // dispatch handles it. A regression that matched on field name
+    // alone would mis-emit `#u` for a structural field read.
+    const { node, ctx } = setup(
+      `interface User { readonly length: number; }
+       function f(u: User): number { return u.length; }`,
+    );
+    assert.equal(tryBuildL1Cardinality(node, ctx), null);
+  });
+
+  it("optional-chain .length is not short-circuited (preserves ?. semantics)", () => {
+    // `xs?.length` short-circuits to undefined when xs is null;
+    // collapsing to `#xs` would silently change semantics. The
+    // recognizer must reject so the optional-chain handler in
+    // `translateBodyExpr` builds the correct functor-lift.
+    const { node, ctx } = setup(
+      `function f(xs: number[] | null): number | undefined { return xs?.length; }`,
+    );
+    assert.equal(tryBuildL1Cardinality(node, ctx), null);
+  });
+});

--- a/tools/ts2pant/tests/ir1-build-parens.test.mts
+++ b/tools/ts2pant/tests/ir1-build-parens.test.mts
@@ -1,0 +1,184 @@
+/**
+ * Unit tests for the M5 Patch 1 universal L1-layering paren-stripping
+ * invariant. The principle: `(e)` and `e` build to identical L1 trees
+ * for every L1 form, so downstream recognizers don't re-implement the
+ * strip themselves.
+ *
+ * Each test runs a paren-wrapped expression and an unwrapped reference
+ * through the L1 build pipeline (or its surface-level entry point) and
+ * asserts the lowered OpaqueExpr texts match. We compare lowered texts
+ * rather than IR shape because some L1 paths route through legacy
+ * via `from-l2`; the lowered text is the observable byte-for-byte
+ * canonical form.
+ *
+ * Type-erasure wrappers (`as T`, `!`, `<T>x`, `satisfies`) are NOT
+ * paren-equivalent — they change the TS-checker type at the AST node
+ * and are intentionally left to the standard build path. This file
+ * does not test paren-stripping THROUGH those wrappers.
+ */
+
+import assert from "node:assert/strict";
+import { before, describe, it } from "node:test";
+import ts from "typescript";
+import { createSourceFileFromSource, getChecker } from "../src/extract.js";
+import { lowerExpr } from "../src/ir-emit.js";
+import {
+  buildL1Conditional,
+  isL1Unsupported,
+  lowerL1ToOpaque,
+} from "../src/ir1-build.js";
+import { getAst, loadAst } from "../src/pant-wasm.js";
+import {
+  type UniqueSupply,
+} from "../src/translate-body.js";
+import {
+  cellRegisterName,
+  IntStrategy,
+  newSynthCell,
+  toPantTermName,
+} from "../src/translate-types.js";
+
+before(async () => {
+  await loadAst();
+});
+
+interface CondSetup {
+  expr: ts.ConditionalExpression;
+  ctx: {
+    checker: ts.TypeChecker;
+    strategy: typeof IntStrategy;
+    paramNames: ReadonlyMap<string, string>;
+    state: undefined;
+    supply: UniqueSupply;
+  };
+}
+
+/**
+ * Parse a function declaration and extract its single
+ * `ConditionalExpression` from `return (cond) ? a : b;`. Builds the
+ * production-style param-name allocation through `synthCell` so the
+ * test exercises the real Pant-name scope.
+ */
+function setupCond(source: string): CondSetup {
+  const sourceFile = createSourceFileFromSource(source);
+  const checker = getChecker(sourceFile);
+  const fn = sourceFile.compilerNode.statements.find(ts.isFunctionDeclaration);
+  if (!fn || !fn.body) {
+    throw new Error("setupCond: expected function declaration with a body");
+  }
+  const synthCell = newSynthCell();
+  const paramNames = new Map<string, string>();
+  for (const p of fn.parameters) {
+    if (ts.isIdentifier(p.name)) {
+      paramNames.set(
+        p.name.text,
+        cellRegisterName(synthCell, toPantTermName(p.name.text)),
+      );
+    }
+  }
+  const supply: UniqueSupply = { n: 0, synthCell };
+  const ctx = {
+    checker,
+    strategy: IntStrategy,
+    paramNames,
+    state: undefined,
+    supply,
+  };
+  const stmt = fn.body.statements[0];
+  if (!stmt || !ts.isReturnStatement(stmt) || !stmt.expression) {
+    throw new Error("setupCond: expected return statement with expression");
+  }
+  let expr: ts.Expression = stmt.expression;
+  while (ts.isParenthesizedExpression(expr)) {
+    // For tests that wrap the entire ternary in parens, descend so the
+    // returned candidate is the inner ConditionalExpression. The test
+    // then re-wraps and compares the build outputs at a known level.
+    expr = expr.expression;
+  }
+  if (!ts.isConditionalExpression(expr)) {
+    throw new Error(
+      `setupCond: expected ConditionalExpression at body root, got ${ts.SyntaxKind[expr.kind]}`,
+    );
+  }
+  return { expr, ctx };
+}
+
+/** Lower an L1 build result and stringify the OpaqueExpr. */
+function lowerToText(
+  result: ReturnType<typeof buildL1Conditional>,
+): string {
+  if (isL1Unsupported(result)) {
+    throw new Error(
+      `expected L1 expression, got unsupported: ${result.unsupported}`,
+    );
+  }
+  return getAst().strExpr(lowerL1ToOpaque(result));
+}
+
+describe("ir1-build-parens", () => {
+  it("parenthesized binop strips to identical L1 binop", () => {
+    // `(x + 1) > 0` and `x + 1 > 0` build to identical L1 conds when
+    // each appears in a value-position ternary guard. The conditional
+    // dispatcher unwraps the guard via `buildSubExpr`, which strips
+    // parens at the L1 build entry. A regression that didn't strip
+    // would route the paren-wrapped binop differently — observable
+    // as a divergent lowered text.
+    const bare = setupCond(
+      `function f(x: number): number {
+         return x + 1 > 0 ? 1 : 0;
+       }`,
+    );
+    const paren = setupCond(
+      `function f(x: number): number {
+         return (x + 1) > 0 ? 1 : 0;
+       }`,
+    );
+    assert.equal(
+      lowerToText(buildL1Conditional(paren.expr, paren.ctx)),
+      lowerToText(buildL1Conditional(bare.expr, bare.ctx)),
+    );
+  });
+
+  it("nested parens around var build identical L1 var", () => {
+    // `((x))` and `x` are operationally indistinguishable; both reach
+    // the same Var lowering through the cond dispatcher's sub-expr
+    // path. Use a ternary with a Bool param so the value-position
+    // arm receives the (parenthesized or bare) var directly.
+    const bare = setupCond(
+      `function f(x: number, b: boolean): number {
+         return b ? x : 0;
+       }`,
+    );
+    const paren = setupCond(
+      `function f(x: number, b: boolean): number {
+         return b ? ((x)) : 0;
+       }`,
+    );
+    assert.equal(
+      lowerToText(buildL1Conditional(paren.expr, paren.ctx)),
+      lowerToText(buildL1Conditional(bare.expr, bare.ctx)),
+    );
+  });
+
+  it("parenthesized conditional strips to identical L1 cond", () => {
+    // The conditional dispatcher itself strips parens at entry, so
+    // `(b ? a : c)` and `b ? a : c` produce identical lowered output
+    // when handed to `buildL1Conditional`. Constructing an outer
+    // ternary that wraps the inner gives both forms a comparable
+    // structural anchor.
+    const bare = setupCond(
+      `function f(b: boolean, c: boolean, x: number, y: number): number {
+         return b ? (c ? x : y) : 0;
+       }`,
+    );
+    const paren = setupCond(
+      `function f(b: boolean, c: boolean, x: number, y: number): number {
+         return b ? ((c ? x : y)) : 0;
+       }`,
+    );
+    assert.equal(
+      lowerToText(buildL1Conditional(paren.expr, paren.ctx)),
+      lowerToText(buildL1Conditional(bare.expr, bare.ctx)),
+    );
+  });
+});

--- a/tools/ts2pant/tests/ir1-build-property-state.test.mts
+++ b/tools/ts2pant/tests/ir1-build-property-state.test.mts
@@ -1,0 +1,119 @@
+/**
+ * Regression tests for symbolic-state lookup preservation across the
+ * M5 P1 property-access cutover.
+ *
+ * The body-position dispatch routes property reads through
+ * `buildL1MemberAccess` (and `tryBuildL1Cardinality` for `.length` /
+ * `.size`). Both paths must consult `state.writes` so that staged
+ * writes from earlier statements in the same mutating body are
+ * visible on subsequent reads — otherwise `a.balance = 1; a.balance =
+ * a.balance + 2;` would emit `balance' a = balance a + 2` instead of
+ * `balance' a = 1 + 2`. This file pins the read-through-writes
+ * behavior end-to-end via `translateBody`.
+ */
+
+import assert from "node:assert/strict";
+import { before, describe, it } from "node:test";
+import { createSourceFileFromSource } from "../src/extract.js";
+import { getAst, loadAst } from "../src/pant-wasm.js";
+import { translateBody } from "../src/translate-body.js";
+import { IntStrategy } from "../src/translate-types.js";
+
+before(async () => {
+  await loadAst();
+});
+
+interface EquationProp {
+  kind: "equation";
+  lhs: unknown;
+  rhs: unknown;
+}
+
+function translate(source: string, fnName: string): EquationProp[] {
+  const sf = createSourceFileFromSource(source);
+  // Standalone path: omit `synthCell` so `translateBody` allocates a
+  // fresh internal one. The signature pass isn't needed because the
+  // body translator independently builds its own param map.
+  const props = translateBody({
+    sourceFile: sf,
+    functionName: fnName,
+    strategy: IntStrategy,
+    declarations: [],
+  });
+  return props.filter((p): p is EquationProp => p.kind === "equation");
+}
+
+function eqText(p: EquationProp): { lhs: string; rhs: string } {
+  const ast = getAst();
+  return {
+    lhs: ast.strExpr(p.lhs as never),
+    rhs: ast.strExpr(p.rhs as never),
+  };
+}
+
+describe("ir1-build-property state preservation", () => {
+  it("plain assignment then read sees the staged value", () => {
+    // a.balance = 1;
+    // a.balance = a.balance + 2;
+    //
+    // The second statement's RHS must read the staged `1`, not the
+    // pre-state accessor `account--balance a`.
+    const eqs = translate(
+      `interface Account { readonly balance: number; }
+       export function f(a: Account): void {
+         a.balance = 1;
+         a.balance = a.balance + 2;
+       }`,
+      "f",
+    );
+    assert.equal(eqs.length, 1, "expected one balance' equation");
+    const { lhs, rhs } = eqText(eqs[0]!);
+    assert.match(lhs, /balance' a/u, `lhs should be primed accessor: ${lhs}`);
+    assert.equal(
+      rhs,
+      "1 + 2",
+      `expected staged 1 to be visible on RHS, got pre-state read: ${rhs}`,
+    );
+  });
+
+  it("compound += desugars and sees the staged value", () => {
+    // a.balance = 1;
+    // a.balance += 2;        // desugars to a.balance = a.balance + 2;
+    const eqs = translate(
+      `interface Account { readonly balance: number; }
+       export function f(a: Account): void {
+         a.balance = 1;
+         a.balance += 2;
+       }`,
+      "f",
+    );
+    assert.equal(eqs.length, 1);
+    const { rhs } = eqText(eqs[0]!);
+    assert.equal(rhs, "1 + 2");
+  });
+
+  it("cardinality reads the staged array value", () => {
+    // a.items = xs;
+    // a.count = a.items.length;
+    //
+    // The second statement's RHS computes `#xs` (cardinality of the
+    // staged value), not `#(items a)` (pre-state accessor through
+    // `length` rule application). This exercises both the Member
+    // dispatch (for `a.items`) and the cardinality dispatch (for the
+    // outer `.length`).
+    const eqs = translate(
+      `interface Bag { readonly count: number; readonly items: number[]; }
+       export function f(a: Bag, xs: number[]): void {
+         a.items = xs;
+         a.count = a.items.length;
+       }`,
+      "f",
+    );
+    // Two equations: items' a = xs, and count' a = #xs.
+    const countEq = eqs.find((p) => /count' a/u.test(eqText(p).lhs));
+    assert.ok(countEq, "expected count' equation");
+    if (countEq) {
+      assert.equal(eqText(countEq).rhs, "#xs");
+    }
+  });
+});

--- a/tools/ts2pant/tests/ir1-build-property.test.mts
+++ b/tools/ts2pant/tests/ir1-build-property.test.mts
@@ -249,6 +249,41 @@ describe("ir1-build-property", () => {
     assert.equal(name, "id");
   });
 
+  it("custom translateReceiverLeaf is honored over translateBodyExpr", () => {
+    // Signature path threads its own `translateExpr`-based leaf
+    // translator so `a.balance` in a guard goes through the
+    // signature-side dispatch rather than the body-side one.
+    // Verify the helper actually invokes the callback for the leaf
+    // (the non-property bottom of the receiver chain) — and not for
+    // intermediate Member levels, which still use Member recursion.
+    const { node, ctx } = setup(
+      `interface Account { readonly balance: number; }
+       function f(a: Account): number {
+         return a.balance;
+       }`,
+    );
+    const ast = getAst();
+    let calls = 0;
+    const result = buildL1MemberAccess(node, ctx, {
+      translateReceiverLeaf: (leaf) => {
+        calls++;
+        // Sanity: the leaf is the identifier `a`, not the whole
+        // `a.balance` expression.
+        assert.ok(ts.isIdentifier(leaf), "leaf should be the bare identifier");
+        return { kind: "expr", expr: ast.var("custom-leaf") };
+      },
+    });
+    assert.equal(calls, 1, "translateReceiverLeaf should fire exactly once");
+    const { receiver, name } = expectMember(result);
+    assert.equal(name, "account--balance");
+    // The receiver is the from-l2-wrapped opaque produced by the
+    // callback. Lower and check the marker name.
+    const lowered = ast.strExpr(
+      lowerExpr(lowerL1Expr(receiver as IR1Expr)),
+    );
+    assert.equal(lowered, "custom-leaf");
+  });
+
   it("type-erasure wrapper is not stripped", () => {
     // `(a as A).owner` must NOT strip the `as A` cast — the cast is
     // load-bearing for the TS-checker type used by `qualifyFieldAccess`.

--- a/tools/ts2pant/tests/ir1-build-property.test.mts
+++ b/tools/ts2pant/tests/ir1-build-property.test.mts
@@ -1,0 +1,254 @@
+/**
+ * Unit tests for the M5 Patch 1 property-access L1 builder
+ * (`buildL1MemberAccess` in `src/ir1-build.ts`).
+ *
+ * The builder canonicalizes TS `PropertyAccessExpression` to L1
+ * `Member(receiverL1, qualifiedName)`. The qualified name comes from
+ * `qualifyFieldAccess` — resolved owners qualify to the rule name
+ * (`account-balance`); unresolved-non-ambiguous types fall back to
+ * the bare kebab'd field name; ambiguous unions reject with
+ * `unsupported`.
+ */
+
+import assert from "node:assert/strict";
+import { before, describe, it } from "node:test";
+import ts from "typescript";
+import { createSourceFileFromSource, getChecker } from "../src/extract.js";
+import {
+  buildL1MemberAccess,
+  type L1BuildContext,
+} from "../src/ir1-build.js";
+import type { IR1Expr } from "../src/ir1.js";
+import { lowerExpr } from "../src/ir-emit.js";
+import { lowerL1Expr } from "../src/ir1-lower.js";
+import { getAst, loadAst } from "../src/pant-wasm.js";
+import {
+  qualifyFieldAccess,
+  type UniqueSupply,
+} from "../src/translate-body.js";
+import {
+  cellRegisterName,
+  IntStrategy,
+  newSynthCell,
+  toPantTermName,
+} from "../src/translate-types.js";
+
+before(async () => {
+  await loadAst();
+});
+
+interface PropertyAccessSetup {
+  node: ts.PropertyAccessExpression;
+  ctx: L1BuildContext;
+}
+
+/**
+ * Parse a function declaration, return the single property-access
+ * expression in its `return` statement plus an L1 build context. The
+ * `paramNames` allocation mirrors `translateSignature`'s parameter
+ * registration so the test exercises real Pant-name lookups.
+ */
+function setup(source: string): PropertyAccessSetup {
+  const sourceFile = createSourceFileFromSource(source);
+  const checker = getChecker(sourceFile);
+  const fn = sourceFile.compilerNode.statements.find(ts.isFunctionDeclaration);
+  if (!fn || !fn.body) {
+    throw new Error("setup: expected a function declaration with a body");
+  }
+  const synthCell = newSynthCell();
+  const paramNames = new Map<string, string>();
+  for (const p of fn.parameters) {
+    if (ts.isIdentifier(p.name)) {
+      const pantName = cellRegisterName(synthCell, toPantTermName(p.name.text));
+      paramNames.set(p.name.text, pantName);
+    }
+  }
+  const supply: UniqueSupply = { n: 0, synthCell };
+  const ctx: L1BuildContext = {
+    checker,
+    strategy: IntStrategy,
+    paramNames,
+    state: undefined,
+    supply,
+  };
+  const stmt = fn.body.statements[0];
+  if (!stmt || !ts.isReturnStatement(stmt) || !stmt.expression) {
+    throw new Error("setup: expected a return statement with an expression");
+  }
+  const expr = stmt.expression;
+  if (!ts.isPropertyAccessExpression(expr)) {
+    throw new Error(
+      `setup: expected a PropertyAccessExpression, got ${ts.SyntaxKind[expr.kind]}`,
+    );
+  }
+  return { node: expr, ctx };
+}
+
+function expectMember(result: IR1Expr | { unsupported: string }): {
+  receiver: IR1Expr;
+  name: string;
+} {
+  if ("unsupported" in result) {
+    throw new Error(`expected Member, got unsupported: ${result.unsupported}`);
+  }
+  if (result.kind !== "member") {
+    throw new Error(`expected Member kind, got ${result.kind}`);
+  }
+  return { receiver: result.receiver, name: result.name };
+}
+
+describe("ir1-build-property", () => {
+  it("simple PropertyAccess builds Member", () => {
+    const { node, ctx } = setup(
+      `interface User { readonly name: string; }
+       function f(u: User): string {
+         return u.name;
+       }`,
+    );
+    const result = buildL1MemberAccess(node, ctx);
+    const { receiver, name } = expectMember(result);
+    assert.equal(name, "user--name");
+    // Receiver bottoms out at a non-property node, translated through
+    // legacy and wrapped via from-l2.
+    assert.equal(receiver.kind, "from-l2");
+  });
+
+  it("nested PropertyAccess chain builds nested Member", () => {
+    const { node, ctx } = setup(
+      `interface Owner { readonly name: string; }
+       interface Document { readonly owner: Owner; }
+       function f(d: Document): string {
+         return d.owner.name;
+       }`,
+    );
+    const result = buildL1MemberAccess(node, ctx);
+    const outer = expectMember(result);
+    assert.equal(outer.name, "owner--name");
+    // Inner Member is the receiver — proves the chain composes as
+    // nested Member trees rather than a single flat from-l2 wrap.
+    const inner = expectMember(outer.receiver);
+    assert.equal(inner.name, "document--owner");
+    assert.equal(inner.receiver.kind, "from-l2");
+  });
+
+  it("ambiguous receiver returns unsupported", () => {
+    const { node, ctx } = setup(
+      `interface A { readonly id: number; }
+       interface B { readonly id: number; }
+       function f(x: A | B): number {
+         return x.id;
+       }`,
+    );
+    const result = buildL1MemberAccess(node, ctx);
+    assert.ok(
+      "unsupported" in result,
+      `expected unsupported, got Member: ${JSON.stringify(result)}`,
+    );
+    if ("unsupported" in result) {
+      assert.match(result.unsupported, /ambiguous owner/u);
+    }
+  });
+
+  it("qualifier matches legacy qualifyFieldAccess output", () => {
+    const { node, ctx } = setup(
+      `interface Account { readonly balance: number; }
+       function f(a: Account): number {
+         return a.balance;
+       }`,
+    );
+    const result = buildL1MemberAccess(node, ctx);
+    const { name } = expectMember(result);
+    // The legacy emission always qualified `Account.balance` →
+    // `account-balance`; M5 Member must preserve the qualifier.
+    const legacyQualifier = qualifyFieldAccess(
+      ctx.checker.getTypeAtLocation(node.expression),
+      "balance",
+      ctx.checker,
+      ctx.strategy,
+      ctx.supply.synthCell,
+    );
+    assert.equal(name, legacyQualifier);
+    assert.equal(name, "account--balance");
+  });
+
+  it("parenthesized receiver strips to identical Member", () => {
+    // `(a).owner` must build to the same Member shape as `a.owner` —
+    // the L1-layering paren-stripping invariant for property access.
+    const bare = setup(
+      `interface Owner { readonly name: string; }
+       interface Document { readonly owner: Owner; }
+       function f(d: Document): Owner {
+         return d.owner;
+       }`,
+    );
+    const paren = setup(
+      `interface Owner { readonly name: string; }
+       interface Document { readonly owner: Owner; }
+       function f(d: Document): Owner {
+         return (d).owner;
+       }`,
+    );
+    const bareOpaque = getAst().strExpr(
+      lowerExpr(lowerL1Expr(buildL1MemberAccess(bare.node, bare.ctx) as IR1Expr)),
+    );
+    const parenOpaque = getAst().strExpr(
+      lowerExpr(
+        lowerL1Expr(buildL1MemberAccess(paren.node, paren.ctx) as IR1Expr),
+      ),
+    );
+    assert.equal(parenOpaque, bareOpaque);
+  });
+
+  it("nested parenthesization strips fully", () => {
+    // `((a)).owner` strips through every paren layer.
+    const bare = setup(
+      `interface Owner { readonly name: string; }
+       interface Document { readonly owner: Owner; }
+       function f(d: Document): Owner {
+         return d.owner;
+       }`,
+    );
+    const paren = setup(
+      `interface Owner { readonly name: string; }
+       interface Document { readonly owner: Owner; }
+       function f(d: Document): Owner {
+         return ((d)).owner;
+       }`,
+    );
+    const bareOpaque = getAst().strExpr(
+      lowerExpr(lowerL1Expr(buildL1MemberAccess(bare.node, bare.ctx) as IR1Expr)),
+    );
+    const parenOpaque = getAst().strExpr(
+      lowerExpr(
+        lowerL1Expr(buildL1MemberAccess(paren.node, paren.ctx) as IR1Expr),
+      ),
+    );
+    assert.equal(parenOpaque, bareOpaque);
+  });
+
+  it("type-erasure wrapper is not stripped", () => {
+    // `(a as A).owner` must NOT strip the `as A` cast — the cast is
+    // load-bearing for the TS-checker type used by `qualifyFieldAccess`.
+    // The receiver is an `AsExpression`; the inner expression's
+    // declared type is `unknown` so `qualifyFieldAccess` would not
+    // resolve to `Document`. Stripping would silently change the
+    // qualifier, so the implementation must leave the cast in place.
+    const { node, ctx } = setup(
+      `interface Owner { readonly name: string; }
+       interface Document { readonly owner: Owner; }
+       function f(a: unknown): Owner {
+         return (a as Document).owner;
+       }`,
+    );
+    const result = buildL1MemberAccess(node, ctx);
+    // The receiver of the property access is the `AsExpression` node;
+    // `unwrapParens` does NOT step into it. So `qualifyFieldAccess` is
+    // called with `Document`'s type (the asserted type), producing the
+    // qualified `document-owner` rule — exactly what the user
+    // intended by writing the cast. A stripping regression would
+    // invoke `qualifyFieldAccess` on `unknown` and fall back to the
+    // bare `owner` name, observable as a divergent qualifier here.
+    const { name } = expectMember(result);
+    assert.equal(name, "document--owner");
+  });
+});

--- a/tools/ts2pant/tests/ir1-build-property.test.mts
+++ b/tools/ts2pant/tests/ir1-build-property.test.mts
@@ -226,6 +226,29 @@ describe("ir1-build-property", () => {
     assert.equal(parenOpaque, bareOpaque);
   });
 
+  it("ambiguous receiver under signature-mode falls back to bare kebab", () => {
+    // The signature path consumes ambiguous-owner cases as best-effort
+    // (a deleted local `qualifyFieldAccess` in `translate-signature.ts`
+    // documented this asymmetry). Surface it on the helper itself via
+    // the `ambiguousOwnerFallback: "bare-kebab"` option so downstream
+    // optional analyses (guard extraction) don't bail the whole
+    // analysis on a single ambiguous accessor.
+    const { node, ctx } = setup(
+      `interface A { readonly id: number; }
+       interface B { readonly id: number; }
+       function f(x: A | B): number {
+         return x.id;
+       }`,
+    );
+    const result = buildL1MemberAccess(node, ctx, {
+      ambiguousOwnerFallback: "bare-kebab",
+    });
+    const { name } = expectMember(result);
+    // Bare kebab fallback — `id` -> `id` (no hyphenation needed) but
+    // the canonical reduction of `toPantTermName("id")` is `id`.
+    assert.equal(name, "id");
+  });
+
   it("type-erasure wrapper is not stripped", () => {
     // `(a as A).owner` must NOT strip the `as A` cast — the cast is
     // load-bearing for the TS-checker type used by `qualifyFieldAccess`.

--- a/tools/ts2pant/tests/translate-signature.test.mts
+++ b/tools/ts2pant/tests/translate-signature.test.mts
@@ -284,6 +284,49 @@ describe("guard expression structure", () => {
     );
   });
 
+  it("signature guard with .length lowers to # cardinality (not length-rule)", () => {
+    // Pre-M5 the signature path emitted `length xs` as an opaque
+    // EUF rule application; spec invariant 8 says cardinality is
+    // universal — the signature path now dispatches through
+    // `tryBuildL1Cardinality` so guards see the same `#x`
+    // primitive that body and pure paths produce.
+    const source = `
+      function assert(condition: unknown): asserts condition {
+        if (!condition) throw new Error();
+      }
+      interface Account { balance: number; }
+      function deposit(account: Account, xs: number[]): void {
+        assert(xs.length > 0);
+        account.balance = account.balance + 1;
+      }
+    `;
+    const result = translate(source, "deposit");
+    assert.equal(result.declaration.kind, "action");
+    if (result.declaration.kind !== "action") {
+      return;
+    }
+    assert.equal(getAst().strExpr(result.declaration.guard!), "#xs > 0");
+  });
+
+  it("signature guard with Set .size lowers to # cardinality", () => {
+    const source = `
+      function assert(condition: unknown): asserts condition {
+        if (!condition) throw new Error();
+      }
+      interface Account { balance: number; }
+      function deposit(account: Account, s: Set<number>): void {
+        assert(s.size !== 0);
+        account.balance = account.balance + 1;
+      }
+    `;
+    const result = translate(source, "deposit");
+    assert.equal(result.declaration.kind, "action");
+    if (result.declaration.kind !== "action") {
+      return;
+    }
+    assert.equal(getAst().strExpr(result.declaration.guard!), "#s ~= 0");
+  });
+
   it("ignores non-assertion calls (stops scanning)", () => {
     const source = `
       function log(msg: string): void { console.log(msg); }


### PR DESCRIPTION
## Patch 1: Add buildL1MemberAccess helper; cut over pure-path PropertyAccess sites

- In `tools/ts2pant/src/ir1-build.ts`, add an `unwrapParens(n: ts.Node): ts.Node` helper near the top: `while (ts.isParenthesizedExpression(n)) n = n.expression; return n;`. This is the L1-layering primitive — operationally-equivalent syntactic wrappers must be normalized at L1 build, not at each downstream recognizer. Type-erasure wrappers (`as T`, `!`, `<T>x`, `satisfies`) are NOT stripped — they change the TS-checker type, which would break `qualifyFieldAccess` and other type-dependent dispatch
- Apply `unwrapParens` at the entry of every TS-AST → L1 dispatch in `ir1-build.ts` (and `ir1-build-body.ts` if it has its own dispatch entry): `buildL1Expr(node, ctx)` becomes `node = unwrapParens(node); switch (node.kind) { … }`. Likewise for any per-kind builder that may be called directly bypassing the dispatcher. Effect: `(x + 1)` and `x + 1` produce identical L1 trees; `(if g then a else b)` and `if g then a else b` produce identical trees; `(u).owner` and `u.owner` produce identical Member trees. Universal at L1 build
- In `tools/ts2pant/src/ir1-build.ts`, add `buildL1MemberAccess(node: ts.PropertyAccessExpression | ts.ElementAccessExpression, ctx: L1BuildCtx): IR1Expr | null`. For Patch 1 the implementation handles only `PropertyAccessExpression`; the `ElementAccessExpression` arm lands in Patch 3. Body: defensively call `unwrapParens` on the input node (in case the helper is invoked directly bypassing the dispatcher) — though the dispatcher should have already stripped them. Then: extract `receiverNode = unwrapParens(node.expression)` and `fieldNode = node.name` (PropertyAccess). Get `receiverType = ctx.checker.getTypeAtLocation(receiverNode)`. Call `qualifiedName = qualifyFieldAccess(receiverType, fieldNode.text, ctx.checker, ctx.strategy, ctx.synthCell)`. If `qualifiedName === null` (ambiguous) return null. Recursively build the receiver: `receiverL1 = buildL1Expr(receiverNode, ctx)` (or `ir1FromL2(translateBodyExpr(receiverNode))` for now until receiver-shape audit completes). Return `ir1Member(receiverL1, qualifiedName)`
- Promote the inline `.length` / `.size` cardunop short-circuit at `ir-build.ts:99-121` into a named `tryBuildL1Cardinality(node: ts.Expression, ctx: L1BuildCtx): IR1Expr | null` helper in `ir1-build.ts`. Behavior: returns `irUnop('card', receiverL1)` when `node` is a non-optional-chain `PropertyAccessExpression` whose receiver type matches one of the five list-shaped TS types and the property name matches the cardinality slot for that type. Coverage list: `Array.length`, `ReadonlyArray.length`, `Set.size`, `ReadonlySet.size`, `Map.size`, `ReadonlyMap.size`. Verify via `checker.isArrayType(t)` for arrays, plus a refreshed `isListLikeForCardinality(t)` predicate that also accepts `ReadonlySet` / `ReadonlyMap` (today's `isSetType` may miss `ReadonlySet`; check). Returns null otherwise — caller falls through to `buildL1MemberAccess`
- In `tools/ts2pant/src/ir-build.ts:130-147`, the `PropertyAccessExpression` branch currently calls `qualifyFieldAccess` and constructs `irApp({ kind: 'name', name: ruleName }, [translateExpr(expr.expression, ...)])`. New dispatch order: try `tryBuildL1Cardinality(expr, ctx)` first; on non-null, lower and return. On null, fall through to `buildL1MemberAccess(expr, ctx)`. The cardinality dispatch must precede Member dispatch — Member's lowering would produce a dangling `length arr` rule application, distinct from `#arr` in EUF. Document this as the first-of-many possible non-Member dispatches, sibling to the workstream's IRSC divergence note
- In `tools/ts2pant/src/translate-signature.ts:962-980`, do the same replacement: `PropertyAccessExpression` builds via `buildL1MemberAccess` → `lowerL1Expr` → emit
- In `tools/ts2pant/src/translate-body.ts:2775-2820`, replace the inline `qualifyFieldAccess` call + `App(...)` construction with the helper invocation. Note the existing branch handles `PropertyAccessExpression` only (line 2775); `ElementAccessExpression` paths are touched by Patch 3
- Create `tools/ts2pant/tests/ir1-build-property.test.mts` with unit tests using a small TS source-fixture pattern (mirroring `ir1-build-nullish.test.mts`'s setup): assert `buildL1MemberAccess(propertyAccessNode, ctx)` returns the expected `Member` shape; assert nested chains compose; assert ambiguous-owner returns `null`; assert `(a).owner` and `((a)).owner` and `a.owner` all build to identical `Member` trees (paren-stripping invariant); assert that paren-stripping does not look through type-erasure wrappers (`(a as A).owner` either keeps the wrapper or falls through to the legacy path — verify whichever the implementation chose)
- Add a sibling test `tools/ts2pant/tests/ir1-build-parens.test.mts` (or extend an existing L1-build test) covering paren-stripping across L1 forms beyond Member: `(x + 1)` builds to the same L1 binop as `x + 1`; `((x))` builds to the same L1 var as `x`; `(if c then a else b)` builds to the same L1 cond as the unparenthesized form. This locks in the L1-layering invariant for future builders
- Run `just ts2pant-test` from the repo root. Snapshots are expected to remain byte-equal in practice; if any snapshot diverges, the patch description must justify the diff as a deliberate consistency improvement — do NOT merge an unexplained divergence. Likely root causes when investigating: receiver translation route changed unexpectedly, or `buildL1MemberAccess` qualifier name differs from `qualifyFieldAccess`. Either align the new path with the legacy behavior, or document the intentional change
- Run `just ts2pant-test-integration` — `pant --check` should still accept every existing M1-M4 fixture as well-typed (no semantic change)

## Changes
- In `tools/ts2pant/src/ir1-build.ts`, add an `unwrapParens(n: ts.Node): ts.Node` helper near the top: `while (ts.isParenthesizedExpression(n)) n = n.expression; return n;`. This is the L1-layering primitive — operationally-equivalent syntactic wrappers must be normalized at L1 build, not at each downstream recognizer. Type-erasure wrappers (`as T`, `!`, `<T>x`, `satisfies`) are NOT stripped — they change the TS-checker type, which would break `qualifyFieldAccess` and other type-dependent dispatch
- Apply `unwrapParens` at the entry of every TS-AST → L1 dispatch in `ir1-build.ts` (and `ir1-build-body.ts` if it has its own dispatch entry): `buildL1Expr(node, ctx)` becomes `node = unwrapParens(node); switch (node.kind) { … }`. Likewise for any per-kind builder that may be called directly bypassing the dispatcher. Effect: `(x + 1)` and `x + 1` produce identical L1 trees; `(if g then a else b)` and `if g then a else b` produce identical trees; `(u).owner` and `u.owner` produce identical Member trees. Universal at L1 build
- In `tools/ts2pant/src/ir1-build.ts`, add `buildL1MemberAccess(node: ts.PropertyAccessExpression | ts.ElementAccessExpression, ctx: L1BuildCtx): IR1Expr | null`. For Patch 1 the implementation handles only `PropertyAccessExpression`; the `ElementAccessExpression` arm lands in Patch 3. Body: defensively call `unwrapParens` on the input node (in case the helper is invoked directly bypassing the dispatcher) — though the dispatcher should have already stripped them. Then: extract `receiverNode = unwrapParens(node.expression)` and `fieldNode = node.name` (PropertyAccess). Get `receiverType = ctx.checker.getTypeAtLocation(receiverNode)`. Call `qualifiedName = qualifyFieldAccess(receiverType, fieldNode.text, ctx.checker, ctx.strategy, ctx.synthCell)`. If `qualifiedName === null` (ambiguous) return null. Recursively build the receiver: `receiverL1 = buildL1Expr(receiverNode, ctx)` (or `ir1FromL2(translateBodyExpr(receiverNode))` for now until receiver-shape audit completes). Return `ir1Member(receiverL1, qualifiedName)`
- Promote the inline `.length` / `.size` cardunop short-circuit at `ir-build.ts:99-121` into a named `tryBuildL1Cardinality(node: ts.Expression, ctx: L1BuildCtx): IR1Expr | null` helper in `ir1-build.ts`. Behavior: returns `irUnop('card', receiverL1)` when `node` is a non-optional-chain `PropertyAccessExpression` whose receiver type matches one of the five list-shaped TS types and the property name matches the cardinality slot for that type. Coverage list: `Array.length`, `ReadonlyArray.length`, `Set.size`, `ReadonlySet.size`, `Map.size`, `ReadonlyMap.size`. Verify via `checker.isArrayType(t)` for arrays, plus a refreshed `isListLikeForCardinality(t)` predicate that also accepts `ReadonlySet` / `ReadonlyMap` (today's `isSetType` may miss `ReadonlySet`; check). Returns null otherwise — caller falls through to `buildL1MemberAccess`
- In `tools/ts2pant/src/ir-build.ts:130-147`, the `PropertyAccessExpression` branch currently calls `qualifyFieldAccess` and constructs `irApp({ kind: 'name', name: ruleName }, [translateExpr(expr.expression, ...)])`. New dispatch order: try `tryBuildL1Cardinality(expr, ctx)` first; on non-null, lower and return. On null, fall through to `buildL1MemberAccess(expr, ctx)`. The cardinality dispatch must precede Member dispatch — Member's lowering would produce a dangling `length arr` rule application, distinct from `#arr` in EUF. Document this as the first-of-many possible non-Member dispatches, sibling to the workstream's IRSC divergence note
- In `tools/ts2pant/src/translate-signature.ts:962-980`, do the same replacement: `PropertyAccessExpression` builds via `buildL1MemberAccess` → `lowerL1Expr` → emit
- In `tools/ts2pant/src/translate-body.ts:2775-2820`, replace the inline `qualifyFieldAccess` call + `App(...)` construction with the helper invocation. Note the existing branch handles `PropertyAccessExpression` only (line 2775); `ElementAccessExpression` paths are touched by Patch 3
- Create `tools/ts2pant/tests/ir1-build-property.test.mts` with unit tests using a small TS source-fixture pattern (mirroring `ir1-build-nullish.test.mts`'s setup): assert `buildL1MemberAccess(propertyAccessNode, ctx)` returns the expected `Member` shape; assert nested chains compose; assert ambiguous-owner returns `null`; assert `(a).owner` and `((a)).owner` and `a.owner` all build to identical `Member` trees (paren-stripping invariant); assert that paren-stripping does not look through type-erasure wrappers (`(a as A).owner` either keeps the wrapper or falls through to the legacy path — verify whichever the implementation chose)
- Add a sibling test `tools/ts2pant/tests/ir1-build-parens.test.mts` (or extend an existing L1-build test) covering paren-stripping across L1 forms beyond Member: `(x + 1)` builds to the same L1 binop as `x + 1`; `((x))` builds to the same L1 var as `x`; `(if c then a else b)` builds to the same L1 cond as the unparenthesized form. This locks in the L1-layering invariant for future builders
- Run `just ts2pant-test` from the repo root. Snapshots are expected to remain byte-equal in practice; if any snapshot diverges, the patch description must justify the diff as a deliberate consistency improvement — do NOT merge an unexplained divergence. Likely root causes when investigating: receiver translation route changed unexpectedly, or `buildL1MemberAccess` qualifier name differs from `qualifyFieldAccess`. Either align the new path with the legacy behavior, or document the intentional change
- Run `just ts2pant-test-integration` — `pant --check` should still accept every existing M1-M4 fixture as well-typed (no semantic change)

## Files to Modify
- tools/ts2pant/src/ir1-build.ts (modify): Add `buildL1MemberAccess(node, ctx)` helper accepting a TS `PropertyAccessExpression`; calls `qualifyFieldAccess` on the receiver type, returns `Member(receiverL1, qualifiedName)` or `null` for ambiguous-owner cases
- tools/ts2pant/src/ir-build.ts (modify): Replace the inline `PropertyAccessExpression` branch (line 130-147) with a call to `buildL1MemberAccess` followed by `lowerL1Expr`. Preserve the `.length` / `.size` cardunop short-circuit at line 100 in front of the Member dispatch
- tools/ts2pant/src/translate-signature.ts (modify): Replace the inline `PropertyAccessExpression` handling at line 962-980 with a call into the L1 build helper
- tools/ts2pant/src/translate-body.ts (modify): Cut over the body-position `PropertyAccessExpression` read site at line 2775-2820 to use `buildL1MemberAccess`
- tools/ts2pant/tests/ir1-build-property.test.mts (create): Unit tests for `buildL1MemberAccess`: simple PropertyAccess returns `Member(Var, qualified)`; nested chain `a.owner.name` returns `Member(Member(Var, owner), user-name)`; ambiguous receiver (union with conflicting owners) returns `null`

## Gameplan Specification

```
module TS2PANT_M5_PROPERTY_ACCESS.

> M5 final state: every property-access surface form ts2pant supports
> flows through L1 Member. The legacy direct-to-L2 App-construction
> path is retired across all 9 documented sites. The hard-rule
> discipline holds for the property-access equivalence class.
>
> Cutover gate is reviewed-snapshot-diff plus `pant --check` plus
> dogfood, not literal byte-equality with pre-M5 output. The two-tier
> qualifier behavior (qualified rule names for resolved owners; bare
> kebab names for built-ins / type parameters; null for ambiguous
> unions) is preserved as-is — the asymmetry is a deliberate EUF
> tier separation, not an inconsistency.

TSExpr.
L1Expr.
OpaqueExpr.
L1Stmt.

> Surface forms in scope.
is-property-access? t: TSExpr => Bool.
is-string-literal-elem-access? t: TSExpr => Bool.
is-computed-elem-access? t: TSExpr => Bool.
is-paren? t: TSExpr => Bool.
paren-inner t: TSExpr, is-paren? t => TSExpr.
unwrap-parens t: TSExpr => TSExpr.

> The property-access surface set is exactly these three forms; every
> TS expression node ts2pant classifies as property-access falls into
> one of them.
is-any-property-form? t: TSExpr, is-property-access? t or is-string-literal-elem-access? t or is-computed-elem-access? t => Bool.

> Field name extraction.
property-receiver t: TSExpr, is-any-property-form? t => TSExpr.
property-key t: TSExpr, is-property-access? t or is-string-literal-elem-access? t => String.
qualify-field r: TSExpr, n: String => String.

> L1 build pass and Member form.
build-l1 t: TSExpr => L1Expr.
is-member? e: L1Expr => Bool.
member-receiver e: L1Expr, is-member? e => L1Expr.
member-name e: L1Expr, is-member? e => String.
is-from-l2? e: L1Expr => Bool.
unsupported? e: L1Expr => Bool.

> Mutating-body assignment statements.
is-assignment-stmt? s: L1Stmt => Bool.
target s: L1Stmt, is-assignment-stmt? s => L1Expr.

> Functor-lift recognizer.
is-functor-lift-shape? t: TSExpr => Bool.
functor-lift-operand t: TSExpr, is-functor-lift-shape? t => TSExpr.
is-each-comprehension? e: L1Expr => Bool.

> Cardinality dispatch (deliberate non-Member path).
is-cardinality-form? t: TSExpr, is-property-access? t => Bool.
is-card-unop? e: L1Expr => Bool.

---

> Invariant 1: Dotted property access builds canonical L1 Member with
> the qualified rule name.
all t: TSExpr, is-property-access? t |
  is-member? (build-l1 t)
  and member-name (build-l1 t) = qualify-field (property-receiver t) (property-key t).

> Invariant 2: String-literal element access shares the canonical
> Member form (one canonical form per construct).
all t: TSExpr, is-string-literal-elem-access? t |
  is-member? (build-l1 t)
  and member-name (build-l1 t) = qualify-field (property-receiver t) (property-key t).

> Invariant 3: Computed (non-literal) element access is rejected
> unconditionally. Uniform reject is the conservative-refusal-3(b)
> answer; the DoD's 'unless type system resolves to a known field set'
> path is deferred to a follow-up.
all t: TSExpr, is-computed-elem-access? t | unsupported? (build-l1 t).

> Invariant 4: Universal L1-layering — paren-wrapped expressions
> build to identical L1 trees as their unwrapped inner expressions,
> for every L1 form. Downstream recognizers do not re-implement
> paren-stripping.
all t: TSExpr, is-paren? t | build-l1 t = build-l1 (unwrap-parens t).

> Invariant 5: Mutating-body assignment targets are L1 Member
> expressions. The hard rule for the property-access equivalence
> class extends to statement-position writes.
all s: L1Stmt, is-assignment-stmt? s | is-member? (target s).

> Invariant 6: Property-access sub-expressions no longer wrap via
> from-l2. The from-l2 adapter still survives for non-property
> sub-expressions awaiting M6 deletion of the form.
all t: TSExpr, is-any-property-form? t | ~(is-from-l2? (build-l1 t)).

> Invariant 7: The functor-lift recognizer accepts operands whose L1
> form is Var or Member (Identifier, dotted-property, or string-
> literal element access). The M4 P5 TS-AST restriction to simple
> identifier is replaced with an L1-shape eligibility check.
all t: TSExpr, is-functor-lift-shape? t |
  is-any-property-form? (functor-lift-operand t)
  or is-each-comprehension? (build-l1 t).

> Invariant 8: Cardinality dispatch. `.length` / `.size` on the six
> list-shaped TS types (Array, ReadonlyArray, Set, ReadonlySet, Map,
> ReadonlyMap) build to L1 Unop(card, receiver) via
> tryBuildL1Cardinality, NOT Member. This dispatch fires before
> Member; the divergence is target-language-driven (Pant's
> cardinality primitive is `#x`, not a `length` / `size` rule).
all t: TSExpr, is-cardinality-form? t | is-card-unop? (build-l1 t).

```

## Patch Specification

```
module TS2PANT_M5_PATCH_1.

> Patch 1 introduces `buildL1MemberAccess`, promotes the existing
> `.length` / `.size` cardinality short-circuit into a named
> `tryBuildL1Cardinality` helper, and cuts over the pure-path
> PropertyAccessExpression sites.
>
> Patch 1 also lands universal paren-stripping at every L1 build
> dispatch entry — `(x)` and `x` produce identical L1 trees regardless
> of which kind-specific builder is reached. This is the L1 layering
> principle: collapse syntactic variation once at build, so downstream
> recognizers see canonical shapes without re-implementing the strip.
>
> The lowered OpaqueExpr is expected to match the legacy construction
> for every fixture; reviewed-snapshot-diff is the cutover gate. A
> deliberate consistency improvement is acceptable if it emerges.

TSExpr.
L1Expr.
OpaqueExpr.

is-property-access? t: TSExpr => Bool.
is-paren? t: TSExpr => Bool.
receiver t: TSExpr, is-property-access? t => TSExpr.
property-name t: TSExpr, is-property-access? t => String.
paren-inner t: TSExpr, is-paren? t => TSExpr.

unwrap-parens t: TSExpr => TSExpr.

> Cardinality dispatch: a property-access node is a cardinality form
> iff its receiver is a list-shaped TS type (Array, ReadonlyArray,
> Set, ReadonlySet, Map, ReadonlyMap) AND the property name is the
> cardinality slot for that type (`length` for arrays, `size` for
> the others) AND it is not part of an optional chain.
is-cardinality-form? t: TSExpr, is-property-access? t => Bool.

build-l1 t: TSExpr => L1Expr.
build-l1-member t: TSExpr, is-property-access? t, ~(is-cardinality-form? t) => L1Expr.
is-member? e: L1Expr => Bool.
member-receiver e: L1Expr, is-member? e => L1Expr.
member-name e: L1Expr, is-member? e => String.
is-card-unop? e: L1Expr => Bool.
card-receiver e: L1Expr, is-card-unop? e => L1Expr.

qualify-field r: TSExpr, n: String => String.

lower-to-opaque e: L1Expr => OpaqueExpr.

---

> Paren-stripping is a fixed point: unwrapping an unwrapped node is
> a no-op, and unwrapping a parenthesized node recurses through the
> inner expression.
all t: TSExpr, ~(is-paren? t) | unwrap-parens t = t.
all t: TSExpr, is-paren? t | unwrap-parens t = unwrap-parens (paren-inner t).

> Universal L1-layering invariant: a parenthesized expression and
> its unwrapped inner expression build to identical L1 trees, for
> EVERY L1 expression form. This is the contract all downstream
> recognizers can rely on.
all t: TSExpr, is-paren? t | build-l1 t = build-l1 (unwrap-parens t).

> Cardinality dispatch fires before Member dispatch. A cardinality
> form builds to L1 Unop(card, receiver), not Member. This is a
> target-language constraint: routing through Member would emit a
> dangling rule application distinct from Pant's `#x` cardinality
> primitive in EUF.
all t: TSExpr, is-cardinality-form? t |
  is-card-unop? (build-l1 t).

> Every non-cardinality property access builds to a Member form with
> the qualified field name.
all t: TSExpr, is-property-access? t, ~(is-cardinality-form? t) |
  is-member? (build-l1-member t)
  and member-name (build-l1-member t) = qualify-field (receiver t) (property-name t).

```


## Implementation Notes

### Key implementation decisions

- **`buildL1MemberAccess` returns `IR1Expr | { unsupported: string }`, not `IR1Expr | null`.** The plan said "return null for ambiguous." In practice three rejection reasons exist (ambiguous owner, unsupported access shape, receiver itself rejects); collapsing all three into `null` and reconstructing `ambiguousFieldMsg` at every call site would lose specificity and double-emit the ambiguity message in non-ambiguous reject paths. The discriminated union mirrors the existing `L1BuildResult` convention used by every other L1 builder in the file.

- **Receiver translation is mode-switched on `ctx.state`.** State-free contexts (pure path, unit tests) recurse on `PropertyAccessExpression` receivers, producing nested `Member` trees. State-bearing contexts (mutating-body path) translate the receiver via legacy `translateBodyExpr` so symbolic-state lookup at every nested level fires identically to pre-M5 — this preserves byte-equality with the existing snapshots while still routing the outer access through L1 Member. The recursion uses `tryBuildL1Cardinality` first inside the recursive branch so a chain like `arr.length.foo` doesn't accidentally route `arr.length` through Member.

- **Outer-level symbolic-state lookup is encapsulated inside `buildL1MemberAccess`** (mirrors `translate-body.ts:2861`'s prior-write check). The body-path call site no longer has to do the `state.writes.get(symbolicKey(...))` dance — it just dispatches and lowers. The lookup re-lowers `receiverL1` to OpaqueExpr to compute the key; a small redundant pass in exchange for one source of truth.

- **`isSetType` and `isMapType` already cover `ReadonlySet`/`ReadonlyMap` by symbol-name match** — the plan suggested they "may miss `ReadonlySet`," but inspection showed they don't. So `isLengthCardinalityType` / `isSizeCardinalityType` simply compose the existing predicates. `Map.size` is now reachable through cardinality (legacy didn't dispatch it through cardunop), but no fixture exercises `Map.size` so no snapshot delta surfaced.

- **Removed the local lenient `qualifyFieldAccess` from `translate-signature.ts`.** That helper collapsed both "ambiguous" and "unresolved" into bare-kebab names; after cutover the strict body-side `qualifyFieldAccess` is used everywhere, so ambiguous unions now reject through `unsupported` instead of falling through to a wrong-but-harmless bare-kebab. Observable effect: optional guard-extraction analyses bail one rejection earlier — but per the original lenient comment the bare-kebab guard "never fires" anyway, so the net behavior on real specs is equivalent.

- **`unwrapParens` strips parens only.** Type-erasure wrappers (`as T`, `!`, `<T>x`, `satisfies`) flow through unchanged — `qualifyFieldAccess` reads the cast/asserted type from `checker.getTypeAtLocation(receiverNode)`, so `(a as Document).owner` qualifies as `document--owner`. The `ir1-build-property` test "type-erasure wrapper is not stripped" pins this.

- **`ir1-build-body.ts` was not modified.** It has no top-level TS-AST→L1 dispatch entry — its statement entry points (`buildL1ForOfMutation`, `buildL1ForEachCall`, `buildL1IfMutation`) all take statement nodes (which can't be paren-wrapped), and sub-expression translation flows through `translateBodyExpr` which already calls `unwrapExpression`. No paren-stripping deficit at the L1 boundary.

- **Snapshots remained byte-equal.** All 619 unit + 19 integration tests pass with no fixture or dogfood diff, exactly as the cutover gate expected for an INFRA patch.

### Out of scope (deferred to later patches in this gameplan)

- Mutating-body assignment-target sites (`ir1-build-body.ts` `qualifyFieldAccess` callers) — Patch 2.
- String-literal `ElementAccess` → Member; computed `ElementAccess` rejection — Patch 3. `buildL1MemberAccess`'s `ElementAccessExpression` arm currently rejects with `"element access not yet routed through L1 Member (M5 Patch 3)"`.
- Lifting the M4 P5 functor-lift recognizer's TS-AST identifier-only operand restriction — Patch 4.
- `from-l2` adapter site shrinkage for property-access sub-expressions — Patch 5.