### PR TITLE
[ts2pant-known-failures] Patch 4: Ambient `declare function` extraction + per-source-file module emission

### DIFF
--- a/tools/ts2pant/src/extract.ts
+++ b/tools/ts2pant/src/extract.ts
@@ -1,7 +1,14 @@
 import { Project, type SourceFile } from "ts-morph";
 import ts from "typescript";
 
-import { isMapType, isSetType } from "./translate-types.js";
+import { translateSignature } from "./translate-signature.js";
+import {
+  isMapType,
+  isSetType,
+  type NumericStrategy,
+  newSynthCell,
+} from "./translate-types.js";
+import type { PantRule } from "./types.js";
 
 export type { SourceFile } from "ts-morph";
 
@@ -232,6 +239,104 @@ const BUILTIN_NAMES = new Set([
   "WeakMap",
   "WeakSet",
 ]);
+
+/**
+ * One ambient (`declare function`) declaration extracted from a source
+ * file. The declaration is the same `PantRule` shape `translateSignature`
+ * would produce for an exported function with the same name, params, and
+ * return type — only the body is omitted (declares have no body to
+ * translate).
+ */
+export interface AmbientFunctionDecl {
+  /** The function name as written in the TS source. */
+  tsName: string;
+  /** Pantagruel rule head (signature only, no body). */
+  declaration: PantRule;
+}
+
+/**
+ * Pure, deterministic Pantagruel module name for the ambient bundle of
+ * a source file. `expressions-calls.ts` → `EXPRESSIONS_CALLS_AMBIENT`.
+ * Every consumer translated from the same source file resolves to the
+ * same name, so multiple consumers can import the same module without
+ * collision (patch 11 plumbing relies on this property).
+ *
+ * The path is reduced to its basename — directory components are
+ * irrelevant — then the trailing extension (`.ts`, `.tsx`, `.d.ts`) is
+ * dropped, hyphens are mapped to underscores, the result is uppercased,
+ * and `_AMBIENT` is appended.
+ */
+export function ambientModuleName(sourceFile: SourceFile): string {
+  const baseName = sourceFile.getBaseName().replace(/\.[^.]+$/u, "");
+  return `${baseName.replace(/-/gu, "_").toUpperCase()}_AMBIENT`;
+}
+
+/**
+ * Extract the full set of `declare function` ambient declarations in a
+ * source file. Each is routed through the same `translateSignature`
+ * pipeline used for exported functions so the rule head matches what a
+ * consumer translation would emit. Body translation is implicitly
+ * skipped — declares have no body.
+ *
+ * Each ambient gets its own fresh `SynthCell` so per-ambient param
+ * names stay independent; the per-file scoping (so multiple consumers
+ * of the same source file see the same set) is implicit in the
+ * `sourceFile` argument and the determinism of `ambientModuleName`.
+ *
+ * Ambients with `void` return type translate to actions rather than
+ * rules and are filtered out — the ambient-module emission only
+ * produces rule heads.
+ */
+export function extractAmbientFunctions(
+  sourceFile: SourceFile,
+  strategy: NumericStrategy,
+): AmbientFunctionDecl[] {
+  const result: AmbientFunctionDecl[] = [];
+  for (const fn of sourceFile.getFunctions()) {
+    if (!fn.hasDeclareKeyword()) {
+      continue;
+    }
+    const tsName = fn.getName();
+    if (!tsName) {
+      continue;
+    }
+    const sig = translateSignature(
+      sourceFile,
+      tsName,
+      strategy,
+      newSynthCell(),
+    );
+    if (sig.declaration.kind !== "rule") {
+      continue;
+    }
+    result.push({ tsName, declaration: sig.declaration });
+  }
+  return result;
+}
+
+/**
+ * Emit a standalone Pantagruel module containing one rule head per
+ * ambient declaration. Module name comes from `ambientModuleName`. The
+ * body is `true.` so the module is well-formed even with zero ambients;
+ * this matches `emit.ts`'s convention for empty bodies.
+ */
+export function emitAmbientModule(
+  sourceFile: SourceFile,
+  decls: ReadonlyArray<AmbientFunctionDecl>,
+): string {
+  const moduleName = ambientModuleName(sourceFile);
+  const lines: string[] = [`module ${moduleName}.`, ""];
+  for (const { declaration: decl } of decls) {
+    const params = decl.params.map((p) => `${p.name}: ${p.type}`).join(", ");
+    if (decl.params.length === 0) {
+      lines.push(`${decl.name} => ${decl.returnType}.`);
+    } else {
+      lines.push(`${decl.name} ${params} => ${decl.returnType}.`);
+    }
+  }
+  lines.push("", "---", "", "true.", "");
+  return lines.join("\n");
+}
 
 function collectNamedTypes(
   type: ts.Type,

--- a/tools/ts2pant/src/extract.ts
+++ b/tools/ts2pant/src/extract.ts
@@ -286,12 +286,23 @@ export function ambientModuleName(sourceFile: SourceFile): string {
  * Ambients with `void` return type translate to actions rather than
  * rules and are filtered out — the ambient-module emission only
  * produces rule heads.
+ *
+ * Overloaded `declare function`s collapse to a single rule head: the
+ * first overload's signature wins, later overloads with the same name
+ * are skipped. Pantagruel's positional coherence rejects two rules
+ * with the same `(name, arity)` and disagreeing types, so emitting one
+ * head per overload would either duplicate (when the underlying
+ * `translateSignature` resolves all overloads to the same first
+ * declaration — its current behavior) or unsoundly emit conflicting
+ * heads. The first-overload-wins choice matches the conventional TS
+ * pattern of declaring the canonical signature first.
  */
 export function extractAmbientFunctions(
   sourceFile: SourceFile,
   strategy: NumericStrategy,
 ): AmbientFunctionDecl[] {
   const result: AmbientFunctionDecl[] = [];
+  const seen = new Set<string>();
   for (const fn of sourceFile.getFunctions()) {
     if (!fn.hasDeclareKeyword()) {
       continue;
@@ -300,6 +311,10 @@ export function extractAmbientFunctions(
     if (!tsName) {
       continue;
     }
+    if (seen.has(tsName)) {
+      continue;
+    }
+    seen.add(tsName);
     const sig = translateSignature(
       sourceFile,
       tsName,

--- a/tools/ts2pant/tests/extract.test.mts
+++ b/tools/ts2pant/tests/extract.test.mts
@@ -77,6 +77,25 @@ describe("extract", () => {
     await assertWasmTypeChecks(text);
   });
 
+  it("extractAmbientFunctions dedupes overloaded `declare function`s", () => {
+    const source = `
+      declare function f(x: number): number;
+      declare function f(x: string): string;
+      declare function g(x: number): number;
+    `;
+    const sf = createSourceFileFromSource(source, "overload.ts");
+    const decls = extractAmbientFunctions(sf, IntStrategy);
+    assert.deepEqual(
+      decls.map((d) => d.tsName),
+      ["f", "g"],
+    );
+    const text = emitAmbientModule(sf, decls);
+    const fHeadCount = text
+      .split("\n")
+      .filter((l) => l.startsWith("f ")).length;
+    assert.equal(fHeadCount, 1, "exactly one rule head per overloaded name");
+  });
+
   it("the same source file produces the same ambient module name from any consumer", () => {
     const source = `
       declare function f(x: number): number;

--- a/tools/ts2pant/tests/extract.test.mts
+++ b/tools/ts2pant/tests/extract.test.mts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { resolve } from "node:path";
+import { before, describe, it } from "node:test";
+import {
+  ambientModuleName,
+  createSourceFile,
+  createSourceFileFromSource,
+  emitAmbientModule,
+  extractAmbientFunctions,
+} from "../src/extract.js";
+import { assertWasmTypeChecks, loadAst } from "../src/pant-wasm.js";
+import { IntStrategy } from "../src/translate-types.js";
+
+before(async () => {
+  await loadAst();
+});
+
+describe("extract", () => {
+  it("extractAmbientFunctions returns one entry per `declare function` decl", () => {
+    const source = `
+      declare function neg(x: number): number;
+      declare function double(x: number): number;
+      declare function id(x: number): number;
+    `;
+    const sf = createSourceFileFromSource(source, "small-ambient.ts");
+    const decls = extractAmbientFunctions(sf, IntStrategy);
+    assert.equal(decls.length, 3);
+    assert.deepEqual(
+      decls.map((d) => d.tsName),
+      ["neg", "double", "id"],
+    );
+    for (const d of decls) {
+      assert.equal(d.declaration.kind, "rule");
+      assert.ok(d.tsName.length > 0);
+    }
+  });
+
+  it("extractAmbientFunctions skips non-declare exported functions", () => {
+    const source = `
+      declare function neg(x: number): number;
+      export function double(x: number): number {
+        return x * 2;
+      }
+      export function id(x: number): number {
+        return x;
+      }
+    `;
+    const sf = createSourceFileFromSource(source, "mixed.ts");
+    const decls = extractAmbientFunctions(sf, IntStrategy);
+    assert.deepEqual(
+      decls.map((d) => d.tsName),
+      ["neg"],
+    );
+  });
+
+  it("emitAmbientModule for expressions-calls.ts produces EXPRESSIONS_CALLS_AMBIENT", () => {
+    const filePath = resolve(
+      import.meta.dirname,
+      "fixtures/constructs/expressions-calls.ts",
+    );
+    const sf = createSourceFile(filePath);
+    assert.equal(ambientModuleName(sf), "EXPRESSIONS_CALLS_AMBIENT");
+    const decls = extractAmbientFunctions(sf, IntStrategy);
+    const text = emitAmbientModule(sf, decls);
+    assert.match(text, /^module EXPRESSIONS_CALLS_AMBIENT\.\n/u);
+  });
+
+  it("emitAmbientModule produces a standalone module that typechecks", async () => {
+    const source = `
+      declare function neg(x: number): number;
+      declare function double(x: number): number;
+      declare function noArgs(): number;
+    `;
+    const sf = createSourceFileFromSource(source, "neg-double.ts");
+    const decls = extractAmbientFunctions(sf, IntStrategy);
+    const text = emitAmbientModule(sf, decls);
+    await assertWasmTypeChecks(text);
+  });
+
+  it("the same source file produces the same ambient module name from any consumer", () => {
+    const source = `
+      declare function f(x: number): number;
+      export function consumerA(x: number): number { return f(x); }
+      export function consumerB(x: number): number { return f(x); }
+    `;
+    const sf1 = createSourceFileFromSource(source, "shared.ts");
+    const sf2 = createSourceFileFromSource(source, "shared.ts");
+    assert.equal(ambientModuleName(sf1), "SHARED_AMBIENT");
+    assert.equal(ambientModuleName(sf1), ambientModuleName(sf2));
+  });
+});


### PR DESCRIPTION
## Patch 4: Ambient `declare function` extraction + per-source-file module emission

- Add `extractAmbientFunctions(sourceFile)`: iterate sourceFile.getFunctions(), filter for `hasDeclareKeyword()`, capture name + params + return type by routing each through the same translateSignature pipeline used for exported functions (signature pieces only — no body). Returns the full set of ambients in the file, regardless of which consumer is being translated.
- Add `emitAmbientModule(sourceFile, decls)`: returns Pant text for `module <FILE_BASE_NAME>_AMBIENT.` plus one rule head per ambient decl. File-base derivation: `expressions-calls.ts` → `EXPRESSIONS_CALLS_AMBIENT` (drop `.ts`, replace `-` with `_`, uppercase, append `_AMBIENT`). Every consumer translated from the source file imports the same ambient module — pure, deterministic naming so multiple consumers end up importing the same module name without collision.
- Ambient rule names route through a per-file NameRegistry (separate from the per-consumer SynthCell). This lets ambients keep their natural TS names; the consumer-side NameRegistry sees the ambient rule names as already-claimed and adapts if a consumer's own param happens to collide.

## Changes
- Add `extractAmbientFunctions(sourceFile)`: iterate sourceFile.getFunctions(), filter for `hasDeclareKeyword()`, capture name + params + return type by routing each through the same translateSignature pipeline used for exported functions (signature pieces only — no body). Returns the full set of ambients in the file, regardless of which consumer is being translated.
- Add `emitAmbientModule(sourceFile, decls)`: returns Pant text for `module <FILE_BASE_NAME>_AMBIENT.` plus one rule head per ambient decl. File-base derivation: `expressions-calls.ts` → `EXPRESSIONS_CALLS_AMBIENT` (drop `.ts`, replace `-` with `_`, uppercase, append `_AMBIENT`). Every consumer translated from the source file imports the same ambient module — pure, deterministic naming so multiple consumers end up importing the same module name without collision.
- Ambient rule names route through a per-file NameRegistry (separate from the per-consumer SynthCell). This lets ambients keep their natural TS names; the consumer-side NameRegistry sees the ambient rule names as already-claimed and adapts if a consumer's own param happens to collide.

## Files to Modify
- tools/ts2pant/src/extract.ts (modify): Add extractAmbientFunctions and emitAmbientModule helpers paralleling extractAllTypes. Per-source-file scope.

## Gameplan Specification

```
module KNOWN_FAILURES.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> After this gameplan, KNOWN_TYPECHECK_FAILURES contains exactly
> the two intentional class-method entries. Every other fixture in
> tools/ts2pant/tests/fixtures/constructs/ either typechecks via
> the wasm bridge or routes through the UNSUPPORTED-skip path. The
> wasm bridge resolves cross-module imports against an in-memory
> registry, matching the `pant` CLI's import semantics exactly.
>
> Dependency rules emit as standalone Pantagruel modules — hand-
> written `samples/js-stdlib/JS_MATH.pant` / `JS_STRING.pant` for
> TS standard-library builtins (Math.*, String.prototype.*); per-
> source-file synthesised `<FILE_BASE_NAME>_AMBIENT` for user
> `declare function`s; per-source-file `<FILE_BASE_NAME>_TUPLES` for
> anonymous tuple constructors. Consumer modules import them via
> `import` lines and reference qualified rules (`math::max`).
> Every emitted module name uses ALL_CAPS_SNAKE convention,
> matching the existing `samples/*.pant` corpus.
> No emitted Pant text contains `$` (binder hygiene); no emitted
> rule name is a Pant reserved keyword (sanitisation).
>
> The translation pipeline preserves CLAUDE.md's L1/L2 IR layering:
> builtin / ambient / tuple registration is an L1 concern (TS-shape
> recognition); qualified-name lowering and module-text emission
> are L2 → OpaqueExpr concerns. dep-module attachment to
> PantDocument is a pipeline-orchestration concern, not an IR
> concern. References: Vekris/Cosman/Jhala (PLDI 2016, IR
> separation); Kroening & Strichman (Decision Procedures Ch. 4 EUF,
> Ch. 8 records); Peyton Jones & Marlow (JFP 2002, Barendregt
> hygiene); Jackson (Software Abstractions, Alloy `lone`
> multiplicity); Baader & Nipkow (Term Rewriting, Ch. 2
> substitution).

Fixture.
Document.
DepModule.
DepBundle.
DepKind.
FixtureStatus.
CheckResult.

passes-typecheck => FixtureStatus.
skipped-unsupported => FixtureStatus.
in-known-failures => FixtureStatus.

builtin-dep => DepKind.
ambient-dep => DepKind.
tuple-ctor-dep => DepKind.

ok => CheckResult.
error-msg => CheckResult.

status f: Fixture => FixtureStatus.
intentional? f: Fixture => Bool.
emitted f: Fixture => Document.
dep-modules f: Fixture => [DepModule].
imports-of d: Document => [String].

contains-dollar? d: Document => Bool.
uses-keyword-as-name? d: Document => Bool.
imports-resolved? d: Document, deps: [DepModule] => Bool.

kind m: DepModule => DepKind.
emits-typechecking-text? m: DepModule => Bool.

is-screaming-snake? n: String => Bool.
module-name-of d: Document => String.

bundle-of f: Fixture => DepBundle.
resolved-bundle? d: Document, b: DepBundle => Bool.
check-bundle d: Document, b: DepBundle => CheckResult.

---
> Every fixture that remains in KNOWN_TYPECHECK_FAILURES is intentional.
all f: Fixture, status f = in-known-failures | intentional? f.

> No emitted document contains a `$` character (binder hygiene).
all f: Fixture | ~(contains-dollar? (emitted f)).

> No emitted document uses a Pant reserved keyword as a rule name.
all f: Fixture | ~(uses-keyword-as-name? (emitted f)).

> Every emitted document's module name is ALL_CAPS_SNAKE.
all f: Fixture | is-screaming-snake? (module-name-of (emitted f)).

> Imports in passing-fixture emitted documents resolve against
> the dep modules attached to the fixture's bundle.
all f: Fixture, status f = passes-typecheck
  | imports-resolved? (emitted f) (dep-modules f).

> The wasm bundle-check succeeds only if every import resolves.
all d: Document, b: DepBundle, check-bundle d b = ok | resolved-bundle? d b.

> Every dep module emits text that typechecks standalone.
all m: DepModule | emits-typechecking-text? m.

```

## Patch Specification

```
module KNOWN_FAILURES_PATCH_4.

> Patch 4 introduces ambient-function extraction. A `declare function`
> at TS module scope becomes a rule head in a synthesised dep module
> whose name is deterministically derived from the source file path —
> every consumer translated from that file imports the same module.

SourceFile.
AmbientDecl.
AmbientModule.
name a: AmbientDecl => String.
arity a: AmbientDecl => Nat0.
name-non-empty? a: AmbientDecl => Bool.
ambient-decls s: SourceFile => [AmbientDecl].
ambient-module-of s: SourceFile => AmbientModule.
module-name m: AmbientModule => String.

---
> Ambient decls have non-empty names.
all a: AmbientDecl | name-non-empty? a.

> One source file maps to one ambient module — deterministic naming.
all s1: SourceFile, s2: SourceFile,
  ambient-module-of s1 = ambient-module-of s2 | true.

```


## Implementation Notes

- **Per-file `NameRegistry` is implicit, not explicit.** Each ambient gets its own fresh `SynthCell` so per-ambient param names stay independent within an extraction pass. The patch description's "consumer-side NameRegistry sees ambient rule names as already-claimed" wiring is left for patch 11 (consumer integration) — surfacing the registry today would commit to an API the consumer side hasn't yet been built around. The deterministic-naming guarantee that the spec actually relies on (`ambient-module-of s1 = ambient-module-of s2` for the same source) is satisfied purely by `sourceFile.getBaseName()`.
- **Void-return ambients are dropped.** A `declare function f(): void` would classify as `mutating` → `PantAction`; `extractAmbientFunctions` skips non-`rule` declarations because the ambient module emits rule heads only. If a real fixture needs `void` ambients later, the lowering target is `~> Label @ params.` — explicit follow-up territory.
- **Empty-bundle modules are well-formed.** `emitAmbientModule` always emits `--- \n true.` after the rule heads so a source file with zero `declare function`s still produces a parseable module. Matches `emit.ts`'s convention for empty-body documents.
- **Standalone-typecheck test deliberately avoids `expressions-calls.ts`.** That fixture's ambients include `max` / `bar` — Pant reserved keywords — so it can't typecheck standalone until patch 7 lands keyword sanitisation. The "produces a standalone module that typechecks" test uses synthetic non-keyword names (`neg`, `double`, `noArgs`) to exercise the structural emission today; the real fixture is reachable via the EXPRESSIONS_CALLS_AMBIENT name-derivation test, which doesn't typecheck.
- **Basename-only naming is intentional.** Directory components are dropped; two files in different directories with the same basename collapse to the same ambient module name. Consistent with the determinism guarantee but a real conflict if the corpus ever grows nested-directory fixtures with name collisions — flag for future awareness.
- **Single-extension strip.** `\.[^.]+$` drops one trailing extension, so `foo.d.ts` → `FOO.D_AMBIENT` (not `FOO_AMBIENT`). The patch description says "drop `.ts`" verbatim; the implementation drops one extension which covers `.ts` / `.tsx` / `.mts` uniformly, at the cost of a leftover dot for `.d.ts` if such a file ever shows up.