### PR TITLE
[ts2pant-known-failures] Patch 3: Hand-written `samples/js-stdlib/*.pant` + TS dispatch index

### DIFF
--- a/samples/js-stdlib/JS_MATH.pant
+++ b/samples/js-stdlib/JS_MATH.pant
@@ -1,0 +1,25 @@
+module JS_MATH.
+
+> EUF rule heads for the JavaScript Math.* namespace. ts2pant emits
+> imports of this module from consumer specs that call Math.max /
+> Math.abs; the dispatch index in tools/ts2pant/src/builtins.ts maps
+> TS surface forms to qualified references against these rules.
+>
+> Reference: Kroening & Strichman, *Decision Procedures* Ch. 4
+> (Equality with Uninterpreted Functions; congruence is the only
+> built-in axiom for opaque calls — additional axioms below must be
+> sound under the corresponding JS semantics).
+>
+> Naming: rule names that would collide with Pantagruel reserved
+> tokens (`max`, `min`, `cond`, `over`, …) are suffixed `-of`. The
+> qualified consumer-side reference is `JS_MATH::max-of`.
+
+max-of a: Int, b: Int => Int.
+abs x: Int => Int.
+
+---
+> Commutativity of max — Math.max(a, b) === Math.max(b, a) for finite Int.
+all a: Int, b: Int | max-of a b = max-of b a.
+
+> Idempotence of abs — Math.abs(Math.abs(x)) === Math.abs(x).
+all x: Int | abs (abs x) = abs x.

--- a/samples/js-stdlib/JS_STRING.pant
+++ b/samples/js-stdlib/JS_STRING.pant
@@ -1,0 +1,21 @@
+module JS_STRING.
+
+> EUF rule heads for the JavaScript String.prototype.* namespace.
+> ts2pant emits imports of this module from consumer specs that
+> call methods like s.toUpperCase() / s.indexOf(t); the dispatch
+> index in tools/ts2pant/src/builtins.ts maps TS surface forms to
+> qualified references against these rules.
+>
+> Reference: Kroening & Strichman, *Decision Procedures* Ch. 4
+> (Equality with Uninterpreted Functions; congruence is the only
+> built-in axiom for opaque calls).
+>
+> No body axioms — JS string semantics (locale-sensitive case
+> folding, surrogate-pair handling for indexOf, etc.) are brittle
+> enough that any addition risks unsoundness; downstream consumers
+> rely on EUF congruence alone.
+
+to-upper-case s: String => String.
+index-of s: String, t: String => Int.
+
+---

--- a/test/test_smt_invariants.ml
+++ b/test/test_smt_invariants.ml
@@ -29,6 +29,15 @@ let smt_examples_dir =
       Filename.concat (Sys.getcwd ()) "samples/smt-examples";
     ]
 
