### PR TITLE
[ts2pant-known-failures] Patch 10: Type-mapping fixes: `unknown` rejection + non-null `(x 1)` for [T]

### DIFF
--- a/tools/ts2pant/src/nullish-recognizer.ts
+++ b/tools/ts2pant/src/nullish-recognizer.ts
@@ -89,7 +89,7 @@ function isNullableType(type: ts.Type): boolean {
  * etc.) we fall back to `getTypeAtLocation` — those are rarely
  * repeated in a chain, so the narrowing risk is low.
  */
-function getOperandDeclaredType(
+export function getOperandDeclaredType(
   operand: ts.Expression,
   checker: ts.TypeChecker,
 ): ts.Type {

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -26,6 +26,7 @@ import {
 import { lowerL1MuSearch, type MuSearchLowerCtx } from "./ir1-lower.js";
 import { lowerL1Body } from "./ir1-lower-body.js";
 import {
+  getOperandDeclaredType,
   type NullishTranslate,
   recognizeNullishForm,
 } from "./nullish-recognizer.js";
@@ -2741,7 +2742,16 @@ export function translateBodyExpr(
       if (isBodyUnsupported(innerResult)) {
         return innerResult;
       }
-      const receiverTsType = checker.getTypeAtLocation(innerExpr);
+      // Use the operand's *declared* type (narrowing-free) so a `!`
+      // inside a flow-narrowed branch — `if (x != null) return x!;` —
+      // still sees `x` as nullable and lowers to singleton extraction.
+      // `checker.getTypeAtLocation` would return the narrowed `T` here
+      // and silently emit a no-op, but the Pant symbol for `x` is
+      // still the list-lifted `[T]` parameter, so the typecheck would
+      // fail. Same fix the nullish recognizer applied (PR for the
+      // long-form chain narrowing bug — see `getOperandDeclaredType`
+      // in nullish-recognizer.ts).
+      const receiverTsType = getOperandDeclaredType(innerExpr, checker);
       // The Map encoding is the one place where a TS-nullable receiver
       // (`m.get(k)`'s `V | undefined`) lowers to an *unboxed* Pant
       // value: the guarded-rule emission yields `entries c k` of type

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -2713,7 +2713,52 @@ export function translateBodyExpr(
   const ast = getAst();
 
   if (ts.isExpression(expr)) {
-    expr = unwrapExpression(expr);
+    // Strip transparent wrappers, but handle `!` separately: when the
+    // receiver's Pant emission is list-lifted `[T]` (Alloy `lone`
+    // multiplicity for a nullable `T | null`), `x!` lowers to singleton
+    // extraction `(x 1)` — the same shape `??` and `?.` produce. When the
+    // receiver's Pant emission is already unboxed `T` (e.g. `m.get(k)`,
+    // which the Map-encoding emits as a guarded rule application of type
+    // `V`), the `!` is structural and passes through. Mirrors the
+    // QuestionQuestionToken / questionDotToken handlers below.
+    while (
+      ts.isParenthesizedExpression(expr) ||
+      ts.isAsExpression(expr) ||
+      ts.isSatisfiesExpression(expr)
+    ) {
+      expr = expr.expression;
+    }
+    if (ts.isNonNullExpression(expr)) {
+      const innerExpr = expr.expression;
+      const innerResult = translateBodyExpr(
+        innerExpr,
+        checker,
+        strategy,
+        paramNames,
+        state,
+        supply,
+      );
+      if (isBodyUnsupported(innerResult)) {
+        return innerResult;
+      }
+      const receiverTsType = checker.getTypeAtLocation(innerExpr);
+      // CallExpression results bypass `mapTsType`-driven list-lift —
+      // `m.get(k)` (the only call shape today that yields a nullable TS
+      // type via a non-list-lifting Pant encoding) emits the unboxed
+      // guarded value directly. Pass through without singleton
+      // extraction; mapTsType-driven nullable shapes (parameter
+      // references, field accesses) wrap as `(x 1)`.
+      const innerUnwrapped = unwrapExpression(innerExpr);
+      if (
+        isNullableTsType(receiverTsType) &&
+        !ts.isCallExpression(innerUnwrapped)
+      ) {
+        return {
+          expr: ast.app(bodyExpr(innerResult), [ast.litNat(1)]),
+        };
+      }
+      return innerResult;
+    }
   }
 
   // M4: nullish surface forms (`x == null`, `x === undefined`, the

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -2742,17 +2742,25 @@ export function translateBodyExpr(
         return innerResult;
       }
       const receiverTsType = checker.getTypeAtLocation(innerExpr);
-      // CallExpression results bypass `mapTsType`-driven list-lift —
-      // `m.get(k)` (the only call shape today that yields a nullable TS
-      // type via a non-list-lifting Pant encoding) emits the unboxed
-      // guarded value directly. Pass through without singleton
-      // extraction; mapTsType-driven nullable shapes (parameter
-      // references, field accesses) wrap as `(x 1)`.
+      // The Map encoding is the one place where a TS-nullable receiver
+      // (`m.get(k)`'s `V | undefined`) lowers to an *unboxed* Pant
+      // value: the guarded-rule emission yields `entries c k` of type
+      // `V`, not `[V]`. Singleton-extracting that would be a type
+      // error. Every other nullable-typed expression (parameter refs,
+      // field accesses, user functions returning `T | null` whose
+      // mapped Pant return type is `[T]`) follows mapTsType's list-
+      // lift, so `!` lowers to singleton extraction `(x 1)`. The
+      // narrow carve-out matches the dispatch in `translateCallExpr`
+      // for `.get` on a Map type (line ~3777).
       const innerUnwrapped = unwrapExpression(innerExpr);
-      if (
-        isNullableTsType(receiverTsType) &&
-        !ts.isCallExpression(innerUnwrapped)
-      ) {
+      const isMapGetCall =
+        ts.isCallExpression(innerUnwrapped) &&
+        ts.isPropertyAccessExpression(innerUnwrapped.expression) &&
+        innerUnwrapped.expression.name.text === "get" &&
+        isMapType(
+          checker.getTypeAtLocation(innerUnwrapped.expression.expression),
+        );
+      if (isNullableTsType(receiverTsType) && !isMapGetCall) {
         return {
           expr: ast.app(bodyExpr(innerResult), [ast.litNat(1)]),
         };

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -455,7 +455,7 @@ exports[`expressions-map.ts > lookupNonNull 1`] = `
 `;
 
 exports[`expressions-misc.ts > asNumber 1`] = `
-"module AsNumber.\\n\\nas-number x: unknown => Int.\\n\\n---\\n\\nas-number x = x.\\n"
+"module AsNumber.\\n\\nas-number x: Int => Int.\\n\\n---\\n\\nas-number x = x.\\n"
 `;
 
 exports[`expressions-misc.ts > negate 1`] = `
@@ -463,7 +463,7 @@ exports[`expressions-misc.ts > negate 1`] = `
 `;
 
 exports[`expressions-misc.ts > nonNull 1`] = `
-"module NonNull.\\n\\nnon-null x: [Int] => Int.\\n\\n---\\n\\nnon-null x = x.\\n"
+"module NonNull.\\n\\nnon-null x: [Int] => Int.\\n\\n---\\n\\nnon-null x = x 1.\\n"
 `;
 
 exports[`expressions-misc.ts > parenAdd 1`] = `

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-misc.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-misc.ts
@@ -6,7 +6,7 @@ export function parenAdd(a: number, b: number): number {
 }
 
 /** type assertion (unwrapped) */
-export function asNumber(x: unknown): number {
+export function asNumber(x: number): number {
   return x as number;
 }
 

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -237,6 +237,42 @@ describe("unsupported patterns", () => {
       assert.equal(ast.strExpr(prop.rhs), "x + 1");
     }
   });
+
+  it("lowers `!` inside flow-narrowed branch to singleton extraction", () => {
+    // The dispatch must use the operand's *declared* type, not the
+    // narrowed type at the `!` site. Inside `if (x != null) return
+    // x!;` TypeScript narrows `x` to `number`, but the Pant symbol
+    // `x` is still the list-lifted `[Int]` parameter — so `!` must
+    // still extract the singleton `(x 1)`. A regression that uses
+    // `getTypeAtLocation` would emit a bare `x` and fail Pant
+    // typechecking.
+    const source = `
+      export function pickWhenPresent(x: number | null): number {
+        if (x !== null) {
+          return x!;
+        }
+        return 0;
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "pickWhenPresent",
+      strategy: IntStrategy,
+    });
+
+    assert.equal(props.length, 1);
+    const prop = props[0]!;
+    assert.equal(prop.kind, "equation");
+    if (prop.kind === "equation") {
+      const ast = getAst();
+      const rhs = ast.strExpr(prop.rhs);
+      assert.ok(
+        rhs.includes("x 1"),
+        `expected singleton extraction \`x 1\` in rhs, got: ${rhs}`,
+      );
+    }
+  });
 });
 
 describe("if-early-return prelude arms", () => {

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -206,6 +206,37 @@ describe("unsupported patterns", () => {
     assert.equal(props.length, 1);
     assert.equal(props[0]?.kind, "unsupported");
   });
+
+  it("unwraps AsExpression at the body translation entry", () => {
+    // The fixture-side `asNumber(x: number)` snapshots `as-number x =
+    // x.` whether `unwrapExpression` strips the `as number` cast or
+    // not — Pant has no cast notation, so the cast is observably
+    // erased even if the unwrap regresses to a fallthrough path.
+    // Exercise the unwrap directly by checking the inner emitted
+    // expression text against a `var`-only baseline. If the
+    // AsExpression strip in `translateBodyExpr` regressed, the cast
+    // would surface in the rhs (e.g. as a stringified call shape) and
+    // this test would fail.
+    const source = `
+      export function castedReturn(x: number): number {
+        return (x + 1) as number;
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "castedReturn",
+      strategy: IntStrategy,
+    });
+
+    assert.equal(props.length, 1);
+    const prop = props[0]!;
+    assert.equal(prop.kind, "equation");
+    if (prop.kind === "equation") {
+      const ast = getAst();
+      assert.equal(ast.strExpr(prop.rhs), "x + 1");
+    }
+  });
 });
 
 describe("if-early-return prelude arms", () => {


### PR DESCRIPTION
## Patch 10: Type-mapping fixes: `unknown` rejection + non-null `(x 1)` for [T]

- In NonNullExpression handler in translate-body.ts: read the translated Pant type of the receiver; when it's `[T]` (list-lifted nullable, Alloy `lone` multiplicity), emit `(receiver 1)` (singleton extraction, the same shape `?.` and `??` already produce); when it's `T`, pass through. Type-driven dispatch — same pattern as QuestionQuestionToken / questionDotToken at the existing nullish handlers.
- Refresh snapshots: nonNull body becomes `non-null x = (x 1).` (was `non-null x = x.`); asNumber unchanged in body, only the parameter type changes (now `number` → `Int`).
- asNumber TS source: change `x: unknown` → `x: number`. The fixture's stated intent is 'type assertion (unwrapped)', so a real type still exercises the `as number` cast unwrap.

## Changes
- In NonNullExpression handler in translate-body.ts: read the translated Pant type of the receiver; when it's `[T]` (list-lifted nullable, Alloy `lone` multiplicity), emit `(receiver 1)` (singleton extraction, the same shape `?.` and `??` already produce); when it's `T`, pass through. Type-driven dispatch — same pattern as QuestionQuestionToken / questionDotToken at the existing nullish handlers.
- Refresh snapshots: nonNull body becomes `non-null x = (x 1).` (was `non-null x = x.`); asNumber unchanged in body, only the parameter type changes (now `number` → `Int`).
- asNumber TS source: change `x: unknown` → `x: number`. The fixture's stated intent is 'type assertion (unwrapped)', so a real type still exercises the `as number` cast unwrap.

## Files to Modify
- tools/ts2pant/src/translate-body.ts (modify): NonNullExpression handler dispatches on receiver's translated type.
- tools/ts2pant/tests/fixtures/constructs/expressions-misc.ts (modify): Update asNumber fixture: change parameter type from `unknown` to `number` so the test exercises only the `as` unwrap (the documented intent).
- tools/ts2pant/tests/constructs.test.mts.snapshot (modify): Update snapshots for asNumber, nonNull.

## Gameplan Specification

```
module KNOWN_FAILURES.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> After this gameplan, KNOWN_TYPECHECK_FAILURES contains exactly
> the two intentional class-method entries. Every other fixture in
> tools/ts2pant/tests/fixtures/constructs/ either typechecks via
> the wasm bridge or routes through the UNSUPPORTED-skip path. The
> wasm bridge resolves cross-module imports against an in-memory
> registry, matching the `pant` CLI's import semantics exactly.
>
> Dependency rules emit as standalone Pantagruel modules — hand-
> written `samples/js-stdlib/JS_MATH.pant` / `JS_STRING.pant` for
> TS standard-library builtins (Math.*, String.prototype.*); per-
> source-file synthesised `<FILE_BASE_NAME>_AMBIENT` for user
> `declare function`s; per-source-file `<FILE_BASE_NAME>_TUPLES` for
> anonymous tuple constructors. Consumer modules import them via
> `import` lines and reference qualified rules (`math::max`).
> Every emitted module name uses ALL_CAPS_SNAKE convention,
> matching the existing `samples/*.pant` corpus.
> No emitted Pant text contains `$` (binder hygiene); no emitted
> rule name is a Pant reserved keyword (sanitisation).
>
> The translation pipeline preserves CLAUDE.md's L1/L2 IR layering:
> builtin / ambient / tuple registration is an L1 concern (TS-shape
> recognition); qualified-name lowering and module-text emission
> are L2 → OpaqueExpr concerns. dep-module attachment to
> PantDocument is a pipeline-orchestration concern, not an IR
> concern. References: Vekris/Cosman/Jhala (PLDI 2016, IR
> separation); Kroening & Strichman (Decision Procedures Ch. 4 EUF,
> Ch. 8 records); Peyton Jones & Marlow (JFP 2002, Barendregt
> hygiene); Jackson (Software Abstractions, Alloy `lone`
> multiplicity); Baader & Nipkow (Term Rewriting, Ch. 2
> substitution).

Fixture.
Document.
DepModule.
DepBundle.
DepKind.
FixtureStatus.
CheckResult.

passes-typecheck => FixtureStatus.
skipped-unsupported => FixtureStatus.
in-known-failures => FixtureStatus.

builtin-dep => DepKind.
ambient-dep => DepKind.
tuple-ctor-dep => DepKind.

ok => CheckResult.
error-msg => CheckResult.

status f: Fixture => FixtureStatus.
intentional? f: Fixture => Bool.
emitted f: Fixture => Document.
dep-modules f: Fixture => [DepModule].
imports-of d: Document => [String].

contains-dollar? d: Document => Bool.
uses-keyword-as-name? d: Document => Bool.
imports-resolved? d: Document, deps: [DepModule] => Bool.

kind m: DepModule => DepKind.
emits-typechecking-text? m: DepModule => Bool.

is-screaming-snake? n: String => Bool.
module-name-of d: Document => String.

bundle-of f: Fixture => DepBundle.
resolved-bundle? d: Document, b: DepBundle => Bool.
check-bundle d: Document, b: DepBundle => CheckResult.

---
> Every fixture that remains in KNOWN_TYPECHECK_FAILURES is intentional.
all f: Fixture, status f = in-known-failures | intentional? f.

> No emitted document contains a `$` character (binder hygiene).
all f: Fixture | ~(contains-dollar? (emitted f)).

> No emitted document uses a Pant reserved keyword as a rule name.
all f: Fixture | ~(uses-keyword-as-name? (emitted f)).

> Every emitted document's module name is ALL_CAPS_SNAKE.
all f: Fixture | is-screaming-snake? (module-name-of (emitted f)).

> Imports in passing-fixture emitted documents resolve against
> the dep modules attached to the fixture's bundle.
all f: Fixture, status f = passes-typecheck
  | imports-resolved? (emitted f) (dep-modules f).

> The wasm bundle-check succeeds only if every import resolves.
all d: Document, b: DepBundle, check-bundle d b = ok | resolved-bundle? d b.

> Every dep module emits text that typechecks standalone.
all m: DepModule | emits-typechecking-text? m.

```

## Patch Specification

```
module KNOWN_FAILURES_PATCH_10.

> Patch 10 fixes two TS-type-mapping bugs. Non-null `x!` on a
> list-lifted receiver lowers to singleton extraction `(x 1)` — Pant
> indexing replaces TS's nullable-flattening; `unknown` is rejected
> at type-mapping time. Reference: Jackson, Software Abstractions
> 2nd ed., Alloy multiplicities (`lone` = list of length 0 or 1).

Receiver.
List. 
list-lifted? r: Receiver => Bool.
non-null-emit r: Receiver => String.
singleton-extract r: Receiver => String.

---
> List-lifted receivers lower `!` to singleton extraction.
all r: Receiver, list-lifted? r | non-null-emit r = singleton-extract r.

```


## Implementation Notes

- **Placement of the handler.** `unwrapExpression` strips `NonNullExpression` in the same loop that strips parens / `as` / `satisfies` — i.e. the `!` is normally erased before any dispatch sees it. The new handler runs at the top of `translateBodyExpr` *in place of* that strip: it walks parens / `as` / `satisfies` itself (so wrapped forms like `(x!)` and `(x as T)!` reach the dispatch), and only then checks `ts.isNonNullExpression`. `unwrapExpression`'s other call sites (purity, signature classification, receiver normalisation in `.get`/`.set`) are unchanged — they still want `!` stripped.

- **CallExpression carve-out for `m.get(k)!`.** The patch spec describes the dispatch as "read the translated Pant type of the receiver", but TypeScript-side we only have the TS type (which is `V | undefined` for `m.get(k)`) and the OpaqueExpr (no type info). Naively dispatching on `isNullableTsType` broke every existing `.get(k)!` test (`lookup`, `lookupNonNull`, `nestedLookup`, `tagsFor`) because the Map encoding emits unboxed `V` via guarded rules — `(cache--entries c k) 1` then errors with "Cannot call Int: not a function". The handler therefore additionally requires the unwrapped inner expression to **not** be a `CallExpression`. Today this carve-out exists only because Map.get is the sole call shape that yields a TS-nullable type via a non-list-lifting Pant encoding; a future user function returning `T | null` and being non-null-asserted (`f()!`) would also fall under this carve-out and pass through unwrapped — no fixture or dogfood site exercises that pattern today, but it's a known under-approximation worth flagging if it surfaces.

- **Snapshot text is `x 1.` not `(x 1).`.** The patch description writes the lowered shape as `(x 1)`; the Pant pretty-printer omits the outer parens at top-level position (consistent with the `(cond … => x 1)` shape `??` / `?.` already produce inside `cond` arms). The snapshot reflects the actual emission — the parsed AST is identical.

- **`unknown`-rejection scope.** Despite the patch title, this patch does not add `unknown` rejection in `mapTsType`; the only `unknown`-related change is removing `unknown` from the `asNumber` fixture so it stops exercising the bug. The "Your Task" section of the gameplan only asked for the fixture edit, and no other fixture in the corpus uses `unknown`. Adding rejection in `mapTsType` would be a separate, cross-cutting change.