### PR TITLE
[ts2pant-m5-property-access] Patch 3: String-literal ElementAccess builds Member; reject computed ElementAccess

### DIFF
--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -195,18 +195,18 @@ export function tryBuildL1Cardinality(
   if (!matches) {
     return null;
   }
-  // Receiver translation. Property-access receivers (e.g.,
-  // `a.items.length`) route through `buildL1MemberAccess` so the
+  // Receiver translation. Member-surface receivers (`a.items.length`,
+  // `a["items"].length`) route through `buildL1MemberAccess` so the
   // entire chain stays on the L1 path — no half-migration where the
-  // outer `card` is L1 but the inner `.items` round-trips through L2
-  // via `from-l2`. Other receiver shapes (Identifier, call, binop,
-  // etc.) translate through the supplied leaf translator (default
-  // `translateBodyExpr`); those aren't property-access and are out of
-  // M5's equivalence class.
-  if (
-    ts.isPropertyAccessExpression(receiverNode) &&
-    (receiverNode.flags & ts.NodeFlags.OptionalChain) === 0
-  ) {
+  // outer `card` is L1 but the inner `.items` / `["items"]` round-trips
+  // through L2 via `from-l2`. Both PropertyAccess and string-literal
+  // ElementAccess belong to the property-access equivalence class
+  // (M5 hard rule), so the recursion gate is the shared
+  // `isMemberSurfaceForm` predicate. Other receiver shapes
+  // (Identifier, call, binop, etc.) translate through the supplied
+  // leaf translator (default `translateBodyExpr`); those aren't
+  // property-access and are out of M5's equivalence class.
+  if (isMemberSurfaceForm(receiverNode)) {
     const innerCard = tryBuildL1Cardinality(receiverNode, ctx, options);
     if (innerCard !== null) {
       return ir1Unop("card", innerCard);

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -246,12 +246,66 @@ export function tryBuildL1Cardinality(
 // ---------------------------------------------------------------------------
 //
 // Build the canonical L1 `Member(receiver, qualified-name)` form for a TS
-// `PropertyAccessExpression` (and, in M5 Patch 3, string-literal
-// `ElementAccessExpression`). The qualified name is resolved at build
-// time via `qualifyFieldAccess` — IRSC discipline preserves the
-// pre-qualification: L1 `Member` is a *normalization* form whose lowering
-// at `ir1-lower.ts` is mechanical (`Member(r, n) → App(n, [lower r])`),
-// matching the legacy `App(qualified-rule, [receiver])` byte-for-byte.
+// `PropertyAccessExpression` or string-literal `ElementAccessExpression`
+// (`obj["field"]`). The two surface forms collapse to the same canonical
+// Member — one canonical form per construct (IRSC discipline). The
+// qualified name is resolved at build time via `qualifyFieldAccess`:
+// L1 `Member` is a *normalization* form whose lowering at `ir1-lower.ts`
+// is mechanical (`Member(r, n) → App(n, [lower r])`), matching the
+// legacy `App(qualified-rule, [receiver])` byte-for-byte.
+
+/**
+ * Computed `obj[expr]` (non-literal index) is rejected unconditionally.
+ * The DoD's "unless the type system resolves to a known field set" path
+ * (literal-union narrowing) is deferred to a follow-up; uniform
+ * rejection is the conservative-refusal policy 3(b) answer.
+ */
+const COMPUTED_ELEMENT_ACCESS_UNSUPPORTED =
+  "computed property access (obj[expr]) is unsupported; " +
+  "use dotted property access or a string-literal index instead";
+
+/**
+ * Extract the literal field name from an `ElementAccessExpression`'s
+ * argument expression. Accepts both `StringLiteral` (`obj["f"]`) and
+ * `NoSubstitutionTemplateLiteral` (`` obj[`f`] ``) — both produce the
+ * same TS type-checker resolution and the same field name. Returns
+ * null for any other argument shape (identifier, computed expression,
+ * numeric literal, template with substitutions, etc.).
+ */
+function elementAccessLiteralKey(
+  node: ts.ElementAccessExpression,
+): string | null {
+  const arg = node.argumentExpression;
+  if (ts.isStringLiteral(arg) || ts.isNoSubstitutionTemplateLiteral(arg)) {
+    return arg.text;
+  }
+  return null;
+}
+
+/**
+ * True when `node` is one of the two surface forms that
+ * `buildL1MemberAccess` recognizes as a non-optional property access:
+ * dotted `obj.field` or string-literal `obj["field"]`. Used by the
+ * recursion gate so nested chains compose into nested Member trees
+ * regardless of which surface form spells each step.
+ */
+function isMemberSurfaceForm(
+  node: ts.Node,
+): node is ts.PropertyAccessExpression | ts.ElementAccessExpression {
+  if (
+    ts.isPropertyAccessExpression(node) &&
+    (node.flags & ts.NodeFlags.OptionalChain) === 0
+  ) {
+    return true;
+  }
+  if (
+    ts.isElementAccessExpression(node) &&
+    (node.flags & ts.NodeFlags.OptionalChain) === 0
+  ) {
+    return elementAccessLiteralKey(node) !== null;
+  }
+  return false;
+}
 
 /**
  * Receiver translation result — either an opaque expression or an
@@ -309,22 +363,25 @@ export interface BuildL1MemberAccessOptions {
  * (under the body-side default), unsupported access shape, or a
  * sub-expression that itself rejects.
  *
+ * Surface forms accepted (one canonical Member output for both):
+ *   - `PropertyAccessExpression` — `obj.field` (with `.field` token).
+ *   - `ElementAccessExpression` whose `argumentExpression` is a
+ *     `StringLiteral` or `NoSubstitutionTemplateLiteral` —
+ *     `obj["field"]` and `` obj[`field`] ``. Computed indices
+ *     (`obj[k]`, `obj[1+1]`) reject with the
+ *     `COMPUTED_ELEMENT_ACCESS_UNSUPPORTED` reason.
+ *
  * Receiver translation:
  *   - State-free contexts (pure path, unit tests) recurse on
- *     `PropertyAccessExpression` receivers, producing nested L1
- *     `Member` trees. The recursion bottoms out at a non-property
- *     receiver translated through the legacy pipeline and wrapped as
- *     `from-l2`.
+ *     property-access receivers (either surface form), producing
+ *     nested L1 `Member` trees. The recursion bottoms out at a
+ *     non-property receiver translated through the legacy pipeline
+ *     and wrapped as `from-l2`.
  *   - State-bearing contexts (mutating-body path) translate the
  *     receiver via the legacy pipeline so symbolic-state lookup at
  *     each nested level fires identically to the pre-M5 path. This
  *     preserves byte-equality with the legacy snapshots while still
  *     routing the outer access through L1 `Member`.
- *
- * Patch 1 handles `PropertyAccessExpression` only; the
- * `ElementAccessExpression` arm (string-literal element access lands
- * on the same canonical Member; computed access rejects) is M5
- * Patch 3.
  */
 export function buildL1MemberAccess(
   node: ts.PropertyAccessExpression | ts.ElementAccessExpression,
@@ -333,25 +390,38 @@ export function buildL1MemberAccess(
 ): L1BuildResult {
   const ambiguousMode = options.ambiguousOwnerFallback ?? "reject";
   const stripped = unwrapParens(node);
-  if (!ts.isPropertyAccessExpression(stripped)) {
-    // Patch 1 scope: ElementAccess lands in Patch 3 (string-literal key
-    // canonicalizes to the same Member; computed key rejects).
+  let receiverNode: ts.Node;
+  let fieldName: string;
+  if (ts.isPropertyAccessExpression(stripped)) {
+    // Optional-chain `.f` (`x?.f` and the chain tail) routes through
+    // the optional-chain functor-lift recognizer, not Member. Caller is
+    // expected to filter optional chains before invoking this helper.
+    if ((stripped.flags & ts.NodeFlags.OptionalChain) !== 0) {
+      return {
+        unsupported:
+          "optional-chain property access uses functor-lift, not Member",
+      };
+    }
+    receiverNode = unwrapParens(stripped.expression);
+    fieldName = stripped.name.text;
+  } else if (ts.isElementAccessExpression(stripped)) {
+    if ((stripped.flags & ts.NodeFlags.OptionalChain) !== 0) {
+      return {
+        unsupported:
+          "optional-chain element access uses functor-lift, not Member",
+      };
+    }
+    const literalKey = elementAccessLiteralKey(stripped);
+    if (literalKey === null) {
+      return { unsupported: COMPUTED_ELEMENT_ACCESS_UNSUPPORTED };
+    }
+    receiverNode = unwrapParens(stripped.expression);
+    fieldName = literalKey;
+  } else {
     return {
-      unsupported:
-        "element access not yet routed through L1 Member (M5 Patch 3)",
+      unsupported: "buildL1MemberAccess: unsupported access shape",
     };
   }
-  // Optional-chain `.f` (`x?.f` and the chain tail) routes through the
-  // optional-chain functor-lift recognizer, not Member. Caller is
-  // expected to filter optional chains before invoking this helper.
-  if ((stripped.flags & ts.NodeFlags.OptionalChain) !== 0) {
-    return {
-      unsupported:
-        "optional-chain property access uses functor-lift, not Member",
-    };
-  }
-  const receiverNode = unwrapParens(stripped.expression);
-  const fieldName = stripped.name.text;
   const receiverType = ctx.checker.getTypeAtLocation(receiverNode);
   const qualifiedStrict = qualifyFieldAccess(
     receiverType,
@@ -380,11 +450,7 @@ export function buildL1MemberAccess(
   }
 
   let receiverL1: IR1Expr;
-  if (
-    ctx.state === undefined &&
-    ts.isPropertyAccessExpression(receiverNode) &&
-    (receiverNode.flags & ts.NodeFlags.OptionalChain) === 0
-  ) {
+  if (ctx.state === undefined && isMemberSurfaceForm(receiverNode)) {
     // Pure path: prefer canonical nested Member trees. Cardinality
     // dispatch fires first so a chain like `arr.length.foo` wouldn't
     // silently route `arr.length` through Member.

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -2848,6 +2848,33 @@ export function translateBodyExpr(
     return { expr: lowerL1ToOpaque(member) };
   }
 
+  // M5 P3: string-literal element access (`obj["field"]`) collapses to
+  // the same canonical L1 Member as dotted access. Computed indices
+  // (`obj[k]`, `obj[1+1]`) reject with the
+  // `computed property access ...` reason returned by the helper.
+  // Optional-chain element access (`obj?.["f"]`) falls through to the
+  // raw-text fallback in `translateExpr`; the optional-chain functor
+  // lift recognizer in this dispatch only handles `?.` on
+  // PropertyAccess today, and adding the element-access variant is a
+  // separate concern.
+  if (
+    ts.isElementAccessExpression(expr) &&
+    (expr.flags & ts.NodeFlags.OptionalChain) === 0
+  ) {
+    const l1Ctx = {
+      checker,
+      strategy,
+      paramNames,
+      state,
+      supply,
+    };
+    const member = buildL1MemberAccess(expr, l1Ctx);
+    if ("unsupported" in member) {
+      return member;
+    }
+    return { expr: lowerL1ToOpaque(member) };
+  }
+
   // Call expression: handle .includes(), .filter().map(), etc.
   // A Map.set/delete call returns a `{ effect }` BodyResult which only
   // `symbolicExecute` consumes as a statement; in any expression context

--- a/tools/ts2pant/src/translate-signature.ts
+++ b/tools/ts2pant/src/translate-signature.ts
@@ -939,10 +939,15 @@ export function translateExpr(
   // them as cardinality. Routing through `tryBuildL1Cardinality`
   // makes signature guards see the same `#x` primitive that body and
   // pure paths now produce, satisfying spec invariant 8 universally.
-  // Optional-chain access and ElementAccess fall through to the rest
-  // of the dispatch.
+  //
+  // M5 P3 extends the same dispatch to string-literal element access
+  // (`obj["field"]`) — same canonical Member output as `obj.field`.
+  // Computed element access (`obj[k]`, `obj[1+1]`) is rejected by
+  // `buildL1MemberAccess` with a specific reason. Optional-chain
+  // access falls through to the rest of the dispatch.
   if (
-    ts.isPropertyAccessExpression(expr) &&
+    (ts.isPropertyAccessExpression(expr) ||
+      ts.isElementAccessExpression(expr)) &&
     (expr.flags & ts.NodeFlags.OptionalChain) === 0
   ) {
     const l1Ctx: L1BuildContext = {
@@ -985,11 +990,12 @@ export function translateExpr(
   }
   // Defensively unwrap parens for the paren-stripping invariant — a
   // paren-wrapped property access (`(a).b`) routes through the same
-  // Member dispatch as `a.b`.
+  // Member dispatch as `a.b`. Same for element access.
   const stripped = unwrapParens(expr) as ts.Expression;
   if (
     stripped !== expr &&
-    ts.isPropertyAccessExpression(stripped) &&
+    (ts.isPropertyAccessExpression(stripped) ||
+      ts.isElementAccessExpression(stripped)) &&
     (stripped.flags & ts.NodeFlags.OptionalChain) === 0
   ) {
     return translateExpr(stripped, checker, _strategy, paramNames, synthCell);

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -486,6 +486,22 @@ exports[`expressions-optional-default.ts > usesOptionalDirectly 1`] = `
 "module UsesOptionalDirectly.\\n\\nuses-optional-directly value: [Int] => Int.\\n\\n---\\n\\nuses-optional-directly value = (cond #value = 0 => 0 + (cond #value = 0 => 1, true => value 1), true => value 1).\\n"
 `;
 
+exports[`expressions-property-element-access.ts > effectiveBalanceByLiteral 1`] = `
+"module EffectiveBalanceByLiteral.\\n\\nUser.\\nuser--name u: User => String.\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--owner a1: Account => User.\\naccount--active a1: Account => Bool.\\neffective-balance-by-literal a: Account => Int.\\n\\n---\\n\\neffective-balance-by-literal a = (cond account--active a => account--balance a, true => 0).\\n"
+`;
+
+exports[`expressions-property-element-access.ts > getByDynamicKey 1`] = `
+"module GetByDynamicKey.\\n\\nUser.\\nuser--name u: User => String.\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--owner a1: Account => User.\\naccount--active a1: Account => Bool.\\nget-by-dynamic-key a: Account, k: String => unknown.\\n\\n---\\n\\n> UNSUPPORTED: computed property access (obj[expr]) is unsupported; use dotted property access or a string-literal index instead.\\n"
+`;
+
+exports[`expressions-property-element-access.ts > getOwnerByLiteral 1`] = `
+"module GetOwnerByLiteral.\\n\\nUser.\\nuser--name u: User => String.\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--owner a1: Account => User.\\naccount--active a1: Account => Bool.\\nget-owner-by-literal a: Account => User.\\n\\n---\\n\\nget-owner-by-literal a = account--owner a.\\n"
+`;
+
+exports[`expressions-property-element-access.ts > getOwnerNameByLiteral 1`] = `
+"module GetOwnerNameByLiteral.\\n\\nUser.\\nuser--name u: User => String.\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--owner a1: Account => User.\\naccount--active a1: Account => Bool.\\nget-owner-name-by-literal a: Account => String.\\n\\n---\\n\\nget-owner-name-by-literal a = user--name (account--owner a).\\n"
+`;
+
 exports[`expressions-property.ts > effectiveBalance 1`] = `
 "module EffectiveBalance.\\n\\nUser.\\nuser--name u: User => String.\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--owner a1: Account => User.\\naccount--active a1: Account => Bool.\\neffective-balance a: Account => Int.\\n\\n---\\n\\neffective-balance a = (cond account--active a => account--balance a, true => 0).\\n"
 `;

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-property-element-access.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-property-element-access.ts
@@ -31,8 +31,10 @@ export function effectiveBalanceByLiteral(a: Account): number {
 /**
  * Deliberate reject: computed element access (`obj[expr]`) cannot
  * resolve to a single qualified rule without literal-union narrowing,
- * which is deferred. The constructs runner skips functions whose
- * translation reports unsupported.
+ * which is deferred. The constructs runner snapshots the emitted
+ * `> UNSUPPORTED: ...` line for functions whose translation reports
+ * unsupported, so the rejection reason is locked into the fixture's
+ * snapshot rather than dropped.
  */
 export function getByDynamicKey(a: Account, k: keyof Account): unknown {
   return a[k];

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-property-element-access.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-property-element-access.ts
@@ -1,0 +1,39 @@
+// String-literal element access (`obj["field"]`) collapses to the same
+// canonical L1 Member as dotted access. Computed indices (`obj[k]`)
+// reject with a specific unsupported reason — the deliberate-reject
+// case at the bottom is skipped by the constructs runner.
+
+interface User {
+  name: string;
+}
+
+interface Account {
+  balance: number;
+  owner: User;
+  active: boolean;
+}
+
+/** simple string-literal element access → same Member as `a.owner` */
+export function getOwnerByLiteral(a: Account): User {
+  return a["owner"];
+}
+
+/** nested string-literal element access composes nested Members */
+export function getOwnerNameByLiteral(a: Account): string {
+  return a["owner"]["name"];
+}
+
+/** string-literal element access in a ternary condition */
+export function effectiveBalanceByLiteral(a: Account): number {
+  return a["active"] ? a["balance"] : 0;
+}
+
+/**
+ * Deliberate reject: computed element access (`obj[expr]`) cannot
+ * resolve to a single qualified rule without literal-union narrowing,
+ * which is deferred. The constructs runner skips functions whose
+ * translation reports unsupported.
+ */
+export function getByDynamicKey(a: Account, k: keyof Account): unknown {
+  return a[k];
+}

--- a/tools/ts2pant/tests/ir1-build-property.test.mts
+++ b/tools/ts2pant/tests/ir1-build-property.test.mts
@@ -434,4 +434,38 @@ describe("ir1-build-property", () => {
     );
     assert.equal(indexedOpaque, dottedOpaque);
   });
+
+  it("no-substitution template-literal ElementAccess builds Member", () => {
+    // ``obj[`field`]`` is the second accepted literal-key form
+    // (`elementAccessLiteralKey` accepts both `StringLiteral` and
+    // `NoSubstitutionTemplateLiteral`); its lowered output must match
+    // the dotted form byte-for-byte, locking the template-literal
+    // path against accidental regression.
+    const { node, ctx } = setupAccess(
+      "interface User { readonly name: string; }\n" +
+        "function f(u: User): string {\n" +
+        "  return u[`name`];\n" +
+        "}",
+    );
+    const result = buildL1MemberAccess(node, ctx);
+    const { receiver, name } = expectMember(result);
+    assert.equal(name, "user--name");
+    assert.equal(receiver.kind, "from-l2");
+
+    const dotted = setupAccess(
+      `interface User { readonly name: string; }
+       function f(u: User): string {
+         return u.name;
+       }`,
+    );
+    const dottedOpaque = getAst().strExpr(
+      lowerExpr(
+        lowerL1Expr(buildL1MemberAccess(dotted.node, dotted.ctx) as IR1Expr),
+      ),
+    );
+    const templateOpaque = getAst().strExpr(
+      lowerExpr(lowerL1Expr(result as IR1Expr)),
+    );
+    assert.equal(templateOpaque, dottedOpaque);
+  });
 });

--- a/tools/ts2pant/tests/ir1-build-property.test.mts
+++ b/tools/ts2pant/tests/ir1-build-property.test.mts
@@ -42,6 +42,11 @@ interface PropertyAccessSetup {
   ctx: L1BuildContext;
 }
 
+interface AccessSetup {
+  node: ts.PropertyAccessExpression | ts.ElementAccessExpression;
+  ctx: L1BuildContext;
+}
+
 /**
  * Parse a function declaration, return the single property-access
  * expression in its `return` statement plus an L1 build context. The
@@ -49,6 +54,21 @@ interface PropertyAccessSetup {
  * registration so the test exercises real Pant-name lookups.
  */
 function setup(source: string): PropertyAccessSetup {
+  const r = setupAccess(source);
+  if (!ts.isPropertyAccessExpression(r.node)) {
+    throw new Error(
+      `setup: expected a PropertyAccessExpression, got ${ts.SyntaxKind[r.node.kind]}`,
+    );
+  }
+  return { node: r.node, ctx: r.ctx };
+}
+
+/**
+ * Like `setup` but returns either a PropertyAccess or ElementAccess.
+ * Used by Patch 3 tests that exercise the string-literal element-access
+ * arm of `buildL1MemberAccess`.
+ */
+function setupAccess(source: string): AccessSetup {
   const sourceFile = createSourceFileFromSource(source);
   const checker = getChecker(sourceFile);
   const fn = sourceFile.compilerNode.statements.find(ts.isFunctionDeclaration);
@@ -76,9 +96,12 @@ function setup(source: string): PropertyAccessSetup {
     throw new Error("setup: expected a return statement with an expression");
   }
   const expr = stmt.expression;
-  if (!ts.isPropertyAccessExpression(expr)) {
+  if (
+    !ts.isPropertyAccessExpression(expr) &&
+    !ts.isElementAccessExpression(expr)
+  ) {
     throw new Error(
-      `setup: expected a PropertyAccessExpression, got ${ts.SyntaxKind[expr.kind]}`,
+      `setup: expected a Property/ElementAccessExpression, got ${ts.SyntaxKind[expr.kind]}`,
     );
   }
   return { node: expr, ctx };
@@ -308,5 +331,107 @@ describe("ir1-build-property", () => {
     // bare `owner` name, observable as a divergent qualifier here.
     const { name } = expectMember(result);
     assert.equal(name, "document--owner");
+  });
+
+  // -------------------------------------------------------------------------
+  // M5 Patch 3: string-literal ElementAccess collapses to canonical Member;
+  // computed ElementAccess rejects with the specific reason.
+  // -------------------------------------------------------------------------
+
+  it("string-literal ElementAccess builds Member", () => {
+    const { node, ctx } = setupAccess(
+      `interface User { readonly name: string; }
+       function f(u: User): string {
+         return u["name"];
+       }`,
+    );
+    const result = buildL1MemberAccess(node, ctx);
+    const { receiver, name } = expectMember(result);
+    assert.equal(name, "user--name");
+    // Mirrors the dotted-access bottom-out: receiver is a non-property
+    // node translated through legacy and wrapped via from-l2.
+    assert.equal(receiver.kind, "from-l2");
+  });
+
+  it("nested string-literal ElementAccess composes", () => {
+    const { node, ctx } = setupAccess(
+      `interface Owner { readonly name: string; }
+       interface Document { readonly owner: Owner; }
+       function f(d: Document): string {
+         return d["owner"]["name"];
+       }`,
+    );
+    const result = buildL1MemberAccess(node, ctx);
+    const outer = expectMember(result);
+    assert.equal(outer.name, "owner--name");
+    // Inner Member proves the nested chain composes through the
+    // string-literal recursion gate, not flattens to one from-l2 wrap.
+    const inner = expectMember(outer.receiver);
+    assert.equal(inner.name, "document--owner");
+    assert.equal(inner.receiver.kind, "from-l2");
+  });
+
+  it("computed Identifier ElementAccess rejects with reason", () => {
+    const { node, ctx } = setupAccess(
+      `interface Account { readonly balance: number; }
+       function f(a: Account, k: keyof Account): unknown {
+         return a[k];
+       }`,
+    );
+    const result = buildL1MemberAccess(node, ctx);
+    assert.ok(
+      "unsupported" in result,
+      `expected unsupported, got Member: ${JSON.stringify(result)}`,
+    );
+    if ("unsupported" in result) {
+      assert.match(result.unsupported, /computed property access/u);
+    }
+  });
+
+  it("computed expression ElementAccess rejects with reason", () => {
+    const { node, ctx } = setupAccess(
+      `interface T { readonly f: number; }
+       function f(t: T): unknown {
+         return t[1 + 1];
+       }`,
+    );
+    const result = buildL1MemberAccess(node, ctx);
+    assert.ok(
+      "unsupported" in result,
+      `expected unsupported, got Member: ${JSON.stringify(result)}`,
+    );
+    if ("unsupported" in result) {
+      assert.match(result.unsupported, /computed property access/u);
+    }
+  });
+
+  it('obj.f and obj["f"] build identical Member trees', () => {
+    // Snapshot equivalence: the two surface forms collapse to the same
+    // canonical Member output. Compare the lowered OpaqueExpr
+    // serialization rather than IR structure so the test exercises the
+    // full lower-to-Pant pipeline.
+    const dotted = setupAccess(
+      `interface User { readonly name: string; }
+       function f(u: User): string {
+         return u.name;
+       }`,
+    );
+    const indexed = setupAccess(
+      `interface User { readonly name: string; }
+       function f(u: User): string {
+         return u["name"];
+       }`,
+    );
+    const dottedOpaque = getAst().strExpr(
+      lowerExpr(
+        lowerL1Expr(buildL1MemberAccess(dotted.node, dotted.ctx) as IR1Expr),
+      ),
+    );
+    const indexedOpaque = getAst().strExpr(
+      lowerExpr(
+        lowerL1Expr(buildL1MemberAccess(indexed.node, indexed.ctx) as IR1Expr),
+      ),
+    );
+    assert.equal(indexedOpaque, dottedOpaque);
   });
 });


### PR DESCRIPTION
## Patch 3: String-literal ElementAccess builds Member; reject computed ElementAccess

- In `tools/ts2pant/src/ir1-build.ts`'s `buildL1MemberAccess`, add the `ElementAccessExpression` arm. Body: if `ts.isStringLiteral(node.argumentExpression)` (or `ts.isNoSubstitutionTemplateLiteral` — accept both), extract `fieldName = node.argumentExpression.text`, get `receiverType = ctx.checker.getTypeAtLocation(node.expression)`, call `qualifyFieldAccess(receiverType, fieldName, ...)`, recurse on receiver, return `ir1Member(receiverL1, qualifiedName)`. Otherwise return a distinguished sentinel — recommend a discriminated union for the return type: `{ kind: 'ok'; value: IR1Expr } | { kind: 'unsupported'; reason: string } | { kind: 'ambiguous' }`. Reason for the rejection: `"computed property access (obj[expr]) is unsupported; use obj.field or obj[\"literal\"]"`
- In `translate-body.ts`, find the dispatch site for `ElementAccessExpression` (currently routes to a generic application path). Replace with the helper invocation: on `kind: 'ok'`, lower; on `kind: 'unsupported'`, emit the unsupported reason; on `kind: 'ambiguous'`, emit the existing ambiguous-field message
- In `translate-signature.ts:475, 524`, the existing rejection of `ElementAccessExpression` in guard-classification is unchanged (guard classification is stricter — element access stays unsupported in guard position regardless of literal-key). For body-position element access, route through the helper
- Create `tools/ts2pant/tests/fixtures/constructs/expressions-property-element-access.ts` with: `getOwnerByLiteral(a: Account): User { return a["owner"]; }` (positive simple), `getOwnerNameByLiteral(a: Account): string { return a["owner"]["name"]; }` (positive nested), `effectiveBalanceByLiteral(a: Account): number { return a["active"] ? a["balance"] : 0; }` (positive conditional), and a deliberate-reject case `getByDynamicKey(a: Account, k: keyof Account): unknown { return a[k]; }` (computed)
- Run `just ts2pant-test-update-snapshots` once to capture the new snapshot. Inspect the diff: the positive cases should produce identical Pant output to the dotted-access fixture; the deliberate-reject function should be skipped from the snapshot (constructs runner skips functions that fail to translate)
- Run `just ts2pant-test-integration` — `pant --check` should accept the positive functions
- Add unit tests in `tests/ir1-build-property.test.mts`: (a) `obj["f"]` builds Member; (b) `obj[k]` (Identifier index) returns unsupported with the expected reason; (c) `obj[1+1]` (computed) returns unsupported; (d) snapshot equivalence — `obj.f` and `obj["f"]` produce identical L1 trees

## Changes
- In `tools/ts2pant/src/ir1-build.ts`'s `buildL1MemberAccess`, add the `ElementAccessExpression` arm. Body: if `ts.isStringLiteral(node.argumentExpression)` (or `ts.isNoSubstitutionTemplateLiteral` — accept both), extract `fieldName = node.argumentExpression.text`, get `receiverType = ctx.checker.getTypeAtLocation(node.expression)`, call `qualifyFieldAccess(receiverType, fieldName, ...)`, recurse on receiver, return `ir1Member(receiverL1, qualifiedName)`. Otherwise return a distinguished sentinel — recommend a discriminated union for the return type: `{ kind: 'ok'; value: IR1Expr } | { kind: 'unsupported'; reason: string } | { kind: 'ambiguous' }`. Reason for the rejection: `"computed property access (obj[expr]) is unsupported; use obj.field or obj[\"literal\"]"`
- In `translate-body.ts`, find the dispatch site for `ElementAccessExpression` (currently routes to a generic application path). Replace with the helper invocation: on `kind: 'ok'`, lower; on `kind: 'unsupported'`, emit the unsupported reason; on `kind: 'ambiguous'`, emit the existing ambiguous-field message
- In `translate-signature.ts:475, 524`, the existing rejection of `ElementAccessExpression` in guard-classification is unchanged (guard classification is stricter — element access stays unsupported in guard position regardless of literal-key). For body-position element access, route through the helper
- Create `tools/ts2pant/tests/fixtures/constructs/expressions-property-element-access.ts` with: `getOwnerByLiteral(a: Account): User { return a["owner"]; }` (positive simple), `getOwnerNameByLiteral(a: Account): string { return a["owner"]["name"]; }` (positive nested), `effectiveBalanceByLiteral(a: Account): number { return a["active"] ? a["balance"] : 0; }` (positive conditional), and a deliberate-reject case `getByDynamicKey(a: Account, k: keyof Account): unknown { return a[k]; }` (computed)
- Run `just ts2pant-test-update-snapshots` once to capture the new snapshot. Inspect the diff: the positive cases should produce identical Pant output to the dotted-access fixture; the deliberate-reject function should be skipped from the snapshot (constructs runner skips functions that fail to translate)
- Run `just ts2pant-test-integration` — `pant --check` should accept the positive functions
- Add unit tests in `tests/ir1-build-property.test.mts`: (a) `obj["f"]` builds Member; (b) `obj[k]` (Identifier index) returns unsupported with the expected reason; (c) `obj[1+1]` (computed) returns unsupported; (d) snapshot equivalence — `obj.f` and `obj["f"]` produce identical L1 trees

## Files to Modify
- tools/ts2pant/src/ir1-build.ts (modify): Extend `buildL1MemberAccess` to accept `ts.ElementAccessExpression` whose `argumentExpression` is a `StringLiteral`; for non-literal argumentExpression, return the unsupported sentinel
- tools/ts2pant/src/translate-body.ts (modify): Route `ElementAccessExpression` through `buildL1MemberAccess`. For string-literal index, build Member; for computed index, emit `unsupported: "computed property access (obj[expr]) is unsupported; use obj.field or obj[\"literal\"]"`
- tools/ts2pant/src/translate-signature.ts (modify): Mirror the routing in the signature-position translator at lines 475 and 524
- tools/ts2pant/tests/fixtures/constructs/expressions-property-element-access.ts (create): Fixture covering string-literal element access (simple + nested + conditional) and a deliberate computed-access reject case
- tools/ts2pant/tests/constructs.test.mts.snapshot (modify): Snapshot updates from the new fixture
- tools/ts2pant/tests/ir1-build-property.test.mts (modify): Extend with string-literal ElementAccess and computed-rejection unit tests

## Gameplan Specification

```
module TS2PANT_M5_PROPERTY_ACCESS.

> M5 final state: every property-access surface form ts2pant supports
> flows through L1 Member. The legacy direct-to-L2 App-construction
> path is retired across all 9 documented sites. The hard-rule
> discipline holds for the property-access equivalence class.
>
> Cutover gate is reviewed-snapshot-diff plus `pant --check` plus
> dogfood, not literal byte-equality with pre-M5 output. The two-tier
> qualifier behavior (qualified rule names for resolved owners; bare
> kebab names for built-ins / type parameters; null for ambiguous
> unions) is preserved as-is — the asymmetry is a deliberate EUF
> tier separation, not an inconsistency.

TSExpr.
L1Expr.
OpaqueExpr.
L1Stmt.

> Surface forms in scope.
is-property-access? t: TSExpr => Bool.
is-string-literal-elem-access? t: TSExpr => Bool.
is-computed-elem-access? t: TSExpr => Bool.
is-paren? t: TSExpr => Bool.
paren-inner t: TSExpr, is-paren? t => TSExpr.
unwrap-parens t: TSExpr => TSExpr.

> The property-access surface set is exactly these three forms; every
> TS expression node ts2pant classifies as property-access falls into
> one of them.
is-any-property-form? t: TSExpr, is-property-access? t or is-string-literal-elem-access? t or is-computed-elem-access? t => Bool.

> Field name extraction.
property-receiver t: TSExpr, is-any-property-form? t => TSExpr.
property-key t: TSExpr, is-property-access? t or is-string-literal-elem-access? t => String.
qualify-field r: TSExpr, n: String => String.

> L1 build pass and Member form.
build-l1 t: TSExpr => L1Expr.
is-member? e: L1Expr => Bool.
member-receiver e: L1Expr, is-member? e => L1Expr.
member-name e: L1Expr, is-member? e => String.
is-from-l2? e: L1Expr => Bool.
unsupported? e: L1Expr => Bool.

> Mutating-body assignment statements.
is-assignment-stmt? s: L1Stmt => Bool.
target s: L1Stmt, is-assignment-stmt? s => L1Expr.

> Functor-lift recognizer.
is-functor-lift-shape? t: TSExpr => Bool.
functor-lift-operand t: TSExpr, is-functor-lift-shape? t => TSExpr.
is-each-comprehension? e: L1Expr => Bool.

> Cardinality dispatch (deliberate non-Member path).
is-cardinality-form? t: TSExpr, is-property-access? t => Bool.
is-card-unop? e: L1Expr => Bool.

---

> Invariant 1: Dotted property access builds canonical L1 Member with
> the qualified rule name.
all t: TSExpr, is-property-access? t |
  is-member? (build-l1 t)
  and member-name (build-l1 t) = qualify-field (property-receiver t) (property-key t).

> Invariant 2: String-literal element access shares the canonical
> Member form (one canonical form per construct).
all t: TSExpr, is-string-literal-elem-access? t |
  is-member? (build-l1 t)
  and member-name (build-l1 t) = qualify-field (property-receiver t) (property-key t).

> Invariant 3: Computed (non-literal) element access is rejected
> unconditionally. Uniform reject is the conservative-refusal-3(b)
> answer; the DoD's 'unless type system resolves to a known field set'
> path is deferred to a follow-up.
all t: TSExpr, is-computed-elem-access? t | unsupported? (build-l1 t).

> Invariant 4: Universal L1-layering — paren-wrapped expressions
> build to identical L1 trees as their unwrapped inner expressions,
> for every L1 form. Downstream recognizers do not re-implement
> paren-stripping.
all t: TSExpr, is-paren? t | build-l1 t = build-l1 (unwrap-parens t).

> Invariant 5: Mutating-body assignment targets are L1 Member
> expressions. The hard rule for the property-access equivalence
> class extends to statement-position writes.
all s: L1Stmt, is-assignment-stmt? s | is-member? (target s).

> Invariant 6: Property-access sub-expressions no longer wrap via
> from-l2. The from-l2 adapter still survives for non-property
> sub-expressions awaiting M6 deletion of the form.
all t: TSExpr, is-any-property-form? t | ~(is-from-l2? (build-l1 t)).

> Invariant 7: The functor-lift recognizer accepts operands whose L1
> form is Var or Member (Identifier, dotted-property, or string-
> literal element access). The M4 P5 TS-AST restriction to simple
> identifier is replaced with an L1-shape eligibility check.
all t: TSExpr, is-functor-lift-shape? t |
  is-any-property-form? (functor-lift-operand t)
  or is-each-comprehension? (build-l1 t).

> Invariant 8: Cardinality dispatch. `.length` / `.size` on the six
> list-shaped TS types (Array, ReadonlyArray, Set, ReadonlySet, Map,
> ReadonlyMap) build to L1 Unop(card, receiver) via
> tryBuildL1Cardinality, NOT Member. This dispatch fires before
> Member; the divergence is target-language-driven (Pant's
> cardinality primitive is `#x`, not a `length` / `size` rule).
all t: TSExpr, is-cardinality-form? t | is-card-unop? (build-l1 t).

```

## Patch Specification

```
module TS2PANT_M5_PATCH_3.

> Patch 3 extends Member to recognize string-literal ElementAccess
> and rejects computed ElementAccess.

TSExpr.
L1Expr.

is-string-literal-elem-access? t: TSExpr => Bool.
is-computed-elem-access? t: TSExpr => Bool.

elem-receiver t: TSExpr, is-string-literal-elem-access? t => TSExpr.
elem-key t: TSExpr, is-string-literal-elem-access? t => String.

build-l1 t: TSExpr => L1Expr.
is-member? e: L1Expr => Bool.
member-name e: L1Expr, is-member? e => String.
unsupported? e: L1Expr => Bool.

qualify-field r: TSExpr, n: String => String.

---

> String-literal element access builds the same canonical Member form
> as dotted property access; one canonical form per construct.
all t: TSExpr, is-string-literal-elem-access? t |
  is-member? (build-l1 t)
  and member-name (build-l1 t) = qualify-field (elem-receiver t) (elem-key t).

> Computed element access (non-literal index) rejects unconditionally.
> The DoD's 'unless type system resolves to a known field set' path
> is deferred; uniform rejection is the conservative-refusal-3(b)
> answer.
all t: TSExpr, is-computed-elem-access? t | unsupported? (build-l1 t).

```


## Implementation Notes

- **Return-shape decision (deviation from plan).** The plan recommended refactoring `buildL1MemberAccess` to a 3-arm discriminated union (`{ kind: 'ok' | 'unsupported' | 'ambiguous' }`). Kept the Patch 1 shape `IR1Expr | { unsupported: string }` instead — refactoring would churn every call site (`translate-body.ts`, `translate-signature.ts`, the unit tests) for no behavioral benefit. The "ambiguous" sub-case is already captured via reason text prefixed with `"ambiguous owner"`, which existing tests match against. Spec invariants 2 and 3 don't depend on the return-shape detail.

- **Reason-text wording (deviation from plan).** The plan's literal text `'... use obj.field or obj["literal"]'` tripped Biome's `lint/security/noSecrets` entropy heuristic on the dense punctuation, and the suppression directive itself was flagged as `suppressions/unused`. Reworded to `"computed property access (obj[expr]) is unsupported; use dotted property access or a string-literal index instead"` — same diagnostic intent, no entropy hit. Unit tests assert against `/computed property access/u`, which matches both wordings; the snapshot was regenerated with the new text.

- **Body-position dispatch site was new, not pre-existing.** `translate-body.ts` had no `ElementAccessExpression` arm — the prior path fell through to `translateExpr`'s raw-text fallback (`ast.var(expr.getText())`), which would have emitted source text as a Pant variable name. Added a fresh dispatch block immediately after the `PropertyAccessExpression` arm, gated on non-optional-chain. Optional-chain element access (`obj?.["f"]`) is left for follow-up; the existing `?.` functor lift only handles PropertyAccess today.

- **Signature-position dispatch widened.** Patch 1's M5 PropertyAccess block in `translate-signature.ts:translateExpr` was widened in place to also accept `ElementAccessExpression` (same optional-chain gate, same helper call, same paren-strip retry). Guard-classification helpers (`containsUnsupportedOperator`, `isPureExpression`) at lines 478/527 were left alone per the plan.

- **Recursion gate generalized.** Added an `isMemberSurfaceForm` predicate (PropertyAccess OR string-literal ElementAccess, both non-optional-chain) so `a["owner"]["name"]` composes into nested Members identical to `a.owner.name` rather than flattening the inner step into a single `from-l2` wrap. The unit test "nested string-literal ElementAccess composes" asserts this directly via `expectMember(outer.receiver)`.

- **`obj["length"]` deliberately routes to Member, not cardinality.** `tryBuildL1Cardinality` only matches `PropertyAccessExpression` per spec Invariant 8 (`is-cardinality-form? t, is-property-access? t`). String-literal element access on a `.length`/`.size` slot would lower to the EUF `length`/`size` rule application, not `#x`. Acceptable today since spec doesn't include it; flagged here in case a fixture later demands the symmetry.

- **z3-gated check skipped locally.** Three `pant --check` integration tests skip with `# z3 not available`; CI has z3. Manually verified the positive fixture's expected output parses + type-checks through the `pant` binary directly. Snapshot diff confirms byte-identity with the dotted-access fixture's propositions modulo function name (e.g. `get-owner-by-literal a = account--owner a.` vs `get-owner a = account--owner a.`).

- **The constructs runner does not skip failing functions.** Plan said the deliberate-reject `getByDynamicKey` would be "skipped from the snapshot"; the actual runner snapshots every exported function unconditionally and the rejection surfaces as a `> UNSUPPORTED: ...` line — which is what landed in the snapshot for that case.