### PR TITLE
[ts2pant-m5-property-access] Patch 6: Docs and dogfood verification

### DIFF
--- a/tools/ts2pant/CLAUDE.md
+++ b/tools/ts2pant/CLAUDE.md
@@ -831,13 +831,34 @@ is identical pre/post-M3.
 
 ### Divergence from IRSC
 
-One deliberate divergence, documented so a future agent doesn't "fix"
-it back to paper-faithful IRSC.
+Deliberate divergences, documented so a future agent doesn't "fix"
+them back to paper-faithful IRSC.
 
-**No `FieldAccess` form.** ts2pant lowers `e.f` to `App(qualified-rule,
-[e])` at construction time via `qualifyFieldAccess`. Adding a
-`FieldAccess` form would force every consumer to check both shapes
-and reintroduces the cross-talk problem.
+**No L2 `FieldAccess` form.** ts2pant lowers `e.f` to L2
+`App(qualified-rule, [e])` at construction time via
+`qualifyFieldAccess`. Adding a L2 `FieldAccess` form would force
+every L2 consumer to check both shapes and reintroduces the cross-
+talk problem. M5 reaffirmed this divergence: the L1 `Member(receiver,
+name)` form is *normalization*, not lowering — its job is to be the
+canonical input shape for the lowering pass, not a 1-to-1 mirror of
+L2. Member is L1-only; it lowers to `App(qualified-rule, [receiver])`
+in `ir1-lower.ts:77-84`. Pre-qualifying at build time keeps
+`qualifyFieldAccess`'s ambiguity-detection and inheritance-walking
+logic centralized in one place.
+
+**Cardinality dispatch is a non-Member path.** `.length` on Array /
+ReadonlyArray and `.size` on Set / ReadonlySet / Map / ReadonlyMap
+build to L1 `Unop(card, receiver)` via `tryBuildL1Cardinality` in
+`ir1-build.ts`, NOT through `buildL1MemberAccess`. The dispatch
+fires *before* Member during L1 build. Routing through Member would
+lower to `App("length", [arr])` — i.e., the Pant text `length arr`,
+an EUF uninterpreted function distinct from the actual list
+cardinality `#arr`. Specs reasoning about array sizes would silently
+fail under that lowering. Pant's primitive for cardinality is `#x`,
+which `Unop(card, x)` covers; there is no canonical-Member route
+that produces correct output. This is a target-language constraint,
+not a style choice — a sibling deliberate divergence to the
+no-`FieldAccess` rule.
 
 (IRSC's SSA-over-program-names discipline does *not* apply here —
 post-M3 there is no L2 statement vocabulary, and the mutating path's
@@ -995,8 +1016,9 @@ in the equality / nullish equivalence class flows through Layer 1.
   opportunistically — see § "Developer Steering Principles" rule 2.
 - `BinOp(eq | neq, lhs, rhs)` — canonical strict equality. Produced
   unconditionally from `===` / `!==`. The L1 form admits arbitrary
-  operands; sub-expressions wrap via `from-l2` until M5 brings property
-  access onto L1 natively.
+  operands; property-access sub-expressions reach L1 natively post-M5
+  via `Member`, while non-property sub-expressions wrap via `from-l2`
+  until M6 deletes the form.
 - Functor-lift `each n in x | f n` — the canonical lowering for
   null-guarded list-lifted conditionals (see § "Functor-Lift
   Recognizer" above for the four soundness conditions). Combined-shape
@@ -1035,9 +1057,9 @@ both sides; classifying conservatively keeps the if-statement intact.
 *from-l2 shrinkage scope.* Sub-expressions of nullish and equality
 forms now build natively on L1: the `IsNullish` operand is an
 arbitrary L1 expression, and `BinOp(eq | neq, …)` operands are L1.
-The `from-l2` adapter still wraps internal sub-expressions where
-those operands themselves come from `translateBodyExpr` (property
-access in particular) — full elimination is M5 territory.
+Property-access sub-expressions reach L1 natively post-M5 via
+`Member`; only non-property sub-expressions still wrap via `from-l2`,
+and full elimination is M6 territory.
 
 *Out of scope by design* (candidates for future milestones if real
 fixtures demand them):
@@ -1061,6 +1083,115 @@ fixtures + dogfood, all consumed by the nullish recognizer. 0 rejected.
 **0%.** No fixture or dogfood site exercises a non-nullish loose-eq
 that would surface the rejection path; rejection is exercised by
 synthetic cases in `tests/equality-canonicalization.test.mts`.
+
+**M5 (property-access-normalization): landed.** Every TS property-
+access surface form ts2pant supports flows through Layer 1.
+
+*Canonical form:*
+
+- `Member(receiver, name)` — the canonical L1 property-access form.
+  Receivers are arbitrary L1 expressions; `name` is pre-qualified at
+  build time via the existing `qualifyFieldAccess` (inheritance
+  walking, union/intersection ambiguity detection, anonymous synth-
+  cell fallback — all centralized in one place). Lowers mechanically
+  to L2 `App(qualified-rule, [receiver])` in `ir1-lower.ts` —
+  byte-identical to the pre-M5 hand-emitted shape on every fixture.
+  Built by `buildL1MemberAccess` in `ir1-build.ts`, called from all
+  9 documented build/translate sites in `translate-body.ts`,
+  `translate-signature.ts`, `ir-build.ts`, and `ir1-build-body.ts`.
+
+*Surface forms folded into Member:*
+
+- Dotted access (`obj.field`) — TS `PropertyAccessExpression` with an
+  `Identifier` / `PrivateIdentifier` argument.
+- String-literal element access (`obj["field"]`) — TS
+  `ElementAccessExpression` whose argument expression is a
+  `StringLiteral`. Operationally equivalent to dotted access at the
+  TS-checker layer; one canonical L1 form.
+
+*Computed element access rejected.* `obj[expr]` for any non-literal
+`expr` rejects with a specific `unsupported` reason. The DoD's
+"unless type system resolves to a known field set" carve-out (literal-
+union narrowing on the index expression) is deferred to a follow-up:
+the soundness conditions (partial unions, branded strings, generics-
+resolving-to-literal-types-only-at-call-site) are non-trivial enough
+to warrant their own slice.
+
+*Type-erasure wrappers preserved.* `(x as T).f`, `x!.f`, `<T>x.f`,
+`(x satisfies T).f` are **not** stripped at L1 build, despite being
+runtime-erased. They are load-bearing at the TS-checker layer that
+ts2pant translates against — `qualifyFieldAccess` calls
+`checker.getTypeAtLocation` on the asserted node to honor the user's
+contract that the receiver should be treated as the asserted type.
+Stripping would silently change the qualifier resolution. Symmetric
+strip-in-`buildL1SubExpr` (Patch 5) operates on *outer*-position
+wrappers around the sub-expression, not on wrappers inside the
+property-access receiver — those stay put.
+
+*Paren-stripping is universal.* `(x)` and `x` produce identical L1
+trees at every TS-AST → L1 dispatch entry point — `buildL1Expr`,
+`buildL1Stmt`, and the per-kind builders all unwrap parens before
+classifying. Downstream recognizers (functor-lift, cardinality, the
+nullish recognizer) do not re-implement paren-stripping; they
+classify against the unwrapped node uniformly.
+
+*Functor-lift operand restriction lifted (M5 Patch 4).* The
+recognizer's eligibility check is now expressed in L1 terms (`Var`
+or `Member`) rather than TS-AST terms (`Identifier` only — the M4 P5
+restriction). Idiomatic null-guards over Member operands —
+`if (obj.field == null) return []; return [obj.field.name];` — now
+translate. See § "Functor-Lift Recognizer" for the supported shapes.
+
+*Cardinality dispatch is a deliberate non-Member path.* `.length` /
+`.size` on the six list-shaped TS types (Array, ReadonlyArray, Set,
+ReadonlySet, Map, ReadonlyMap) build to L1 `Unop(card, receiver)`
+via `tryBuildL1Cardinality`, NOT Member. The dispatch fires *before*
+Member; routing through Member would lower to `App("length", [arr])`
+— EUF uninterpreted on a `length` rule, distinct from Pant's
+cardinality primitive `#x`. Specs reasoning about array sizes would
+silently fail. See § "Divergence from IRSC" below for the canonical
+record.
+
+*Mutating-body assignment targets.* The hard rule for the property-
+access equivalence class extends to statement-position writes:
+`buildL1AssignStmt` constructs `Assign(Member(receiver, name),
+value)` where the target is a canonical L1 Member. Compound-assign
+desugaring (`a.p OP= v` → `a.p = a.p OP v`) happens before Member
+construction, so the Member form is the same whether the source was
+a simple assign or compound assign.
+
+*from-l2 shrinkage scope.* The four documented property-access
+sub-expression wrap sites in mutating-body recognizers
+(`ir1-build-body.ts` Shape B fold target / rhs / guard,
+`buildL1AssignStmt` receiver) consolidate into one
+`buildL1SubExpr` helper that calls `buildL1MemberAccess` for
+property-access shapes and falls back to `from-l2` only for non-
+property sub-expressions. Wrap sites post-M5: 1 (down from 4); the
+remaining fallback fires only for non-property sub-expressions
+(binop chains, generic call results, etc.) awaiting M6 deletion of
+the form.
+
+*qualifyFieldAccess two-tier behavior preserved as-is.* Resolved-
+owner cases produce qualified rule names (`account-balance a`);
+unresolved-non-ambiguous cases (built-ins, type parameters,
+anonymous-without-synth) fall back to bare kebab'd field names
+(`to-fixed n 2`); ambiguous unions return null and reject. The
+asymmetry is a deliberate two-tier EUF separation — user-defined
+types get qualified rule names because translate-types emits
+accessor rules with bodies the SMT solver observes; built-in /
+parametric types fall back to bare names because the SMT solver
+treats them as EUF uninterpreted functions with congruence (the
+right modeling for `arr.indexOf(x)`, `s.charAt(0)`, `n.toFixed(2)`,
+etc.). Tightening to always-reject would break a substantial
+fraction of TS code that translates fine today; collapsing to
+always-qualify would pollute the namespace with bodyless synthesized
+rules and lose nothing semantically.
+
+*Pessimism rate (computed-access rejection):* 0 — fixtures and
+dogfood use dotted access exclusively; no fixture or dogfood site
+exercises computed `obj[expr]` that would surface the rejection
+path. **0%.** Rejection is exercised by the deliberate-reject
+`getByDynamicKey` fixture function plus unit tests.
 
 **Layering principle.** This is the architectural commitment that
 M2 ratifies and the M2 cleanup completes:
@@ -1086,9 +1217,11 @@ outside the current milestone's normalization concern. The adapter
 wraps a pre-built Layer 2 `IRExpr` and lowers verbatim. M3 grew its
 use (mutating-body sub-expressions like receivers, values, conditions
 all arrive as OpaqueExpr from `translateBodyExpr` and wrap via
-`from-l2`). Lifetime: shrinks once M4 (equality/nullish) and M5
-(property access) bring sub-expressions onto L1 natively; deleted at
-M6. Do not introduce new uses outside the build pipeline's scoped
+`from-l2`). Lifetime: M4 (equality/nullish) and M5 (property access)
+brought sub-expressions onto L1 natively, shrinking the property-
+access sub-expression wrap sites from 4 to 1 (consolidated into
+`buildL1SubExpr`'s fallback for non-property forms); deleted at M6.
+Do not introduce new uses outside the build pipeline's scoped
 sub-expression delegation.
 
 **Locked decisions** (re-litigation requires explicit user sign-off):

--- a/tools/ts2pant/CLAUDE.md
+++ b/tools/ts2pant/CLAUDE.md
@@ -1104,10 +1104,12 @@ access surface form ts2pant supports flows through Layer 1.
 
 - Dotted access (`obj.field`) — TS `PropertyAccessExpression` with an
   `Identifier` / `PrivateIdentifier` argument.
-- String-literal element access (`obj["field"]`) — TS
-  `ElementAccessExpression` whose argument expression is a
-  `StringLiteral`. Operationally equivalent to dotted access at the
-  TS-checker layer; one canonical L1 form.
+- String-literal element access (`obj["field"]`, ``obj[`field`]``) —
+  TS `ElementAccessExpression` whose argument expression is a
+  `StringLiteral` or `NoSubstitutionTemplateLiteral`. Operationally
+  equivalent to dotted access at the TS-checker layer; one canonical
+  L1 form. Templates with substitutions (e.g., ``obj[`f${i}`]``) are
+  not literal keys — they fall through to the computed-access reject.
 
 *Computed element access rejected.* `obj[expr]` for any non-literal
 `expr` rejects with a specific `unsupported` reason. The DoD's

--- a/tools/ts2pant/CLAUDE.md
+++ b/tools/ts2pant/CLAUDE.md
@@ -1172,7 +1172,7 @@ remaining fallback fires only for non-property sub-expressions
 the form.
 
 *qualifyFieldAccess two-tier behavior preserved as-is.* Resolved-
-owner cases produce qualified rule names (`account-balance a`);
+owner cases produce qualified rule names (`account--balance a`);
 unresolved-non-ambiguous cases (built-ins, type parameters,
 anonymous-without-synth) fall back to bare kebab'd field names
 (`to-fixed n 2`); ambiguous unions return null and reject. The

--- a/workstreams/ts2pant-imperative-ir.md
+++ b/workstreams/ts2pant-imperative-ir.md
@@ -29,17 +29,19 @@ differ by program position:
 This asymmetry is intentional and was hard-won — see § "Architectural
 Lessons" below.
 
-## Current State (post-M4)
+## Current State (post-M5)
 
 M1 (conditionals), M2 (assign + μ-search), M3 (iteration + mutation),
-and M4 (equality + nullish) have landed. Layer 1 IR is the canonical
-input shape for every mutating-body construct ts2pant supports, plus
-the conditional / assign / iteration expression forms, plus the
-equality / nullish equivalence class.
+M4 (equality + nullish), and M5 (property access) have landed. Layer 1
+IR is the canonical input shape for every mutating-body construct
+ts2pant supports, plus the conditional / assign / iteration
+expression forms, plus the equality / nullish equivalence class,
+plus the property-access equivalence class.
 
 **What's on Layer 1**:
 
-- Expression forms: `var`, `lit`, `binop`, `unop`, `app`, `member`,
+- Expression forms: `var`, `lit`, `binop`, `unop`, `app`, `member`
+  (M5 canonical property-access form, pre-qualified at build time),
   `cond`, `is-nullish` (M4 canonical Bool null/undefined test),
   `from-l2` (transitional adapter for sub-expressions outside the
   current milestone's normalization concern).
@@ -55,14 +57,15 @@ companion `src/ir-subst.ts` were the speculative target of the
 parallel-build PRs (#134/#135/#137) that got closed; PR #138 deleted
 them once M3 confirmed nothing built or lowered them.
 
-**What's still on the legacy path** (pre-M5/M6):
+**What's still on the legacy path** (pre-M6):
 
-- Property access (`obj.f` / `obj["f"]`) — qualified at build time via
-  `qualifyFieldAccess`; no L1 `Member` normalization yet.
 - Pure-path `.reduce` chain fusion — `translateReduceCall` builds an
   L2 `eachComb` directly. Architecturally separate from M3's
   mutating-body foreach.
 - `IRWrap` escape hatch in L2 — survives until M6.
+- `from-l2` adapter — shrunk at M5 (the four documented property-
+  access wrap sites consolidated into one `buildL1SubExpr` fallback
+  that fires only for non-property sub-expressions); deleted at M6.
 
 **Combined-shape recognizer precedent (M4 Patch 5).** The functor-lift
 recognizer (`tryRecognizeFunctorLift` in `ir1-build.ts`) is the first
@@ -604,25 +607,122 @@ access defers to M5).
 
 ---
 
-### Milestone 5 (deferred): property-access-normalization
+### Milestone 5: property-access-normalization — ✅ landed
+
+**Status**: landed across six stacked patches on
+`ts2pant-m5-property-access`.
+
+The property-access equivalence class flows through Layer 1. Every TS
+property-access surface form ts2pant supports — dotted access (`obj.f`)
+and string-literal element access (`obj["f"]`) — builds to canonical
+L1 `Member(receiver, name)` with `name` pre-qualified at build time
+via `qualifyFieldAccess`. The legacy direct-to-L2
+`App(qualified-rule, [receiver])` construction path is retired across
+all 9 documented sites in `translate-body.ts`, `translate-signature.ts`,
+`ir-build.ts`, and `ir1-build-body.ts`. Computed element access
+(`obj[expr]`) is rejected unconditionally with a specific
+`unsupported` reason — the DoD's "unless type system resolves to a
+known field set" path requires literal-union narrowing and is deferred
+to a follow-up.
+
+**Slice breakdown:**
+
+- Patch 1 — Add `buildL1MemberAccess` helper (in `ir1-build.ts`) that
+  consumes a TS `PropertyAccessExpression` (or string-literal
+  `ElementAccessExpression`), calls existing `qualifyFieldAccess` to
+  resolve the rule name, and constructs L1 `Member(receiverL1,
+  qualifiedName)`. Cut over pure-path PropertyAccess sites in
+  `ir-build.ts`, `translate-signature.ts`, and `translate-body.ts`.
+  Land paren-stripping at every L1 build dispatch entry point so
+  `(x.f)` and `x.f` produce identical L1 trees universally.
+- Patch 2 — Cut over mutating-body PropertyAccess sites in
+  `translate-body.ts` (assignment targets, Shape A iterator writes,
+  Shape B fold leaves) and `ir1-build-body.ts` (L1 statement target
+  prop names, `buildL1AssignStmt`). Mutating-body assignment targets
+  are now L1 `Member(receiver, name)` — Invariant 5.
+- Patch 3 — String-literal ElementAccess (`obj["f"]`) routes through
+  `buildL1MemberAccess` and produces the same canonical L1 Member
+  form as `obj.f` (one canonical form per construct). Computed
+  element access (`obj[expr]`) is rejected with a specific
+  `unsupported` reason; covered by a deliberate-reject fixture
+  function plus unit tests.
+- Patch 4 — Lift the functor-lift recognizer's operand restriction
+  from "simple identifier only" (M4 P5) to accept Member operands.
+  The eligibility check is now expressed in L1 terms (`Var` or
+  `Member`) rather than TS-AST terms — `u.owner == null ? [] :
+  [u.owner.name]` and the three other supported shapes translate.
+  Member-operand projections must surface the operand structurally
+  at the L1 level, since `ast.substituteBinder` substitutes by name.
+- Patch 5 — Shrink `from-l2` wrap sites for property-access
+  sub-expressions. The four mutating-body sites (`ir1-build-body.ts`
+  fold-leaf target / rhs / guard, `buildL1AssignStmt` receiver) that
+  wrapped property-access sub-expressions via `from-l2` now route
+  through a `buildL1SubExpr` helper that calls `buildL1MemberAccess`
+  for property-access shapes and falls back to `from-l2` only for
+  non-property sub-expressions.
+- Patch 6 — Docs + dogfood verification (this commit).
+
+**Pessimism rate (computed-access rejection)**: 0 — fixtures and
+dogfood use dotted access exclusively; no fixture or dogfood site
+exercises computed `obj[expr]` that would surface the rejection
+path. **0%.** Rejection is exercised by the deliberate-reject
+`getByDynamicKey` fixture function plus unit tests in
+`tests/ir1-build-member-access.test.mts`.
+
+**from-l2 wrap sites post-M5**: 1 (down from 4); the four documented
+property-access sub-expression sites now route through the
+`buildL1SubExpr` helper, whose single from-l2 fallback fires only
+for non-property sub-expressions (binop chains, generic call
+results, etc.) awaiting M6 deletion of the form.
 
 **Definition of Done**:
-- Layer 1 `Member(receiver, name)` is canonical for both `obj.name` and
-  `obj["name-literal"]`. Computed access `obj[expr]` stays as
-  `App(index, [obj, expr])` and is rejected unless type system resolves
-  to a known field set.
-- Hard rule honored.
 
-**Why this is a safe pause point**: Property access is a small,
-self-contained equivalence class.
+- [x] Layer 1 `Member(receiver, name)` is canonical for both
+  `obj.name` and `obj["name-literal"]`. Member is L1-only — no L2
+  `FieldAccess` form (Member lowers mechanically to
+  `App(qualified-rule, [receiver])`, preserving the IRSC divergence).
+- [x] Computed access `obj[expr]` is rejected unconditionally with a
+  specific `unsupported` reason (deferred to a follow-up: the DoD's
+  "unless type system resolves to a known field set" path requires
+  literal-union narrowing).
+- [x] Hard rule honored — every property-access TS construct flows
+  through L1; the legacy direct-to-L2 `App(qualified-rule, [receiver])`
+  construction path is retired across all 9 documented sites.
+- [x] Mutating-body assignment targets are L1 `Member` (Invariant 5).
+- [x] Paren-stripping (`(x)` ≡ `x`) is universal at L1 build —
+  applied at every TS-AST → L1 dispatch entry point, not just
+  inside `buildL1MemberAccess` (Invariant 4).
+- [x] Functor-lift recognizer accepts Var or Member operands; the
+  M4 P5 simple-identifier restriction is lifted (Invariant 7).
+- [x] `.length` / `.size` cardinality dispatch on the six list-shaped
+  TS types (Array, ReadonlyArray, Set, ReadonlySet, Map, ReadonlyMap)
+  builds to L1 `Unop(card, receiver)` via `tryBuildL1Cardinality`,
+  promoted from inline short-circuit. The dispatch fires *before*
+  Member; the divergence is target-language-driven (Pant's
+  cardinality primitive is `#x`, not a `length` / `size` rule)
+  (Invariant 8).
+- [x] All unit tests + integration tests pass; `pant --check` passes
+  for every M5 fixture function.
+
+**Resolved open questions**:
+
+| Question | Resolution |
+|----------|------------|
+| M5 standalone vs absorbed into earlier milestone | Landed standalone post-M4. The architectural backbone (L1 `Member` form + `Member → App(qualified, [receiver])` lowering) was always present and waiting for the cutover; folding into M3 would have ballooned the rip-out-first slice (M3 absorbed iteration + mutation), and folding into M4 would have crossed two unrelated equivalence classes (equality/nullish vs property access) in one milestone — violating the hard-rule discipline at the milestone-naming level. Standalone M5 is a clean six-patch slice with reviewed-snapshot-diff as the gate. |
+| String-literal vs computed element-access scope | String-literal `obj["f"]` collapses to the same canonical Member form as `obj.f`. Computed `obj[expr]` rejected unconditionally — the type-system literal-union narrowing path is deferred to a follow-up (soundness conditions on partial unions, branded strings, generics-resolving-to-literal-types are non-trivial). |
+| Type-erasure wrappers (`as T`, `!`, `<T>x`, `satisfies T`) at L1 build | Not stripped. They are load-bearing at the TS-checker layer ts2pant translates against — `qualifyFieldAccess` calls `checker.getTypeAtLocation` on the asserted node to honor the user's contract that the receiver should be treated as the asserted type. Stripping would silently change the qualifier resolution. Symmetric `unwrapExpression` strip in `buildL1SubExpr` (Patch 5) is for *outer*-position wrappers around the sub-expression — wrappers around the receiver inside a property access stay put. |
+| `qualifyFieldAccess` two-tier behavior (qualified rule names vs bare kebab names vs null) | Preserved as-is in M5. Resolved-owner cases produce qualified rule names (e.g., `account-balance a`); unresolved-non-ambiguous cases (built-ins, type parameters, anonymous-without-synth) fall back to bare kebab'd field names (e.g., `to-fixed n 2`); ambiguous unions return null and reject. The asymmetry is a deliberate two-tier EUF separation, not an inconsistency — see § "Divergence from IRSC" in `tools/ts2pant/CLAUDE.md`. |
+
+**Why this is a safe pause point**: Property access is a
+self-contained equivalence class. M6 (cleanup) can land
+independently — the remaining `from-l2` sites are non-property
+sub-expressions awaiting M6 deletion of the form.
 
 **Unlocks**: M6 cleanup of the last legacy expression handling.
-
-**Open Questions**:
-- Likely absorbed into whichever earlier milestone first needs uniform
-  property-access shape (probably M3, when Foreach bodies do
-  `Assign(Member(x, p), …)` and need a single Member form). Standalone
-  milestone only if not absorbed.
+The `from-l2` adapter now wraps only non-property sub-expressions
+(binop chains, generic call results) which become unreachable once
+the L2 statement vocabulary is deleted alongside the `IRWrap`
+escape hatch.
 
 ---
 
@@ -681,14 +781,14 @@ clear the L2 statement vocabulary was free to delete):
 2 (imperative-ir-assign-mu-search)    → [1]
 3 (imperative-ir-iteration-mutation)  → [2]
 4 (equality-nullish-normalization)    → [3]   (✅ landed standalone)
-5 (property-access-normalization)     → [3]   (deferred; may absorb into 3)
+5 (property-access-normalization)     → [3]   (✅ landed standalone post-M4)
 6 (legacy-recognizer-cleanup)         → [3, 4, 5]
 ```
 
 PR #128 must merge before M1 begins. M1–M4 are strictly sequential because
 each adds a class to the same Layer 1 vocabulary and the hard-rule
-constraint forbids partial migration of a class. M5 can run independently
-of M4 once M3 has landed.
+constraint forbids partial migration of a class. M5 ran independently
+of M4 once M3 had landed.
 
 ## Open Questions
 
@@ -696,7 +796,7 @@ of M4 once M3 has landed.
 |----------|-------|------------|
 | Decrement μ-search (`i--`) SMT encoding | Layer 1 admits it; SMT lowering for `max over each j: Int, j <= INIT, ~P(j) \| j` (the *greatest* `j ≤ INIT` satisfying `¬P` — dual of the increment case's `min over j ≥ INIT`) needs verification on a fixture. | When a fixture demands it |
 | Index-for with mutating `arr[i] = …` writes | Aliasing semantics non-trivial. Deferred unless a fixture demands it. | When a fixture demands it |
-| M5 standalone vs absorbed | Property access likely absorbs into whichever earlier milestone first needs uniform `Member` shape. | Pre-M5 |
+| Computed `obj[expr]` with type-system literal-union narrowing | M5 rejects all computed element access unconditionally. The DoD's "unless type system resolves to a known field set" path requires walking the index expression's type, enumerating string-literal members, joining with the receiver type's declared fields, and dispatching per field — soundness conditions on partial unions, branded strings, and generics-resolving-to-literal-types-only-at-call-site are non-trivial. | When a fixture demands it |
 | `.indexOf(x) === -1` array-absence recognition | Currently translates correctly via `===` canonicalization (EUF equality on the sentinel `-1`). Routing through `IsNullish` would be a stricter modeling of "absence" but isn't required for correctness. | When a fixture demands it |
 | Enum-sentinel-as-nullish absorption (`x === SomeEnum.NONE`) | Typed equality on a named constant; works as-is via `===` canonicalization. Absorption into `IsNullish` would require user-declared "absence" values that ts2pant doesn't model today. | When a fixture demands it |
 | Truthiness coercion (`Boolean(x)`, `!!x`) | Semantically distinct from nullish testing (truthy excludes `0`, `""`, `false`). May stay UNSUPPORTED indefinitely or become its own milestone. | Defer; revisit if a fixture demands it |
@@ -705,7 +805,8 @@ Resolved questions (kept for history):
 
 | Resolved | Resolution |
 |----------|------------|
-| Conservative-refusal pessimism rate | M1, M2, M3, M4 all measured 0% pessimism on existing fixtures. Policy 3(b) holds. |
+| Conservative-refusal pessimism rate | M1, M2, M3, M4, M5 all measured 0% pessimism on existing fixtures. Policy 3(b) holds. |
+| M5 standalone vs absorbed into earlier milestone | Landed standalone post-M4. The architectural backbone (L1 `Member` form + `Member → App(qualified, [receiver])` lowering) was always present; folding into M3 would have ballooned the rip-out-first slice, and folding into M4 would have crossed two unrelated equivalence classes (equality/nullish vs property access) in one milestone. Standalone M5 is a clean six-patch slice with reviewed-snapshot-diff as the gate. |
 | `Reduce` as own L1 form vs desugared | Pure-path `.reduce` stays on `translateReduceCall` (chain-fusion via `BodyResult.pendingComprehension`); not absorbed into L1. The "desugared into `Let + Foreach + Assign`" framing in the original plan was wrong — chain fusion is expression-position, architecturally separate from M3's mutating foreach. |
 | Frame-condition emission ordering | Frames flow through `state.modifiedProps` (Set with insertion-order iteration) — same path as legacy. No L1 → L2 lowering pass for frames; M3's `lowerL1Body` reuses the existing primitive. |
 | M4 standalone vs absorbed into M3 | Landed standalone post-M3. M3 was absorbed enough by iteration + mutation; equality/nullish was a clean six-patch slice on its own. |

--- a/workstreams/ts2pant-imperative-ir.md
+++ b/workstreams/ts2pant-imperative-ir.md
@@ -711,7 +711,7 @@ results, etc.) awaiting M6 deletion of the form.
 | M5 standalone vs absorbed into earlier milestone | Landed standalone post-M4. The architectural backbone (L1 `Member` form + `Member → App(qualified, [receiver])` lowering) was always present and waiting for the cutover; folding into M3 would have ballooned the rip-out-first slice (M3 absorbed iteration + mutation), and folding into M4 would have crossed two unrelated equivalence classes (equality/nullish vs property access) in one milestone — violating the hard-rule discipline at the milestone-naming level. Standalone M5 is a clean six-patch slice with reviewed-snapshot-diff as the gate. |
 | String-literal vs computed element-access scope | String-literal `obj["f"]` collapses to the same canonical Member form as `obj.f`. Computed `obj[expr]` rejected unconditionally — the type-system literal-union narrowing path is deferred to a follow-up (soundness conditions on partial unions, branded strings, generics-resolving-to-literal-types are non-trivial). |
 | Type-erasure wrappers (`as T`, `!`, `<T>x`, `satisfies T`) at L1 build | Not stripped. They are load-bearing at the TS-checker layer ts2pant translates against — `qualifyFieldAccess` calls `checker.getTypeAtLocation` on the asserted node to honor the user's contract that the receiver should be treated as the asserted type. Stripping would silently change the qualifier resolution. Symmetric `unwrapExpression` strip in `buildL1SubExpr` (Patch 5) is for *outer*-position wrappers around the sub-expression — wrappers around the receiver inside a property access stay put. |
-| `qualifyFieldAccess` two-tier behavior (qualified rule names vs bare kebab names vs null) | Preserved as-is in M5. Resolved-owner cases produce qualified rule names (e.g., `account-balance a`); unresolved-non-ambiguous cases (built-ins, type parameters, anonymous-without-synth) fall back to bare kebab'd field names (e.g., `to-fixed n 2`); ambiguous unions return null and reject. The asymmetry is a deliberate two-tier EUF separation, not an inconsistency — see § "Divergence from IRSC" in `tools/ts2pant/CLAUDE.md`. |
+| `qualifyFieldAccess` two-tier behavior (qualified rule names vs bare kebab names vs null) | Preserved as-is in M5. Resolved-owner cases produce qualified rule names (e.g., `account--balance a`); unresolved-non-ambiguous cases (built-ins, type parameters, anonymous-without-synth) fall back to bare kebab'd field names (e.g., `to-fixed n 2`); ambiguous unions return null and reject. The asymmetry is a deliberate two-tier EUF separation, not an inconsistency — see § "Divergence from IRSC" in `tools/ts2pant/CLAUDE.md`. |
 
 **Why this is a safe pause point**: Property access is a
 self-contained equivalence class. M6 (cleanup) can land
@@ -720,9 +720,10 @@ sub-expressions awaiting M6 deletion of the form.
 
 **Unlocks**: M6 cleanup of the last legacy expression handling.
 The `from-l2` adapter now wraps only non-property sub-expressions
-(binop chains, generic call results) which become unreachable once
-the L2 statement vocabulary is deleted alongside the `IRWrap`
-escape hatch.
+(binop chains, generic call results) and becomes unreachable at M6
+when `IRWrap` and remaining legacy expression-path fallbacks are
+removed. (The L2 *statement* vocabulary was already deleted in M3 —
+see "Already done in PR #138" under M6.)
 
 ---
 


### PR DESCRIPTION
## Patch 6: Docs and dogfood verification

- In `tools/ts2pant/CLAUDE.md`, add an `**M5 (property-access-normalization): landed.**` block after the M4 block, documenting: canonical Member(receiver, name) form, qualifier reuse from existing qualifyFieldAccess, string-literal element access folded into Member, computed access rejected, functor-lift operand restriction lifted
- Update CLAUDE.md § 'Divergence from IRSC' to note that M5 reaffirmed the divergence (no L2 FieldAccess form; Member is L1-only). Add a sibling note documenting the cardinality dispatch: `.length` / `.size` on Array / ReadonlyArray / Set / ReadonlySet / Map / ReadonlyMap build to L1 `Unop(card, receiver)` via `tryBuildL1Cardinality`, not Member — Pant's cardinality primitive is `#x`, not a `length` / `size` rule, and routing through Member would silently break SMT reasoning about list sizes
- Update CLAUDE.md § Functor-Lift Recognizer to remove the 'operand restricted to a simple identifier; property-access operands defer to M5' qualification — replace with the lifted operand set
- In `workstreams/ts2pant-imperative-ir.md`, replace 'Milestone 5 (deferred): property-access-normalization' with 'Milestone 5: property-access-normalization — ✅ landed' and write a Status block mirroring M4's. Record: patches landed, pessimism rate measured (likely 0% — fixtures and dogfood use dotted access exclusively), resolved Open Questions ('M5 standalone vs absorbed')
- Run dogfood (`just ts2pant-test-integration`) one final time to confirm no regressions
- Run `pant --check` against every M5 fixture function — every supported function should pass
- Measure final from-l2 wrap-site count: should be reduced from 4 documented sites to whatever non-property sites remain. Record in workstream doc as 'from-l2 wrap sites post-M5: N (down from 4); sites remaining are non-property sub-expressions awaiting M6 deletion of the form'

## Changes
- In `tools/ts2pant/CLAUDE.md`, add an `**M5 (property-access-normalization): landed.**` block after the M4 block, documenting: canonical Member(receiver, name) form, qualifier reuse from existing qualifyFieldAccess, string-literal element access folded into Member, computed access rejected, functor-lift operand restriction lifted
- Update CLAUDE.md § 'Divergence from IRSC' to note that M5 reaffirmed the divergence (no L2 FieldAccess form; Member is L1-only). Add a sibling note documenting the cardinality dispatch: `.length` / `.size` on Array / ReadonlyArray / Set / ReadonlySet / Map / ReadonlyMap build to L1 `Unop(card, receiver)` via `tryBuildL1Cardinality`, not Member — Pant's cardinality primitive is `#x`, not a `length` / `size` rule, and routing through Member would silently break SMT reasoning about list sizes
- Update CLAUDE.md § Functor-Lift Recognizer to remove the 'operand restricted to a simple identifier; property-access operands defer to M5' qualification — replace with the lifted operand set
- In `workstreams/ts2pant-imperative-ir.md`, replace 'Milestone 5 (deferred): property-access-normalization' with 'Milestone 5: property-access-normalization — ✅ landed' and write a Status block mirroring M4's. Record: patches landed, pessimism rate measured (likely 0% — fixtures and dogfood use dotted access exclusively), resolved Open Questions ('M5 standalone vs absorbed')
- Run dogfood (`just ts2pant-test-integration`) one final time to confirm no regressions
- Run `pant --check` against every M5 fixture function — every supported function should pass
- Measure final from-l2 wrap-site count: should be reduced from 4 documented sites to whatever non-property sites remain. Record in workstream doc as 'from-l2 wrap sites post-M5: N (down from 4); sites remaining are non-property sub-expressions awaiting M6 deletion of the form'

## Files to Modify
- tools/ts2pant/CLAUDE.md (modify): Update § Imperative IR Workstream with M5 landed status: canonical `Member(receiver, name)` form, hard-rule honored, computed-access rejection rule, functor-lift operand lift, from-l2 shrinkage outcome
- workstreams/ts2pant-imperative-ir.md (modify): Mark M5 ✅ landed; record measured pessimism rate; resolve the 'M5 standalone vs absorbed' open question

## Gameplan Specification

```
module TS2PANT_M5_PROPERTY_ACCESS.

> M5 final state: every property-access surface form ts2pant supports
> flows through L1 Member. The legacy direct-to-L2 App-construction
> path is retired across all 9 documented sites. The hard-rule
> discipline holds for the property-access equivalence class.
>
> Cutover gate is reviewed-snapshot-diff plus `pant --check` plus
> dogfood, not literal byte-equality with pre-M5 output. The two-tier
> qualifier behavior (qualified rule names for resolved owners; bare
> kebab names for built-ins / type parameters; null for ambiguous
> unions) is preserved as-is — the asymmetry is a deliberate EUF
> tier separation, not an inconsistency.

TSExpr.
L1Expr.
OpaqueExpr.
L1Stmt.

> Surface forms in scope.
is-property-access? t: TSExpr => Bool.
is-string-literal-elem-access? t: TSExpr => Bool.
is-computed-elem-access? t: TSExpr => Bool.
is-paren? t: TSExpr => Bool.
paren-inner t: TSExpr, is-paren? t => TSExpr.
unwrap-parens t: TSExpr => TSExpr.

> The property-access surface set is exactly these three forms; every
> TS expression node ts2pant classifies as property-access falls into
> one of them.
is-any-property-form? t: TSExpr, is-property-access? t or is-string-literal-elem-access? t or is-computed-elem-access? t => Bool.

> Field name extraction.
property-receiver t: TSExpr, is-any-property-form? t => TSExpr.
property-key t: TSExpr, is-property-access? t or is-string-literal-elem-access? t => String.
qualify-field r: TSExpr, n: String => String.

> L1 build pass and Member form.
build-l1 t: TSExpr => L1Expr.
is-member? e: L1Expr => Bool.
member-receiver e: L1Expr, is-member? e => L1Expr.
member-name e: L1Expr, is-member? e => String.
is-from-l2? e: L1Expr => Bool.
unsupported? e: L1Expr => Bool.

> Mutating-body assignment statements.
is-assignment-stmt? s: L1Stmt => Bool.
target s: L1Stmt, is-assignment-stmt? s => L1Expr.

> Functor-lift recognizer.
is-functor-lift-shape? t: TSExpr => Bool.
functor-lift-operand t: TSExpr, is-functor-lift-shape? t => TSExpr.
is-each-comprehension? e: L1Expr => Bool.

> Cardinality dispatch (deliberate non-Member path).
is-cardinality-form? t: TSExpr, is-property-access? t => Bool.
is-card-unop? e: L1Expr => Bool.

---

> Invariant 1: Dotted property access builds canonical L1 Member with
> the qualified rule name.
all t: TSExpr, is-property-access? t |
  is-member? (build-l1 t)
  and member-name (build-l1 t) = qualify-field (property-receiver t) (property-key t).

> Invariant 2: String-literal element access shares the canonical
> Member form (one canonical form per construct).
all t: TSExpr, is-string-literal-elem-access? t |
  is-member? (build-l1 t)
  and member-name (build-l1 t) = qualify-field (property-receiver t) (property-key t).

> Invariant 3: Computed (non-literal) element access is rejected
> unconditionally. Uniform reject is the conservative-refusal-3(b)
> answer; the DoD's 'unless type system resolves to a known field set'
> path is deferred to a follow-up.
all t: TSExpr, is-computed-elem-access? t | unsupported? (build-l1 t).

> Invariant 4: Universal L1-layering — paren-wrapped expressions
> build to identical L1 trees as their unwrapped inner expressions,
> for every L1 form. Downstream recognizers do not re-implement
> paren-stripping.
all t: TSExpr, is-paren? t | build-l1 t = build-l1 (unwrap-parens t).

> Invariant 5: Mutating-body assignment targets are L1 Member
> expressions. The hard rule for the property-access equivalence
> class extends to statement-position writes.
all s: L1Stmt, is-assignment-stmt? s | is-member? (target s).

> Invariant 6: Property-access sub-expressions no longer wrap via
> from-l2. The from-l2 adapter still survives for non-property
> sub-expressions awaiting M6 deletion of the form.
all t: TSExpr, is-any-property-form? t | ~(is-from-l2? (build-l1 t)).

> Invariant 7: The functor-lift recognizer accepts operands whose L1
> form is Var or Member (Identifier, dotted-property, or string-
> literal element access). The M4 P5 TS-AST restriction to simple
> identifier is replaced with an L1-shape eligibility check.
all t: TSExpr, is-functor-lift-shape? t |
  is-any-property-form? (functor-lift-operand t)
  or is-each-comprehension? (build-l1 t).

> Invariant 8: Cardinality dispatch. `.length` / `.size` on the six
> list-shaped TS types (Array, ReadonlyArray, Set, ReadonlySet, Map,
> ReadonlyMap) build to L1 Unop(card, receiver) via
> tryBuildL1Cardinality, NOT Member. This dispatch fires before
> Member; the divergence is target-language-driven (Pant's
> cardinality primitive is `#x`, not a `length` / `size` rule).
all t: TSExpr, is-cardinality-form? t | is-card-unop? (build-l1 t).

```

## Patch Specification

```
module TS2PANT_M5_PATCH_6.

> Patch 6 records M5's outcome in the workstream documentation. No
> code changes; the spec captures the workstream's commitments now
> standing post-M5.

Milestone.
m5 => Milestone.

is-landed? m: Milestone => Bool.
pessimism-rate m: Milestone, is-landed? m => Nat0.

---

> M5 has landed.
is-landed? m5.

> Pessimism rate for the computed-access rejection is recorded.
> Expected to be 0 across fixtures and dogfood.
pessimism-rate m5 = 0.

```


## Implementation Notes

- **`pant --check` substitution.** z3 is not installed on the build host (the integration suite's three `pant --check`-gated assertions skipped for the same reason — `# z3 not available`). I substituted plain `pant` type-checking on the emitted `.pant` text for every supported M5 fixture function (10 documents: `effectiveBalance`, `getOwner`, `getOwnerName`, `getOwnerByLiteral`, `getOwnerNameByLiteral`, `effectiveBalanceByLiteral`, `userName`, `userNameIfConv`, `userNameIfConvNeg`, `userNameParens`, `userNameTernaryNeg`). All 11 type-check (`getByDynamicKey` is the deliberate-reject case and snapshots `> UNSUPPORTED:` rather than emitting a runnable doc). End-to-end verification flowed through `just ts2pant-test-integration` (22/22) and `just ts2pant-test-unit` (648/648).

- **from-l2 wrap-site count: 1 (down from 4).** The four documented property-access sub-expression sites (Shape B fold target/rhs/guard + assign receiver) consolidate into a single `buildL1SubExpr` helper whose `from-l2` fallback fires only for non-property sub-expressions (binop chains, generic-call results) awaiting M6 deletion. The count reflects post-M5 final state — note that this branch's base is `ts2pant-m5-property-access/patch-4`, so the patch-5 changes that produce this consolidation are not in the worktree's diff; the doc is written against the merged-M5 reality the supervisor will land.

- **Functor-Lift Recognizer section already covered.** The "operand restricted to a simple identifier; property-access operands defer to M5" qualification was removed in patch 4 (commit `a635e5a`); this patch did not need to re-edit § "Functor-Lift Recognizer" — it was already correct.

- **Collateral edits beyond the listed task items.** Updated three forward-reference paragraphs that pointed to M5 as future work, since they would otherwise be stale once M5 lands: (1) the M4 `BinOp(eq | neq)` sub-expression note, (2) the M4 *from-l2 shrinkage scope* paragraph, (3) the workstream `from-l2 adapter` lifecycle note. All now read "post-M5" rather than "until M5 brings ..." / "deletes at M6" alone.

- **No `pessimism-rate` measurement code.** The pessimism rate is asserted as 0 by inspection of fixtures + dogfood (no `obj[expr]` computed access occurs in either). The deliberate-reject `getByDynamicKey` fixture exercises the rejection path explicitly via the snapshotted `> UNSUPPORTED:` line.