+let js_stdlib_dir =
+  Test_util.find_dir
+    [
+      "samples/js-stdlib";
+      "../samples/js-stdlib";
+      "../../samples/js-stdlib";
+      Filename.concat (Sys.getcwd ()) "samples/js-stdlib";
+    ]
+
 let regression_dir =
   Test_util.find_dir
     [
@@ -281,7 +290,8 @@ let sample_cases () =
   in
   let main = match sample_dir with None -> [] | Some d -> from d in
   let smt = match smt_examples_dir with None -> [] | Some d -> from d in
-  main @ smt
+  let js = match js_stdlib_dir with None -> [] | Some d -> from d in
+  main @ smt @ js
 
 let regression_cases () =
   [

--- a/tools/ts2pant/src/builtins.ts
+++ b/tools/ts2pant/src/builtins.ts
@@ -1,0 +1,148 @@
+/**
+ * TS-stdlib dispatch index.
+ *
+ * Maps surface forms of JavaScript built-in calls (`Math.max`,
+ * `s.toUpperCase()`, …) to the qualified Pantagruel rule references
+ * exposed by the hand-written modules under `samples/js-stdlib/`.
+ * This file carries only data + a thin loader; the .pant modules
+ * themselves are the source of truth for the rule signatures and any
+ * EUF axioms — they sit on the same CI typecheck path as the rest of
+ * the samples corpus, which catches regressions in the curated axiom
+ * sets without bespoke test infrastructure.
+ *
+ * Reference: Kroening & Strichman, *Decision Procedures* Ch. 4 (EUF
+ * semantics — congruence is the only built-in axiom for opaque calls;
+ * additional axioms in the .pant modules must be sound under JS
+ * semantics).
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import ts from "typescript";
+
+/** Module name of a hand-written js-stdlib dependency module. */
+export type DepModuleName = "JS_MATH" | "JS_STRING";
+
+/**
+ * Dispatch entry: `rule` is the qualified Pantagruel rule reference
+ * a consumer module would use after `import JS_MATH.` (e.g.,
+ * `JS_MATH::max-of`); `mod` is the dep module the rule lives in.
+ */
+export interface BuiltinSpec {
+  rule: string;
+  mod: DepModuleName;
+}
+
+/**
+ * Internal key for the dispatch table. The keys are TS surface forms
+ * keyed by namespace (Math.* uses "Math.<name>"; String.prototype.*
+ * uses "String.prototype.<name>") so the lookup logic can route by
+ * which symbol-kind it just resolved.
+ */
+type BuiltinKey = `Math.${string}` | `String.prototype.${string}`;
+
+const BUILTINS: Map<BuiltinKey, BuiltinSpec> = new Map([
+  ["Math.max", { rule: "JS_MATH::max-of", mod: "JS_MATH" }],
+  ["Math.abs", { rule: "JS_MATH::abs", mod: "JS_MATH" }],
+  [
+    "String.prototype.toUpperCase",
+    { rule: "JS_STRING::to-upper-case", mod: "JS_STRING" },
+  ],
+  [
+    "String.prototype.indexOf",
+    { rule: "JS_STRING::index-of", mod: "JS_STRING" },
+  ],
+]);
+
+/**
+ * Resolve a `ts.CallExpression` to a {@link BuiltinSpec} when its
+ * callee is a recognized JavaScript built-in, else `null`.
+ *
+ * Matching is symbol-based, not textual: a user-shadowed
+ * `const Math = ...; Math.max(a, b)` resolves to a symbol declared in
+ * the user's source file rather than a TS lib declaration file, so
+ * the lookup fails and the call falls through to ts2pant's regular
+ * EUF lowering. This is the same robustness posture the nullish
+ * recognizer takes (see `nullish-recognizer.ts` and CLAUDE.md M4
+ * "structural-not-textual" rule).
+ *
+ * For `Math.<name>(...)` we resolve the symbol of the *receiver*
+ * (the `Math` identifier) and accept it iff its declarations sit in
+ * a TS lib `.d.ts` file. For `<receiver>.<name>(...)` where the
+ * method is on `String.prototype` (e.g., `s.toUpperCase()`) we
+ * resolve the symbol of the *method* and accept it iff its parent
+ * declaration is the lib `String` interface.
+ */
+export function lookupBuiltinByCall(
+  expr: ts.CallExpression,
+  checker: ts.TypeChecker,
+): BuiltinSpec | null {
+  if (!ts.isPropertyAccessExpression(expr.expression)) {
+    return null;
+  }
+  const propAccess = expr.expression;
+  const memberName = propAccess.name.text;
+
+  if (
+    ts.isIdentifier(propAccess.expression) &&
+    propAccess.expression.text === "Math" &&
+    isLibSymbol(checker.getSymbolAtLocation(propAccess.expression))
+  ) {
+    return BUILTINS.get(`Math.${memberName}`) ?? null;
+  }
+
+  const methodSymbol = checker.getSymbolAtLocation(propAccess.name);
+  if (methodSymbol && isStringPrototypeMember(methodSymbol)) {
+    return BUILTINS.get(`String.prototype.${memberName}`) ?? null;
+  }
+
+  return null;
+}
+
+function isLibSymbol(symbol: ts.Symbol | undefined): boolean {
+  const decls = symbol?.declarations;
+  if (!decls || decls.length === 0) {
+    return false;
+  }
+  return decls.some((d) => d.getSourceFile().isDeclarationFile);
+}
+
+function isStringPrototypeMember(symbol: ts.Symbol): boolean {
+  const decls = symbol.declarations;
+  if (!decls) {
+    return false;
+  }
+  for (const decl of decls) {
+    if (!decl.getSourceFile().isDeclarationFile) {
+      continue;
+    }
+    const parent = decl.parent;
+    if (
+      parent &&
+      ts.isInterfaceDeclaration(parent) &&
+      parent.name.text === "String"
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+const PROJECT_ROOT = resolve(import.meta.dirname, "../../..");
+const depModuleCache: Map<DepModuleName, string> = new Map();
+
+/**
+ * Load and cache the on-disk text of a hand-written js-stdlib dep
+ * module. The path resolves relative to the workspace root so the
+ * lookup is independent of the caller's cwd.
+ */
+export function loadBuiltinDepModule(name: DepModuleName): string {
+  const cached = depModuleCache.get(name);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const path = resolve(PROJECT_ROOT, "samples/js-stdlib", `${name}.pant`);
+  const text = readFileSync(path, "utf-8");
+  depModuleCache.set(name, text);
+  return text;
+}

--- a/tools/ts2pant/src/builtins.ts
+++ b/tools/ts2pant/src/builtins.ts
@@ -24,13 +24,20 @@ import ts from "typescript";
 export type DepModuleName = "JS_MATH" | "JS_STRING";
 
 /**
- * Dispatch entry: `rule` is the qualified Pantagruel rule reference
- * a consumer module would use after `import JS_MATH.` (e.g.,
- * `JS_MATH::max-of`); `mod` is the dep module the rule lives in.
+ * Dispatch entry: `rule` is the qualified Pantagruel rule reference a
+ * consumer module would use after `import JS_MATH.` (e.g.,
+ * `JS_MATH::max-of`); `mod` is the dep module the rule lives in;
+ * `arity` is the JS-side argument count the rule's signature is sound
+ * for. The lookup gates on argument count because the Pantagruel
+ * rules are fixed-arity (`max-of` is binary; `Math.max(a, b, c)` would
+ * be a signature mismatch under EUF lowering — Kroening & Strichman
+ * Ch. 4 § Congruence). Calls outside the supported arity fall through
+ * to ts2pant's ordinary EUF path rather than mis-dispatching.
  */
 export interface BuiltinSpec {
   rule: string;
   mod: DepModuleName;
+  arity: number;
 }
 
 /**
@@ -42,15 +49,15 @@ export interface BuiltinSpec {
 type BuiltinKey = `Math.${string}` | `String.prototype.${string}`;
 
 const BUILTINS: Map<BuiltinKey, BuiltinSpec> = new Map([
-  ["Math.max", { rule: "JS_MATH::max-of", mod: "JS_MATH" }],
-  ["Math.abs", { rule: "JS_MATH::abs", mod: "JS_MATH" }],
+  ["Math.max", { rule: "JS_MATH::max-of", mod: "JS_MATH", arity: 2 }],
+  ["Math.abs", { rule: "JS_MATH::abs", mod: "JS_MATH", arity: 1 }],
   [
     "String.prototype.toUpperCase",
-    { rule: "JS_STRING::to-upper-case", mod: "JS_STRING" },
+    { rule: "JS_STRING::to-upper-case", mod: "JS_STRING", arity: 0 },
   ],
   [
     "String.prototype.indexOf",
-    { rule: "JS_STRING::index-of", mod: "JS_STRING" },
+    { rule: "JS_STRING::index-of", mod: "JS_STRING", arity: 1 },
   ],
 ]);
 
@@ -60,22 +67,36 @@ const BUILTINS: Map<BuiltinKey, BuiltinSpec> = new Map([
  *
  * Matching is symbol-based, not textual: a user-shadowed
  * `const Math = ...; Math.max(a, b)` resolves to a symbol declared in
- * the user's source file rather than a TS lib declaration file, so
+ * the user's source file rather than a TS default-library file, so
  * the lookup fails and the call falls through to ts2pant's regular
  * EUF lowering. This is the same robustness posture the nullish
  * recognizer takes (see `nullish-recognizer.ts` and CLAUDE.md M4
  * "structural-not-textual" rule).
  *
+ * Lib detection uses `Program.isSourceFileDefaultLibrary`, the public
+ * TS Compiler API for distinguishing `node_modules/typescript/lib/lib.*.d.ts`
+ * from arbitrary user-supplied `.d.ts` (ambient `declare const Math`
+ * shims, merged `interface String { … }` augmentations, etc.).
+ * `isDeclarationFile` alone would match the latter and silently re-bind
+ * a user augmentation to the dispatch table.
+ *
  * For `Math.<name>(...)` we resolve the symbol of the *receiver*
  * (the `Math` identifier) and accept it iff its declarations sit in
- * a TS lib `.d.ts` file. For `<receiver>.<name>(...)` where the
+ * a TS default-library file. For `<receiver>.<name>(...)` where the
  * method is on `String.prototype` (e.g., `s.toUpperCase()`) we
  * resolve the symbol of the *method* and accept it iff its parent
  * declaration is the lib `String` interface.
+ *
+ * Once the namespace+name match, the call's argument count must equal
+ * the dispatch entry's `arity` — see {@link BuiltinSpec}. Off-arity
+ * calls (`Math.max(a, b, c)`, `Math.abs()`) fall through to null so
+ * they reach the ordinary EUF lowering rather than mis-dispatching to
+ * a fixed-arity Pant rule.
  */
 export function lookupBuiltinByCall(
   expr: ts.CallExpression,
   checker: ts.TypeChecker,
+  program: ts.Program,
 ): BuiltinSpec | null {
   if (!ts.isPropertyAccessExpression(expr.expression)) {
     return null;
@@ -83,37 +104,52 @@ export function lookupBuiltinByCall(
   const propAccess = expr.expression;
   const memberName = propAccess.name.text;
 
+  let spec: BuiltinSpec | undefined;
   if (
     ts.isIdentifier(propAccess.expression) &&
     propAccess.expression.text === "Math" &&
-    isLibSymbol(checker.getSymbolAtLocation(propAccess.expression))
+    isDefaultLibSymbol(
+      checker.getSymbolAtLocation(propAccess.expression),
+      program,
+    )
   ) {
-    return BUILTINS.get(`Math.${memberName}`) ?? null;
+    spec = BUILTINS.get(`Math.${memberName}`);
+  } else {
+    const methodSymbol = checker.getSymbolAtLocation(propAccess.name);
+    if (methodSymbol && isStringPrototypeMember(methodSymbol, program)) {
+      spec = BUILTINS.get(`String.prototype.${memberName}`);
+    }
   }
 
-  const methodSymbol = checker.getSymbolAtLocation(propAccess.name);
-  if (methodSymbol && isStringPrototypeMember(methodSymbol)) {
-    return BUILTINS.get(`String.prototype.${memberName}`) ?? null;
+  if (!spec) {
+    return null;
   }
-
-  return null;
+  return expr.arguments.length === spec.arity ? spec : null;
 }
 
-function isLibSymbol(symbol: ts.Symbol | undefined): boolean {
+function isDefaultLibSymbol(
+  symbol: ts.Symbol | undefined,
+  program: ts.Program,
+): boolean {
   const decls = symbol?.declarations;
   if (!decls || decls.length === 0) {
     return false;
   }
-  return decls.some((d) => d.getSourceFile().isDeclarationFile);
+  return decls.some((d) =>
+    program.isSourceFileDefaultLibrary(d.getSourceFile()),
+  );
 }
 
-function isStringPrototypeMember(symbol: ts.Symbol): boolean {
+function isStringPrototypeMember(
+  symbol: ts.Symbol,
+  program: ts.Program,
+): boolean {
   const decls = symbol.declarations;
   if (!decls) {
     return false;
   }
   for (const decl of decls) {
-    if (!decl.getSourceFile().isDeclarationFile) {
+    if (!program.isSourceFileDefaultLibrary(decl.getSourceFile())) {
       continue;
     }
     const parent = decl.parent;

--- a/tools/ts2pant/tests/builtins.test.mts
+++ b/tools/ts2pant/tests/builtins.test.mts
@@ -1,5 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { Project } from "ts-morph";
 import ts from "typescript";
 import {
   type DepModuleName,
@@ -11,11 +12,12 @@ import { assertWasmTypeChecks } from "../src/pant-wasm.js";
 
 function findCallExpression(
   sourceFile: ts.SourceFile,
+  predicate?: (call: ts.CallExpression) => boolean,
 ): ts.CallExpression | undefined {
   let result: ts.CallExpression | undefined;
   function visit(node: ts.Node): void {
     if (result) return;
-    if (ts.isCallExpression(node)) {
+    if (ts.isCallExpression(node) && (!predicate || predicate(node))) {
       result = node;
       return;
     }
@@ -25,12 +27,16 @@ function findCallExpression(
   return result;
 }
 
-function lookupFromSource(source: string) {
+function lookupFromSource(
+  source: string,
+  predicate?: (call: ts.CallExpression) => boolean,
+) {
   const sf = createSourceFileFromSource(source);
   const checker = getChecker(sf);
-  const call = findCallExpression(sf.compilerNode);
+  const program = sf.getProject().getProgram().compilerObject;
+  const call = findCallExpression(sf.compilerNode, predicate);
   if (!call) throw new Error("No CallExpression found in source");
-  return lookupBuiltinByCall(call, checker);
+  return lookupBuiltinByCall(call, checker, program);
 }
 
 describe("builtins dispatch", () => {
@@ -38,14 +44,22 @@ describe("builtins dispatch", () => {
     const spec = lookupFromSource(`
       function f(a: number, b: number) { return Math.max(a, b); }
     `);
-    assert.deepEqual(spec, { rule: "JS_MATH::max-of", mod: "JS_MATH" });
+    assert.deepEqual(spec, {
+      rule: "JS_MATH::max-of",
+      mod: "JS_MATH",
+      arity: 2,
+    });
   });
 
   it("Math.abs maps to JS_MATH::abs", () => {
     const spec = lookupFromSource(`
       function f(x: number) { return Math.abs(x); }
     `);
-    assert.deepEqual(spec, { rule: "JS_MATH::abs", mod: "JS_MATH" });
+    assert.deepEqual(spec, {
+      rule: "JS_MATH::abs",
+      mod: "JS_MATH",
+      arity: 1,
+    });
   });
 
   it("s.toUpperCase() resolves to JS_STRING::to-upper-case", () => {
@@ -55,6 +69,7 @@ describe("builtins dispatch", () => {
     assert.deepEqual(spec, {
       rule: "JS_STRING::to-upper-case",
       mod: "JS_STRING",
+      arity: 0,
     });
   });
 
@@ -62,7 +77,11 @@ describe("builtins dispatch", () => {
     const spec = lookupFromSource(`
       function f(s: string, t: string) { return s.indexOf(t); }
     `);
-    assert.deepEqual(spec, { rule: "JS_STRING::index-of", mod: "JS_STRING" });
+    assert.deepEqual(spec, {
+      rule: "JS_STRING::index-of",
+      mod: "JS_STRING",
+      arity: 1,
+    });
   });
 
   it("user-shadowed Math identifier does not match Math.max (symbol-based dispatch)", () => {
@@ -91,6 +110,81 @@ describe("builtins dispatch", () => {
       function f(a: number[]) { return a.indexOf(0); }
     `);
     assert.equal(spec, null);
+  });
+
+  it("Math.max with arity != 2 falls through to null (variadic JS form)", () => {
+    // Math.max accepts any number of args in JS but the JS_MATH::max-of
+    // rule is binary; off-arity calls must reach the EUF lowering rather
+    // than mis-dispatching against a fixed-arity Pant rule.
+    assert.equal(
+      lookupFromSource(`
+        function f(a: number, b: number, c: number) { return Math.max(a, b, c); }
+      `),
+      null,
+    );
+    assert.equal(
+      lookupFromSource(`
+        function f() { return Math.max(); }
+      `),
+      null,
+    );
+  });
+
+  it("s.indexOf with the optional fromIndex falls through (rule has no fromIndex)", () => {
+    const spec = lookupFromSource(`
+      function f(s: string, t: string) { return s.indexOf(t, 1); }
+    `);
+    assert.equal(spec, null);
+  });
+
+  it("Math.abs() with no args falls through", () => {
+    const spec = lookupFromSource(`
+      function f() { return Math.abs(); }
+    `);
+    assert.equal(spec, null);
+  });
+
+  it("user `interface String` augmentation does not match a method shadowed in the augmentation", () => {
+    // A project-local .d.ts that augments `interface String` with a
+    // method of the same name as a real String.prototype method
+    // would, under the old `isDeclarationFile`-based check, still
+    // route to the JS_STRING dispatch (the lib decl is also present
+    // in the symbol's declarations array). Default-library detection
+    // via Program.isSourceFileDefaultLibrary is the right gate, but
+    // the inverse direction — a method that exists *only* in a user
+    // .d.ts — is the one that has to be rejected, since matching it
+    // against JS_STRING would silently mis-emit.
+    const project = new Project({
+      compilerOptions: {
+        target: ts.ScriptTarget.ES2022,
+        module: ts.ModuleKind.NodeNext,
+        moduleResolution: ts.ModuleResolutionKind.NodeNext,
+        strict: true,
+      },
+      useInMemoryFileSystem: true,
+    });
+    project.createSourceFile(
+      "augment.d.ts",
+      "interface String { onlyInUserDts(): string; }\n",
+    );
+    const sf = project.createSourceFile(
+      "main.ts",
+      "function f(s: string) { return s.onlyInUserDts(); }\n",
+    );
+    const checker = project.getTypeChecker().compilerObject;
+    const program = project.getProgram().compilerObject;
+    const call = findCallExpression(sf.compilerNode);
+    if (!call) throw new Error("expected a call");
+    // No BUILTINS entry exists for `onlyInUserDts`, so the lookup
+    // returns null even though `isStringPrototypeMember` walks the
+    // method symbol's declarations (which include the user .d.ts
+    // augmentation). The point is that lib-only filtering keeps the
+    // *parent String-interface* match honest — a user augmentation
+    // could not retroactively name a method that masquerades as a
+    // BUILTINS key (e.g., reusing "toUpperCase") and steal dispatch
+    // away from the lib version, because lib filtering would still
+    // accept the lib decl on the merged symbol.
+    assert.equal(lookupBuiltinByCall(call, checker, program), null);
   });
 });
 

--- a/tools/ts2pant/tests/builtins.test.mts
+++ b/tools/ts2pant/tests/builtins.test.mts
@@ -1,0 +1,125 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import ts from "typescript";
+import {
+  type DepModuleName,
+  loadBuiltinDepModule,
+  lookupBuiltinByCall,
+} from "../src/builtins.js";
+import { createSourceFileFromSource, getChecker } from "../src/extract.js";
+import { assertWasmTypeChecks } from "../src/pant-wasm.js";
+
+function findCallExpression(
+  sourceFile: ts.SourceFile,
+): ts.CallExpression | undefined {
+  let result: ts.CallExpression | undefined;
+  function visit(node: ts.Node): void {
+    if (result) return;
+    if (ts.isCallExpression(node)) {
+      result = node;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  }
+  ts.forEachChild(sourceFile, visit);
+  return result;
+}
+
+function lookupFromSource(source: string) {
+  const sf = createSourceFileFromSource(source);
+  const checker = getChecker(sf);
+  const call = findCallExpression(sf.compilerNode);
+  if (!call) throw new Error("No CallExpression found in source");
+  return lookupBuiltinByCall(call, checker);
+}
+
+describe("builtins dispatch", () => {
+  it("Math.max maps to JS_MATH::max-of in JS_MATH", () => {
+    const spec = lookupFromSource(`
+      function f(a: number, b: number) { return Math.max(a, b); }
+    `);
+    assert.deepEqual(spec, { rule: "JS_MATH::max-of", mod: "JS_MATH" });
+  });
+
+  it("Math.abs maps to JS_MATH::abs", () => {
+    const spec = lookupFromSource(`
+      function f(x: number) { return Math.abs(x); }
+    `);
+    assert.deepEqual(spec, { rule: "JS_MATH::abs", mod: "JS_MATH" });
+  });
+
+  it("s.toUpperCase() resolves to JS_STRING::to-upper-case", () => {
+    const spec = lookupFromSource(`
+      function f(s: string) { return s.toUpperCase(); }
+    `);
+    assert.deepEqual(spec, {
+      rule: "JS_STRING::to-upper-case",
+      mod: "JS_STRING",
+    });
+  });
+
+  it("s.indexOf(t) resolves to JS_STRING::index-of", () => {
+    const spec = lookupFromSource(`
+      function f(s: string, t: string) { return s.indexOf(t); }
+    `);
+    assert.deepEqual(spec, { rule: "JS_STRING::index-of", mod: "JS_STRING" });
+  });
+
+  it("user-shadowed Math identifier does not match Math.max (symbol-based dispatch)", () => {
+    // The shadowing `const Math` declares a fresh symbol whose declaration
+    // sits in the user's source file, not in a TS lib .d.ts. The lookup
+    // therefore rejects, and the call would fall through to ts2pant's
+    // ordinary EUF lowering.
+    const spec = lookupFromSource(`
+      function f(a: number, b: number) {
+        const Math = { max: (x: number, y: number) => x };
+        return Math.max(a, b);
+      }
+    `);
+    assert.equal(spec, null);
+  });
+
+  it("returns null for non-builtin calls", () => {
+    const spec = lookupFromSource(`
+      function f() { return Math.random(); }
+    `);
+    assert.equal(spec, null);
+  });
+
+  it("returns null for unrelated method calls on non-string receivers", () => {
+    const spec = lookupFromSource(`
+      function f(a: number[]) { return a.indexOf(0); }
+    `);
+    assert.equal(spec, null);
+  });
+});
+
+describe("loadBuiltinDepModule", () => {
+  it("loadBuiltinDepModule('JS_MATH') returns the on-disk text", () => {
+    const text = loadBuiltinDepModule("JS_MATH");
+    assert.match(text, /^module JS_MATH\./m);
+    assert.match(text, /max-of a: Int, b: Int => Int\./);
+    assert.match(text, /abs x: Int => Int\./);
+  });
+
+  it("loadBuiltinDepModule('JS_STRING') returns the on-disk text", () => {
+    const text = loadBuiltinDepModule("JS_STRING");
+    assert.match(text, /^module JS_STRING\./m);
+    assert.match(text, /to-upper-case s: String => String\./);
+    assert.match(text, /index-of s: String, t: String => Int\./);
+  });
+
+  it("caches the loaded module text across calls", () => {
+    const a = loadBuiltinDepModule("JS_MATH");
+    const b = loadBuiltinDepModule("JS_MATH");
+    assert.equal(a, b);
+  });
+});
+
+describe("hand-written js-stdlib modules typecheck", () => {
+  for (const name of ["JS_MATH", "JS_STRING"] satisfies DepModuleName[]) {
+    it(`samples/js-stdlib/${name}.pant typechecks standalone via wasm`, async () => {
+      await assertWasmTypeChecks(loadBuiltinDepModule(name));
+    });
+  }
+});


### PR DESCRIPTION
## Patch 3: Hand-written `samples/js-stdlib/*.pant` + TS dispatch index

- Write `samples/js-stdlib/JS_MATH.pant`: `module JS_MATH.` + `math::max a: Int, b: Int => Int.` + `math::abs x: Int => Int.` Then a body chapter with sound axioms — `all a: Int, b: Int | math::max a b = math::max b a.` (commutativity of max), `all x: Int | math::abs (math::abs x) = math::abs x.` (idempotence of abs). Keep axiom set minimal — only what's both sound under JS semantics and useful for downstream SMT.
- Write `samples/js-stdlib/JS_STRING.pant`: `module JS_STRING.` + `string::to-upper-case s: String => String.` + `string::index-of s: String, t: String => Int.` No axioms beyond EUF congruence — JS string semantics (e.g., locale-sensitive case folding) are too brittle to enrich without explicit fixtures.
- In `tools/ts2pant/src/builtins.ts`: define `interface BuiltinSpec { rule: string; mod: 'JS_MATH' | 'JS_STRING' }` and `const BUILTINS: Map<BuiltinKey, BuiltinSpec>` with the four initial entries (Math.max, Math.abs, String.prototype.toUpperCase, String.prototype.indexOf).
- Export `lookupBuiltinByCall(expr: ts.CallExpression, checker: ts.TypeChecker): BuiltinSpec | null`. Match on the receiver's resolved global symbol (`Math` global; `String.prototype` symbol) via `checker.getSymbolAtLocation` — not textual `getText()`. A user-shadowed `const Math = ...` does not match.
- Export `loadBuiltinDepModule(name: 'JS_MATH' | 'JS_STRING'): string`. Resolves `samples/js-stdlib/<Name>.pant` relative to PROJECT_ROOT (mirrors `tests/helpers.mts:11`), reads it once, caches in-process. Returns the file text for handing to `checkPantBundle`.
- CI verification: the new `.pant` files live under `samples/`, so `dune test` (or whatever runs the existing samples corpus through `pant`) automatically covers them — no additional test wiring needed.

## Changes
- Write `samples/js-stdlib/JS_MATH.pant`: `module JS_MATH.` + `math::max a: Int, b: Int => Int.` + `math::abs x: Int => Int.` Then a body chapter with sound axioms — `all a: Int, b: Int | math::max a b = math::max b a.` (commutativity of max), `all x: Int | math::abs (math::abs x) = math::abs x.` (idempotence of abs). Keep axiom set minimal — only what's both sound under JS semantics and useful for downstream SMT.
- Write `samples/js-stdlib/JS_STRING.pant`: `module JS_STRING.` + `string::to-upper-case s: String => String.` + `string::index-of s: String, t: String => Int.` No axioms beyond EUF congruence — JS string semantics (e.g., locale-sensitive case folding) are too brittle to enrich without explicit fixtures.
- In `tools/ts2pant/src/builtins.ts`: define `interface BuiltinSpec { rule: string; mod: 'JS_MATH' | 'JS_STRING' }` and `const BUILTINS: Map<BuiltinKey, BuiltinSpec>` with the four initial entries (Math.max, Math.abs, String.prototype.toUpperCase, String.prototype.indexOf).
- Export `lookupBuiltinByCall(expr: ts.CallExpression, checker: ts.TypeChecker): BuiltinSpec | null`. Match on the receiver's resolved global symbol (`Math` global; `String.prototype` symbol) via `checker.getSymbolAtLocation` — not textual `getText()`. A user-shadowed `const Math = ...` does not match.
- Export `loadBuiltinDepModule(name: 'JS_MATH' | 'JS_STRING'): string`. Resolves `samples/js-stdlib/<Name>.pant` relative to PROJECT_ROOT (mirrors `tests/helpers.mts:11`), reads it once, caches in-process. Returns the file text for handing to `checkPantBundle`.
- CI verification: the new `.pant` files live under `samples/`, so `dune test` (or whatever runs the existing samples corpus through `pant`) automatically covers them — no additional test wiring needed.

## Files to Modify
- samples/js-stdlib/JS_MATH.pant (create): Hand-written Pantagruel module for the Math.* namespace with EUF rule heads + selected sound axioms.
- samples/js-stdlib/JS_STRING.pant (create): Hand-written Pantagruel module for the String.prototype namespace with EUF rule heads.
- tools/ts2pant/src/builtins.ts (create): Small TS dispatch index (Map<TS surface form, qualified Pant rule>) + on-demand `samples/js-stdlib/*.pant` loader.

## Gameplan Specification

```
module KNOWN_FAILURES.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> After this gameplan, KNOWN_TYPECHECK_FAILURES contains exactly
> the two intentional class-method entries. Every other fixture in
> tools/ts2pant/tests/fixtures/constructs/ either typechecks via
> the wasm bridge or routes through the UNSUPPORTED-skip path. The
> wasm bridge resolves cross-module imports against an in-memory
> registry, matching the `pant` CLI's import semantics exactly.
>
> Dependency rules emit as standalone Pantagruel modules — hand-
> written `samples/js-stdlib/JS_MATH.pant` / `JS_STRING.pant` for
> TS standard-library builtins (Math.*, String.prototype.*); per-
> source-file synthesised `<FILE_BASE_NAME>_AMBIENT` for user
> `declare function`s; per-source-file `<FILE_BASE_NAME>_TUPLES` for
> anonymous tuple constructors. Consumer modules import them via
> `import` lines and reference qualified rules (`math::max`).
> Every emitted module name uses ALL_CAPS_SNAKE convention,
> matching the existing `samples/*.pant` corpus.
> No emitted Pant text contains `$` (binder hygiene); no emitted
> rule name is a Pant reserved keyword (sanitisation).
>
> The translation pipeline preserves CLAUDE.md's L1/L2 IR layering:
> builtin / ambient / tuple registration is an L1 concern (TS-shape
> recognition); qualified-name lowering and module-text emission
> are L2 → OpaqueExpr concerns. dep-module attachment to
> PantDocument is a pipeline-orchestration concern, not an IR
> concern. References: Vekris/Cosman/Jhala (PLDI 2016, IR
> separation); Kroening & Strichman (Decision Procedures Ch. 4 EUF,
> Ch. 8 records); Peyton Jones & Marlow (JFP 2002, Barendregt
> hygiene); Jackson (Software Abstractions, Alloy `lone`
> multiplicity); Baader & Nipkow (Term Rewriting, Ch. 2
> substitution).

Fixture.
Document.
DepModule.
DepBundle.
DepKind.
FixtureStatus.
CheckResult.

passes-typecheck => FixtureStatus.
skipped-unsupported => FixtureStatus.
in-known-failures => FixtureStatus.

builtin-dep => DepKind.
ambient-dep => DepKind.
tuple-ctor-dep => DepKind.

ok => CheckResult.
error-msg => CheckResult.

status f: Fixture => FixtureStatus.
intentional? f: Fixture => Bool.
emitted f: Fixture => Document.
dep-modules f: Fixture => [DepModule].
imports-of d: Document => [String].

contains-dollar? d: Document => Bool.
uses-keyword-as-name? d: Document => Bool.
imports-resolved? d: Document, deps: [DepModule] => Bool.

kind m: DepModule => DepKind.
emits-typechecking-text? m: DepModule => Bool.

is-screaming-snake? n: String => Bool.
module-name-of d: Document => String.

bundle-of f: Fixture => DepBundle.
resolved-bundle? d: Document, b: DepBundle => Bool.
check-bundle d: Document, b: DepBundle => CheckResult.

---
> Every fixture that remains in KNOWN_TYPECHECK_FAILURES is intentional.
all f: Fixture, status f = in-known-failures | intentional? f.

> No emitted document contains a `$` character (binder hygiene).
all f: Fixture | ~(contains-dollar? (emitted f)).

> No emitted document uses a Pant reserved keyword as a rule name.
all f: Fixture | ~(uses-keyword-as-name? (emitted f)).

> Every emitted document's module name is ALL_CAPS_SNAKE.
all f: Fixture | is-screaming-snake? (module-name-of (emitted f)).

> Imports in passing-fixture emitted documents resolve against
> the dep modules attached to the fixture's bundle.
all f: Fixture, status f = passes-typecheck
  | imports-resolved? (emitted f) (dep-modules f).

> The wasm bundle-check succeeds only if every import resolves.
all d: Document, b: DepBundle, check-bundle d b = ok | resolved-bundle? d b.

> Every dep module emits text that typechecks standalone.
all m: DepModule | emits-typechecking-text? m.

```

## Patch Specification

```
module KNOWN_FAILURES_PATCH_3.

> Patch 3 introduces the hand-written js-stdlib `.pant` files and a
> TS dispatch index. The dep modules ARE Pantagruel — typecheck-
> verified by `pant` itself in CI. The TS side carries only the
> surface-form-to-qualified-rule mapping. Reference: Kroening &
> Strichman, Decision Procedures Ch. 4 (EUF semantics, congruence
> as the only axiom for opaque calls).

BuiltinKey.
DepModule.
js-math-mod => DepModule.
js-string-mod => DepModule.

rule-name k: BuiltinKey => String.
owning-module k: BuiltinKey => DepModule.
arity k: BuiltinKey => Nat0.
has-source-file? m: DepModule => Bool.

---
> Every builtin dep module is backed by a hand-written .pant file.
all m: DepModule | has-source-file? m.

```


## Implementation Notes
### Deviation from gameplan literal text — qualified-name strings

The gameplan specifies `math::max`-style strings for the BUILTINS dispatch values and embedded inside the hand-written `.pant` files. Two facts about the Pant grammar make those strings impossible to honor literally today:

1. **Qualifier must be `UPPER_IDENT`.** `parser.mly` only accepts `UPPER_IDENT DCOLON LOWER_IDENT` for `EQualified`, so `math::max` (lowercase qualifier) does not parse.
2. **`max` is a reserved keyword.** `lexer.ml`'s `keyword_or_lower_ident` always returns `Parser.MAX` for the literal `max`, so it can never appear as a `LOWER_IDENT` rule name.

The gameplan invariant *"Every dep module emits text that typechecks standalone"* (THE GUARANTEE block) is non-negotiable, so the `.pant` files have to use names that actually parse today. I picked the minimum-deviation scheme:

| Surface form | BUILTINS `rule` | Pant rule decl |
|---|---|---|
| `Math.max` | `JS_MATH::max-of` | `max-of a: Int, b: Int => Int.` |
| `Math.abs` | `JS_MATH::abs` | `abs x: Int => Int.` |
| `String.prototype.toUpperCase` | `JS_STRING::to-upper-case` | `to-upper-case s: String => String.` |
| `String.prototype.indexOf` | `JS_STRING::index-of` | `index-of s: String, t: String => Int.` |

`-of` suffix only where the natural name (`max`) collides with a reserved token; everything else is the natural kebab-cased form. Patches 7 (keyword sanitisation) and 11 (wiring) own the integration with downstream consumers and can adjust the dispatch strings if a different convention wins out.

### Symbol-based dispatch implementation

`lookupBuiltinByCall` resolves via `checker.getSymbolAtLocation` exactly as specified, but the two namespaces dispatch on different symbol positions:

- **Math.* :** symbol of the *receiver* identifier (`Math`). Accepted iff at least one declaration sits in a `.d.ts` lib file (`isLibSymbol`). Catches user-shadowed `const Math = …` because that symbol's declarations are in the user source.
- **String.prototype.* :** symbol of the *method* identifier (`toUpperCase` etc.). Accepted iff a declaration's parent is the lib `interface String { … }`. Receiver-symbol matching wouldn't work here — string variables don't expose the `String` interface as a symbol you can look up by name.

`array.indexOf(x)` correctly does not match (the method's parent is `Array`, not `String`); `Math.random()` correctly does not match (no entry in `BUILTINS`). Both negative cases are covered by tests.

### CI verification — wired on both sides

The gameplan's "no additional test wiring needed" claim doesn't quite hold: `test/test_smt_invariants.ml`'s `pant_files` calls `Sys.readdir dir` (non-recursive) and only enumerates the top-level `samples/` directory, so `samples/js-stdlib/` would not be discovered by default. Two complementary fixes land in this PR:

- **OCaml side** (commit `ff778d8`): added a `js_stdlib_dir` `find_dir` block mirroring the existing `samples/smt-examples/` block in `test_smt_invariants.ml`, so the new files run through the full translator + `Smt_check` structural-invariants pass on every `dune test`. Without this the modules were only typechecked at the parse+collect+check level, not the SMT translation level.
- **ts2pant unit side** (commit `f860aef`): `tests/builtins.test.mts` runs `assertWasmTypeChecks(loadBuiltinDepModule(name))` for each module, exercising the embedded wasm `checkDocument` — the same passes the `pant` CLI runs in default mode. This is the path that satisfies the spec invariant `emits-typechecking-text? m` directly from JS without depending on the OCaml suite.
