### PR TITLE
[ts2pant-known-failures] Patch 9: Hygiene fixes: $-binder leak (5 sites) + keyword sanitisation

### DIFF
--- a/tools/ts2pant/src/ir-build.ts
+++ b/tools/ts2pant/src/ir-build.ts
@@ -36,9 +36,9 @@ import {
 } from "./ir1-build.js";
 import { lowerL1Expr } from "./ir1-lower.js";
 import {
+  allocComprehensionBinder,
   ambiguousFieldMsg,
   bodyExpr,
-  freshHygienicBinder,
   isBodyUnsupported,
   isNullableTsType,
   qualifyFieldAccess,
@@ -165,7 +165,7 @@ export function buildIR(
         if (isBuildUnsupported(innerIR)) {
           return innerIR;
         }
-        const binderName = freshHygienicBinder(supply);
+        const binderName = allocComprehensionBinder(supply, "n");
         return irEach(
           binderName,
           innerIR,

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -3269,15 +3269,14 @@ function translateArrayMethod(
 
   const pending = receiver.pendingComprehension;
   const isComposing = pending !== undefined;
-  // Comprehension binders allocated through the document-wide name registry
-  // (when a synthCell is plumbed through) so they round-trip through Pant's
-  // parser and stay collision-free against user params and accessor rules.
-  // See `allocComprehensionBinder` and PR #84 post-mortem in CLAUDE.md.
+  // Binders that survive into emitted comprehensions go through the
+  // document-wide registry. In composing paths, callback-only binders are
+  // substituted away before emission and should stay hygienic.
   const sourceBinder = isComposing
     ? pending.binder
     : allocComprehensionBinder(supply, "x");
   const callbackBinder = isComposing
-    ? allocComprehensionBinder(supply, "x")
+    ? freshHygienicBinder(supply)
     : sourceBinder;
   const extendedParams = new Map(paramNames);
   extendedParams.set(callbackBinder, callbackBinder);
@@ -3468,11 +3467,11 @@ function translateReduceCall(
   }
 
   const pending = receiver.pendingComprehension;
-  // Comprehension binder for the callback's `x`; in the composing case we'll
-  // substitute it away with the prior projection so the outer guard binds
-  // `pending.binder`. Routes through `allocComprehensionBinder` so the name
-  // is parser-roundtrippable when a synthCell is in scope.
-  const xBinder = allocComprehensionBinder(supply, "x");
+  // In the composing case, the callback's `x` is substituted away with the
+  // prior projection, so it should not reserve a public registry name.
+  const xBinder = pending
+    ? freshHygienicBinder(supply)
+    : allocComprehensionBinder(supply, "x");
   const extendedParams = new Map(paramNames);
   extendedParams.set(xName, xBinder);
 

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -111,13 +111,10 @@ export function freshHygienicBinder(supply: UniqueSupply): string {
 }
 
 /**
- * Allocate a parser-roundtrippable comprehension binder. When a synthCell
- * is plumbed through (the normal pipeline), routes through `cellRegisterName`
- * so the name is collision-safe against the document-wide `NameRegistry`
- * and emits as a real Pant identifier (`hint`, `hint1`, …). Standalone
- * test paths without a synthCell fall back to `freshHygienicBinder`'s
- * `$N` form, which the parser rejects but is acceptable in unit tests
- * that assert on substituted output.
+ * Allocate a parser-roundtrippable comprehension binder through
+ * `cellRegisterName`, so the name is collision-safe against the
+ * document-wide `NameRegistry` and emits as a real Pant identifier
+ * (`hint`, `hint1`, …).
  *
  * Use this — not `freshHygienicBinder` directly — at any site that emits
  * a binder into a quantifier or comprehension that survives to Pant text.
@@ -127,9 +124,12 @@ export function allocComprehensionBinder(
   supply: UniqueSupply,
   hint: string,
 ): string {
-  return supply.synthCell
-    ? cellRegisterName(supply.synthCell, hint)
-    : freshHygienicBinder(supply);
+  if (!supply.synthCell) {
+    throw new Error(
+      "allocComprehensionBinder requires synthCell for emitted binders",
+    );
+  }
+  return cellRegisterName(supply.synthCell, hint);
 }
 
 /**

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -111,6 +111,28 @@ export function freshHygienicBinder(supply: UniqueSupply): string {
 }
 
 /**
+ * Allocate a parser-roundtrippable comprehension binder. When a synthCell
+ * is plumbed through (the normal pipeline), routes through `cellRegisterName`
+ * so the name is collision-safe against the document-wide `NameRegistry`
+ * and emits as a real Pant identifier (`hint`, `hint1`, …). Standalone
+ * test paths without a synthCell fall back to `freshHygienicBinder`'s
+ * `$N` form, which the parser rejects but is acceptable in unit tests
+ * that assert on substituted output.
+ *
+ * Use this — not `freshHygienicBinder` directly — at any site that emits
+ * a binder into a quantifier or comprehension that survives to Pant text.
+ * See PR #84 post-mortem in `CLAUDE.md` for the bug class this prevents.
+ */
+export function allocComprehensionBinder(
+  supply: UniqueSupply,
+  hint: string,
+): string {
+  return supply.synthCell
+    ? cellRegisterName(supply.synthCell, hint)
+    : freshHygienicBinder(supply);
+}
+
+/**
  * True when a TypeScript type includes `null`, `undefined`, or `void` —
  * i.e., when `mapTsType` will list-lift it to `[T]`. Used at `??` and `?.`
  * sites to decide whether the receiver needs the cardinality-based lowering
@@ -2899,7 +2921,7 @@ export function translateBodyExpr(
         if (ruleName === null) {
           return { unsupported: ambiguousFieldMsg(prop) };
         }
-        const binderName = freshHygienicBinder(supply);
+        const binderName = allocComprehensionBinder(supply, "n");
         return {
           expr: ast.each(
             [],
@@ -3247,14 +3269,15 @@ function translateArrayMethod(
 
   const pending = receiver.pendingComprehension;
   const isComposing = pending !== undefined;
-  // Hygienic `$N` binders (Barendregt convention): they cannot clash with
-  // user-visible identifiers or with other fresh binders from the same
-  // translation session.
+  // Comprehension binders allocated through the document-wide name registry
+  // (when a synthCell is plumbed through) so they round-trip through Pant's
+  // parser and stay collision-free against user params and accessor rules.
+  // See `allocComprehensionBinder` and PR #84 post-mortem in CLAUDE.md.
   const sourceBinder = isComposing
     ? pending.binder
-    : freshHygienicBinder(supply);
+    : allocComprehensionBinder(supply, "x");
   const callbackBinder = isComposing
-    ? freshHygienicBinder(supply)
+    ? allocComprehensionBinder(supply, "x")
     : sourceBinder;
   const extendedParams = new Map(paramNames);
   extendedParams.set(callbackBinder, callbackBinder);
@@ -3445,10 +3468,11 @@ function translateReduceCall(
   }
 
   const pending = receiver.pendingComprehension;
-  // Hygienic `$N` binder for the callback's `x`; in the composing case we'll
+  // Comprehension binder for the callback's `x`; in the composing case we'll
   // substitute it away with the prior projection so the outer guard binds
-  // `pending.binder`.
-  const xBinder = freshHygienicBinder(supply);
+  // `pending.binder`. Routes through `allocComprehensionBinder` so the name
+  // is parser-roundtrippable when a synthCell is in scope.
+  const xBinder = allocComprehensionBinder(supply, "x");
   const extendedParams = new Map(paramNames);
   extendedParams.set(xName, xBinder);
 
@@ -4275,7 +4299,7 @@ function translateMutatingBody(
   // internal `freshHygienicBinder` which emits `$N` names that don't
   // round-trip through the Pantagruel parser.
   const allocBinder = (hint: string): string =>
-    synthCell ? cellRegisterName(synthCell, hint) : freshHygienicBinder(supply);
+    allocComprehensionBinder(supply, hint);
   for (const [, entry] of state.writes) {
     switch (entry.kind) {
       case "property":

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -63,7 +63,7 @@ exports[`expressions-arithmetic.ts > remainder 1`] = `
 `;
 
 exports[`expressions-array.ts > activeNames 1`] = `
-"module ActiveNames.\\n\\nUser.\\nuser--name u: User => String.\\nuser--active u: User => Bool.\\nuser--score u: User => Int.\\nactive-names users: [User] => [String].\\n\\n---\\n\\nactive-names users = (each $0 in users, user--active $0 | user--name $0).\\n"
+"module ActiveNames.\\n\\nUser.\\nuser--name u: User => String.\\nuser--active u: User => Bool.\\nuser--score u: User => Int.\\nactive-names users: [User] => [String].\\n\\n---\\n\\nactive-names users = (each x in users, user--active x | user--name x).\\n"
 `;
 
 exports[`expressions-array.ts > contains 1`] = `
@@ -75,11 +75,11 @@ exports[`expressions-array.ts > count 1`] = `
 `;
 
 exports[`expressions-array.ts > highScores 1`] = `
-"module HighScores.\\n\\nUser.\\nuser--name u: User => String.\\nuser--active u: User => Bool.\\nuser--score u: User => Int.\\nhigh-scores users: [User] => [Int].\\n\\n---\\n\\nhigh-scores users = (each $0 in users, user--score $0 > 0 | user--score $0).\\n"
+"module HighScores.\\n\\nUser.\\nuser--name u: User => String.\\nuser--active u: User => Bool.\\nuser--score u: User => Int.\\nhigh-scores users: [User] => [Int].\\n\\n---\\n\\nhigh-scores users = (each x in users, user--score x > 0 | user--score x).\\n"
 `;
 
 exports[`expressions-array.ts > nameLengths 1`] = `
-"module NameLengths.\\n\\nUser.\\nuser--name u: User => String.\\nuser--active u: User => Bool.\\nuser--score u: User => Int.\\nname-lengths users: [User] => [Int].\\n\\n---\\n\\nname-lengths users = (each $0 in users | length (user--name $0)).\\n"
+"module NameLengths.\\n\\nUser.\\nuser--name u: User => String.\\nuser--active u: User => Bool.\\nuser--score u: User => Int.\\nname-lengths users: [User] => [Int].\\n\\n---\\n\\nname-lengths users = (each x in users | length (user--name x)).\\n"
 `;
 
 exports[`expressions-boolean.ts > and 1`] = `
@@ -475,15 +475,15 @@ exports[`expressions-nullish.ts > defaultToZero 1`] = `
 `;
 
 exports[`expressions-nullish.ts > maybeBalance 1`] = `
-"module MaybeBalance.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--owner a1: Account => Owner.\\nOwner.\\nowner--id o: Owner => Int.\\nmaybe-balance a: [Account] => [Int].\\n\\n---\\n\\nmaybe-balance a = (each $0 in a | account--balance $0).\\n"
+"module MaybeBalance.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--owner a1: Account => Owner.\\nOwner.\\nowner--id o: Owner => Int.\\nmaybe-balance a: [Account] => [Int].\\n\\n---\\n\\nmaybe-balance a = (each n in a | account--balance n).\\n"
 `;
 
 exports[`expressions-nullish.ts > maybeOwnerId 1`] = `
-"module MaybeOwnerId.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--owner a1: Account => Owner.\\nOwner.\\nowner--id o: Owner => Int.\\nmaybe-owner-id a: [Account] => [Int].\\n\\n---\\n\\nmaybe-owner-id a = (each $1 in (each $0 in a | account--owner $0) | owner--id $1).\\n"
+"module MaybeOwnerId.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--owner a1: Account => Owner.\\nOwner.\\nowner--id o: Owner => Int.\\nmaybe-owner-id a: [Account] => [Int].\\n\\n---\\n\\nmaybe-owner-id a = (each n1 in (each n in a | account--owner n) | owner--id n1).\\n"
 `;
 
 exports[`expressions-nullish.ts > maybeOwnerIdOptional 1`] = `
-"module MaybeOwnerIdOptional.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--owner a1: Account => Owner.\\nOwner.\\nowner--id o: Owner => Int.\\nmaybe-owner-id-optional a: [Account] => [Int].\\n\\n---\\n\\nmaybe-owner-id-optional a = (each $1 in (each $0 in a | account--owner $0) | owner--id $1).\\n"
+"module MaybeOwnerIdOptional.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--owner a1: Account => Owner.\\nOwner.\\nowner--id o: Owner => Int.\\nmaybe-owner-id-optional a: [Account] => [Int].\\n\\n---\\n\\nmaybe-owner-id-optional a = (each n1 in (each n in a | account--owner n) | owner--id n1).\\n"
 `;
 
 exports[`expressions-nullish.ts > nonNullDefault 1`] = `
@@ -587,31 +587,31 @@ exports[`expressions-record-return.ts > translate 1`] = `
 `;
 
 exports[`expressions-reduce.ts > allActive 1`] = `
-"module AllActive.\\n\\nItem.\\nitem--value i: Item => Int.\\nitem--active i: Item => Bool.\\nall-active xs: [Item] => Bool.\\n\\n---\\n\\nall-active xs = (and over each $0 in xs | item--active $0).\\n"
+"module AllActive.\\n\\nItem.\\nitem--value i: Item => Int.\\nitem--active i: Item => Bool.\\nall-active xs: [Item] => Bool.\\n\\n---\\n\\nall-active xs = (and over each x in xs | item--active x).\\n"
 `;
 
 exports[`expressions-reduce.ts > anyActive 1`] = `
-"module AnyActive.\\n\\nItem.\\nitem--value i: Item => Int.\\nitem--active i: Item => Bool.\\nany-active xs: [Item] => Bool.\\n\\n---\\n\\nany-active xs = (or over each $0 in xs | item--active $0).\\n"
+"module AnyActive.\\n\\nItem.\\nitem--value i: Item => Int.\\nitem--active i: Item => Bool.\\nany-active xs: [Item] => Bool.\\n\\n---\\n\\nany-active xs = (or over each x in xs | item--active x).\\n"
 `;
 
 exports[`expressions-reduce.ts > productValues 1`] = `
-"module ProductValues.\\n\\nItem.\\nitem--value i: Item => Int.\\nitem--active i: Item => Bool.\\nproduct-values xs: [Item] => Int.\\n\\n---\\n\\nproduct-values xs = (* over each $0 in xs | item--value $0).\\n"
+"module ProductValues.\\n\\nItem.\\nitem--value i: Item => Int.\\nitem--active i: Item => Bool.\\nproduct-values xs: [Item] => Int.\\n\\n---\\n\\nproduct-values xs = (* over each x in xs | item--value x).\\n"
 `;
 
 exports[`expressions-reduce.ts > subtractAll 1`] = `
-"module SubtractAll.\\n\\nItem.\\nitem--value i: Item => Int.\\nitem--active i: Item => Bool.\\nsubtract-all xs: [Item] => Int.\\n\\n---\\n\\nsubtract-all xs = 1000 - (+ over each $0 in xs | item--value $0).\\n"
+"module SubtractAll.\\n\\nItem.\\nitem--value i: Item => Int.\\nitem--active i: Item => Bool.\\nsubtract-all xs: [Item] => Int.\\n\\n---\\n\\nsubtract-all xs = 1000 - (+ over each x in xs | item--value x).\\n"
 `;
 
 exports[`expressions-reduce.ts > sumAmounts 1`] = `
-"module SumAmounts.\\n\\nItem.\\nitem--value i: Item => Int.\\nitem--active i: Item => Bool.\\nsum-amounts xs: [Item] => Int.\\n\\n---\\n\\nsum-amounts xs = (+ over each $0 in xs | item--value $0).\\n"
+"module SumAmounts.\\n\\nItem.\\nitem--value i: Item => Int.\\nitem--active i: Item => Bool.\\nsum-amounts xs: [Item] => Int.\\n\\n---\\n\\nsum-amounts xs = (+ over each x in xs | item--value x).\\n"
 `;
 
 exports[`expressions-reduce.ts > sumAmountsRight 1`] = `
-"module SumAmountsRight.\\n\\nItem.\\nitem--value i: Item => Int.\\nitem--active i: Item => Bool.\\nsum-amounts-right xs: [Item] => Int.\\n\\n---\\n\\nsum-amounts-right xs = (+ over each $0 in xs | item--value $0).\\n"
+"module SumAmountsRight.\\n\\nItem.\\nitem--value i: Item => Int.\\nitem--active i: Item => Bool.\\nsum-amounts-right xs: [Item] => Int.\\n\\n---\\n\\nsum-amounts-right xs = (+ over each x in xs | item--value x).\\n"
 `;
 
 exports[`expressions-reduce.ts > sumFromBase 1`] = `
-"module SumFromBase.\\n\\nItem.\\nitem--value i: Item => Int.\\nitem--active i: Item => Bool.\\nsum-from-base xs: [Item] => Int.\\n\\n---\\n\\nsum-from-base xs = 100 + (+ over each $0 in xs | item--value $0).\\n"
+"module SumFromBase.\\n\\nItem.\\nitem--value i: Item => Int.\\nitem--active i: Item => Bool.\\nsum-from-base xs: [Item] => Int.\\n\\n---\\n\\nsum-from-base xs = 100 + (+ over each x in xs | item--value x).\\n"
 `;
 
 exports[`expressions-set-mutation-field.ts > tagAdd 1`] = `

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -241,6 +241,11 @@ describe("unsupported patterns", () => {
 
     assert.equal(props.length, 1);
     assert.equal(props[0]?.kind, "equation");
+    if (props[0]?.kind === "equation") {
+      const rhs = getAst().strExpr(props[0].rhs);
+      assert.match(rhs, /\bx\b/u);
+      assert.doesNotMatch(rhs, /\bx1\b/u);
+    }
     assert.ok(synthCell.registry.used.has("x"));
     assert.ok(!synthCell.registry.used.has("x1"));
   });

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -215,6 +215,36 @@ describe("unsupported patterns", () => {
     }
   });
 
+  it("composed array callbacks do not reserve public binder names", () => {
+    const source = `
+      interface User { name: string; active: boolean; }
+      function activeNames(users: User[]): string[] {
+        return users.filter((u) => u.active).map((u) => u.name);
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const synthCell = newSynthCell();
+    const { paramNameMap } = translateSignature(
+      sourceFile,
+      "activeNames",
+      IntStrategy,
+      synthCell,
+    );
+
+    const props = translateBody({
+      sourceFile,
+      functionName: "activeNames",
+      strategy: IntStrategy,
+      synthCell,
+      paramNameMap,
+    });
+
+    assert.equal(props.length, 1);
+    assert.equal(props[0]?.kind, "equation");
+    assert.ok(synthCell.registry.used.has("x"));
+    assert.ok(!synthCell.registry.used.has("x1"));
+  });
+
   it("returns unsupported for single non-translatable statement", () => {
     const source = `
       function loop(x: number): number {

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -45,6 +45,26 @@ function assertUnsupportedReason(
   );
 }
 
+function translateBodyWithSynth(
+  sourceFile: ReturnType<typeof createSourceFileFromSource>,
+  functionName: string,
+): PropResult[] {
+  const synthCell = newSynthCell();
+  const { paramNameMap } = translateSignature(
+    sourceFile,
+    functionName,
+    IntStrategy,
+    synthCell,
+  );
+  return translateBody({
+    sourceFile,
+    functionName,
+    strategy: IntStrategy,
+    synthCell,
+    paramNameMap,
+  });
+}
+
 // Tests for internal translateBody API edge cases not coverable via
 // exported fixture functions (see tests/fixtures/constructs/ for
 // exhaustive construct coverage).
@@ -1590,18 +1610,14 @@ describe("structured iteration (for-of, forEach, reduce)", () => {
       }
     `;
     const sourceFile = createSourceFileFromSource(source);
-    const props = translateBody({
-      sourceFile,
-      functionName: "f",
-      strategy: IntStrategy,
-    });
+    const props = translateBodyWithSynth(sourceFile, "f");
     const eqs = props.filter((p) => p.kind === "equation");
     assert.equal(eqs.length, 1);
     const ast = getAst();
     if (eqs[0]?.kind === "equation") {
       assert.equal(
         ast.strExpr(eqs[0].rhs),
-        "+ over each $0 in xs | item--value $0",
+        "+ over each x in xs | item--value x",
       );
     }
   });
@@ -1614,17 +1630,13 @@ describe("structured iteration (for-of, forEach, reduce)", () => {
       }
     `;
     const sourceFile = createSourceFileFromSource(source);
-    const props = translateBody({
-      sourceFile,
-      functionName: "f",
-      strategy: IntStrategy,
-    });
+    const props = translateBodyWithSynth(sourceFile, "f");
     const eqs = props.filter((p) => p.kind === "equation");
     const ast = getAst();
     if (eqs[0]?.kind === "equation") {
       assert.equal(
         ast.strExpr(eqs[0].rhs),
-        "100 + (+ over each $0 in xs | item--value $0)",
+        "100 + (+ over each x in xs | item--value x)",
       );
     }
   });
@@ -1757,18 +1769,14 @@ describe("structured iteration (for-of, forEach, reduce)", () => {
         }
       `;
       const sourceFile = createSourceFileFromSource(source);
-      const props = translateBody({
-        sourceFile,
-        functionName: "f",
-        strategy: IntStrategy,
-      });
+      const props = translateBodyWithSynth(sourceFile, "f");
       const eqs = props.filter((p) => p.kind === "equation");
       assert.equal(eqs.length, 1, `variant ${initText}: expected 1 equation`);
       const ast = getAst();
       if (eqs[0]?.kind === "equation") {
         assert.equal(
           ast.strExpr(eqs[0].rhs),
-          "+ over each $0 in xs | item--value $0",
+          "+ over each x in xs | item--value x",
           `variant ${initText}: init should have been elided`,
         );
       }
@@ -2275,11 +2283,7 @@ describe("Set mutation (Stage A: interface-field .add / .delete / .clear)", () =
       }
     `;
     const sourceFile = createSourceFileFromSource(source);
-    const props = translateBody({
-      sourceFile,
-      functionName: "f",
-      strategy: IntStrategy,
-    });
+    const props = translateBodyWithSynth(sourceFile, "f");
     const assertions = props.filter((p) => p.kind === "assertion");
     assert.equal(assertions.length, 1);
     const ast = getAst();
@@ -2306,11 +2310,7 @@ describe("Set mutation (Stage A: interface-field .add / .delete / .clear)", () =
       }
     `;
     const sourceFile = createSourceFileFromSource(source);
-    const props = translateBody({
-      sourceFile,
-      functionName: "f",
-      strategy: IntStrategy,
-    });
+    const props = translateBodyWithSynth(sourceFile, "f");
     const assertions = props.filter((p) => p.kind === "assertion");
     assert.equal(assertions.length, 1);
     const ast = getAst();


### PR DESCRIPTION
## Patch 9: Hygiene fixes: $-binder leak (5 sites) + keyword sanitisation

- Extract `function allocComprehensionBinder(supply: Supply, hint: string): string` near translate-body.ts:4197 — body is `supply.synthCell ? cellRegisterName(supply.synthCell, hint) : freshHygienicBinder(supply)`.
- Apply at translate-body.ts:2822 (optional-chaining nullish each, hint 'n'), :3175 (reduce sourceBinder, hint 'x'), :3177 (reduce callbackBinder, hint 'x'), :3371 (filter binder, hint 'x').
- Apply at ir-build.ts:168 (L1-IR optional-chaining, hint 'n'). L1BuildContext already carries synthCell.
- Refresh constructs.test.mts.snapshot for the 13 binder-leak fixtures (expressions-array's 3 entries + expressions-nullish's 3 + expressions-reduce's 7) and the 3 keyword-collision fixtures (control-flow > max, expressions-boolean > and, > or). Module names for the keyword-collision fixtures may also change (Max → Max1) since module names route through the same registry.

## Changes
- Extract `function allocComprehensionBinder(supply: Supply, hint: string): string` near translate-body.ts:4197 — body is `supply.synthCell ? cellRegisterName(supply.synthCell, hint) : freshHygienicBinder(supply)`.
- Apply at translate-body.ts:2822 (optional-chaining nullish each, hint 'n'), :3175 (reduce sourceBinder, hint 'x'), :3177 (reduce callbackBinder, hint 'x'), :3371 (filter binder, hint 'x').
- Apply at ir-build.ts:168 (L1-IR optional-chaining, hint 'n'). L1BuildContext already carries synthCell.
- Refresh constructs.test.mts.snapshot for the 13 binder-leak fixtures (expressions-array's 3 entries + expressions-nullish's 3 + expressions-reduce's 7) and the 3 keyword-collision fixtures (control-flow > max, expressions-boolean > and, > or). Module names for the keyword-collision fixtures may also change (Max → Max1) since module names route through the same registry.

## Files to Modify
- tools/ts2pant/src/translate-body.ts (modify): Extract allocComprehensionBinder helper; apply at 4 leaky sites (2822, 3175, 3177, 3371).
- tools/ts2pant/src/ir-build.ts (modify): Apply allocComprehensionBinder at the L1-IR optional-chaining site (line 168).
- tools/ts2pant/tests/constructs.test.mts.snapshot (modify): Update snapshots for the 16 fixtures whose emitted text changes ($N → real names; max/and/or → max1/and1/or1 + module names).

## Gameplan Specification

```
module KNOWN_FAILURES.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> After this gameplan, KNOWN_TYPECHECK_FAILURES contains exactly
> the two intentional class-method entries. Every other fixture in
> tools/ts2pant/tests/fixtures/constructs/ either typechecks via
> the wasm bridge or routes through the UNSUPPORTED-skip path. The
> wasm bridge resolves cross-module imports against an in-memory
> registry, matching the `pant` CLI's import semantics exactly.
>
> Dependency rules emit as standalone Pantagruel modules — hand-
> written `samples/js-stdlib/JS_MATH.pant` / `JS_STRING.pant` for
> TS standard-library builtins (Math.*, String.prototype.*); per-
> source-file synthesised `<FILE_BASE_NAME>_AMBIENT` for user
> `declare function`s; per-source-file `<FILE_BASE_NAME>_TUPLES` for
> anonymous tuple constructors. Consumer modules import them via
> `import` lines and reference qualified rules (`math::max`).
> Every emitted module name uses ALL_CAPS_SNAKE convention,
> matching the existing `samples/*.pant` corpus.
> No emitted Pant text contains `$` (binder hygiene); no emitted
> rule name is a Pant reserved keyword (sanitisation).
>
> The translation pipeline preserves CLAUDE.md's L1/L2 IR layering:
> builtin / ambient / tuple registration is an L1 concern (TS-shape
> recognition); qualified-name lowering and module-text emission
> are L2 → OpaqueExpr concerns. dep-module attachment to
> PantDocument is a pipeline-orchestration concern, not an IR
> concern. References: Vekris/Cosman/Jhala (PLDI 2016, IR
> separation); Kroening & Strichman (Decision Procedures Ch. 4 EUF,
> Ch. 8 records); Peyton Jones & Marlow (JFP 2002, Barendregt
> hygiene); Jackson (Software Abstractions, Alloy `lone`
> multiplicity); Baader & Nipkow (Term Rewriting, Ch. 2
> substitution).

Fixture.
Document.
DepModule.
DepBundle.
DepKind.
FixtureStatus.
CheckResult.

passes-typecheck => FixtureStatus.
skipped-unsupported => FixtureStatus.
in-known-failures => FixtureStatus.

builtin-dep => DepKind.
ambient-dep => DepKind.
tuple-ctor-dep => DepKind.

ok => CheckResult.
error-msg => CheckResult.

status f: Fixture => FixtureStatus.
intentional? f: Fixture => Bool.
emitted f: Fixture => Document.
dep-modules f: Fixture => [DepModule].
imports-of d: Document => [String].

contains-dollar? d: Document => Bool.
uses-keyword-as-name? d: Document => Bool.
imports-resolved? d: Document, deps: [DepModule] => Bool.

kind m: DepModule => DepKind.
emits-typechecking-text? m: DepModule => Bool.

is-screaming-snake? n: String => Bool.
module-name-of d: Document => String.

bundle-of f: Fixture => DepBundle.
resolved-bundle? d: Document, b: DepBundle => Bool.
check-bundle d: Document, b: DepBundle => CheckResult.

---
> Every fixture that remains in KNOWN_TYPECHECK_FAILURES is intentional.
all f: Fixture, status f = in-known-failures | intentional? f.

> No emitted document contains a `$` character (binder hygiene).
all f: Fixture | ~(contains-dollar? (emitted f)).

> No emitted document uses a Pant reserved keyword as a rule name.
all f: Fixture | ~(uses-keyword-as-name? (emitted f)).

> Every emitted document's module name is ALL_CAPS_SNAKE.
all f: Fixture | is-screaming-snake? (module-name-of (emitted f)).

> Imports in passing-fixture emitted documents resolve against
> the dep modules attached to the fixture's bundle.
all f: Fixture, status f = passes-typecheck
  | imports-resolved? (emitted f) (dep-modules f).

> The wasm bundle-check succeeds only if every import resolves.
all d: Document, b: DepBundle, check-bundle d b = ok | resolved-bundle? d b.

> Every dep module emits text that typechecks standalone.
all m: DepModule | emits-typechecking-text? m.

```

## Patch Specification

```
module KNOWN_FAILURES_PATCH_9.

> Patch 9 closes the binder hygiene gaps. Five lowering call sites
> route comprehension binders through cellRegisterName; the name
> registry sanitises Pant reserved keywords. Reference: Peyton Jones
> & Marlow, Secrets of the GHC Inliner, JFP 2002 (Barendregt
> convention, hygienic binders); Baader & Nipkow, Term Rewriting
> and All That, Ch. 2 (substitution and capture-avoidance).

Document.
emitted d: Document => String.
contains-dollar? d: Document => Bool.
uses-keyword-as-name? d: Document => Bool.

---
> No emitted document contains a `$` character.
all d: Document | ~(contains-dollar? d).

> No emitted document uses a Pant reserved keyword as a rule name.
all d: Document | ~(uses-keyword-as-name? d).

```


## Implementation Notes

- The 5 binder-leak edits landed verbatim. Opportunistically collapsed the existing inline `allocBinder` closure inside `translateMutatingBody` (translate-body.ts:4222) to call the new helper, since its body was the literal definition being extracted.
- Removed the now-unused `freshHygienicBinder` import from `ir-build.ts` (the L1-IR optional-chaining site was its only caller there).
- **Snapshot diff covered 13 fixtures, not 16.** The 3 keyword-collision fixtures (`control-flow > max`, `expressions-boolean > and`, `expressions-boolean > or`) did **not** change. Patch 7's keyword sanitisation in `registerName` is in place, but `translate-signature.ts:1237` builds the rule name as `baseName = toPantTermName(functionName)` and uses it directly — it never flows through `registerName` or `cellRegisterName`. The keyword sanitiser therefore never fires for the function's own rule name. Routing `baseName` through the document registry is out of scope for this patch's explicit Changes list and will be needed (presumably in a follow-up before patch 13's prune) to satisfy the patch-9 spec clause `~(uses-keyword-as-name? (emitted f))` for those 3 fixtures.
- Module names (`Max`, `And`, `Or`) are derived in `pipeline.ts:76` by capitalising the TS function name and don't pass through `registerName` either; the description's "Max → Max1" prediction also did not occur. Pant reserved keywords are lowercase-only, so capitalised module names wouldn't be sanitised even if routed.
- Verification: 655 unit tests pass; 22 integration tests pass (3 z3-skipped on this machine, expected). Pre-commit (biome + tsc + unit + integration) green; one preexisting nursery-rule biome warning in `ir1-lower.ts:214` is unrelated to this patch.