### PR TITLE
[ts2pant-known-failures] Patch 8: Fix `rangeCheck` annotation in fixture

### DIFF
--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -11,7 +11,7 @@ exports[`annotations.ts > noAnnot 1`] = `
 `;
 
 exports[`annotations.ts > rangeCheck 1`] = `
-"module RangeCheck.\\n\\nrange-check x: Int => Bool.\\n\\n---\\n\\nrange-check x = (x >= 0).\\n\\ncheck\\n\\nall x: Int | range-check x >= 0.\\n"
+"module RangeCheck.\\n\\nrange-check x: Int => Bool.\\n\\n---\\n\\nrange-check x = (x >= 0).\\n\\ncheck\\n\\nall x: Int, x >= 0 | range-check x.\\n"
 `;
 
 exports[`annotations.ts > sum 1`] = `

--- a/tools/ts2pant/tests/fixtures/constructs/annotations.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/annotations.ts
@@ -20,8 +20,8 @@ export function sum(a: number, b: number): number {
 /**
  * Multi-line annotation block.
  * @pant-begin
- * all x: Int |
- *   rangeCheck x >= 0
+ * all x: Int, x >= 0 |
+ *   rangeCheck x
  * @pant-end
  */
 export function rangeCheck(x: number): boolean {


### PR DESCRIPTION
## Patch 8: Fix `rangeCheck` annotation in fixture

- Change the `@pant-begin` block from `all x: Int |\n  rangeCheck x >= 0` to `all x: Int, x >= 0 |\n  rangeCheck x` — a Bool postcondition asserting that range-check returns true for non-negative inputs (entailed by the body `x >= 0`).
- Update the snapshot for `annotations.ts > rangeCheck` to match (snapshot will now also include this fixture in the wasm-typecheck path; it leaves KNOWN_TYPECHECK_FAILURES in patch 12).

## Changes
- Change the `@pant-begin` block from `all x: Int |\n  rangeCheck x >= 0` to `all x: Int, x >= 0 |\n  rangeCheck x` — a Bool postcondition asserting that range-check returns true for non-negative inputs (entailed by the body `x >= 0`).
- Update the snapshot for `annotations.ts > rangeCheck` to match (snapshot will now also include this fixture in the wasm-typecheck path; it leaves KNOWN_TYPECHECK_FAILURES in patch 12).

## Files to Modify
- tools/ts2pant/tests/fixtures/constructs/annotations.ts (modify): Replace ill-typed annotation with a typed postcondition.

## Gameplan Specification

```
module KNOWN_FAILURES.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> After this gameplan, KNOWN_TYPECHECK_FAILURES contains exactly
> the two intentional class-method entries. Every other fixture in
> tools/ts2pant/tests/fixtures/constructs/ either typechecks via
> the wasm bridge or routes through the UNSUPPORTED-skip path. The
> wasm bridge resolves cross-module imports against an in-memory
> registry, matching the `pant` CLI's import semantics exactly.
>
> Dependency rules emit as standalone Pantagruel modules — hand-
> written `samples/js-stdlib/JS_MATH.pant` / `JS_STRING.pant` for
> TS standard-library builtins (Math.*, String.prototype.*); per-
> source-file synthesised `<FILE_BASE_NAME>_AMBIENT` for user
> `declare function`s; per-source-file `<FILE_BASE_NAME>_TUPLES` for
> anonymous tuple constructors. Consumer modules import them via
> `import` lines and reference qualified rules (`math::max`).
> Every emitted module name uses ALL_CAPS_SNAKE convention,
> matching the existing `samples/*.pant` corpus.
> No emitted Pant text contains `$` (binder hygiene); no emitted
> rule name is a Pant reserved keyword (sanitisation).
>
> The translation pipeline preserves CLAUDE.md's L1/L2 IR layering:
> builtin / ambient / tuple registration is an L1 concern (TS-shape
> recognition); qualified-name lowering and module-text emission
> are L2 → OpaqueExpr concerns. dep-module attachment to
> PantDocument is a pipeline-orchestration concern, not an IR
> concern. References: Vekris/Cosman/Jhala (PLDI 2016, IR
> separation); Kroening & Strichman (Decision Procedures Ch. 4 EUF,
> Ch. 8 records); Peyton Jones & Marlow (JFP 2002, Barendregt
> hygiene); Jackson (Software Abstractions, Alloy `lone`
> multiplicity); Baader & Nipkow (Term Rewriting, Ch. 2
> substitution).

