### PR TITLE
[ts2pant-known-failures] Patch 6: Test framework: UNSUPPORTED-skip path

### DIFF
--- a/tools/ts2pant/CLAUDE.md
+++ b/tools/ts2pant/CLAUDE.md
@@ -1299,6 +1299,8 @@ The split exists for stability, not just performance. `getPantBin()` in `tests/h
 
 **Reintroducing the lazy-build pattern is forbidden.** If a new test needs the pant binary, route it through the integration suite — don't add an `execSync("dune build")` to `helpers.mts` or any `tests/*.test.mts` file.
 
+**`> UNSUPPORTED:` skip path.** An emitted line beginning with `> UNSUPPORTED:` is a deliberate-rejection signal recognised by `emitAndCheck` (and mirrored on the IR-equivalence path); the document is not wasm-typechecked, but the snapshot still captures the rejection message verbatim. This lets fixtures that exercise an `unsupported`-PropResult emission stay in the snapshot suite without polluting `KNOWN_TYPECHECK_FAILURES` (which is reserved for fixtures whose *non-rejection* output the wasm checker rejects).
+
 ### Snapshot files
 
 Each snapshot-based `*.test.mts` has a sibling `*.test.mts.snapshot` (Node test runner's snapshot format). When snapshot tests are moved between directories, their `.snapshot` files must move with them; the runner resolves snapshot paths from the test file's location, so a missing-snapshot error usually means a mismatched move.

--- a/tools/ts2pant/tests/helpers.mts
+++ b/tools/ts2pant/tests/helpers.mts
@@ -2,7 +2,7 @@ import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { emitDocument } from "../src/emit.js";
-import { type SourceFile, createSourceFile } from "../src/extract.js";
+import { createSourceFile, type SourceFile } from "../src/extract.js";
 import { assertWasmTypeChecks } from "../src/pant-wasm.js";
 import { buildPantDocument } from "../src/pipeline.js";
 import { IntStrategy } from "../src/translate-types.js";
@@ -102,11 +102,34 @@ export { emitDocument };
  * through this so we don't snapshot output that the OCaml typechecker
  * would reject.
  *
+ * If the emitted text contains a `> UNSUPPORTED:` line, the document
+ * is a deliberate-rejection signal and the wasm typecheck is skipped —
+ * the snapshot still captures the rejection message verbatim. See
+ * `tools/ts2pant/CLAUDE.md` § "Test layout".
+ *
+ * If the document carries a `bundleModules` map (added by the dep-
+ * module pipeline), it is forwarded as the in-memory dep registry so
+ * the consumer's `import` declarations resolve.
+ *
  * Returns the emitted text so the caller can still snapshot or assert
  * on it. Throws (with a snippet of the input) if checking fails.
  */
