### PR TITLE
[ts2pant-m6-legacy-cleanup] Patch 1: Lock M6 cleanup tests and unsupported boundaries

### DIFF
--- a/tools/ts2pant/tests/ir-build.test.mts
+++ b/tools/ts2pant/tests/ir-build.test.mts
@@ -71,8 +71,12 @@ function containsKind(expr: IRExpr, kind: IRExpr["kind"]): boolean {
         expr.args.some((arg) => containsKind(arg, kind))
       );
     case "cond":
-      return expr.arms.some(
-        ([guard, value]) => containsKind(guard, kind) || containsKind(value, kind),
+      return (
+        expr.arms.some(
+          ([guard, value]) =>
+            containsKind(guard, kind) || containsKind(value, kind),
+        ) ||
+        (expr.otherwise !== undefined && containsKind(expr.otherwise, kind))
       );
     case "let":
       return containsKind(expr.value, kind) || containsKind(expr.body, kind);

--- a/tools/ts2pant/tests/ir-build.test.mts
+++ b/tools/ts2pant/tests/ir-build.test.mts
@@ -1,0 +1,219 @@
+import assert from "node:assert/strict";
+import { before, describe, it } from "node:test";
+import ts from "typescript";
+import { buildIR, isBuildUnsupported } from "../src/ir-build.js";
+import type { IRExpr } from "../src/ir.js";
+import { createSourceFileFromSource, getChecker } from "../src/extract.js";
+import { loadAst } from "../src/pant-wasm.js";
+import { IntStrategy, newSynthCell } from "../src/translate-types.js";
+import type { UniqueSupply } from "../src/translate-body.js";
+
+before(async () => {
+  await loadAst();
+});
+
+interface ExprSetup {
+  expr: ts.Expression;
+  checker: ts.TypeChecker;
+  paramNames: ReadonlyMap<string, string>;
+  supply: UniqueSupply;
+}
+
+function setupReturnExpr(source: string, functionName = "f"): ExprSetup {
+  const sourceFile = createSourceFileFromSource(source);
+  const checker = getChecker(sourceFile);
+  const fn = sourceFile.compilerNode.statements.find(
+    (stmt): stmt is ts.FunctionDeclaration =>
+      ts.isFunctionDeclaration(stmt) && stmt.name?.text === functionName,
+  );
+  if (!fn?.body) {
+    throw new Error(`expected function ${functionName} with a body`);
+  }
+  const stmt = fn.body.statements.find(ts.isReturnStatement);
+  if (!stmt?.expression) {
+    throw new Error(`expected function ${functionName} to return an expression`);
+  }
+  const paramNames = new Map<string, string>();
+  for (const param of fn.parameters) {
+    if (ts.isIdentifier(param.name)) {
+      paramNames.set(param.name.text, param.name.text);
+    }
+  }
+  return {
+    expr: stmt.expression,
+    checker,
+    paramNames,
+    supply: { n: 0, synthCell: newSynthCell() },
+  };
+}
+
+function buildFromSource(source: string): IRExpr | { unsupported: string } {
+  const { expr, checker, paramNames, supply } = setupReturnExpr(source);
+  return buildIR(expr, checker, IntStrategy, paramNames, supply);
+}
+
+function expectIR(source: string): IRExpr {
+  const result = buildFromSource(source);
+  if (isBuildUnsupported(result)) {
+    throw new Error(`expected IR, got unsupported: ${result.unsupported}`);
+  }
+  return result;
+}
+
+function containsKind(expr: IRExpr, kind: IRExpr["kind"]): boolean {
+  if (expr.kind === kind) {
+    return true;
+  }
+  switch (expr.kind) {
+    case "app":
+      return (
+        (expr.head.kind === "expr" && containsKind(expr.head.expr, kind)) ||
+        expr.args.some((arg) => containsKind(arg, kind))
+      );
+    case "cond":
+      return expr.arms.some(
+        ([guard, value]) => containsKind(guard, kind) || containsKind(value, kind),
+      );
+    case "let":
+      return containsKind(expr.value, kind) || containsKind(expr.body, kind);
+    case "each":
+      return (
+        containsKind(expr.src, kind) ||
+        expr.guards.some((guard) => containsKind(guard, kind)) ||
+        containsKind(expr.proj, kind)
+      );
+    case "comb":
+      return containsKind(expr.each, kind);
+    case "comb-typed":
+      return (
+        expr.guards.some((guard) => containsKind(guard, kind)) ||
+        containsKind(expr.proj, kind)
+      );
+    case "forall":
+    case "exists":
+      return (
+        (expr.guard !== undefined && containsKind(expr.guard, kind)) ||
+        containsKind(expr.body, kind)
+      );
+    case "var":
+    case "lit":
+    case "ir-wrap":
+      return false;
+  }
+}
+
+function expectNoIRWrap(expr: IRExpr): void {
+  assert.equal(containsKind(expr, "ir-wrap"), false);
+}
+
+describe("ir-build M6 native construction stubs", () => {
+  // M6 Patch 2 unskips this after ordinary arithmetic/comparison
+  // binary expressions build as native App(binop, ...) nodes.
+  it.skip("builds arithmetic and comparison without IRWrap", () => {
+    const arithmetic = expectIR(`
+      function f(a: number, b: number): number {
+        return (a + b) * 2;
+      }
+    `);
+    const comparison = expectIR(`
+      function f(a: number, b: number): boolean {
+        return a <= b;
+      }
+    `);
+    expectNoIRWrap(arithmetic);
+    expectNoIRWrap(comparison);
+  });
+
+  // M6 Patch 2 unskips this after general pure calls build as native
+  // App nodes instead of delegating through `translateBodyExpr`.
+  it.skip("builds general calls without IRWrap", () => {
+    const ir = expectIR(`
+      function score(a: number, b: number): number {
+        return a + b;
+      }
+      function f(a: number, b: number): number {
+        return score(a, b);
+      }
+    `);
+    assert.equal(ir.kind, "app");
+    expectNoIRWrap(ir);
+  });
+
+  // M6 Patch 2 unskips this after optional/nullish lowering avoids
+  // L1 `from-l2` and native IR carries the complete conditional shape.
+  it.skip("builds optional chains and nullish coalescing without IRWrap", () => {
+    const optional = expectIR(`
+      interface Owner { readonly id: number; }
+      interface Account { readonly owner?: Owner; }
+      function f(a: Account): number[] {
+        return a.owner?.id;
+      }
+    `);
+    const nullish = expectIR(`
+      function f(x: number | null | undefined): number {
+        return x ?? 0;
+      }
+    `);
+    expectNoIRWrap(optional);
+    expectNoIRWrap(nullish);
+  });
+
+  // M6 Patch 2 unskips this after chain fusion constructs real Each
+  // and Comb nodes rather than preserving legacy opaque comprehensions.
+  it.skip("builds filter/map/reduce chains as native Each/Comb", () => {
+    const each = expectIR(`
+      interface User { readonly active: boolean; readonly name: string; }
+      function f(users: User[]): string[] {
+        return users.filter((u) => u.active).map((u) => u.name);
+      }
+    `);
+    const comb = expectIR(`
+      interface Item { readonly amount: number; }
+      function f(items: Item[]): number {
+        return items.reduce((sum, item) => sum + item.amount, 0);
+      }
+    `);
+    assert.equal(containsKind(each, "each"), true);
+    assert.equal(containsKind(comb, "comb"), true);
+    expectNoIRWrap(each);
+    expectNoIRWrap(comb);
+  });
+
+  // M6 Patch 2 unskips the string-literal optional-element case; the
+  // computed-key case should remain unsupported through M6.
+  it.skip("records optional element access boundary", () => {
+    const literalKey = expectIR(`
+      interface User { readonly name: string; }
+      function f(u: User | null): string[] {
+        return u?.["name"];
+      }
+    `);
+    expectNoIRWrap(literalKey);
+
+    const computedKey = buildFromSource(`
+      interface User { readonly name: string; }
+      function f(u: User | null, key: keyof User): unknown {
+        return u?.[key];
+      }
+    `);
+    assert.ok(isBuildUnsupported(computedKey));
+    if (isBuildUnsupported(computedKey)) {
+      assert.match(computedKey.unsupported, /computed property access/u);
+    }
+  });
+
+  // M6 Patch 2 keeps computed element access outside the cleanup
+  // boundary unless the key is syntactically a string literal.
+  it.skip("keeps computed element access unsupported", () => {
+    const result = buildFromSource(`
+      interface User { readonly name: string; }
+      function f(u: User, key: keyof User): unknown {
+        return u[key];
+      }
+    `);
+    assert.ok(isBuildUnsupported(result));
+    if (isBuildUnsupported(result)) {
+      assert.match(result.unsupported, /computed property access/u);
+    }
+  });
+});

--- a/tools/ts2pant/tests/ir-equivalence.test.mts
+++ b/tools/ts2pant/tests/ir-equivalence.test.mts
@@ -170,3 +170,88 @@ describe("Stage 1 IR-equivalence: legacy and IR produce identical output", () =>
     );
   });
 });