Fixture.
Document.
DepModule.
DepBundle.
DepKind.
FixtureStatus.
CheckResult.

passes-typecheck => FixtureStatus.
skipped-unsupported => FixtureStatus.
in-known-failures => FixtureStatus.

builtin-dep => DepKind.
ambient-dep => DepKind.
tuple-ctor-dep => DepKind.

ok => CheckResult.
error-msg => CheckResult.

status f: Fixture => FixtureStatus.
intentional? f: Fixture => Bool.
emitted f: Fixture => Document.
dep-modules f: Fixture => [DepModule].
imports-of d: Document => [String].

contains-dollar? d: Document => Bool.
uses-keyword-as-name? d: Document => Bool.
imports-resolved? d: Document, deps: [DepModule] => Bool.

kind m: DepModule => DepKind.
emits-typechecking-text? m: DepModule => Bool.

is-screaming-snake? n: String => Bool.
module-name-of d: Document => String.

bundle-of f: Fixture => DepBundle.
resolved-bundle? d: Document, b: DepBundle => Bool.
check-bundle d: Document, b: DepBundle => CheckResult.

---
> Every fixture that remains in KNOWN_TYPECHECK_FAILURES is intentional.
all f: Fixture, status f = in-known-failures | intentional? f.

> No emitted document contains a `$` character (binder hygiene).
all f: Fixture | ~(contains-dollar? (emitted f)).

> No emitted document uses a Pant reserved keyword as a rule name.
all f: Fixture | ~(uses-keyword-as-name? (emitted f)).

> Every emitted document's module name is ALL_CAPS_SNAKE.
all f: Fixture | is-screaming-snake? (module-name-of (emitted f)).

> Imports in passing-fixture emitted documents resolve against
> the dep modules attached to the fixture's bundle.
all f: Fixture, status f = passes-typecheck
  | imports-resolved? (emitted f) (dep-modules f).

> The wasm bundle-check succeeds only if every import resolves.
all d: Document, b: DepBundle, check-bundle d b = ok | resolved-bundle? d b.

> Every dep module emits text that typechecks standalone.
all m: DepModule | emits-typechecking-text? m.

```

## Patch Specification

```
module KNOWN_FAILURES_PATCH_8.

> Patch 8 fixes the rangeCheck fixture's annotation so the
> annotation entailment is well-typed against the emitted signature.

Fixture.
range-check-fixture => Fixture.
annotation-typechecks? f: Fixture => Bool.

---
> The rangeCheck fixture's annotation typechecks.
annotation-typechecks? range-check-fixture.

```


## Implementation Notes

Straightforward two-line edit — fixture annotation + matching snapshot. No deviations from the gameplan; all 650 unit tests pass.

- The original annotation `all x: Int | rangeCheck x >= 0` was ill-typed because `range-check x` returns `Bool`, and `Bool >= Int` is not well-typed in Pantagruel. The replacement `all x: Int, x >= 0 | range-check x` shifts `x >= 0` from a comparison-against-result into a guard, leaving a Bool postcondition that is directly entailed by the body `return x >= 0`.
- The patch only touches the fixture and snapshot; the `KNOWN_TYPECHECK_FAILURES` entry for `annotations.ts > rangeCheck` is intentionally left in place and is removed in patch 12 alongside the rest of the prune.