### PR TITLE
[ts2pant-m5-property-access] Patch 2: Cut over mutating-body PropertyAccess sites

### DIFF
--- a/tools/ts2pant/src/ir1-build-body.ts
+++ b/tools/ts2pant/src/ir1-build-body.ts
@@ -1052,7 +1052,7 @@ const COMPOUND_ASSIGN_TO_BINOP: Map<ts.SyntaxKind, ts.BinaryOperator> = new Map(
  * `lhs = lhs OP rhs` via `COMPOUND_ASSIGN_TO_BINOP` so the IR carries
  * one canonical assign shape regardless of surface spelling.
  */
-function buildL1AssignStmt(
+export function buildL1AssignStmt(
   stmt: ts.ExpressionStatement,
   ctx: BuildBodyCtx,
 ): BuildResult<IR1Stmt> {

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -17,6 +17,7 @@ import {
   tryRecognizeFunctorLift,
 } from "./ir1-build.js";
 import {
+  buildL1AssignStmt,
   buildL1ForEachCall,
   buildL1ForOfMutation,
   buildL1IfMutation,
@@ -3460,17 +3461,27 @@ export function translateCallExpr(
         return { unsupported: "parameter-level Set mutation" };
       }
       const innerObj = normalizedReceiver.expression;
-      const rawFieldName = normalizedReceiver.name.text;
-      const fieldName = qualifyFieldAccess(
-        checker.getTypeAtLocation(innerObj),
-        rawFieldName,
+      // M5: route Stage A receiver-property qualification through the
+      // canonical L1 Member helper. It bundles `qualifyFieldAccess` +
+      // receiver translation in one call and yields the rule name and
+      // receiver L1 expression for the effect descriptor.
+      const memberR = buildL1MemberAccess(normalizedReceiver, {
         checker,
         strategy,
-        supply.synthCell,
-      );
-      if (fieldName === null) {
-        return { unsupported: ambiguousFieldMsg(rawFieldName) };
+        paramNames,
+        state,
+        supply,
+      });
+      if (isL1Unsupported(memberR)) {
+        return { unsupported: memberR.unsupported };
       }
+      if (memberR.kind !== "member") {
+        return {
+          unsupported:
+            "Set mutation receiver did not resolve to canonical L1 Member",
+        };
+      }
+      const fieldName = memberR.name;
       const ownerType = mapTsType(
         checker.getTypeAtLocation(innerObj),
         checker,
@@ -3489,18 +3500,7 @@ export function translateCallExpr(
         strategy,
         supply.synthCell,
       );
-      const objRaw = translateBodyExpr(
-        innerObj,
-        checker,
-        strategy,
-        paramNames,
-        state,
-        supply,
-      );
-      const objExpr = rejectEffect(objRaw);
-      if (isBodyUnsupported(objExpr)) {
-        return objExpr;
-      }
+      const objOpaque = lowerL1ToOpaque(memberR.receiver);
       let elemOpaque: OpaqueExpr | null = null;
       if (methodName !== "clear") {
         const eRaw = translateBodyExpr(
@@ -3523,7 +3523,7 @@ export function translateCallExpr(
           ruleName: fieldName,
           ownerType,
           elemType,
-          objExpr: bodyExpr(objExpr),
+          objExpr: objOpaque,
           elemExpr: elemOpaque,
         },
       };
@@ -3579,38 +3579,33 @@ export function translateCallExpr(
       }
 
       if (stageA && ts.isPropertyAccessExpression(normalizedReceiver)) {
-        const rawFieldName = normalizedReceiver.name.text;
         const innerObj = normalizedReceiver.expression;
-        const objRaw = translateBodyExpr(
-          innerObj,
+        // M5: Stage A receiver-property qualification through the
+        // canonical L1 Member helper. The qualified rule + receiver
+        // OpaqueExpr feed the Map effect descriptor.
+        const memberR = buildL1MemberAccess(normalizedReceiver, {
           checker,
           strategy,
           paramNames,
           state,
           supply,
-        );
-        const objExpr = rejectEffect(objRaw);
-        if (isBodyUnsupported(objExpr)) {
-          return objExpr;
+        });
+        if (isL1Unsupported(memberR)) {
+          return { unsupported: memberR.unsupported };
         }
+        if (memberR.kind !== "member") {
+          return {
+            unsupported:
+              "Map mutation receiver did not resolve to canonical L1 Member",
+          };
+        }
+        const fieldName = memberR.name;
         const ownerType = mapTsType(
           checker.getTypeAtLocation(innerObj),
           checker,
           strategy,
           supply.synthCell,
         );
-        // Qualify the field-derived rule + keyPred names, matching the
-        // Stage A emission in translateTypes.
-        const fieldName = qualifyFieldAccess(
-          checker.getTypeAtLocation(innerObj),
-          rawFieldName,
-          checker,
-          strategy,
-          supply.synthCell,
-        );
-        if (fieldName === null) {
-          return { unsupported: ambiguousFieldMsg(rawFieldName) };
-        }
         const typeArgs = checker.getTypeArguments(
           checker.getTypeAtLocation(normalizedReceiver) as ts.TypeReference,
         );
@@ -3630,7 +3625,7 @@ export function translateCallExpr(
             keyPredName: `${fieldName}-key`,
             ownerType,
             keyType,
-            objExpr: bodyExpr(objExpr),
+            objExpr: lowerL1ToOpaque(memberR.receiver),
             keyExpr: bodyExpr(kExpr),
             valueExpr,
           },
@@ -3717,18 +3712,27 @@ export function translateCallExpr(
         isInterfaceFieldAccess(normalizedReceiver, checker);
 
       if (stageA && ts.isPropertyAccessExpression(normalizedReceiver)) {
-        const rawFieldName = normalizedReceiver.name.text;
         const innerObj = normalizedReceiver.expression;
-        const fieldName = qualifyFieldAccess(
-          checker.getTypeAtLocation(innerObj),
-          rawFieldName,
+        // M5: Stage A receiver-property qualification through the L1
+        // Member helper. The receiver L1 lowers to an OpaqueExpr for
+        // `readMapThroughWrites`.
+        const memberR = buildL1MemberAccess(normalizedReceiver, {
           checker,
           strategy,
-          supply.synthCell,
-        );
-        if (fieldName === null) {
-          return { unsupported: ambiguousFieldMsg(rawFieldName) };
+          paramNames,
+          state,
+          supply,
+        });
+        if (isL1Unsupported(memberR)) {
+          return { unsupported: memberR.unsupported };
         }
+        if (memberR.kind !== "member") {
+          return {
+            unsupported:
+              "Map read receiver did not resolve to canonical L1 Member",
+          };
+        }
+        const fieldName = memberR.name;
         const kExpr = translateBodyExpr(
           expr.arguments[0]!,
           checker,
@@ -3739,17 +3743,6 @@ export function translateCallExpr(
         );
         if (isBodyUnsupported(kExpr)) {
           return kExpr;
-        }
-        const objExpr = translateBodyExpr(
-          innerObj,
-          checker,
-          strategy,
-          paramNames,
-          state,
-          supply,
-        );
-        if (isBodyUnsupported(objExpr)) {
-          return objExpr;
         }
         const typeArgs = checker.getTypeArguments(
           checker.getTypeAtLocation(normalizedReceiver) as ts.TypeReference,
@@ -3777,7 +3770,7 @@ export function translateCallExpr(
             `${fieldName}-key`,
             ownerType,
             keyType,
-            bodyExpr(objExpr),
+            lowerL1ToOpaque(memberR.receiver),
             bodyExpr(kExpr),
           ),
         };
@@ -3911,15 +3904,19 @@ export function translateCallExpr(
           isInterfaceFieldAccess(normalizedReceiver, checker)
         ) {
           const innerObj = normalizedReceiver.expression;
-          const rawFieldName = normalizedReceiver.name.text;
-          const fieldName = qualifyFieldAccess(
-            checker.getTypeAtLocation(innerObj),
-            rawFieldName,
+          // M5: route Stage A field qualification through L1 Member.
+          // Falls through to the generic membership construction below
+          // if the helper rejects (ambiguous owner / non-Member result),
+          // mirroring the legacy `fieldName === null` graceful fallback.
+          const memberR = buildL1MemberAccess(normalizedReceiver, {
             checker,
             strategy,
-            supply.synthCell,
-          );
-          if (fieldName !== null) {
+            paramNames,
+            state,
+            supply,
+          });
+          if (!isL1Unsupported(memberR) && memberR.kind === "member") {
+            const fieldName = memberR.name;
             const ownerType = mapTsType(
               checker.getTypeAtLocation(innerObj),
               checker,
@@ -3934,25 +3931,13 @@ export function translateCallExpr(
                 ? mapTsType(typeArgs[0]!, checker, strategy, supply.synthCell)
                 : null;
             if (elemType !== null) {
-              const innerObjRaw = translateBodyExpr(
-                innerObj,
-                checker,
-                strategy,
-                paramNames,
-                state,
-                supply,
-              );
-              const innerObjExpr = rejectEffect(innerObjRaw);
-              if (isBodyUnsupported(innerObjExpr)) {
-                return innerObjExpr;
-              }
               return {
                 expr: readSetThroughWrites(
                   state,
                   fieldName,
                   ownerType,
                   elemType,
-                  bodyExpr(innerObjExpr),
+                  lowerL1ToOpaque(memberR.receiver),
                   bodyExpr(arg),
                 ),
               };
@@ -4587,7 +4572,12 @@ function symbolicExecute(
       // Otherwise fall through to forEach / side-effect handling below.
     }
 
-    // Property assignment: obj.prop = rhs
+    // Property assignment: obj.prop = rhs. Routes through L1: build
+    // canonical `Assign(Member(receiver, name), value)` via
+    // `buildL1AssignStmt`, then `lowerL1Body` installs the write into
+    // `SymbolicState`. Output is byte-equal to the legacy direct
+    // construction (M5 hard-rule cutover for the property-access
+    // equivalence class — assignment targets are L1 Member).
     if (
       ts.isExpressionStatement(stmt) &&
       ts.isBinaryExpression(unwrapExpression(stmt.expression))
@@ -4600,77 +4590,25 @@ function symbolicExecute(
         (isSimpleAssign || compoundOp !== undefined) &&
         ts.isPropertyAccessExpression(bin.left)
       ) {
-        const rawProp = bin.left.name.text;
-        const receiverType = checker.getTypeAtLocation(bin.left.expression);
-        // Qualify once at the write site; the state keys, primed-lhs
-        // emission, modifiedProps tracking, and frame conditions all see
-        // the same already-qualified rule name.
-        const prop = qualifyFieldAccess(
-          receiverType,
-          rawProp,
+        const built = buildL1AssignStmt(stmt, {
           checker,
           strategy,
-          supply.synthCell,
-        );
-        if (prop === null) {
+          paramNames,
+          state,
+          supply,
+          applyConst,
+        });
+        if (isUnsupported(built)) {
           ok = false;
           propositions.push({
             kind: "unsupported",
-            reason: ambiguousFieldMsg(rawProp),
+            reason: built.unsupported,
           });
           continue;
         }
-        // `rejectEffect` collapses a value-position Map/Set mutation
-        // (e.g. `a.p = m.set(k, v)`) into `unsupported` so `bodyExpr`
-        // never throws on the `{ effect }` shape downstream.
-        const obj = rejectEffect(
-          translateBodyExpr(
-            bin.left.expression,
-            checker,
-            strategy,
-            paramNames,
-            state,
-            supply,
-          ),
-        );
-        if (isBodyUnsupported(obj)) {
+        if (!lowerL1Body(built, state, propositions, { applyConst })) {
           ok = false;
-          propositions.push({ kind: "unsupported", reason: obj.unsupported });
-          continue;
         }
-        // For compound assignment `a.p OP= v`, desugar rhs to `a.p OP v`.
-        // The rhs's `a.p` read goes through translateBodyExpr, which
-        // consults the symbolic state and returns the prior-write value
-        // or the pre-state identity.
-        const rhsNode =
-          compoundOp !== undefined
-            ? ts.factory.createBinaryExpression(bin.left, compoundOp, bin.right)
-            : bin.right;
-        const val = rejectEffect(
-          translateBodyExpr(
-            rhsNode,
-            checker,
-            strategy,
-            paramNames,
-            state,
-            supply,
-          ),
-        );
-        if (isBodyUnsupported(val)) {
-          ok = false;
-          propositions.push({ kind: "unsupported", reason: val.unsupported });
-          continue;
-        }
-        const objExpr = applyConst(bodyExpr(obj));
-        const valExpr = applyConst(bodyExpr(val));
-        const key = symbolicKey(prop, objExpr);
-        state.writes = putWrite(state.writes, key, {
-          kind: "property",
-          prop,
-          objExpr,
-          value: valExpr,
-        });
-        state.writtenKeys = addWrittenKey(state.writtenKeys, key);
         continue;
       }
     }


### PR DESCRIPTION
## Patch 2: Cut over mutating-body PropertyAccess sites

- Audit each call site of `qualifyFieldAccess` in `translate-body.ts` (lines 2846, 3484, 3624, 3742, 3935, 4628). For each, the call signature is `qualifyFieldAccess(receiverType, fieldName, checker, strategy, synthCell)` — the receiver TS node is in scope at each site. Replace the direct call with `buildL1MemberAccess(receiverPropertyAccessNode, ctx)` to get the L1 Member, then unwrap via `lowerL1Expr` if the surrounding code expects an OpaqueExpr
- For Foreach Shape A sites (`translate-body.ts:3624, 3742, 3935`): the per-iter equation `all $N in src | prop' $N = …` references the property name. Today the code carries the qualified name as a string and constructs the equation via `ast.binop(opEq, ast.primed(prop, [binder]), value)`. With M5, the property name is the `name` field of an L1 `Member` — keep the existing equation construction (it doesn't need an L1 expression-form transformation, just uses the same qualified string). The `Member` form is the build-time canonicalization for *expression-position* reads; statement-position assignment targets continue to carry the qualified name as a string in the L1 statement form (`IR1Stmt.assign.target` is already an `IR1Expr` and accepts `Member`)
- For mutating-target sites in `ir1-build-body.ts:600, 786, 1093` (where the assignment target's property name is qualified): construct the L1 statement's `target` field as `ir1Member(receiverL1, qualifiedName)` rather than carrying the qualified name as a separate string field. This may require a small adjustment to `IR1Stmt.assign`'s target handling in `ir1-lower-body.ts` if the lower pass currently expects a string-shaped target — verify by reading the lower pass and aligning
- Run `just ts2pant-test` — `tests/fixtures/constructs/expressions-map-mutation-field.ts` and `expressions-set-mutation-field.ts` snapshots are reviewed for sensibility. Expected to be byte-equal in practice; deliberate consistency improvements must be justified in the patch description
- Run `just ts2pant-test-integration` — pant --check should still accept every M3 mutation fixture as well-typed
- Run dogfood (`tests/integration/dogfood.test.mts`) — ts2pant translates its own source. Property accesses are pervasive; this is the broadest snapshot check

## Changes
- Audit each call site of `qualifyFieldAccess` in `translate-body.ts` (lines 2846, 3484, 3624, 3742, 3935, 4628). For each, the call signature is `qualifyFieldAccess(receiverType, fieldName, checker, strategy, synthCell)` — the receiver TS node is in scope at each site. Replace the direct call with `buildL1MemberAccess(receiverPropertyAccessNode, ctx)` to get the L1 Member, then unwrap via `lowerL1Expr` if the surrounding code expects an OpaqueExpr
- For Foreach Shape A sites (`translate-body.ts:3624, 3742, 3935`): the per-iter equation `all $N in src | prop' $N = …` references the property name. Today the code carries the qualified name as a string and constructs the equation via `ast.binop(opEq, ast.primed(prop, [binder]), value)`. With M5, the property name is the `name` field of an L1 `Member` — keep the existing equation construction (it doesn't need an L1 expression-form transformation, just uses the same qualified string). The `Member` form is the build-time canonicalization for *expression-position* reads; statement-position assignment targets continue to carry the qualified name as a string in the L1 statement form (`IR1Stmt.assign.target` is already an `IR1Expr` and accepts `Member`)
- For mutating-target sites in `ir1-build-body.ts:600, 786, 1093` (where the assignment target's property name is qualified): construct the L1 statement's `target` field as `ir1Member(receiverL1, qualifiedName)` rather than carrying the qualified name as a separate string field. This may require a small adjustment to `IR1Stmt.assign`'s target handling in `ir1-lower-body.ts` if the lower pass currently expects a string-shaped target — verify by reading the lower pass and aligning
- Run `just ts2pant-test` — `tests/fixtures/constructs/expressions-map-mutation-field.ts` and `expressions-set-mutation-field.ts` snapshots are reviewed for sensibility. Expected to be byte-equal in practice; deliberate consistency improvements must be justified in the patch description
- Run `just ts2pant-test-integration` — pant --check should still accept every M3 mutation fixture as well-typed
- Run dogfood (`tests/integration/dogfood.test.mts`) — ts2pant translates its own source. Property accesses are pervasive; this is the broadest snapshot check

## Files to Modify
- tools/ts2pant/src/translate-body.ts (modify): Cut over the mutating-body `qualifyFieldAccess` callers at lines 2846, 3484, 3624, 3742, 3935, 4628 to construct L1 `Member` for the receiver/target rather than calling `qualifyFieldAccess` directly and reconstructing
- tools/ts2pant/src/ir1-build-body.ts (modify): Cut over the three target-property sites (lines 600, 786, 1093) to build the assignment target as L1 `Member(receiverL1, qualifiedName)` — the assignment statement form already accepts an L1 expression target

## Gameplan Specification

```
module TS2PANT_M5_PROPERTY_ACCESS.

> M5 final state: every property-access surface form ts2pant supports
> flows through L1 Member. The legacy direct-to-L2 App-construction
> path is retired across all 9 documented sites. The hard-rule
> discipline holds for the property-access equivalence class.
>
> Cutover gate is reviewed-snapshot-diff plus `pant --check` plus
> dogfood, not literal byte-equality with pre-M5 output. The two-tier
> qualifier behavior (qualified rule names for resolved owners; bare
> kebab names for built-ins / type parameters; null for ambiguous
> unions) is preserved as-is — the asymmetry is a deliberate EUF
> tier separation, not an inconsistency.

TSExpr.
L1Expr.
OpaqueExpr.
L1Stmt.

> Surface forms in scope.
is-property-access? t: TSExpr => Bool.
is-string-literal-elem-access? t: TSExpr => Bool.
is-computed-elem-access? t: TSExpr => Bool.
is-paren? t: TSExpr => Bool.
paren-inner t: TSExpr, is-paren? t => TSExpr.
unwrap-parens t: TSExpr => TSExpr.

> The property-access surface set is exactly these three forms; every
> TS expression node ts2pant classifies as property-access falls into
> one of them.
is-any-property-form? t: TSExpr, is-property-access? t or is-string-literal-elem-access? t or is-computed-elem-access? t => Bool.

> Field name extraction.
property-receiver t: TSExpr, is-any-property-form? t => TSExpr.
property-key t: TSExpr, is-property-access? t or is-string-literal-elem-access? t => String.
qualify-field r: TSExpr, n: String => String.

> L1 build pass and Member form.
build-l1 t: TSExpr => L1Expr.
is-member? e: L1Expr => Bool.
member-receiver e: L1Expr, is-member? e => L1Expr.
member-name e: L1Expr, is-member? e => String.
is-from-l2? e: L1Expr => Bool.
unsupported? e: L1Expr => Bool.

> Mutating-body assignment statements.
is-assignment-stmt? s: L1Stmt => Bool.
target s: L1Stmt, is-assignment-stmt? s => L1Expr.

> Functor-lift recognizer.
is-functor-lift-shape? t: TSExpr => Bool.
functor-lift-operand t: TSExpr, is-functor-lift-shape? t => TSExpr.
is-each-comprehension? e: L1Expr => Bool.

> Cardinality dispatch (deliberate non-Member path).
is-cardinality-form? t: TSExpr, is-property-access? t => Bool.
is-card-unop? e: L1Expr => Bool.

---

> Invariant 1: Dotted property access builds canonical L1 Member with
> the qualified rule name.
all t: TSExpr, is-property-access? t |
  is-member? (build-l1 t)
  and member-name (build-l1 t) = qualify-field (property-receiver t) (property-key t).

> Invariant 2: String-literal element access shares the canonical
> Member form (one canonical form per construct).
all t: TSExpr, is-string-literal-elem-access? t |
  is-member? (build-l1 t)
  and member-name (build-l1 t) = qualify-field (property-receiver t) (property-key t).

> Invariant 3: Computed (non-literal) element access is rejected
> unconditionally. Uniform reject is the conservative-refusal-3(b)
> answer; the DoD's 'unless type system resolves to a known field set'
> path is deferred to a follow-up.
all t: TSExpr, is-computed-elem-access? t | unsupported? (build-l1 t).

> Invariant 4: Universal L1-layering — paren-wrapped expressions
> build to identical L1 trees as their unwrapped inner expressions,
> for every L1 form. Downstream recognizers do not re-implement
> paren-stripping.
all t: TSExpr, is-paren? t | build-l1 t = build-l1 (unwrap-parens t).

> Invariant 5: Mutating-body assignment targets are L1 Member
> expressions. The hard rule for the property-access equivalence
> class extends to statement-position writes.
all s: L1Stmt, is-assignment-stmt? s | is-member? (target s).

> Invariant 6: Property-access sub-expressions no longer wrap via
> from-l2. The from-l2 adapter still survives for non-property
> sub-expressions awaiting M6 deletion of the form.
all t: TSExpr, is-any-property-form? t | ~(is-from-l2? (build-l1 t)).

> Invariant 7: The functor-lift recognizer accepts operands whose L1
> form is Var or Member (Identifier, dotted-property, or string-
> literal element access). The M4 P5 TS-AST restriction to simple
> identifier is replaced with an L1-shape eligibility check.
all t: TSExpr, is-functor-lift-shape? t |
  is-any-property-form? (functor-lift-operand t)
  or is-each-comprehension? (build-l1 t).

> Invariant 8: Cardinality dispatch. `.length` / `.size` on the six
> list-shaped TS types (Array, ReadonlyArray, Set, ReadonlySet, Map,
> ReadonlyMap) build to L1 Unop(card, receiver) via
> tryBuildL1Cardinality, NOT Member. This dispatch fires before
> Member; the divergence is target-language-driven (Pant's
> cardinality primitive is `#x`, not a `length` / `size` rule).
all t: TSExpr, is-cardinality-form? t | is-card-unop? (build-l1 t).

```

## Patch Specification

```
module TS2PANT_M5_PATCH_2.

> Patch 2 cuts over the mutating-body PropertyAccessExpression sites.
> Assignment targets and Foreach receiver-property reads now route
> through L1 Member construction.
>
> The PropResult output is expected to match the legacy mutating path
> for every fixture; reviewed-snapshot-diff across map/set mutation
> fixtures and dogfood is the cutover gate. A deliberate consistency
> improvement is acceptable if it emerges.

L1Expr.
L1Stmt.
PropResult.

is-member? e: L1Expr => Bool.

is-assignment-stmt? s: L1Stmt => Bool.
target s: L1Stmt, is-assignment-stmt? s => L1Expr.

lower-body s: L1Stmt => PropResult.

---

> Every mutating-body assignment statement carries an L1 Member
> expression as its target. The hard rule for the property-access
> equivalence class extends to statement-position writes.
all s: L1Stmt, is-assignment-stmt? s | is-member? (target s).

```


## Implementation Notes

### Site-by-site mapping (gameplan line numbers shifted post-Patch-1)

The gameplan's `translate-body.ts` line numbers (2846, 3484, 3624, 3742, 3935, 4628) are pre-Patch-1; the actual sites are at 2811, 3464, 3604, 3722, 3915, 4608. Six sites total — same six callers, all audited:

- **2811 (optional-chain functor lift)** — deliberately **not** cut over. The receiver here is the inner of a `?.` chain and the comprehension body uses a *fresh binder* (not the original receiver), so there is no canonical TS property-access node to feed `buildL1MemberAccess`. Per the existing comment at 2776 "M5 doesn't touch `?.`," and the helper itself rejects optional-chain inputs at line 260. The `qualifyFieldAccess` direct call stays.
- **3464 / 3604 / 3722 / 3915 (Set / Map Stage A method calls)** — consolidated. Each replaces the `qualifyFieldAccess(...)` + `translateBodyExpr(innerObj, ...)` pair with a single `buildL1MemberAccess(normalizedReceiver, l1Ctx)`; `member.name` feeds the effect/read descriptor's `ruleName`, `lowerL1ToOpaque(member.receiver)` feeds `objExpr`. The Set `.has` site keeps its graceful-fallback shape: helper-unsupported / non-Member result falls through to the generic `arg in receiver` membership form, mirroring the legacy `fieldName === null` behavior.
- **4608 (top-level property assignment in `symbolicExecute`)** — fully cut over to L1. Routes through the now-exported `buildL1AssignStmt` followed by `lowerL1Body`, which installs the write into `SymbolicState` identically to the legacy direct path. This is the site that delivers Patch 2's spec invariant (assignment statement target is Member).

### `ir1-build-body.ts` sites — already correct pre-patch

The gameplan called for cutting over three sites at `ir1-build-body.ts:600, 786, 1093`. On audit:
- **1093 (`buildL1AssignStmt`)** — already constructs `ir1Assign(ir1Member(obj, prop), val)` (M3 shape); `lowerAssign` in `ir1-lower-body.ts:122` already discriminates on `target.kind === "member"`. No change needed.
- **600 (`classifyForeachStmt`'s Shape B leaf)** and **786 (`simulateShapeA`'s subState write)** — neither produces an `IR1Stmt.assign.target`. 600 stores the qualified name on a `ShapeBLeafTS` descriptor whose lowered form is the Shape B fold equation (`prop' target = prop target OP (comb over each ... | rhs)`); 786 keys a `SymbolicState.writes` entry for in-iter Shape A simulation. The gameplan's own task description acknowledges this: "statement-position assignment targets continue to carry the qualified name as a string in the L1 statement form" — these two sites are exactly the string-name shape, and per the spec invariant only `IR1Stmt.assign` targets need to be Member.

The only change to `ir1-build-body.ts` is exporting `buildL1AssignStmt` so `symbolicExecute` can call it.

### Behavioral parity

The four Stage A consolidations introduce one theoretical behavior change: `buildL1MemberAccess` does a symbolic-state lookup at the field level (`(qualified, canonical(receiver))`). For Stage A patterns, no `c.tags = newSet` property-rewrites coexist with `c.tags.add(...)` calls in the same body, so the lookup misses and behavior is byte-equal in practice. The defensive `memberR.kind !== "member"` rejections cover the corner where a future fixture might trigger this.

All snapshots (constructs, e2e, dogfood) are byte-equal against pre-patch output — no deliberate consistency improvements landed.