### PR TITLE
[ts2pant-known-failures] Patch 2: PantDocument.imports + bundleModules + emit

### DIFF
--- a/tools/ts2pant/src/emit.ts
+++ b/tools/ts2pant/src/emit.ts
@@ -70,6 +70,9 @@ function renderPropResult(prop: PropResult): string {
 export function emitDocument(doc: PantDocument): string {
   const lines: string[] = [];
   lines.push(`module ${doc.moduleName}.`);
+  for (const imp of doc.imports) {
+    lines.push(`import ${imp.name}.`);
+  }
   lines.push("");
 
   for (const decl of doc.declarations) {

--- a/tools/ts2pant/src/pipeline.ts
+++ b/tools/ts2pant/src/pipeline.ts
@@ -76,6 +76,7 @@ export async function buildPantDocument(
   const moduleName = baseName.charAt(0).toUpperCase() + baseName.slice(1);
   let doc: PantDocument = {
     moduleName,
+    imports: [],
     declarations,
     propositions: [],
     checks: [],

--- a/tools/ts2pant/src/types.ts
+++ b/tools/ts2pant/src/types.ts
@@ -63,12 +63,24 @@ export type PropResult =
   | { kind: "unsupported"; reason: string }
   | { kind: "raw"; text: string };
 
+/** A Pantagruel `import <Name>.` line. */
+export interface ImportSpec {
+  name: string;
+}
+
 /** A complete Pantagruel document ready for emission. */
 export interface PantDocument {
   moduleName: string;
+  imports: ImportSpec[];
   declarations: PantDeclaration[];
   propositions: PropResult[];
   checks: { text: string }[];
+  /**
+   * In-memory dependency module sources keyed by module name. Populated by
+   * later patches that synthesize / bundle dep modules; the wasm bridge's
+   * cross-module typecheck path resolves `imports` against this map.
+   */
+  bundleModules?: Map<string, string>;
 }
 
 /** CLI options parsed from command-line arguments. */

--- a/tools/ts2pant/tests/emit.test.mts
+++ b/tools/ts2pant/tests/emit.test.mts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { emitDocument } from "../src/emit.js";
+import type { PantDocument } from "../src/types.js";
+
+function emptyDoc(overrides: Partial<PantDocument> = {}): PantDocument {
+  return {
+    moduleName: "M",
+    imports: [],
+    declarations: [],
+    propositions: [],
+    checks: [],
+    ...overrides,
+  };
+}
+
+describe("emit", () => {
+  it("document with no imports is byte-stable vs. pre-patch snapshot", () => {
+    const doc = emptyDoc();
+    // Lines pushed: ["module M.", "", "", "---", "", "true.", ""]
+    // joined with "\n" — trailing empty entry yields a trailing newline.
+    const expected = "module M.\n\n\n---\n\ntrue.\n";
+    assert.equal(emitDocument(doc), expected);
+  });
+
+  it("document with imports renders `import X.` after module line", () => {
+    const doc = emptyDoc({
+      imports: [{ name: "JS_MATH" }, { name: "FOO_AMBIENT" }],
+    });
+    const out = emitDocument(doc);
+    const lines = out.split("\n");
+    assert.equal(lines[0], "module M.");
+    assert.equal(lines[1], "import JS_MATH.");
+    assert.equal(lines[2], "import FOO_AMBIENT.");
+    assert.equal(lines[3], "");
+  });
+});


### PR DESCRIPTION
## Patch 2: PantDocument.imports + bundleModules + emit

- Define `interface ImportSpec { name: string }` in types.ts.
- Add `imports: ImportSpec[]` and optional `bundleModules?: Map<string, string>` to PantDocument. Default-initialise imports to [] in pipeline.ts and any test-helper construction site so existing call paths stay unchanged.
- In emit.ts, after the `module X.` line, emit one `import <Name>.` per entry in doc.imports, separated by newlines. Verify byte-stability against the constructs snapshot when imports is empty.

## Changes
- Define `interface ImportSpec { name: string }` in types.ts.
- Add `imports: ImportSpec[]` and optional `bundleModules?: Map<string, string>` to PantDocument. Default-initialise imports to [] in pipeline.ts and any test-helper construction site so existing call paths stay unchanged.
- In emit.ts, after the `module X.` line, emit one `import <Name>.` per entry in doc.imports, separated by newlines. Verify byte-stability against the constructs snapshot when imports is empty.

## Files to Modify
- tools/ts2pant/src/types.ts (modify): Add `imports: ImportSpec[]` and `bundleModules?: Map<string, string>` to PantDocument.
- tools/ts2pant/src/emit.ts (modify): Extend emitDocument to print `import X.` lines after the module declaration. Empty imports list keeps emission byte-stable.

## Gameplan Specification

```
module KNOWN_FAILURES.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> After this gameplan, KNOWN_TYPECHECK_FAILURES contains exactly
> the two intentional class-method entries. Every other fixture in
> tools/ts2pant/tests/fixtures/constructs/ either typechecks via
> the wasm bridge or routes through the UNSUPPORTED-skip path. The
> wasm bridge resolves cross-module imports against an in-memory
> registry, matching the `pant` CLI's import semantics exactly.
>
> Dependency rules emit as standalone Pantagruel modules — hand-
> written `samples/js-stdlib/JS_MATH.pant` / `JS_STRING.pant` for
> TS standard-library builtins (Math.*, String.prototype.*); per-
> source-file synthesised `<FILE_BASE_NAME>_AMBIENT` for user
> `declare function`s; per-source-file `<FILE_BASE_NAME>_TUPLES` for
> anonymous tuple constructors. Consumer modules import them via
> `import` lines and reference qualified rules (`math::max`).
> Every emitted module name uses ALL_CAPS_SNAKE convention,
> matching the existing `samples/*.pant` corpus.
> No emitted Pant text contains `$` (binder hygiene); no emitted
> rule name is a Pant reserved keyword (sanitisation).
>
> The translation pipeline preserves CLAUDE.md's L1/L2 IR layering:
> builtin / ambient / tuple registration is an L1 concern (TS-shape
> recognition); qualified-name lowering and module-text emission
> are L2 → OpaqueExpr concerns. dep-module attachment to
> PantDocument is a pipeline-orchestration concern, not an IR
> concern. References: Vekris/Cosman/Jhala (PLDI 2016, IR
> separation); Kroening & Strichman (Decision Procedures Ch. 4 EUF,
> Ch. 8 records); Peyton Jones & Marlow (JFP 2002, Barendregt
> hygiene); Jackson (Software Abstractions, Alloy `lone`
> multiplicity); Baader & Nipkow (Term Rewriting, Ch. 2
> substitution).

Fixture.
Document.
DepModule.
DepBundle.
DepKind.
FixtureStatus.
CheckResult.

passes-typecheck => FixtureStatus.
skipped-unsupported => FixtureStatus.
in-known-failures => FixtureStatus.

builtin-dep => DepKind.
ambient-dep => DepKind.
tuple-ctor-dep => DepKind.

ok => CheckResult.
error-msg => CheckResult.

status f: Fixture => FixtureStatus.
intentional? f: Fixture => Bool.
emitted f: Fixture => Document.
dep-modules f: Fixture => [DepModule].
imports-of d: Document => [String].

contains-dollar? d: Document => Bool.
uses-keyword-as-name? d: Document => Bool.
imports-resolved? d: Document, deps: [DepModule] => Bool.

kind m: DepModule => DepKind.
emits-typechecking-text? m: DepModule => Bool.

is-screaming-snake? n: String => Bool.
module-name-of d: Document => String.

bundle-of f: Fixture => DepBundle.
resolved-bundle? d: Document, b: DepBundle => Bool.
check-bundle d: Document, b: DepBundle => CheckResult.

---
> Every fixture that remains in KNOWN_TYPECHECK_FAILURES is intentional.
all f: Fixture, status f = in-known-failures | intentional? f.

> No emitted document contains a `$` character (binder hygiene).
all f: Fixture | ~(contains-dollar? (emitted f)).

> No emitted document uses a Pant reserved keyword as a rule name.
all f: Fixture | ~(uses-keyword-as-name? (emitted f)).

> Every emitted document's module name is ALL_CAPS_SNAKE.
all f: Fixture | is-screaming-snake? (module-name-of (emitted f)).

> Imports in passing-fixture emitted documents resolve against
> the dep modules attached to the fixture's bundle.
all f: Fixture, status f = passes-typecheck
  | imports-resolved? (emitted f) (dep-modules f).

> The wasm bundle-check succeeds only if every import resolves.
all d: Document, b: DepBundle, check-bundle d b = ok | resolved-bundle? d b.

> Every dep module emits text that typechecks standalone.
all m: DepModule | emits-typechecking-text? m.

```

## Patch Specification

```
module KNOWN_FAILURES_PATCH_2.

> Patch 2 extends PantDocument with an imports list and the emitter
> with a fixed import-line shape. No consumer wires this yet — it's
> a schema and emit-format addition.

Document.
emitted d: Document => String.
imports d: Document => [String].

---
> Empty imports list keeps the emitted text byte-stable.
all d: Document, #(imports d) = 0 | true.

```


## Implementation Notes

- **Single construction site touched.** The audit for `PantDocument` literal construction found exactly one site outside type/test surface: `pipeline.ts`'s `let doc: PantDocument = { ... }`. `tests/helpers.mts` and `tests/integration/e2e.test.mts` both go through `buildPantDocument`, and `tests/ir1-build-property-state.test.mts` passes a bare `declarations: []` to `translateBody` (not a `PantDocument`), so no test-helper construction site needed defaulting.

- **Emit shape: imports go between `module` and the blank line, not after it.** Pushed the `import X.` lines directly after `module ${doc.moduleName}.` and before the existing `lines.push("")`. With an empty imports array the for-loop is a no-op, so the emitted byte sequence is identical to pre-patch — verified by the existing 130-entry `constructs.test.mts.snapshot` continuing to pass unchanged. Alternative (push the blank line first, then imports) would also be byte-stable but would put imports adjacent to the declarations block, which reads less like the `pant` CLI convention.

- **`bundleModules` is `Map<string, string>`, not `ImportSpec[]`-keyed.** The wasm bridge's in-memory registry (Patch 1) is keyed by module name, so a `Map<moduleName, sourceText>` is the natural shape. Keeping it optional (`?`) means existing construction sites don't have to allocate an empty Map for the common no-deps case.

- **New `tests/emit.test.mts` rather than extending an existing file.** No prior emit-only unit test existed — `constructs.test.mts` is snapshot-driven through the full pipeline, and `wasm-ast.test.mts` covers the AST layer below emit. A dedicated emit test file is the right home for future emit-shape regressions (import ordering, future `bundleModules` interactions).

- **Byte-stability is asserted two ways.** The new `emit > document with no imports is byte-stable` test pins the exact pre-patch output string for a minimal doc; the existing `constructs.test.mts` snapshot pins it across all 130 fixture functions. Both pass without snapshot updates.