+
+describe("M6 pure-path cutover stubs", () => {
+  const CUTOVER_CASES: Array<{ file: string; functions: string[] }> = [
+    {
+      file: "expressions-arithmetic.ts",
+      functions: ["add", "double", "netBalance"],
+    },
+    {
+      file: "expressions-comparison.ts",
+      functions: ["lt", "gte"],
+    },
+    {
+      file: "expressions-calls.ts",
+      functions: ["freeCall", "nestedCalls", "callInArithmetic"],
+    },
+    {
+      file: "expressions-nullish.ts",
+      functions: ["maybeOwnerIdOptional", "defaultToZero"],
+    },
+    {
+      file: "expressions-array.ts",
+      functions: ["activeNames", "nameLengths", "highScores"],
+    },
+    {
+      file: "expressions-reduce.ts",
+      functions: ["sumAmounts", "allActive"],
+    },
+  ];
+
+  for (const { file, functions } of CUTOVER_CASES) {
+    const filePath = resolve(CONSTRUCTS_DIR, file);
+    for (const funcName of functions) {
+      // M6 Patch 3 unskips these after `translatePureBody` routes
+      // expression terminals through IR unconditionally and the
+      // `TS2PANT_USE_IR` migration flag is deleted.
+      it.skip(`${file} > ${funcName} emits the always-on IR snapshot`, async () => {
+        const prior = process.env.TS2PANT_USE_IR;
+        delete process.env.TS2PANT_USE_IR;
+        try {
+          const sf = createSourceFile(filePath);
+          const doc = await buildDocumentFromSourceFile(sf, funcName);
+          const output = emitDocument(doc);
+          assert.ok(
+            !containsUnsupportedLine(output),
+            `${funcName} should be supported by the native IR pure path`,
+          );
+          await assertWasmTypeChecks(output);
+        } finally {
+          if (prior === undefined) {
+            delete process.env.TS2PANT_USE_IR;
+          } else {
+            process.env.TS2PANT_USE_IR = prior;
+          }
+        }
+      });
+    }
+  }
+
+  // M6 Patch 3 unskips this as the direct flag-deletion tripwire: the
+  // environment setting must no longer affect pure return translation.
+  it.skip("translatePureBody uses pure IR path without TS2PANT_USE_IR", async () => {
+    const sourceFile = createSourceFile(
+      resolve(CONSTRUCTS_DIR, "expressions-arithmetic.ts"),
+    );
+    const prior = process.env.TS2PANT_USE_IR;
+    try {
+      delete process.env.TS2PANT_USE_IR;
+      const withoutFlag = emitDocument(
+        await buildDocumentFromSourceFile(sourceFile, "netBalance"),
+      );
+      process.env.TS2PANT_USE_IR = "1";
+      const withFlag = emitDocument(
+        await buildDocumentFromSourceFile(sourceFile, "netBalance"),
+      );
+      assert.equal(withoutFlag, withFlag);
+      await assertWasmTypeChecks(withoutFlag);
+    } finally {
+      if (prior === undefined) {
+        delete process.env.TS2PANT_USE_IR;
+      } else {
+        process.env.TS2PANT_USE_IR = prior;
+      }
+    }
+  });
+});

