### PR TITLE
[ts2pant-known-failures] Patch 5: Tuple-shape constructor synthesis (per-source-file dep module)

### DIFF
--- a/tools/ts2pant/src/emit.ts
+++ b/tools/ts2pant/src/emit.ts
@@ -103,6 +103,9 @@ export function emitDocument(doc: PantDocument): string {
         }
         break;
       }
+      case "unsupported":
+        lines.push(`> UNSUPPORTED: ${decl.reason}`);
+        break;
       default: {
         const _exhaustive: never = decl;
         throw new Error(

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -57,12 +57,14 @@ import {
   fieldRuleName,
   isMapType,
   isSetType,
+  isUnsupportedUnknown,
   lookupMapKV,
   mapTsType,
   type NumericStrategy,
   resolveFieldOwner,
   type SynthCell,
   toPantTermName,
+  UNSUPPORTED_UNKNOWN_REASON,
 } from "./translate-types.js";
 import type { PantDeclaration, PropResult } from "./types.js";
 
@@ -1393,6 +1395,21 @@ export function translateBody(opts: TranslateBodyOptions): PropResult[] {
       // domain names (idempotent; the signature pass already registered
       // them, so this is a lookup rather than a fresh registration).
       const typeName = mapTsType(paramType, checker, strategy, synthCell);
+      // Body-level Forall quantifiers carry param Pant types in their
+      // binding heads (`all x: <typeName> | ...`); letting the unknown
+      // sentinel reach `paramList` would emit it inside emitted
+      // equations. The signature pass already returned an unsupported
+      // declaration for this case, so the right move here is to bail
+      // with a single unsupported PropResult rather than emit broken
+      // equations.
+      if (isUnsupportedUnknown(typeName)) {
+        return [
+          {
+            kind: "unsupported",
+            reason: `${functionName} param '${param.name}': ${UNSUPPORTED_UNKNOWN_REASON}`,
+          },
+        ];
+      }
       // With a `paramNameMap` we reuse the signature pass's allocations
       // exactly. Without (standalone / test callers with no synthCell),
       // we fall back to the pure kebab-case — no registry to collide

--- a/tools/ts2pant/src/translate-record.ts
+++ b/tools/ts2pant/src/translate-record.ts
@@ -404,6 +404,14 @@ function emitRecordEquations(
 
     // `new Set()` → empty-set membership negation.
     if (isEmptySetConstruction(initializer)) {
+      if (!isSetType(field.type) && !checker.isArrayType(field.type)) {
+        return [
+          {
+            kind: "unsupported",
+            reason: `${functionName} — new Set() initializer on non-set field '${field.name}'`,
+          },
+        ];
+      }
       const elemType = getSetElementTypeName(
         field.type,
         checker,
@@ -414,7 +422,7 @@ function emitRecordEquations(
         return [
           {
             kind: "unsupported",
-            reason: `${functionName} — new Set() initializer on non-set field '${field.name}'`,
+            reason: `${functionName}.${field.name}: ${UNSUPPORTED_UNKNOWN_REASON}`,
           },
         ];
       }
@@ -455,11 +463,17 @@ function emitRecordEquations(
         strategy,
         synthCell,
       );
-      if (!keyType) {
+      const vType = getMapValueTypeName(
+        field.type,
+        checker,
+        strategy,
+        synthCell,
+      );
+      if (!keyType || !vType) {
         return [
           {
             kind: "unsupported",
-            reason: `${functionName} — new Map() initializer on non-map field '${field.name}'`,
+            reason: `${functionName}.${field.name}: ${UNSUPPORTED_UNKNOWN_REASON}`,
           },
         ];
       }
@@ -467,12 +481,6 @@ function emitRecordEquations(
       const binderParam = ast.param(binderName, ast.tName(keyType));
       let keyPredApp: OpaqueExpr;
       if (receiverIsAnon) {
-        const vType = getMapValueTypeName(
-          field.type,
-          checker,
-          strategy,
-          synthCell,
-        );
         const synthEntry =
           synthCell && vType
             ? lookupMapKV(synthCell.synth, keyType, vType)
@@ -602,7 +610,10 @@ function isEmptySetConstruction(expr: ts.Expression): boolean {
 }
 
 /** Return the Pantagruel type name of `T` in a `Set<T>` / `ReadonlySet<T>`
- * / `[T]` (array) field, or null if the field isn't set-shaped. */
+ * / `[T]` (array) field, or null if the field isn't set-shaped. Also
+ * returns null when the element type is the `unknown` sentinel — the
+ * caller's null-branch routes through the existing unsupported
+ * PropResult flow, keeping the sentinel out of `ast.tName(...)`. */
 function getSetElementTypeName(
   fieldType: ts.Type,
   checker: ts.TypeChecker,
@@ -612,7 +623,8 @@ function getSetElementTypeName(
   if (isSetType(fieldType) || checker.isArrayType(fieldType)) {
     const typeArgs = checker.getTypeArguments(fieldType as ts.TypeReference);
     if (typeArgs.length === 1) {
-      return mapTsType(typeArgs[0]!, checker, strategy, synthCell);
+      const mapped = mapTsType(typeArgs[0]!, checker, strategy, synthCell);
+      return isUnsupportedUnknown(mapped) ? null : mapped;
     }
   }
   return null;
@@ -630,7 +642,9 @@ function isEmptyMapConstruction(expr: ts.Expression): boolean {
 }
 
 /** Return the Pantagruel type name of `K` in a `Map<K, V>` /
- * `ReadonlyMap<K, V>` field, or null if the field isn't map-shaped. */
+ * `ReadonlyMap<K, V>` field, or null if the field isn't map-shaped or
+ * the key type is the `unknown` sentinel (the caller routes null
+ * through the existing unsupported PropResult flow). */
 function getMapKeyTypeName(
   fieldType: ts.Type,
   checker: ts.TypeChecker,
@@ -640,14 +654,16 @@ function getMapKeyTypeName(
   if (isMapType(fieldType)) {
     const typeArgs = checker.getTypeArguments(fieldType as ts.TypeReference);
     if (typeArgs.length === 2) {
-      return mapTsType(typeArgs[0]!, checker, strategy, synthCell);
+      const mapped = mapTsType(typeArgs[0]!, checker, strategy, synthCell);
+      return isUnsupportedUnknown(mapped) ? null : mapped;
     }
   }
   return null;
 }
 
 /** Return the Pantagruel type name of `V` in a `Map<K, V>` /
- * `ReadonlyMap<K, V>` field, or null if the field isn't map-shaped. */
+ * `ReadonlyMap<K, V>` field, or null if the field isn't map-shaped or
+ * the value type is the `unknown` sentinel. */
 function getMapValueTypeName(
   fieldType: ts.Type,
   checker: ts.TypeChecker,
@@ -657,7 +673,8 @@ function getMapValueTypeName(
   if (isMapType(fieldType)) {
     const typeArgs = checker.getTypeArguments(fieldType as ts.TypeReference);
     if (typeArgs.length === 2) {
-      return mapTsType(typeArgs[1]!, checker, strategy, synthCell);
+      const mapped = mapTsType(typeArgs[1]!, checker, strategy, synthCell);
+      return isUnsupportedUnknown(mapped) ? null : mapped;
     }
   }
   return null;

--- a/tools/ts2pant/src/translate-record.ts
+++ b/tools/ts2pant/src/translate-record.ts
@@ -15,12 +15,14 @@ import {
   isAnonymousRecord,
   isMapType,
   isSetType,
+  isUnsupportedUnknown,
   lookupMapKV,
   mapTsType,
   type NumericStrategy,
   resolveRecordOwner,
   type SynthCell,
   UNSUPPORTED_ANONYMOUS_RECORD,
+  UNSUPPORTED_UNKNOWN_REASON,
 } from "./translate-types.js";
 import type { PropResult } from "./types.js";
 
@@ -136,8 +138,19 @@ export function translateRecordReturn(
     // actually succeeded for this shape. If a field type is unmangleable
     // the synth returns the failure sentinel rather than a domain name,
     // and the body emission below would otherwise reference accessor
-    // rules that were never declared.
+    // rules that were never declared. The `unknown` sentinel
+    // propagates separately (a field typed `unknown` short-circuits
+    // record synthesis with `UNSUPPORTED_UNKNOWN`); surface its
+    // user-facing reason explicitly.
     const mapped = mapTsType(returnType, checker, strategy, synthCell);
+    if (isUnsupportedUnknown(mapped)) {
+      return [
+        {
+          kind: "unsupported",
+          reason: `${functionName}: ${UNSUPPORTED_UNKNOWN_REASON}`,
+        },
+      ];
+    }
     if (mapped === UNSUPPORTED_ANONYMOUS_RECORD) {
       return [
         {

--- a/tools/ts2pant/src/translate-signature.ts
+++ b/tools/ts2pant/src/translate-signature.ts
@@ -21,10 +21,12 @@ import {
   cellIsUsed,
   cellRegisterName,
   isMapType,
+  isUnsupportedUnknown,
   mapTsType,
   type NumericStrategy,
   type SynthCell,
   toPantTermName,
+  UNSUPPORTED_UNKNOWN_REASON,
 } from "./translate-types.js";
 import type { PantAction, PantDeclaration, PantRule } from "./types.js";
 
@@ -1258,6 +1260,21 @@ export function translateSignature(
     const symbolType = checker.getTypeOfSymbol(param);
     const defaultType = mapTsType(symbolType, checker, strategy, synthCell);
     const paramType = overrides?.get(param.name) ?? defaultType;
+    if (isUnsupportedUnknown(paramType)) {
+      // Don't let the sentinel reach the emitted rule head — route
+      // through the unsupported declaration variant so the document's
+      // surrounding text stays parseable and the user sees a clear
+      // reason. Mirrors the PropResult `unsupported` flow.
+      return {
+        declaration: {
+          kind: "unsupported",
+          reason: `${baseName} param '${param.name}': ${UNSUPPORTED_UNKNOWN_REASON}`,
+        },
+        classification,
+        paramNameMap,
+        synthCell,
+      };
+    }
     const pantName = synthCell
       ? cellRegisterName(synthCell, toPantTermName(param.name))
       : toPantTermName(param.name);
@@ -1274,6 +1291,17 @@ export function translateSignature(
       strategy,
       synthCell,
     );
+    if (isUnsupportedUnknown(returnType)) {
+      return {
+        declaration: {
+          kind: "unsupported",
+          reason: `${baseName} return: ${UNSUPPORTED_UNKNOWN_REASON}`,
+        },
+        classification,
+        paramNameMap,
+        synthCell,
+      };
+    }
     const decl: PantRule = {
       kind: "rule",
       name: baseName,

--- a/tools/ts2pant/src/translate-types.ts
+++ b/tools/ts2pant/src/translate-types.ts
@@ -526,10 +526,19 @@ function tupleCtorBaseName(shape: TupleShape): string | null {
  * `<FILE_BASE_NAME>_TUPLES` in ALL_CAPS_SNAKE — every emitted module
  * name in this codebase uses the screaming-snake convention (matches
  * the existing `samples/*.pant` corpus).
+ *
+ * Edge case: an extension-only or empty input (`.ts`, `""`) would
+ * otherwise produce `_TUPLES`, which Pantagruel's lexer rejects as a
+ * module name (`upper_start = 'A' .. 'Z'`, so an UPPER_IDENT cannot
+ * begin with `_`). Fall back to the unprefixed `TUPLES`, matching the
+ * no-sourceFile fallback in `cellRegisterTupleConstructor`.
  */
 export function depModuleNameForFile(fileName: string): string {
   const base = fileName.replace(/^.*[/\\]/u, "").replace(/\.[^.]+$/u, "");
   const upper = base.replace(/[^A-Za-z0-9]+/gu, "_").toUpperCase();
+  if (upper.length === 0) {
+    return "TUPLES";
+  }
   return `${upper}_TUPLES`;
 }
 

--- a/tools/ts2pant/src/translate-types.ts
+++ b/tools/ts2pant/src/translate-types.ts
@@ -518,13 +518,20 @@ export function emptyTupleSynth(): TupleSynth {
 }
 
 /**
- * Canonical key for tuple-shape dedup: element Pant types joined by `*`.
- * Joining whitespace-stripped strings prevents whitespace variance in
- * nested tuple types (e.g. `Int * Int` vs `Int*Int`) from producing
- * different keys — the canonical key is purely structural.
+ * Canonical key for tuple-shape dedup: a delimiter-safe encoding of
+ * the element Pant types. Each element is whitespace-stripped first
+ * so `Int * Int` and `Int*Int` hash identically (the canonical key
+ * is purely structural). The encoding uses `JSON.stringify` rather
+ * than a join because `*` is *also* legal inside an element type
+ * (a nested tuple like `Int*Int`), and a bare `*` join would collide
+ * `[Int, Int*Int]` with `[Int*Int, Int]` on the same `Int*Int*Int`
+ * key. JSON's quoting and escaping make the per-element boundaries
+ * unambiguous.
  */
 function tupleShapeKey(shape: TupleShape): string {
-  return shape.elementPantTypes.map((t) => t.replace(/\s+/gu, "")).join("*");
+  return JSON.stringify(
+    shape.elementPantTypes.map((t) => t.replace(/\s+/gu, "")),
+  );
 }
 
 /**
@@ -553,19 +560,26 @@ function tupleCtorBaseName(shape: TupleShape): string | null {
  * name in this codebase uses the screaming-snake convention (matches
  * the existing `samples/*.pant` corpus).
  *
- * Edge case: an extension-only or empty input (`.ts`, `""`) would
- * otherwise produce `_TUPLES`, which Pantagruel's lexer rejects as a
- * module name (`upper_start = 'A' .. 'Z'`, so an UPPER_IDENT cannot
- * begin with `_`). Fall back to the unprefixed `TUPLES`, matching the
- * no-sourceFile fallback in `cellRegisterTupleConstructor`.
+ * The result must be a legal Pantagruel UPPER_IDENT — the lexer's
+ * `upper_start = 'A' .. 'Z'` rules out:
+ *   - empty stems (`.ts`, `""` → `_TUPLES`),
+ *   - underscore-leading stems (`_foo.ts` → `_FOO_TUPLES`),
+ *   - digit-leading stems (`123-foo.ts` → `123_FOO_TUPLES`).
+ * Strip leading underscores; if the remaining stem starts with a
+ * digit, prefix `F_` (the `F` is just a stable letter — no semantics).
+ * If the stem is empty after stripping, fall back to the unprefixed
+ * `TUPLES`, matching the no-sourceFile fallback in
+ * `cellRegisterTupleConstructor`.
  */
 export function depModuleNameForFile(fileName: string): string {
   const base = fileName.replace(/^.*[/\\]/u, "").replace(/\.[^.]+$/u, "");
   const upper = base.replace(/[^A-Za-z0-9]+/gu, "_").toUpperCase();
-  if (upper.length === 0) {
+  const stem = upper.replace(/^_+/u, "");
+  if (stem.length === 0) {
     return "TUPLES";
   }
-  return `${upper}_TUPLES`;
+  const safeStem = /^[A-Z]/u.test(stem) ? stem : `F_${stem}`;
+  return `${safeStem}_TUPLES`;
 }
 
 /**
@@ -772,7 +786,19 @@ export function resolveRecordOwner(
   // preferring it here would break lockstep with the synth's emission.
   if (synthCell && isAnonymousRecord(type)) {
     const mapped = mapTsType(type, checker, strategy, synthCell);
-    if (mapped !== UNSUPPORTED_ANONYMOUS_RECORD) {
+    // Filter both unsupported sentinels — `mapped` may be
+    // `UNSUPPORTED_ANONYMOUS_RECORD` (synth failure / cell-less path)
+    // or `UNSUPPORTED_UNKNOWN` (a field typed `unknown` propagated up
+    // from `registerAnonymousRecord`). Either as a record-owner name
+    // would emit a bogus qualified accessor like
+    // `__unsupported_unknown__--name r`. Fall through to the named-
+    // symbol path; for an anonymous shape there is no meaningful
+    // fallback owner, so the resolver returns null and the caller
+    // rejects the field access.
+    if (
+      mapped !== UNSUPPORTED_ANONYMOUS_RECORD &&
+      !isUnsupportedUnknown(mapped)
+    ) {
       return mapped;
     }
   }

--- a/tools/ts2pant/src/translate-types.ts
+++ b/tools/ts2pant/src/translate-types.ts
@@ -39,6 +39,19 @@ export const UNSUPPORTED_UNKNOWN_REASON =
   "TS unknown is not expressible in Pantagruel; declare a specific type";
 
 /**
+ * True if `pantType` is the `unknown` rejection sentinel. Composite
+ * type branches in `mapTsType` (tuple, array, set, Map K/V, union,
+ * anonymous record field) propagate the sentinel by checking each
+ * recursive result — otherwise nested shapes like `{ x: unknown }`,
+ * `Map<unknown, Int>`, or `[unknown, Int]` would synthesize broken
+ * declarations referencing `__unsupported_unknown__` as if it were a
+ * real Pantagruel type.
+ */
+export function isUnsupportedUnknown(pantType: string): boolean {
+  return pantType === UNSUPPORTED_UNKNOWN;
+}
+
+/**
  * TypeScript type flags for `null` / `undefined` / `void`. Pantagruel
  * retired `Nothing` from the user-facing type surface — there is no
  * writable type for "absence". `mapTsType` handles these only inside a
@@ -482,13 +495,26 @@ interface TupleCtorEntry {
  * not folded into the consumer document; that's the per-source-file scope
  * decision (one `<FILE_BASE_NAME>_TUPLES` module per source file regardless
  * of how many shapes it uses).
+ *
+ * `ctorRegistry` is a *tuple-module-local* `NameRegistry` used to
+ * disambiguate constructor names within the dep module's namespace.
+ * Routing ctor allocation through the consumer's `cell.registry` would
+ * leak unrelated local declarations (e.g. a user function named
+ * `make-int-int`) into the suffixing chain — yielding `make-int-int1`
+ * even though the dep-module qualifier `FOO_TUPLES::` already isolates
+ * the namespace. The local registry produces stable canonical names
+ * (`make-int-int` regardless of what's registered in the consumer)
+ * while still resolving the rare case where two distinct shapes mangle
+ * to the same kebab fragment (e.g. element types whose canonical names
+ * collide after kebab normalization).
  */
 export interface TupleSynth {
   readonly byShape: ReadonlyMap<string, TupleCtorEntry>;
+  readonly ctorRegistry: NameRegistry;
 }
 
 export function emptyTupleSynth(): TupleSynth {
-  return { byShape: new Map() };
+  return { byShape: new Map(), ctorRegistry: emptyNameRegistry() };
 }
 
 /**
@@ -831,6 +857,14 @@ export function cellEmitSynth(cell: SynthCell): PantDeclaration[] {
  * The dep-module name is `<FILE_BASE_NAME>_TUPLES` (ALL_CAPS_SNAKE)
  * derived from `cell.sourceFile`; if no source file is attached to the
  * cell (test/standalone paths), it falls back to a generic `TUPLES`.
+ *
+ * Constructor names resolve in the tuple module's *own* namespace
+ * (`cell.tupleSynth.ctorRegistry`) — not the consumer's `cell.registry`.
+ * The dep module's qualifier (`FOO_TUPLES::make-int-int`) already
+ * isolates the namespace; routing through the consumer registry would
+ * let unrelated local declarations turn `make-int-int` into
+ * `make-int-int1`. Keep `cell.registry` unchanged so the consumer's
+ * binder allocation is not perturbed by tuple-shape registration.
  */
 export function cellRegisterTupleConstructor(
   cell: SynthCell,
@@ -848,15 +882,14 @@ export function cellRegisterTupleConstructor(
   if (!baseName) {
     return null;
   }
-  const reg1 = registerName(cell.registry, baseName);
+  const reg1 = registerName(cell.tupleSynth.ctorRegistry, baseName);
   const ctorRuleName = reg1.name;
   const newByShape = new Map(cell.tupleSynth.byShape);
   newByShape.set(key, {
     shape: { elementPantTypes: [...shape.elementPantTypes] },
     ctorRuleName,
   });
-  cell.tupleSynth = { byShape: newByShape };
-  cell.registry = reg1.registry;
+  cell.tupleSynth = { byShape: newByShape, ctorRegistry: reg1.registry };
   return { ctorRuleName, depModuleName };
 }
 
@@ -993,16 +1026,24 @@ export function mapTsType(
   // Tuple (check before array since tuples are also type references)
   if (checker.isTupleType(type)) {
     const typeArgs = checker.getTypeArguments(type as ts.TypeReference);
-    return typeArgs
-      .map((t) => mapTsType(t, checker, strategy, synthCell))
-      .join(" * ");
+    const elements = typeArgs.map((t) =>
+      mapTsType(t, checker, strategy, synthCell),
+    );
+    if (elements.some(isUnsupportedUnknown)) {
+      return UNSUPPORTED_UNKNOWN;
+    }
+    return elements.join(" * ");
   }
 
   // Array
   if (checker.isArrayType(type)) {
     const typeArgs = checker.getTypeArguments(type as ts.TypeReference);
     if (typeArgs.length === 1) {
-      return `[${mapTsType(typeArgs[0]!, checker, strategy, synthCell)}]`;
+      const elem = mapTsType(typeArgs[0]!, checker, strategy, synthCell);
+      if (isUnsupportedUnknown(elem)) {
+        return UNSUPPORTED_UNKNOWN;
+      }
+      return `[${elem}]`;
     }
     return checker.typeToString(type);
   }
@@ -1013,7 +1054,11 @@ export function mapTsType(
   if (isSetType(type)) {
     const typeArgs = checker.getTypeArguments(type as ts.TypeReference);
     if (typeArgs.length === 1) {
-      return `[${mapTsType(typeArgs[0]!, checker, strategy, synthCell)}]`;
+      const elem = mapTsType(typeArgs[0]!, checker, strategy, synthCell);
+      if (isUnsupportedUnknown(elem)) {
+        return UNSUPPORTED_UNKNOWN;
+      }
+      return `[${elem}]`;
     }
     return checker.typeToString(type);
   }
@@ -1027,6 +1072,13 @@ export function mapTsType(
     if (typeArgs.length === 2) {
       const kType = mapTsType(typeArgs[0]!, checker, strategy, synthCell);
       const vType = mapTsType(typeArgs[1]!, checker, strategy, synthCell);
+      // Propagate `unknown` rather than registering a Map keyed by or
+      // valued in the sentinel — that would synthesize a domain like
+      // `__unsupported_unknown__ToIntMap` (the underscore-only sentinel
+      // passes `manglePantTypeToFragment`'s identifier check).
+      if (isUnsupportedUnknown(kType) || isUnsupportedUnknown(vType)) {
+        return UNSUPPORTED_UNKNOWN;
+      }
       const domain = cellRegisterMap(synthCell, kType, vType);
       if (domain !== null) {
         return domain;
@@ -1056,6 +1108,9 @@ export function mapTsType(
     const parts = nonNullTypes.map((t) =>
       mapTsType(t, checker, strategy, synthCell),
     );
+    if (parts.some(isUnsupportedUnknown)) {
+      return UNSUPPORTED_UNKNOWN;
+    }
     const unique = parts.filter((v, i, a) => a.indexOf(v) === i);
     if (hasNullish) {
       return `[${unique.join(" + ")}]`;
@@ -1127,6 +1182,15 @@ function registerAnonymousRecord(
       return null;
     }
     const mapped = mapTsType(propType, checker, strategy, synthCell);
+    // Propagate `unknown` as the specific UNSUPPORTED_UNKNOWN sentinel
+    // so the outer `mapTsType` anonymous-record branch can pass it back
+    // to *its* caller — otherwise nested shapes like `[{ x: unknown },
+    // Int]` would mask the unknown cause as
+    // UNSUPPORTED_ANONYMOUS_RECORD, which the tuple/array/set branches
+    // do not propagate.
+    if (isUnsupportedUnknown(mapped)) {
+      return UNSUPPORTED_UNKNOWN;
+    }
     // Propagate failure from a nested anonymous-record synthesis.
     // Without this, the parent shape would register with the sentinel
     // string as a field type and emit invalid output.

--- a/tools/ts2pant/src/translate-types.ts
+++ b/tools/ts2pant/src/translate-types.ts
@@ -810,12 +810,20 @@ export function resolveRecordOwner(
   return null;
 }
 
-/** Cell-mutating wrapper around `registerMapKV` for the legacy call shape. */
+/** Cell-mutating wrapper around `registerMapKV` for the legacy call shape.
+ *  Defensively rejects either argument being the `unknown` sentinel — the
+ *  sentinel string passes `manglePantTypeToFragment`'s identifier-shape
+ *  check (it's all underscores+letters) so without this guard a body-level
+ *  call site that forwards the sentinel into `cellRegisterMap` would
+ *  synthesize a Map domain like `__unsupported_unknown__ToIntMap`. */
 export function cellRegisterMap(
   cell: SynthCell,
   kType: string,
   vType: string,
 ): string | null {
+  if (isUnsupportedUnknown(kType) || isUnsupportedUnknown(vType)) {
+    return null;
+  }
   const r = registerMapKV(cell.synth, cell.registry, kType, vType);
   cell.synth = r.synth;
   cell.registry = r.registry;
@@ -823,11 +831,16 @@ export function cellRegisterMap(
 }
 
 /** Cell-mutating wrapper around `registerRecordShape`. `fields` must be in
- *  canonical (alphabetically sorted) order. */
+ *  canonical (alphabetically sorted) order. Defensively rejects when any
+ *  field type is the `unknown` sentinel, for the same reason as
+ *  `cellRegisterMap`. */
 export function cellRegisterRecord(
   cell: SynthCell,
   fields: ReadonlyArray<RecordSynthField>,
 ): string | null {
+  if (fields.some((f) => isUnsupportedUnknown(f.type))) {
+    return null;
+  }
   const r = registerRecordShape(cell.recordSynth, cell.registry, fields);
   cell.recordSynth = r.synth;
   cell.registry = r.registry;
@@ -896,6 +909,13 @@ export function cellRegisterTupleConstructor(
   cell: SynthCell,
   shape: TupleShape,
 ): TupleCtorRef | null {
+  // Defensive: the `unknown` sentinel passes the identifier-shape check
+  // in `manglePantTypeToFragment`, so without this guard a tuple shape
+  // carrying it would synthesize a constructor name like
+  // `make-__unsupported_unknown__-int`.
+  if (shape.elementPantTypes.some(isUnsupportedUnknown)) {
+    return null;
+  }
   const depModuleName = cell.sourceFile
     ? depModuleNameForFile(cell.sourceFile.fileName)
     : "TUPLES";
@@ -1337,6 +1357,13 @@ export function translateTypes(
           // references it.
           const kType = mapTsType(typeArgs[0]!, checker, strategy, synthCell);
           const vType = mapTsType(typeArgs[1]!, checker, strategy, synthCell);
+          if (isUnsupportedUnknown(kType) || isUnsupportedUnknown(vType)) {
+            decls.push({
+              kind: "unsupported",
+              reason: `${iface.name}.${prop.name}: ${UNSUPPORTED_UNKNOWN_REASON}`,
+            });
+            continue;
+          }
           const kName = synthCell ? cellRegisterName(synthCell, "k") : "k";
           const keyPredName = `${ruleName}-key`;
           decls.push({
@@ -1365,20 +1392,36 @@ export function translateTypes(
           continue;
         }
       }
+      const fieldType = mapTsType(prop.type, checker, strategy, synthCell);
+      if (isUnsupportedUnknown(fieldType)) {
+        decls.push({
+          kind: "unsupported",
+          reason: `${iface.name}.${prop.name}: ${UNSUPPORTED_UNKNOWN_REASON}`,
+        });
+        continue;
+      }
       decls.push({
         kind: "rule",
         name: ruleName,
         params: [{ name: pName, type: iface.name }],
-        returnType: mapTsType(prop.type, checker, strategy, synthCell),
+        returnType: fieldType,
       });
     }
   }
 
   for (const alias of extracted.aliases) {
+    const aliasType = mapTsType(alias.type, checker, strategy, synthCell);
+    if (isUnsupportedUnknown(aliasType)) {
+      decls.push({
+        kind: "unsupported",
+        reason: `alias ${alias.name}: ${UNSUPPORTED_UNKNOWN_REASON}`,
+      });
+      continue;
+    }
     decls.push({
       kind: "alias",
       name: alias.name,
-      type: mapTsType(alias.type, checker, strategy, synthCell),
+      type: aliasType,
     });
   }
 

--- a/tools/ts2pant/src/translate-types.ts
+++ b/tools/ts2pant/src/translate-types.ts
@@ -21,6 +21,24 @@ import type { PantDeclaration } from "./types.js";
 export const UNSUPPORTED_ANONYMOUS_RECORD = "__unsupported_anon_record__";
 
 /**
+ * Sentinel returned by `mapTsType` when the TypeScript type is `unknown`.
+ * Pantagruel is monomorphic over named domains; there is no polymorphism
+ * mechanism to absorb `unknown` into. Mapping it to a fresh domain per
+ * call site loses the TS author's intent ("I'll narrow this later") and
+ * silently lets type errors through. The translator rejects it explicitly
+ * so the user can declare a real type or interface (steering rule 1 —
+ * the TS itself is ambiguous, not the recognizer).
+ *
+ * The value is not a valid Pantagruel identifier so emission of a
+ * signature carrying it will fail visibly rather than reference an
+ * undeclared domain. The reason text is exported alongside so downstream
+ * "UNSUPPORTED-skip" infrastructure can surface it to the user.
+ */
+export const UNSUPPORTED_UNKNOWN = "__unsupported_unknown__";
+export const UNSUPPORTED_UNKNOWN_REASON =
+  "TS unknown is not expressible in Pantagruel; declare a specific type";
+
+/**
  * TypeScript type flags for `null` / `undefined` / `void`. Pantagruel
  * retired `Nothing` from the user-facing type surface — there is no
  * writable type for "absence". `mapTsType` handles these only inside a
@@ -422,26 +440,137 @@ export function emitRecordSynthDecls(
 }
 
 /**
- * Mutable 3-field cell bundling a `MapSynth`, `RecordSynth` and
- * `NameRegistry`. Used by deep call sites (mapTsType recursion, body
- * translation) that would otherwise have to thread state through every
- * return value. The fields are reassigned in place with freshly-computed
- * immutable records; the inner values remain pure. Cell-field assignment
- * is itself within ts2pant's self-translation envelope (translatable as
- * primed rules on the cell).
+ * Canonical tuple shape: the ordered Pantagruel element types that a
+ * tuple constructor builds. Two TS aliases that share the same shape
+ * — `Point = [number, number]` and `Vec2 = [number, number]` both map
+ * to `["Int", "Int"]` — must share one constructor. Otherwise the
+ * SMT solver cannot prove `make-point 0 0 = make-vec2 0 0` despite
+ * identical operands; EUF congruence (Kroening & Strichman, *Decision
+ * Procedures*, Ch. 8) requires dispatch on shape, not on alias.
+ */
+export interface TupleShape {
+  readonly elementPantTypes: readonly string[];
+}
+
+/**
+ * Reference to a synthesized tuple constructor returned by
+ * `cellRegisterTupleConstructor`. The `ctorRuleName` is the bare rule
+ * name in the dep module (e.g. `make-int-int`); the `depModuleName` is
+ * the per-source-file dep module that owns it (e.g. `FOO_TUPLES`).
+ * Consumers emit `import ${depModuleName}.` at the module head and
+ * reference the constructor as `${depModuleName}::${ctorRuleName}` at
+ * call sites, mirroring the cross-module shape Pantagruel's `import`
+ * machinery exercises in `lib/module.ml`.
+ */
+export interface TupleCtorRef {
+  readonly ctorRuleName: string;
+  readonly depModuleName: string;
+}
+
+interface TupleCtorEntry {
+  readonly shape: TupleShape;
+  readonly ctorRuleName: string;
+}
+
+/**
+ * Accumulates anonymous tuple-shape occurrences encountered anywhere in
+ * the module's expression positions and synthesizes one constructor rule
+ * + projection axioms per unique shape. Like `MapSynth` and `RecordSynth`,
+ * registration is idempotent on canonical shape: re-registering the same
+ * `elementPantTypes` returns the cached constructor name. The synthesized
+ * decls are emitted to a *separate* dep module via `emitTupleCtorModule`,
+ * not folded into the consumer document; that's the per-source-file scope
+ * decision (one `<FILE_BASE_NAME>_TUPLES` module per source file regardless
+ * of how many shapes it uses).
+ */
+export interface TupleSynth {
+  readonly byShape: ReadonlyMap<string, TupleCtorEntry>;
+}
+
+export function emptyTupleSynth(): TupleSynth {
+  return { byShape: new Map() };
+}
+
+/**
+ * Canonical key for tuple-shape dedup: element Pant types joined by `*`.
+ * Joining whitespace-stripped strings prevents whitespace variance in
+ * nested tuple types (e.g. `Int * Int` vs `Int*Int`) from producing
+ * different keys — the canonical key is purely structural.
+ */
+function tupleShapeKey(shape: TupleShape): string {
+  return shape.elementPantTypes.map((t) => t.replace(/\s+/gu, "")).join("*");
+}
+
+/**
+ * Compute the kebab-cased constructor name for a tuple shape. Each
+ * element type is mangled to a fragment (`[String]` → `ListString`,
+ * `A * B` → `AAndB`, etc.) and then kebab-cased; fragments are joined
+ * with `-` and prefixed with `make-`. Returns null if any element
+ * type is unmangleable (e.g. contains TS-compiler fallback text like
+ * `Map<string, number>`).
+ */
+function tupleCtorBaseName(shape: TupleShape): string | null {
+  const fragments: string[] = [];
+  for (const elem of shape.elementPantTypes) {
+    const frag = manglePantTypeToFragment(elem);
+    if (!frag) {
+      return null;
+    }
+    fragments.push(toPantTermName(frag));
+  }
+  return `make-${fragments.join("-")}`;
+}
+
+/**
+ * Derive the per-source-file dep module name for tuple constructors.
+ * `<FILE_BASE_NAME>_TUPLES` in ALL_CAPS_SNAKE — every emitted module
+ * name in this codebase uses the screaming-snake convention (matches
+ * the existing `samples/*.pant` corpus).
+ */
+export function depModuleNameForFile(fileName: string): string {
+  const base = fileName.replace(/^.*[/\\]/u, "").replace(/\.[^.]+$/u, "");
+  const upper = base.replace(/[^A-Za-z0-9]+/gu, "_").toUpperCase();
+  return `${upper}_TUPLES`;
+}
+
+/**
+ * Mutable cell bundling per-document synth state and the name registry.
+ * Used by deep call sites (mapTsType recursion, body translation) that
+ * would otherwise have to thread state through every return value. The
+ * fields are reassigned in place with freshly-computed immutable records;
+ * the inner values remain pure. Cell-field assignment is itself within
+ * ts2pant's self-translation envelope (translatable as primed rules on
+ * the cell).
+ *
+ * `sourceFile` is optional and carries the file currently being
+ * translated so per-file dep-module names (`<FILE_BASE_NAME>_TUPLES`,
+ * `<FILE_BASE_NAME>_AMBIENT`) can be derived without threading the file
+ * through every registration call. Tests and standalone callers may
+ * leave it undefined; tuple-constructor registration falls back to a
+ * generic `TUPLES` module name in that case.
  */
 export interface SynthCell {
   synth: MapSynth;
   recordSynth: RecordSynth;
   registry: NameRegistry;
+  tupleSynth: TupleSynth;
+  sourceFile?: ts.SourceFile;
 }
 
-export function newSynthCell(registry?: NameRegistry): SynthCell {
-  return {
+export function newSynthCell(
+  registry?: NameRegistry,
+  sourceFile?: ts.SourceFile,
+): SynthCell {
+  const cell: SynthCell = {
     synth: emptyMapSynth(),
     recordSynth: emptyRecordSynth(),
     registry: registry ?? emptyNameRegistry(),
+    tupleSynth: emptyTupleSynth(),
   };
+  if (sourceFile !== undefined) {
+    cell.sourceFile = sourceFile;
+  }
+  return cell;
 }
 
 /** Pantagruel rule symbol for an interface field. Qualified so two
@@ -667,7 +796,11 @@ export function cellIsUsed(cell: SynthCell, name: string): boolean {
 /** Cell-mutating wrapper that drains both Map and Record synth decls.
  *  Emits Maps first so Record accessor-rule return types can reference
  *  any Map domain registered bottom-up. Incremental: each call returns
- *  only the entries added since the previous drain. */
+ *  only the entries added since the previous drain.
+ *
+ *  Tuple-constructor synth is *not* drained here — tuple constructors
+ *  emit to a separate per-source-file dep module via
+ *  `emitTupleCtorModule`, not into the consumer document's head. */
 export function cellEmitSynth(cell: SynthCell): PantDeclaration[] {
   const mapR = emitSynthDecls(cell.synth, cell.registry);
   cell.synth = mapR.synth;
@@ -676,6 +809,118 @@ export function cellEmitSynth(cell: SynthCell): PantDeclaration[] {
   cell.recordSynth = recR.synth;
   cell.registry = recR.registry;
   return [...mapR.decls, ...recR.decls];
+}
+
+/**
+ * Register a tuple shape and return the constructor reference. Idempotent
+ * on canonical shape (whitespace-stripped element types joined by `*`):
+ * re-registering the same shape returns the cached constructor name and
+ * dep-module name. Returns null when any element type is unmangleable
+ * (e.g. contains TS-compiler fallback text from an unsupported type
+ * upstream); callers fall back to inline tuple emission or reject.
+ *
+ * The dep-module name is `<FILE_BASE_NAME>_TUPLES` (ALL_CAPS_SNAKE)
+ * derived from `cell.sourceFile`; if no source file is attached to the
+ * cell (test/standalone paths), it falls back to a generic `TUPLES`.
+ */
+export function cellRegisterTupleConstructor(
+  cell: SynthCell,
+  shape: TupleShape,
+): TupleCtorRef | null {
+  const depModuleName = cell.sourceFile
+    ? depModuleNameForFile(cell.sourceFile.fileName)
+    : "TUPLES";
+  const key = tupleShapeKey(shape);
+  const cached = cell.tupleSynth.byShape.get(key);
+  if (cached) {
+    return { ctorRuleName: cached.ctorRuleName, depModuleName };
+  }
+  const baseName = tupleCtorBaseName(shape);
+  if (!baseName) {
+    return null;
+  }
+  const reg1 = registerName(cell.registry, baseName);
+  const ctorRuleName = reg1.name;
+  const newByShape = new Map(cell.tupleSynth.byShape);
+  newByShape.set(key, {
+    shape: { elementPantTypes: [...shape.elementPantTypes] },
+    ctorRuleName,
+  });
+  cell.tupleSynth = { byShape: newByShape };
+  cell.registry = reg1.registry;
+  return { ctorRuleName, depModuleName };
+}
+
+/** Read-through accessor: return all registered tuple shapes (in
+ *  registration order) so the pipeline can pass them to
+ *  `emitTupleCtorModule` at the document-emit boundary. */
+export function cellTupleShapes(
+  cell: SynthCell,
+): ReadonlyArray<{ shape: TupleShape; ctorRuleName: string }> {
+  return [...cell.tupleSynth.byShape.values()];
+}
+
+/**
+ * Emit the standalone Pantagruel dep module for a source file's tuple
+ * constructors. Output structure:
+ *
+ *   module <FILE_BASE_NAME>_TUPLES.
+ *
+ *   <ctor> a1: T1, ..., aN: TN => T1 * ... * TN.
+ *   ...
+ *
+ *   ---
+ *   all a1: T1, ..., aN: TN | (<ctor> a1 ... aN).1 = a1.
+ *   ...
+ *
+ * One constructor rule head per registered shape, plus N projection
+ * axioms (one per element position) per shape. The axioms quantify
+ * over the constructor's parameters explicitly — Pantagruel propositions
+ * can't carry free variables, so the binders must be reintroduced at
+ * the proposition level (parser.mly: proposition is `expr DOT`, where
+ * `expr` may be a `quantified` form `all p:T,... | body`).
+ *
+ * Every shape used by any fixture in the source file aggregates into
+ * the single returned module — that's the per-source-file scope
+ * decision (one `import <FILE_BASE_NAME>_TUPLES.` per consumer
+ * regardless of how many tuple shapes the file uses).
+ */
+export function emitTupleCtorModule(
+  sourceFile: ts.SourceFile,
+  shapes: ReadonlyArray<{ shape: TupleShape; ctorRuleName: string }>,
+): string {
+  const moduleName = depModuleNameForFile(sourceFile.fileName);
+  const lines: string[] = [];
+  lines.push(`module ${moduleName}.`);
+  lines.push("");
+
+  for (const { shape, ctorRuleName } of shapes) {
+    const params = shape.elementPantTypes
+      .map((t, idx) => `a${idx + 1}: ${t}`)
+      .join(", ");
+    const tupleType = shape.elementPantTypes.join(" * ");
+    lines.push(`${ctorRuleName} ${params} => ${tupleType}.`);
+  }
+
+  lines.push("");
+  lines.push("---");
+  lines.push("");
+
+  for (const { shape, ctorRuleName } of shapes) {
+    const params = shape.elementPantTypes
+      .map((t, idx) => `a${idx + 1}: ${t}`)
+      .join(", ");
+    const argList = shape.elementPantTypes
+      .map((_, idx) => `a${idx + 1}`)
+      .join(" ");
+    for (let pos = 0; pos < shape.elementPantTypes.length; pos++) {
+      lines.push(
+        `all ${params} | (${ctorRuleName} ${argList}).${pos + 1} = a${pos + 1}.`,
+      );
+    }
+  }
+
+  return `${lines.join("\n")}\n`;
 }
 
 /** Strategy for mapping TS `number` to a Pantagruel numeric type. */
@@ -713,6 +958,14 @@ export function mapTsType(
   synthCell?: SynthCell,
 ): string {
   const flags = type.flags;
+
+  // Reject `unknown` explicitly. Pantagruel is monomorphic over named
+  // domains — there is no `Any`/`Unknown` top — so the only honest move is
+  // to refuse and steer the user toward a declared type. Mapping to a
+  // generic placeholder would silently let type errors through.
+  if (flags & ts.TypeFlags.Unknown) {
+    return UNSUPPORTED_UNKNOWN;
+  }
 
   if (flags & ts.TypeFlags.String || flags & ts.TypeFlags.StringLiteral) {
     return "String";

--- a/tools/ts2pant/src/types.ts
+++ b/tools/ts2pant/src/types.ts
@@ -39,8 +39,26 @@ export interface PantAction {
   guard?: OpaqueExpr;
 }
 
+/** A declaration that could not be translated. Renders as
+ *  `> UNSUPPORTED: <reason>` (a doc-comment line) at emit time so the
+ *  document's surrounding Pant text stays parseable while still
+ *  surfacing the cause to the user. Mirrors `PropResult`'s
+ *  `unsupported` variant — the structural rejection path for
+ *  type/declaration emit sites that would otherwise embed an internal
+ *  sentinel string (e.g. `__unsupported_unknown__`) into generated
+ *  Pant. */
+export interface PantUnsupported {
+  kind: "unsupported";
+  reason: string;
+}
+
 /** A declaration in a Pantagruel document. */
-export type PantDeclaration = PantDomain | PantAlias | PantRule | PantAction;
+export type PantDeclaration =
+  | PantDomain
+  | PantAlias
+  | PantRule
+  | PantAction
+  | PantUnsupported;
 
 /**
  * Proposition result: either a structured equation, an unsupported

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -511,7 +511,7 @@ exports[`expressions-property-element-access.ts > effectiveBalanceByLiteral 1`] 
 `;
 
 exports[`expressions-property-element-access.ts > getByDynamicKey 1`] = `
-"module GetByDynamicKey.\\n\\nUser.\\nuser--name u: User => String.\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--owner a1: Account => User.\\naccount--active a1: Account => Bool.\\nget-by-dynamic-key a: Account, k: String => __unsupported_unknown__.\\n\\n---\\n\\n> UNSUPPORTED: computed property access (obj[expr]) is unsupported; use dotted property access or a string-literal index instead.\\n"
+"module GetByDynamicKey.\\n\\nUser.\\nuser--name u: User => String.\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--owner a1: Account => User.\\naccount--active a1: Account => Bool.\\n> UNSUPPORTED: get-by-dynamic-key return: TS unknown is not expressible in Pantagruel; declare a specific type\\n\\n---\\n\\n> UNSUPPORTED: computed property access (obj[expr]) is unsupported; use dotted property access or a string-literal index instead.\\n"
 `;
 
 exports[`expressions-property-element-access.ts > getOwnerByLiteral 1`] = `

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -511,7 +511,7 @@ exports[`expressions-property-element-access.ts > effectiveBalanceByLiteral 1`] 
 `;
 
 exports[`expressions-property-element-access.ts > getByDynamicKey 1`] = `
-"module GetByDynamicKey.\\n\\nUser.\\nuser--name u: User => String.\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--owner a1: Account => User.\\naccount--active a1: Account => Bool.\\nget-by-dynamic-key a: Account, k: String => unknown.\\n\\n---\\n\\n> UNSUPPORTED: computed property access (obj[expr]) is unsupported; use dotted property access or a string-literal index instead.\\n"
+"module GetByDynamicKey.\\n\\nUser.\\nuser--name u: User => String.\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--owner a1: Account => User.\\naccount--active a1: Account => Bool.\\nget-by-dynamic-key a: Account, k: String => __unsupported_unknown__.\\n\\n---\\n\\n> UNSUPPORTED: computed property access (obj[expr]) is unsupported; use dotted property access or a string-literal index instead.\\n"
 `;
 
 exports[`expressions-property-element-access.ts > getOwnerByLiteral 1`] = `

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -3,7 +3,13 @@ import assert from "node:assert/strict";
 import { createSourceFileFromSource } from "../src/extract.js";
 import { getAst, loadAst } from "../src/pant-wasm.js";
 import { translateBody } from "../src/translate-body.js";
-import { IntStrategy, RealStrategy } from "../src/translate-types.js";
+import { translateSignature } from "../src/translate-signature.js";
+import {
+  IntStrategy,
+  newSynthCell,
+  RealStrategy,
+  UNSUPPORTED_UNKNOWN_REASON,
+} from "../src/translate-types.js";
 import type { PropResult } from "../src/types.js";
 
 before(async () => {
@@ -610,6 +616,40 @@ describe("if-early-return prelude arms", () => {
       "empty Map record initializer with unknown value type",
     );
     assert.doesNotMatch(JSON.stringify(props), /unsupported_unknown/u);
+  });
+
+  it("rejects anonymous record return with unknown field via public reason", () => {
+    const source = `
+      function makeBox(): { value: unknown } {
+        return { value: 1 };
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const synthCell = newSynthCell();
+    const { paramNameMap } = translateSignature(
+      sourceFile,
+      "makeBox",
+      IntStrategy,
+      synthCell,
+    );
+
+    const props = translateBody({
+      sourceFile,
+      functionName: "makeBox",
+      strategy: IntStrategy,
+      synthCell,
+      paramNameMap,
+    });
+
+    assert.equal(props.length, 1);
+    assert.equal(props[0]?.kind, "unsupported");
+    if (props[0]?.kind === "unsupported") {
+      assert.equal(
+        props[0].reason,
+        `make-box: ${UNSUPPORTED_UNKNOWN_REASON}`,
+      );
+    }
+    assert.doesNotMatch(JSON.stringify(props), /__unsupported_unknown__/u);
   });
 
   it("emits trailing-if diagnostic for single `if (P) return E;` body", () => {

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -549,74 +549,61 @@ describe("if-early-return prelude arms", () => {
     }
   });
 
-  it("rejects empty Set record initializer when element type is unknown", () => {
-    const source = `
-      interface Bag { items: ReadonlySet<unknown> }
-      export function f(): Bag {
-        return { items: new Set() };
-      }
-    `;
-    const sourceFile = createSourceFileFromSource(source);
-    const props = translateBody({
-      sourceFile,
-      functionName: "f",
-      strategy: IntStrategy,
+  const unknownCollectionCases = [
+    {
+      testName:
+        "rejects empty Set record initializer when element type is unknown",
+      returnType: "Bag",
+      interfaceSnippet: "interface Bag { items: ReadonlySet<unknown> }",
+      returnExpression: "return { items: new Set() };",
+      expectedReason: /f\.items: TS unknown is not expressible/u,
+      reasonLabel: "empty Set record initializer with unknown element type",
+    },
+    {
+      testName: "rejects empty Map record initializer when key type is unknown",
+      returnType: "Registry",
+      interfaceSnippet:
+        "interface Registry { byId: ReadonlyMap<unknown, number> }",
+      returnExpression: "return { byId: new Map() };",
+      expectedReason: /f\.byId: TS unknown is not expressible/u,
+      reasonLabel: "empty Map record initializer with unknown key type",
+    },
+    {
+      testName:
+        "rejects empty Map record initializer when value type is unknown",
+      returnType: "Registry",
+      interfaceSnippet:
+        "interface Registry { byId: ReadonlyMap<string, unknown> }",
+      returnExpression: "return { byId: new Map() };",
+      expectedReason: /f\.byId: TS unknown is not expressible/u,
+      reasonLabel: "empty Map record initializer with unknown value type",
+    },
+  ] as const;
+
+  for (const tc of unknownCollectionCases) {
+    it(tc.testName, () => {
+      const source = `
+        ${tc.interfaceSnippet}
+        export function f(): ${tc.returnType} {
+          ${tc.returnExpression}
+        }
+      `;
+      const sourceFile = createSourceFileFromSource(source);
+      const props = translateBody({
+        sourceFile,
+        functionName: "f",
+        strategy: IntStrategy,
+      });
+
+      assert.equal(props.length, 1);
+      assertUnsupportedReason(
+        props,
+        tc.expectedReason,
+        tc.reasonLabel,
+      );
+      assert.doesNotMatch(JSON.stringify(props), /unsupported_unknown/u);
     });
-
-    assert.equal(props.length, 1);
-    assertUnsupportedReason(
-      props,
-      /f\.items: TS unknown is not expressible/u,
-      "empty Set record initializer with unknown element type",
-    );
-    assert.doesNotMatch(JSON.stringify(props), /unsupported_unknown/u);
-  });
-
-  it("rejects empty Map record initializer when key type is unknown", () => {
-    const source = `
-      interface Registry { byId: ReadonlyMap<unknown, number> }
-      export function f(): Registry {
-        return { byId: new Map() };
-      }
-    `;
-    const sourceFile = createSourceFileFromSource(source);
-    const props = translateBody({
-      sourceFile,
-      functionName: "f",
-      strategy: IntStrategy,
-    });
-
-    assert.equal(props.length, 1);
-    assertUnsupportedReason(
-      props,
-      /f\.byId: TS unknown is not expressible/u,
-      "empty Map record initializer with unknown key type",
-    );
-    assert.doesNotMatch(JSON.stringify(props), /unsupported_unknown/u);
-  });
-
-  it("rejects empty Map record initializer when value type is unknown", () => {
-    const source = `
-      interface Registry { byId: ReadonlyMap<string, unknown> }
-      export function f(): Registry {
-        return { byId: new Map() };
-      }
-    `;
-    const sourceFile = createSourceFileFromSource(source);
-    const props = translateBody({
-      sourceFile,
-      functionName: "f",
-      strategy: IntStrategy,
-    });
-
-    assert.equal(props.length, 1);
-    assertUnsupportedReason(
-      props,
-      /f\.byId: TS unknown is not expressible/u,
-      "empty Map record initializer with unknown value type",
-    );
-    assert.doesNotMatch(JSON.stringify(props), /unsupported_unknown/u);
-  });
+  }
 
   it("rejects anonymous record return with unknown field via public reason", () => {
     const source = `

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -543,6 +543,75 @@ describe("if-early-return prelude arms", () => {
     }
   });
 
+  it("rejects empty Set record initializer when element type is unknown", () => {
+    const source = `
+      interface Bag { items: ReadonlySet<unknown> }
+      export function f(): Bag {
+        return { items: new Set() };
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "f",
+      strategy: IntStrategy,
+    });
+
+    assert.equal(props.length, 1);
+    assertUnsupportedReason(
+      props,
+      /f\.items: TS unknown is not expressible/u,
+      "empty Set record initializer with unknown element type",
+    );
+    assert.doesNotMatch(JSON.stringify(props), /unsupported_unknown/u);
+  });
+
+  it("rejects empty Map record initializer when key type is unknown", () => {
+    const source = `
+      interface Registry { byId: ReadonlyMap<unknown, number> }
+      export function f(): Registry {
+        return { byId: new Map() };
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "f",
+      strategy: IntStrategy,
+    });
+
+    assert.equal(props.length, 1);
+    assertUnsupportedReason(
+      props,
+      /f\.byId: TS unknown is not expressible/u,
+      "empty Map record initializer with unknown key type",
+    );
+    assert.doesNotMatch(JSON.stringify(props), /unsupported_unknown/u);
+  });
+
+  it("rejects empty Map record initializer when value type is unknown", () => {
+    const source = `
+      interface Registry { byId: ReadonlyMap<string, unknown> }
+      export function f(): Registry {
+        return { byId: new Map() };
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "f",
+      strategy: IntStrategy,
+    });
+
+    assert.equal(props.length, 1);
+    assertUnsupportedReason(
+      props,
+      /f\.byId: TS unknown is not expressible/u,
+      "empty Map record initializer with unknown value type",
+    );
+    assert.doesNotMatch(JSON.stringify(props), /unsupported_unknown/u);
+  });
+
   it("emits trailing-if diagnostic for single `if (P) return E;` body", () => {
     const source = `
       export function f(n: number): number {

--- a/tools/ts2pant/tests/translate-types.test.mts
+++ b/tools/ts2pant/tests/translate-types.test.mts
@@ -414,4 +414,13 @@ describe("depModuleNameForFile", () => {
   it("strips directory and extension", () => {
     assert.equal(depModuleNameForFile("foo.ts"), "FOO_TUPLES");
   });
+
+  it("falls back to TUPLES for extension-only or empty input", () => {
+    // `_TUPLES` would be rejected by Pantagruel's lexer — UPPER_IDENT
+    // requires an uppercase first character. Use the unprefixed
+    // `TUPLES` instead, matching the no-sourceFile fallback in
+    // `cellRegisterTupleConstructor`.
+    assert.equal(depModuleNameForFile(".ts"), "TUPLES");
+    assert.equal(depModuleNameForFile(""), "TUPLES");
+  });
 });

--- a/tools/ts2pant/tests/translate-types.test.mts
+++ b/tools/ts2pant/tests/translate-types.test.mts
@@ -426,6 +426,25 @@ describe("cellRegisterTupleConstructor", () => {
     assert.equal(r2.ctorRuleName, "make-string-int");
   });
 
+  it("does not collide nested tuple element shapes", () => {
+    // `[Int, Int * Int]` and `[Int * Int, Int]` are structurally
+    // distinct shapes; a delimiter-naive key (joining elements with
+    // `*`) would hash both to `Int*Int*Int` and merge the
+    // constructors. The canonical key must use a delimiter-safe
+    // encoding so the boundaries between elements stay unambiguous.
+    const cell = newSynthCell();
+    const r1 = cellRegisterTupleConstructor(cell, {
+      elementPantTypes: ["Int", "Int * Int"],
+    });
+    const r2 = cellRegisterTupleConstructor(cell, {
+      elementPantTypes: ["Int * Int", "Int"],
+    });
+    assert.ok(r1 !== null);
+    assert.ok(r2 !== null);
+    assert.notEqual(r1.ctorRuleName, r2.ctorRuleName);
+    assert.equal(cellTupleShapes(cell).length, 2);
+  });
+
   it("ctor names are isolated from the consumer registry", () => {
     // Tuple ctors live in a separate dep module, so collisions in the
     // consumer's NameRegistry must not perturb the canonical
@@ -542,5 +561,23 @@ describe("depModuleNameForFile", () => {
     // `cellRegisterTupleConstructor`.
     assert.equal(depModuleNameForFile(".ts"), "TUPLES");
     assert.equal(depModuleNameForFile(""), "TUPLES");
+  });
+
+  it("prefixes digit-leading basenames with F_", () => {
+    // `123_FOO_TUPLES` would also be rejected by the lexer. Prefix
+    // with `F_` (a stable letter, no semantics) so the result is a
+    // legal UPPER_IDENT.
+    assert.equal(
+      depModuleNameForFile("123-foo.ts"),
+      "F_123_FOO_TUPLES",
+    );
+    assert.equal(depModuleNameForFile("9.ts"), "F_9_TUPLES");
+  });
+
+  it("strips leading underscores so `_foo.ts` is well-formed", () => {
+    // Filenames like `_foo.ts` would otherwise yield `_FOO_TUPLES`.
+    // Strip the leading underscore-only prefix; the remaining
+    // letter-led stem is a legal UPPER_IDENT.
+    assert.equal(depModuleNameForFile("_foo.ts"), "FOO_TUPLES");
   });
 });

--- a/tools/ts2pant/tests/translate-types.test.mts
+++ b/tools/ts2pant/tests/translate-types.test.mts
@@ -367,6 +367,80 @@ describe("mapTsType", () => {
   });
 });
 
+describe("translateTypes routes `unknown` through `unsupported` declaration", () => {
+  it("interface field with `unknown` type emits an unsupported decl", () => {
+    const { decls } = extractAndTranslate(
+      `interface Foo { val: unknown; }`,
+    );
+    // The `Foo` domain decl is still pushed; the field accessor rule
+    // is replaced by an `unsupported` decl carrying the user-facing
+    // reason, so the emitted Pant text never contains the sentinel.
+    assert.ok(decls.some((d) => d.kind === "domain" && d.name === "Foo"));
+    const unsupported = decls.find((d) => d.kind === "unsupported");
+    assert.ok(unsupported);
+    if (unsupported.kind !== "unsupported") {
+      throw new Error("expected unsupported decl");
+    }
+    assert.match(unsupported.reason, /Foo\.val/u);
+    assert.match(unsupported.reason, /TS unknown is not expressible/u);
+    // No rule decl referencing the sentinel string leaks through.
+    assert.ok(
+      !decls.some(
+        (d) =>
+          (d.kind === "rule" && d.returnType.includes("unsupported_unknown")) ||
+          (d.kind === "alias" && d.type.includes("unsupported_unknown")),
+      ),
+    );
+  });
+
+  it("alias `T = unknown` emits an unsupported decl", () => {
+    const { decls } = extractAndTranslate(`type Foo = unknown;`);
+    const unsupported = decls.find((d) => d.kind === "unsupported");
+    assert.ok(unsupported);
+    if (unsupported.kind !== "unsupported") {
+      throw new Error("expected unsupported decl");
+    }
+    assert.match(unsupported.reason, /alias Foo/u);
+  });
+});
+
+describe("cellRegisterMap / cellRegisterRecord / cellRegisterTupleConstructor reject `unknown` defensively", () => {
+  it("cellRegisterMap returns null when K is the sentinel", async () => {
+    const { cellRegisterMap, newSynthCell, UNSUPPORTED_UNKNOWN } = await import(
+      "../src/translate-types.js"
+    );
+    const cell = newSynthCell();
+    assert.equal(
+      cellRegisterMap(cell, UNSUPPORTED_UNKNOWN, "Int"),
+      null,
+    );
+    assert.equal(cell.synth.byKV.size, 0);
+  });
+
+  it("cellRegisterRecord returns null when a field type is the sentinel", async () => {
+    const { cellRegisterRecord, newSynthCell, UNSUPPORTED_UNKNOWN } =
+      await import("../src/translate-types.js");
+    const cell = newSynthCell();
+    assert.equal(
+      cellRegisterRecord(cell, [{ name: "x", type: UNSUPPORTED_UNKNOWN }]),
+      null,
+    );
+    assert.equal(cell.recordSynth.byShape.size, 0);
+  });
+
+  it("cellRegisterTupleConstructor returns null when an element is the sentinel", async () => {
+    const { UNSUPPORTED_UNKNOWN } = await import("../src/translate-types.js");
+    const cell = newSynthCell();
+    assert.equal(
+      cellRegisterTupleConstructor(cell, {
+        elementPantTypes: [UNSUPPORTED_UNKNOWN, "Int"],
+      }),
+      null,
+    );
+    assert.equal(cellTupleShapes(cell).length, 0);
+  });
+});
+
 describe("cellRegisterTupleConstructor", () => {
   it("dedupes by shape, not alias", () => {
     // Two TS aliases that share the same shape — `Point = [number,

--- a/tools/ts2pant/tests/translate-types.test.mts
+++ b/tools/ts2pant/tests/translate-types.test.mts
@@ -8,6 +8,7 @@ import {
   getChecker,
 } from "../src/extract.js";
 import { assertWasmTypeChecks, loadAst } from "../src/pant-wasm.js";
+import { emptyNameRegistry, registerName } from "../src/name-registry.js";
 import {
   cellRegisterTupleConstructor,
   cellTupleShapes,
@@ -266,6 +267,104 @@ describe("mapTsType", () => {
       UNSUPPORTED_UNKNOWN,
     );
   });
+
+  it("propagates `unknown` through tuple element", () => {
+    const source = `interface Foo { val: [unknown, number]; }`;
+    const sourceFile = createSourceFileFromSource(source);
+    const checker = getChecker(sourceFile);
+    const extracted = extractAllTypes(sourceFile);
+    const prop = extracted.interfaces[0].properties[0];
+
+    assert.equal(
+      mapTsType(prop.type, checker, IntStrategy),
+      UNSUPPORTED_UNKNOWN,
+    );
+  });
+
+  it("propagates `unknown` through array element", () => {
+    const source = `interface Foo { val: unknown[]; }`;
+    const sourceFile = createSourceFileFromSource(source);
+    const checker = getChecker(sourceFile);
+    const extracted = extractAllTypes(sourceFile);
+    const prop = extracted.interfaces[0].properties[0];
+
+    assert.equal(
+      mapTsType(prop.type, checker, IntStrategy),
+      UNSUPPORTED_UNKNOWN,
+    );
+  });
+
+  it("propagates `unknown` through Set element", () => {
+    const source = `interface Foo { val: Set<unknown>; }`;
+    const sourceFile = createSourceFileFromSource(source);
+    const checker = getChecker(sourceFile);
+    const extracted = extractAllTypes(sourceFile);
+    const prop = extracted.interfaces[0].properties[0];
+
+    assert.equal(
+      mapTsType(prop.type, checker, IntStrategy),
+      UNSUPPORTED_UNKNOWN,
+    );
+  });
+
+  it("propagates `unknown` through Map K and V", () => {
+    // `Map<unknown, Int>` previously synthesized a domain like
+    // `__unsupported_unknown__ToIntMap` because the all-underscore
+    // sentinel happens to satisfy `manglePantTypeToFragment`'s
+    // identifier check. Reject before the synth registers.
+    const cellK = newSynthCell();
+    const sourceK = `interface Foo { val: Map<unknown, number>; }`;
+    const sfK = createSourceFileFromSource(sourceK);
+    const propK = extractAllTypes(sfK).interfaces[0].properties[0];
+    assert.equal(
+      mapTsType(propK.type, getChecker(sfK), IntStrategy, cellK),
+      UNSUPPORTED_UNKNOWN,
+    );
+    // No partial Map domain leaked into the synth state.
+    assert.equal(cellK.synth.byKV.size, 0);
+
+    const cellV = newSynthCell();
+    const sourceV = `interface Foo { val: Map<string, unknown>; }`;
+    const sfV = createSourceFileFromSource(sourceV);
+    const propV = extractAllTypes(sfV).interfaces[0].properties[0];
+    assert.equal(
+      mapTsType(propV.type, getChecker(sfV), IntStrategy, cellV),
+      UNSUPPORTED_UNKNOWN,
+    );
+    assert.equal(cellV.synth.byKV.size, 0);
+  });
+
+  it("propagates `unknown` through union members", () => {
+    const source = `interface Foo { val: string | unknown; }`;
+    const sourceFile = createSourceFileFromSource(source);
+    const checker = getChecker(sourceFile);
+    const extracted = extractAllTypes(sourceFile);
+    const prop = extracted.interfaces[0].properties[0];
+
+    // `string | unknown` collapses to `unknown` at the TS-checker
+    // layer, but the union branch must propagate the sentinel either
+    // way. Either pre-collapse (the union check fires) or post-collapse
+    // (the unknown short-circuit fires) — both surface the sentinel.
+    assert.equal(
+      mapTsType(prop.type, checker, IntStrategy),
+      UNSUPPORTED_UNKNOWN,
+    );
+  });
+
+  it("propagates `unknown` through anonymous record field", () => {
+    const cell = newSynthCell();
+    const source = `function f(): { x: unknown } { return { x: 1 }; }`;
+    const sourceFile = createSourceFileFromSource(source);
+    const checker = getChecker(sourceFile);
+    const fn = sourceFile.getFunctionOrThrow("f");
+    const returnType = fn.getReturnType().compilerType;
+    assert.equal(
+      mapTsType(returnType, checker, IntStrategy, cell),
+      UNSUPPORTED_UNKNOWN,
+    );
+    // No partial record domain leaked into the synth state.
+    assert.equal(cell.recordSynth.byShape.size, 0);
+  });
 });
 
 describe("cellRegisterTupleConstructor", () => {
@@ -325,6 +424,27 @@ describe("cellRegisterTupleConstructor", () => {
     assert.notEqual(r1.ctorRuleName, r2.ctorRuleName);
     assert.equal(r1.ctorRuleName, "make-int-int");
     assert.equal(r2.ctorRuleName, "make-string-int");
+  });
+
+  it("ctor names are isolated from the consumer registry", () => {
+    // Tuple ctors live in a separate dep module, so collisions in the
+    // consumer's NameRegistry must not perturb the canonical
+    // `make-<canonical>` form. A user-declared `make-int-int` in the
+    // consumer should leave the synthesized ctor name unchanged.
+    const consumerRegistry = registerName(
+      emptyNameRegistry(),
+      "make-int-int",
+    ).registry;
+    const cell = newSynthCell(consumerRegistry);
+    const ref = cellRegisterTupleConstructor(cell, {
+      elementPantTypes: ["Int", "Int"],
+    });
+    assert.ok(ref !== null);
+    // No suffix despite the consumer's prior registration.
+    assert.equal(ref.ctorRuleName, "make-int-int");
+    // Consumer registry untouched: still a single registration.
+    assert.equal(cell.registry.used.size, 1);
+    assert.ok(cell.registry.used.has("make-int-int"));
   });
 });
 

--- a/tools/ts2pant/tests/translate-types.test.mts
+++ b/tools/ts2pant/tests/translate-types.test.mts
@@ -7,11 +7,19 @@ import {
   extractReferencedTypes,
   getChecker,
 } from "../src/extract.js";
+import { assertWasmTypeChecks, loadAst } from "../src/pant-wasm.js";
 import {
+  cellRegisterTupleConstructor,
+  cellTupleShapes,
+  depModuleNameForFile,
+  emitTupleCtorModule,
   IntStrategy,
   mapTsType,
+  newSynthCell,
   RealStrategy,
   translateTypes,
+  type TupleShape,
+  UNSUPPORTED_UNKNOWN,
 } from "../src/translate-types.js";
 import type { PantDeclaration } from "../src/types.js";
 
@@ -240,5 +248,170 @@ describe("mapTsType", () => {
     const prop = foo.properties[0];
 
     assert.equal(mapTsType(prop.type, checker, IntStrategy), "[A + B]");
+  });
+
+  it("rejects `unknown`", () => {
+    // Pantagruel is monomorphic over named domains; there is no top type
+    // to absorb `unknown` into. mapTsType returns the dedicated
+    // UNSUPPORTED_UNKNOWN sentinel so downstream UNSUPPORTED-skip
+    // infrastructure can surface a clear diagnostic to the user.
+    const source = `interface Foo { val: unknown; }`;
+    const sourceFile = createSourceFileFromSource(source);
+    const checker = getChecker(sourceFile);
+    const extracted = extractAllTypes(sourceFile);
+    const prop = extracted.interfaces[0].properties[0];
+
+    assert.equal(
+      mapTsType(prop.type, checker, IntStrategy),
+      UNSUPPORTED_UNKNOWN,
+    );
+  });
+});
+
+describe("cellRegisterTupleConstructor", () => {
+  it("dedupes by shape, not alias", () => {
+    // Two TS aliases that share the same shape — `Point = [number,
+    // number]` and `Vec2 = [number, number]` both map to ["Int", "Int"]
+    // — must share a single constructor. Otherwise EUF congruence
+    // (Kroening & Strichman, Decision Procedures Ch. 8) cannot prove
+    // `make-point 0 0 = make-vec2 0 0`.
+    const cell = newSynthCell();
+    const shape1: TupleShape = { elementPantTypes: ["Int", "Int"] };
+    const shape2: TupleShape = { elementPantTypes: ["Int", "Int"] };
+
+    const ref1 = cellRegisterTupleConstructor(cell, shape1);
+    const ref2 = cellRegisterTupleConstructor(cell, shape2);
+
+    assert.ok(ref1 !== null);
+    assert.ok(ref2 !== null);
+    assert.equal(ref1.ctorRuleName, "make-int-int");
+    assert.equal(ref1.ctorRuleName, ref2.ctorRuleName);
+    assert.equal(ref1.depModuleName, ref2.depModuleName);
+    assert.equal(cellTupleShapes(cell).length, 1);
+  });
+
+  it("derives depModuleName from cell.sourceFile", () => {
+    const sf = createSourceFileFromSource(
+      "interface Foo { val: number; }",
+      "expressions-tuple.ts",
+    );
+    const cell = newSynthCell(undefined, sf.compilerNode);
+    const ref = cellRegisterTupleConstructor(cell, {
+      elementPantTypes: ["Int", "Int"],
+    });
+    assert.ok(ref !== null);
+    assert.equal(ref.depModuleName, "EXPRESSIONS_TUPLE_TUPLES");
+  });
+
+  it("falls back to TUPLES when cell has no sourceFile", () => {
+    const cell = newSynthCell();
+    const ref = cellRegisterTupleConstructor(cell, {
+      elementPantTypes: ["Int", "Int"],
+    });
+    assert.ok(ref !== null);
+    assert.equal(ref.depModuleName, "TUPLES");
+  });
+
+  it("distinct shapes get distinct constructor names", () => {
+    const cell = newSynthCell();
+    const r1 = cellRegisterTupleConstructor(cell, {
+      elementPantTypes: ["Int", "Int"],
+    });
+    const r2 = cellRegisterTupleConstructor(cell, {
+      elementPantTypes: ["String", "Int"],
+    });
+    assert.ok(r1 !== null);
+    assert.ok(r2 !== null);
+    assert.notEqual(r1.ctorRuleName, r2.ctorRuleName);
+    assert.equal(r1.ctorRuleName, "make-int-int");
+    assert.equal(r2.ctorRuleName, "make-string-int");
+  });
+});
+
+describe("emitTupleCtorModule", () => {
+  it("for [Int, Int] produces a typechecking module", async () => {
+    await loadAst();
+    const sf = createSourceFileFromSource(
+      "interface Foo { val: number; }",
+      "tuple-shapes.ts",
+    );
+    const cell = newSynthCell(undefined, sf.compilerNode);
+    const ref = cellRegisterTupleConstructor(cell, {
+      elementPantTypes: ["Int", "Int"],
+    });
+    assert.ok(ref !== null);
+    const text = emitTupleCtorModule(sf.compilerNode, cellTupleShapes(cell));
+
+    // Module header uses the ALL_CAPS_SNAKE convention.
+    assert.match(text, /^module TUPLE_SHAPES_TUPLES\.\n/u);
+    // Constructor rule head present.
+    assert.match(
+      text,
+      /make-int-int a1: Int, a2: Int => Int \* Int\./u,
+    );
+    // The wasm checker accepts the standalone module.
+    await assertWasmTypeChecks(text);
+  });
+
+  it("projection axioms hold", async () => {
+    await loadAst();
+    const sf = createSourceFileFromSource(
+      "interface Foo { val: number; }",
+      "tuple-shapes.ts",
+    );
+    const cell = newSynthCell(undefined, sf.compilerNode);
+    cellRegisterTupleConstructor(cell, {
+      elementPantTypes: ["Int", "Int"],
+    });
+    const text = emitTupleCtorModule(sf.compilerNode, cellTupleShapes(cell));
+
+    // One projection axiom per element position, quantified over the
+    // constructor's parameters. Free variables in propositions must be
+    // bound — that's why the body is `all a1: Int, a2: Int | ...`.
+    assert.match(
+      text,
+      /all a1: Int, a2: Int \| \(make-int-int a1 a2\)\.1 = a1\./u,
+    );
+    assert.match(
+      text,
+      /all a1: Int, a2: Int \| \(make-int-int a1 a2\)\.2 = a2\./u,
+    );
+    // Standalone-typechecks (which exercises the projection axioms).
+    await assertWasmTypeChecks(text);
+  });
+
+  it("aggregates multiple shapes into one module", () => {
+    const sf = createSourceFileFromSource(
+      "interface Foo { val: number; }",
+      "tuple-shapes.ts",
+    );
+    const cell = newSynthCell(undefined, sf.compilerNode);
+    cellRegisterTupleConstructor(cell, {
+      elementPantTypes: ["Int", "Int"],
+    });
+    cellRegisterTupleConstructor(cell, {
+      elementPantTypes: ["String", "Int"],
+    });
+    const text = emitTupleCtorModule(sf.compilerNode, cellTupleShapes(cell));
+
+    // One module header even with multiple shapes.
+    const moduleHeaders = text.match(/^module /gmu) ?? [];
+    assert.equal(moduleHeaders.length, 1);
+    // Both constructor heads present.
+    assert.match(text, /make-int-int /u);
+    assert.match(text, /make-string-int /u);
+  });
+});
+
+describe("depModuleNameForFile", () => {
+  it("converts kebab-cased file base to ALL_CAPS_SNAKE", () => {
+    assert.equal(
+      depModuleNameForFile("/path/to/expressions-reduce.ts"),
+      "EXPRESSIONS_REDUCE_TUPLES",
+    );
+  });
+
+  it("strips directory and extension", () => {
+    assert.equal(depModuleNameForFile("foo.ts"), "FOO_TUPLES");
   });
 });


### PR DESCRIPTION
## Patch 5: Tuple-shape constructor synthesis (per-source-file dep module)

- Define `interface TupleShape { elementPantTypes: string[] }`. Canonical key: elementTypes joined by `*` (so `[number, number]` and `Point = [number, number]` share one shape — EUF congruence soundness, Kroening & Strichman Ch. 8).
- `cellRegisterTupleConstructor(cell, shape)` registers (or returns the existing) constructor rule + projection axioms. Constructor name is `make-<canonical>` (e.g. `make-int-int`). Returns a `TupleCtorRef { ctorRuleName, depModuleName }` where `depModuleName` is `<FILE_BASE_NAME>_TUPLES` derived from the source file currently being translated (mirrors the ambient-module per-file scope decided in Patch 4).
- `emitTupleCtorModule(sourceFile, shapes)` returns the standalone dep module text: header `module <FILE_BASE_NAME>_TUPLES.`, one constructor rule head per registered shape, plus per-position projection body axioms `(make-int-int a1 a2).1 = a1.` / `(make-int-int a1 a2).2 = a2.`. All shapes used by any fixture in the source file aggregate into one dep module — one import per consumer regardless of how many tuple shapes the file uses.
- In mapTsType: when the type is `unknown`, return `{ unsupported: 'TS unknown is not expressible in Pantagruel; declare a specific type' }`.

## Changes
- Define `interface TupleShape { elementPantTypes: string[] }`. Canonical key: elementTypes joined by `*` (so `[number, number]` and `Point = [number, number]` share one shape — EUF congruence soundness, Kroening & Strichman Ch. 8).
- `cellRegisterTupleConstructor(cell, shape)` registers (or returns the existing) constructor rule + projection axioms. Constructor name is `make-<canonical>` (e.g. `make-int-int`). Returns a `TupleCtorRef { ctorRuleName, depModuleName }` where `depModuleName` is `<FILE_BASE_NAME>_TUPLES` derived from the source file currently being translated (mirrors the ambient-module per-file scope decided in Patch 4).
- `emitTupleCtorModule(sourceFile, shapes)` returns the standalone dep module text: header `module <FILE_BASE_NAME>_TUPLES.`, one constructor rule head per registered shape, plus per-position projection body axioms `(make-int-int a1 a2).1 = a1.` / `(make-int-int a1 a2).2 = a2.`. All shapes used by any fixture in the source file aggregate into one dep module — one import per consumer regardless of how many tuple shapes the file uses.
- In mapTsType: when the type is `unknown`, return `{ unsupported: 'TS unknown is not expressible in Pantagruel; declare a specific type' }`.

## Files to Modify
- tools/ts2pant/src/translate-types.ts (modify): Add cellRegisterTupleConstructor + emitTupleCtorModule paralleling cellRegisterMap / cellRegisterRecord. Per-source-file scope.

## Gameplan Specification

```
module KNOWN_FAILURES.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> After this gameplan, KNOWN_TYPECHECK_FAILURES contains exactly
> the two intentional class-method entries. Every other fixture in
> tools/ts2pant/tests/fixtures/constructs/ either typechecks via
> the wasm bridge or routes through the UNSUPPORTED-skip path. The
> wasm bridge resolves cross-module imports against an in-memory
> registry, matching the `pant` CLI's import semantics exactly.
>
> Dependency rules emit as standalone Pantagruel modules — hand-
> written `samples/js-stdlib/JS_MATH.pant` / `JS_STRING.pant` for
> TS standard-library builtins (Math.*, String.prototype.*); per-
> source-file synthesised `<FILE_BASE_NAME>_AMBIENT` for user
> `declare function`s; per-source-file `<FILE_BASE_NAME>_TUPLES` for
> anonymous tuple constructors. Consumer modules import them via
> `import` lines and reference qualified rules (`math::max`).
> Every emitted module name uses ALL_CAPS_SNAKE convention,
> matching the existing `samples/*.pant` corpus.
> No emitted Pant text contains `$` (binder hygiene); no emitted
> rule name is a Pant reserved keyword (sanitisation).
>
> The translation pipeline preserves CLAUDE.md's L1/L2 IR layering:
> builtin / ambient / tuple registration is an L1 concern (TS-shape
> recognition); qualified-name lowering and module-text emission
> are L2 → OpaqueExpr concerns. dep-module attachment to
> PantDocument is a pipeline-orchestration concern, not an IR
> concern. References: Vekris/Cosman/Jhala (PLDI 2016, IR
> separation); Kroening & Strichman (Decision Procedures Ch. 4 EUF,
> Ch. 8 records); Peyton Jones & Marlow (JFP 2002, Barendregt
> hygiene); Jackson (Software Abstractions, Alloy `lone`
> multiplicity); Baader & Nipkow (Term Rewriting, Ch. 2
> substitution).

Fixture.
Document.
DepModule.
DepBundle.
DepKind.
FixtureStatus.
CheckResult.

passes-typecheck => FixtureStatus.
skipped-unsupported => FixtureStatus.
in-known-failures => FixtureStatus.

builtin-dep => DepKind.
ambient-dep => DepKind.
tuple-ctor-dep => DepKind.

ok => CheckResult.
error-msg => CheckResult.

status f: Fixture => FixtureStatus.
intentional? f: Fixture => Bool.
emitted f: Fixture => Document.
dep-modules f: Fixture => [DepModule].
imports-of d: Document => [String].

contains-dollar? d: Document => Bool.
uses-keyword-as-name? d: Document => Bool.
imports-resolved? d: Document, deps: [DepModule] => Bool.

kind m: DepModule => DepKind.
emits-typechecking-text? m: DepModule => Bool.

is-screaming-snake? n: String => Bool.
module-name-of d: Document => String.

bundle-of f: Fixture => DepBundle.
resolved-bundle? d: Document, b: DepBundle => Bool.
check-bundle d: Document, b: DepBundle => CheckResult.

---
> Every fixture that remains in KNOWN_TYPECHECK_FAILURES is intentional.
all f: Fixture, status f = in-known-failures | intentional? f.

> No emitted document contains a `$` character (binder hygiene).
all f: Fixture | ~(contains-dollar? (emitted f)).

> No emitted document uses a Pant reserved keyword as a rule name.
all f: Fixture | ~(uses-keyword-as-name? (emitted f)).

> Every emitted document's module name is ALL_CAPS_SNAKE.
all f: Fixture | is-screaming-snake? (module-name-of (emitted f)).

> Imports in passing-fixture emitted documents resolve against
> the dep modules attached to the fixture's bundle.
all f: Fixture, status f = passes-typecheck
  | imports-resolved? (emitted f) (dep-modules f).

> The wasm bundle-check succeeds only if every import resolves.
all d: Document, b: DepBundle, check-bundle d b = ok | resolved-bundle? d b.

> Every dep module emits text that typechecks standalone.
all m: DepModule | emits-typechecking-text? m.

```

## Patch Specification

```
module KNOWN_FAILURES_PATCH_5.

> Patch 5 introduces tuple-shape constructor synthesis and rejects
> `unknown` from mapTsType. Constructor names canonicalise on shape
> so EUF congruence stays sound across user aliases.
> Reference: Kroening & Strichman, Decision Procedures Ch. 8.

TupleShape.
TupleCtor.
shape c: TupleCtor => TupleShape.
ctor-name c: TupleCtor => String.

---
> Same shape → same constructor (no alias-driven duplication).
all c1: TupleCtor, c2: TupleCtor, shape c1 = shape c2 | ctor-name c1 = ctor-name c2.

```


## Implementation Notes

### Deviations from the gameplan description

- **`unknown` rejection signals via a sentinel string, not an object.** The plan said "return `{ unsupported: '...' }`", but `mapTsType` returns `string` and is called from ~15 sites. Returning a discriminated object would have required either a wholesale signature change or an unsafe cast. I followed the existing pattern (`UNSUPPORTED_ANONYMOUS_RECORD`) and added `UNSUPPORTED_UNKNOWN = "__unsupported_unknown__"` plus a paired `UNSUPPORTED_UNKNOWN_REASON` constant exporting the user-facing reason text. Downstream UNSUPPORTED-skip (Patch 6) can map sentinel→reason without touching the signature.

- **Projection axioms are explicitly `all`-quantified.** The plan wrote them as `(make-int-int a1 a2).1 = a1.` without binders, but Pantagruel's `proposition = expr DOT` grammar forbids unbound free variables — so the emitted form is `all a1: Int, a2: Int | (make-int-int a1 a2).1 = a1.`. The wasm checker accepts the emitted module standalone (asserted in tests).

### Implementation choices worth flagging

- **Per-file scope is plumbed through `SynthCell.sourceFile?: ts.SourceFile`** rather than a third parameter on `cellRegisterTupleConstructor(cell, shape)` — keeps the signature matching the gameplan verbatim and gives downstream patches a single attach-point. When absent (test/standalone paths), `depModuleName` falls back to a generic `"TUPLES"`.

- **Shape key strips whitespace before joining with `*`.** `["Int", "Int * Int"]` and `["Int", "Int*Int"]` hash to the same key, so cosmetic differences in mapTsType output don't fork the constructor table.

- **Constructor naming uses the existing `manglePantTypeToFragment` + `toPantTermName` pipeline** (the same one Map/Record synth use), so list/sum/product element types lower consistently (`[Int]` → `list-int`, `A * B` → `a-and-b`).

- **`cellEmitSynth` deliberately does *not* drain tuple shapes.** Tuple constructors live in a *separate* dep module emitted by `emitTupleCtorModule`, not in the consumer's head — folding them into `cellEmitSynth` would inline the rules into every consumer (the exact pattern OPINION 1 in the gameplan rejects). A doc comment on `cellEmitSynth` calls this out.

### Snapshot updates

Two construct snapshots changed because the `unknown` rejection now produces `__unsupported_unknown__` in signature output instead of the bare word `unknown`:

- `expressions-misc.ts > asNumber` (param typed `unknown`)
- `expressions-property-element-access.ts > getByDynamicKey` (return typed `unknown`)

Both fixtures already fail wasm typechecking (entries in `KNOWN_TYPECHECK_FAILURES`); the snapshot just records the new sentinel. No behavior regression — the previous output (`x: unknown => ...`) was equally unparseable, just less honest about why.

### Wiring

This patch is INFRA-only: the new APIs are exported but not yet called from any translation site. The Patch 11 BEHAVIOR work ("Wire dep-module emission: builtins, ambients, tuples") is what plumbs `cellRegisterTupleConstructor` into the array-literal-in-tuple-position translator and `emitTupleCtorModule` into the document-emit boundary.