### PR TITLE
[ts2pant-m5-property-access] Patch 4: Lift functor-lift recognizer's operand restriction to accept Member

### DIFF
--- a/tools/ts2pant/CLAUDE.md
+++ b/tools/ts2pant/CLAUDE.md
@@ -544,16 +544,22 @@ load-bearing; see `workstreams/ts2pant-imperative-ir.md`
 
 **Supported TS shapes.** The operand may be a simple `Identifier`
 (`Var`) or a property-access / string-literal element-access chain
-(`Member`); paren-wrapped variants of either are accepted because L1
-build normalizes parens away before the operand is classified.
-Member-operand support landed in M5 P4 (lifting the M4 P5 simple-
-identifier restriction); the eligibility check is now expressed in
-L1 terms (`Var` or `Member`) rather than TS-AST terms. Member-
-operand projections must surface the operand structurally at the L1
-level — `ast.substituteBinder` substitutes by name and cannot target
-a `Member` subtree, so a Member-operand projection that buries the
-operand inside a non-Member sub-expression (e.g., a method call)
-falls through.
+(`Member`); transparently-wrapped variants of either are accepted
+because the recognizer's outer boundary (`unwrapTransparentExpression`)
+and the recursive Member-chain build (`buildL1MemberOrVarForLift`)
+both strip the same wrapper set — parens, `as` casts, non-null
+assertions (`!`), and `satisfies` — at every level of the chain, so
+eligibility is driven by the operand's L1 shape rather than its
+TS-AST spelling. `qualifyFieldAccess` is still given the parens-
+stripped (but type-erasure-preserving) receiver, so a user's `as T`
+cast continues to drive qualifier resolution. Member-operand support
+landed in M5 P4 (lifting the M4 P5 simple-identifier restriction);
+the eligibility check is now expressed in L1 terms (`Var` or `Member`)
+rather than TS-AST terms. Member-operand projections must surface
+the operand structurally at the L1 level — `ast.substituteBinder`
+substitutes by name and cannot target a `Member` subtree, so a
+Member-operand projection that buries the operand inside a non-
+Member sub-expression (e.g., a method call) falls through.
 
 ```ts
 // (a) Positive ternary, with array wrapper or bare projection.
@@ -575,8 +581,11 @@ return [];
 All four lower to `each n in u | name n` (or `age n`, etc.) — `n` is
 the emitted comprehension binder (a fresh kebab-cased name allocated
 through `cellRegisterName`, suffixed `n1`/`n2`/… on collision), not the
-internal `$N` hygienic class. The fixture is
-`tests/fixtures/constructs/expressions-functor-lift.ts`.
+internal `$N` hygienic class. Fixtures:
+`tests/fixtures/constructs/expressions-functor-lift.ts` (Var
+operand, M4 P5) and
+`tests/fixtures/constructs/expressions-functor-lift-property.ts`
+(Member operand, M5 P4).
 
 **Deliberate rejection of multi-element non-empty branches.** A shape
 like `if (xs == null) return []; return [xs[0], xs[1]];` would require

--- a/tools/ts2pant/CLAUDE.md
+++ b/tools/ts2pant/CLAUDE.md
@@ -39,7 +39,7 @@ These cover the full scope of ts2pant's translation work:
 | Primed variables, frame conditions | Lamport, [*Specifying Systems*](https://lamport.azurewebsites.net/tla/book.html), Addison-Wesley 2002 | TLA+ approach to next-state relations, `UNCHANGED`, and the frame problem |
 | Frame problem in specifications | Borgida et al., ["And Nothing Else Changes"](https://www.researchgate.net/publication/221555223_And_Nothing_Else_Changes_The_Frame_Problem_in_Procedure_Specifications), IEEE TSE 1995 | Definitive treatment of frame conditions in procedure specifications |
 | Capture-avoiding substitution | [Locally Nameless Representation](https://boarders.github.io/posts/locally-nameless/) (Charguéraud 2012) | Alternative to named substitution; useful background for understanding why hygiene matters |
-| Term rewriting | Baader & Nipkow, *Term Rewriting and All That*, Cambridge 1998 | Positions, subterms, first-order substitution; basis for the functor-lift's L1 operand-rewriting (`body[e := $n]`) and the structural matcher in `substituteL1Subtree` |
+| Term rewriting | Baader & Nipkow, *Term Rewriting and All That*, Cambridge 1998 | Positions, subterms, first-order substitution; basis for the functor-lift's L1 operand-rewriting (`body[e := n]`) and the structural matcher in `substituteL1Subtree` |
 | Partial functions / option types | [Dafny Reference Manual](https://dafny.org/dafny/DafnyRef/DafnyRef) | Nullable types, preconditions, `modifies` clauses — practical verification language patterns |
 | IRSC / SSA-based IR | Vekris, Cosman, Jhala, ["Refinement Types for TypeScript"](https://arxiv.org/pdf/1604.02480), PLDI 2016 | Lifting surface-syntax recognizers into a typed intermediate representation via SSA-style translation; precedent for the IR introduced in §"Intermediate Representation" |
 
@@ -232,8 +232,8 @@ without a recognizer: Pant has no list literal, so the alternative
 cardinality-dispatch lowering `cond #u = 0 => [], true => [name (u 1)]`
 has no expressible target. The functor-lift recognizer (M4 Patch 5) is
 the canonical handling for this family — see § "Functor-Lift Recognizer"
-below. The four supported TS shapes lower uniformly to `each $n in u |
-name $n`, the same comprehension shape `?.` already uses.
+below. The four supported TS shapes lower uniformly to `each n in u |
+name n`, the same comprehension shape `?.` already uses.
 
 ### Partial Rules (Map<K, V>)
 
@@ -487,8 +487,11 @@ ops require acc on the left.
 encoding makes `T | null` into `[T]` (length 0 or 1); the recognizer is
 exactly `fmap : (a -> b) -> Maybe a -> Maybe b` specialized to the
 list-as-Maybe representation. The substitution half of the
