### PR TITLE
[ts2pant-known-failures] Patch 1: Wasm bridge: in-memory module registry for cross-module typechecking

### DIFF
--- a/lib_parser/dune
+++ b/lib_parser/dune
@@ -41,3 +41,5 @@
 (copy_files ../lib/check.mli)
 
 (copy_files ../lib/error.ml)
+
+(copy_files ../lib/module.ml)

--- a/tools/ts2pant/src/ir1-lower.ts
+++ b/tools/ts2pant/src/ir1-lower.ts
@@ -211,7 +211,7 @@ export interface MuSearchLowerCtx {
    */
   counterPantName: string;
   /** Allocate a fresh binder name (e.g., `j`, `j1`, …). */
-  allocateBinder(hint: string): string;
+  allocateBinder: (hint: string) => string;
 }
 
 /**

--- a/tools/ts2pant/src/pant-wasm.ts
+++ b/tools/ts2pant/src/pant-wasm.ts
@@ -15,6 +15,10 @@ interface PantParserModule {
   parseAndRename: (text: string, renames: [string, string][]) => string | null;
   prettyPrint: (text: string) => string | null;
   checkDocument: (text: string) => string | null;
+  checkDocumentWithDeps: (
+    consumer: string,
+    deps: [string, string][],
+  ) => string | null;
 }
 
 let wasmLoadPromise: Promise<void> | null = null;
@@ -114,9 +118,9 @@ export function rewriteAnnotation(
  * Type-check a full Pantagruel document string via the embedded wasm
  * checker (parse + collect + check, same passes the `pant` CLI runs in
  * its default mode). Returns `null` on success or an error message on
- * failure. Documents with imports are unsupported in this path — the
- * wasm build has no module registry; route those through the `pant`
- * CLI in integration tests.
+ * failure. For documents with imports, use {@link checkPantBundle} —
+ * this entry point routes through the legacy single-document path that
+ * rejects imports.
  */
 export async function checkPantDocument(text: string): Promise<string | null> {
   const parser = await loadParser();
@@ -124,12 +128,40 @@ export async function checkPantDocument(text: string): Promise<string | null> {
 }
 
 /**
+ * Type-check a consumer Pantagruel document together with an in-memory
+ * bundle of dep modules. Each entry of `deps` is `(module-name, text)`
+ * — the consumer's `import NAME.` declarations resolve against the
+ * module-name keys. Returns `null` on success or an error message on
+ * failure. Mirrors the `pant` CLI's import semantics (parse + collect +
+ * check across the full registry).
+ *
+ * With an empty `deps`, behaves as if the consumer were checked alone —
+ * any unresolved import in the consumer surfaces as a missing-module
+ * error.
+ */
+export async function checkPantBundle(
+  consumer: string,
+  deps: Map<string, string> = new Map(),
+): Promise<string | null> {
+  const parser = await loadParser();
+  const depsArray: [string, string][] = [...deps.entries()];
+  return parser.checkDocumentWithDeps(consumer, depsArray);
+}
+
+/**
  * Assert that a Pantagruel document string type-checks via the wasm
  * checker. Throws with the formatted error message on failure,
  * including a bounded preview of the input for diagnostics.
+ *
+ * Pass `deps` to resolve cross-module imports against an in-memory
+ * bundle (see {@link checkPantBundle}); the default empty map mirrors
+ * the legacy single-document behaviour.
  */
-export async function assertWasmTypeChecks(text: string): Promise<void> {
-  const error = await checkPantDocument(text);
+export async function assertWasmTypeChecks(
+  text: string,
+  deps: Map<string, string> = new Map(),
+): Promise<void> {
+  const error = await checkPantBundle(text, deps);
   if (error !== null) {
     const maxPreview = 4_000;
     const preview =

--- a/tools/ts2pant/tests/pant-wasm-bundle.test.mts
+++ b/tools/ts2pant/tests/pant-wasm-bundle.test.mts
@@ -1,0 +1,71 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { checkPantBundle } from "../src/pant-wasm.js";
+
+describe("pant-wasm > checkPantBundle", () => {
+  it("resolves a single import against an in-memory dep", async () => {
+    const dep = `module DEP_LIB.
+
+User.
+nobody => User.
+---
+true.
+`;
+
+    const consumer = `module CONSUMER.
+
+import DEP_LIB.
+
+Doc.
+---
+all u: User | u = nobody.
+`;
+
+    const error = await checkPantBundle(
+      consumer,
+      new Map([["DEP_LIB", dep]]),
+    );
+    assert.equal(error, null);
+  });
+
+  it("reports unresolved import name as a missing-module error", async () => {
+    const consumer = `module CONSUMER.
+
+import MISSING.
+
+Doc.
+---
+true.
+`;
+
+    const error = await checkPantBundle(consumer, new Map());
+    assert.notEqual(error, null);
+    assert.match(error!, /MISSING/);
+  });
+
+  it("reports a typecheck error in a dep module", async () => {
+    // The dep references an undeclared type 'Bogus', so collecting its
+    // environment fails; that error must surface to the caller.
+    const dep = `module BROKEN_DEP.
+
+f x: Bogus => Bool.
+---
+true.
+`;
+
+    const consumer = `module CONSUMER.
+
+import BROKEN_DEP.
+
+Doc.
+---
+true.
+`;
+
+    const error = await checkPantBundle(
+      consumer,
+      new Map([["BROKEN_DEP", dep]]),
+    );
+    assert.notEqual(error, null);
+  });
+});

--- a/tools/ts2pant/tests/pant-wasm-bundle.test.mts
+++ b/tools/ts2pant/tests/pant-wasm-bundle.test.mts
@@ -67,5 +67,6 @@ true.
       new Map([["BROKEN_DEP", dep]]),
     );
     assert.notEqual(error, null);
+    assert.match(error!, /Bogus/);
   });
 });