--- a/tools/ts2pant/tests/ir1-build-no-from-l2.test.mts
+++ b/tools/ts2pant/tests/ir1-build-no-from-l2.test.mts
@@ -1,0 +1,294 @@
+import assert from "node:assert/strict";
+import { before, describe, it } from "node:test";
+import ts from "typescript";
+import {
+  buildL1AssignStmt,
+  buildL1ForEachCall,
+  buildL1ForOfMutation,
+  buildL1IfMutation,
+  isUnsupported,
+  type BuildBodyCtx,
+} from "../src/ir1-build-body.js";
+import type { IR1Expr, IR1FoldLeaf, IR1Stmt } from "../src/ir1.js";
+import { createSourceFileFromSource, getChecker } from "../src/extract.js";
+import { loadAst } from "../src/pant-wasm.js";
+import {
+  makeSymbolicState,
+  type SymbolicState,
+  type UniqueSupply,
+} from "../src/translate-body.js";
+import { IntStrategy, newSynthCell } from "../src/translate-types.js";
+
+before(async () => {
+  await loadAst();
+});
+
+interface FunctionSetup {
+  fn: ts.FunctionDeclaration;
+  ctx: BuildBodyCtx;
+}
+
+function setupFunction(source: string, functionName = "f"): FunctionSetup {
+  const sourceFile = createSourceFileFromSource(source);
+  const checker = getChecker(sourceFile);
+  const fn = sourceFile.compilerNode.statements.find(
+    (stmt): stmt is ts.FunctionDeclaration =>
+      ts.isFunctionDeclaration(stmt) && stmt.name?.text === functionName,
+  );
+  if (!fn?.body) {
+    throw new Error(`expected function ${functionName} with a body`);
+  }
+  const paramNames = new Map<string, string>();
+  for (const param of fn.parameters) {
+    if (ts.isIdentifier(param.name)) {
+      paramNames.set(param.name.text, param.name.text);
+    }
+  }
+  const state: SymbolicState = makeSymbolicState();
+  const supply: UniqueSupply = { n: 0, synthCell: newSynthCell() };
+  return {
+    fn,
+    ctx: {
+      checker,
+      strategy: IntStrategy,
+      paramNames,
+      state,
+      supply,
+      applyConst: (expr) => expr,
+    },
+  };
+}
+
+function firstStatement<T extends ts.Statement>(
+  source: string,
+  guard: (stmt: ts.Statement) => stmt is T,
+): { stmt: T; ctx: BuildBodyCtx } {
+  const { fn, ctx } = setupFunction(source);
+  const stmt = fn.body?.statements.find(guard);
+  if (!stmt) {
+    throw new Error("expected matching statement in function body");
+  }
+  return { stmt, ctx };
+}
+
+function containsFromL2Expr(expr: IR1Expr): boolean {
+  switch (expr.kind) {
+    case "from-l2":
+      return true;
+    case "binop":
+      return containsFromL2Expr(expr.lhs) || containsFromL2Expr(expr.rhs);
+    case "unop":
+      return containsFromL2Expr(expr.arg);
+    case "app":
+      return (
+        containsFromL2Expr(expr.callee) ||
+        expr.args.some((arg) => containsFromL2Expr(arg))
+      );
+    case "member":
+      return containsFromL2Expr(expr.receiver);
+    case "cond":
+      return (
+        expr.arms.some(
+          ([guard, value]) =>
+            containsFromL2Expr(guard) || containsFromL2Expr(value),
+        ) || containsFromL2Expr(expr.otherwise)
+      );
+    case "is-nullish":
+      return containsFromL2Expr(expr.operand);
+    case "var":
+    case "lit":
+      return false;
+  }
+}
+
+function containsFromL2FoldLeaf(leaf: IR1FoldLeaf): boolean {
+  return (
+    containsFromL2Expr(leaf.target) ||
+    containsFromL2Expr(leaf.rhs) ||
+    (leaf.guard !== null && containsFromL2Expr(leaf.guard))
+  );
+}
+
+function containsFromL2Stmt(stmt: IR1Stmt): boolean {
+  switch (stmt.kind) {
+    case "block":
+      return stmt.stmts.some((child) => containsFromL2Stmt(child));
+    case "let":
+      return containsFromL2Expr(stmt.value);
+    case "assign":
+      return containsFromL2Expr(stmt.target) || containsFromL2Expr(stmt.value);
+    case "cond-stmt":
+      return (
+        stmt.arms.some(
+          ([guard, body]) =>
+            containsFromL2Expr(guard) || containsFromL2Stmt(body),
+        ) ||
+        (stmt.otherwise !== null && containsFromL2Stmt(stmt.otherwise))
+      );
+    case "foreach":
+      return (
+        containsFromL2Expr(stmt.source) ||
+        (stmt.body !== null && containsFromL2Stmt(stmt.body)) ||
+        stmt.foldLeaves.some((leaf) => containsFromL2FoldLeaf(leaf))
+      );
+    case "for":
+      return (
+        (stmt.init !== null && containsFromL2Stmt(stmt.init)) ||
+        (stmt.cond !== null && containsFromL2Expr(stmt.cond)) ||
+        (stmt.step !== null && containsFromL2Stmt(stmt.step)) ||
+        containsFromL2Stmt(stmt.body)
+      );
+    case "while":
+      return containsFromL2Expr(stmt.cond) || containsFromL2Stmt(stmt.body);
+    case "return":
+      return stmt.expr !== null && containsFromL2Expr(stmt.expr);
+    case "throw":
+      return containsFromL2Expr(stmt.expr);
+    case "expr-stmt":
+      return containsFromL2Expr(stmt.expr);
+    case "map-effect":
+      return (
+        containsFromL2Expr(stmt.objExpr) ||
+        containsFromL2Expr(stmt.keyExpr) ||
+        (stmt.valueExpr !== null && containsFromL2Expr(stmt.valueExpr))
+      );
+    case "set-effect":
+      return (
+        containsFromL2Expr(stmt.objExpr) ||
+        (stmt.elemExpr !== null && containsFromL2Expr(stmt.elemExpr))
+      );
+  }
+}
+
+function expectNoFromL2(stmt: IR1Stmt): void {
+  assert.equal(containsFromL2Stmt(stmt), false);
+}
+
+describe("ir1-build-body M6 no-from-l2 stubs", () => {
+  // M6 Patch 4 unskips this after mutating if guards use native L1
+  // builders or return targeted unsupported results.
+  it.skip("builds if guards without from-l2", () => {
+    const { stmt, ctx } = firstStatement(
+      `
+      interface Account { balance: number; }
+      function f(a: Account, amount: number): void {
+        if (amount > 0) {
+          a.balance = amount;
+        }
+      }
+      `,
+      ts.isIfStatement,
+    );
+    const built = buildL1IfMutation(stmt, ctx);
+    assert.ok(!isUnsupported(built));
+    if (!isUnsupported(built)) {
+      expectNoFromL2(built);
+    }
+  });
+
+  // M6 Patch 4 unskips this after foreach sources build as native L1
+  // expressions instead of `from-l2(ir-wrap(...))`.
+  it.skip("builds foreach sources without from-l2", () => {
+    const { stmt, ctx } = firstStatement(
+      `
+      interface Item { value: number; }
+      interface Account { total: number; }
+      function f(items: Item[], account: Account): void {
+        for (const item of items) {
+          account.total += item.value;
+        }
+      }
+      `,
+      ts.isForOfStatement,
+    );
+    const built = buildL1ForOfMutation(stmt, ctx);
+    assert.ok(!isUnsupported(built));
+    if (!isUnsupported(built)) {
+      expectNoFromL2(built);
+    }
+  });
+
+  // M6 Patch 4 unskips this after Shape B rhs/guard sub-expressions
+  // build natively under the per-iteration L1 context.
+  it.skip("builds Shape B rhs and guard without from-l2", () => {
+    const { stmt, ctx } = firstStatement(
+      `
+      interface Item { value: number; active: boolean; }
+      interface Account { total: number; }
+      function f(items: Item[], account: Account): void {
+        items.forEach((item) => {
+          if (item.active) {
+            account.total += item.value + 1;
+          }
+        });
+      }
+      `,
+      (stmt): stmt is ts.ExpressionStatement =>
+        ts.isExpressionStatement(stmt) && ts.isCallExpression(stmt.expression),
+    );
+    const built = buildL1ForEachCall(stmt.expression, ctx);
+    assert.ok(!isUnsupported(built));
+    if (!isUnsupported(built)) {
+      expectNoFromL2(built);
+    }
+  });
+
+  // M6 Patch 4 unskips this after assignment RHS construction stops
+  // delegating through `translateBodyExpr` for supported expressions.
+  it.skip("builds Shape A rhs without from-l2", () => {
+    const { stmt, ctx } = firstStatement(
+      `
+      interface Account { balance: number; }
+      function f(a: Account, amount: number): void {
+        a.balance = amount + 1;
+      }
+      `,
+      ts.isExpressionStatement,
+    );
+    const built = buildL1AssignStmt(stmt, ctx);
+    assert.ok(!isUnsupported(built));
+    if (!isUnsupported(built)) {
+      expectNoFromL2(built);
+    }
+  });
+
+  // M6 Patch 4 unskips this after Map mutation object/key/value
+  // payloads build as native L1 forms or reject explicitly.
+  it.skip("builds map object/key/value payloads without from-l2", () => {
+    const { stmt, ctx } = firstStatement(
+      `
+      function f(m: Map<string, number>, suffix: string, value: number): void {
+        if (value > 0) {
+          m.set("k" + suffix, value + 1);
+        }
+      }
+      `,
+      ts.isIfStatement,
+    );
+    const built = buildL1IfMutation(stmt, ctx);
+    assert.ok(!isUnsupported(built));
+    if (!isUnsupported(built)) {
+      expectNoFromL2(built);
+    }
+  });
+
+  // M6 Patch 4 unskips this after Set mutation object/element payloads
+  // build as native L1 forms or reject explicitly.
+  it.skip("builds set object/element payloads without from-l2", () => {
+    const { stmt, ctx } = firstStatement(
+      `
+      function f(s: Set<string>, suffix: string): void {
+        if (suffix !== "") {
+          s.add("k" + suffix);
+        }
+      }
+      `,
+      ts.isIfStatement,
+    );
+    const built = buildL1IfMutation(stmt, ctx);
+    assert.ok(!isUnsupported(built));
+    if (!isUnsupported(built)) {
+      expectNoFromL2(built);
+    }
+  });
+});


