### PR TITLE
[ts2pant-known-failures] Patch 7: Pant reserved keyword sanitisation in name registry

### DIFF
--- a/tools/ts2pant/src/name-registry.ts
+++ b/tools/ts2pant/src/name-registry.ts
@@ -14,6 +14,34 @@ export interface NameRegistry {
   readonly used: ReadonlySet<string>;
 }
 
+/**
+ * Pant reserved keywords (mirrors lib/lexer.ml:101-122). A registered name
+ * matching any of these collides with the language grammar — sanitise by
+ * routing through the same numeric-suffix loop used for name collisions.
+ */
+const PANT_RESERVED_KEYWORDS = new Set<string>([
+  "module",
+  "import",
+  "where",
+  "true",
+  "false",
+  "and",
+  "or",
+  "all",
+  "some",
+  "each",
+  "in",
+  "subset",
+  "context",
+  "initially",
+  "closure",
+  "cond",
+  "over",
+  "min",
+  "max",
+  "check",
+]);
+
 export function emptyNameRegistry(): NameRegistry {
   return { used: new Set() };
 }
@@ -24,14 +52,16 @@ export function isUsed(registry: NameRegistry, name: string): boolean {
 }
 
 /**
- * Register a name. If already used, appends numeric suffixes (1, 2, ...)
- * until unique. Returns the chosen name and the updated registry.
+ * Register a name. If already used or a Pant reserved keyword, appends
+ * numeric suffixes (1, 2, ...) until unique. Returns the chosen name and
+ * the updated registry.
  */
 export function registerName(
   registry: NameRegistry,
   name: string,
 ): { name: string; registry: NameRegistry } {
-  if (!registry.used.has(name)) {
+  const isReserved = PANT_RESERVED_KEYWORDS.has(name);
+  if (!isReserved && !registry.used.has(name)) {
     const used = new Set(registry.used);
     used.add(name);
     return { name, registry: { used } };

--- a/tools/ts2pant/tests/name-registry.test.mts
+++ b/tools/ts2pant/tests/name-registry.test.mts
@@ -1,9 +1,30 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import {
   emptyNameRegistry,
   registerName,
 } from "../src/name-registry.js";
+
+/**
+ * Read the canonical reserved-keyword list from `lib/lexer.ml` so the test
+ * fails if the lexer adds or removes a keyword without a matching update
+ * to `PANT_RESERVED_KEYWORDS` in `name-registry.ts`. The lexer dispatches
+ * keywords through lines like `| "module" -> Parser.MODULE`. The same
+ * shape appears for symbolic operators (`"---"`, `"=>"`, `"::"`, ...) so
+ * we filter to alphabetic identifiers — the universe `name-registry`
+ * cares about, since symbolic strings can't be registered as TS names.
+ */
+function lexerReservedKeywords(): string[] {
+  const lexerPath = resolve(import.meta.dirname, "../../../lib/lexer.ml");
+  const src = readFileSync(lexerPath, "utf8");
+  const keywords = Array.from(
+    src.matchAll(/\|\s*"([^"]+)"\s*->\s*Parser\.[A-Z_]+/g),
+    (m) => m[1],
+  ).filter((s) => /^[a-z]+$/.test(s));
+  return keywords;
+}
 
 describe("name-registry", () => {
   it("registerName('max') returns 'max1'", () => {
@@ -46,29 +67,12 @@ describe("name-registry", () => {
     assert.equal(d.name, "foo");
   });
 
-  it("sanitises every reserved keyword", () => {
-    const reserved = [
-      "module",
-      "import",
-      "where",
-      "true",
-      "false",
-      "and",
-      "or",
-      "all",
-      "some",
-      "each",
-      "in",
-      "subset",
-      "context",
-      "initially",
-      "closure",
-      "cond",
-      "over",
-      "min",
-      "max",
-      "check",
-    ];
+  it("sanitises every reserved keyword (derived from lib/lexer.ml)", () => {
+    const reserved = lexerReservedKeywords();
+    assert.ok(
+      reserved.length > 0,
+      "expected lexer keyword list to be non-empty",
+    );
     for (const kw of reserved) {
       const { name } = registerName(emptyNameRegistry(), kw);
       assert.equal(name, `${kw}1`, `expected '${kw}' to sanitise to '${kw}1'`);

--- a/tools/ts2pant/tests/name-registry.test.mts
+++ b/tools/ts2pant/tests/name-registry.test.mts
@@ -1,0 +1,77 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  emptyNameRegistry,
+  registerName,
+} from "../src/name-registry.js";
+
+describe("name-registry", () => {
+  it("registerName('max') returns 'max1'", () => {
+    const r0 = emptyNameRegistry();
+    const { name, registry } = registerName(r0, "max");
+    assert.equal(name, "max1");
+    assert.ok(registry.used.has("max1"));
+    assert.ok(!registry.used.has("max"));
+  });
+
+  it("registerName('and') returns 'and1'", () => {
+    const r0 = emptyNameRegistry();
+    const { name } = registerName(r0, "and");
+    assert.equal(name, "and1");
+  });
+
+  it("registerName('foo') returns 'foo' (no sanitisation when not a keyword)", () => {
+    const r0 = emptyNameRegistry();
+    const { name, registry } = registerName(r0, "foo");
+    assert.equal(name, "foo");
+    assert.ok(registry.used.has("foo"));
+  });
+
+  it("registerName sanitises keyword + handles collision interleaving", () => {
+    let registry = emptyNameRegistry();
+
+    const a = registerName(registry, "max");
+    assert.equal(a.name, "max1");
+    registry = a.registry;
+
+    const b = registerName(registry, "max");
+    assert.equal(b.name, "max2");
+    registry = b.registry;
+
+    const c = registerName(registry, "max1");
+    assert.equal(c.name, "max11");
+    registry = c.registry;
+
+    const d = registerName(registry, "foo");
+    assert.equal(d.name, "foo");
+  });
+
+  it("sanitises every reserved keyword", () => {
+    const reserved = [
+      "module",
+      "import",
+      "where",
+      "true",
+      "false",
+      "and",
+      "or",
+      "all",
+      "some",
+      "each",
+      "in",
+      "subset",
+      "context",
+      "initially",
+      "closure",
+      "cond",
+      "over",
+      "min",
+      "max",
+      "check",
+    ];
+    for (const kw of reserved) {
+      const { name } = registerName(emptyNameRegistry(), kw);
+      assert.equal(name, `${kw}1`, `expected '${kw}' to sanitise to '${kw}1'`);
+    }
+  });
+});


### PR DESCRIPTION
## Patch 7: Pant reserved keyword sanitisation in name registry

- Add `const PANT_RESERVED_KEYWORDS = new Set<string>(['module','import','where','true','false','and','or','all','some','each','in','subset','context','initially','closure','cond','over','min','max','check'])` mirroring lib/lexer.ml:101–122.
- In registerName(registry, baseName): if baseName is in PANT_RESERVED_KEYWORDS, treat it the same as a collision — start the suffix loop at `${baseName}1`. The collision suffix loop already exists; the keyword check just gates the entry condition.
- Apply uniformly: function names, parameter names, binder names. A user param named `each` would also be sanitised.

## Changes
- Add `const PANT_RESERVED_KEYWORDS = new Set<string>(['module','import','where','true','false','and','or','all','some','each','in','subset','context','initially','closure','cond','over','min','max','check'])` mirroring lib/lexer.ml:101–122.
- In registerName(registry, baseName): if baseName is in PANT_RESERVED_KEYWORDS, treat it the same as a collision — start the suffix loop at `${baseName}1`. The collision suffix loop already exists; the keyword check just gates the entry condition.
- Apply uniformly: function names, parameter names, binder names. A user param named `each` would also be sanitised.

## Files to Modify
- tools/ts2pant/src/name-registry.ts (modify): Add PANT_RESERVED_KEYWORDS set; treat keyword hits as collisions when registering names.

## Gameplan Specification

```
module KNOWN_FAILURES.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> After this gameplan, KNOWN_TYPECHECK_FAILURES contains exactly
> the two intentional class-method entries. Every other fixture in
> tools/ts2pant/tests/fixtures/constructs/ either typechecks via
> the wasm bridge or routes through the UNSUPPORTED-skip path. The
> wasm bridge resolves cross-module imports against an in-memory
> registry, matching the `pant` CLI's import semantics exactly.
>
> Dependency rules emit as standalone Pantagruel modules — hand-
> written `samples/js-stdlib/JS_MATH.pant` / `JS_STRING.pant` for
> TS standard-library builtins (Math.*, String.prototype.*); per-
> source-file synthesised `<FILE_BASE_NAME>_AMBIENT` for user
> `declare function`s; per-source-file `<FILE_BASE_NAME>_TUPLES` for
> anonymous tuple constructors. Consumer modules import them via
> `import` lines and reference qualified rules (`math::max`).
> Every emitted module name uses ALL_CAPS_SNAKE convention,
> matching the existing `samples/*.pant` corpus.
> No emitted Pant text contains `$` (binder hygiene); no emitted
> rule name is a Pant reserved keyword (sanitisation).
>
> The translation pipeline preserves CLAUDE.md's L1/L2 IR layering:
> builtin / ambient / tuple registration is an L1 concern (TS-shape
> recognition); qualified-name lowering and module-text emission
> are L2 → OpaqueExpr concerns. dep-module attachment to
> PantDocument is a pipeline-orchestration concern, not an IR
> concern. References: Vekris/Cosman/Jhala (PLDI 2016, IR
> separation); Kroening & Strichman (Decision Procedures Ch. 4 EUF,
> Ch. 8 records); Peyton Jones & Marlow (JFP 2002, Barendregt
> hygiene); Jackson (Software Abstractions, Alloy `lone`
> multiplicity); Baader & Nipkow (Term Rewriting, Ch. 2
> substitution).

Fixture.
Document.
DepModule.
DepBundle.
DepKind.
FixtureStatus.
CheckResult.

passes-typecheck => FixtureStatus.
skipped-unsupported => FixtureStatus.
in-known-failures => FixtureStatus.

builtin-dep => DepKind.
ambient-dep => DepKind.
tuple-ctor-dep => DepKind.

ok => CheckResult.
error-msg => CheckResult.

status f: Fixture => FixtureStatus.
intentional? f: Fixture => Bool.
emitted f: Fixture => Document.
dep-modules f: Fixture => [DepModule].
imports-of d: Document => [String].

contains-dollar? d: Document => Bool.
uses-keyword-as-name? d: Document => Bool.
imports-resolved? d: Document, deps: [DepModule] => Bool.

kind m: DepModule => DepKind.
emits-typechecking-text? m: DepModule => Bool.

is-screaming-snake? n: String => Bool.
module-name-of d: Document => String.

bundle-of f: Fixture => DepBundle.
resolved-bundle? d: Document, b: DepBundle => Bool.
check-bundle d: Document, b: DepBundle => CheckResult.

---
> Every fixture that remains in KNOWN_TYPECHECK_FAILURES is intentional.
all f: Fixture, status f = in-known-failures | intentional? f.

> No emitted document contains a `$` character (binder hygiene).
all f: Fixture | ~(contains-dollar? (emitted f)).

> No emitted document uses a Pant reserved keyword as a rule name.
all f: Fixture | ~(uses-keyword-as-name? (emitted f)).

> Every emitted document's module name is ALL_CAPS_SNAKE.
all f: Fixture | is-screaming-snake? (module-name-of (emitted f)).

> Imports in passing-fixture emitted documents resolve against
> the dep modules attached to the fixture's bundle.
all f: Fixture, status f = passes-typecheck
  | imports-resolved? (emitted f) (dep-modules f).

> The wasm bundle-check succeeds only if every import resolves.
all d: Document, b: DepBundle, check-bundle d b = ok | resolved-bundle? d b.

> Every dep module emits text that typechecks standalone.
all m: DepModule | emits-typechecking-text? m.

```

## Patch Specification

```
module KNOWN_FAILURES_PATCH_7.

> Patch 7: no emitted Pant identifier coincides with a reserved
> keyword. Routed through the existing NameRegistry collision
> mechanism; keyword-sanitisation is a special case of collision.

NameRegistry.
Name.
reserved? n: Name => Bool.
register r: NameRegistry, n: Name => Name.

---
> Registered names are never reserved keywords.
all r: NameRegistry, n: Name | ~(reserved? (register r n)).

```


## Implementation Notes

- Implementation matches the plan exactly: a 20-element `PANT_RESERVED_KEYWORDS` set gates the entry condition of the existing collision suffix loop, so a reserved baseName produces `${name}1` (or `${name}2`, `${name}3`, … on further collisions) without changing the loop body.
- Added `tests/name-registry.test.mts` with the four stub cases plus an exhaustive sweep asserting every keyword in the set sanitises to `${kw}1`. The sweep keeps the test list aligned with the source set if either drifts.
- The `name1` form is itself not registered until it's actually returned, so a later `registerName('max1')` would treat `max1` as a fresh non-reserved name and return it as-is. This matches the "keyword-sanitisation is a special case of collision" framing in the spec — the keyword check only gates the *initial* lookup, not the suffix-form lookups.
- Pre-commit hook surfaced one pre-existing biome warning in `ir1-lower.ts:214` (unrelated to this patch); the hook still passed and committed cleanly.
- This is an INFRA patch — it does not, on its own, fix any KNOWN_TYPECHECK_FAILURES entries. Patch 9 (the hygiene + sanitisation behavior patch) consumes this primitive at every emit-bound site.