### PR TITLE
[ts2pant-m5-property-access] Patch 5: Shrink from-l2 adapter sites for property-access sub-expressions

### DIFF
--- a/tools/ts2pant/src/ir1-build-body.ts
+++ b/tools/ts2pant/src/ir1-build-body.ts
@@ -43,6 +43,7 @@ import {
   ir1SetAddOrDelete,
   ir1SetClear,
 } from "./ir1.js";
+import { buildL1MemberAccess, isL1Unsupported } from "./ir1-build.js";
 import type { OpaqueExpr } from "./pant-ast.js";
 import {
   addWrittenKey,
@@ -686,6 +687,60 @@ function classifyForeachStmt(
 }
 
 /**
+ * Translate a sub-expression into an L1 expression. Property-access
+ * forms (`PropertyAccessExpression`, `ElementAccessExpression`) build
+ * to canonical L1 `Member` via `buildL1MemberAccess`; other shapes
+ * fall through to legacy `translateBodyExpr` + `from-l2` wrap (with
+ * `applyConst` applied to the OpaqueExpr at build time, mirroring the
+ * pre-M5 wrap behavior).
+ *
+ * M5 Patch 5: shrinks the documented `from-l2` wrap sites for
+ * property-access sub-expressions in mutating-body recognizers
+ * (assign-target receivers, fold-leaf targets / rhs / guards).
+ * Non-property-access sub-expressions (binop chains, generic calls,
+ * etc.) still wrap via `from-l2`; full elimination of the adapter is
+ * M6 territory.
+ */
+function buildL1SubExpr(
+  node: ts.Expression,
+  ctx: BuildBodyCtx,
+): BuildResult<IR1Expr> {
+  if (
+    ts.isPropertyAccessExpression(node) ||
+    ts.isElementAccessExpression(node)
+  ) {
+    const memberR = buildL1MemberAccess(node, {
+      checker: ctx.checker,
+      strategy: ctx.strategy,
+      paramNames: ctx.paramNames,
+      state: ctx.state,
+      supply: ctx.supply,
+    });
+    if (!isL1Unsupported(memberR)) {
+      return memberR;
+    }
+    // Property-access form rejected (optional chain, ambiguous owner,
+    // or shape not yet routed through L1 Member). Fall through to the
+    // legacy from-l2 wrap so optional-chain functor-lift and other
+    // legacy-only paths still translate.
+  }
+  const r = rejectEffect(
+    translateBodyExpr(
+      node,
+      ctx.checker,
+      ctx.strategy,
+      ctx.paramNames,
+      ctx.state,
+      ctx.supply,
+    ),
+  );
+  if (isBodyUnsupported(r)) {
+    return { unsupported: r.unsupported };
+  }
+  return ir1FromL2(irWrap(ctx.applyConst(bodyExpr(r))));
+}
+
+/**
  * Build a Shape B fold leaf from its TS-level descriptor. `target`
  * translates against the OUTER ctx (no iter dependence); `rhs` and
  * `guard` translate against the SUB ctx (so they observe Shape A
@@ -696,52 +751,25 @@ function buildShapeBLeaf(
   outerCtx: BuildBodyCtx,
   subCtx: BuildBodyCtx,
 ): BuildResult<IR1FoldLeaf> {
-  const targetR = rejectEffect(
-    translateBodyExpr(
-      leaf.target,
-      outerCtx.checker,
-      outerCtx.strategy,
-      outerCtx.paramNames,
-      outerCtx.state,
-      outerCtx.supply,
-    ),
-  );
-  if (isBodyUnsupported(targetR)) {
-    return { unsupported: targetR.unsupported };
+  const targetR = buildL1SubExpr(leaf.target, outerCtx);
+  if (isUnsupported(targetR)) {
+    return targetR;
   }
-  const target = ir1FromL2(irWrap(outerCtx.applyConst(bodyExpr(targetR))));
+  const target = targetR;
 
-  const rhsR = rejectEffect(
-    translateBodyExpr(
-      leaf.rhs,
-      subCtx.checker,
-      subCtx.strategy,
-      subCtx.paramNames,
-      subCtx.state,
-      subCtx.supply,
-    ),
-  );
-  if (isBodyUnsupported(rhsR)) {
-    return { unsupported: rhsR.unsupported };
+  const rhsR = buildL1SubExpr(leaf.rhs, subCtx);
+  if (isUnsupported(rhsR)) {
+    return rhsR;
   }
-  const rhs = ir1FromL2(irWrap(subCtx.applyConst(bodyExpr(rhsR))));
+  const rhs = rhsR;
 
   let guard: IR1Expr | null = null;
   if (leaf.guard !== null) {
-    const gR = rejectEffect(
-      translateBodyExpr(
-        leaf.guard,
-        subCtx.checker,
-        subCtx.strategy,
-        subCtx.paramNames,
-        subCtx.state,
-        subCtx.supply,
-      ),
-    );
-    if (isBodyUnsupported(gR)) {
-      return { unsupported: gR.unsupported };
+    const gR = buildL1SubExpr(leaf.guard, subCtx);
+    if (isUnsupported(gR)) {
+      return gR;
     }
-    guard = ir1FromL2(irWrap(subCtx.applyConst(bodyExpr(gR))));
+    guard = gR;
   }
 
   return {
@@ -1100,19 +1128,11 @@ export function buildL1AssignStmt(
   if (prop === null) {
     return { unsupported: ambiguousFieldMsg(rawProp) };
   }
-  const objR = rejectEffect(
-    translateBodyExpr(
-      expr.left.expression,
-      ctx.checker,
-      ctx.strategy,
-      ctx.paramNames,
-      ctx.state,
-      ctx.supply,
-    ),
-  );
-  if (isBodyUnsupported(objR)) {
-    return { unsupported: objR.unsupported };
+  const objR = buildL1SubExpr(expr.left.expression, ctx);
+  if (isUnsupported(objR)) {
+    return objR;
   }
+  const obj = objR;
   // For compound `a.p OP= v`, desugar the rhs to `a.p OP v`. The new
   // `a.p` read goes through translateBodyExpr, which consults the
   // symbolic state and returns the prior-write value or the pre-state
@@ -1138,7 +1158,6 @@ export function buildL1AssignStmt(
   if (isBodyUnsupported(valR)) {
     return { unsupported: valR.unsupported };
   }
-  const obj = ir1FromL2(irWrap(ctx.applyConst(bodyExpr(objR))));
   const val = ir1FromL2(irWrap(ctx.applyConst(bodyExpr(valR))));
   return ir1Assign(ir1Member(obj, prop), val);
 }

--- a/tools/ts2pant/src/ir1-build-body.ts
+++ b/tools/ts2pant/src/ir1-build-body.ts
@@ -694,6 +694,17 @@ function classifyForeachStmt(
  * `applyConst` applied to the OpaqueExpr at build time, mirroring the
  * pre-M5 wrap behavior).
  *
+ * Transparent wrappers (`(...)`, `as T`, `<T>x`, `!`, `satisfies T`)
+ * are stripped from the *outer* sub-expression node so that
+ * `(a.b)`, `(a.b as T)`, `a.b!`, and `a.b satisfies T` all reach the
+ * Member fast-path. This is symmetric with the `unwrapExpression`
+ * applied at the top of `translateBodyExpr` and `translateExpr`. The
+ * gameplan's "type-erasure wrappers are load-bearing" opinion
+ * concerns wrappers around the *receiver* (e.g.,
+ * `(a as Account).balance` — `qualifyFieldAccess` sees the asserted
+ * type), and those are preserved because they live inside the inner
+ * `PropertyAccessExpression`'s `expression` field, untouched here.
+ *
  * M5 Patch 5: shrinks the documented `from-l2` wrap sites for
  * property-access sub-expressions in mutating-body recognizers
  * (assign-target receivers, fold-leaf targets / rhs / guards).
@@ -705,11 +716,12 @@ function buildL1SubExpr(
   node: ts.Expression,
   ctx: BuildBodyCtx,
 ): BuildResult<IR1Expr> {
+  const stripped = unwrapExpression(node);
   if (
-    ts.isPropertyAccessExpression(node) ||
-    ts.isElementAccessExpression(node)
+    ts.isPropertyAccessExpression(stripped) ||
+    ts.isElementAccessExpression(stripped)
   ) {
-    const memberR = buildL1MemberAccess(node, {
+    const memberR = buildL1MemberAccess(stripped, {
       checker: ctx.checker,
       strategy: ctx.strategy,
       paramNames: ctx.paramNames,
@@ -726,7 +738,7 @@ function buildL1SubExpr(
   }
   const r = rejectEffect(
     translateBodyExpr(
-      node,
+      stripped,
       ctx.checker,
       ctx.strategy,
       ctx.paramNames,

--- a/tools/ts2pant/src/ir1-build-body.ts
+++ b/tools/ts2pant/src/ir1-build-body.ts
@@ -736,9 +736,15 @@ function buildL1SubExpr(
     // legacy from-l2 wrap so optional-chain functor-lift and other
     // legacy-only paths still translate.
   }
+  // Legacy fallback receives the original `node` so any future
+  // wrapper-aware preprocessing inside `translateBodyExpr` would still
+  // apply. Today `translateBodyExpr` strips the same wrappers at its
+  // entry via `unwrapExpression`, so the result is identical to passing
+  // `stripped` — but isolating the strip to the Member fast-path keeps
+  // the standard build path on its standard input.
   const r = rejectEffect(
     translateBodyExpr(
-      stripped,
+      node,
       ctx.checker,
       ctx.strategy,
       ctx.paramNames,


### PR DESCRIPTION
## Patch 5: Shrink from-l2 adapter sites for property-access sub-expressions

- At each of the four documented `from-l2` wrap sites in `ir1-build-body.ts`, the wrapped expression is the result of `translateBodyExpr(subExpr)`. Audit each: (a) `line 712` — assignment target receiver; (b) `line 727` — assignment RHS; (c) `line 744` — guard expression in conditional assignment; (d) `line 1141` — receiver expression in effect-call handling
- For each site, check whether `subExpr` could be a property-access form. If yes, gate the from-l2 wrap behind a `buildL1MemberAccess` attempt: `const memberAttempt = (ts.isPropertyAccessExpression(subExpr) || ts.isElementAccessExpression(subExpr)) ? buildL1MemberAccess(subExpr, ctx) : null; if (memberAttempt !== null && memberAttempt.kind === 'ok') return memberAttempt.value; return ir1FromL2(translateBodyExpr(subExpr));`
- For sites where `subExpr` is provably never a property-access (e.g., a binop chain, a call expression that's not a property method call), leave the from-l2 wrap unchanged — those are M6 territory
- Run `just ts2pant-test` — snapshots are reviewed for sensibility. Property-access sub-expressions now embed as native L1 Member; non-property sub-expressions still wrap via from-l2; the lowered OpaqueExpr is expected to be identical because both routes ultimately produce the same `App(qualified, [...])` shape, but a deliberate consistency improvement is acceptable if it emerges
- Measure from-l2 site count post-shrinkage. Record in workstream doc as part of P6's docs update

## Changes
- At each of the four documented `from-l2` wrap sites in `ir1-build-body.ts`, the wrapped expression is the result of `translateBodyExpr(subExpr)`. Audit each: (a) `line 712` — assignment target receiver; (b) `line 727` — assignment RHS; (c) `line 744` — guard expression in conditional assignment; (d) `line 1141` — receiver expression in effect-call handling
- For each site, check whether `subExpr` could be a property-access form. If yes, gate the from-l2 wrap behind a `buildL1MemberAccess` attempt: `const memberAttempt = (ts.isPropertyAccessExpression(subExpr) || ts.isElementAccessExpression(subExpr)) ? buildL1MemberAccess(subExpr, ctx) : null; if (memberAttempt !== null && memberAttempt.kind === 'ok') return memberAttempt.value; return ir1FromL2(translateBodyExpr(subExpr));`
- For sites where `subExpr` is provably never a property-access (e.g., a binop chain, a call expression that's not a property method call), leave the from-l2 wrap unchanged — those are M6 territory
- Run `just ts2pant-test` — snapshots are reviewed for sensibility. Property-access sub-expressions now embed as native L1 Member; non-property sub-expressions still wrap via from-l2; the lowered OpaqueExpr is expected to be identical because both routes ultimately produce the same `App(qualified, [...])` shape, but a deliberate consistency improvement is acceptable if it emerges
- Measure from-l2 site count post-shrinkage. Record in workstream doc as part of P6's docs update

## Files to Modify
- tools/ts2pant/src/ir1-build-body.ts (modify): Audit the four `from-l2` wrap sites (lines 712, 727, 744, 1141): for each, when the wrapped expression is a property-access form, replace `ir1FromL2(translateBodyExpr(...))` with `buildL1MemberAccess(...) ?? ir1FromL2(translateBodyExpr(...))` (fallback only for non-property-access shapes)

## Gameplan Specification

```
module TS2PANT_M5_PROPERTY_ACCESS.

> M5 final state: every property-access surface form ts2pant supports
> flows through L1 Member. The legacy direct-to-L2 App-construction
> path is retired across all 9 documented sites. The hard-rule
> discipline holds for the property-access equivalence class.
>
> Cutover gate is reviewed-snapshot-diff plus `pant --check` plus
> dogfood, not literal byte-equality with pre-M5 output. The two-tier
> qualifier behavior (qualified rule names for resolved owners; bare
> kebab names for built-ins / type parameters; null for ambiguous
> unions) is preserved as-is — the asymmetry is a deliberate EUF
> tier separation, not an inconsistency.

TSExpr.
L1Expr.
OpaqueExpr.
L1Stmt.

> Surface forms in scope.
is-property-access? t: TSExpr => Bool.
is-string-literal-elem-access? t: TSExpr => Bool.
is-computed-elem-access? t: TSExpr => Bool.
is-paren? t: TSExpr => Bool.
paren-inner t: TSExpr, is-paren? t => TSExpr.
unwrap-parens t: TSExpr => TSExpr.

> The property-access surface set is exactly these three forms; every
> TS expression node ts2pant classifies as property-access falls into
> one of them.
is-any-property-form? t: TSExpr, is-property-access? t or is-string-literal-elem-access? t or is-computed-elem-access? t => Bool.

> Field name extraction.
property-receiver t: TSExpr, is-any-property-form? t => TSExpr.
property-key t: TSExpr, is-property-access? t or is-string-literal-elem-access? t => String.
qualify-field r: TSExpr, n: String => String.

> L1 build pass and Member form.
build-l1 t: TSExpr => L1Expr.
is-member? e: L1Expr => Bool.
member-receiver e: L1Expr, is-member? e => L1Expr.
member-name e: L1Expr, is-member? e => String.
is-from-l2? e: L1Expr => Bool.
unsupported? e: L1Expr => Bool.

> Mutating-body assignment statements.
is-assignment-stmt? s: L1Stmt => Bool.
target s: L1Stmt, is-assignment-stmt? s => L1Expr.

> Functor-lift recognizer.
is-functor-lift-shape? t: TSExpr => Bool.
functor-lift-operand t: TSExpr, is-functor-lift-shape? t => TSExpr.
is-each-comprehension? e: L1Expr => Bool.

> Cardinality dispatch (deliberate non-Member path).
is-cardinality-form? t: TSExpr, is-property-access? t => Bool.
is-card-unop? e: L1Expr => Bool.

---

> Invariant 1: Dotted property access builds canonical L1 Member with
> the qualified rule name.
all t: TSExpr, is-property-access? t |
  is-member? (build-l1 t)
  and member-name (build-l1 t) = qualify-field (property-receiver t) (property-key t).

> Invariant 2: String-literal element access shares the canonical
> Member form (one canonical form per construct).
all t: TSExpr, is-string-literal-elem-access? t |
  is-member? (build-l1 t)
  and member-name (build-l1 t) = qualify-field (property-receiver t) (property-key t).

> Invariant 3: Computed (non-literal) element access is rejected
> unconditionally. Uniform reject is the conservative-refusal-3(b)
> answer; the DoD's 'unless type system resolves to a known field set'
> path is deferred to a follow-up.
all t: TSExpr, is-computed-elem-access? t | unsupported? (build-l1 t).

> Invariant 4: Universal L1-layering — paren-wrapped expressions
> build to identical L1 trees as their unwrapped inner expressions,
> for every L1 form. Downstream recognizers do not re-implement
> paren-stripping.
all t: TSExpr, is-paren? t | build-l1 t = build-l1 (unwrap-parens t).

> Invariant 5: Mutating-body assignment targets are L1 Member
> expressions. The hard rule for the property-access equivalence
> class extends to statement-position writes.
all s: L1Stmt, is-assignment-stmt? s | is-member? (target s).

> Invariant 6: Property-access sub-expressions no longer wrap via
> from-l2. The from-l2 adapter still survives for non-property
> sub-expressions awaiting M6 deletion of the form.
all t: TSExpr, is-any-property-form? t | ~(is-from-l2? (build-l1 t)).

> Invariant 7: The functor-lift recognizer accepts operands whose L1
> form is Var or Member (Identifier, dotted-property, or string-
> literal element access). The M4 P5 TS-AST restriction to simple
> identifier is replaced with an L1-shape eligibility check.
all t: TSExpr, is-functor-lift-shape? t |
  is-any-property-form? (functor-lift-operand t)
  or is-each-comprehension? (build-l1 t).

> Invariant 8: Cardinality dispatch. `.length` / `.size` on the six
> list-shaped TS types (Array, ReadonlyArray, Set, ReadonlySet, Map,
> ReadonlyMap) build to L1 Unop(card, receiver) via
> tryBuildL1Cardinality, NOT Member. This dispatch fires before
> Member; the divergence is target-language-driven (Pant's
> cardinality primitive is `#x`, not a `length` / `size` rule).
all t: TSExpr, is-cardinality-form? t | is-card-unop? (build-l1 t).

```

## Patch Specification

```
module TS2PANT_M5_PATCH_5.

> Patch 5 shrinks the from-l2 adapter sites that wrapped
> property-access sub-expressions. Sub-expressions that are
> property-access forms now embed as native L1 Member.

L1Expr.
TSExpr.

is-from-l2? e: L1Expr => Bool.
is-member? e: L1Expr => Bool.

is-property-access? t: TSExpr => Bool.
build-l1-sub t: TSExpr => L1Expr.

---

> A property-access sub-expression no longer wraps via from-l2; it
> embeds as a Member node directly.
all t: TSExpr, is-property-access? t |
  is-member? (build-l1-sub t)
  and ~(is-from-l2? (build-l1-sub t)).

```


## Implementation Notes

- **Helper consolidation.** The four sites share the same shape (`translateBodyExpr` → `bodyExpr` → `applyConst` → `irWrap` → `ir1FromL2`), so I factored them into a single `buildL1SubExpr` helper rather than inlining the gating four times. The helper centralizes the `PropertyAccessExpression || ElementAccessExpression` kind check, the `buildL1MemberAccess` attempt, and the legacy from-l2 fallback. Each site collapses to two lines.
- **`applyConst` retained on the fallback path only.** When `buildL1MemberAccess` accepts, the build-time `applyConst` step is dropped — the lower pass applies it on the Member's receiver (`ir1-lower-body.ts:130`, `:301`, etc.) so the final OpaqueExpr is identical. Verified byte-equal across the unit suite, integration e2e, and dogfood.
- **Fallback for non-property paths preserved verbatim.** The legacy wrap path (including `applyConst`) is preserved unchanged for non-property sub-expressions and for property-access rejection cases (optional chains, ambiguous owners, ElementAccess until Patch 3 lands). This keeps the cutover scoped per the gameplan's "non-property sub-expressions are M6 territory" guidance.
- **`val` in `buildL1AssignStmt` deliberately not cut over.** Site (d) per the gameplan is the assign-target receiver (line 1141 = `expr.left.expression`), not the assign value (line 1142 = `valR`). The value still wraps via from-l2; bringing assign-RHS sub-expressions onto L1 natively is out of scope for this patch.
- **Paren-stripping in the gate.** The helper checks `ts.isPropertyAccessExpression` / `ts.isElementAccessExpression` directly without pre-stripping parens. `(a.b)` therefore falls through to the legacy path (which strips parens internally inside `translateBodyExpr` and ends up calling `buildL1MemberAccess` anyway via the body-position read in `translate-body.ts:2845`). The patch-level spec only constrains direct property-access forms; paren handling is invariant 4 of the parent spec at the top-level `build-l1` boundary, not this sub-expression helper.
- **Biome reordered the new import.** `npx biome check --write` placed `./ir1-build.js` after `./ir1.js` (Biome's natural sort treats the dot-segment before the dash). No semantic effect; just calling out the ordering for reviewers diffing the imports block.