### PR TITLE
[ts2pant-m6-legacy-cleanup] Patch 3: Promote pure IR path to always-on

### DIFF
--- a/tools/ts2pant/src/ir-build.ts
+++ b/tools/ts2pant/src/ir-build.ts
@@ -30,6 +30,7 @@ import {
   irVar,
   irWrap,
 } from "./ir.js";
+import { ir1FromL2 } from "./ir1.js";
 import {
   buildL1MemberAccess,
   computedElementAccessUnsupportedReason,
@@ -43,6 +44,7 @@ import { lowerL1Expr } from "./ir1-lower.js";
 import {
   type NullishTranslate,
   recognizeNullishForm,
+  unwrapTransparentExpression,
 } from "./nullish-recognizer.js";
 import { isStaticallyBoolTyped } from "./purity.js";
 import {
@@ -801,11 +803,21 @@ function buildCollectionMembershipCall(
     return null;
   }
 
-  const normalizedReceiver = unwrapParens(tsReceiver) as ts.Expression;
-  if (ts.isPropertyAccessExpression(normalizedReceiver)) {
-    const member = buildL1MemberAccess(normalizedReceiver, l1Ctx, {
-      nativeReceiverLeaf: true,
-    });
+  const normalizedReceiver = unwrapTransparentExpression(tsReceiver);
+  const isMemberSurface =
+    (ts.isPropertyAccessExpression(normalizedReceiver) &&
+      (normalizedReceiver.flags & ts.NodeFlags.OptionalChain) === 0) ||
+    (ts.isElementAccessExpression(normalizedReceiver) &&
+      (normalizedReceiver.flags & ts.NodeFlags.OptionalChain) === 0 &&
+      elementAccessLiteralKey(normalizedReceiver) !== null);
+  if (isMemberSurface) {
+    const member = buildL1MemberAccess(
+      normalizedReceiver as
+        | ts.PropertyAccessExpression
+        | ts.ElementAccessExpression,
+      l1Ctx,
+      { nativeReceiverLeaf: true },
+    );
     if ("unsupported" in member) {
       return member;
     }
@@ -1026,14 +1038,11 @@ export function buildIR(
 
   if (ts.isBinaryExpression(expr)) {
     const nullishTranslate: NullishTranslate = (sub) => {
-      const result = tryBuildL1PureSubExpression(sub, l1Ctx);
-      if (result === null) {
-        return { unsupported: "unsupported nullish operand" };
-      }
-      if ("unsupported" in result) {
+      const result = buildIR(sub, checker, strategy, paramNames, supply);
+      if (isBuildUnsupported(result)) {
         return { unsupported: result.unsupported };
       }
-      return result;
+      return ir1FromL2(result);
     };
     const recognized = recognizeNullishForm(expr, checker, nullishTranslate);
     if (recognized !== null) {

--- a/tools/ts2pant/src/ir-build.ts
+++ b/tools/ts2pant/src/ir-build.ts
@@ -40,6 +40,10 @@ import {
   unwrapParens,
 } from "./ir1-build.js";
 import { lowerL1Expr } from "./ir1-lower.js";
+import {
+  type NullishTranslate,
+  recognizeNullishForm,
+} from "./nullish-recognizer.js";
 import { isStaticallyBoolTyped } from "./purity.js";
 import {
   allocComprehensionBinder,
@@ -53,7 +57,14 @@ import {
   translateBodyExpr,
   type UniqueSupply,
 } from "./translate-body.js";
-import type { NumericStrategy } from "./translate-types.js";
+import {
+  cellRegisterMap,
+  isMapType,
+  isSetType,
+  lookupMapKV,
+  mapTsType,
+  type NumericStrategy,
+} from "./translate-types.js";
 
 interface PendingIRComprehension {
   binder: string;
@@ -734,6 +745,103 @@ function buildArrayReduce(
   return { expr: folded };
 }
 
+function buildCollectionMembershipCall(
+  expr: ts.CallExpression,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  paramNames: ReadonlyMap<string, string>,
+  supply: UniqueSupply,
+  l1Ctx: L1BuildContext,
+): IRExpr | { unsupported: string } | null {
+  if (
+    !ts.isPropertyAccessExpression(expr.expression) ||
+    expr.arguments.length !== 1
+  ) {
+    return null;
+  }
+
+  const methodName = expr.expression.name.text;
+  const tsReceiver = expr.expression.expression;
+  const receiverType = checker.getTypeAtLocation(tsReceiver);
+  const arg = buildIR(
+    expr.arguments[0]!,
+    checker,
+    strategy,
+    paramNames,
+    supply,
+  );
+  if (isBuildUnsupported(arg)) {
+    return arg;
+  }
+
+  if (methodName === "includes") {
+    if (!checker.isArrayType(receiverType)) {
+      return null;
+    }
+    const receiver = buildIR(tsReceiver, checker, strategy, paramNames, supply);
+    if (isBuildUnsupported(receiver)) {
+      return receiver;
+    }
+    return irBinop("in", arg, receiver);
+  }
+
+  if (methodName !== "has") {
+    return null;
+  }
+
+  if (isSetType(receiverType)) {
+    const receiver = buildIR(tsReceiver, checker, strategy, paramNames, supply);
+    if (isBuildUnsupported(receiver)) {
+      return receiver;
+    }
+    return irBinop("in", arg, receiver);
+  }
+
+  if (!isMapType(receiverType)) {
+    return null;
+  }
+
+  const normalizedReceiver = unwrapParens(tsReceiver) as ts.Expression;
+  if (ts.isPropertyAccessExpression(normalizedReceiver)) {
+    const member = buildL1MemberAccess(normalizedReceiver, l1Ctx, {
+      nativeReceiverLeaf: true,
+    });
+    if ("unsupported" in member) {
+      return member;
+    }
+    if (member.kind !== "member") {
+      return {
+        unsupported: "Map .has receiver did not resolve to canonical L1 Member",
+      };
+    }
+    return irAppName(`${member.name}-key`, [lowerL1Expr(member.receiver), arg]);
+  }
+
+  const typeArgs = checker.getTypeArguments(receiverType as ts.TypeReference);
+  if (typeArgs.length !== 2) {
+    return { unsupported: "Map with unexpected arity" };
+  }
+  const kType = mapTsType(typeArgs[0]!, checker, strategy, supply.synthCell);
+  const vType = mapTsType(typeArgs[1]!, checker, strategy, supply.synthCell);
+  let info = supply.synthCell
+    ? lookupMapKV(supply.synthCell.synth, kType, vType)
+    : undefined;
+  if (!info && supply.synthCell) {
+    cellRegisterMap(supply.synthCell, kType, vType);
+    info = lookupMapKV(supply.synthCell.synth, kType, vType);
+  }
+  if (!info) {
+    return {
+      unsupported: `Map<${kType}, ${vType}>: key or value type cannot be mangled into a synthesized domain name`,
+    };
+  }
+  const receiver = buildIR(tsReceiver, checker, strategy, paramNames, supply);
+  if (isBuildUnsupported(receiver)) {
+    return receiver;
+  }
+  return irAppName(info.names.keyPred, [receiver, arg]);
+}
+
 /**
  * Translate a TypeScript expression to IR.
  *
@@ -781,6 +889,20 @@ export function buildIR(
         return built;
       }
       return materializeBuildValue(built);
+    }
+  }
+
+  if (ts.isCallExpression(expr)) {
+    const membership = buildCollectionMembershipCall(
+      expr,
+      checker,
+      strategy,
+      paramNames,
+      supply,
+      l1Ctx,
+    );
+    if (membership !== null) {
+      return membership;
     }
   }
 
@@ -900,6 +1022,26 @@ export function buildIR(
       return member;
     }
     return lowerL1Expr(member);
+  }
+
+  if (ts.isBinaryExpression(expr)) {
+    const nullishTranslate: NullishTranslate = (sub) => {
+      const result = tryBuildL1PureSubExpression(sub, l1Ctx);
+      if (result === null) {
+        return { unsupported: "unsupported nullish operand" };
+      }
+      if ("unsupported" in result) {
+        return { unsupported: result.unsupported };
+      }
+      return result;
+    };
+    const recognized = recognizeNullishForm(expr, checker, nullishTranslate);
+    if (recognized !== null) {
+      if ("unsupported" in recognized) {
+        return { unsupported: recognized.unsupported };
+      }
+      return lowerL1Expr(recognized);
+    }
   }
 
   const nativeL1 = tryBuildL1PureSubExpression(expr, l1Ctx);

--- a/tools/ts2pant/src/ir-build.ts
+++ b/tools/ts2pant/src/ir-build.ts
@@ -763,22 +763,28 @@ function buildCollectionMembershipCall(
   }
 
   const methodName = expr.expression.name.text;
+  if (methodName !== "includes" && methodName !== "has") {
+    return null;
+  }
+
   const tsReceiver = expr.expression.expression;
   const receiverType = checker.getTypeAtLocation(tsReceiver);
-  const arg = buildIR(
-    expr.arguments[0]!,
-    checker,
-    strategy,
-    paramNames,
-    supply,
-  );
-  if (isBuildUnsupported(arg)) {
-    return arg;
-  }
+
+  // Probe-time `UniqueSupply` isolation: defer building `arg` and the
+  // receiver until the receiver shape commits this probe to a known
+  // membership lowering. Returning `null` from a non-matching probe
+  // must not advance `supply`, or deterministic-name allocation drifts
+  // for downstream callers.
+  const buildArg = (): IRExpr | { unsupported: string } =>
+    buildIR(expr.arguments[0]!, checker, strategy, paramNames, supply);
 
   if (methodName === "includes") {
     if (!checker.isArrayType(receiverType)) {
       return null;
+    }
+    const arg = buildArg();
+    if (isBuildUnsupported(arg)) {
+      return arg;
     }
     const receiver = buildIR(tsReceiver, checker, strategy, paramNames, supply);
     if (isBuildUnsupported(receiver)) {
@@ -787,11 +793,11 @@ function buildCollectionMembershipCall(
     return irBinop("in", arg, receiver);
   }
 
-  if (methodName !== "has") {
-    return null;
-  }
-
   if (isSetType(receiverType)) {
+    const arg = buildArg();
+    if (isBuildUnsupported(arg)) {
+      return arg;
+    }
     const receiver = buildIR(tsReceiver, checker, strategy, paramNames, supply);
     if (isBuildUnsupported(receiver)) {
       return receiver;
@@ -811,6 +817,10 @@ function buildCollectionMembershipCall(
       (normalizedReceiver.flags & ts.NodeFlags.OptionalChain) === 0 &&
       elementAccessLiteralKey(normalizedReceiver) !== null);
   if (isMemberSurface) {
+    const arg = buildArg();
+    if (isBuildUnsupported(arg)) {
+      return arg;
+    }
     const member = buildL1MemberAccess(
       normalizedReceiver as
         | ts.PropertyAccessExpression
@@ -846,6 +856,10 @@ function buildCollectionMembershipCall(
     return {
       unsupported: `Map<${kType}, ${vType}>: key or value type cannot be mangled into a synthesized domain name`,
     };
+  }
+  const arg = buildArg();
+  if (isBuildUnsupported(arg)) {
+    return arg;
   }
   const receiver = buildIR(tsReceiver, checker, strategy, paramNames, supply);
   if (isBuildUnsupported(receiver)) {

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -68,17 +68,6 @@ import {
 } from "./translate-types.js";
 import type { PantDeclaration, PropResult } from "./types.js";
 
-/**
- * Read the `TS2PANT_USE_IR` env var safely from globalThis without
- * pulling in @types/node into the tsconfig. The flag routes the
- * pure-path return-expression translation through the IR pipeline
- * (Stage 1 — see CLAUDE.md §"Intermediate Representation").
- */
-function useIRPipeline(): boolean {
-  const g = globalThis as { process?: { env?: Record<string, string> } };
-  return g.process?.env?.["TS2PANT_USE_IR"] === "1";
-}
-
 // --- Const-binding inlining infrastructure (let-elimination) ---
 
 /**
@@ -1599,16 +1588,15 @@ function translatePureBody(
     ];
   }
 
-  // IR pipeline: when `TS2PANT_USE_IR=1` is set in the environment,
-  // route the return-expression translation through the IR (ir-build →
-  // ir-emit). See CLAUDE.md §"Intermediate Representation" for the
-  // migration roadmap.
+  // Pure expression terminals route through the IR unconditionally. The
+  // record, functor-lift, and L1 conditional cases above remain ordered
+  // ahead of this terminal expression path.
   let rhs: OpaqueExpr;
 
   // Layer 1 imperative-IR conditional pipeline (workstream M1).
   // Routes when the body has prelude arms (early-return if-conversion)
   // or a conditional terminal (if/switch/ternary/Bool-typed `&&`/`||`).
-  // Plain non-conditional returns fall through to the IR or legacy path.
+  // Plain non-conditional returns fall through to the pure IR path.
   const l1IsConditionalReturn =
     ts.isIfStatement(extracted.returnExpr) ||
     ts.isSwitchStatement(extracted.returnExpr) ||
@@ -1653,7 +1641,7 @@ function translatePureBody(
       bodyIR = irLet(tb.hygienicName, irWrap(tb.initExpr), bodyIR);
     }
     rhs = lowerExpr(bodyIR);
-  } else if (useIRPipeline() && ts.isExpression(extracted.returnExpr)) {
+  } else if (ts.isExpression(extracted.returnExpr)) {
     const ir = buildIR(
       extracted.returnExpr,
       checker,
@@ -1693,28 +1681,12 @@ function translatePureBody(
     }
     rhs = lowerExpr(bodyIR);
   } else {
-    const body = translateBodyExpr(
-      extracted.returnExpr,
-      checker,
-      strategy,
-      inlined.scopedParams,
-      undefined,
-      supply,
-    );
-
-    if (isBodyUnsupported(body)) {
-      return [{ kind: "unsupported", reason: body.unsupported }];
-    }
-
-    const terminal = bodyExpr(body);
-    const merged =
-      inlined.arms.length === 0
-        ? terminal
-        : ast.cond([
-            ...inlined.arms.map(([g, v]) => [g, v] as [OpaqueExpr, OpaqueExpr]),
-            [ast.litBool(true), terminal] as [OpaqueExpr, OpaqueExpr],
-          ]);
-    rhs = inlined.applyTo(merged);
+    return [
+      {
+        kind: "unsupported",
+        reason: `${functionName} — unsupported pure return terminal`,
+      },
+    ];
   }
 
   const argExprs = params.map((p) => ast.var(p.name));

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -127,7 +127,7 @@ exports[`expressions-calls.ts > freeCall 1`] = `
 `;
 
 exports[`expressions-calls.ts > methodCall 1`] = `
-"module MethodCall.\\n\\nmethod-call s: String => String.\\n\\n---\\n\\nmethod-call s = to-upper-case s.\\n"
+"module MethodCall.\\n\\nmethod-call s: String => String.\\n\\n---\\n\\nmethod-call s = (to-upper-case s).\\n"
 `;
 
 exports[`expressions-calls.ts > nestedCalls 1`] = `
@@ -135,7 +135,7 @@ exports[`expressions-calls.ts > nestedCalls 1`] = `
 `;
 
 exports[`expressions-calls.ts > spreadCall 1`] = `
-"module SpreadCall.\\n\\nspread-call args: [Int] => Int.\\n\\n---\\n\\n> UNSUPPORTED: max(...args).\\n"
+"module SpreadCall.\\n\\nspread-call args: [Int] => Int.\\n\\n---\\n\\n> UNSUPPORTED: call with spread arguments is unsupported.\\n"
 `;
 
 exports[`expressions-calls.ts > zeroArityCall 1`] = `
@@ -995,11 +995,11 @@ exports[`types-primitives.ts > isActive 1`] = `
 `;
 
 exports[`unsupported.ts > arrowWithLocals 1`] = `
-"module ArrowWithLocals.\\n\\nUser.\\nuser--name u: User => String.\\nuser--active u: User => Bool.\\nuser--score u: User => Int.\\narrow-with-locals users: [User] => [String].\\n\\n---\\n\\n> UNSUPPORTED: users.filter((u) => u.active).map((u) => { const s = u.score; return u.name; }).\\n"
+"module ArrowWithLocals.\\n\\nUser.\\nuser--name u: User => String.\\nuser--active u: User => Bool.\\nuser--score u: User => Int.\\narrow-with-locals users: [User] => [String].\\n\\n---\\n\\n> UNSUPPORTED: array callback block body must be a single return.\\n"
 `;
 
 exports[`unsupported.ts > destructuredParam 1`] = `
-"module DestructuredParam.\\n\\nUser.\\nuser--name u: User => String.\\nuser--active u: User => Bool.\\nuser--score u: User => Int.\\ndestructured-param users: [User] => [String].\\n\\n---\\n\\n> UNSUPPORTED: filter/map callback must have exactly one identifier parameter.\\n"
+"module DestructuredParam.\\n\\nUser.\\nuser--name u: User => String.\\nuser--active u: User => Bool.\\nuser--score u: User => Int.\\ndestructured-param users: [User] => [String].\\n\\n---\\n\\n> UNSUPPORTED: array callback parameters must be plain identifiers (no defaults/rest/optional).\\n"
 `;
 
 exports[`unsupported.ts > impureGuardAssign 1`] = `

--- a/tools/ts2pant/tests/ir-equivalence.test.mts
+++ b/tools/ts2pant/tests/ir-equivalence.test.mts
@@ -16,27 +16,16 @@ before(async () => {
 });
 
 /**
- * Per-stage IR equivalence gate.
+ * Always-on pure IR regression gate.
  *
- * Translates each anchor function with `TS2PANT_USE_IR=0` (legacy
- * pipeline) and `TS2PANT_USE_IR=1` (IR pipeline), then asserts the
- * emitted strings are identical. This is the smoke-test gate; the
- * fuller cutover gate runs `pant --ast` on both outputs and structurally
- * compares the resulting OCaml AST. Snapshot equality is brittle for
- * binder-allocation orderings; for now string equality suffices because
- * Stage 1's IRWrap fallback is a true no-op.
- *
- * As stages migrate recognizers from legacy to IR, this test set grows
- * to cover the migrated forms. By Stage 8 (pure-path cutover) it covers
- * the entire pure path.
+ * The legacy pure-expression fallback is gone, so these tests translate
+ * each migrated anchor once and assert the emitted Pant is supported and
+ * type-checkable where the shared known-bad list allows it.
  */
 
 const CONSTRUCTS_DIR = resolve(import.meta.dirname, "fixtures/constructs");
 
-/**
- * Anchor fixtures the IR pipeline should produce identical output for at
- * the current stage. The list grows monotonically as stages migrate.
- */
+/** Anchor fixtures covered by the always-on pure IR path. */
 const ANCHORS: Array<{ file: string; functions: string[] }> = [
   {
     file: "expressions-ir-anchor.ts",
@@ -88,10 +77,7 @@ const ANCHORS: Array<{ file: string; functions: string[] }> = [
     file: "expressions-while-mu-search.ts",
     functions: ["firstUnusedSuffix", "nextSlotPlusOne", "offsetUnusedSuffix"],
   },
-  // Stage 7: chain fusion (.filter/.map/.reduce). These work via the
-  // IRWrap fallback today (legacy materialization produces an
-  // OpaqueExpr `each(...)` that ir-build wraps); native IR construction
-  // in ir-build replaces the fallback in Stage 7 itself.
+  // Chain fusion (.filter/.map/.reduce) now builds native IR nodes.
   {
     file: "expressions-array.ts",
     functions: ["activeNames", "nameLengths", "highScores"],
@@ -110,53 +96,25 @@ const ANCHORS: Array<{ file: string; functions: string[] }> = [
   },
 ];
 
-async function emitWithFlag(
-  filePath: string,
-  funcName: string,
-  useIR: boolean,
-): Promise<string> {
-  // Mutate the env var, build, then restore — the underlying
-  // translateBody reads `process.env.TS2PANT_USE_IR` per-call.
-  const g = globalThis as { process?: { env?: Record<string, string> } };
-  const env = g.process?.env;
-  if (!env) {
-    throw new Error("ir-equivalence test requires Node process.env");
-  }
-  const prior = env["TS2PANT_USE_IR"];
-  env["TS2PANT_USE_IR"] = useIR ? "1" : "0";
-  try {
-    const sf = createSourceFile(filePath);
-    const doc = await buildDocumentFromSourceFile(sf, funcName);
-    return emitDocument(doc);
-  } finally {
-    if (prior === undefined) {
-      delete env["TS2PANT_USE_IR"];
-    } else {
-      env["TS2PANT_USE_IR"] = prior;
-    }
-  }
+async function emitAlwaysOn(filePath: string, funcName: string): Promise<string> {
+  const sf = createSourceFile(filePath);
+  const doc = await buildDocumentFromSourceFile(sf, funcName);
+  return emitDocument(doc);
 }
 
-describe("Stage 1 IR-equivalence: legacy and IR produce identical output", () => {
+describe("pure IR path: always-on regression coverage", () => {
   for (const { file, functions } of ANCHORS) {
     const filePath = resolve(CONSTRUCTS_DIR, file);
     for (const funcName of functions) {
       const knownBad = KNOWN_TYPECHECK_FAILURES.get(`${file} > ${funcName}`);
       it(`${file} > ${funcName}`, async () => {
-        const legacy = await emitWithFlag(filePath, funcName, false);
-        const ir = await emitWithFlag(filePath, funcName, true);
-        assert.equal(
-          ir,
-          legacy,
-          `IR pipeline output differs from legacy for ${funcName}`,
+        const output = await emitAlwaysOn(filePath, funcName);
+        assert.ok(
+          !containsUnsupportedLine(output),
+          `${funcName} should be supported by the always-on pure IR path`,
         );
-        // Both pipelines produced the same string — also assert it's valid
-        // Pant. Skip for fixtures shared with the constructs.test.mts
-        // known-bad list (same emit bugs surface in both suites). Also
-        // skip on a `> UNSUPPORTED:` line — see helpers.emitAndCheck and
-        // CLAUDE.md § "Test layout".
-        if (!knownBad && !containsUnsupportedLine(ir)) {
-          await assertWasmTypeChecks(ir);
+        if (!knownBad) {
+          await assertWasmTypeChecks(output);
         }
       });
     }
@@ -202,56 +160,26 @@ describe("M6 pure-path cutover stubs", () => {
   for (const { file, functions } of CUTOVER_CASES) {
     const filePath = resolve(CONSTRUCTS_DIR, file);
     for (const funcName of functions) {
-      // M6 Patch 3 unskips these after `translatePureBody` routes
-      // expression terminals through IR unconditionally and the
-      // `TS2PANT_USE_IR` migration flag is deleted.
-      it.skip(`${file} > ${funcName} emits the always-on IR snapshot`, async () => {
-        const prior = process.env.TS2PANT_USE_IR;
-        delete process.env.TS2PANT_USE_IR;
-        try {
-          const sf = createSourceFile(filePath);
-          const doc = await buildDocumentFromSourceFile(sf, funcName);
-          const output = emitDocument(doc);
-          assert.ok(
-            !containsUnsupportedLine(output),
-            `${funcName} should be supported by the native IR pure path`,
-          );
+      const knownBad = KNOWN_TYPECHECK_FAILURES.get(`${file} > ${funcName}`);
+      it(`${file} > ${funcName} emits through the always-on IR path`, async () => {
+        const output = await emitAlwaysOn(filePath, funcName);
+        assert.ok(
+          !containsUnsupportedLine(output),
+          `${funcName} should be supported by the native IR pure path`,
+        );
+        if (!knownBad) {
           await assertWasmTypeChecks(output);
-        } finally {
-          if (prior === undefined) {
-            delete process.env.TS2PANT_USE_IR;
-          } else {
-            process.env.TS2PANT_USE_IR = prior;
-          }
         }
       });
     }
   }
 
-  // M6 Patch 3 unskips this as the direct flag-deletion tripwire: the
-  // environment setting must no longer affect pure return translation.
-  it.skip("translatePureBody uses pure IR path without TS2PANT_USE_IR", async () => {
-    const sourceFile = createSourceFile(
+  it("translatePureBody uses pure IR path without TS2PANT_USE_IR", async () => {
+    const output = await emitAlwaysOn(
       resolve(CONSTRUCTS_DIR, "expressions-arithmetic.ts"),
+      "netBalance",
     );
-    const prior = process.env.TS2PANT_USE_IR;
-    try {
-      delete process.env.TS2PANT_USE_IR;
-      const withoutFlag = emitDocument(
-        await buildDocumentFromSourceFile(sourceFile, "netBalance"),
-      );
-      process.env.TS2PANT_USE_IR = "1";
-      const withFlag = emitDocument(
-        await buildDocumentFromSourceFile(sourceFile, "netBalance"),
-      );
-      assert.equal(withoutFlag, withFlag);
-      await assertWasmTypeChecks(withoutFlag);
-    } finally {
-      if (prior === undefined) {
-        delete process.env.TS2PANT_USE_IR;
-      } else {
-        process.env.TS2PANT_USE_IR = prior;
-      }
-    }
+    assert.ok(!containsUnsupportedLine(output));
+    await assertWasmTypeChecks(output);
   });
 });

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -756,7 +756,7 @@ describe("translateCallExpr", () => {
     assert.equal(prop.kind, "equation");
     if (prop.kind === "equation") {
       const ast = getAst();
-      assert.equal(ast.strExpr(prop.rhs), "to-upper-case s");
+      assert.equal(ast.strExpr(prop.rhs), "(to-upper-case s)");
     }
   });
 


### PR DESCRIPTION
## Patch 3: Promote pure IR path to always-on

- Remove the `TS2PANT_USE_IR` read and the fallback branch that calls `translateBodyExpr` for plain pure returns.
- Preserve special-case order for record returns, functor-lift, and L1 conditional returns; only the terminal pure-expression branch changes to unconditional `buildIR`.
- Convert parity tests into regression tests that run once with no environment mutation.
- Run snapshots and review every diff. Diffs are acceptable only when they are caused by native IR construction preserving or improving existing semantics.

## Changes
- Remove the `TS2PANT_USE_IR` read and the fallback branch that calls `translateBodyExpr` for plain pure returns.
- Preserve special-case order for record returns, functor-lift, and L1 conditional returns; only the terminal pure-expression branch changes to unconditional `buildIR`.
- Convert parity tests into regression tests that run once with no environment mutation.
- Run snapshots and review every diff. Diffs are acceptable only when they are caused by native IR construction preserving or improving existing semantics.

## Files to Modify
- tools/ts2pant/src/translate-body.ts (modify): Delete `useIRPipeline()` and legacy pure-return fallback; call `buildIR` unconditionally for pure expression terminals.
- tools/ts2pant/tests/ir-equivalence.test.mts (modify): Remove environment-toggle tests and assert always-on path output directly.
- tools/ts2pant/tests/constructs.test.mts.snapshot (modify): Snapshot updates if native IR emits cleaner but semantically equivalent Pant.
- tools/ts2pant/tests/integration/e2e.test.mts.snapshot (modify): Integration snapshot updates from the always-on pure path, if any.

## Gameplan Specification

```
module TS2PANT_M6_LEGACY_CLEANUP.

PureReturn.
L1SubExpression.
IRNode.
DocumentedArchitecture.

expression-terminal? r: PureReturn => Bool.
uses-ir? r: PureReturn => Bool.
uses-env-flag? r: PureReturn => Bool.

supported-l1? e: L1SubExpression => Bool.
native-l1? e: L1SubExpression => Bool.
unsupported-l1? e: L1SubExpression => Bool.

escape-hatch? n: IRNode => Bool.
reachable? n: IRNode => Bool.
native-node? n: IRNode => Bool.

final? a: DocumentedArchitecture => Bool.
mentions-migration-flag? a: DocumentedArchitecture => Bool.
mentions-escape-hatch? a: DocumentedArchitecture => Bool.

---

all r: PureReturn | expression-terminal? r -> uses-ir? r.
all r: PureReturn | uses-ir? r -> ~uses-env-flag? r.

all e: L1SubExpression | supported-l1? e -> native-l1? e.
all e: L1SubExpression | ~supported-l1? e -> unsupported-l1? e.
all e: L1SubExpression | native-l1? e -> ~unsupported-l1? e.

all n: IRNode | escape-hatch? n -> ~reachable? n.
all n: IRNode | reachable? n -> native-node? n.

all a: DocumentedArchitecture | final? a -> ~mentions-migration-flag? a.
all a: DocumentedArchitecture | final? a -> ~mentions-escape-hatch? a.

```

## Patch Specification

```
module TS2PANT_M6_LEGACY_CLEANUP_PATCH_3.

PureReturn.
expression-terminal? r: PureReturn => Bool.
uses-ir? r: PureReturn => Bool.
uses-env-flag? r: PureReturn => Bool.

---

all r: PureReturn | expression-terminal? r -> uses-ir? r.
all r: PureReturn | uses-ir? r -> ~uses-env-flag? r.

```


## Implementation Notes

- The cutover is scoped to the terminal pure-body branch in `translatePureBody`; record returns, functor-lift, and L1 conditional handling still run first and keep their existing behavior.
- `buildIR` still contains an internal legacy-wrap fallback for IR subexpressions that have not been migrated to native nodes yet. That path is not the old pure-return fallback and is still needed for partially migrated constructs.
- The regression coverage intentionally asserts supported/type-checkable output from a single no-env translation pass instead of comparing two pipelines. Cases listed in `KNOWN_TYPECHECK_FAILURES` still skip the wasm type-check assertion but must not emit unsupported Pant.
- Historical docs still mention `TS2PANT_USE_IR`; this patch removes the runtime switch from the pure path, not the broader documentation cleanup covered by later/final M6 work.