### PR DESCRIPTION
## Patch 1: Lock M6 cleanup tests and unsupported boundaries

- Add skipped tests for always-on pure returns: arithmetic, comparison, general call, optional chain, nullish coalescing, filter-map chain, and reduce chain.
- Add skipped tests for L1 sub-expression construction in mutating contexts: if guard, foreach source, Shape B rhs/guard, map/set object/key/value payloads.
- Record current unsupported expectations for optional element access and computed element access so cleanup does not accidentally add unplanned semantics.
- Keep the tests skipped with comments naming the implementing patch numbers.

## Changes
- Add skipped tests for always-on pure returns: arithmetic, comparison, general call, optional chain, nullish coalescing, filter-map chain, and reduce chain.
- Add skipped tests for L1 sub-expression construction in mutating contexts: if guard, foreach source, Shape B rhs/guard, map/set object/key/value payloads.
- Record current unsupported expectations for optional element access and computed element access so cleanup does not accidentally add unplanned semantics.
- Keep the tests skipped with comments naming the implementing patch numbers.

## Files to Modify
- tools/ts2pant/tests/ir-equivalence.test.mts (modify): Add skipped replacements for legacy-vs-IR parity tests that assert always-on pure path snapshots after Patch 3.
- tools/ts2pant/tests/ir-build.test.mts (create): Native build coverage stubs for binop/unop/call/array-chain/nullish-coalescing paths that currently reach `IRWrap`.
- tools/ts2pant/tests/ir1-build-no-from-l2.test.mts (create): Skipped tests asserting mutating-body L1 sub-expression builders return native L1 forms or unsupported results rather than `from-l2`.

