### PR TITLE
[ts2pant-m6-legacy-cleanup] Patch 2: Build remaining pure expression shapes natively

### DIFF
--- a/tools/ts2pant/src/ir-build.ts
+++ b/tools/ts2pant/src/ir-build.ts
@@ -185,13 +185,17 @@ function substituteIR(expr: IRExpr, name: string, replacement: IRExpr): IRExpr {
             : expr.head,
         args: expr.args.map((arg) => substituteIR(arg, name, replacement)),
       };
-    case "cond":
-      return irCond(
-        expr.arms.map(([g, v]) => [
-          substituteIR(g, name, replacement),
-          substituteIR(v, name, replacement),
-        ]),
-      );
+    case "cond": {
+      const arms: Array<[IRExpr, IRExpr]> = expr.arms.map(([g, v]) => [
+        substituteIR(g, name, replacement),
+        substituteIR(v, name, replacement),
+      ]);
+      const otherwise =
+        expr.otherwise === undefined
+          ? undefined
+          : substituteIR(expr.otherwise, name, replacement);
+      return irCond(arms, otherwise);
+    }
     case "let":
       return {
         kind: "let",

--- a/tools/ts2pant/src/ir-build.ts
+++ b/tools/ts2pant/src/ir-build.ts
@@ -40,6 +40,7 @@ import {
   unwrapParens,
 } from "./ir1-build.js";
 import { lowerL1Expr } from "./ir1-lower.js";
+import { isStaticallyBoolTyped } from "./purity.js";
 import {
   allocComprehensionBinder,
   ambiguousFieldMsg,
@@ -71,6 +72,7 @@ interface ReduceOpInfo {
   outer: "add" | "sub" | "mul" | "div" | "and" | "or";
   identityText: string | null;
   commutative: boolean;
+  operandType: "number" | "boolean";
 }
 
 function binopToReduceInfo(kind: ts.SyntaxKind): ReduceOpInfo | null {
@@ -81,6 +83,7 @@ function binopToReduceInfo(kind: ts.SyntaxKind): ReduceOpInfo | null {
         outer: "add",
         identityText: "0",
         commutative: true,
+        operandType: "number",
       };
     case ts.SyntaxKind.MinusToken:
       return {
@@ -88,6 +91,7 @@ function binopToReduceInfo(kind: ts.SyntaxKind): ReduceOpInfo | null {
         outer: "sub",
         identityText: null,
         commutative: false,
+        operandType: "number",
       };
     case ts.SyntaxKind.AsteriskToken:
       return {
@@ -95,6 +99,7 @@ function binopToReduceInfo(kind: ts.SyntaxKind): ReduceOpInfo | null {
         outer: "mul",
         identityText: "1",
         commutative: true,
+        operandType: "number",
       };
     case ts.SyntaxKind.SlashToken:
       return {
@@ -102,6 +107,7 @@ function binopToReduceInfo(kind: ts.SyntaxKind): ReduceOpInfo | null {
         outer: "div",
         identityText: null,
         commutative: false,
+        operandType: "number",
       };
     case ts.SyntaxKind.AmpersandAmpersandToken:
       return {
@@ -109,6 +115,7 @@ function binopToReduceInfo(kind: ts.SyntaxKind): ReduceOpInfo | null {
         outer: "and",
         identityText: "true",
         commutative: true,
+        operandType: "boolean",
       };
     case ts.SyntaxKind.BarBarToken:
       return {
@@ -116,6 +123,7 @@ function binopToReduceInfo(kind: ts.SyntaxKind): ReduceOpInfo | null {
         outer: "or",
         identityText: "false",
         commutative: true,
+        operandType: "boolean",
       };
     default:
       return null;
@@ -280,6 +288,9 @@ function extractArrowExpressionBody(
   if (!ts.isArrowFunction(fn)) {
     return { unsupported: "array callback must be an arrow function" };
   }
+  if (fn.modifiers?.some((m) => m.kind === ts.SyntaxKind.AsyncKeyword)) {
+    return { unsupported: "array callback must not be async" };
+  }
   if (fn.parameters.length !== expectedParams) {
     return {
       unsupported:
@@ -289,8 +300,16 @@ function extractArrowExpressionBody(
     };
   }
   for (const param of fn.parameters) {
-    if (!ts.isIdentifier(param.name)) {
-      return { unsupported: "array callback parameters must be identifiers" };
+    if (
+      !ts.isIdentifier(param.name) ||
+      param.initializer !== undefined ||
+      param.dotDotDotToken !== undefined ||
+      param.questionToken !== undefined
+    ) {
+      return {
+        unsupported:
+          "array callback parameters must be plain identifiers (no defaults/rest/optional)",
+      };
     }
   }
   if (ts.isBlock(fn.body)) {
@@ -327,6 +346,74 @@ function getArrayElementType(
   return typeArgs.length === 1 ? typeArgs[0]! : null;
 }
 
+function arrayMethodCall(expr: ts.CallExpression): {
+  methodName: "filter" | "map" | "reduce" | "reduceRight";
+  receiver: ts.Expression;
+} | null {
+  const callee = expr.expression;
+  if (ts.isPropertyAccessExpression(callee)) {
+    const methodName = callee.name.text;
+    if (
+      methodName === "filter" ||
+      methodName === "map" ||
+      methodName === "reduce" ||
+      methodName === "reduceRight"
+    ) {
+      return { methodName, receiver: callee.expression };
+    }
+    return null;
+  }
+  if (ts.isElementAccessExpression(callee)) {
+    const arg = callee.argumentExpression;
+    if (ts.isStringLiteral(arg) || ts.isNoSubstitutionTemplateLiteral(arg)) {
+      const methodName = arg.text;
+      if (
+        methodName === "filter" ||
+        methodName === "map" ||
+        methodName === "reduce" ||
+        methodName === "reduceRight"
+      ) {
+        return { methodName, receiver: callee.expression };
+      }
+    }
+  }
+  return null;
+}
+
+function isStaticallyNumberTyped(
+  expr: ts.Expression,
+  checker: ts.TypeChecker,
+): boolean {
+  const isAllNumber = (type: ts.Type): boolean => {
+    if (type.isUnion()) {
+      return type.types.every(isAllNumber);
+    }
+    if (type.isIntersection()) {
+      return type.types.every(isAllNumber);
+    }
+    return (type.flags & ts.TypeFlags.NumberLike) !== 0;
+  };
+  return isAllNumber(checker.getTypeAtLocation(expr));
+}
+
+function reduceOperandsMatchCombiner(
+  left: ts.Expression,
+  right: ts.Expression,
+  info: ReduceOpInfo,
+  checker: ts.TypeChecker,
+): boolean {
+  if (info.operandType === "boolean") {
+    return (
+      isStaticallyBoolTyped(left, checker) &&
+      isStaticallyBoolTyped(right, checker)
+    );
+  }
+  return (
+    isStaticallyNumberTyped(left, checker) &&
+    isStaticallyNumberTyped(right, checker)
+  );
+}
+
 function buildIRValue(
   expr: ts.Expression,
   checker: ts.TypeChecker,
@@ -335,40 +422,36 @@ function buildIRValue(
   supply: UniqueSupply,
 ): IRBuildValue | { unsupported: string } {
   expr = unwrapParens(expr) as ts.Expression;
-  if (
-    ts.isCallExpression(expr) &&
-    ts.isPropertyAccessExpression(expr.expression)
-  ) {
-    const methodName = expr.expression.name.text;
-    if (
-      (methodName === "filter" || methodName === "map") &&
-      expr.arguments.length === 1
-    ) {
-      const result = buildArrayMapFilter(
-        methodName,
-        expr.expression.expression,
-        expr,
-        checker,
-        strategy,
-        paramNames,
-        supply,
-      );
-      if (result !== null) {
-        return result;
-      }
-    }
-    if (methodName === "reduce" || methodName === "reduceRight") {
-      const result = buildArrayReduce(
-        methodName,
-        expr.expression.expression,
-        expr,
-        checker,
-        strategy,
-        paramNames,
-        supply,
-      );
-      if (result !== null) {
-        return result;
+  if (ts.isCallExpression(expr)) {
+    const arrayMethod = arrayMethodCall(expr);
+    if (arrayMethod !== null) {
+      const { methodName, receiver } = arrayMethod;
+      if (methodName === "filter" || methodName === "map") {
+        const result = buildArrayMapFilter(
+          methodName,
+          receiver,
+          expr,
+          checker,
+          strategy,
+          paramNames,
+          supply,
+        );
+        if (result !== null) {
+          return result;
+        }
+      } else {
+        const result = buildArrayReduce(
+          methodName,
+          receiver,
+          expr,
+          checker,
+          strategy,
+          paramNames,
+          supply,
+        );
+        if (result !== null) {
+          return result;
+        }
       }
     }
   }
@@ -391,6 +474,11 @@ function buildArrayMapFilter(
 ): IRBuildValue | { unsupported: string } | null {
   if (getArrayElementType(tsReceiver, checker) === null) {
     return null;
+  }
+  if (expr.arguments.length !== 1) {
+    return {
+      unsupported: `.${methodName} callback must have exactly one argument`,
+    };
   }
   const receiver = buildIRValue(
     tsReceiver,
@@ -436,6 +524,11 @@ function buildArrayMapFilter(
     : rawBody;
 
   if (methodName === "filter") {
+    if (!isStaticallyBoolTyped(callbackBody(arrow), checker)) {
+      return {
+        unsupported: ".filter callback must return a boolean predicate",
+      };
+    }
     if (isComposing) {
       return {
         expr: pending.proj,
@@ -543,6 +636,11 @@ function buildArrayReduce(
       unsupported: `.${methodName} callback must reference acc exactly once`,
     };
   }
+  if (!reduceOperandsMatchCombiner(body.left, body.right, info, checker)) {
+    return {
+      unsupported: `.${methodName} operator ${ts.SyntaxKind[body.operatorToken.kind]} operands do not match ${info.operandType} combiner`,
+    };
+  }
   if (expressionReferencesNames(innerExpr, new Set([accName]))) {
     return {
       unsupported: `.${methodName} inner expression must not reference acc`,
@@ -618,17 +716,9 @@ export function buildIR(
     supply,
   };
 
-  if (
-    ts.isCallExpression(expr) &&
-    ts.isPropertyAccessExpression(expr.expression)
-  ) {
-    const methodName = expr.expression.name.text;
-    if (
-      methodName === "filter" ||
-      methodName === "map" ||
-      methodName === "reduce" ||
-      methodName === "reduceRight"
-    ) {
+  if (ts.isCallExpression(expr)) {
+    const arrayMethod = arrayMethodCall(expr);
+    if (arrayMethod !== null) {
       const built = buildIRValue(expr, checker, strategy, paramNames, supply);
       if ("unsupported" in built) {
         return built;

--- a/tools/ts2pant/src/ir-build.ts
+++ b/tools/ts2pant/src/ir-build.ts
@@ -423,36 +423,15 @@ function buildIRValue(
 ): IRBuildValue | { unsupported: string } {
   expr = unwrapParens(expr) as ts.Expression;
   if (ts.isCallExpression(expr)) {
-    const arrayMethod = arrayMethodCall(expr);
-    if (arrayMethod !== null) {
-      const { methodName, receiver } = arrayMethod;
-      if (methodName === "filter" || methodName === "map") {
-        const result = buildArrayMapFilter(
-          methodName,
-          receiver,
-          expr,
-          checker,
-          strategy,
-          paramNames,
-          supply,
-        );
-        if (result !== null) {
-          return result;
-        }
-      } else {
-        const result = buildArrayReduce(
-          methodName,
-          receiver,
-          expr,
-          checker,
-          strategy,
-          paramNames,
-          supply,
-        );
-        if (result !== null) {
-          return result;
-        }
-      }
+    const arrayResult = tryBuildArrayMethodValue(
+      expr,
+      checker,
+      strategy,
+      paramNames,
+      supply,
+    );
+    if (arrayResult !== null) {
+      return arrayResult;
     }
   }
 
@@ -461,6 +440,48 @@ function buildIRValue(
     return ir;
   }
   return { expr: ir };
+}
+
+function tryBuildArrayMethodValue(
+  expr: ts.CallExpression,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  paramNames: ReadonlyMap<string, string>,
+  supply: UniqueSupply,
+): IRBuildValue | { unsupported: string } | null {
+  const arrayMethod = arrayMethodCall(expr);
+  if (arrayMethod === null) {
+    return null;
+  }
+  const { methodName, receiver } = arrayMethod;
+  if (methodName === "filter" || methodName === "map") {
+    const result = buildArrayMapFilter(
+      methodName,
+      receiver,
+      expr,
+      checker,
+      strategy,
+      paramNames,
+      supply,
+    );
+    if (result !== null) {
+      return result;
+    }
+  } else {
+    const result = buildArrayReduce(
+      methodName,
+      receiver,
+      expr,
+      checker,
+      strategy,
+      paramNames,
+      supply,
+    );
+    if (result !== null) {
+      return result;
+    }
+  }
+  return null;
 }
 
 function buildArrayMapFilter(
@@ -717,9 +738,14 @@ export function buildIR(
   };
 
   if (ts.isCallExpression(expr)) {
-    const arrayMethod = arrayMethodCall(expr);
-    if (arrayMethod !== null) {
-      const built = buildIRValue(expr, checker, strategy, paramNames, supply);
+    const built = tryBuildArrayMethodValue(
+      expr,
+      checker,
+      strategy,
+      paramNames,
+      supply,
+    );
+    if (built !== null) {
       if ("unsupported" in built) {
         return built;
       }

--- a/tools/ts2pant/src/ir-build.ts
+++ b/tools/ts2pant/src/ir-build.ts
@@ -155,17 +155,6 @@ function isIdentityInit(node: ts.Expression, identityText: string): boolean {
   return n !== null && n === Number(identityText);
 }
 
-function getRootIdentifier(expr: ts.Expression): string | null {
-  expr = unwrapParens(expr) as ts.Expression;
-  if (ts.isIdentifier(expr)) {
-    return expr.text;
-  }
-  if (ts.isPropertyAccessExpression(expr)) {
-    return getRootIdentifier(expr.expression);
-  }
-  return null;
-}
-
 function substituteIR(expr: IRExpr, name: string, replacement: IRExpr): IRExpr {
   switch (expr.kind) {
     case "var":
@@ -535,12 +524,14 @@ function buildArrayReduce(
   if (methodName === "reduceRight" && !info.commutative) {
     return { unsupported: ".reduceRight with non-commutative operator" };
   }
-  const leftRoot = getRootIdentifier(body.left);
-  const rightRoot = getRootIdentifier(body.right);
+  const leftExpr = unwrapParens(body.left) as ts.Expression;
+  const rightExpr = unwrapParens(body.right) as ts.Expression;
+  const leftIsAcc = ts.isIdentifier(leftExpr) && leftExpr.text === accName;
+  const rightIsAcc = ts.isIdentifier(rightExpr) && rightExpr.text === accName;
   let innerExpr: ts.Expression;
-  if (leftRoot === accName && rightRoot !== accName) {
+  if (leftIsAcc && !rightIsAcc) {
     innerExpr = body.right;
-  } else if (rightRoot === accName && leftRoot !== accName) {
+  } else if (rightIsAcc && !leftIsAcc) {
     if (!info.commutative) {
       return {
         unsupported: `.${methodName} with acc on the right of a non-commutative operator`,

--- a/tools/ts2pant/src/ir-build.ts
+++ b/tools/ts2pant/src/ir-build.ts
@@ -17,8 +17,11 @@
 import ts from "typescript";
 import {
   type IRExpr,
-  irAppExpr,
+  type IRExprEach,
+  type IRFoldCombiner,
   irAppName,
+  irBinop,
+  irComb,
   irCond,
   irEach,
   irLitBool,
@@ -27,11 +30,13 @@ import {
   irVar,
   irWrap,
 } from "./ir.js";
-import { ir1FromL2, ir1IsNullish } from "./ir1.js";
 import {
   buildL1MemberAccess,
+  computedElementAccessUnsupportedReason,
+  elementAccessLiteralKey,
   type L1BuildContext,
   tryBuildL1Cardinality,
+  tryBuildL1PureSubExpression,
   unwrapParens,
 } from "./ir1-build.js";
 import { lowerL1Expr } from "./ir1-lower.js";
@@ -39,6 +44,8 @@ import {
   allocComprehensionBinder,
   ambiguousFieldMsg,
   bodyExpr,
+  expressionReferencesNames,
+  freshHygienicBinder,
   isBodyUnsupported,
   isNullableTsType,
   qualifyFieldAccess,
@@ -46,6 +53,541 @@ import {
   type UniqueSupply,
 } from "./translate-body.js";
 import type { NumericStrategy } from "./translate-types.js";
+
+interface PendingIRComprehension {
+  binder: string;
+  src: IRExpr;
+  guards: IRExpr[];
+  proj: IRExpr;
+}
+
+interface IRBuildValue {
+  expr: IRExpr;
+  pendingComprehension?: PendingIRComprehension;
+}
+
+interface ReduceOpInfo {
+  combiner: IRFoldCombiner;
+  outer: "add" | "sub" | "mul" | "div" | "and" | "or";
+  identityText: string | null;
+  commutative: boolean;
+}
+
+function binopToReduceInfo(kind: ts.SyntaxKind): ReduceOpInfo | null {
+  switch (kind) {
+    case ts.SyntaxKind.PlusToken:
+      return {
+        combiner: "add",
+        outer: "add",
+        identityText: "0",
+        commutative: true,
+      };
+    case ts.SyntaxKind.MinusToken:
+      return {
+        combiner: "add",
+        outer: "sub",
+        identityText: null,
+        commutative: false,
+      };
+    case ts.SyntaxKind.AsteriskToken:
+      return {
+        combiner: "mul",
+        outer: "mul",
+        identityText: "1",
+        commutative: true,
+      };
+    case ts.SyntaxKind.SlashToken:
+      return {
+        combiner: "mul",
+        outer: "div",
+        identityText: null,
+        commutative: false,
+      };
+    case ts.SyntaxKind.AmpersandAmpersandToken:
+      return {
+        combiner: "and",
+        outer: "and",
+        identityText: "true",
+        commutative: true,
+      };
+    case ts.SyntaxKind.BarBarToken:
+      return {
+        combiner: "or",
+        outer: "or",
+        identityText: "false",
+        commutative: true,
+      };
+    default:
+      return null;
+  }
+}
+
+function evaluateNumericLiteral(node: ts.Expression): number | null {
+  node = unwrapParens(node) as ts.Expression;
+  if (ts.isNumericLiteral(node)) {
+    const n = Number(node.text);
+    return Number.isFinite(n) ? n : null;
+  }
+  if (
+    ts.isPrefixUnaryExpression(node) &&
+    (node.operator === ts.SyntaxKind.PlusToken ||
+      node.operator === ts.SyntaxKind.MinusToken) &&
+    ts.isNumericLiteral(node.operand)
+  ) {
+    const n = Number(node.operand.text);
+    if (!Number.isFinite(n)) {
+      return null;
+    }
+    return node.operator === ts.SyntaxKind.MinusToken ? -n : n;
+  }
+  return null;
+}
+
+function isIdentityInit(node: ts.Expression, identityText: string): boolean {
+  const inner = unwrapParens(node) as ts.Expression;
+  if (identityText === "true") {
+    return inner.kind === ts.SyntaxKind.TrueKeyword;
+  }
+  if (identityText === "false") {
+    return inner.kind === ts.SyntaxKind.FalseKeyword;
+  }
+  const n = evaluateNumericLiteral(inner);
+  return n !== null && n === Number(identityText);
+}
+
+function getRootIdentifier(expr: ts.Expression): string | null {
+  expr = unwrapParens(expr) as ts.Expression;
+  if (ts.isIdentifier(expr)) {
+    return expr.text;
+  }
+  if (ts.isPropertyAccessExpression(expr)) {
+    return getRootIdentifier(expr.expression);
+  }
+  return null;
+}
+
+function substituteIR(expr: IRExpr, name: string, replacement: IRExpr): IRExpr {
+  switch (expr.kind) {
+    case "var":
+      return expr.name === name && !expr.primed ? replacement : expr;
+    case "lit":
+    case "ir-wrap":
+      return expr;
+    case "app":
+      return {
+        ...expr,
+        head:
+          expr.head.kind === "expr"
+            ? {
+                kind: "expr",
+                expr: substituteIR(expr.head.expr, name, replacement),
+              }
+            : expr.head,
+        args: expr.args.map((arg) => substituteIR(arg, name, replacement)),
+      };
+    case "cond":
+      return irCond(
+        expr.arms.map(([g, v]) => [
+          substituteIR(g, name, replacement),
+          substituteIR(v, name, replacement),
+        ]),
+      );
+    case "let":
+      return {
+        kind: "let",
+        name: expr.name,
+        value: substituteIR(expr.value, name, replacement),
+        body:
+          expr.name === name
+            ? expr.body
+            : substituteIR(expr.body, name, replacement),
+      };
+    case "each":
+      return {
+        ...expr,
+        src: substituteIR(expr.src, name, replacement),
+        guards:
+          expr.binder === name
+            ? expr.guards
+            : expr.guards.map((guard) =>
+                substituteIR(guard, name, replacement),
+              ),
+        proj:
+          expr.binder === name
+            ? expr.proj
+            : substituteIR(expr.proj, name, replacement),
+      };
+    case "comb":
+      if (expr.combiner === "min" || expr.combiner === "max") {
+        return {
+          kind: "comb",
+          combiner: expr.combiner,
+          each: substituteIR(expr.each, name, replacement) as IRExprEach,
+        };
+      }
+      if ("init" in expr && expr.init !== undefined) {
+        return {
+          kind: "comb",
+          combiner: expr.combiner,
+          init: substituteIR(expr.init, name, replacement),
+          each: substituteIR(expr.each, name, replacement) as IRExprEach,
+        };
+      }
+      return {
+        kind: "comb",
+        combiner: expr.combiner,
+        each: substituteIR(expr.each, name, replacement) as IRExprEach,
+      };
+    case "comb-typed":
+      return expr.binder === name
+        ? expr
+        : {
+            ...expr,
+            guards: expr.guards.map((guard) =>
+              substituteIR(guard, name, replacement),
+            ),
+            proj: substituteIR(expr.proj, name, replacement),
+          };
+    case "forall":
+    case "exists":
+      if (expr.binder === name) {
+        return expr;
+      }
+      if (expr.guard !== undefined) {
+        return {
+          ...expr,
+          guard: substituteIR(expr.guard, name, replacement),
+          body: substituteIR(expr.body, name, replacement),
+        };
+      }
+      return {
+        ...expr,
+        body: substituteIR(expr.body, name, replacement),
+      };
+    default: {
+      const _exhaustive: never = expr;
+      void _exhaustive;
+      throw new Error("unreachable: IRExpr");
+    }
+  }
+}
+
+function materializeBuildValue(value: IRBuildValue): IRExpr {
+  if (value.pendingComprehension === undefined) {
+    return value.expr;
+  }
+  const pending = value.pendingComprehension;
+  return irEach(pending.binder, pending.src, pending.guards, pending.proj);
+}
+
+function extractArrowExpressionBody(
+  fn: ts.Expression,
+  expectedParams: number,
+): ts.ArrowFunction | { unsupported: string } {
+  if (!ts.isArrowFunction(fn)) {
+    return { unsupported: "array callback must be an arrow function" };
+  }
+  if (fn.parameters.length !== expectedParams) {
+    return {
+      unsupported:
+        expectedParams === 1
+          ? "filter/map callback must have exactly one identifier parameter"
+          : "reduce callback must take exactly (acc, x)",
+    };
+  }
+  for (const param of fn.parameters) {
+    if (!ts.isIdentifier(param.name)) {
+      return { unsupported: "array callback parameters must be identifiers" };
+    }
+  }
+  if (ts.isBlock(fn.body)) {
+    const stmts = fn.body.statements;
+    if (
+      stmts.length !== 1 ||
+      !ts.isReturnStatement(stmts[0]!) ||
+      !stmts[0]!.expression
+    ) {
+      return {
+        unsupported: "array callback block body must be a single return",
+      };
+    }
+  }
+  return fn;
+}
+
+function callbackBody(fn: ts.ArrowFunction): ts.Expression {
+  if (ts.isBlock(fn.body)) {
+    return (fn.body.statements[0] as ts.ReturnStatement).expression!;
+  }
+  return fn.body;
+}
+
+function getArrayElementType(
+  tsExpr: ts.Expression,
+  checker: ts.TypeChecker,
+): ts.Type | null {
+  const sourceType = checker.getTypeAtLocation(tsExpr);
+  if (!checker.isArrayType(sourceType)) {
+    return null;
+  }
+  const typeArgs = checker.getTypeArguments(sourceType as ts.TypeReference);
+  return typeArgs.length === 1 ? typeArgs[0]! : null;
+}
+
+function buildIRValue(
+  expr: ts.Expression,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  paramNames: ReadonlyMap<string, string>,
+  supply: UniqueSupply,
+): IRBuildValue | { unsupported: string } {
+  expr = unwrapParens(expr) as ts.Expression;
+  if (
+    ts.isCallExpression(expr) &&
+    ts.isPropertyAccessExpression(expr.expression)
+  ) {
+    const methodName = expr.expression.name.text;
+    if (
+      (methodName === "filter" || methodName === "map") &&
+      expr.arguments.length === 1
+    ) {
+      const result = buildArrayMapFilter(
+        methodName,
+        expr.expression.expression,
+        expr,
+        checker,
+        strategy,
+        paramNames,
+        supply,
+      );
+      if (result !== null) {
+        return result;
+      }
+    }
+    if (methodName === "reduce" || methodName === "reduceRight") {
+      const result = buildArrayReduce(
+        methodName,
+        expr.expression.expression,
+        expr,
+        checker,
+        strategy,
+        paramNames,
+        supply,
+      );
+      if (result !== null) {
+        return result;
+      }
+    }
+  }
+
+  const ir = buildIR(expr, checker, strategy, paramNames, supply);
+  if (isBuildUnsupported(ir)) {
+    return ir;
+  }
+  return { expr: ir };
+}
+
+function buildArrayMapFilter(
+  methodName: "filter" | "map",
+  tsReceiver: ts.Expression,
+  expr: ts.CallExpression,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  paramNames: ReadonlyMap<string, string>,
+  supply: UniqueSupply,
+): IRBuildValue | { unsupported: string } | null {
+  if (getArrayElementType(tsReceiver, checker) === null) {
+    return null;
+  }
+  const receiver = buildIRValue(
+    tsReceiver,
+    checker,
+    strategy,
+    paramNames,
+    supply,
+  );
+  if ("unsupported" in receiver) {
+    return receiver;
+  }
+
+  const arrow = extractArrowExpressionBody(expr.arguments[0]!, 1);
+  if ("unsupported" in arrow) {
+    return arrow;
+  }
+  const pending = receiver.pendingComprehension;
+  const isComposing = pending !== undefined;
+  const sourceBinder = isComposing
+    ? pending.binder
+    : allocComprehensionBinder(supply, "x");
+  const callbackBinder = isComposing
+    ? freshHygienicBinder(supply)
+    : sourceBinder;
+  const arrowParams = new Map(paramNames);
+  arrowParams.set(
+    (arrow.parameters[0]!.name as ts.Identifier).text,
+    callbackBinder,
+  );
+
+  const rawBody = buildIR(
+    callbackBody(arrow),
+    checker,
+    strategy,
+    arrowParams,
+    supply,
+  );
+  if (isBuildUnsupported(rawBody)) {
+    return rawBody;
+  }
+  const body = isComposing
+    ? substituteIR(rawBody, callbackBinder, pending.proj)
+    : rawBody;
+
+  if (methodName === "filter") {
+    if (isComposing) {
+      return {
+        expr: pending.proj,
+        pendingComprehension: {
+          binder: pending.binder,
+          src: pending.src,
+          guards: [...pending.guards, body],
+          proj: pending.proj,
+        },
+      };
+    }
+    return {
+      expr: irVar(sourceBinder),
+      pendingComprehension: {
+        binder: sourceBinder,
+        src: receiver.expr,
+        guards: [body],
+        proj: irVar(sourceBinder),
+      },
+    };
+  }
+
+  if (isComposing) {
+    return {
+      expr: body,
+      pendingComprehension: {
+        ...pending,
+        proj: body,
+      },
+    };
+  }
+  return {
+    expr: body,
+    pendingComprehension: {
+      binder: sourceBinder,
+      src: receiver.expr,
+      guards: [],
+      proj: body,
+    },
+  };
+}
+
+function buildArrayReduce(
+  methodName: "reduce" | "reduceRight",
+  tsReceiver: ts.Expression,
+  expr: ts.CallExpression,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  paramNames: ReadonlyMap<string, string>,
+  supply: UniqueSupply,
+): IRBuildValue | { unsupported: string } | null {
+  if (expr.arguments.length !== 2) {
+    return { unsupported: `.${methodName} requires an explicit initial value` };
+  }
+  if (getArrayElementType(tsReceiver, checker) === null) {
+    return null;
+  }
+  const receiver = buildIRValue(
+    tsReceiver,
+    checker,
+    strategy,
+    paramNames,
+    supply,
+  );
+  if ("unsupported" in receiver) {
+    return receiver;
+  }
+  const arrow = extractArrowExpressionBody(expr.arguments[0]!, 2);
+  if ("unsupported" in arrow) {
+    return arrow;
+  }
+  const accName = (arrow.parameters[0]!.name as ts.Identifier).text;
+  const xName = (arrow.parameters[1]!.name as ts.Identifier).text;
+  const body = unwrapParens(callbackBody(arrow)) as ts.Expression;
+  if (!ts.isBinaryExpression(body)) {
+    return {
+      unsupported: `.${methodName} callback body must be 'acc OP f(x)'`,
+    };
+  }
+  const info = binopToReduceInfo(body.operatorToken.kind);
+  if (info === null) {
+    return {
+      unsupported: `.${methodName} operator ${ts.SyntaxKind[body.operatorToken.kind]} has no combiner`,
+    };
+  }
+  if (methodName === "reduceRight" && !info.commutative) {
+    return { unsupported: ".reduceRight with non-commutative operator" };
+  }
+  const leftRoot = getRootIdentifier(body.left);
+  const rightRoot = getRootIdentifier(body.right);
+  let innerExpr: ts.Expression;
+  if (leftRoot === accName && rightRoot !== accName) {
+    innerExpr = body.right;
+  } else if (rightRoot === accName && leftRoot !== accName) {
+    if (!info.commutative) {
+      return {
+        unsupported: `.${methodName} with acc on the right of a non-commutative operator`,
+      };
+    }
+    innerExpr = body.left;
+  } else {
+    return {
+      unsupported: `.${methodName} callback must reference acc exactly once`,
+    };
+  }
+  if (expressionReferencesNames(innerExpr, new Set([accName]))) {
+    return {
+      unsupported: `.${methodName} inner expression must not reference acc`,
+    };
+  }
+
+  const pending = receiver.pendingComprehension;
+  const xBinder = pending
+    ? freshHygienicBinder(supply)
+    : allocComprehensionBinder(supply, "x");
+  const arrowParams = new Map(paramNames);
+  arrowParams.set(xName, xBinder);
+  const inner = buildIR(innerExpr, checker, strategy, arrowParams, supply);
+  if (isBuildUnsupported(inner)) {
+    return inner;
+  }
+  const proj = pending ? substituteIR(inner, xBinder, pending.proj) : inner;
+  const each = (
+    pending
+      ? irEach(pending.binder, pending.src, pending.guards, proj)
+      : irEach(xBinder, receiver.expr, [], proj)
+  ) as IRExprEach;
+  let folded = irComb(info.combiner, each);
+
+  const initNode = expr.arguments[1]!;
+  if (
+    info.identityText === null ||
+    !isIdentityInit(initNode, info.identityText)
+  ) {
+    const init = buildIR(initNode, checker, strategy, paramNames, supply);
+    if (isBuildUnsupported(init)) {
+      return init;
+    }
+    folded =
+      info.outer === info.combiner
+        ? irComb(info.combiner, each, init)
+        : irBinop(info.outer, init, folded);
+  }
+  return { expr: folded };
+}
 
 /**
  * Translate a TypeScript expression to IR.
@@ -80,6 +622,25 @@ export function buildIR(
     state: undefined,
     supply,
   };
+
+  if (
+    ts.isCallExpression(expr) &&
+    ts.isPropertyAccessExpression(expr.expression)
+  ) {
+    const methodName = expr.expression.name.text;
+    if (
+      methodName === "filter" ||
+      methodName === "map" ||
+      methodName === "reduce" ||
+      methodName === "reduceRight"
+    ) {
+      const built = buildIRValue(expr, checker, strategy, paramNames, supply);
+      if ("unsupported" in built) {
+        return built;
+      }
+      return materializeBuildValue(built);
+    }
+  }
 
   // Boolean keywords
   if (expr.kind === ts.SyntaxKind.TrueKeyword) {
@@ -119,10 +680,67 @@ export function buildIR(
   // EUF function distinct from the actual cardinality. Fires before the
   // Member dispatch below for the six list-shaped TS types.
   if (ts.isPropertyAccessExpression(expr)) {
-    const card = tryBuildL1Cardinality(expr, l1Ctx);
+    const card = tryBuildL1Cardinality(expr, l1Ctx, {
+      nativeReceiverLeaf: true,
+    });
     if (card !== null) {
       return lowerL1Expr(card);
     }
+  }
+
+  if (ts.isElementAccessExpression(expr)) {
+    const inOptionalChain = (expr.flags & ts.NodeFlags.OptionalChain) !== 0;
+    if (inOptionalChain) {
+      const prop = elementAccessLiteralKey(expr);
+      if (prop === null) {
+        return { unsupported: computedElementAccessUnsupportedReason };
+      }
+      let shouldLift = false;
+      if (expr.questionDotToken !== undefined) {
+        const receiverTsType = checker.getTypeAtLocation(expr.expression);
+        shouldLift = isNullableTsType(receiverTsType);
+      } else if (ts.isOptionalChain(expr.expression)) {
+        shouldLift = true;
+      }
+      if (shouldLift) {
+        const receiverTsType = checker.getTypeAtLocation(expr.expression);
+        const ruleName = qualifyFieldAccess(
+          receiverTsType,
+          prop,
+          checker,
+          strategy,
+          supply.synthCell,
+        );
+        if (ruleName === null) {
+          return { unsupported: ambiguousFieldMsg(prop) };
+        }
+        const innerIR = buildIR(
+          expr.expression,
+          checker,
+          strategy,
+          paramNames,
+          supply,
+        );
+        if (isBuildUnsupported(innerIR)) {
+          return innerIR;
+        }
+        const binderName = allocComprehensionBinder(supply, "n");
+        return irEach(
+          binderName,
+          innerIR,
+          [],
+          irAppName(ruleName, [irVar(binderName)]),
+        );
+      }
+    }
+  }
+
+  const nativeL1 = tryBuildL1PureSubExpression(expr, l1Ctx);
+  if (nativeL1 !== null) {
+    if ("unsupported" in nativeL1) {
+      return nativeL1;
+    }
+    return lowerL1Expr(nativeL1);
   }
 
   // Stage 2: Optional chain `x?.prop` (and tail of a chain marked by
@@ -185,49 +803,13 @@ export function buildIR(
     ts.isPropertyAccessExpression(expr) &&
     (expr.flags & ts.NodeFlags.OptionalChain) === 0
   ) {
-    const member = buildL1MemberAccess(expr, l1Ctx);
+    const member = buildL1MemberAccess(expr, l1Ctx, {
+      nativeReceiverLeaf: true,
+    });
     if ("unsupported" in member) {
       return member;
     }
     return lowerL1Expr(member);
-  }
-
-  // Stage 3: Nullish coalescing `x ?? y` under list-lift. With `x: [T]`
-  // on the Pant side, `#x = 0` is the null test:
-  //   - `y: T` (non-nullable default) → `cond #x = 0 => y, true => (x 1)`
-  //   - `y: [T]` (nested nullable) → `cond #x = 0 => y, true => x`
-  //   - `x` not nullable in TS → `??` degenerates to just `x`.
-  // See CLAUDE.md "Option-Type Elimination" for the broader encoding.
-  if (
-    ts.isBinaryExpression(expr) &&
-    expr.operatorToken.kind === ts.SyntaxKind.QuestionQuestionToken
-  ) {
-    const leftTsType = checker.getTypeAtLocation(expr.left);
-    const leftIR = buildIR(expr.left, checker, strategy, paramNames, supply);
-    if (isBuildUnsupported(leftIR)) {
-      return leftIR;
-    }
-    if (!isNullableTsType(leftTsType)) {
-      // LHS can never be nullish — `??` degenerates.
-      return leftIR;
-    }
-    const rightIR = buildIR(expr.right, checker, strategy, paramNames, supply);
-    if (isBuildUnsupported(rightIR)) {
-      return rightIR;
-    }
-    const rightTsType = checker.getTypeAtLocation(expr.right);
-    // Construct the cardinality-zero null test through L1 IsNullish so
-    // every nullish-shape lowering shares one source of truth (M4).
-    // The lowering chain `from-l2 → IsNullish → eq(card(_), 0)` is
-    // byte-identical to the inlined form, which is the cutover gate.
-    const cardZero = lowerL1Expr(ir1IsNullish(ir1FromL2(leftIR)));
-    const presentBranch: IRExpr = isNullableTsType(rightTsType)
-      ? leftIR
-      : irAppExpr(leftIR, [irLitNat(1)]);
-    return irCond([
-      [cardZero, rightIR],
-      [irLitBool(true), presentBranch],
-    ]);
   }
 
   // Fallback: translate via the legacy pipeline and wrap. Subsequent

--- a/tools/ts2pant/src/ir-build.ts
+++ b/tools/ts2pant/src/ir-build.ts
@@ -334,16 +334,34 @@ function callbackBody(fn: ts.ArrowFunction): ts.Expression {
   return fn.body;
 }
 
-function getArrayElementType(
+function getArrayElementTypesFromType(
+  sourceType: ts.Type,
+  checker: ts.TypeChecker,
+): readonly ts.Type[] | null {
+  if (sourceType.isUnion()) {
+    const elementTypes: ts.Type[] = [];
+    for (const member of sourceType.types) {
+      const memberElementTypes = getArrayElementTypesFromType(member, checker);
+      if (memberElementTypes === null) {
+        return null;
+      }
+      elementTypes.push(...memberElementTypes);
+    }
+    return elementTypes.length > 0 ? elementTypes : null;
+  }
+  if (checker.isArrayType(sourceType) || checker.isTupleType(sourceType)) {
+    const typeArgs = checker.getTypeArguments(sourceType as ts.TypeReference);
+    return typeArgs.length > 0 ? typeArgs : null;
+  }
+  return null;
+}
+
+function getArrayElementTypes(
   tsExpr: ts.Expression,
   checker: ts.TypeChecker,
-): ts.Type | null {
+): readonly ts.Type[] | null {
   const sourceType = checker.getTypeAtLocation(tsExpr);
-  if (!checker.isArrayType(sourceType)) {
-    return null;
-  }
-  const typeArgs = checker.getTypeArguments(sourceType as ts.TypeReference);
-  return typeArgs.length === 1 ? typeArgs[0]! : null;
+  return getArrayElementTypesFromType(sourceType, checker);
 }
 
 function arrayMethodCall(expr: ts.CallExpression): {
@@ -493,7 +511,7 @@ function buildArrayMapFilter(
   paramNames: ReadonlyMap<string, string>,
   supply: UniqueSupply,
 ): IRBuildValue | { unsupported: string } | null {
-  if (getArrayElementType(tsReceiver, checker) === null) {
+  if (getArrayElementTypes(tsReceiver, checker) === null) {
     return null;
   }
   if (expr.arguments.length !== 1) {
@@ -604,7 +622,7 @@ function buildArrayReduce(
   if (expr.arguments.length !== 2) {
     return { unsupported: `.${methodName} requires an explicit initial value` };
   }
-  if (getArrayElementType(tsReceiver, checker) === null) {
+  if (getArrayElementTypes(tsReceiver, checker) === null) {
     return null;
   }
   const receiver = buildIRValue(

--- a/tools/ts2pant/src/ir-build.ts
+++ b/tools/ts2pant/src/ir-build.ts
@@ -460,6 +460,13 @@ function buildIRValue(
   return { expr: ir };
 }
 
+function buildNativeReceiverLeafIR(
+  expr: ts.Expression,
+  ctx: L1BuildContext,
+): IRExpr | { unsupported: string } | null {
+  return buildIR(expr, ctx.checker, ctx.strategy, ctx.paramNames, ctx.supply);
+}
+
 function tryBuildArrayMethodValue(
   expr: ts.CallExpression,
   checker: ts.TypeChecker,
@@ -557,6 +564,9 @@ function buildArrayMapFilter(
   );
   if (isBuildUnsupported(rawBody)) {
     return rawBody;
+  }
+  if (isComposing && rawBody.kind === "ir-wrap") {
+    return null;
   }
   const body = isComposing
     ? substituteIR(rawBody, callbackBinder, pending.proj)
@@ -696,6 +706,9 @@ function buildArrayReduce(
   if (isBuildUnsupported(inner)) {
     return inner;
   }
+  if (pending !== undefined && inner.kind === "ir-wrap") {
+    return null;
+  }
   const proj = pending ? substituteIR(inner, xBinder, pending.proj) : inner;
   const each = (
     pending
@@ -811,6 +824,7 @@ export function buildIR(
   if (ts.isPropertyAccessExpression(expr)) {
     const card = tryBuildL1Cardinality(expr, l1Ctx, {
       nativeReceiverLeaf: true,
+      nativeReceiverLeafIR: buildNativeReceiverLeafIR,
     });
     if (card !== null) {
       return lowerL1Expr(card);
@@ -819,6 +833,15 @@ export function buildIR(
 
   if (ts.isElementAccessExpression(expr)) {
     const inOptionalChain = (expr.flags & ts.NodeFlags.OptionalChain) !== 0;
+    if (!inOptionalChain) {
+      const card = tryBuildL1Cardinality(expr, l1Ctx, {
+        nativeReceiverLeaf: true,
+        nativeReceiverLeafIR: buildNativeReceiverLeafIR,
+      });
+      if (card !== null) {
+        return lowerL1Expr(card);
+      }
+    }
     if (inOptionalChain) {
       const prop = elementAccessLiteralKey(expr);
       if (prop === null) {
@@ -862,6 +885,21 @@ export function buildIR(
         );
       }
     }
+  }
+
+  if (
+    (ts.isPropertyAccessExpression(expr) ||
+      ts.isElementAccessExpression(expr)) &&
+    (expr.flags & ts.NodeFlags.OptionalChain) === 0
+  ) {
+    const member = buildL1MemberAccess(expr, l1Ctx, {
+      nativeReceiverLeaf: true,
+      nativeReceiverLeafIR: buildNativeReceiverLeafIR,
+    });
+    if ("unsupported" in member) {
+      return member;
+    }
+    return lowerL1Expr(member);
   }
 
   const nativeL1 = tryBuildL1PureSubExpression(expr, l1Ctx);
@@ -921,24 +959,6 @@ export function buildIR(
         );
       }
     }
-  }
-
-  // M5: plain (non-optional) property access → canonical L1 Member.
-  // The lowering at `ir1-lower.ts` produces `App(qualifiedName,
-  // [receiver])` — byte-equal to the legacy direct construction.
-  // Cardinality dispatch above already handled the `.length` / `.size`
-  // path, so anything reaching here is a genuine field accessor.
-  if (
-    ts.isPropertyAccessExpression(expr) &&
-    (expr.flags & ts.NodeFlags.OptionalChain) === 0
-  ) {
-    const member = buildL1MemberAccess(expr, l1Ctx, {
-      nativeReceiverLeaf: true,
-    });
-    if ("unsupported" in member) {
-      return member;
-    }
-    return lowerL1Expr(member);
   }
 
   // Fallback: translate via the legacy pipeline and wrap. Subsequent

--- a/tools/ts2pant/src/ir-emit.ts
+++ b/tools/ts2pant/src/ir-emit.ts
@@ -159,8 +159,16 @@ export function lowerExpr(e: IRExpr): OpaqueExpr {
     case "app":
       return lowerApp(e.head, e.args.map(lowerExpr));
 
-    case "cond":
-      return ast.cond(e.arms.map(([g, v]) => [lowerExpr(g), lowerExpr(v)]));
+    case "cond": {
+      const arms: Array<[OpaqueExpr, OpaqueExpr]> = e.arms.map(([g, v]) => [
+        lowerExpr(g),
+        lowerExpr(v),
+      ]);
+      if (e.otherwise !== undefined) {
+        arms.push([ast.litBool(true), lowerExpr(e.otherwise)]);
+      }
+      return ast.cond(arms);
+    }
 
     case "let": {
       // Pant has no let — inline the value into the body via

--- a/tools/ts2pant/src/ir.ts
+++ b/tools/ts2pant/src/ir.ts
@@ -123,11 +123,11 @@ export type IRExpr =
    */
   | { kind: "app"; head: IRHead; args: IRExpr[] }
   /**
-   * Multi-armed conditional (value position). Last arm canonically
-   * `(true, default)`. Mirrors Pant's `cond` constructor and the
-   * existing `ast.cond([[g, v], [true, d]])` invariant.
+   * Multi-armed conditional (value position). `otherwise` carries the
+   * default branch when the source layer has one; lowering appends it as
+   * Pant's canonical trailing `(true, default)` arm.
    */
-  | { kind: "cond"; arms: Array<[IRExpr, IRExpr]> }
+  | { kind: "cond"; arms: Array<[IRExpr, IRExpr]>; otherwise?: IRExpr }
   /**
    * Hygienic let-binding. Substituted out at emission (Pant has no
    * `let`). Names come from the document-wide `UniqueSupply` /
@@ -298,10 +298,13 @@ export const irUnop = (op: IRUnop, arg: IRExpr): IRExpr => ({
   args: [arg],
 });
 
-export const irCond = (arms: Array<[IRExpr, IRExpr]>): IRExpr => ({
-  kind: "cond",
-  arms,
-});
+export const irCond = (
+  arms: Array<[IRExpr, IRExpr]>,
+  otherwise?: IRExpr,
+): IRExpr =>
+  otherwise === undefined
+    ? { kind: "cond", arms }
+    : { kind: "cond", arms, otherwise };
 
 export const irLet = (name: string, value: IRExpr, body: IRExpr): IRExpr => ({
   kind: "let",

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -39,6 +39,7 @@ import {
   type IR1Binop,
   type IR1Expr,
   type IR1Stmt,
+  ir1App,
   ir1Assign,
   ir1Binop,
   ir1Block,
@@ -123,6 +124,191 @@ export function unwrapParens(n: ts.Node): ts.Node {
     n = n.expression;
   }
   return n;
+}
+
+function binaryOperatorToL1(kind: ts.SyntaxKind): IR1Binop | null {
+  switch (kind) {
+    case ts.SyntaxKind.AmpersandAmpersandToken:
+      return "and";
+    case ts.SyntaxKind.BarBarToken:
+      return "or";
+    case ts.SyntaxKind.EqualsEqualsEqualsToken:
+      return "eq";
+    case ts.SyntaxKind.ExclamationEqualsEqualsToken:
+      return "neq";
+    case ts.SyntaxKind.LessThanToken:
+      return "lt";
+    case ts.SyntaxKind.GreaterThanToken:
+      return "gt";
+    case ts.SyntaxKind.LessThanEqualsToken:
+      return "le";
+    case ts.SyntaxKind.GreaterThanEqualsToken:
+      return "ge";
+    case ts.SyntaxKind.PlusToken:
+      return "add";
+    case ts.SyntaxKind.MinusToken:
+      return "sub";
+    case ts.SyntaxKind.AsteriskToken:
+      return "mul";
+    case ts.SyntaxKind.SlashToken:
+      return "div";
+    default:
+      return null;
+  }
+}
+
+/**
+ * Native L1 construction for ordinary pure sub-expressions. Returns
+ * `null` when the expression is outside this cleanup patch's native
+ * coverage and should continue to the temporary legacy safety net.
+ * Explicitly unsupported boundaries still return `{ unsupported }`.
+ */
+export function tryBuildL1PureSubExpression(
+  expr: ts.Expression,
+  ctx: L1BuildContext,
+): L1BuildResult | null {
+  expr = unwrapParens(expr) as ts.Expression;
+
+  if (expr.kind === ts.SyntaxKind.TrueKeyword) {
+    return ir1LitBool(true);
+  }
+  if (expr.kind === ts.SyntaxKind.FalseKeyword) {
+    return ir1LitBool(false);
+  }
+  if (ts.isNumericLiteral(expr)) {
+    const n = Number(expr.text);
+    if (Number.isFinite(n) && Number.isInteger(n) && n >= 0) {
+      return ir1LitNat(n);
+    }
+    return null;
+  }
+  if (ts.isStringLiteral(expr) || ts.isNoSubstitutionTemplateLiteral(expr)) {
+    return ir1LitString(expr.text);
+  }
+  if (ts.isIdentifier(expr)) {
+    return ir1Var(ctx.paramNames.get(expr.text) ?? expr.text);
+  }
+  if (expr.kind === ts.SyntaxKind.ThisKeyword) {
+    return ir1Var(ctx.paramNames.get("this") ?? "this");
+  }
+
+  if (
+    (ts.isPropertyAccessExpression(expr) ||
+      ts.isElementAccessExpression(expr)) &&
+    (expr.flags & ts.NodeFlags.OptionalChain) === 0
+  ) {
+    if (ts.isPropertyAccessExpression(expr)) {
+      const card = tryBuildL1Cardinality(expr, ctx, {
+        nativeReceiverLeaf: true,
+      });
+      if (card !== null) {
+        return card;
+      }
+    }
+    return buildL1MemberAccess(expr, ctx, { nativeReceiverLeaf: true });
+  }
+
+  if (ts.isPrefixUnaryExpression(expr)) {
+    const op =
+      expr.operator === ts.SyntaxKind.ExclamationToken
+        ? "not"
+        : expr.operator === ts.SyntaxKind.MinusToken
+          ? "neg"
+          : null;
+    if (op === null) {
+      return null;
+    }
+    const operand = tryBuildL1PureSubExpression(expr.operand, ctx);
+    if (operand === null || isL1Unsupported(operand)) {
+      return operand;
+    }
+    return ir1Unop(op, operand);
+  }
+
+  if (ts.isBinaryExpression(expr)) {
+    if (
+      expr.operatorToken.kind === ts.SyntaxKind.EqualsEqualsToken ||
+      expr.operatorToken.kind === ts.SyntaxKind.ExclamationEqualsToken
+    ) {
+      return {
+        unsupported: "loose equality (== / !=) is unsupported; use === / !==",
+      };
+    }
+    if (expr.operatorToken.kind === ts.SyntaxKind.QuestionQuestionToken) {
+      const left = tryBuildL1PureSubExpression(expr.left, ctx);
+      if (left === null || isL1Unsupported(left)) {
+        return left;
+      }
+      const leftTsType = ctx.checker.getTypeAtLocation(expr.left);
+      if (!isNullableTsType(leftTsType)) {
+        return left;
+      }
+      const right = tryBuildL1PureSubExpression(expr.right, ctx);
+      if (right === null || isL1Unsupported(right)) {
+        return right;
+      }
+      const rightTsType = ctx.checker.getTypeAtLocation(expr.right);
+      const present = isNullableTsType(rightTsType)
+        ? left
+        : ir1App(left, [ir1LitNat(1)]);
+      return ir1Cond([[ir1IsNullish(left), right]], present);
+    }
+    const op = binaryOperatorToL1(expr.operatorToken.kind);
+    if (op === null) {
+      return null;
+    }
+    const left = tryBuildL1PureSubExpression(expr.left, ctx);
+    if (left === null || isL1Unsupported(left)) {
+      return left;
+    }
+    const right = tryBuildL1PureSubExpression(expr.right, ctx);
+    if (right === null || isL1Unsupported(right)) {
+      return right;
+    }
+    return ir1Binop(op, left, right);
+  }
+
+  if (ts.isCallExpression(expr)) {
+    if (expr.arguments.some(ts.isSpreadElement)) {
+      return { unsupported: expr.getText() };
+    }
+    let callee: IR1Expr | null;
+    let args: IR1Expr[];
+    if (ts.isIdentifier(expr.expression)) {
+      const fnName =
+        ctx.paramNames.get(expr.expression.text) ??
+        toPantTermName(expr.expression.text);
+      callee = ir1Var(fnName);
+      args = [];
+    } else if (ts.isPropertyAccessExpression(expr.expression)) {
+      callee = ir1Var(toPantTermName(expr.expression.name.text));
+      const receiver = tryBuildL1PureSubExpression(
+        expr.expression.expression,
+        ctx,
+      );
+      if (receiver === null || isL1Unsupported(receiver)) {
+        return receiver;
+      }
+      args = [receiver];
+    } else {
+      const builtCallee = tryBuildL1PureSubExpression(expr.expression, ctx);
+      if (builtCallee === null || isL1Unsupported(builtCallee)) {
+        return builtCallee;
+      }
+      callee = builtCallee;
+      args = [];
+    }
+    for (const arg of expr.arguments) {
+      const builtArg = tryBuildL1PureSubExpression(arg, ctx);
+      if (builtArg === null || isL1Unsupported(builtArg)) {
+        return builtArg;
+      }
+      args.push(builtArg);
+    }
+    return ir1App(callee, args);
+  }
+
+  return null;
 }
 
 // ---------------------------------------------------------------------------
@@ -225,6 +411,15 @@ export function tryBuildL1Cardinality(
     }
     return ir1Unop("card", ir1FromL2(irWrap(r.expr)));
   }
+  if (ctx.state === undefined && options.nativeReceiverLeaf === true) {
+    const nativeReceiver = tryBuildL1PureSubExpression(
+      receiverNode as ts.Expression,
+      ctx,
+    );
+    if (nativeReceiver !== null && !isL1Unsupported(nativeReceiver)) {
+      return ir1Unop("card", nativeReceiver);
+    }
+  }
   const r = translateBodyExpr(
     receiverNode as ts.Expression,
     ctx.checker,
@@ -265,6 +460,9 @@ const COMPUTED_ELEMENT_ACCESS_UNSUPPORTED =
   "computed property access (obj[expr]) is unsupported; " +
   "use dotted property access or a string-literal index instead";
 
+export const computedElementAccessUnsupportedReason =
+  COMPUTED_ELEMENT_ACCESS_UNSUPPORTED;
+
 /**
  * Extract the literal field name from an `ElementAccessExpression`'s
  * argument expression. Accepts both `StringLiteral` (`obj["f"]`) and
@@ -273,7 +471,7 @@ const COMPUTED_ELEMENT_ACCESS_UNSUPPORTED =
  * null for any other argument shape (identifier, computed expression,
  * numeric literal, template with substitutions, etc.).
  */
-function elementAccessLiteralKey(
+export function elementAccessLiteralKey(
   node: ts.ElementAccessExpression,
 ): string | null {
   const arg = node.argumentExpression;
@@ -352,6 +550,7 @@ export type MemberReceiverResult =
  */
 export interface BuildL1MemberAccessOptions {
   ambiguousOwnerFallback?: "reject" | "bare-kebab";
+  nativeReceiverLeaf?: boolean;
   translateReceiverLeaf?: (
     expr: ts.Expression,
     ctx: L1BuildContext,
@@ -477,6 +676,35 @@ export function buildL1MemberAccess(
       return { unsupported: r.reason };
     }
     receiverL1 = ir1FromL2(irWrap(r.expr));
+  } else if (ctx.state === undefined && options.nativeReceiverLeaf === true) {
+    const nativeReceiver = tryBuildL1PureSubExpression(
+      receiverNode as ts.Expression,
+      ctx,
+    );
+    if (nativeReceiver !== null) {
+      if (isL1Unsupported(nativeReceiver)) {
+        return nativeReceiver;
+      }
+      receiverL1 = nativeReceiver;
+    } else {
+      const r = translateBodyExpr(
+        receiverNode as ts.Expression,
+        ctx.checker,
+        ctx.strategy,
+        ctx.paramNames,
+        ctx.state,
+        ctx.supply,
+      );
+      if (isBodyUnsupported(r)) {
+        return { unsupported: r.unsupported };
+      }
+      if ("effect" in r) {
+        return {
+          unsupported: "collection mutation as property-access receiver",
+        };
+      }
+      receiverL1 = ir1FromL2(irWrap(bodyExpr(r)));
+    }
   } else {
     const r = translateBodyExpr(
       receiverNode as ts.Expression,

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -166,6 +166,8 @@ const MUTATING_ARRAY_METHODS = new Set([
   "unshift",
 ]);
 
+const ARRAY_CHAIN_METHODS = new Set(["filter", "map", "reduce", "reduceRight"]);
+
 function callMemberName(
   callee: ts.Expression,
 ): { receiver: ts.Expression; methodName: string } | null {
@@ -217,6 +219,28 @@ function isKnownEffectfulNativeCall(
 
 function isArrayOrTupleType(t: ts.Type, checker: ts.TypeChecker): boolean {
   return checker.isArrayType(t) || checker.isTupleType(t);
+}
+
+function isArrayOrTupleUnionType(t: ts.Type, checker: ts.TypeChecker): boolean {
+  if (isArrayOrTupleType(t, checker)) {
+    return true;
+  }
+  return (
+    t.isUnion() &&
+    t.types.every((member) => isArrayOrTupleType(member, checker))
+  );
+}
+
+function isArrayChainCall(
+  expr: ts.CallExpression,
+  checker: ts.TypeChecker,
+): boolean {
+  const member = callMemberName(expr.expression);
+  if (member === null || !ARRAY_CHAIN_METHODS.has(member.methodName)) {
+    return false;
+  }
+  const receiverType = checker.getTypeAtLocation(member.receiver);
+  return isArrayOrTupleUnionType(receiverType, checker);
 }
 
 /**
@@ -358,6 +382,12 @@ export function tryBuildL1PureSubExpression(
   if (ts.isCallExpression(expr)) {
     if (expr.arguments.some(ts.isSpreadElement)) {
       return { unsupported: "call with spread arguments is unsupported" };
+    }
+    if (expressionHasSideEffects(expr.expression, ctx.checker)) {
+      return null;
+    }
+    if (isArrayChainCall(expr, ctx.checker)) {
+      return null;
     }
     const member = callMemberName(expr.expression);
     if (

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -57,6 +57,7 @@ import {
 } from "./ir1.js";
 import { lowerL1Expr } from "./ir1-lower.js";
 import {
+  getOperandDeclaredType,
   type NullishTranslate,
   recognizeAnyLeaf,
   recognizeNullishForm,
@@ -153,6 +154,71 @@ function binaryOperatorToL1(kind: ts.SyntaxKind): IR1Binop | null {
   }
 }
 
+const MUTATING_ARRAY_METHODS = new Set([
+  "copyWithin",
+  "fill",
+  "pop",
+  "push",
+  "reverse",
+  "shift",
+  "sort",
+  "splice",
+  "unshift",
+]);
+
+function callMemberName(
+  callee: ts.Expression,
+): { receiver: ts.Expression; methodName: string } | null {
+  if (ts.isPropertyAccessExpression(callee)) {
+    return {
+      receiver: callee.expression,
+      methodName: callee.name.text,
+    };
+  }
+  if (ts.isElementAccessExpression(callee)) {
+    const methodName = elementAccessLiteralKey(callee);
+    if (methodName !== null) {
+      return { receiver: callee.expression, methodName };
+    }
+  }
+  return null;
+}
+
+function isKnownEffectfulNativeCall(
+  expr: ts.CallExpression,
+  checker: ts.TypeChecker,
+): boolean {
+  const member = callMemberName(expr.expression);
+  if (member === null) {
+    return false;
+  }
+  const receiverType = checker.getTypeAtLocation(member.receiver);
+  if (
+    (member.methodName === "add" ||
+      member.methodName === "delete" ||
+      member.methodName === "clear") &&
+    isSetType(receiverType)
+  ) {
+    return true;
+  }
+  if (
+    (member.methodName === "set" ||
+      member.methodName === "delete" ||
+      member.methodName === "clear") &&
+    isMapType(receiverType)
+  ) {
+    return true;
+  }
+  return (
+    isArrayOrTupleType(receiverType, checker) &&
+    MUTATING_ARRAY_METHODS.has(member.methodName)
+  );
+}
+
+function isArrayOrTupleType(t: ts.Type, checker: ts.TypeChecker): boolean {
+  return checker.isArrayType(t) || checker.isTupleType(t);
+}
+
 /**
  * Native L1 construction for ordinary pure sub-expressions. Returns
  * `null` when the expression is outside this cleanup patch's native
@@ -245,7 +311,7 @@ export function tryBuildL1PureSubExpression(
       if (left === null || isL1Unsupported(left)) {
         return left;
       }
-      const leftTsType = ctx.checker.getTypeAtLocation(expr.left);
+      const leftTsType = getOperandDeclaredType(expr.left, ctx.checker);
       if (!isNullableTsType(leftTsType)) {
         return left;
       }
@@ -253,7 +319,7 @@ export function tryBuildL1PureSubExpression(
       if (right === null || isL1Unsupported(right)) {
         return right;
       }
-      const rightTsType = ctx.checker.getTypeAtLocation(expr.right);
+      const rightTsType = getOperandDeclaredType(expr.right, ctx.checker);
       const present = isNullableTsType(rightTsType)
         ? left
         : ir1App(left, [ir1LitNat(1)]);
@@ -292,6 +358,14 @@ export function tryBuildL1PureSubExpression(
   if (ts.isCallExpression(expr)) {
     if (expr.arguments.some(ts.isSpreadElement)) {
       return { unsupported: "call with spread arguments is unsupported" };
+    }
+    const member = callMemberName(expr.expression);
+    if (
+      isKnownEffectfulNativeCall(expr, ctx.checker) ||
+      (member !== null &&
+        expressionHasSideEffects(member.receiver, ctx.checker))
+    ) {
+      return null;
     }
     let callee: IR1Expr | null;
     let args: IR1Expr[];

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -33,7 +33,7 @@
  */
 
 import ts from "typescript";
-import { irWrap } from "./ir.js";
+import { type IRExpr, irWrap } from "./ir.js";
 import { lowerExpr } from "./ir-emit.js";
 import {
   type IR1Binop,
@@ -550,6 +550,14 @@ export function tryBuildL1Cardinality(
     if (nativeReceiver !== null && !isL1Unsupported(nativeReceiver)) {
       return ir1Unop("card", nativeReceiver);
     }
+    const nativeReceiverIR = tryBuildNativeReceiverLeafIR(
+      receiverNode as ts.Expression,
+      ctx,
+      options,
+    );
+    if (nativeReceiverIR !== null && !isL1Unsupported(nativeReceiverIR)) {
+      return ir1Unop("card", nativeReceiverIR);
+    }
   }
   const r = translateBodyExpr(
     receiverNode as ts.Expression,
@@ -682,10 +690,38 @@ export type MemberReceiverResult =
 export interface BuildL1MemberAccessOptions {
   ambiguousOwnerFallback?: "reject" | "bare-kebab";
   nativeReceiverLeaf?: boolean;
+  nativeReceiverLeafIR?: (
+    expr: ts.Expression,
+    ctx: L1BuildContext,
+  ) => IRExpr | { unsupported: string } | null;
   translateReceiverLeaf?: (
     expr: ts.Expression,
     ctx: L1BuildContext,
   ) => MemberReceiverResult;
+}
+
+function tryBuildNativeReceiverLeafIR(
+  receiverNode: ts.Expression,
+  ctx: L1BuildContext,
+  options: BuildL1MemberAccessOptions,
+): IR1Expr | { unsupported: string } | null {
+  if (
+    ctx.state !== undefined ||
+    options.nativeReceiverLeaf !== true ||
+    options.nativeReceiverLeafIR === undefined ||
+    !ts.isCallExpression(receiverNode) ||
+    !isArrayChainCall(receiverNode, ctx.checker)
+  ) {
+    return null;
+  }
+  const nativeReceiver = options.nativeReceiverLeafIR(receiverNode, ctx);
+  if (nativeReceiver === null) {
+    return null;
+  }
+  if ("unsupported" in nativeReceiver) {
+    return nativeReceiver;
+  }
+  return ir1FromL2(nativeReceiver);
 }
 
 /**
@@ -818,23 +854,35 @@ export function buildL1MemberAccess(
       }
       receiverL1 = nativeReceiver;
     } else {
-      const r = translateBodyExpr(
+      const nativeReceiverIR = tryBuildNativeReceiverLeafIR(
         receiverNode as ts.Expression,
-        ctx.checker,
-        ctx.strategy,
-        ctx.paramNames,
-        ctx.state,
-        ctx.supply,
+        ctx,
+        options,
       );
-      if (isBodyUnsupported(r)) {
-        return { unsupported: r.unsupported };
+      if (nativeReceiverIR !== null) {
+        if (isL1Unsupported(nativeReceiverIR)) {
+          return nativeReceiverIR;
+        }
+        receiverL1 = nativeReceiverIR;
+      } else {
+        const r = translateBodyExpr(
+          receiverNode as ts.Expression,
+          ctx.checker,
+          ctx.strategy,
+          ctx.paramNames,
+          ctx.state,
+          ctx.supply,
+        );
+        if (isBodyUnsupported(r)) {
+          return { unsupported: r.unsupported };
+        }
+        if ("effect" in r) {
+          return {
+            unsupported: "collection mutation as property-access receiver",
+          };
+        }
+        receiverL1 = ir1FromL2(irWrap(bodyExpr(r)));
       }
-      if ("effect" in r) {
-        return {
-          unsupported: "collection mutation as property-access receiver",
-        };
-      }
-      receiverL1 = ir1FromL2(irWrap(bodyExpr(r)));
     }
   } else {
     const r = translateBodyExpr(
@@ -1077,8 +1125,12 @@ function isSingleElementProducingShape(expr: ts.Expression): boolean {
   if (ts.isSpreadElement(u)) {
     return false;
   }
-  if (ts.isCallExpression(u) && ts.isPropertyAccessExpression(u.expression)) {
-    if (ARRAY_MULTI_PRODUCING_METHODS.has(u.expression.name.text)) {
+  if (ts.isCallExpression(u)) {
+    const member = callMemberName(u.expression);
+    if (
+      member !== null &&
+      ARRAY_MULTI_PRODUCING_METHODS.has(member.methodName)
+    ) {
       return false;
     }
   }

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -193,7 +193,11 @@ export function tryBuildL1PureSubExpression(
       ts.isElementAccessExpression(expr)) &&
     (expr.flags & ts.NodeFlags.OptionalChain) === 0
   ) {
-    if (ts.isPropertyAccessExpression(expr)) {
+    if (
+      ts.isPropertyAccessExpression(expr) ||
+      elementAccessLiteralKey(expr) === "length" ||
+      elementAccessLiteralKey(expr) === "size"
+    ) {
       const card = tryBuildL1Cardinality(expr, ctx, {
         nativeReceiverLeaf: true,
       });
@@ -293,8 +297,7 @@ export function tryBuildL1PureSubExpression(
     let args: IR1Expr[];
     if (ts.isIdentifier(expr.expression)) {
       const fnName =
-        ctx.paramNames.get(expr.expression.text) ??
-        toPantTermName(expr.expression.text);
+        ctx.paramNames.get(expr.expression.text) ?? expr.expression.text;
       callee = ir1Var(fnName);
       args = [];
     } else if (
@@ -359,10 +362,10 @@ function isSizeCardinalityType(t: ts.Type): boolean {
 
 /**
  * Try to build an L1 `Unop(card, receiver)` for `node` if it is a
- * non-optional `PropertyAccessExpression` whose receiver is a list-
- * shaped TS type and whose property is the cardinality slot for that
- * type. Returns null when the node is not a cardinality form — caller
- * falls through to `buildL1MemberAccess`.
+ * non-optional property access (`xs.length` or `xs["length"]`) whose
+ * receiver is a list-shaped TS type and whose property is the cardinality
+ * slot for that type. Returns null when the node is not a cardinality
+ * form — caller falls through to `buildL1MemberAccess`.
  *
  * `options` propagate through to the inner Member dispatch when the
  * cardinality receiver is itself a property access (e.g.,
@@ -377,7 +380,10 @@ export function tryBuildL1Cardinality(
   options: BuildL1MemberAccessOptions = {},
 ): IR1Expr | null {
   const stripped = unwrapParens(node);
-  if (!ts.isPropertyAccessExpression(stripped)) {
+  if (
+    !ts.isPropertyAccessExpression(stripped) &&
+    !ts.isElementAccessExpression(stripped)
+  ) {
     return null;
   }
   // Optional-chain `.length` / `.size` (i.e., `xs?.length`) preserves
@@ -388,7 +394,9 @@ export function tryBuildL1Cardinality(
   if ((stripped.flags & ts.NodeFlags.OptionalChain) !== 0) {
     return null;
   }
-  const propName = stripped.name.text;
+  const propName = ts.isPropertyAccessExpression(stripped)
+    ? stripped.name.text
+    : elementAccessLiteralKey(stripped);
   if (propName !== "length" && propName !== "size") {
     return null;
   }

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -195,11 +195,14 @@ function isKnownEffectfulNativeCall(
     return false;
   }
   const receiverType = checker.getTypeAtLocation(member.receiver);
+  const receiverTypes = receiverType.isUnion()
+    ? receiverType.types
+    : [receiverType];
   if (
     (member.methodName === "add" ||
       member.methodName === "delete" ||
       member.methodName === "clear") &&
-    isSetType(receiverType)
+    receiverTypes.some((t) => isSetType(t))
   ) {
     return true;
   }
@@ -207,13 +210,14 @@ function isKnownEffectfulNativeCall(
     (member.methodName === "set" ||
       member.methodName === "delete" ||
       member.methodName === "clear") &&
-    isMapType(receiverType)
+    receiverTypes.some((t) => isMapType(t))
   ) {
     return true;
   }
-  return (
-    isArrayOrTupleType(receiverType, checker) &&
-    MUTATING_ARRAY_METHODS.has(member.methodName)
+  return receiverTypes.some(
+    (t) =>
+      MUTATING_ARRAY_METHODS.has(member.methodName) &&
+      isArrayOrTupleType(t, checker),
   );
 }
 

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -128,10 +128,6 @@ export function unwrapParens(n: ts.Node): ts.Node {
 
 function binaryOperatorToL1(kind: ts.SyntaxKind): IR1Binop | null {
   switch (kind) {
-    case ts.SyntaxKind.AmpersandAmpersandToken:
-      return "and";
-    case ts.SyntaxKind.BarBarToken:
-      return "or";
     case ts.SyntaxKind.EqualsEqualsEqualsToken:
       return "eq";
     case ts.SyntaxKind.ExclamationEqualsEqualsToken:
@@ -226,6 +222,12 @@ export function tryBuildL1PureSubExpression(
   }
 
   if (ts.isBinaryExpression(expr)) {
+    const nullishProbe = recognizeNullishForm(expr, ctx.checker, () =>
+      ir1Var("__nullish_probe"),
+    );
+    if (nullishProbe !== null) {
+      return null;
+    }
     if (
       expr.operatorToken.kind === ts.SyntaxKind.EqualsEqualsToken ||
       expr.operatorToken.kind === ts.SyntaxKind.ExclamationEqualsToken
@@ -253,7 +255,22 @@ export function tryBuildL1PureSubExpression(
         : ir1App(left, [ir1LitNat(1)]);
       return ir1Cond([[ir1IsNullish(left), right]], present);
     }
-    const op = binaryOperatorToL1(expr.operatorToken.kind);
+    let op = binaryOperatorToL1(expr.operatorToken.kind);
+    if (
+      expr.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken ||
+      expr.operatorToken.kind === ts.SyntaxKind.BarBarToken
+    ) {
+      if (
+        !isStaticallyBoolTyped(expr.left, ctx.checker) ||
+        !isStaticallyBoolTyped(expr.right, ctx.checker)
+      ) {
+        return null;
+      }
+      op =
+        expr.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken
+          ? "and"
+          : "or";
+    }
     if (op === null) {
       return null;
     }
@@ -280,16 +297,18 @@ export function tryBuildL1PureSubExpression(
         toPantTermName(expr.expression.text);
       callee = ir1Var(fnName);
       args = [];
-    } else if (ts.isPropertyAccessExpression(expr.expression)) {
-      callee = ir1Var(toPantTermName(expr.expression.name.text));
-      const receiver = tryBuildL1PureSubExpression(
-        expr.expression.expression,
-        ctx,
-      );
-      if (receiver === null || isL1Unsupported(receiver)) {
-        return receiver;
+    } else if (
+      ts.isPropertyAccessExpression(expr.expression) ||
+      ts.isElementAccessExpression(expr.expression)
+    ) {
+      const builtCallee = buildL1MemberAccess(expr.expression, ctx, {
+        nativeReceiverLeaf: true,
+      });
+      if (isL1Unsupported(builtCallee)) {
+        return builtCallee;
       }
-      args = [receiver];
+      callee = builtCallee;
+      args = [];
     } else {
       const builtCallee = tryBuildL1PureSubExpression(expr.expression, ctx);
       if (builtCallee === null || isL1Unsupported(builtCallee)) {

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -287,7 +287,7 @@ export function tryBuildL1PureSubExpression(
 
   if (ts.isCallExpression(expr)) {
     if (expr.arguments.some(ts.isSpreadElement)) {
-      return { unsupported: expr.getText() };
+      return { unsupported: "call with spread arguments is unsupported" };
     }
     let callee: IR1Expr | null;
     let args: IR1Expr[];

--- a/tools/ts2pant/src/ir1-lower.ts
+++ b/tools/ts2pant/src/ir1-lower.ts
@@ -30,7 +30,6 @@ import {
   irBinop,
   irCombTyped,
   irCond,
-  irLitBool,
   irLitNat,
   irUnop,
   irVar,
@@ -88,8 +87,7 @@ export function lowerL1Expr(e: IR1Expr): IRExpr {
         lowerL1Expr(g),
         lowerL1Expr(v),
       ]);
-      armPairs.push([irLitBool(true), lowerL1Expr(e.otherwise)]);
-      return irCond(armPairs);
+      return irCond(armPairs, lowerL1Expr(e.otherwise));
     }
 
     case "is-nullish":

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -37,7 +37,7 @@ import type {
   OpaqueParam,
 } from "./pant-ast.js";
 import { getAst } from "./pant-wasm.js";
-import { isKnownPureCall } from "./purity.js";
+import { isKnownPureCall, isStaticallyBoolTyped } from "./purity.js";
 import { translateRecordReturn } from "./translate-record.js";
 import {
   classifyFunction,
@@ -3118,6 +3118,17 @@ export function translateBodyExpr(
       const lhsL1 = ir1FromL2(irWrap(bodyExpr(left)));
       const rhsL1 = ir1FromL2(irWrap(bodyExpr(right)));
       return { expr: lowerL1ToOpaque(ir1Binop(l1Op, lhsL1, rhsL1)) };
+    }
+    if (
+      (expr.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken ||
+        expr.operatorToken.kind === ts.SyntaxKind.BarBarToken) &&
+      (!isStaticallyBoolTyped(expr.left, checker) ||
+        !isStaticallyBoolTyped(expr.right, checker))
+    ) {
+      return {
+        unsupported:
+          "&&/|| requires both operands to be statically Bool-typed (workstream conservative-refusal 3(b))",
+      };
     }
     const op = translateOperator(expr.operatorToken.kind);
     if (op === null) {

--- a/tools/ts2pant/src/translate-signature.ts
+++ b/tools/ts2pant/src/translate-signature.ts
@@ -17,6 +17,7 @@ import {
 } from "./nullish-recognizer.js";
 import type { OpaqueBinop, OpaqueExpr } from "./pant-ast.js";
 import { getAst } from "./pant-wasm.js";
+import { isStaticallyBoolTyped } from "./purity.js";
 import {
   cellIsUsed,
   cellRegisterName,
@@ -1054,6 +1055,17 @@ export function translateExpr(
     ) {
       return {
         unsupported: "loose equality (== / !=) is unsupported; use === / !==",
+      };
+    }
+    if (
+      (expr.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken ||
+        expr.operatorToken.kind === ts.SyntaxKind.BarBarToken) &&
+      (!isStaticallyBoolTyped(expr.left, checker) ||
+        !isStaticallyBoolTyped(expr.right, checker))
+    ) {
+      return {
+        unsupported:
+          "&&/|| requires both operands to be statically Bool-typed (workstream conservative-refusal 3(b))",
       };
     }
     const left = translateExpr(

--- a/tools/ts2pant/tests/ir-build.test.mts
+++ b/tools/ts2pant/tests/ir-build.test.mts
@@ -188,6 +188,54 @@ describe("ir-build M6 native construction stubs", () => {
     expectNoIRWrap(comb);
   });
 
+  it("preserves conditional otherwise during map-chain substitution", () => {
+    const ir = expectIR(`
+      interface Item { readonly amount: number | null; }
+      function f(items: Item[]): number[] {
+        return items
+          .map((item) => item.amount)
+          .map((amount) => amount ?? 0);
+      }
+    `);
+    assert.equal(ir.kind, "each");
+    if (ir.kind === "each") {
+      assert.equal(ir.proj.kind, "cond");
+      if (ir.proj.kind === "cond") {
+        assert.notEqual(ir.proj.otherwise, undefined);
+      }
+    }
+    expectNoIRWrap(ir);
+  });
+
+  it("normalizes dotted and string-literal method calls identically", () => {
+    const dotted = expectIR(`
+      interface Service { readonly run: (n: number) => number; }
+      function f(s: Service, n: number): number {
+        return s.run(n);
+      }
+    `);
+    const indexed = expectIR(`
+      interface Service { readonly run: (n: number) => number; }
+      function f(s: Service, n: number): number {
+        return s["run"](n);
+      }
+    `);
+    assert.deepEqual(indexed, dotted);
+    assert.equal(dotted.kind, "app");
+    if (dotted.kind === "app") {
+      assert.equal(dotted.head.kind, "expr");
+      if (dotted.head.kind === "expr") {
+        assert.equal(dotted.head.expr.kind, "app");
+        if (dotted.head.expr.kind === "app") {
+          assert.equal(dotted.head.expr.head.kind, "name");
+          if (dotted.head.expr.head.kind === "name") {
+            assert.equal(dotted.head.expr.head.name, "service--run");
+          }
+        }
+      }
+    }
+  });
+
   // M6 Patch 2 unskips the string-literal optional-element case; the
   // computed-key case should remain unsupported through M6.
   it("records optional element access boundary", () => {

--- a/tools/ts2pant/tests/ir-build.test.mts
+++ b/tools/ts2pant/tests/ir-build.test.mts
@@ -188,6 +188,116 @@ describe("ir-build M6 native construction stubs", () => {
     expectNoIRWrap(comb);
   });
 
+  it("recognizes string-literal array method calls", () => {
+    const dotted = expectIR(`
+      interface Item { readonly amount: number; }
+      function f(items: Item[]): number[] {
+        return items.map((item) => item.amount);
+      }
+    `);
+    const indexed = expectIR(`
+      interface Item { readonly amount: number; }
+      function f(items: Item[]): number[] {
+        return items["map"]((item) => item.amount);
+      }
+    `);
+    assert.deepEqual(indexed, dotted);
+    expectNoIRWrap(indexed);
+  });
+
+  it("rejects async, defaulted, optional, and rest array callbacks", () => {
+    const cases = [
+      {
+        source: `
+          function f(xs: number[]): Promise<boolean>[] {
+            return xs.map(async (x) => x > 0);
+          }
+        `,
+        reason: /must not be async/u,
+      },
+      {
+        source: `
+          function f(xs: number[]): number[] {
+            return xs.map((x = 0) => x + 1);
+          }
+        `,
+        reason: /plain identifiers/u,
+      },
+      {
+        source: `
+          function f(xs: number[]): number[] {
+            return xs.map((x?: number) => x ?? 0);
+          }
+        `,
+        reason: /plain identifiers/u,
+      },
+      {
+        source: `
+          function f(xs: number[]): number[] {
+            return xs.map((...x) => x.length);
+          }
+        `,
+        reason: /plain identifiers/u,
+      },
+    ];
+    for (const { source, reason } of cases) {
+      const result = buildFromSource(source);
+      assert.ok(isBuildUnsupported(result));
+      if (isBuildUnsupported(result)) {
+        assert.match(result.unsupported, reason);
+      }
+    }
+  });
+
+  it("rejects array-method calls with unsupported signatures", () => {
+    const result = buildFromSource(`
+      function f(xs: number[]): number[] {
+        return xs["filter"]((x) => x > 0, undefined);
+      }
+    `);
+    assert.ok(isBuildUnsupported(result));
+    if (isBuildUnsupported(result)) {
+      assert.match(result.unsupported, /callback must have exactly one argument/u);
+    }
+  });
+
+  it("rejects non-boolean filter predicates", () => {
+    const result = buildFromSource(`
+      interface Item { readonly id: number; }
+      function f(items: Item[]): Item[] {
+        return items.filter((item) => item.id);
+      }
+    `);
+    assert.ok(isBuildUnsupported(result));
+    if (isBuildUnsupported(result)) {
+      assert.match(result.unsupported, /boolean predicate/u);
+    }
+  });
+
+  it("rejects reducer operators when operand types do not match the combiner", () => {
+    const stringConcat = buildFromSource(`
+      interface Item { readonly name: string; }
+      function f(items: Item[]): string {
+        return items.reduce((s, item) => s + item.name, "");
+      }
+    `);
+    assert.ok(isBuildUnsupported(stringConcat));
+    if (isBuildUnsupported(stringConcat)) {
+      assert.match(stringConcat.unsupported, /number combiner/u);
+    }
+
+    const truthyOr = buildFromSource(`
+      interface Item { readonly value: number; }
+      function f(items: Item[]): number {
+        return items.reduce((a, item) => a || item.value, 0);
+      }
+    `);
+    assert.ok(isBuildUnsupported(truthyOr));
+    if (isBuildUnsupported(truthyOr)) {
+      assert.match(truthyOr.unsupported, /boolean combiner/u);
+    }
+  });
+
   it("rejects reduce callbacks that use a property access in the accumulator slot", () => {
     for (const expr of ["sum.total + item.amount", "item.amount + sum.total"]) {
       const result = buildFromSource(`

--- a/tools/ts2pant/tests/ir-build.test.mts
+++ b/tools/ts2pant/tests/ir-build.test.mts
@@ -205,6 +205,23 @@ describe("ir-build M6 native construction stubs", () => {
     expectNoIRWrap(indexed);
   });
 
+  it("does not recurse on syntactic array method names for non-array receivers", () => {
+    const method = buildFromSource(`
+      interface Service { readonly map: (n: number) => number; }
+      function f(service: Service, n: number): number {
+        return service.map(n);
+      }
+    `);
+    const indexed = buildFromSource(`
+      interface Service { readonly reduce: (n: number, init: number) => number; }
+      function f(service: Service, n: number): number {
+        return service["reduce"](n, 0);
+      }
+    `);
+    assert.equal(isBuildUnsupported(method), false);
+    assert.equal(isBuildUnsupported(indexed), false);
+  });
+
   it("rejects async, defaulted, optional, and rest array callbacks", () => {
     const cases = [
       {

--- a/tools/ts2pant/tests/ir-build.test.mts
+++ b/tools/ts2pant/tests/ir-build.test.mts
@@ -87,7 +87,12 @@ function containsKind(expr: IRExpr, kind: IRExpr["kind"]): boolean {
         containsKind(expr.proj, kind)
       );
     case "comb":
-      return containsKind(expr.each, kind);
+      return (
+        containsKind(expr.each, kind) ||
+        ("init" in expr &&
+          expr.init !== undefined &&
+          containsKind(expr.init, kind))
+      );
     case "comb-typed":
       return (
         expr.guards.some((guard) => containsKind(guard, kind)) ||
@@ -113,7 +118,7 @@ function expectNoIRWrap(expr: IRExpr): void {
 describe("ir-build M6 native construction stubs", () => {
   // M6 Patch 2 unskips this after ordinary arithmetic/comparison
   // binary expressions build as native App(binop, ...) nodes.
-  it.skip("builds arithmetic and comparison without IRWrap", () => {
+  it("builds arithmetic and comparison without IRWrap", () => {
     const arithmetic = expectIR(`
       function f(a: number, b: number): number {
         return (a + b) * 2;
@@ -130,7 +135,7 @@ describe("ir-build M6 native construction stubs", () => {
 
   // M6 Patch 2 unskips this after general pure calls build as native
   // App nodes instead of delegating through `translateBodyExpr`.
-  it.skip("builds general calls without IRWrap", () => {
+  it("builds general calls without IRWrap", () => {
     const ir = expectIR(`
       function score(a: number, b: number): number {
         return a + b;
@@ -145,7 +150,7 @@ describe("ir-build M6 native construction stubs", () => {
 
   // M6 Patch 2 unskips this after optional/nullish lowering avoids
   // L1 `from-l2` and native IR carries the complete conditional shape.
-  it.skip("builds optional chains and nullish coalescing without IRWrap", () => {
+  it("builds optional chains and nullish coalescing without IRWrap", () => {
     const optional = expectIR(`
       interface Owner { readonly id: number; }
       interface Account { readonly owner?: Owner; }
@@ -164,7 +169,7 @@ describe("ir-build M6 native construction stubs", () => {
 
   // M6 Patch 2 unskips this after chain fusion constructs real Each
   // and Comb nodes rather than preserving legacy opaque comprehensions.
-  it.skip("builds filter/map/reduce chains as native Each/Comb", () => {
+  it("builds filter/map/reduce chains as native Each/Comb", () => {
     const each = expectIR(`
       interface User { readonly active: boolean; readonly name: string; }
       function f(users: User[]): string[] {
@@ -185,7 +190,7 @@ describe("ir-build M6 native construction stubs", () => {
 
   // M6 Patch 2 unskips the string-literal optional-element case; the
   // computed-key case should remain unsupported through M6.
-  it.skip("records optional element access boundary", () => {
+  it("records optional element access boundary", () => {
     const literalKey = expectIR(`
       interface User { readonly name: string; }
       function f(u: User | null): string[] {
@@ -208,7 +213,7 @@ describe("ir-build M6 native construction stubs", () => {
 
   // M6 Patch 2 keeps computed element access outside the cleanup
   // boundary unless the key is syntactically a string literal.
-  it.skip("keeps computed element access unsupported", () => {
+  it("keeps computed element access unsupported", () => {
     const result = buildFromSource(`
       interface User { readonly name: string; }
       function f(u: User, key: keyof User): unknown {

--- a/tools/ts2pant/tests/ir-build.test.mts
+++ b/tools/ts2pant/tests/ir-build.test.mts
@@ -190,6 +190,23 @@ describe("ir-build M6 native construction stubs", () => {
     expectNoIRWrap(comb);
   });
 
+  it("builds array-chain receivers natively before member/cardinality fallback", () => {
+    const length = expectIR(`
+      function f(xs: number[]): number {
+        return xs.filter((x) => x > 0).length;
+      }
+    `);
+    const indexedLength = expectIR(`
+      function f(xs: number[]): number {
+        return xs["filter"]((x) => x > 0)["length"];
+      }
+    `);
+    assert.equal(containsKind(length, "each"), true);
+    assert.equal(containsKind(indexedLength, "each"), true);
+    expectNoIRWrap(length);
+    expectNoIRWrap(indexedLength);
+  });
+
   it("recognizes string-literal array method calls", () => {
     const dotted = expectIR(`
       interface Item { readonly amount: number; }
@@ -239,6 +256,14 @@ describe("ir-build M6 native construction stubs", () => {
     `);
     assert.equal(isBuildUnsupported(method), false);
     assert.equal(isBuildUnsupported(indexed), false);
+    if (!isBuildUnsupported(method)) {
+      assert.equal(containsKind(method, "each"), false);
+      assert.equal(containsKind(method, "comb"), false);
+    }
+    if (!isBuildUnsupported(indexed)) {
+      assert.equal(containsKind(indexed, "each"), false);
+      assert.equal(containsKind(indexed, "comb"), false);
+    }
   });
 
   it("rejects async, defaulted, optional, and rest array callbacks", () => {

--- a/tools/ts2pant/tests/ir-build.test.mts
+++ b/tools/ts2pant/tests/ir-build.test.mts
@@ -31,7 +31,9 @@ function setupReturnExpr(source: string, functionName = "f"): ExprSetup {
   }
   const stmt = fn.body.statements.find(ts.isReturnStatement);
   if (!stmt?.expression) {
-    throw new Error(`expected function ${functionName} to return an expression`);
+    throw new Error(
+      `expected function ${functionName} to return an expression`,
+    );
   }
   const paramNames = new Map<string, string>();
   for (const param of fn.parameters) {
@@ -205,6 +207,23 @@ describe("ir-build M6 native construction stubs", () => {
     expectNoIRWrap(indexed);
   });
 
+  it("recognizes tuple and union array-method receivers", () => {
+    const tuple = expectIR(`
+      function f(items: readonly [number, number]): number[] {
+        return items.map((item) => item + 1);
+      }
+    `);
+    const union = expectIR(`
+      function f(items: number[] | readonly number[]): number[] {
+        return items.map((item) => item + 1);
+      }
+    `);
+    assert.equal(containsKind(tuple, "each"), true);
+    assert.equal(containsKind(union, "each"), true);
+    expectNoIRWrap(tuple);
+    expectNoIRWrap(union);
+  });
+
   it("does not recurse on syntactic array method names for non-array receivers", () => {
     const method = buildFromSource(`
       interface Service { readonly map: (n: number) => number; }
@@ -274,7 +293,10 @@ describe("ir-build M6 native construction stubs", () => {
     `);
     assert.ok(isBuildUnsupported(result));
     if (isBuildUnsupported(result)) {
-      assert.match(result.unsupported, /callback must have exactly one argument/u);
+      assert.match(
+        result.unsupported,
+        /callback must have exactly one argument/u,
+      );
     }
   });
 
@@ -325,7 +347,10 @@ describe("ir-build M6 native construction stubs", () => {
       `);
       assert.ok(isBuildUnsupported(result));
       if (isBuildUnsupported(result)) {
-        assert.match(result.unsupported, /callback must reference acc exactly once/u);
+        assert.match(
+          result.unsupported,
+          /callback must reference acc exactly once/u,
+        );
       }
     }
   });

--- a/tools/ts2pant/tests/ir-build.test.mts
+++ b/tools/ts2pant/tests/ir-build.test.mts
@@ -188,6 +188,21 @@ describe("ir-build M6 native construction stubs", () => {
     expectNoIRWrap(comb);
   });
 
+  it("rejects reduce callbacks that use a property access in the accumulator slot", () => {
+    for (const expr of ["sum.total + item.amount", "item.amount + sum.total"]) {
+      const result = buildFromSource(`
+        interface Item { readonly amount: number; }
+        function f(items: Item[]): number {
+          return items.reduce((sum, item) => ${expr}, 0);
+        }
+      `);
+      assert.ok(isBuildUnsupported(result));
+      if (isBuildUnsupported(result)) {
+        assert.match(result.unsupported, /callback must reference acc exactly once/u);
+      }
+    }
+  });
+
   it("preserves conditional otherwise during map-chain substitution", () => {
     const ir = expectIR(`
       interface Item { readonly amount: number | null; }

--- a/tools/ts2pant/tests/ir1-build-call-purity.test.mts
+++ b/tools/ts2pant/tests/ir1-build-call-purity.test.mts
@@ -60,6 +60,16 @@ function setupReturnExpr(source: string): {
 }
 
 describe("ir1-build call purity", () => {
+  it("lowers a known pure call when callee and receiver are pure", () => {
+    const pure = setupReturnExpr(`
+      function f(xs: Set<number>, x: number): boolean {
+        return xs.has(x);
+      }
+    `);
+
+    assert.notEqual(tryBuildL1PureSubExpression(pure.expr, pure.ctx), null);
+  });
+
   it("does not lower known collection mutations as pure native calls", () => {
     const setAdd = setupReturnExpr(`
       function f(xs: Set<number>, x: number): Set<number> {

--- a/tools/ts2pant/tests/ir1-build-call-purity.test.mts
+++ b/tools/ts2pant/tests/ir1-build-call-purity.test.mts
@@ -96,6 +96,36 @@ describe("ir1-build call purity", () => {
     );
   });
 
+  it("does not lower union-typed collection mutations as pure native calls", () => {
+    const arrayPushUnion = setupReturnExpr(`
+      function f(xs: number[] | string[]): number {
+        return xs.push();
+      }
+    `);
+    const setClearUnion = setupReturnExpr(`
+      function f(xs: Set<number> | Set<string>): void {
+        return xs.clear();
+      }
+    `);
+    const mapClearUnion = setupReturnExpr(`
+      function f(xs: Map<string, number> | Map<number, string>): void {
+        return xs.clear();
+      }
+    `);
+    assert.equal(
+      tryBuildL1PureSubExpression(arrayPushUnion.expr, arrayPushUnion.ctx),
+      null,
+    );
+    assert.equal(
+      tryBuildL1PureSubExpression(setClearUnion.expr, setClearUnion.ctx),
+      null,
+    );
+    assert.equal(
+      tryBuildL1PureSubExpression(mapClearUnion.expr, mapClearUnion.ctx),
+      null,
+    );
+  });
+
   it("does not lower a member call whose receiver has unknown effects", () => {
     const { expr, ctx } = setupReturnExpr(`
       declare function makeSet(): Set<number>;

--- a/tools/ts2pant/tests/ir1-build-call-purity.test.mts
+++ b/tools/ts2pant/tests/ir1-build-call-purity.test.mts
@@ -71,9 +71,27 @@ describe("ir1-build call purity", () => {
         return xs.push(x);
       }
     `);
+    const setAddBracket = setupReturnExpr(`
+      function f(xs: Set<number>, x: number): Set<number> {
+        return xs["add"](x);
+      }
+    `);
+    const arrayPushBracket = setupReturnExpr(`
+      function f(xs: number[], x: number): number {
+        return xs["push"](x);
+      }
+    `);
     assert.equal(tryBuildL1PureSubExpression(setAdd.expr, setAdd.ctx), null);
     assert.equal(
       tryBuildL1PureSubExpression(arrayPush.expr, arrayPush.ctx),
+      null,
+    );
+    assert.equal(
+      tryBuildL1PureSubExpression(setAddBracket.expr, setAddBracket.ctx),
+      null,
+    );
+    assert.equal(
+      tryBuildL1PureSubExpression(arrayPushBracket.expr, arrayPushBracket.ctx),
       null,
     );
   });
@@ -83,6 +101,24 @@ describe("ir1-build call purity", () => {
       declare function makeSet(): Set<number>;
       function f(x: number): boolean {
         return makeSet().has(x);
+      }
+    `);
+    assert.equal(tryBuildL1PureSubExpression(expr, ctx), null);
+
+    const bracket = setupReturnExpr(`
+      declare function makeSet(): Set<number>;
+      function f(x: number): boolean {
+        return makeSet()["has"](x);
+      }
+    `);
+    assert.equal(tryBuildL1PureSubExpression(bracket.expr, bracket.ctx), null);
+  });
+
+  it("does not lower a higher-order call with an effectful callee", () => {
+    const { expr, ctx } = setupReturnExpr(`
+      declare function makeFn(): (x: number) => number;
+      function f(x: number): number {
+        return (makeFn())(x);
       }
     `);
     assert.equal(tryBuildL1PureSubExpression(expr, ctx), null);

--- a/tools/ts2pant/tests/ir1-build-call-purity.test.mts
+++ b/tools/ts2pant/tests/ir1-build-call-purity.test.mts
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { before, describe, it } from "node:test";
+import ts from "typescript";
+import { createSourceFileFromSource, getChecker } from "../src/extract.js";
+import {
+  type L1BuildContext,
+  tryBuildL1PureSubExpression,
+} from "../src/ir1-build.js";
+import { loadAst } from "../src/pant-wasm.js";
+import type { UniqueSupply } from "../src/translate-body.js";
+import {
+  cellRegisterName,
+  IntStrategy,
+  newSynthCell,
+  toPantTermName,
+} from "../src/translate-types.js";
+
+before(async () => {
+  await loadAst();
+});
+
+function setupReturnExpr(source: string): {
+  expr: ts.Expression;
+  ctx: L1BuildContext;
+} {
+  const sourceFile = createSourceFileFromSource(source);
+  const checker = getChecker(sourceFile);
+  const fn = sourceFile.compilerNode.statements.find(
+    (stmt): stmt is ts.FunctionDeclaration =>
+      ts.isFunctionDeclaration(stmt) && stmt.body !== undefined,
+  );
+  if (!fn?.body) {
+    throw new Error("setup: expected function body");
+  }
+  const synthCell = newSynthCell();
+  const paramNames = new Map<string, string>();
+  for (const param of fn.parameters) {
+    if (ts.isIdentifier(param.name)) {
+      paramNames.set(
+        param.name.text,
+        cellRegisterName(synthCell, toPantTermName(param.name.text)),
+      );
+    }
+  }
+  const stmt = fn.body.statements[0];
+  if (!stmt || !ts.isReturnStatement(stmt) || !stmt.expression) {
+    throw new Error("setup: expected return expression");
+  }
+  const supply: UniqueSupply = { n: 0, synthCell };
+  return {
+    expr: stmt.expression,
+    ctx: {
+      checker,
+      strategy: IntStrategy,
+      paramNames,
+      state: undefined,
+      supply,
+    },
+  };
+}
+
+describe("ir1-build call purity", () => {
+  it("does not lower known collection mutations as pure native calls", () => {
+    const setAdd = setupReturnExpr(`
+      function f(xs: Set<number>, x: number): Set<number> {
+        return xs.add(x);
+      }
+    `);
+    const arrayPush = setupReturnExpr(`
+      function f(xs: number[], x: number): number {
+        return xs.push(x);
+      }
+    `);
+    assert.equal(tryBuildL1PureSubExpression(setAdd.expr, setAdd.ctx), null);
+    assert.equal(
+      tryBuildL1PureSubExpression(arrayPush.expr, arrayPush.ctx),
+      null,
+    );
+  });
+
+  it("does not lower a member call whose receiver has unknown effects", () => {
+    const { expr, ctx } = setupReturnExpr(`
+      declare function makeSet(): Set<number>;
+      function f(x: number): boolean {
+        return makeSet().has(x);
+      }
+    `);
+    assert.equal(tryBuildL1PureSubExpression(expr, ctx), null);
+  });
+});

--- a/tools/ts2pant/tests/ir1-build-cardinality.test.mts
+++ b/tools/ts2pant/tests/ir1-build-cardinality.test.mts
@@ -22,6 +22,7 @@ import { createSourceFileFromSource, getChecker } from "../src/extract.js";
 import {
   type L1BuildContext,
   tryBuildL1Cardinality,
+  tryBuildL1PureSubExpression,
 } from "../src/ir1-build.js";
 import type { IR1Expr } from "../src/ir1.js";
 import { loadAst } from "../src/pant-wasm.js";
@@ -40,7 +41,7 @@ before(async () => {
 });
 
 interface AccessSetup {
-  node: ts.PropertyAccessExpression;
+  node: ts.Expression;
   ctx: L1BuildContext;
 }
 
@@ -78,9 +79,12 @@ function setup(source: string): AccessSetup {
   if (!stmt || !ts.isReturnStatement(stmt) || !stmt.expression) {
     throw new Error("setup: expected return statement");
   }
-  if (!ts.isPropertyAccessExpression(stmt.expression)) {
+  if (
+    !ts.isPropertyAccessExpression(stmt.expression) &&
+    !ts.isElementAccessExpression(stmt.expression)
+  ) {
     throw new Error(
-      `setup: expected PropertyAccess, got ${ts.SyntaxKind[stmt.expression.kind]}`,
+      `setup: expected property access, got ${ts.SyntaxKind[stmt.expression.kind]}`,
     );
   }
   return { node: stmt.expression, ctx };
@@ -136,6 +140,17 @@ describe("ir1-build-cardinality", () => {
       `function f(m: ReadonlyMap<string, number>): number { return m.size; }`,
     );
     expectCardUnop(tryBuildL1Cardinality(node, ctx));
+  });
+
+  it('string-literal "length" and "size" build Unop(card)', () => {
+    const length = setup(
+      `function f(xs: number[]): number { return xs["length"]; }`,
+    );
+    const size = setup(
+      `function f(xs: Set<number>): number { return xs["size"]; }`,
+    );
+    expectCardUnop(tryBuildL1PureSubExpression(length.node, length.ctx));
+    expectCardUnop(tryBuildL1PureSubExpression(size.node, size.ctx));
   });
 
   it("user-typed .length on a non-list interface falls through to Member", () => {

--- a/tools/ts2pant/tests/ir1-build-cardinality.test.mts
+++ b/tools/ts2pant/tests/ir1-build-cardinality.test.mts
@@ -84,7 +84,7 @@ function setup(source: string): AccessSetup {
     !ts.isElementAccessExpression(stmt.expression)
   ) {
     throw new Error(
-      `setup: expected property access, got ${ts.SyntaxKind[stmt.expression.kind]}`,
+      `setup: expected property or element access, got ${ts.SyntaxKind[stmt.expression.kind]}`,
     );
   }
   return { node: stmt.expression, ctx };
@@ -149,8 +149,16 @@ describe("ir1-build-cardinality", () => {
     const size = setup(
       `function f(xs: Set<number>): number { return xs["size"]; }`,
     );
+    const lengthTpl = setup(
+      "function f(xs: number[]): number { return xs[`length`]; }",
+    );
+    const sizeTpl = setup(
+      "function f(xs: Set<number>): number { return xs[`size`]; }",
+    );
     expectCardUnop(tryBuildL1PureSubExpression(length.node, length.ctx));
     expectCardUnop(tryBuildL1PureSubExpression(size.node, size.ctx));
+    expectCardUnop(tryBuildL1PureSubExpression(lengthTpl.node, lengthTpl.ctx));
+    expectCardUnop(tryBuildL1PureSubExpression(sizeTpl.node, sizeTpl.ctx));
   });
 
   it("user-typed .length on a non-list interface falls through to Member", () => {

--- a/tools/ts2pant/tests/ir1-build-functor-lift.test.mts
+++ b/tools/ts2pant/tests/ir1-build-functor-lift.test.mts
@@ -495,6 +495,15 @@ describe("ir1-build-functor-lift", () => {
     assert.equal(tryRecognizeFunctorLift(candidate, ctx), null);
   });
 
+  it("string-literal multi-producing calls are not single-element lift projections", () => {
+    const { candidate, ctx } = setup(
+      `function f(maybeXs: number[] | null): number[] {
+         return maybeXs == null ? [] : maybeXs["map"]((x) => x + 1);
+       }`,
+    );
+    assert.equal(tryRecognizeFunctorLift(candidate, ctx), null);
+  });
+
   it("present side does not reference the operand falls through", () => {
     const { candidate, ctx } = setup(
       `interface User { readonly name: string; }

--- a/tools/ts2pant/tests/ir1-build-nullish.test.mts
+++ b/tools/ts2pant/tests/ir1-build-nullish.test.mts
@@ -22,10 +22,17 @@ import { irWrap } from "../src/ir.js";
 import { type IR1Expr, ir1FromL2 } from "../src/ir1.js";
 import { createSourceFileFromSource, getChecker } from "../src/extract.js";
 import {
+  isL1Unsupported,
+  tryBuildL1PureSubExpression,
+  type L1BuildContext,
+} from "../src/ir1-build.js";
+import {
   type NullishTranslate,
   recognizeNullishForm,
 } from "../src/nullish-recognizer.js";
 import { getAst, loadAst } from "../src/pant-wasm.js";
+import type { UniqueSupply } from "../src/translate-body.js";
+import { IntStrategy, newSynthCell } from "../src/translate-types.js";
 
 before(async () => {
   await loadAst();
@@ -95,6 +102,45 @@ function parseBinExpr(
 function makeTranslate(): NullishTranslate {
   const ast = getAst();
   return (e) => ir1FromL2(irWrap(ast.var(e.getText())));
+}
+
+function parseNarrowedNullishReturn(source: string): {
+  expr: ts.Expression;
+  ctx: L1BuildContext;
+} {
+  const sourceFile = createSourceFileFromSource(source);
+  const checker = getChecker(sourceFile);
+  const fn = sourceFile.compilerNode.statements.find(ts.isFunctionDeclaration);
+  if (!fn?.body) {
+    throw new Error("test helper: expected function body");
+  }
+  const first = fn.body.statements[0];
+  if (!first || !ts.isIfStatement(first)) {
+    throw new Error("test helper: expected leading if statement");
+  }
+  const thenStmt = ts.isBlock(first.thenStatement)
+    ? first.thenStatement.statements[0]
+    : first.thenStatement;
+  if (!thenStmt || !ts.isReturnStatement(thenStmt) || !thenStmt.expression) {
+    throw new Error("test helper: expected return inside if");
+  }
+  const paramNames = new Map<string, string>();
+  for (const param of fn.parameters) {
+    if (ts.isIdentifier(param.name)) {
+      paramNames.set(param.name.text, param.name.text);
+    }
+  }
+  const supply: UniqueSupply = { n: 0, synthCell: newSynthCell() };
+  return {
+    expr: thenStmt.expression,
+    ctx: {
+      checker,
+      strategy: IntStrategy,
+      paramNames,
+      state: undefined,
+      supply,
+    },
+  };
 }
 
 function asL1(
@@ -441,6 +487,48 @@ describe("ir1-build-nullish", () => {
       if (l1.rhs.kind === "is-nullish") {
         expectOperandText(l1.rhs.operand, "y");
       }
+    }
+  });
+});
+
+describe("ir1-build nullish coalescing", () => {
+  it("uses declared left nullability when the left operand is flow-narrowed", () => {
+    const { expr, ctx } = parseNarrowedNullishReturn(`
+      function f(x: number | null, y: number): number {
+        if (x !== null) {
+          return x ?? y;
+        }
+        return y;
+      }
+    `);
+    const l1 = tryBuildL1PureSubExpression(expr, ctx);
+    assert.notEqual(l1, null);
+    if (l1 === null || isL1Unsupported(l1)) {
+      throw new Error("expected nullish coalescing to build");
+    }
+    assert.equal(l1.kind, "cond");
+    if (l1.kind === "cond") {
+      assert.equal(l1.otherwise.kind, "app");
+    }
+  });
+
+  it("uses declared right nullability when the right operand is flow-narrowed", () => {
+    const { expr, ctx } = parseNarrowedNullishReturn(`
+      function f(x: number | null, y: number | null): number | null {
+        if (y !== null) {
+          return x ?? y;
+        }
+        return x;
+      }
+    `);
+    const l1 = tryBuildL1PureSubExpression(expr, ctx);
+    assert.notEqual(l1, null);
+    if (l1 === null || isL1Unsupported(l1)) {
+      throw new Error("expected nullish coalescing to build");
+    }
+    assert.equal(l1.kind, "cond");
+    if (l1.kind === "cond") {
+      assert.equal(l1.otherwise.kind, "var");
     }
   });
 });

--- a/tools/ts2pant/tests/ir1-build-nullish.test.mts
+++ b/tools/ts2pant/tests/ir1-build-nullish.test.mts
@@ -110,8 +110,11 @@ function parseNarrowedNullishReturn(source: string): {
 } {
   const sourceFile = createSourceFileFromSource(source);
   const checker = getChecker(sourceFile);
-  const fn = sourceFile.compilerNode.statements.find(ts.isFunctionDeclaration);
-  if (!fn?.body) {
+  const fn = sourceFile.compilerNode.statements.find(
+    (stmt): stmt is ts.FunctionDeclaration =>
+      ts.isFunctionDeclaration(stmt) && stmt.body !== undefined,
+  );
+  if (!fn) {
     throw new Error("test helper: expected function body");
   }
   const first = fn.body.statements[0];
@@ -143,23 +146,21 @@ function parseNarrowedNullishReturn(source: string): {
   };
 }
 
-function asL1(
-  result: IR1Expr | { unsupported: string } | null,
-): IR1Expr {
+function asL1(result: IR1Expr | { unsupported: string } | null): IR1Expr {
   if (result === null) {
     throw new Error("expected an L1 expression, got null (no match)");
   }
   if ("unsupported" in result) {
-    throw new Error(`expected an L1 expression, got unsupported: ${result.unsupported}`);
+    throw new Error(
+      `expected an L1 expression, got unsupported: ${result.unsupported}`,
+    );
   }
   return result;
 }
 
 function expectIsNullish(l1: IR1Expr): IR1Expr {
   if (l1.kind !== "is-nullish") {
-    throw new Error(
-      `expected is-nullish at top level, got ${l1.kind}`,
-    );
+    throw new Error(`expected is-nullish at top level, got ${l1.kind}`);
   }
   return l1.operand;
 }
@@ -211,9 +212,7 @@ describe("ir1-build-nullish", () => {
   });
 
   it("x === null || x === undefined builds is-nullish (operand identity)", () => {
-    const { expr, checker } = parseBinExpr(
-      "x === null || x === undefined",
-    );
+    const { expr, checker } = parseBinExpr("x === null || x === undefined");
     const l1 = asL1(recognizeNullishForm(expr, checker, makeTranslate()));
     // The recognizer folds the pair into one `is-nullish` (not nested
     // inside `or` — that's the point of the long-form recognizer).
@@ -232,10 +231,9 @@ describe("ir1-build-nullish", () => {
     // against `undefined` is an always-false comparison in TS, but
     // syntactically it's still part of the nullish pattern, and
     // collapsing to `IsNullish(x)` lowers to a sound `#x = 0` test.
-    const { expr, checker } = parseBinExpr(
-      "x === null || x === undefined",
-      { x: "number | null" },
-    );
+    const { expr, checker } = parseBinExpr("x === null || x === undefined", {
+      x: "number | null",
+    });
     const l1 = asL1(recognizeNullishForm(expr, checker, makeTranslate()));
     const operand = expectIsNullish(l1);
     expectOperandText(operand, "x");
@@ -263,9 +261,7 @@ describe("ir1-build-nullish", () => {
   });
 
   it("x !== null && x !== undefined builds not(is-nullish)", () => {
-    const { expr, checker } = parseBinExpr(
-      "x !== null && x !== undefined",
-    );
+    const { expr, checker } = parseBinExpr("x !== null && x !== undefined");
     const l1 = asL1(recognizeNullishForm(expr, checker, makeTranslate()));
     const operand = expectNotIsNullish(l1);
     expectOperandText(operand, "x");

--- a/tools/ts2pant/tests/ir1-lower.test.mts
+++ b/tools/ts2pant/tests/ir1-lower.test.mts
@@ -146,20 +146,17 @@ describe("lowerL1Expr — applications", () => {
 });
 
 describe("lowerL1Expr — cond (byte-equality with legacy ast.cond)", () => {
-  it("single-arm cond produces L2 cond with literal-true tail", () => {
-    // cond [(g, v)] otherwise=d  →  irCond [(g, v), (true, d)]
+  it("single-arm cond preserves L2 otherwise", () => {
+    // cond [(g, v)] otherwise=d  →  irCond [(g, v)] otherwise=d
     const l1 = ir1Cond([[ir1Var("g"), ir1Var("v")]], ir1Var("d"));
     const l2 = lowerL1Expr(l1);
     assert.deepEqual(
       l2,
-      irCond([
-        [irVar("g", false), irVar("v", false)],
-        [irLitBool(true), irVar("d", false)],
-      ]),
+      irCond([[irVar("g", false), irVar("v", false)]], irVar("d", false)),
     );
   });
 
-  it("multi-arm cond preserves arm order and emits literal-true tail", () => {
+  it("multi-arm cond preserves arm order and otherwise", () => {
     // cond [(g1, v1), (g2, v2), (g3, v3)] otherwise=d
     const l1 = ir1Cond(
       [
@@ -176,8 +173,7 @@ describe("lowerL1Expr — cond (byte-equality with legacy ast.cond)", () => {
         [irVar("g1", false), irVar("v1", false)],
         [irVar("g2", false), irVar("v2", false)],
         [irVar("g3", false), irVar("v3", false)],
-        [irLitBool(true), irVar("d", false)],
-      ]),
+      ], irVar("d", false)),
     );
   });
 
@@ -186,16 +182,13 @@ describe("lowerL1Expr — cond (byte-equality with legacy ast.cond)", () => {
     const inner = ir1Cond([[ir1Var("h"), ir1Var("x")]], ir1Var("y"));
     const outer = ir1Cond([[ir1Var("g"), inner]], ir1Var("z"));
     const l2 = lowerL1Expr(outer);
-    const expectedInner = irCond([
-      [irVar("h", false), irVar("x", false)],
-      [irLitBool(true), irVar("y", false)],
-    ]);
+    const expectedInner = irCond(
+      [[irVar("h", false), irVar("x", false)]],
+      irVar("y", false),
+    );
     assert.deepEqual(
       l2,
-      irCond([
-        [irVar("g", false), expectedInner],
-        [irLitBool(true), irVar("z", false)],
-      ]),
+      irCond([[irVar("g", false), expectedInner]], irVar("z", false)),
     );
   });
 });
@@ -250,7 +243,7 @@ describe("lowerL1Expr — from-l2 transitional adapter", () => {
 
   it("from-l2 inside a cond arm composes correctly", () => {
     // cond [(g, from-l2(a + 1))] otherwise=0  →
-    //   cond [(g, a+1), (true, 0)]
+    //   cond [(g, a+1)] otherwise=0
     const l1 = ir1Cond(
       [
         [
@@ -268,8 +261,7 @@ describe("lowerL1Expr — from-l2 transitional adapter", () => {
           irVar("g", false),
           irBinop("add", irVar("a", false), irLitNat(1)),
         ],
-        [irLitBool(true), irLitNat(0)],
-      ]),
+      ], irLitNat(0)),
     );
   });
 });

--- a/tools/ts2pant/tests/l1-plumbing.test.mts
+++ b/tools/ts2pant/tests/l1-plumbing.test.mts
@@ -209,19 +209,17 @@ describe("L1: conservative-refusal rejection cases", () => {
     assert.match(unsupported!, /literal/);
   });
 
-  it("non-Bool && stays on the legacy operator path (degraded but accepted)", () => {
-    // Non-Bool `&&` / `||` is *not* an L1 conditional form — `isL1ConditionalForm`
-    // requires both operands Bool-typed. So `a && b` with `a: number` falls
-    // through to the legacy `translateOperator` path and lowers to `a and b`
-    // as a binop. Translation succeeds.
+  it("non-Bool && rejects instead of lowering truthy/falsy semantics", () => {
+    // Non-Bool `&&` / `||` returns one operand in TS, not a boolean
+    // conjunction/disjunction. Reject instead of lowering to `and`/`or`.
     const source = `
       function combine(a: number, b: number): number {
         return a && b;
       }
     `;
-    const { unsupported, pant } = translate(source, "combine");
-    assert.equal(unsupported, null);
-    assert.match(pant!, /and/);
+    const { unsupported } = translate(source, "combine");
+    assert.notEqual(unsupported, null);
+    assert.match(unsupported!, /statically Bool-typed/u);
   });
 });
 

--- a/tools/ts2pant/tests/l1-plumbing.test.mts
+++ b/tools/ts2pant/tests/l1-plumbing.test.mts
@@ -221,6 +221,17 @@ describe("L1: conservative-refusal rejection cases", () => {
     assert.notEqual(unsupported, null);
     assert.match(unsupported!, /statically Bool-typed/u);
   });
+
+  it("non-Bool || rejects instead of lowering truthy/falsy semantics", () => {
+    const source = `
+      function combine(a: number, b: number): number {
+        return a || b;
+      }
+    `;
+    const { unsupported } = translate(source, "combine");
+    assert.notEqual(unsupported, null);
+    assert.match(unsupported!, /statically Bool-typed/u);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Patch 2: Build remaining pure expression shapes natively

- Teach `buildIR` to construct native IR for prefix unary, ordinary binary operators, strict equality, general calls, and nullish coalescing using L1 helpers where the class already belongs to L1.
- Extend optional-chain functor-lift from dotted `PropertyAccessExpression` to string-literal `ElementAccessExpression`: `obj?.["field"]` and ``obj?.[`field`]`` use the same rule-name qualification, nullable-receiver check, binder allocation, and `Each` lowering as `obj?.field`. Computed `obj?.[expr]` returns the existing computed-access unsupported reason; do not add literal-union or `keyof` dispatch in M6.
- Move array `.filter` / `.map` / `.reduce` chain construction out of legacy `translateBodyExpr` fallback and into native `Each` / `Comb` IR construction.
- Keep the old fallback temporarily only as a dead-code safety net until Patch 3 proves always-on behavior; new tests must assert the covered shapes do not produce `ir-wrap`.
- Unskip Patch 2 `ir-build` tests.

## Changes
- Teach `buildIR` to construct native IR for prefix unary, ordinary binary operators, strict equality, general calls, and nullish coalescing using L1 helpers where the class already belongs to L1.
- Extend optional-chain functor-lift from dotted `PropertyAccessExpression` to string-literal `ElementAccessExpression`: `obj?.["field"]` and ``obj?.[`field`]`` use the same rule-name qualification, nullable-receiver check, binder allocation, and `Each` lowering as `obj?.field`. Computed `obj?.[expr]` returns the existing computed-access unsupported reason; do not add literal-union or `keyof` dispatch in M6.
- Move array `.filter` / `.map` / `.reduce` chain construction out of legacy `translateBodyExpr` fallback and into native `Each` / `Comb` IR construction.
- Keep the old fallback temporarily only as a dead-code safety net until Patch 3 proves always-on behavior; new tests must assert the covered shapes do not produce `ir-wrap`.
- Unskip Patch 2 `ir-build` tests.

## Files to Modify
- tools/ts2pant/src/ir-build.ts (modify): Replace fallback-only coverage with native IR/L1 construction for ordinary pure expressions and array chains.
- tools/ts2pant/src/ir1-build.ts (modify): Expose reusable native L1 expression construction for nullish/equality/cardinality/member/call/binop sub-expressions.
- tools/ts2pant/tests/ir-build.test.mts (modify): Unskip and implement Patch 2 native-build tests.

## Gameplan Specification

```
module TS2PANT_M6_LEGACY_CLEANUP.

PureReturn.
L1SubExpression.
IRNode.
DocumentedArchitecture.

expression-terminal? r: PureReturn => Bool.
uses-ir? r: PureReturn => Bool.
uses-env-flag? r: PureReturn => Bool.

supported-l1? e: L1SubExpression => Bool.
native-l1? e: L1SubExpression => Bool.
unsupported-l1? e: L1SubExpression => Bool.

escape-hatch? n: IRNode => Bool.
reachable? n: IRNode => Bool.
native-node? n: IRNode => Bool.

final? a: DocumentedArchitecture => Bool.
mentions-migration-flag? a: DocumentedArchitecture => Bool.
mentions-escape-hatch? a: DocumentedArchitecture => Bool.

---

all r: PureReturn | expression-terminal? r -> uses-ir? r.
all r: PureReturn | uses-ir? r -> ~uses-env-flag? r.

all e: L1SubExpression | supported-l1? e -> native-l1? e.
all e: L1SubExpression | ~supported-l1? e -> unsupported-l1? e.
all e: L1SubExpression | native-l1? e -> ~unsupported-l1? e.

all n: IRNode | escape-hatch? n -> ~reachable? n.
all n: IRNode | reachable? n -> native-node? n.

all a: DocumentedArchitecture | final? a -> ~mentions-migration-flag? a.
all a: DocumentedArchitecture | final? a -> ~mentions-escape-hatch? a.

```

## Patch Specification

```
module TS2PANT_M6_LEGACY_CLEANUP_PATCH_2.

PureExpression.
supported? e: PureExpression => Bool.
native-ir? e: PureExpression => Bool.
opaque-fallback? e: PureExpression => Bool.

---

all e: PureExpression | supported? e -> native-ir? e.
all e: PureExpression | native-ir? e -> ~opaque-fallback? e.

```


## Implementation Notes

- Native ordinary-expression construction is centralized in `tryBuildL1PureSubExpression`, then lowered back through the existing L1 lowering path. This keeps binary/unary/call/nullish/member/cardinality behavior aligned with the L1 canonical forms instead of adding a second IR-only spelling of those constructs.
- Parentheses are stripped at the IR/L1 build boundary, but type-affecting wrappers are intentionally left intact because field qualification and nullability checks depend on the checker-visible type at the original node.
- Array chain lowering keeps `.filter()`/`.map()` as a pending comprehension until the chain is materialized, which lets consecutive filters/maps become one `Each` with accumulated guards and a final projection. `.reduce()` consumes that pending comprehension and emits a `Comb` over the fused `Each`.
- `.reduce()` support is deliberately structural and conservative: it requires an explicit initial value, an `(acc, x)` arrow callback, and an `acc OP f(x)`-style body. Identity initializers are elided for the matching combiner; non-identity initializers are preserved either as combiner init or as an outer binary op for subtraction/division.
- `reduceRight` is only accepted for commutative combiners. Non-commutative `reduceRight` remains unsupported rather than pretending traversal order is irrelevant.
- Optional element access only treats syntactic string literal keys, including no-substitution template literals, as the same field-access class as dotted access. Computed keys continue to fail before legacy fallback so they cannot silently re-enter as opaque IR.