--- a/wasm/pant_wasm.ml
+++ b/wasm/pant_wasm.ml
@@ -54,6 +54,69 @@ let check_document_string (text : string) : string option =
             | Ok _warnings -> None
             | Error e -> Some (Error.format_type_error e)))
 
+(** Format a [Module.module_error] into a human-readable string. The pant CLI
+    produces these via [Error.format_module_error]; we format inline here to
+    match the wasm-side error-string convention used by [check_document_string].
+*)
+let format_module_error : Module.module_error -> string = function
+  | Module.ModuleNotFound name ->
+      Printf.sprintf "error: module not found: %s" name
+  | Module.CyclicImport chain ->
+      Printf.sprintf "error: cyclic import: %s" (String.concat " -> " chain)
+  | Module.ParseError (_file, msg) ->
+      (* [msg] already carries file:line:col when sourced from a parse error;
+         pass through verbatim so callers see one error string, not a doubled
+         "file: file:line:col: ..." prefix. *)
+      msg
+
+(** Type-check a consumer document against an in-memory bundle of dep modules.
+    Each [(name, text)] pair is parsed and registered as a [module_entry] keyed
+    by [name] — the same key the consumer's [import NAME.] declarations resolve
+    against. Returns [None] on success or [Some message] on failure. Mirrors the
+    pant CLI's import semantics ([Module.check_with_imports]) by populating
+    [module_entry.ast] from in-memory text rather than reading a file. *)
+let check_document_with_deps (consumer_text : string)
+    (deps : (string * string) list) : string option =
+  match parse_document_string "<wasm-input>" consumer_text with
+  | Error msg -> Some msg
+  | Ok consumer_doc -> (
+      let parse_one_dep (name, text) =
+        match parse_document_string ("<dep:" ^ name ^ ">") text with
+        | Error msg -> Error msg
+        | Ok ast -> Ok (name, ast)
+      in
+      let rec parse_deps = function
+        | [] -> Ok []
+        | dep :: rest -> (
+            match parse_one_dep dep with
+            | Error msg -> Error msg
+            | Ok parsed -> (
+                match parse_deps rest with
+                | Error msg -> Error msg
+                | Ok rest' -> Ok (parsed :: rest')))
+      in
+      match parse_deps deps with
+      | Error msg -> Some msg
+      | Ok parsed_deps -> (
+          let modules =
+            List.fold_left
+              (fun acc (name, ast) ->
+                let entry : Module.module_entry =
+                  {
+                    name;
+                    path = "<in-memory:" ^ name ^ ">";
+                    ast = Some ast;
+                    env = None;
+                  }
+                in
+                Module.StringMap.add name entry acc)
+              Module.StringMap.empty parsed_deps
+          in
+          let registry = { Module.modules; loading = [] } in
+          match Module.check_with_imports registry consumer_doc with
+          | Ok _ -> None
+          | Error e -> Some (format_module_error e)))
+
 (** Collect names bound by guards (GIn introduces a binding). *)
 let bound_names_from_guards (guards : Ast.guard list) : string list =
   List.filter_map