-transformation (`body[e := $n]`) is first-order term rewriting on the
-L1 IR — see § "Operand-Substitution Rule" below.
+transformation (`body[e := n]`) is first-order term rewriting on the
+L1 IR — see § "Operand-Substitution Rule" below. The metavariable `n`
+denotes a parser-roundtrippable comprehension binder allocated via
+`allocateLiftBinder` / `cellRegisterName` (`n`, `n1`, `n2`, …); it is
+*not* the `$N` internal-hygienic class which exists only pre-emission.
 **Reference:** Wadler, ["The Essence of Functional Programming"](https://homepages.inf.ed.ac.uk/wadler/papers/essence/essence.ps),
 POPL 1992, §2 (the Maybe monad and `fmap`); Hutton & Meijer,
 ["Monadic Parsing in Haskell"](https://www.cs.nott.ac.uk/~pszgmh/pearl.pdf), JFP 1998
@@ -498,7 +501,7 @@ projections); Baader & Nipkow, *Term Rewriting and All That* (Cambridge
 half of the transformation, described below).
 
 `if (x == null) return []; return [f(x)];` and the equivalent ternary /
-negated forms lower to `each $n in x | f $n`. This is *not* an
+negated forms lower to `each n in x | f n`. This is *not* an
 optimization — Pantagruel has no list literal, so the alternative
 cardinality-dispatch lowering `cond #x = 0 => [], true => [f (x 1)]`
 has no expressible Pant target. Without the recognizer these
@@ -569,8 +572,11 @@ if (u !== null) { return [u.name]; }
 return [];
 ```
 
-All four lower to `each $n in u | name $n` (or `age $n`, etc.). The
-fixture is `tests/fixtures/constructs/expressions-functor-lift.ts`.
+All four lower to `each n in u | name n` (or `age n`, etc.) — `n` is
+the emitted comprehension binder (a fresh kebab-cased name allocated
+through `cellRegisterName`, suffixed `n1`/`n2`/… on collision), not the
+internal `$N` hygienic class. The fixture is
+`tests/fixtures/constructs/expressions-functor-lift.ts`.
 
 **Deliberate rejection of multi-element non-empty branches.** A shape
 like `if (xs == null) return []; return [xs[0], xs[1]];` would require
@@ -582,12 +588,16 @@ translatable target). This is intentional under the steering principle's
 rule 1: the TS itself is fine, but ts2pant cannot translate
 "sometimes-multi-element" pattern-matching without misrepresenting it.
 
-**Operand-Substitution Rule (`body[e := $n]`).** The lift's right-hand
-side `each $n in e | body'` is built by replacing every syntactic
+**Operand-Substitution Rule (`body[e := n]`).** The lift's right-hand
+side `each n in e | body'` is built by replacing every syntactic
 occurrence of the operand subterm `e` inside `body` with the fresh
-binder `$n`. This is *first-order term rewriting* (Baader & Nipkow ch. 2):
+binder `n`. This is *first-order term rewriting* (Baader & Nipkow ch. 2):
 match the operand `e` as a needle, replace each match with the binder,
-return the rewritten haystack.
+return the rewritten haystack. The binder `n` here denotes the actual
+emitted name (`n`, `n1`, `n2`, … allocated through `allocateLiftBinder`
+→ `cellRegisterName`); it is *not* the `$N` internal-hygienic class,
+which is reserved for binders that disappear before emission and would
+not round-trip through Pantagruel's lexer.
 
 For Var operands (M4 P5) the substitution primitive is Pant's
 `ast.substituteBinder` post-lowering — the operand's Pant name is
@@ -601,9 +611,11 @@ directly.
 
 The four invariants the rewrite depends on, restated:
 
-1. **Hygiene.** `$n` is allocated via `cellRegisterName` against the
-   document-wide `NameRegistry` — Barendregt convention applied to
-   the comprehension binder.
+1. **Hygiene.** The comprehension binder is allocated via
+   `cellRegisterName` (through `allocateLiftBinder`) against the
+   document-wide `NameRegistry` — a parser-roundtrippable name (`n`,
+   `n1`, `n2`, …), not the `$N` internal class. Barendregt convention
+   applied at the emission layer.
 2. **Structural reachability.** The operand must occur as a syntactic
    subterm of the projection. Var operands are checked via
    `expressionReferencesNames` at the TS-AST level; Member operands
@@ -976,7 +988,7 @@ in the equality / nullish equivalence class flows through Layer 1.
   unconditionally from `===` / `!==`. The L1 form admits arbitrary
   operands; sub-expressions wrap via `from-l2` until M5 brings property
   access onto L1 natively.
-- Functor-lift `each $n in x | f $n` — the canonical lowering for
+- Functor-lift `each n in x | f n` — the canonical lowering for
   null-guarded list-lifted conditionals (see § "Functor-Lift
   Recognizer" above for the four soundness conditions). Combined-shape
   match crossing M1 (Cond) + M4 (IsNullish); load-bearing because

--- a/tools/ts2pant/CLAUDE.md
+++ b/tools/ts2pant/CLAUDE.md
@@ -39,6 +39,7 @@ These cover the full scope of ts2pant's translation work:
 | Primed variables, frame conditions | Lamport, [*Specifying Systems*](https://lamport.azurewebsites.net/tla/book.html), Addison-Wesley 2002 | TLA+ approach to next-state relations, `UNCHANGED`, and the frame problem |
 | Frame problem in specifications | Borgida et al., ["And Nothing Else Changes"](https://www.researchgate.net/publication/221555223_And_Nothing_Else_Changes_The_Frame_Problem_in_Procedure_Specifications), IEEE TSE 1995 | Definitive treatment of frame conditions in procedure specifications |
 | Capture-avoiding substitution | [Locally Nameless Representation](https://boarders.github.io/posts/locally-nameless/) (Charguéraud 2012) | Alternative to named substitution; useful background for understanding why hygiene matters |
+| Term rewriting | Baader & Nipkow, *Term Rewriting and All That*, Cambridge 1998 | Positions, subterms, first-order substitution; basis for the functor-lift's L1 operand-rewriting (`body[e := $n]`) and the structural matcher in `substituteL1Subtree` |
 | Partial functions / option types | [Dafny Reference Manual](https://dafny.org/dafny/DafnyRef/DafnyRef) | Nullable types, preconditions, `modifies` clauses — practical verification language patterns |
 | IRSC / SSA-based IR | Vekris, Cosman, Jhala, ["Refinement Types for TypeScript"](https://arxiv.org/pdf/1604.02480), PLDI 2016 | Lifting surface-syntax recognizers into a typed intermediate representation via SSA-style translation; precedent for the IR introduced in §"Intermediate Representation" |
 
@@ -485,12 +486,16 @@ ops require acc on the left.
 **Standard name:** Functor lift / `Maybe` (option) `fmap`. The list-lift
 encoding makes `T | null` into `[T]` (length 0 or 1); the recognizer is
 exactly `fmap : (a -> b) -> Maybe a -> Maybe b` specialized to the
-list-as-Maybe representation.
+list-as-Maybe representation. The substitution half of the
+transformation (`body[e := $n]`) is first-order term rewriting on the
+L1 IR — see § "Operand-Substitution Rule" below.
 **Reference:** Wadler, ["The Essence of Functional Programming"](https://homepages.inf.ed.ac.uk/wadler/papers/essence/essence.ps),
 POPL 1992, §2 (the Maybe monad and `fmap`); Hutton & Meijer,
 ["Monadic Parsing in Haskell"](https://www.cs.nott.ac.uk/~pszgmh/pearl.pdf), JFP 1998
 (structural lift over `Maybe` as the canonical idiom for null-guarded
-projections).
+projections); Baader & Nipkow, *Term Rewriting and All That* (Cambridge
+1998), ch. 2 (positions, subterms, and substitution — the rewriting
+half of the transformation, described below).
 
 `if (x == null) return []; return [f(x)];` and the equivalent ternary /
 negated forms lower to `each $n in x | f $n`. This is *not* an
@@ -576,6 +581,50 @@ refuses, and these forms fall through to the standard L1 Cond build
 translatable target). This is intentional under the steering principle's
 rule 1: the TS itself is fine, but ts2pant cannot translate
 "sometimes-multi-element" pattern-matching without misrepresenting it.
+
+**Operand-Substitution Rule (`body[e := $n]`).** The lift's right-hand
+side `each $n in e | body'` is built by replacing every syntactic
+occurrence of the operand subterm `e` inside `body` with the fresh
+binder `$n`. This is *first-order term rewriting* (Baader & Nipkow ch. 2):
+match the operand `e` as a needle, replace each match with the binder,
+return the rewritten haystack.
+
+For Var operands (M4 P5) the substitution primitive is Pant's
+`ast.substituteBinder` post-lowering — the operand's Pant name is
+known and the OpaqueExpr walker rewrites every reference. For Member
+operands (M5 P4), `ast.substituteBinder` cannot target a Member
+subtree (it substitutes only by Var name), so the substitution lives
+at the L1 level via `substituteL1Subtree` in `ir1-build.ts`. The
+operand and projection are both built into native L1 (no `from-l2`
+wraps along the chain) so the structural matcher can compare them
+directly.
+
+The four invariants the rewrite depends on, restated:
+
+1. **Hygiene.** `$n` is allocated via `cellRegisterName` against the
+   document-wide `NameRegistry` — Barendregt convention applied to
+   the comprehension binder.
+2. **Structural reachability.** The operand must occur as a syntactic
+   subterm of the projection. Var operands are checked via
+   `expressionReferencesNames` at the TS-AST level; Member operands
+   are gated on the explicit `changed` flag returned by
+   `substituteL1Subtree` (a reference-equality check on the rewritten
+   tree is unreliable because the walker rebuilds compound parents
+   unconditionally).
+3. **Referential transparency at the operand position.** The
+   comprehension evaluates `e` once at its source position; each
+   in-`body` occurrence is replaced by the binder. Sound iff `e` has
+   no observable effects whose duplication or removal would change
+   semantics — implicitly enforced by the recognizer matching only
+   list-lifted nullable shapes that don't admit side effects.
+4. **Closed form on Var/Member.** `structuralEqualL1` only compares
+   `Var` and `Member` shapes; the pure-L1 builder
+   `buildL1MemberOrVarForLift` produces only those shapes. Extending
+   the eligible operand vocabulary (e.g., to `App`) requires
+   extending both the matcher and the accept-set together.
+
+Adding new operand shapes or comparable forms must re-verify all
+four invariants. Update this section when the rewrite changes.
 
 ### Chain Fusion (.filter / .map / .reduce)
 

--- a/tools/ts2pant/CLAUDE.md
+++ b/tools/ts2pant/CLAUDE.md
@@ -534,8 +534,18 @@ load-bearing; see `workstreams/ts2pant-imperative-ir.md`
    from the `ConditionalExpression` for ternaries; from the enclosing
    function's return type for if-conversion entry points.
 
-**Supported TS shapes** (operand restricted to a simple identifier;
-property-access operands defer to M5):
+**Supported TS shapes.** The operand may be a simple `Identifier`
+(`Var`) or a property-access / string-literal element-access chain
+(`Member`); paren-wrapped variants of either are accepted because L1
+build normalizes parens away before the operand is classified.
+Member-operand support landed in M5 P4 (lifting the M4 P5 simple-
+identifier restriction); the eligibility check is now expressed in
+L1 terms (`Var` or `Member`) rather than TS-AST terms. Member-
+operand projections must surface the operand structurally at the L1
+level — `ast.substituteBinder` substitutes by name and cannot target
+a `Member` subtree, so a Member-operand projection that buries the
+operand inside a non-Member sub-expression (e.g., a method call)
+falls through.
 
 ```ts
 // (a) Positive ternary, with array wrapper or bare projection.

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -932,7 +932,17 @@ function buildL1MemberOrVarForLift(
   node: ts.Expression,
   ctx: L1BuildContext,
 ): IR1Expr | null {
-  const stripped = unwrapParens(node) as ts.Expression;
+  // Strip the same set of transparent wrappers the recognizer's
+  // outermost operand uses (`unwrapTransparentExpression`: parens +
+  // `as` + `!` + `satisfies`). Stripping inside the chain keeps
+  // member-lift eligibility driven by the operand's L1 shape rather
+  // than re-introducing TS-syntax sensitivity for wrappers the
+  // recognizer already treats as semantically neutral at the
+  // boundary. `qualifyFieldAccess` is still given the *unstripped*
+  // receiver via `getTypeAtLocation`, so a user's `as T` cast
+  // continues to drive the type-checker resolution that picks the
+  // qualified rule name.
+  const stripped = unwrapTransparentExpression(node);
   if (ts.isIdentifier(stripped)) {
     const pantName = ctx.paramNames.get(stripped.text) ?? stripped.text;
     return ir1Var(pantName);
@@ -941,12 +951,18 @@ function buildL1MemberOrVarForLift(
     ts.isPropertyAccessExpression(stripped) &&
     (stripped.flags & ts.NodeFlags.OptionalChain) === 0
   ) {
-    const receiverNode = unwrapParens(stripped.expression) as ts.Expression;
-    const receiverL1 = buildL1MemberOrVarForLift(receiverNode, ctx);
+    // For `getTypeAtLocation`, use the parens-stripped (but type-
+    // erasure-preserving) receiver so the user's `as T` cast still
+    // drives qualifier resolution. For the recursive L1 build, strip
+    // wrappers via `unwrapTransparentExpression` so the chain
+    // composes regardless of inner wrappers.
+    const receiverForType = unwrapParens(stripped.expression) as ts.Expression;
+    const receiverForRecurse = unwrapTransparentExpression(receiverForType);
+    const receiverL1 = buildL1MemberOrVarForLift(receiverForRecurse, ctx);
     if (receiverL1 === null) {
       return null;
     }
-    const receiverType = ctx.checker.getTypeAtLocation(receiverNode);
+    const receiverType = ctx.checker.getTypeAtLocation(receiverForType);
     const qualified = qualifyFieldAccess(
       receiverType,
       stripped.name.text,
@@ -967,12 +983,13 @@ function buildL1MemberOrVarForLift(
     if (fieldName === null) {
       return null;
     }
-    const receiverNode = unwrapParens(stripped.expression) as ts.Expression;
-    const receiverL1 = buildL1MemberOrVarForLift(receiverNode, ctx);
+    const receiverForType = unwrapParens(stripped.expression) as ts.Expression;
+    const receiverForRecurse = unwrapTransparentExpression(receiverForType);
+    const receiverL1 = buildL1MemberOrVarForLift(receiverForRecurse, ctx);
     if (receiverL1 === null) {
       return null;
     }
-    const receiverType = ctx.checker.getTypeAtLocation(receiverNode);
+    const receiverType = ctx.checker.getTypeAtLocation(receiverForType);
     const qualified = qualifyFieldAccess(
       receiverType,
       fieldName,
@@ -1010,9 +1027,13 @@ function buildL1MemberOrVarForLift(
  * (a simple `Identifier`) or `Member` (a `PropertyAccessExpression`
  * or string-literal `ElementAccessExpression` chain bottoming out at
  * a `Var`). Anything else — calls, binops, computed indices, optional
- * chains, type-erasure wrappers in the chain — falls through to the
- * standard L1 Cond build. Source-level parens are normalized away
- * by L1 build before eligibility is consulted.
+ * chains — falls through to the standard L1 Cond build. Transparent
+ * wrappers (parens, `as`, `!`, `satisfies`) are normalized away by
+ * `unwrapTransparentExpression` at every level of the chain build,
+ * so eligibility stays driven by the operand's L1 shape rather than
+ * its TS-AST spelling. Type-checker resolution for qualified rule
+ * names still consults the unstripped (cast-bearing) receiver, so a
+ * user's `as T` continues to drive qualifier picks.
  *
  * Substitution strategy. For `Var` operands the projection translates
  * through the legacy pipeline (`buildSubExpr`, producing a `from-l2`
@@ -1042,14 +1063,45 @@ export function tryRecognizeFunctorLift(
   }
 
   // M5 P4: classify operand by its L1 shape (Var or Member).
-  // `unwrapTransparentExpression` strips type-erasure wrappers from the
-  // outermost operand for the same reason M4 P5 did — those wrappers are
-  // type-level only and the runtime value is the inner expression. The
-  // recursive Member-chain build (`buildL1MemberOrVarForLift`) only strips
-  // parens, not type-erasure, so a wrapper *inside* the chain (e.g.,
-  // `(u as User).owner`) takes the chain off the pure-L1 path and the lift
-  // falls through.
+  // `unwrapTransparentExpression` strips type-erasure wrappers (parens,
+  // `as`, `!`, `satisfies`) from the outermost operand for the same
+  // reason M4 P5 did — those wrappers are type-level only and the
+  // runtime value is the inner expression. The recursive Member-chain
+  // build inside `buildL1MemberOrVarForLift` strips the same set of
+  // wrappers at every level so eligibility for the lift is driven by
+  // the operand's L1 shape, not its TS-AST spelling.
   const operandNode = unwrapTransparentExpression(leaf.operand);
+
+  // Snapshot supply counter and synth-cell state. Both the operand
+  // build (Member operand path → `qualifyFieldAccess` → anonymous-
+  // record synthesis can mutate `synthCell.recordSynth` /
+  // `synthCell.registry`) and the projection build (`buildSubExpr` for
+  // Var operand can advance `supply.n` via deferred-comprehension
+  // allocations) are reversible at this granularity: the inner
+  // synth-cell records are immutable, so saving the three field
+  // references and restoring them on failure undoes any registrations
+  // accumulated along the rejected path. Without this, eligibility-
+  // failure paths leak anonymous-record domains into the document
+  // even when the lift never fires.
+  const supplyCounterSnapshot = ctx.supply.n;
+  const synthCell = ctx.supply.synthCell;
+  const synthSnapshot = synthCell
+    ? {
+        synth: synthCell.synth,
+        recordSynth: synthCell.recordSynth,
+        registry: synthCell.registry,
+      }
+    : null;
+  const restore = (): null => {
+    ctx.supply.n = supplyCounterSnapshot;
+    if (synthCell && synthSnapshot) {
+      synthCell.synth = synthSnapshot.synth;
+      synthCell.recordSynth = synthSnapshot.recordSynth;
+      synthCell.registry = synthSnapshot.registry;
+    }
+    return null;
+  };
+
   let operandText: string | null = null;
   let operandL1: IR1Expr;
   if (ts.isIdentifier(operandNode)) {
@@ -1059,7 +1111,7 @@ export function tryRecognizeFunctorLift(
   } else {
     const memberOperand = buildL1MemberOrVarForLift(operandNode, ctx);
     if (memberOperand === null || memberOperand.kind !== "member") {
-      return null;
+      return restore();
     }
     operandL1 = memberOperand;
   }
@@ -1072,14 +1124,14 @@ export function tryRecognizeFunctorLift(
 
   // (b) Empty side is empty-equivalent.
   if (!isEmptyEquivalent(emptyExpr, ctx.checker)) {
-    return null;
+    return restore();
   }
 
   // (c) Present side, after stripping a singleton array wrapper, is
   //     not a multi-element-producing shape and references the operand.
   const projection = unwrapSingletonArray(presentExpr);
   if (!isSingleElementProducingShape(projection)) {
-    return null;
+    return restore();
   }
   if (operandText !== null) {
     // Var operand: TS-AST text-walk catches references at any depth,
@@ -1092,23 +1144,15 @@ export function tryRecognizeFunctorLift(
         new Set([operandText]),
       )
     ) {
-      return null;
+      return restore();
     }
   }
   // For Member operand, the L1 substitution-fired check below decides.
 
   // (d) Result type is list-lifted.
   if (!isListLiftedAtNode(cand.contextNode, ctx.checker)) {
-    return null;
+    return restore();
   }
-
-  // Snapshot the hygienic supply counter so failure inside `buildSubExpr`
-  // (which can advance `supply.n` via deferred-comprehension allocations
-  // before returning unsupported) doesn't perturb the fallback Cond
-  // path's binder sequencing. The synthCell registration via
-  // `cellRegisterName` runs only after the last failure point, so it
-  // needs no rollback.
-  const supplyCounterSnapshot = ctx.supply.n;
 
   // Build the projection. Path differs by operand kind:
   //   - Var: standard `buildSubExpr`. The projection comes back as
@@ -1124,15 +1168,13 @@ export function tryRecognizeFunctorLift(
   if (operandL1.kind === "var") {
     const sub = buildSubExpr(projection, ctx);
     if (isL1Unsupported(sub)) {
-      ctx.supply.n = supplyCounterSnapshot;
-      return null;
+      return restore();
     }
     projectionL1 = sub;
   } else {
     const pure = buildL1MemberOrVarForLift(projection, ctx);
     if (pure === null) {
-      ctx.supply.n = supplyCounterSnapshot;
-      return null;
+      return restore();
     }
     projectionL1 = pure;
   }
@@ -1149,8 +1191,7 @@ export function tryRecognizeFunctorLift(
   // operand isn't structurally present in the projection's L1
   // form), reject.
   if (operandL1.kind === "member" && substitutedL1 === projectionL1) {
-    ctx.supply.n = supplyCounterSnapshot;
-    return null;
+    return restore();
   }
 
   // Lower.

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -828,10 +828,30 @@ function structuralEqualL1(a: IR1Expr, b: IR1Expr): boolean {
 }
 
 /**
+ * Result of an `substituteL1Subtree` walk. `changed` reports whether
+ * any subtree structurally matched `needle` and was replaced. The
+ * Member-operand functor-lift path uses this to detect "operand not
+ * structurally referenced" — a reference-equality check on the
+ * returned tree is unreliable because the walker reconstructs every
+ * compound node it traverses (e.g., `ir1Member(rec, name)`) regardless
+ * of whether the recursive sub-call substituted. A projection like
+ * `v.next.name` against operand `u.next` would otherwise rebuild a
+ * fresh top-level Member tree even though no substitution fired,
+ * letting projections that don't reference the operand silently emit
+ * a comprehension body with a free variable.
+ */
+interface L1SubstResult {
+  result: IR1Expr;
+  changed: boolean;
+}
+
+/**
  * Replace every subtree of `root` whose L1 form structurally equals
  * `needle` with `replacement`. The walker recurses through every L1
  * form but does not enter `from-l2` wraps — those expose only an
  * opaque L2 tree to L1 callers, which the L1 walker has no handle on.
+ * Returns the rewritten tree plus a `changed` flag indicating whether
+ * substitution actually fired anywhere along the walk.
  *
  * Used by the functor-lift recognizer: the operand's L1 form (a `Var`
  * or `Member` chain) is replaced by a fresh `Var(binder)` inside the
@@ -846,61 +866,93 @@ function substituteL1Subtree(
   root: IR1Expr,
   needle: IR1Expr,
   replacement: IR1Expr,
-): IR1Expr {
+): L1SubstResult {
   if (structuralEqualL1(root, needle)) {
-    return replacement;
+    return { result: replacement, changed: true };
   }
   switch (root.kind) {
     case "var":
     case "lit":
     case "from-l2":
-      return root;
-    case "binop":
-      return ir1Binop(
-        root.op,
-        substituteL1Subtree(root.lhs, needle, replacement),
-        substituteL1Subtree(root.rhs, needle, replacement),
-      );
-    case "unop":
-      return ir1Unop(
-        root.op,
-        substituteL1Subtree(root.arg, needle, replacement),
-      );
-    case "app":
-      return {
-        kind: "app",
-        callee: substituteL1Subtree(root.callee, needle, replacement),
-        args: root.args.map((a) => substituteL1Subtree(a, needle, replacement)),
-      };
-    case "member":
-      return ir1Member(
-        substituteL1Subtree(root.receiver, needle, replacement),
-        root.name,
-      );
-    case "cond": {
-      const armsRewritten = root.arms.map(
-        ([g, v]) =>
-          [
-            substituteL1Subtree(g, needle, replacement),
-            substituteL1Subtree(v, needle, replacement),
-          ] as const,
-      );
-      return ir1Cond(
-        armsRewritten as [
-          readonly [IR1Expr, IR1Expr],
-          ...ReadonlyArray<readonly [IR1Expr, IR1Expr]>,
-        ],
-        substituteL1Subtree(root.otherwise, needle, replacement),
-      );
+      return { result: root, changed: false };
+    case "binop": {
+      const lhs = substituteL1Subtree(root.lhs, needle, replacement);
+      const rhs = substituteL1Subtree(root.rhs, needle, replacement);
+      const changed = lhs.changed || rhs.changed;
+      return changed
+        ? { result: ir1Binop(root.op, lhs.result, rhs.result), changed: true }
+        : { result: root, changed: false };
     }
-    case "is-nullish":
-      return ir1IsNullish(
-        substituteL1Subtree(root.operand, needle, replacement),
+    case "unop": {
+      const arg = substituteL1Subtree(root.arg, needle, replacement);
+      return arg.changed
+        ? { result: ir1Unop(root.op, arg.result), changed: true }
+        : { result: root, changed: false };
+    }
+    case "app": {
+      const callee = substituteL1Subtree(root.callee, needle, replacement);
+      const args = root.args.map((a) =>
+        substituteL1Subtree(a, needle, replacement),
       );
+      const changed = callee.changed || args.some((a) => a.changed);
+      return changed
+        ? {
+            result: {
+              kind: "app",
+              callee: callee.result,
+              args: args.map((a) => a.result),
+            },
+            changed: true,
+          }
+        : { result: root, changed: false };
+    }
+    case "member": {
+      const recv = substituteL1Subtree(root.receiver, needle, replacement);
+      return recv.changed
+        ? { result: ir1Member(recv.result, root.name), changed: true }
+        : { result: root, changed: false };
+    }
+    case "cond": {
+      const armsRewritten = root.arms.map(([g, v]) => {
+        const gr = substituteL1Subtree(g, needle, replacement);
+        const vr = substituteL1Subtree(v, needle, replacement);
+        return { gr, vr } as const;
+      });
+      const otherwise = substituteL1Subtree(
+        root.otherwise,
+        needle,
+        replacement,
+      );
+      const changed =
+        otherwise.changed ||
+        armsRewritten.some(({ gr, vr }) => gr.changed || vr.changed);
+      if (!changed) {
+        return { result: root, changed: false };
+      }
+      const newArms = armsRewritten.map(
+        ({ gr, vr }) => [gr.result, vr.result] as const,
+      );
+      return {
+        result: ir1Cond(
+          newArms as [
+            readonly [IR1Expr, IR1Expr],
+            ...ReadonlyArray<readonly [IR1Expr, IR1Expr]>,
+          ],
+          otherwise.result,
+        ),
+        changed: true,
+      };
+    }
+    case "is-nullish": {
+      const operand = substituteL1Subtree(root.operand, needle, replacement);
+      return operand.changed
+        ? { result: ir1IsNullish(operand.result), changed: true }
+        : { result: root, changed: false };
+    }
     default: {
       const _exhaustive: never = root;
       void _exhaustive;
-      return root;
+      return { result: root, changed: false };
     }
   }
 }
@@ -1183,14 +1235,20 @@ export function tryRecognizeFunctorLift(
   const binderVar = ir1Var(binderName);
 
   // L1 rewriter: replace operand-shape subtrees with `Var(binder)`.
-  const substitutedL1 = substituteL1Subtree(projectionL1, operandL1, binderVar);
+  const { result: substitutedL1, changed: substitutionFired } =
+    substituteL1Subtree(projectionL1, operandL1, binderVar);
 
   // For Member operand: the L1 rewriter is the only substitution
   // mechanism — `ast.substituteBinder` substitutes by name and cannot
   // target a Member subtree. If the rewriter didn't fire (the
   // operand isn't structurally present in the projection's L1
-  // form), reject.
-  if (operandL1.kind === "member" && substitutedL1 === projectionL1) {
+  // form, e.g., projection `v.next.name` against operand `u.next`),
+  // reject. Without the explicit `changed` flag the walker's
+  // unconditional parent reconstruction (`ir1Member(rec, name)` and
+  // siblings) breaks reference equality even when no substitution
+  // fired, letting projections that don't reference the operand emit
+  // a comprehension body with a free variable.
+  if (operandL1.kind === "member" && !substitutionFired) {
     return restore();
   }
 

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -44,6 +44,7 @@ import {
   ir1Block,
   ir1Cond,
   ir1FromL2,
+  ir1IsNullish,
   ir1Let,
   ir1LitBool,
   ir1LitNat,
@@ -701,16 +702,15 @@ function unwrapSingletonArray(expr: ts.Expression): ts.Expression {
 }
 
 /**
- * True when `expr` is a single-element-producing expression of
- * `operandName`. After stripping a single-element array wrapper, the
- * expression must reference the operand and not be a multi-element
- * construction (multi-element array literal, spread, or known
- * multi-producing array method like `.concat` / `.flat`).
+ * True when `expr` is a single-element-producing shape: not an array
+ * literal, not a spread, and not a known multi-producing array method
+ * (`.concat`, `.flat`, `.flatMap`, `.filter`, `.map`, `.slice`,
+ * `.splice`). The "references the operand" half of the eligibility
+ * check is operand-kind specific and lives at the recognizer level —
+ * `Var` operands use `expressionReferencesNames` against the operand
+ * text; `Member` operands defer to the L1 substitution-fired check.
  */
-function isSingleElementProducingOf(
-  expr: ts.Expression,
-  operandName: string,
-): boolean {
+function isSingleElementProducingShape(expr: ts.Expression): boolean {
   const u = unwrapTransparentExpression(expr);
   if (ts.isArrayLiteralExpression(u)) {
     return false;
@@ -723,7 +723,7 @@ function isSingleElementProducingOf(
       return false;
     }
   }
-  return expressionReferencesNames(u, new Set([operandName]));
+  return true;
 }
 
 /**
@@ -802,6 +802,193 @@ function allocateLiftBinder(ctx: L1BuildContext, hint: string): string {
 }
 
 /**
+ * Structural equality on L1 expressions, scoped to the shapes the
+ * functor-lift recognizer compares: `Var` (name + primed) and `Member`
+ * (name + receiver, recursing). Other forms compare false — the
+ * recognizer's eligibility check builds operand and projection through
+ * a pure-L1 path that produces only Var/Member trees, so any other
+ * form is a structural mismatch by construction. Parens and other
+ * source-level wrappers are normalized away by L1 build before this
+ * function ever sees the trees.
+ */
+function structuralEqualL1(a: IR1Expr, b: IR1Expr): boolean {
+  if (a === b) {
+    return true;
+  }
+  if (a.kind !== b.kind) {
+    return false;
+  }
+  if (a.kind === "var" && b.kind === "var") {
+    return a.name === b.name && (a.primed ?? false) === (b.primed ?? false);
+  }
+  if (a.kind === "member" && b.kind === "member") {
+    return a.name === b.name && structuralEqualL1(a.receiver, b.receiver);
+  }
+  return false;
+}
+
+/**
+ * Replace every subtree of `root` whose L1 form structurally equals
+ * `needle` with `replacement`. The walker recurses through every L1
+ * form but does not enter `from-l2` wraps — those expose only an
+ * opaque L2 tree to L1 callers, which the L1 walker has no handle on.
+ *
+ * Used by the functor-lift recognizer: the operand's L1 form (a `Var`
+ * or `Member` chain) is replaced by a fresh `Var(binder)` inside the
+ * projection's L1 form, so the comprehension body references the
+ * binder rather than the operand. For `Var` operands, post-lowering
+ * `ast.substituteBinder` catches references buried inside `from-l2`
+ * wraps; for `Member` operands, the projection must be in pure L1 for
+ * substitution to fire (no equivalent OpaqueExpr-level substitution
+ * exists for arbitrary subtrees).
+ */
+function substituteL1Subtree(
+  root: IR1Expr,
+  needle: IR1Expr,
+  replacement: IR1Expr,
+): IR1Expr {
+  if (structuralEqualL1(root, needle)) {
+    return replacement;
+  }
+  switch (root.kind) {
+    case "var":
+    case "lit":
+    case "from-l2":
+      return root;
+    case "binop":
+      return ir1Binop(
+        root.op,
+        substituteL1Subtree(root.lhs, needle, replacement),
+        substituteL1Subtree(root.rhs, needle, replacement),
+      );
+    case "unop":
+      return ir1Unop(
+        root.op,
+        substituteL1Subtree(root.arg, needle, replacement),
+      );
+    case "app":
+      return {
+        kind: "app",
+        callee: substituteL1Subtree(root.callee, needle, replacement),
+        args: root.args.map((a) => substituteL1Subtree(a, needle, replacement)),
+      };
+    case "member":
+      return ir1Member(
+        substituteL1Subtree(root.receiver, needle, replacement),
+        root.name,
+      );
+    case "cond": {
+      const armsRewritten = root.arms.map(
+        ([g, v]) =>
+          [
+            substituteL1Subtree(g, needle, replacement),
+            substituteL1Subtree(v, needle, replacement),
+          ] as const,
+      );
+      return ir1Cond(
+        armsRewritten as [
+          readonly [IR1Expr, IR1Expr],
+          ...ReadonlyArray<readonly [IR1Expr, IR1Expr]>,
+        ],
+        substituteL1Subtree(root.otherwise, needle, replacement),
+      );
+    }
+    case "is-nullish":
+      return ir1IsNullish(
+        substituteL1Subtree(root.operand, needle, replacement),
+      );
+    default: {
+      const _exhaustive: never = root;
+      void _exhaustive;
+      return root;
+    }
+  }
+}
+
+/**
+ * Build a pure-L1 representation of `node` for the functor-lift
+ * recognizer. Accepts only `Identifier` (→ `Var`) and member surface
+ * forms (`PropertyAccessExpression` / string-literal
+ * `ElementAccessExpression`, → `Member`); recursion bottoms out at a
+ * bare `Identifier`. Returns `null` for any other shape (calls,
+ * binops, optional chains, computed element access, ambiguous owner,
+ * etc.).
+ *
+ * Distinct from `buildL1MemberAccess`: the production helper falls
+ * back to `translateBodyExpr` for non-member receivers, producing
+ * `from-l2` wraps that the L1 walker can't see into. The lift's
+ * substitution requires the operand's structure to be visible at the
+ * L1 level, so this builder either produces a fully-native chain or
+ * rejects.
+ *
+ * Identifier names are looked up against `paramNames` to match the
+ * Pant name that `translateExpr` emits — for parameters,
+ * `paramNames.get(text)` (sanitized at signature translation via
+ * `toPantTermName` + `cellRegisterName`); for bare locals/captures,
+ * the raw TS text. The lowered operand and the lowered projection
+ * must reference the same Pant name for the substitution to fire.
+ */
+function buildL1MemberOrVarForLift(
+  node: ts.Expression,
+  ctx: L1BuildContext,
+): IR1Expr | null {
+  const stripped = unwrapParens(node) as ts.Expression;
+  if (ts.isIdentifier(stripped)) {
+    const pantName = ctx.paramNames.get(stripped.text) ?? stripped.text;
+    return ir1Var(pantName);
+  }
+  if (
+    ts.isPropertyAccessExpression(stripped) &&
+    (stripped.flags & ts.NodeFlags.OptionalChain) === 0
+  ) {
+    const receiverNode = unwrapParens(stripped.expression) as ts.Expression;
+    const receiverL1 = buildL1MemberOrVarForLift(receiverNode, ctx);
+    if (receiverL1 === null) {
+      return null;
+    }
+    const receiverType = ctx.checker.getTypeAtLocation(receiverNode);
+    const qualified = qualifyFieldAccess(
+      receiverType,
+      stripped.name.text,
+      ctx.checker,
+      ctx.strategy,
+      ctx.supply.synthCell,
+    );
+    if (qualified === null) {
+      return null;
+    }
+    return ir1Member(receiverL1, qualified);
+  }
+  if (
+    ts.isElementAccessExpression(stripped) &&
+    (stripped.flags & ts.NodeFlags.OptionalChain) === 0
+  ) {
+    const fieldName = elementAccessLiteralKey(stripped);
+    if (fieldName === null) {
+      return null;
+    }
+    const receiverNode = unwrapParens(stripped.expression) as ts.Expression;
+    const receiverL1 = buildL1MemberOrVarForLift(receiverNode, ctx);
+    if (receiverL1 === null) {
+      return null;
+    }
+    const receiverType = ctx.checker.getTypeAtLocation(receiverNode);
+    const qualified = qualifyFieldAccess(
+      receiverType,
+      fieldName,
+      ctx.checker,
+      ctx.strategy,
+      ctx.supply.synthCell,
+    );
+    if (qualified === null) {
+      return null;
+    }
+    return ir1Member(receiverL1, qualified);
+  }
+  return null;
+}
+
+/**
  * Functor-lift recognizer. Returns an L1 `from-l2(each n in x | proj
  * n)` when the four eligibility checks pass; returns `null` to fall
  * through to the standard L1 Cond build.
@@ -819,12 +1006,26 @@ function allocateLiftBinder(ctx: L1BuildContext, hint: string): string {
  *   (d) The conditional's static result type is list-lifted (`T[]`,
  *       `T | null`, `T | undefined`, …).
  *
- * Operand restriction: the leaf operand must be a simple identifier.
- * Substitution maps the operand's Pant name to the binder via
- * `ast.substituteBinder`, which only rewrites variable references.
- * Property-access operands (`obj.prop == null`) would require
- * generalizing substitution to arbitrary expressions and are out of
- * scope for Patch 5; they fall through to the standard Cond build.
+ * Operand eligibility (M5 P4): the operand's L1 form must be `Var`
+ * (a simple `Identifier`) or `Member` (a `PropertyAccessExpression`
+ * or string-literal `ElementAccessExpression` chain bottoming out at
+ * a `Var`). Anything else — calls, binops, computed indices, optional
+ * chains, type-erasure wrappers in the chain — falls through to the
+ * standard L1 Cond build. Source-level parens are normalized away
+ * by L1 build before eligibility is consulted.
+ *
+ * Substitution strategy. For `Var` operands the projection translates
+ * through the legacy pipeline (`buildSubExpr`, producing a `from-l2`
+ * wrap) and post-lowering `ast.substituteBinder` substitutes the
+ * operand's Pant name with the fresh comprehension binder — exactly
+ * the M4 P5 flow, preserved unchanged. For `Member` operands the
+ * projection must be a pure-L1 chain (built via
+ * `buildL1MemberOrVarForLift`); the L1 rewriter
+ * `substituteL1Subtree` then replaces operand-shape subtrees with the
+ * binder. `ast.substituteBinder` substitutes only by name and cannot
+ * target arbitrary subtrees, so a Member-operand projection that
+ * isn't pure L1 (e.g., a method call wrapping the operand) falls
+ * through.
  */
 export function tryRecognizeFunctorLift(
   cand: FunctorLiftCandidate,
@@ -839,11 +1040,29 @@ export function tryRecognizeFunctorLift(
   if (leaf === null) {
     return null;
   }
+
+  // M5 P4: classify operand by its L1 shape (Var or Member).
+  // `unwrapTransparentExpression` strips type-erasure wrappers from the
+  // outermost operand for the same reason M4 P5 did — those wrappers are
+  // type-level only and the runtime value is the inner expression. The
+  // recursive Member-chain build (`buildL1MemberOrVarForLift`) only strips
+  // parens, not type-erasure, so a wrapper *inside* the chain (e.g.,
+  // `(u as User).owner`) takes the chain off the pure-L1 path and the lift
+  // falls through.
   const operandNode = unwrapTransparentExpression(leaf.operand);
-  if (!ts.isIdentifier(operandNode)) {
-    return null;
+  let operandText: string | null = null;
+  let operandL1: IR1Expr;
+  if (ts.isIdentifier(operandNode)) {
+    operandText = operandNode.text;
+    const pantName = ctx.paramNames.get(operandText) ?? operandText;
+    operandL1 = ir1Var(pantName);
+  } else {
+    const memberOperand = buildL1MemberOrVarForLift(operandNode, ctx);
+    if (memberOperand === null || memberOperand.kind !== "member") {
+      return null;
+    }
+    operandL1 = memberOperand;
   }
-  const operandName = operandNode.text;
 
   // Polarity: a positive nullish guard (`x === null`) means the
   // then-branch is the empty side; a negated guard (`x !== null`)
@@ -856,70 +1075,107 @@ export function tryRecognizeFunctorLift(
     return null;
   }
 
-  // (c) Present side, after stripping a singleton array wrapper, is a
-  //     single-element-producing expression of `operandName`.
+  // (c) Present side, after stripping a singleton array wrapper, is
+  //     not a multi-element-producing shape and references the operand.
   const projection = unwrapSingletonArray(presentExpr);
-  if (!isSingleElementProducingOf(projection, operandName)) {
+  if (!isSingleElementProducingShape(projection)) {
     return null;
   }
+  if (operandText !== null) {
+    // Var operand: TS-AST text-walk catches references at any depth,
+    // including those buried inside non-Member sub-expressions
+    // (calls, binops, nested ternaries). The post-lower
+    // `ast.substituteBinder` will pick up the same references.
+    if (
+      !expressionReferencesNames(
+        unwrapTransparentExpression(projection),
+        new Set([operandText]),
+      )
+    ) {
+      return null;
+    }
+  }
+  // For Member operand, the L1 substitution-fired check below decides.
 
   // (d) Result type is list-lifted.
   if (!isListLiftedAtNode(cand.contextNode, ctx.checker)) {
     return null;
   }
 
-  // Build the lifted L1 expression.
-  //
-  // The operand and projection both translate through the legacy
-  // pipeline so embedded sub-expressions stay normalized exactly as
-  // they would on the standard Cond path. The substitution then
-  // rewrites references to the operand's Pant name with the fresh
-  // binder; `ast.substituteBinder` is Pant's capture-avoiding
-  // substitution, so a fresh hygienic binder is sufficient.
-  //
-  // Snapshot the hygienic supply counter so that a `buildSubExpr`
-  // failure (which can advance `supply.n` via deferred-comprehension
-  // allocations before returning unsupported) doesn't perturb the
-  // fallback Cond path's binder sequencing. The synthCell registration
-  // via `cellRegisterName` runs only after the last failure point, so
-  // it needs no rollback. Counter increments past the last failure
-  // point are the lift's real allocations and stay committed.
+  // Snapshot the hygienic supply counter so failure inside `buildSubExpr`
+  // (which can advance `supply.n` via deferred-comprehension allocations
+  // before returning unsupported) doesn't perturb the fallback Cond
+  // path's binder sequencing. The synthCell registration via
+  // `cellRegisterName` runs only after the last failure point, so it
+  // needs no rollback.
   const supplyCounterSnapshot = ctx.supply.n;
-  const operandSub = buildSubExpr(operandNode, ctx);
-  if (isL1Unsupported(operandSub)) {
-    ctx.supply.n = supplyCounterSnapshot;
-    return null;
-  }
-  const projectionSub = buildSubExpr(projection, ctx);
-  if (isL1Unsupported(projectionSub)) {
-    ctx.supply.n = supplyCounterSnapshot;
-    return null;
+
+  // Build the projection. Path differs by operand kind:
+  //   - Var: standard `buildSubExpr`. The projection comes back as
+  //     `from-l2(opaque)`; post-lower `ast.substituteBinder`
+  //     substitutes Var-name references at the OpaqueExpr level. This
+  //     is the M4 P5 flow.
+  //   - Member: pure-L1 chain via `buildL1MemberOrVarForLift`. The L1
+  //     rewriter then walks the projection and replaces operand-shape
+  //     subtrees with the comprehension binder. A non-pure-L1
+  //     projection (e.g., a method call wrapping the operand)
+  //     rejects.
+  let projectionL1: IR1Expr;
+  if (operandL1.kind === "var") {
+    const sub = buildSubExpr(projection, ctx);
+    if (isL1Unsupported(sub)) {
+      ctx.supply.n = supplyCounterSnapshot;
+      return null;
+    }
+    projectionL1 = sub;
+  } else {
+    const pure = buildL1MemberOrVarForLift(projection, ctx);
+    if (pure === null) {
+      ctx.supply.n = supplyCounterSnapshot;
+      return null;
+    }
+    projectionL1 = pure;
   }
 
-  const operandOpaque = lowerExpr(lowerL1Expr(operandSub));
-  const projectionOpaque = lowerExpr(lowerL1Expr(projectionSub));
-
-  // Mirror `translateExpr`'s identifier handling
-  // (`translate-signature.ts:1122` — `paramNames.get(expr.text) ?? expr.text`).
-  // Only *parameters* go through name sanitization on translation;
-  // bare identifiers (locals, captures from outer scope) are emitted
-  // as their raw TS text. Sanitizing here would produce
-  // `toPantTermName("maybeUser") = "maybe-user"`, which the lowered
-  // projection — which still references `maybeUser` — would never
-  // match, leaving the binder unsubstituted and the lift broken.
-  const operandPantName = ctx.paramNames.get(operandName) ?? operandName;
   const binderName = allocateLiftBinder(ctx, "n");
+  const binderVar = ir1Var(binderName);
+
+  // L1 rewriter: replace operand-shape subtrees with `Var(binder)`.
+  const substitutedL1 = substituteL1Subtree(projectionL1, operandL1, binderVar);
+
+  // For Member operand: the L1 rewriter is the only substitution
+  // mechanism — `ast.substituteBinder` substitutes by name and cannot
+  // target a Member subtree. If the rewriter didn't fire (the
+  // operand isn't structurally present in the projection's L1
+  // form), reject.
+  if (operandL1.kind === "member" && substitutedL1 === projectionL1) {
+    ctx.supply.n = supplyCounterSnapshot;
+    return null;
+  }
+
+  // Lower.
   const ast = getAst();
-  const substitutedProjection = ast.substituteBinder(
-    projectionOpaque,
-    operandPantName,
-    ast.var(binderName),
-  );
+  let projectionOpaque = lowerExpr(lowerL1Expr(substitutedL1));
+  const operandOpaque = lowerExpr(lowerL1Expr(operandL1));
+
+  // For Var operand: post-lower name substitution catches references
+  // buried inside `from-l2` wraps (which the L1 rewriter cannot enter).
+  // Mirror `translateExpr`'s identifier handling
+  // (`translate-signature.ts:1122` — `paramNames.get(text) ?? text`):
+  // params get sanitized; bare locals / captures emit as raw text.
+  if (operandL1.kind === "var" && operandText !== null) {
+    const operandPantName = ctx.paramNames.get(operandText) ?? operandText;
+    projectionOpaque = ast.substituteBinder(
+      projectionOpaque,
+      operandPantName,
+      ast.var(binderName),
+    );
+  }
 
   const opaqueEach = ast.each(
     [],
     [ast.gIn(binderName, operandOpaque)],
-    substitutedProjection,
+    projectionOpaque,
   );
   return ir1FromL2(irWrap(opaqueEach));
 }

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -801,6 +801,66 @@ function allocateLiftBinder(ctx: L1BuildContext, hint: string): string {
   return name;
 }
 
+// ---------------------------------------------------------------------------
+// Operand-substitution rule for the functor-lift recognizer
+// ---------------------------------------------------------------------------
+//
+// **Standard name:** First-order term rewriting / common-subexpression
+// abstraction. The lift transforms
+//   `if e == null then [] else [body]` → `each $n in e | body[e := $n]`
+// where `body[e := $n]` is the substitution of every syntactic
+// occurrence of the operand subterm `e` with the fresh binder `$n`.
+// The functor lift itself is structurally `Maybe` `fmap` — see
+// CLAUDE.md § "Functor-Lift Recognizer" (Wadler POPL 1992, Hutton &
+// Meijer JFP 1998). The substitution rule below is the term-rewriting
+// half of that transformation.
+//
+// **Reference:** Baader & Nipkow, *Term Rewriting and All That*
+// (Cambridge 1998), ch. 2 (basic notions of position, subterm, and
+// substitution); Peyton Jones & Marlow, "Secrets of the GHC Inliner"
+// JFP 2002 (hygienic-binder discipline / Barendregt convention).
+//
+// **Invariants justifying soundness:**
+//
+// 1. **Hygiene.** The replacement is a fresh `Var($n)` allocated via
+//    `cellRegisterName` against the document-wide `NameRegistry`, so
+//    the binder cannot collide with any other name in scope. This is
+//    the Barendregt convention applied to the comprehension binder.
+//
+// 2. **Structural reachability.** Soundness requires that the operand
+//    `e` actually occurs as a syntactic subterm of `body` — otherwise
+//    the comprehension would emit a body with `$n` as a free variable
+//    (substitution wouldn't fire) or, worse, with the operand still
+//    referenced free of the binder. The recognizer enforces this by
+//    gating on the explicit `changed` flag returned by
+//    `substituteL1Subtree` for Member operands; for Var operands, the
+//    TS-AST walk (`expressionReferencesNames`) is the precondition and
+//    post-lowering `ast.substituteBinder` is the substitution
+//    primitive.
+//
+// 3. **Referential transparency at the operand position.** The
+//    comprehension evaluates `e` once at its source position
+//    (`each $n in e | …`); each occurrence of `e` inside `body` is
+//    replaced by the binder. This is sound iff `e` has no observable
+//    effects whose duplication or removal would change semantics.
+//    M4 P5's eligibility check enforces this implicitly — list-
+//    lifted nullable types under TypeScript don't admit side effects
+//    in the comparison position the recognizer matches.
+//
+// 4. **Closed form on Var/Member.** `structuralEqualL1` only compares
+//    `Var` and `Member` shapes. The pure-L1 builder
+//    `buildL1MemberOrVarForLift` produces only those shapes, so
+//    operand and projection trees are exhaustively comparable along
+//    the Member-operand path. For `from-l2` and other compound forms
+//    the walker descends but the structural-match leaves never fire
+//    for a Member needle, falling out via `changed: false`.
+//
+// Future changes to this rewrite should re-verify these four
+// invariants. Adding new comparable forms (e.g., to support `App` as
+// an eligible operand) requires extending both `structuralEqualL1`
+// and the `buildL1MemberOrVarForLift` accept-set together; partial
+// extension breaks invariant 4.
+
 /**
  * Structural equality on L1 expressions, scoped to the shapes the
  * functor-lift recognizer compares: `Var` (name + primed) and `Member`
@@ -810,6 +870,10 @@ function allocateLiftBinder(ctx: L1BuildContext, hint: string): string {
  * form is a structural mismatch by construction. Parens and other
  * source-level wrappers are normalized away by L1 build before this
  * function ever sees the trees.
+ *
+ * See the comment block above for the underlying term-rewriting
+ * reference and the four soundness invariants this comparator
+ * supports.
  */
 function structuralEqualL1(a: IR1Expr, b: IR1Expr): boolean {
   if (a === b) {
@@ -852,6 +916,11 @@ interface L1SubstResult {
  * opaque L2 tree to L1 callers, which the L1 walker has no handle on.
  * Returns the rewritten tree plus a `changed` flag indicating whether
  * substitution actually fired anywhere along the walk.
+ *
+ * This is the term-rewriting primitive that backs the functor-lift's
+ * `body[e := $n]` substitution — see the comment block above
+ * `structuralEqualL1` for the algorithm reference (Baader & Nipkow ch. 2)
+ * and the four soundness invariants it depends on.
  *
  * Used by the functor-lift recognizer: the operand's L1 form (a `Var`
  * or `Member` chain) is replaced by a fresh `Var(binder)` inside the

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -270,6 +270,26 @@ exports[`expressions-equality-nullish.ts > typeofUndefinedNeq 1`] = `
 "module TypeofUndefinedNeq.\\n\\ntypeof-undefined-neq x: [Int] => Bool.\\n\\n---\\n\\ntypeof-undefined-neq x = (~(#x = 0)).\\n"
 `;
 
+exports[`expressions-functor-lift-property.ts > userName 1`] = `
+"module UserName.\\n\\nUser.\\nuser--name u1: User => String.\\nAccount.\\naccount--owner a: Account => [User].\\nuser-name u: Account => [String].\\n\\n---\\n\\nuser-name u = (each n in account--owner u | user--name n).\\n"
+`;
+
+exports[`expressions-functor-lift-property.ts > userNameIfConv 1`] = `
+"module UserNameIfConv.\\n\\nUser.\\nuser--name u1: User => String.\\nAccount.\\naccount--owner a: Account => [User].\\nuser-name-if-conv u: Account => [String].\\n\\n---\\n\\nuser-name-if-conv u = (each n in account--owner u | user--name n).\\n"
+`;
+
+exports[`expressions-functor-lift-property.ts > userNameIfConvNeg 1`] = `
+"module UserNameIfConvNeg.\\n\\nUser.\\nuser--name u1: User => String.\\nAccount.\\naccount--owner a: Account => [User].\\nuser-name-if-conv-neg u: Account => [String].\\n\\n---\\n\\nuser-name-if-conv-neg u = (each n in account--owner u | user--name n).\\n"
+`;
+
+exports[`expressions-functor-lift-property.ts > userNameParens 1`] = `
+"module UserNameParens.\\n\\nUser.\\nuser--name u1: User => String.\\nAccount.\\naccount--owner a: Account => [User].\\nuser-name-parens u: Account => [String].\\n\\n---\\n\\nuser-name-parens u = (each n in account--owner u | user--name n).\\n"
+`;
+
+exports[`expressions-functor-lift-property.ts > userNameTernaryNeg 1`] = `
+"module UserNameTernaryNeg.\\n\\nUser.\\nuser--name u1: User => String.\\nAccount.\\naccount--owner a: Account => [User].\\nuser-name-ternary-neg u: Account => [String].\\n\\n---\\n\\nuser-name-ternary-neg u = (each n in account--owner u | user--name n).\\n"
+`;
+
 exports[`expressions-functor-lift.ts > ifConversion 1`] = `
 "module IfConversion.\\n\\nUser.\\nuser--name u1: User => String.\\nuser--age u1: User => Int.\\nif-conversion u: [User] => [String].\\n\\n---\\n\\nif-conversion u = (each n in u | user--name n).\\n"
 `;

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-functor-lift-property.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-functor-lift-property.ts
@@ -1,0 +1,56 @@
+// Functor-lift recognizer (M5 Patch 4) — Member operand.
+//
+// M5 P4 lifts the operand restriction from M4 P5: the recognizer now
+// accepts a property-access (or string-literal element-access) operand
+// alongside the simple-identifier operand it shipped with. The four
+// canonical TS shapes still apply (positive ternary, negated ternary,
+// positive if-conversion, negated if-conversion); the only change is
+// the eligible operand vocabulary. All four lower to
+// `each $n in (owner u) | name $n` (or equivalent).
+
+interface User {
+  readonly name: string;
+}
+
+interface Account {
+  readonly owner: User | null;
+}
+
+/** Positive ternary, Member operand. */
+export function userName(u: Account): string[] {
+  return u.owner == null ? [] : [u.owner.name];
+}
+
+/** Negated ternary, Member operand. */
+export function userNameTernaryNeg(u: Account): string[] {
+  return u.owner !== null ? [u.owner.name] : [];
+}
+
+/** Positive if-conversion, Member operand. */
+export function userNameIfConv(u: Account): string[] {
+  if (u.owner === null) return [];
+  return [u.owner.name];
+}
+
+/** Negated if-conversion, Member operand. */
+export function userNameIfConvNeg(u: Account): string[] {
+  if (u.owner !== null) return [u.owner.name];
+  return [];
+}
+
+/** Paren-equivalence: source-level `( ... )` wrappers around the
+ *  Member operand and the projection must produce the same Pant as
+ *  the unwrapped form. Verifies the L1-layering invariant — paren
+ *  normalization happens at L1 build, downstream recognizers don't
+ *  re-implement it. */
+export function userNameParens(u: Account): string[] {
+  return (u.owner) == null ? [] : [(u.owner).name];
+}
+
+// The deliberate-reject case for a multi-element non-empty branch
+// (`return u.owner == null ? [] : [u.owner.name, u.owner.name];`) is
+// not included as a fixture entry — it has no translatable Pant target
+// and would emit raw source text into the snapshot. The unit test
+// `Member operand multi-element non-empty branch rejects` in
+// `tests/ir1-build-functor-lift.test.mts` exercises that path
+// directly.

--- a/tools/ts2pant/tests/ir1-build-functor-lift.test.mts
+++ b/tools/ts2pant/tests/ir1-build-functor-lift.test.mts
@@ -401,6 +401,24 @@ describe("ir1-build-functor-lift", () => {
     expectLifted(tryRecognizeFunctorLift(candidate, ctx));
   });
 
+  it("Member operand falls through when projection references a different receiver", () => {
+    // Projection `v.next.name` is a valid Member chain but doesn't
+    // reference the operand `u.next`. The L1 rewriter walks the chain
+    // structurally; if no subtree matches the operand, the
+    // substitution-fired check rejects the lift. Without that check
+    // (or with one that relies on reference equality after
+    // unconditional parent reconstruction), the lift would silently
+    // emit a comprehension whose body has a free variable —
+    // `each n in (next u) | name (next v)`.
+    const { candidate, ctx } = setup(
+      `interface User { readonly name: string; readonly next: User | null; }
+       function f(u: User, v: User): string[] {
+         return u.next == null ? [] : [v.next!.name];
+       }`,
+    );
+    assert.equal(tryRecognizeFunctorLift(candidate, ctx), null);
+  });
+
   it("Member operand falls through when projection isn't a Member chain", () => {
     // Projection is a method call that doesn't structurally surface
     // the Member operand at the L1 level. `ast.substituteBinder`

--- a/tools/ts2pant/tests/ir1-build-functor-lift.test.mts
+++ b/tools/ts2pant/tests/ir1-build-functor-lift.test.mts
@@ -316,15 +316,94 @@ describe("ir1-build-functor-lift", () => {
     assert.equal(tryRecognizeFunctorLift(candidate, ctx), null);
   });
 
-  it("non-identifier operand falls through (`u.next == null`)", () => {
+  it("Member operand (positive ternary) recognizes (`u.next == null`)", () => {
     const { candidate, ctx } = setup(
       `interface User { readonly name: string; readonly next: User | null; }
        function f(u: User): string[] {
          return u.next == null ? [] : [u.next.name];
        }`,
     );
-    // Operand restriction: only simple identifiers participate in the
-    // lift; property-access operands fall through.
+    // M5 P4: the operand restriction is lifted — property-access
+    // operands recognize via the L1 Member chain.
+    expectLifted(tryRecognizeFunctorLift(candidate, ctx));
+  });
+
+  it("Member operand (negated ternary) recognizes (`u.next !== null ? [u.next.name] : []`)", () => {
+    const { candidate, ctx } = setup(
+      `interface User { readonly name: string; readonly next: User | null; }
+       function f(u: User): string[] {
+         return u.next !== null ? [u.next.name] : [];
+       }`,
+    );
+    expectLifted(tryRecognizeFunctorLift(candidate, ctx));
+  });
+
+  it("Member operand (positive if-conversion) recognizes", () => {
+    const { candidate, ctx } = setup(
+      `interface User { readonly name: string; readonly next: User | null; }
+       function f(u: User): string[] {
+         if (u.next === null) return [];
+         return [u.next.name];
+       }`,
+    );
+    expectLifted(tryRecognizeFunctorLift(candidate, ctx));
+  });
+
+  it("Member operand (negated if-conversion) recognizes", () => {
+    const { candidate, ctx } = setup(
+      `interface User { readonly name: string; readonly next: User | null; }
+       function f(u: User): string[] {
+         if (u.next !== null) return [u.next.name];
+         return [];
+       }`,
+    );
+    expectLifted(tryRecognizeFunctorLift(candidate, ctx));
+  });
+
+  it("Member operand multi-element non-empty branch rejects", () => {
+    const { candidate, ctx } = setup(
+      `interface User { readonly name: string; readonly next: User | null; }
+       function f(u: User): string[] {
+         return u.next == null ? [] : [u.next.name, u.next.name];
+       }`,
+    );
+    // Multi-element array literal on the present branch is the same
+    // sound-rejection as the Var-operand case (`each` over a length-≤1
+    // list can't produce two output elements per input).
+    assert.equal(tryRecognizeFunctorLift(candidate, ctx), null);
+  });
+
+  it("Member operand string-literal element-access (`u[\"next\"] == null`) recognizes", () => {
+    const { candidate, ctx } = setup(
+      `interface User { readonly name: string; readonly next: User | null; }
+       function f(u: User): string[] {
+         return u["next"] == null ? [] : [u["next"].name];
+       }`,
+    );
+    // Member surface form covers both `obj.field` and `obj["field"]`.
+    expectLifted(tryRecognizeFunctorLift(candidate, ctx));
+  });
+
+  it("Member operand falls through when projection isn't a Member chain", () => {
+    // Projection is a method call that doesn't structurally surface
+    // the Member operand at the L1 level. `ast.substituteBinder`
+    // substitutes only by name and cannot replace a Member subtree;
+    // the L1 rewriter doesn't enter `from-l2` wraps; so the lift
+    // can't safely connect the operand to the comprehension binder
+    // and falls through. (Identifier-operand parallels of this shape
+    // — the existing nested-null-guard test — DO recognize because
+    // `ast.substituteBinder` handles Var-name references buried in
+    // any expression.)
+    const { candidate, ctx } = setup(
+      `interface User {
+         readonly name: string;
+         readonly next: User | null;
+         combine(arg: string | null): string;
+       }
+       function f(u: User, fallback: string | null): string | null {
+         return u.next == null ? null : u.next.combine(fallback);
+       }`,
+    );
     assert.equal(tryRecognizeFunctorLift(candidate, ctx), null);
   });
 

--- a/tools/ts2pant/tests/ir1-build-functor-lift.test.mts
+++ b/tools/ts2pant/tests/ir1-build-functor-lift.test.mts
@@ -373,6 +373,23 @@ describe("ir1-build-functor-lift", () => {
     assert.equal(tryRecognizeFunctorLift(candidate, ctx), null);
   });
 
+  it("Member operand recognizes through inner type-erasure wrappers (`(u as User).next == null`)", () => {
+    // The reviewer's example: a Member chain whose receiver carries an
+    // `as` cast must still recognize, since `tryRecognizeFunctorLift`
+    // already treats type-erasure wrappers as semantically neutral at
+    // the recognizer's outer boundary. `buildL1MemberOrVarForLift`
+    // strips the same wrapper set (`unwrapTransparentExpression`) at
+    // every level of the chain, so the inner cast doesn't take the
+    // operand off the pure-L1 path.
+    const { candidate, ctx } = setup(
+      `interface User { readonly name: string; readonly next: User | null; }
+       function f(u: User): string[] {
+         return (u as User).next == null ? [] : [(u as User).next!.name];
+       }`,
+    );
+    expectLifted(tryRecognizeFunctorLift(candidate, ctx));
+  });
+
   it("Member operand string-literal element-access (`u[\"next\"] == null`) recognizes", () => {
     const { candidate, ctx } = setup(
       `interface User { readonly name: string; readonly next: User | null; }

--- a/tools/ts2pant/tests/ir1-build-functor-lift.test.mts
+++ b/tools/ts2pant/tests/ir1-build-functor-lift.test.mts
@@ -419,6 +419,59 @@ describe("ir1-build-functor-lift", () => {
     assert.equal(tryRecognizeFunctorLift(candidate, ctx), null);
   });
 
+  it("Member operand probe rolls back synthCell + supply on failure (anonymous record)", () => {
+    // The receiver type of the operand `u.next` is the anonymous record
+    // `{ next: { name: string } | null }`. Qualifying the field `next`
+    // routes through `qualifyFieldAccess → resolveFieldOwner →
+    // resolveRecordOwner → mapTsType → registerAnonymousRecord →
+    // cellRegisterRecord`, which mutates `synthCell.recordSynth` and
+    // `synthCell.registry`. The lift then fails the multi-element check
+    // on the present branch (`[u.next.name, u.next.name]`).
+    //
+    // Failed probes must restore `ctx.supply.n` AND the three synthCell
+    // field references, so the synthesized record domain doesn't leak
+    // into the document on the rejected path. Snapshotting the field
+    // references is sufficient because the inner synth records and
+    // registry are immutable values.
+    const { candidate, ctx } = setup(
+      `function f(u: { next: { name: string } | null }): string[] {
+         return u.next == null ? [] : [u.next.name, u.next.name];
+       }`,
+    );
+    const synthCell = ctx.supply.synthCell;
+    if (!synthCell) {
+      throw new Error("test setup: expected synthCell");
+    }
+    const supplyBefore = ctx.supply.n;
+    const synthBefore = synthCell.synth;
+    const recordSynthBefore = synthCell.recordSynth;
+    const registryBefore = synthCell.registry;
+
+    const result = tryRecognizeFunctorLift(candidate, ctx);
+
+    assert.equal(result, null);
+    assert.equal(
+      ctx.supply.n,
+      supplyBefore,
+      "supply.n leaked from failed probe",
+    );
+    assert.equal(
+      synthCell.synth,
+      synthBefore,
+      "synthCell.synth leaked",
+    );
+    assert.equal(
+      synthCell.recordSynth,
+      recordSynthBefore,
+      "synthCell.recordSynth leaked — anonymous-record domain registered during failed probe",
+    );
+    assert.equal(
+      synthCell.registry,
+      registryBefore,
+      "synthCell.registry leaked — name registered during failed probe",
+    );
+  });
+
   it("Member operand falls through when projection isn't a Member chain", () => {
     // Projection is a method call that doesn't structurally surface
     // the Member operand at the L1 level. `ast.substituteBinder`


### PR DESCRIPTION
## Patch 4: Lift functor-lift recognizer's operand restriction to accept Member

- In `tools/ts2pant/src/ir1-build.ts`'s `tryRecognizeFunctorLift`, refactor the operand-extraction step. Currently the recognizer restricts to `ts.isIdentifier(...)` on the TS-AST node. The new shape: build the operand through `buildL1Expr` (which handles Identifier → `Var` and PropertyAccess / string-literal ElementAccess → `Member`, with paren-stripping inherited from `buildL1MemberAccess`), then accept iff `operand.kind === 'var' || operand.kind === 'member'`. Anything else (calls, binops, type-erasure wrappers) falls through to the standard L1 Cond build
- Update the operand-identity check: M4 P5 compared operands by Identifier text. With the L1-shape eligibility check, identity is `structuralEqualL1(a, b)` — recurse on Var (compare name) and Member (compare name + recurse on receiver). This is purely on the L1 side; no `structurallyEqualExpression` call needed because L1 build has already normalized parens away
- Update the comprehension-binder substitution: M4 P5 replaced the operand identifier inside the projection branch with the comprehension binder. With the L1-shape approach, build the projection branch through `buildL1Expr` and then substitute the L1 operand with a fresh L1 `Var` (the comprehension binder) via a small L1 rewriter that handles Var/Member identity. The lowering then runs Pant's `substituteBinder` on the lowered OpaqueExpr — same final shape as M4 P5, but the substitution lives at the L1 level rather than the TS-AST level
- Create `tools/ts2pant/tests/fixtures/constructs/expressions-functor-lift-property.ts` with: `userName(u: Account): string[] { return u.owner == null ? [] : [u.owner.name]; }` (positive ternary, Member operand), `userNameTernaryNeg(u: Account): string[] { return u.owner !== null ? [u.owner.name] : []; }`, `userNameIfConv(u: Account): string[] { if (u.owner === null) return []; return [u.owner.name]; }`, `userNameIfConvNeg(u: Account): string[] { if (u.owner !== null) return [u.owner.name]; return []; }`, a paren-equivalence case `userNameParens(u: Account): string[] { return (u.owner) == null ? [] : [(u.owner).name]; }` (must produce the same Pant as the unwrapped version — verifies the L1-layering invariant), plus a deliberate-reject `userNameMulti(u: Account): string[] { return u.owner == null ? [] : [u.owner.name, u.owner.name]; }` (multi-element non-empty branch)
- Run `just ts2pant-test-update-snapshots` once. Verify the four supported shapes lower to `each n in (owner u) | name n` (or equivalent), and the deliberate-reject case is skipped from the snapshot
- Run `just ts2pant-test-integration` — `pant --check` should accept the four supported functions
- Add unit tests in `tests/ir1-build-functor-lift.test.mts`: each of the four supported Member-operand shapes recognizes; multi-element-branch rejects; identifier-operand cases (M4 P5's coverage) still recognize unchanged
- Update `tools/ts2pant/CLAUDE.md` § Functor-Lift Recognizer / Supported TS shapes to remove the 'operand restricted to a simple identifier; property-access operands defer to M5' note

## Changes
- In `tools/ts2pant/src/ir1-build.ts`'s `tryRecognizeFunctorLift`, refactor the operand-extraction step. Currently the recognizer restricts to `ts.isIdentifier(...)` on the TS-AST node. The new shape: build the operand through `buildL1Expr` (which handles Identifier → `Var` and PropertyAccess / string-literal ElementAccess → `Member`, with paren-stripping inherited from `buildL1MemberAccess`), then accept iff `operand.kind === 'var' || operand.kind === 'member'`. Anything else (calls, binops, type-erasure wrappers) falls through to the standard L1 Cond build
- Update the operand-identity check: M4 P5 compared operands by Identifier text. With the L1-shape eligibility check, identity is `structuralEqualL1(a, b)` — recurse on Var (compare name) and Member (compare name + recurse on receiver). This is purely on the L1 side; no `structurallyEqualExpression` call needed because L1 build has already normalized parens away
- Update the comprehension-binder substitution: M4 P5 replaced the operand identifier inside the projection branch with the comprehension binder. With the L1-shape approach, build the projection branch through `buildL1Expr` and then substitute the L1 operand with a fresh L1 `Var` (the comprehension binder) via a small L1 rewriter that handles Var/Member identity. The lowering then runs Pant's `substituteBinder` on the lowered OpaqueExpr — same final shape as M4 P5, but the substitution lives at the L1 level rather than the TS-AST level
- Create `tools/ts2pant/tests/fixtures/constructs/expressions-functor-lift-property.ts` with: `userName(u: Account): string[] { return u.owner == null ? [] : [u.owner.name]; }` (positive ternary, Member operand), `userNameTernaryNeg(u: Account): string[] { return u.owner !== null ? [u.owner.name] : []; }`, `userNameIfConv(u: Account): string[] { if (u.owner === null) return []; return [u.owner.name]; }`, `userNameIfConvNeg(u: Account): string[] { if (u.owner !== null) return [u.owner.name]; return []; }`, a paren-equivalence case `userNameParens(u: Account): string[] { return (u.owner) == null ? [] : [(u.owner).name]; }` (must produce the same Pant as the unwrapped version — verifies the L1-layering invariant), plus a deliberate-reject `userNameMulti(u: Account): string[] { return u.owner == null ? [] : [u.owner.name, u.owner.name]; }` (multi-element non-empty branch)
- Run `just ts2pant-test-update-snapshots` once. Verify the four supported shapes lower to `each n in (owner u) | name n` (or equivalent), and the deliberate-reject case is skipped from the snapshot
- Run `just ts2pant-test-integration` — `pant --check` should accept the four supported functions
- Add unit tests in `tests/ir1-build-functor-lift.test.mts`: each of the four supported Member-operand shapes recognizes; multi-element-branch rejects; identifier-operand cases (M4 P5's coverage) still recognize unchanged
- Update `tools/ts2pant/CLAUDE.md` § Functor-Lift Recognizer / Supported TS shapes to remove the 'operand restricted to a simple identifier; property-access operands defer to M5' note

## Files to Modify
- tools/ts2pant/src/ir1-build.ts (modify): Refactor `tryRecognizeFunctorLift`'s operand eligibility to be expressed in L1 terms (Var or Member) rather than TS-AST terms. The recognizer builds the operand via `buildL1Expr` (which routes through `buildL1MemberAccess` and inherits its paren-stripping), then checks `operand.kind === 'var' || operand.kind === 'member'`. Source-level wrappers like parens are normalized away by L1 build itself
- tools/ts2pant/tests/fixtures/constructs/expressions-functor-lift-property.ts (create): Fixture covering functor-lift with property-access operand: positive ternary, negated ternary, positive if-conversion, negated if-conversion, and a deliberate-reject multi-element-branch case
- tools/ts2pant/tests/constructs.test.mts.snapshot (modify): Snapshot updates
- tools/ts2pant/tests/ir1-build-functor-lift.test.mts (modify): Extend with Member-operand recognition tests; assert the existing simple-identifier tests still pass

## Gameplan Specification

```
module TS2PANT_M5_PROPERTY_ACCESS.

> M5 final state: every property-access surface form ts2pant supports
> flows through L1 Member. The legacy direct-to-L2 App-construction
> path is retired across all 9 documented sites. The hard-rule
> discipline holds for the property-access equivalence class.
>
> Cutover gate is reviewed-snapshot-diff plus `pant --check` plus
> dogfood, not literal byte-equality with pre-M5 output. The two-tier
> qualifier behavior (qualified rule names for resolved owners; bare
> kebab names for built-ins / type parameters; null for ambiguous
> unions) is preserved as-is — the asymmetry is a deliberate EUF
> tier separation, not an inconsistency.

TSExpr.
L1Expr.
OpaqueExpr.
L1Stmt.

> Surface forms in scope.
is-property-access? t: TSExpr => Bool.
is-string-literal-elem-access? t: TSExpr => Bool.
is-computed-elem-access? t: TSExpr => Bool.
is-paren? t: TSExpr => Bool.
paren-inner t: TSExpr, is-paren? t => TSExpr.
unwrap-parens t: TSExpr => TSExpr.

> The property-access surface set is exactly these three forms; every
> TS expression node ts2pant classifies as property-access falls into
> one of them.
is-any-property-form? t: TSExpr, is-property-access? t or is-string-literal-elem-access? t or is-computed-elem-access? t => Bool.

> Field name extraction.
property-receiver t: TSExpr, is-any-property-form? t => TSExpr.
property-key t: TSExpr, is-property-access? t or is-string-literal-elem-access? t => String.
qualify-field r: TSExpr, n: String => String.

> L1 build pass and Member form.
build-l1 t: TSExpr => L1Expr.
is-member? e: L1Expr => Bool.
member-receiver e: L1Expr, is-member? e => L1Expr.
member-name e: L1Expr, is-member? e => String.
is-from-l2? e: L1Expr => Bool.
unsupported? e: L1Expr => Bool.

> Mutating-body assignment statements.
is-assignment-stmt? s: L1Stmt => Bool.
target s: L1Stmt, is-assignment-stmt? s => L1Expr.

> Functor-lift recognizer.
is-functor-lift-shape? t: TSExpr => Bool.
functor-lift-operand t: TSExpr, is-functor-lift-shape? t => TSExpr.
is-each-comprehension? e: L1Expr => Bool.

> Cardinality dispatch (deliberate non-Member path).
is-cardinality-form? t: TSExpr, is-property-access? t => Bool.
is-card-unop? e: L1Expr => Bool.

---

> Invariant 1: Dotted property access builds canonical L1 Member with
> the qualified rule name.
all t: TSExpr, is-property-access? t |
  is-member? (build-l1 t)
  and member-name (build-l1 t) = qualify-field (property-receiver t) (property-key t).

> Invariant 2: String-literal element access shares the canonical
> Member form (one canonical form per construct).
all t: TSExpr, is-string-literal-elem-access? t |
  is-member? (build-l1 t)
  and member-name (build-l1 t) = qualify-field (property-receiver t) (property-key t).

> Invariant 3: Computed (non-literal) element access is rejected
> unconditionally. Uniform reject is the conservative-refusal-3(b)
> answer; the DoD's 'unless type system resolves to a known field set'
> path is deferred to a follow-up.
all t: TSExpr, is-computed-elem-access? t | unsupported? (build-l1 t).

> Invariant 4: Universal L1-layering — paren-wrapped expressions
> build to identical L1 trees as their unwrapped inner expressions,
> for every L1 form. Downstream recognizers do not re-implement
> paren-stripping.
all t: TSExpr, is-paren? t | build-l1 t = build-l1 (unwrap-parens t).

> Invariant 5: Mutating-body assignment targets are L1 Member
> expressions. The hard rule for the property-access equivalence
> class extends to statement-position writes.
all s: L1Stmt, is-assignment-stmt? s | is-member? (target s).

> Invariant 6: Property-access sub-expressions no longer wrap via
> from-l2. The from-l2 adapter still survives for non-property
> sub-expressions awaiting M6 deletion of the form.
all t: TSExpr, is-any-property-form? t | ~(is-from-l2? (build-l1 t)).

> Invariant 7: The functor-lift recognizer accepts operands whose L1
> form is Var or Member (Identifier, dotted-property, or string-
> literal element access). The M4 P5 TS-AST restriction to simple
> identifier is replaced with an L1-shape eligibility check.
all t: TSExpr, is-functor-lift-shape? t |
  is-any-property-form? (functor-lift-operand t)
  or is-each-comprehension? (build-l1 t).

> Invariant 8: Cardinality dispatch. `.length` / `.size` on the six
> list-shaped TS types (Array, ReadonlyArray, Set, ReadonlySet, Map,
> ReadonlyMap) build to L1 Unop(card, receiver) via
> tryBuildL1Cardinality, NOT Member. This dispatch fires before
> Member; the divergence is target-language-driven (Pant's
> cardinality primitive is `#x`, not a `length` / `size` rule).
all t: TSExpr, is-cardinality-form? t | is-card-unop? (build-l1 t).

```

## Patch Specification

```
module TS2PANT_M5_PATCH_4.

> Patch 4 lifts the functor-lift recognizer's operand restriction.
> Eligibility is checked on the L1 form of the operand, not the TS
> AST: `Var` (from Identifier) or `Member` (from PropertyAccess or
> string-literal ElementAccess). Source-level wrappers like parens
> are normalized away by L1 build itself.

TSExpr.
L1Expr.

build-l1 t: TSExpr => L1Expr.
is-var? e: L1Expr => Bool.
is-member? e: L1Expr => Bool.

is-functor-lift-shape? t: TSExpr => Bool.
functor-lift-operand t: TSExpr, is-functor-lift-shape? t => TSExpr.
is-each-comprehension? e: L1Expr => Bool.

---

> The recognizer accepts an operand iff its L1 form is Var or
> Member. Calls, binops, type-erasure wrappers, etc. fall through.
> Parenthesized variants are accepted transparently because L1 build
> normalizes parens before producing Var or Member.
all t: TSExpr, is-functor-lift-shape? t,
  is-var? (build-l1 (functor-lift-operand t)) or is-member? (build-l1 (functor-lift-operand t)) |
  is-each-comprehension? (build-l1 t).

```


## Implementation Notes

- **Two substitution paths, not one.** The gameplan reads as "build operand and projection through `buildL1Expr`, do L1 substitution, run `ast.substituteBinder` afterward." In practice that doesn't quite work for `Var` operands: `buildSubExpr` (the legacy projection path) wraps everything as `from-l2`, and the L1 rewriter cannot enter `from-l2` to find buried `Var` references. So the implementation splits:
  - **Var operand**: projection built via `buildSubExpr` (M4 P5 path), `ast.substituteBinder` does the work post-lowering. Byte-identical to M4 P5 for the existing identifier-operand fixtures and unit tests.
  - **Member operand**: projection built via a new pure-L1 chain builder (`buildL1MemberOrVarForLift`); the L1 rewriter (`substituteL1Subtree`) is the only substitution mechanism, since `ast.substituteBinder` substitutes by name and cannot target a Member subtree. Member-operand projections that aren't pure L1 (e.g., a method call wrapping the operand) reject.
- **Why a new pure-L1 chain builder rather than reusing `buildL1MemberAccess`.** The production helper falls back to `translateBodyExpr` for non-Member receivers (including bare `Identifier`s), producing `from-l2` wraps that hide the operand's structure from the L1 walker. The lift's substitution requires the operand chain to be entirely native L1, so `buildL1MemberOrVarForLift` either produces a pure `Var`/`Member` chain or returns `null`. This stays in the lift's narrow scope; the production helper's behavior is unchanged.
- **`userNameMulti` deliberate-reject case is in the fixture as a comment, not an exported function.** When functor-lift falls through and the standard L1 Cond build then encounters the multi-element array literal, `translateExpr`'s `ast.var(getText())` fallback emits the raw TS text (`[u.owner.name, u.owner.name]`) as a Pant variable name — a syntactically-valid but semantically-broken snapshot that would fail `pant --check`. Rather than pollute the snapshot, the unit test `Member operand multi-element non-empty branch rejects` exercises the rejection directly, and a comment in the fixture documents the intent. (The four supported shapes plus the paren-equivalence shape do `pant --check` cleanly — verified manually outside the harness, since the e2e suite doesn't auto-discover constructs fixtures and z3 isn't available locally.)
- **`isSingleElementProducingOf` split.** The original combined "not a multi-element shape" + "references operand by name" into one predicate. M5 P4 separates them: `isSingleElementProducingShape` is uniform (TS-AST level array-literal/spread/multi-producing-method check), and the reference check is operand-kind specific — Var uses `expressionReferencesNames` (TS-AST text walk, mirrors M4 P5), Member defers to the L1 substitution-fired check at the end. This is the cleanest way to keep Var-path behavior byte-identical while admitting Member operands.
- **Existing "non-identifier operand falls through" test replaced, not deleted.** That test asserted the M4 P5 restriction and is now wrong by construction. It's been replaced with seven new tests covering the four canonical shapes with Member operand, multi-element rejection, string-literal element-access operand, and a Member-operand-with-non-pure-L1-projection rejection. The eight other M4 P5 tests (Var-operand recognitions, eligibility-failure cases, capture-avoidance, nested null-guards) all pass unchanged.