-export async function emitAndCheck(doc: PantDocument): Promise<string> {
+export async function emitAndCheck(
+  doc: PantDocument & { bundleModules?: Map<string, string> },
+): Promise<string> {
   const output = emitDocument(doc);
-  await assertWasmTypeChecks(output);
+  if (containsUnsupportedLine(output)) {
+    return output;
+  }
+  await assertWasmTypeChecks(output, doc.bundleModules);
   return output;
+}
+
+/**
+ * Detect a deliberate-rejection signal — an emitted line beginning with
+ * `> UNSUPPORTED:`. Mirrors the marker `emit.ts` writes for
+ * `kind: "unsupported"` PropResults.
+ */
+export function containsUnsupportedLine(output: string): boolean {
+  return /^> UNSUPPORTED:/mu.test(output);
 }

--- a/tools/ts2pant/tests/helpers.mts
+++ b/tools/ts2pant/tests/helpers.mts
@@ -107,16 +107,14 @@ export { emitDocument };
  * the snapshot still captures the rejection message verbatim. See
  * `tools/ts2pant/CLAUDE.md` § "Test layout".
  *
- * If the document carries a `bundleModules` map (added by the dep-
- * module pipeline), it is forwarded as the in-memory dep registry so
- * the consumer's `import` declarations resolve.
+ * If the document carries a `bundleModules` map, it is forwarded as
+ * the in-memory dep registry so the consumer's `import` declarations
+ * resolve.
  *
  * Returns the emitted text so the caller can still snapshot or assert
  * on it. Throws (with a snippet of the input) if checking fails.
  */
-export async function emitAndCheck(
-  doc: PantDocument & { bundleModules?: Map<string, string> },
-): Promise<string> {
+export async function emitAndCheck(doc: PantDocument): Promise<string> {
   const output = emitDocument(doc);
   if (containsUnsupportedLine(output)) {
     return output;

--- a/tools/ts2pant/tests/helpers.test.mts
+++ b/tools/ts2pant/tests/helpers.test.mts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import { before, describe, it } from "node:test";
+import { loadAst } from "../src/pant-wasm.js";
+import type { PantDocument } from "../src/types.js";
+import { containsUnsupportedLine, emitAndCheck } from "./helpers.mjs";
+
+before(async () => {
+  await loadAst();
+});
+
+/**
+ * Build a minimal PantDocument fixture programmatically. Avoids the
+ * full ts-morph translation pipeline so the helpers under test stay
+ * the only moving part.
+ */
+function buildDoc(opts: {
+  moduleName: string;
+  propositions: PantDocument["propositions"];
+  bundleModules?: Map<string, string>;
+}): PantDocument & { bundleModules?: Map<string, string> } {
+  return {
+    moduleName: opts.moduleName,
+    declarations: [],
+    propositions: opts.propositions,
+    checks: [],
+    bundleModules: opts.bundleModules,
+  };
+}
+
+describe("helpers > containsUnsupportedLine", () => {
+  it("matches a `> UNSUPPORTED:` line at start-of-line", () => {
+    const text = "module Foo.\n\n---\n\n> UNSUPPORTED: bar.\n";
+    assert.equal(containsUnsupportedLine(text), true);
+  });
+
+  it("does not match `> UNSUPPORTED:` mid-line", () => {
+    const text = "module Foo.\n\n---\n\nfoo > UNSUPPORTED: bar.\n";
+    assert.equal(containsUnsupportedLine(text), false);
+  });
+
+  it("returns false on a clean document", () => {
+    const text = "module Foo.\n\n---\n\ntrue.\n";
+    assert.equal(containsUnsupportedLine(text), false);
+  });
+});
+
+describe("helpers > emitAndCheck", () => {
+  it("skips wasm typecheck on `> UNSUPPORTED:`", async () => {
+    // The propositions list contains an "unsupported" PropResult, so
+    // `emitDocument` writes a `> UNSUPPORTED:` marker. The reason text
+    // ("not real Pant") is also not Pantagruel-valid as a free-standing
+    // proposition — if `emitAndCheck` did NOT skip the typecheck, the
+    // wasm checker would reject and throw. The test passing without a
+    // throw is the deliberate-rejection skip working.
+    const doc = buildDoc({
+      moduleName: "Skipped",
+      propositions: [{ kind: "unsupported", reason: "not real Pant" }],
+    });
+
+    const output = await emitAndCheck(doc);
+
+    assert.match(output, /> UNSUPPORTED: not real Pant/u);
+    assert.ok(
+      containsUnsupportedLine(output),
+      "snapshot should still capture the marker line",
+    );
+  });
+
+  it("still typechecks documents without UNSUPPORTED", async () => {
+    // A clean doc with a single domain declaration and a trivial
+    // `true.` proposition should round-trip through the wasm checker
+    // without complaint.
+    const doc: PantDocument & { bundleModules?: Map<string, string> } = {
+      moduleName: "Clean",
+      declarations: [{ kind: "domain", name: "Item" }],
+      propositions: [{ kind: "raw", text: "true" }],
+      checks: [],
+    };
+
+    const output = await emitAndCheck(doc);
+
+    assert.ok(!containsUnsupportedLine(output));
+    assert.match(output, /module Clean\./u);
+  });
+
+  it("passes deps to checkPantBundle when bundleModules is set", async () => {
+    // The wasm bridge parses every dep entry up front (see
+    // `parse_deps` in wasm/pant_wasm.ml), so a syntactically broken
+    // dep surfaces as a parse error from `assertWasmTypeChecks` even
+    // though the consumer module never imports it. If `emitAndCheck`
+    // did NOT forward `bundleModules`, the broken dep would never be
+    // parsed and this test would mistakenly succeed.
+    const brokenDep = "this is not pantagruel at all";
+    const doc = buildDoc({
+      moduleName: "Consumer",
+      propositions: [{ kind: "raw", text: "true" }],
+      bundleModules: new Map([["BROKEN_DEP", brokenDep]]),
+    });
+
+    await assert.rejects(
+      () => emitAndCheck(doc),
+      /pant typecheck failed/u,
+      "broken dep in bundleModules must surface as a typecheck failure",
+    );
+  });
+});

--- a/tools/ts2pant/tests/helpers.test.mts
+++ b/tools/ts2pant/tests/helpers.test.mts
@@ -15,12 +15,14 @@ before(async () => {
  */
 function buildDoc(opts: {
   moduleName: string;
+  declarations?: PantDocument["declarations"];
   propositions: PantDocument["propositions"];
   bundleModules?: Map<string, string>;
-}): PantDocument & { bundleModules?: Map<string, string> } {
+}): PantDocument {
   return {
     moduleName: opts.moduleName,
-    declarations: [],
+    imports: [],
+    declarations: opts.declarations ?? [],
     propositions: opts.propositions,
     checks: [],
     bundleModules: opts.bundleModules,
@@ -70,12 +72,11 @@ describe("helpers > emitAndCheck", () => {
     // A clean doc with a single domain declaration and a trivial
     // `true.` proposition should round-trip through the wasm checker
     // without complaint.
-    const doc: PantDocument & { bundleModules?: Map<string, string> } = {
+    const doc = buildDoc({
       moduleName: "Clean",
       declarations: [{ kind: "domain", name: "Item" }],
       propositions: [{ kind: "raw", text: "true" }],
-      checks: [],
-    };
+    });
 
     const output = await emitAndCheck(doc);
 

--- a/tools/ts2pant/tests/ir-equivalence.test.mts
+++ b/tools/ts2pant/tests/ir-equivalence.test.mts
@@ -4,7 +4,11 @@ import { resolve } from "node:path";
 import { before, describe, it } from "node:test";
 import { createSourceFile } from "../src/extract.js";
 import { assertWasmTypeChecks, loadAst } from "../src/pant-wasm.js";
-import { buildDocumentFromSourceFile, emitDocument } from "./helpers.mjs";
+import {
+  buildDocumentFromSourceFile,
+  containsUnsupportedLine,
+  emitDocument,
+} from "./helpers.mjs";
 import { KNOWN_TYPECHECK_FAILURES } from "./known-typecheck-failures.mjs";
 
 before(async () => {
@@ -148,8 +152,10 @@ describe("Stage 1 IR-equivalence: legacy and IR produce identical output", () =>
         );
         // Both pipelines produced the same string — also assert it's valid
         // Pant. Skip for fixtures shared with the constructs.test.mts
-        // known-bad list (same emit bugs surface in both suites).
-        if (!knownBad) {
+        // known-bad list (same emit bugs surface in both suites). Also
+        // skip on a `> UNSUPPORTED:` line — see helpers.emitAndCheck and
+        // CLAUDE.md § "Test layout".
+        if (!knownBad && !containsUnsupportedLine(ir)) {
           await assertWasmTypeChecks(ir);
         }
       });


### PR DESCRIPTION
## Patch 6: Test framework: UNSUPPORTED-skip path

- In helpers.mts emitAndCheck: after emitDocument, scan for a line beginning with `> UNSUPPORTED:`. If found, skip assertWasmTypeChecks and return the output unchanged. Snapshot still captures the rejection message exactly.
- Mirror the same skip in ir-equivalence.test.mts:153.
- Document the skip in tools/ts2pant/CLAUDE.md § Test layout — one short paragraph: 'An `> UNSUPPORTED:` line in emitted output is a deliberate-rejection signal recognised by the runner; the document is not wasm-typechecked, but the snapshot still captures the message.'

## Changes
- In helpers.mts emitAndCheck: after emitDocument, scan for a line beginning with `> UNSUPPORTED:`. If found, skip assertWasmTypeChecks and return the output unchanged. Snapshot still captures the rejection message exactly.
- Mirror the same skip in ir-equivalence.test.mts:153.
- Document the skip in tools/ts2pant/CLAUDE.md § Test layout — one short paragraph: 'An `> UNSUPPORTED:` line in emitted output is a deliberate-rejection signal recognised by the runner; the document is not wasm-typechecked, but the snapshot still captures the message.'

## Files to Modify
- tools/ts2pant/tests/helpers.mts (modify): emitAndCheck detects `> UNSUPPORTED:` lines and skips wasm typecheck.
- tools/ts2pant/tests/ir-equivalence.test.mts (modify): Mirror the UNSUPPORTED detection on the IR-equivalence path.

## Gameplan Specification

```
module KNOWN_FAILURES.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> After this gameplan, KNOWN_TYPECHECK_FAILURES contains exactly
> the two intentional class-method entries. Every other fixture in
> tools/ts2pant/tests/fixtures/constructs/ either typechecks via
> the wasm bridge or routes through the UNSUPPORTED-skip path. The
> wasm bridge resolves cross-module imports against an in-memory
> registry, matching the `pant` CLI's import semantics exactly.
>
> Dependency rules emit as standalone Pantagruel modules — hand-
> written `samples/js-stdlib/JS_MATH.pant` / `JS_STRING.pant` for
> TS standard-library builtins (Math.*, String.prototype.*); per-
> source-file synthesised `<FILE_BASE_NAME>_AMBIENT` for user
> `declare function`s; per-source-file `<FILE_BASE_NAME>_TUPLES` for
> anonymous tuple constructors. Consumer modules import them via
> `import` lines and reference qualified rules (`math::max`).
> Every emitted module name uses ALL_CAPS_SNAKE convention,
> matching the existing `samples/*.pant` corpus.
> No emitted Pant text contains `$` (binder hygiene); no emitted
> rule name is a Pant reserved keyword (sanitisation).
>
> The translation pipeline preserves CLAUDE.md's L1/L2 IR layering:
> builtin / ambient / tuple registration is an L1 concern (TS-shape
> recognition); qualified-name lowering and module-text emission
> are L2 → OpaqueExpr concerns. dep-module attachment to
> PantDocument is a pipeline-orchestration concern, not an IR
> concern. References: Vekris/Cosman/Jhala (PLDI 2016, IR
> separation); Kroening & Strichman (Decision Procedures Ch. 4 EUF,
> Ch. 8 records); Peyton Jones & Marlow (JFP 2002, Barendregt
> hygiene); Jackson (Software Abstractions, Alloy `lone`
> multiplicity); Baader & Nipkow (Term Rewriting, Ch. 2
> substitution).

Fixture.
Document.
DepModule.
DepBundle.
DepKind.
FixtureStatus.
CheckResult.

passes-typecheck => FixtureStatus.
skipped-unsupported => FixtureStatus.
in-known-failures => FixtureStatus.

builtin-dep => DepKind.
ambient-dep => DepKind.
tuple-ctor-dep => DepKind.

ok => CheckResult.
error-msg => CheckResult.

status f: Fixture => FixtureStatus.
intentional? f: Fixture => Bool.
emitted f: Fixture => Document.
dep-modules f: Fixture => [DepModule].
imports-of d: Document => [String].

contains-dollar? d: Document => Bool.
uses-keyword-as-name? d: Document => Bool.
imports-resolved? d: Document, deps: [DepModule] => Bool.

kind m: DepModule => DepKind.
emits-typechecking-text? m: DepModule => Bool.

is-screaming-snake? n: String => Bool.
module-name-of d: Document => String.

bundle-of f: Fixture => DepBundle.
resolved-bundle? d: Document, b: DepBundle => Bool.
check-bundle d: Document, b: DepBundle => CheckResult.

---
> Every fixture that remains in KNOWN_TYPECHECK_FAILURES is intentional.
all f: Fixture, status f = in-known-failures | intentional? f.

> No emitted document contains a `$` character (binder hygiene).
all f: Fixture | ~(contains-dollar? (emitted f)).

> No emitted document uses a Pant reserved keyword as a rule name.
all f: Fixture | ~(uses-keyword-as-name? (emitted f)).

> Every emitted document's module name is ALL_CAPS_SNAKE.
all f: Fixture | is-screaming-snake? (module-name-of (emitted f)).

> Imports in passing-fixture emitted documents resolve against
> the dep modules attached to the fixture's bundle.
all f: Fixture, status f = passes-typecheck
  | imports-resolved? (emitted f) (dep-modules f).

> The wasm bundle-check succeeds only if every import resolves.
all d: Document, b: DepBundle, check-bundle d b = ok | resolved-bundle? d b.

> Every dep module emits text that typechecks standalone.
all m: DepModule | emits-typechecking-text? m.

```

## Patch Specification

```
module KNOWN_FAILURES_PATCH_6.

> Patch 6 adds an UNSUPPORTED-skip path to emitAndCheck so
> deliberately-rejected fixtures stay in the snapshot suite without
> polluting KNOWN_TYPECHECK_FAILURES.

Document.
CheckOutcome.
pass => CheckOutcome.
skipped-unsupported => CheckOutcome.
fail => CheckOutcome.

has-unsupported-line? d: Document => Bool.
emit-and-check d: Document => CheckOutcome.

---
> A document with an UNSUPPORTED line is skipped, not failed.
all d: Document, has-unsupported-line? d | emit-and-check d = skipped-unsupported.

```


## Implementation Notes

- **Detection lives in a small exported helper.** `containsUnsupportedLine(output)` (`tests/helpers.mts`) is a one-liner — `/^> UNSUPPORTED:/mu.test(output)` — anchored at start-of-line so a `> UNSUPPORTED:` substring inside a longer rendered expression cannot accidentally trigger the skip. Both `emitAndCheck` and the IR-equivalence path import the same helper so the two skip points cannot drift.

- **`bundleModules` was added a patch ahead of schedule.** The third test stub from the gameplan (`emitAndCheck passes deps to checkPantBundle when bundleModules is set`) requires a deps map on the document. Patch 2 will add `imports` + `bundleModules` to `PantDocument` proper; this patch declares the field on the `emitAndCheck` parameter as `PantDocument & { bundleModules?: Map<string, string> }` so the helper can forward it today without modifying `types.ts`. Patch 2's PantDocument extension will subsume the intersection type cleanly (the intersection becomes a no-op once the field is on the base interface).

- **Forwarding is verified via a parse-broken dep.** The third test exploits a wasm-bridge property (`check_document_with_deps` parses every dep up front in `wasm/pant_wasm.ml`), so a syntactically broken dep in `bundleModules` surfaces as a typecheck failure even though the consumer never imports it. If `emitAndCheck` failed to forward `bundleModules`, the broken dep would never be parsed and the test would silently pass — i.e., the negative-control direction is the correct one.

- **The skip is silent — no console noise.** Skipped documents return their text verbatim; callers (`constructs.test.mts`, snapshot tests) still capture the `> UNSUPPORTED:` line in their snapshots, which is the deliberate single source of truth that the rejection happened. No extra "(skipped)" annotation is added so existing snapshot files don't churn.

- **`KNOWN_TYPECHECK_FAILURES` is unchanged in this patch.** The skip path is the *mechanism* the later prune patch (Patch 13) will lean on; pruning the list itself is out of scope here.

- **Trivial diff to `tests/helpers.mts` imports** (`createSourceFile, type SourceFile` reordered) was applied by `biome check --write` as a safe fix, not a manual edit.