@@ -279,6 +342,18 @@ let () =
        method checkDocument text =
          let text = Js.to_string text in
          match check_document_string text with
+         | None -> Js.null
+         | Some msg -> Js.some (Js.string msg)
+
+       method checkDocumentWithDeps consumer_text deps_array =
+         let consumer = Js.to_string consumer_text in
+         let deps =
+           Js.to_array deps_array |> Array.to_list
+           |> List.map (fun pair ->
+               let arr = Js.to_array pair in
+               (Js.to_string (Array.get arr 0), Js.to_string (Array.get arr 1)))
+         in
+         match check_document_with_deps consumer deps with
          | None -> Js.null
          | Some msg -> Js.some (Js.string msg)
     end)


### PR DESCRIPTION
## Patch 1: Wasm bridge: in-memory module registry for cross-module typechecking

- In wasm/pant_wasm.ml, add `let check_document_with_deps consumer deps = let registry = Module.create_registry () in (* parse each (name, text), populate module_entry.ast, registry.modules *) ... Module.check_with_imports registry consumer_doc`. Reuse Module.parse_module_header pattern but parse_document_string the in-memory text to populate ast directly, bypassing parse_file (open_in).
- Add Js.export method `checkDocumentWithDeps consumerText depsArray` that converts the JS array of (name, text) pairs to the OCaml shape and calls check_document_with_deps. Returns Js.null on success, Js.some(message) on failure (same shape as existing checkDocument).
- In tools/ts2pant/src/pant-wasm.ts, add `export async function checkPantBundle(consumer: string, deps: Map<string, string>): Promise<string | null>` that calls the new wasm method. Default `deps = new Map()` route stays equivalent to the existing checkPantDocument.
- Update assertWasmTypeChecks signature: `assertWasmTypeChecks(text: string, deps?: Map<string, string>): Promise<void>`.

## Changes
- In wasm/pant_wasm.ml, add `let check_document_with_deps consumer deps = let registry = Module.create_registry () in (* parse each (name, text), populate module_entry.ast, registry.modules *) ... Module.check_with_imports registry consumer_doc`. Reuse Module.parse_module_header pattern but parse_document_string the in-memory text to populate ast directly, bypassing parse_file (open_in).
- Add Js.export method `checkDocumentWithDeps consumerText depsArray` that converts the JS array of (name, text) pairs to the OCaml shape and calls check_document_with_deps. Returns Js.null on success, Js.some(message) on failure (same shape as existing checkDocument).
- In tools/ts2pant/src/pant-wasm.ts, add `export async function checkPantBundle(consumer: string, deps: Map<string, string>): Promise<string | null>` that calls the new wasm method. Default `deps = new Map()` route stays equivalent to the existing checkPantDocument.
- Update assertWasmTypeChecks signature: `assertWasmTypeChecks(text: string, deps?: Map<string, string>): Promise<void>`.