## Gameplan Specification

```
module TS2PANT_M6_LEGACY_CLEANUP.

PureReturn.
L1SubExpression.
IRNode.
DocumentedArchitecture.

expression-terminal? r: PureReturn => Bool.
uses-ir? r: PureReturn => Bool.
uses-env-flag? r: PureReturn => Bool.

supported-l1? e: L1SubExpression => Bool.
native-l1? e: L1SubExpression => Bool.
unsupported-l1? e: L1SubExpression => Bool.

escape-hatch? n: IRNode => Bool.
reachable? n: IRNode => Bool.
native-node? n: IRNode => Bool.

final? a: DocumentedArchitecture => Bool.
mentions-migration-flag? a: DocumentedArchitecture => Bool.
mentions-escape-hatch? a: DocumentedArchitecture => Bool.

---

all r: PureReturn | expression-terminal? r -> uses-ir? r.
all r: PureReturn | uses-ir? r -> ~uses-env-flag? r.

all e: L1SubExpression | supported-l1? e -> native-l1? e.
all e: L1SubExpression | ~supported-l1? e -> unsupported-l1? e.
all e: L1SubExpression | native-l1? e -> ~unsupported-l1? e.

all n: IRNode | escape-hatch? n -> ~reachable? n.
all n: IRNode | reachable? n -> native-node? n.

all a: DocumentedArchitecture | final? a -> ~mentions-migration-flag? a.
all a: DocumentedArchitecture | final? a -> ~mentions-escape-hatch? a.

```

## Patch Specification

```
module TS2PANT_M6_LEGACY_CLEANUP_PATCH_1.

CleanupTest.
stubbed? t: CleanupTest => Bool.
implemented? t: CleanupTest => Bool.

---

all t: CleanupTest | stubbed? t -> ~implemented? t.

```


## Implementation Notes

- The stubs are intentionally assertion-complete even though skipped, so later patches should only need to unskip and update the implementation rather than redesign expected coverage.
- Unsupported optional/computed element access cases are captured as explicit boundary tests to make accidental support visible during cleanup.
- No implementation behavior is changed in this patch; the trade-off is added skipped-test noise now in exchange for tighter regression targets across the follow-up patches.