## Files to Modify
- wasm/pant_wasm.ml (modify): Add a parsing path that populates Module.registry's module_entry.ast from in-memory text, then dispatch through Module.check_with_imports. Export new pantParser.checkDocumentWithDeps method.
- tools/ts2pant/src/pant-wasm.ts (modify): Add checkPantBundle(consumer, deps). Update assertWasmTypeChecks to optionally take deps. Drop the 'documents with imports unsupported' restriction in checkPantDocument's docstring once the bundle path is wired.

## Gameplan Specification

```
module KNOWN_FAILURES.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> After this gameplan, KNOWN_TYPECHECK_FAILURES contains exactly
> the two intentional class-method entries. Every other fixture in
> tools/ts2pant/tests/fixtures/constructs/ either typechecks via
> the wasm bridge or routes through the UNSUPPORTED-skip path. The
> wasm bridge resolves cross-module imports against an in-memory
> registry, matching the `pant` CLI's import semantics exactly.
>
> Dependency rules emit as standalone Pantagruel modules — hand-
> written `samples/js-stdlib/JS_MATH.pant` / `JS_STRING.pant` for
> TS standard-library builtins (Math.*, String.prototype.*); per-
> source-file synthesised `<FILE_BASE_NAME>_AMBIENT` for user
> `declare function`s; per-source-file `<FILE_BASE_NAME>_TUPLES` for
> anonymous tuple constructors. Consumer modules import them via
> `import` lines and reference qualified rules (`math::max`).
> Every emitted module name uses ALL_CAPS_SNAKE convention,
> matching the existing `samples/*.pant` corpus.
> No emitted Pant text contains `$` (binder hygiene); no emitted
> rule name is a Pant reserved keyword (sanitisation).
>
> The translation pipeline preserves CLAUDE.md's L1/L2 IR layering:
> builtin / ambient / tuple registration is an L1 concern (TS-shape
> recognition); qualified-name lowering and module-text emission
> are L2 → OpaqueExpr concerns. dep-module attachment to
> PantDocument is a pipeline-orchestration concern, not an IR
> concern. References: Vekris/Cosman/Jhala (PLDI 2016, IR
> separation); Kroening & Strichman (Decision Procedures Ch. 4 EUF,
> Ch. 8 records); Peyton Jones & Marlow (JFP 2002, Barendregt
> hygiene); Jackson (Software Abstractions, Alloy `lone`
> multiplicity); Baader & Nipkow (Term Rewriting, Ch. 2
> substitution).

Fixture.
Document.
DepModule.
DepBundle.
DepKind.
FixtureStatus.
CheckResult.

passes-typecheck => FixtureStatus.
skipped-unsupported => FixtureStatus.
in-known-failures => FixtureStatus.

builtin-dep => DepKind.
ambient-dep => DepKind.
tuple-ctor-dep => DepKind.

ok => CheckResult.
error-msg => CheckResult.

status f: Fixture => FixtureStatus.
intentional? f: Fixture => Bool.
emitted f: Fixture => Document.
dep-modules f: Fixture => [DepModule].
imports-of d: Document => [String].

contains-dollar? d: Document => Bool.
uses-keyword-as-name? d: Document => Bool.
imports-resolved? d: Document, deps: [DepModule] => Bool.

kind m: DepModule => DepKind.
emits-typechecking-text? m: DepModule => Bool.

is-screaming-snake? n: String => Bool.
module-name-of d: Document => String.

bundle-of f: Fixture => DepBundle.
resolved-bundle? d: Document, b: DepBundle => Bool.
check-bundle d: Document, b: DepBundle => CheckResult.

---
> Every fixture that remains in KNOWN_TYPECHECK_FAILURES is intentional.
all f: Fixture, status f = in-known-failures | intentional? f.

> No emitted document contains a `$` character (binder hygiene).
all f: Fixture | ~(contains-dollar? (emitted f)).

> No emitted document uses a Pant reserved keyword as a rule name.
all f: Fixture | ~(uses-keyword-as-name? (emitted f)).

> Every emitted document's module name is ALL_CAPS_SNAKE.
all f: Fixture | is-screaming-snake? (module-name-of (emitted f)).

> Imports in passing-fixture emitted documents resolve against
> the dep modules attached to the fixture's bundle.
all f: Fixture, status f = passes-typecheck
  | imports-resolved? (emitted f) (dep-modules f).

> The wasm bundle-check succeeds only if every import resolves.
all d: Document, b: DepBundle, check-bundle d b = ok | resolved-bundle? d b.

> Every dep module emits text that typechecks standalone.
all m: DepModule | emits-typechecking-text? m.

```

## Patch Specification

```
module KNOWN_FAILURES_PATCH_1.

> Patch 1 introduces the multi-document wasm registry API.
> Postcondition: the wasm bridge can typecheck a consumer document
> together with an in-memory bundle of dep modules; semantics match
> the OCaml CLI's import resolution exactly.

Document.
DepBundle.
CheckResult.
ok => CheckResult.
error-msg => CheckResult.

imports d: Document => [String].
resolved? d: Document, b: DepBundle => Bool.
check-bundle d: Document, b: DepBundle => CheckResult.

---
> Bundle check succeeds only if every import resolves.
all d: Document, b: DepBundle, check-bundle d b = ok | resolved? d b.

> Empty imports list: bundle check is equivalent to single-document check.
> (Modelled as: an empty bundle plus no imports is always resolved.)
all d: Document, b: DepBundle, #(imports d) = 0 | resolved? d b.

```


## Implementation Notes

- **`lib/module.ml` is now copied into the wasm build** via a new `(copy_files ../lib/module.ml)` line in `lib_parser/dune`. The wasm executable links only `pantagruel_parser`, not the full `pantagruel` library, so reaching `Module.registry` / `Module.check_with_imports` required adding the file to that library's curated copy list. `Module` carries some functions that touch the filesystem (`parse_file`, `scan_module_path`, `parse_module_header`); they compile under wasm but are never reached on the new path — `check_document_with_deps` populates `module_entry.ast` directly so `load_module` short-circuits before any `open_in`.

- **`checkPantDocument` was left routing through the legacy `checkDocument` wasm method** rather than rewired through `checkPantBundle`. The two paths are observably equivalent for import-free documents, and the legacy entry point still serves as the explicit "no imports allowed" gate (its `checkDocument` rejects imports with a clear message). Callers that need import resolution use `checkPantBundle` / `assertWasmTypeChecks(text, deps)` directly. Docstring on `checkPantDocument` was updated to point at the bundle entry point.

- **Module-error formatting passes the `ParseError` message through verbatim** rather than re-prefixing with the file. `Module.parse_channel` already produces `file:line:col: error: ...` strings, so re-wrapping with the file name on the wasm side would double-prefix. `ModuleNotFound` and `CyclicImport` get inline formatting (no `Error.format_module_error` exists in `lib/error.ml`).

- **One drive-by lint fix lives in this PR**: `tools/ts2pant/src/ir1-lower.ts:214` migrated `allocateBinder(hint: string): string;` to property-signature `allocateBinder: (hint: string) => string;`. A pre-existing biome `useConsistentMethodSignatures` warning on that line was failing the lefthook pre-commit hook on every commit; rather than `--no-verify`-bypassing, the one-line conversion clears the hook for this PR and any subsequent ones. Mentioned in the commit body so it's not silent.

- **New test file** is `tools/ts2pant/tests/pant-wasm-bundle.test.mts` (unit suite — no pant binary needed). Three cases match the gameplan stubs: success, missing-module, broken-dep collect error. Dep + consumer text both need a `---` separator (the parser requires a non-empty chapter head), so the fixtures include a placeholder `Doc.` declaration; not a wasm-bridge constraint, just minimum-document syntax.