### PR TITLE
[ts2pant-m6-legacy-cleanup] Patch 4: Remove remaining mutating-body from-l2 dependencies

### DIFF
--- a/tools/ts2pant/src/ir1-build-body.ts
+++ b/tools/ts2pant/src/ir1-build-body.ts
@@ -1023,7 +1023,10 @@ function buildL1EffectCall(
   // access (`m["set"](k, v)`) for the call's callee — they're equivalent
   // surface forms (M5 property-access equivalence class). Computed
   // element access (`m[expr]`) and other shapes still reject.
-  const callee = call.expression;
+  // `unwrapExpression` strips parens / `as` / `!` / `satisfies` from the
+  // callee so equivalent wrapped forms (`(m.set)(k, v)`,
+  // `(s["add"])(x)`) match the same gate.
+  const callee = unwrapExpression(call.expression);
   let receiverNode: ts.Expression;
   if (ts.isPropertyAccessExpression(callee)) {
     receiverNode = callee.expression;

--- a/tools/ts2pant/src/ir1-build-body.ts
+++ b/tools/ts2pant/src/ir1-build-body.ts
@@ -43,6 +43,7 @@ import {
 } from "./ir1.js";
 import {
   buildL1MemberAccess,
+  elementAccessLiteralKey,
   isCollectionMutationCall,
   isL1Unsupported,
   tryBuildL1Cardinality,
@@ -1018,10 +1019,26 @@ function buildL1EffectCall(
     return { unsupported: "branch call is not a recognized Map/Set effect" };
   }
   const effect = result.effect;
-  if (!ts.isPropertyAccessExpression(call.expression)) {
-    return { unsupported: "Map/Set effect receiver must be a property access" };
+  // Accept both dotted access (`m.set(k, v)`) and string-literal element
+  // access (`m["set"](k, v)`) for the call's callee — they're equivalent
+  // surface forms (M5 property-access equivalence class). Computed
+  // element access (`m[expr]`) and other shapes still reject.
+  const callee = call.expression;
+  let receiverNode: ts.Expression;
+  if (ts.isPropertyAccessExpression(callee)) {
+    receiverNode = callee.expression;
+  } else if (
+    ts.isElementAccessExpression(callee) &&
+    elementAccessLiteralKey(callee) !== null
+  ) {
+    receiverNode = callee.expression;
+  } else {
+    return {
+      unsupported:
+        "Map/Set effect callee must use dotted access or string-literal element access",
+    };
   }
-  const objExpr = buildL1SubExpr(call.expression.expression, ctx);
+  const objExpr = buildL1SubExpr(receiverNode, ctx);
   if (isUnsupported(objExpr)) {
     return objExpr;
   }

--- a/tools/ts2pant/src/ir1-build-body.ts
+++ b/tools/ts2pant/src/ir1-build-body.ts
@@ -704,23 +704,27 @@ function buildL1SubExpr(
     ts.isPropertyAccessExpression(stripped) ||
     ts.isElementAccessExpression(stripped)
   ) {
-    const card = tryBuildL1Cardinality(stripped, {
+    // `nativeReceiverLeaf: true` keeps the cardinality probe and
+    // Member build inside the "native L1 or explicit unsupported"
+    // boundary on the mutating-body path — without it the cardinality
+    // receiver would fall through to `translateBodyExpr` and re-wrap
+    // via `ir1FromL2`, defeating the M6 from-l2 elimination work.
+    // Member already gates non-pure receivers via its
+    // `ctx.state !== undefined` branch, but passing the option here
+    // keeps both probes consistent.
+    const l1Options = { nativeReceiverLeaf: true } as const;
+    const ctxOptions = {
       checker: ctx.checker,
       strategy: ctx.strategy,
       paramNames: ctx.paramNames,
       state: ctx.state,
       supply: ctx.supply,
-    });
+    };
+    const card = tryBuildL1Cardinality(stripped, ctxOptions, l1Options);
     if (card !== null) {
       return card;
     }
-    const memberR = buildL1MemberAccess(stripped, {
-      checker: ctx.checker,
-      strategy: ctx.strategy,
-      paramNames: ctx.paramNames,
-      state: ctx.state,
-      supply: ctx.supply,
-    });
+    const memberR = buildL1MemberAccess(stripped, ctxOptions, l1Options);
     if (!isL1Unsupported(memberR)) {
       return memberR;
     }

--- a/tools/ts2pant/src/ir1-build-body.ts
+++ b/tools/ts2pant/src/ir1-build-body.ts
@@ -43,6 +43,7 @@ import {
 } from "./ir1.js";
 import {
   buildL1MemberAccess,
+  isCollectionMutationCall,
   isL1Unsupported,
   tryBuildL1Cardinality,
   tryBuildL1PureSubExpression,
@@ -734,6 +735,18 @@ function buildL1SubExpr(
   });
   if (native !== null) {
     return native;
+  }
+  // Surface Map/Set point-mutation calls in value position with a
+  // specific reason. `tryBuildL1PureSubExpression` returns null for
+  // these (they are not pure), and the generic fallback below would
+  // hide which idiom is unsupported.
+  if (
+    ts.isCallExpression(stripped) &&
+    isCollectionMutationCall(stripped, ctx.checker)
+  ) {
+    return {
+      unsupported: "collection mutation outside statement position",
+    };
   }
   return {
     unsupported: `unsupported mutating-body sub-expression: ${stripped.getText()}`,

--- a/tools/ts2pant/src/ir1-build-body.ts
+++ b/tools/ts2pant/src/ir1-build-body.ts
@@ -26,7 +26,6 @@
 
 import ts from "typescript";
 import type { IRBinop } from "./ir.js";
-import { irWrap } from "./ir.js";
 import {
   type IR1Expr,
   type IR1FoldLeaf,
@@ -36,14 +35,18 @@ import {
   ir1Block,
   ir1CondStmt,
   ir1Foreach,
-  ir1FromL2,
   ir1MapDelete,
   ir1MapSet,
   ir1Member,
   ir1SetAddOrDelete,
   ir1SetClear,
 } from "./ir1.js";
-import { buildL1MemberAccess, isL1Unsupported } from "./ir1-build.js";
+import {
+  buildL1MemberAccess,
+  isL1Unsupported,
+  tryBuildL1Cardinality,
+  tryBuildL1PureSubExpression,
+} from "./ir1-build.js";
 import type { OpaqueExpr } from "./pant-ast.js";
 import {
   addWrittenKey,
@@ -54,7 +57,6 @@ import {
   expressionReferencesNames,
   freshHygienicBinder,
   getRootIdentifier,
-  isBodyEffect,
   isBodyUnsupported,
   isGuardStatement,
   putWrite,
@@ -207,20 +209,10 @@ export function buildL1ForOfMutation(
     return { unsupported: "for-of destructuring pattern is not supported" };
   }
   const iterName = decl.name.text;
-  const sourceR = rejectEffect(
-    translateBodyExpr(
-      stmt.expression,
-      ctx.checker,
-      ctx.strategy,
-      ctx.paramNames,
-      ctx.state,
-      ctx.supply,
-    ),
-  );
-  if (isBodyUnsupported(sourceR)) {
-    return { unsupported: sourceR.unsupported };
+  const source = buildL1SubExpr(stmt.expression, ctx);
+  if (isUnsupported(source)) {
+    return source;
   }
-  const source = ir1FromL2(irWrap(ctx.applyConst(bodyExpr(sourceR))));
   return finishForeach(iterName, source, stmt.statement, ctx);
 }
 
@@ -267,20 +259,10 @@ export function buildL1ForEachCall(
     };
   }
   const iterName = param.name.text;
-  const sourceR = rejectEffect(
-    translateBodyExpr(
-      call.expression.expression,
-      ctx.checker,
-      ctx.strategy,
-      ctx.paramNames,
-      ctx.state,
-      ctx.supply,
-    ),
-  );
-  if (isBodyUnsupported(sourceR)) {
-    return { unsupported: sourceR.unsupported };
+  const source = buildL1SubExpr(call.expression.expression, ctx);
+  if (isUnsupported(source)) {
+    return source;
   }
-  const source = ir1FromL2(irWrap(ctx.applyConst(bodyExpr(sourceR))));
   const bodyStmt = ts.isBlock(arg.body)
     ? arg.body
     : ts.factory.createBlock([ts.factory.createExpressionStatement(arg.body)]);
@@ -721,6 +703,16 @@ function buildL1SubExpr(
     ts.isPropertyAccessExpression(stripped) ||
     ts.isElementAccessExpression(stripped)
   ) {
+    const card = tryBuildL1Cardinality(stripped, {
+      checker: ctx.checker,
+      strategy: ctx.strategy,
+      paramNames: ctx.paramNames,
+      state: ctx.state,
+      supply: ctx.supply,
+    });
+    if (card !== null) {
+      return card;
+    }
     const memberR = buildL1MemberAccess(stripped, {
       checker: ctx.checker,
       strategy: ctx.strategy,
@@ -731,31 +723,21 @@ function buildL1SubExpr(
     if (!isL1Unsupported(memberR)) {
       return memberR;
     }
-    // Property-access form rejected (optional chain, ambiguous owner,
-    // or shape not yet routed through L1 Member). Fall through to the
-    // legacy from-l2 wrap so optional-chain functor-lift and other
-    // legacy-only paths still translate.
+    return memberR;
   }
-  // Legacy fallback receives the original `node` so any future
-  // wrapper-aware preprocessing inside `translateBodyExpr` would still
-  // apply. Today `translateBodyExpr` strips the same wrappers at its
-  // entry via `unwrapExpression`, so the result is identical to passing
-  // `stripped` — but isolating the strip to the Member fast-path keeps
-  // the standard build path on its standard input.
-  const r = rejectEffect(
-    translateBodyExpr(
-      node,
-      ctx.checker,
-      ctx.strategy,
-      ctx.paramNames,
-      ctx.state,
-      ctx.supply,
-    ),
-  );
-  if (isBodyUnsupported(r)) {
-    return { unsupported: r.unsupported };
+  const native = tryBuildL1PureSubExpression(stripped, {
+    checker: ctx.checker,
+    strategy: ctx.strategy,
+    paramNames: ctx.paramNames,
+    state: ctx.state,
+    supply: ctx.supply,
+  });
+  if (native !== null) {
+    return native;
   }
-  return ir1FromL2(irWrap(ctx.applyConst(bodyExpr(r))));
+  return {
+    unsupported: `unsupported mutating-body sub-expression: ${stripped.getText()}`,
+  };
 }
 
 /**
@@ -897,18 +879,10 @@ export function buildL1IfMutation(
   if (expressionHasSideEffects(stmt.expression, ctx.checker)) {
     return { unsupported: "impure if-condition in mutating body" };
   }
-  const gResult = translateBodyExpr(
-    stmt.expression,
-    ctx.checker,
-    ctx.strategy,
-    ctx.paramNames,
-    ctx.state,
-    ctx.supply,
-  );
-  if (isBodyUnsupported(gResult)) {
-    return { unsupported: gResult.unsupported };
+  const guard = buildL1SubExpr(stmt.expression, ctx);
+  if (isUnsupported(guard)) {
+    return guard;
   }
-  const guard: IR1Expr = ir1FromL2(irWrap(ctx.applyConst(bodyExpr(gResult))));
 
   const thenBody = buildL1MutationBody(stmt.thenStatement, ctx);
   if (isUnsupported(thenBody)) {
@@ -1023,29 +997,51 @@ function buildL1EffectCall(
   if (isBodyUnsupported(result)) {
     return { unsupported: result.unsupported };
   }
-  if (!isBodyEffect(result)) {
+  if (!("effect" in result)) {
     return { unsupported: "branch call is not a recognized Map/Set effect" };
   }
   const effect = result.effect;
+  if (!ts.isPropertyAccessExpression(call.expression)) {
+    return { unsupported: "Map/Set effect receiver must be a property access" };
+  }
+  const objExpr = buildL1SubExpr(call.expression.expression, ctx);
+  if (isUnsupported(objExpr)) {
+    return objExpr;
+  }
+  const effectObjExpr = objExpr.kind === "member" ? objExpr.receiver : objExpr;
   if (effect.op === "set" || (effect.op === "delete" && "keyExpr" in effect)) {
     // Map mutation
     const m = effect as Extract<typeof effect, { op: "set" | "delete" }> & {
       keyExpr: OpaqueExpr;
     };
-    const objExpr = ir1FromL2(irWrap(ctx.applyConst(m.objExpr)));
-    const keyExpr = ir1FromL2(irWrap(ctx.applyConst(m.keyExpr)));
+    const keyArg = call.arguments[0];
+    if (keyArg === undefined) {
+      return { unsupported: "Map mutation is missing a key argument" };
+    }
+    const keyExpr = buildL1SubExpr(keyArg, ctx);
+    if (isUnsupported(keyExpr)) {
+      return keyExpr;
+    }
     if (m.op === "set") {
       // Upstream MapMutation still types valueExpr as nullable; for op
       // "set" it's invariably non-null (translateCallExpr guarantees it),
       // so assert here at the boundary into the discriminated IR1 form.
+      const valueArg = call.arguments[1];
+      if (valueArg === undefined) {
+        return { unsupported: "Map.set mutation is missing a value argument" };
+      }
+      const valueExpr = buildL1SubExpr(valueArg, ctx);
+      if (isUnsupported(valueExpr)) {
+        return valueExpr;
+      }
       return ir1MapSet(
         m.ruleName,
         m.keyPredName,
         m.ownerType,
         m.keyType,
-        objExpr,
+        effectObjExpr,
         keyExpr,
-        ir1FromL2(irWrap(ctx.applyConst(m.valueExpr!))),
+        valueExpr,
       );
     }
     return ir1MapDelete(
@@ -1053,7 +1049,7 @@ function buildL1EffectCall(
       m.keyPredName,
       m.ownerType,
       m.keyType,
-      objExpr,
+      effectObjExpr,
       keyExpr,
     );
   }
@@ -1062,9 +1058,18 @@ function buildL1EffectCall(
     typeof effect,
     { op: "add" | "delete" | "clear" }
   > & { elemExpr: OpaqueExpr | null };
-  const objExpr = ir1FromL2(irWrap(ctx.applyConst(s.objExpr)));
   if (s.op === "clear") {
-    return ir1SetClear(s.ruleName, s.ownerType, s.elemType, objExpr);
+    return ir1SetClear(s.ruleName, s.ownerType, s.elemType, effectObjExpr);
+  }
+  const elemArg = call.arguments[0];
+  if (elemArg === undefined) {
+    return {
+      unsupported: `Set.${s.op} mutation is missing an element argument`,
+    };
+  }
+  const elemExpr = buildL1SubExpr(elemArg, ctx);
+  if (isUnsupported(elemExpr)) {
+    return elemExpr;
   }
   // add / delete — elemExpr is non-null per translateCallExpr.
   return ir1SetAddOrDelete(
@@ -1072,8 +1077,8 @@ function buildL1EffectCall(
     s.ruleName,
     s.ownerType,
     s.elemType,
-    objExpr,
-    ir1FromL2(irWrap(ctx.applyConst(s.elemExpr!))),
+    effectObjExpr,
+    elemExpr,
   );
 }
 
@@ -1159,23 +1164,9 @@ export function buildL1AssignStmt(
     compoundOp !== undefined
       ? ts.factory.createBinaryExpression(expr.left, compoundOp, expr.right)
       : expr.right;
-  // `rejectEffect` turns a Map/Set mutation result into `unsupported`
-  // — without this, a value-position `m.set(k, v)` (or `s.add(x)`)
-  // would slip past `isBodyUnsupported` and `bodyExpr` would throw
-  // when called on the `{ effect }` shape downstream.
-  const valR = rejectEffect(
-    translateBodyExpr(
-      rhsNode,
-      ctx.checker,
-      ctx.strategy,
-      ctx.paramNames,
-      ctx.state,
-      ctx.supply,
-    ),
-  );
-  if (isBodyUnsupported(valR)) {
-    return { unsupported: valR.unsupported };
+  const val = buildL1SubExpr(rhsNode, ctx);
+  if (isUnsupported(val)) {
+    return val;
   }
-  const val = ir1FromL2(irWrap(ctx.applyConst(bodyExpr(valR))));
   return ir1Assign(ir1Member(obj, prop), val);
 }

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -418,9 +418,9 @@ export function tryBuildL1PureSubExpression(
     ) {
       return null;
     }
-    if (ts.isPropertyAccessExpression(expr.expression)) {
-      const methodName = expr.expression.name.text;
-      const receiverNode = expr.expression.expression;
+    if (member !== null) {
+      const methodName = member.methodName;
+      const receiverNode = member.receiver;
       const receiverType = ctx.checker.getTypeAtLocation(receiverNode);
       if (
         ((methodName === "set" || methodName === "delete") &&

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -87,6 +87,7 @@ import {
   cellRegisterName,
   isMapType,
   isSetType,
+  isUnsupportedUnknown,
   lookupMapKV,
   mapTsType,
   type NumericStrategy,
@@ -510,6 +511,17 @@ export function tryBuildL1PureSubExpression(
           ctx.strategy,
           ctx.supply.synthCell,
         );
+        // mapTsType returns the unsupported-unknown sentinel for
+        // unresolvable TS types (e.g., raw `unknown`). Bail before
+        // lookupMapKV / cellRegisterMap so we don't synthesize a domain
+        // built on the sentinel — translate-types.ts already guards this
+        // path elsewhere.
+        if (isUnsupportedUnknown(kType) || isUnsupportedUnknown(vType)) {
+          return {
+            unsupported:
+              "Map key or value type is unsupported in native call lowering",
+          };
+        }
         let info = ctx.supply.synthCell
           ? lookupMapKV(ctx.supply.synthCell.synth, kType, vType)
           : undefined;

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -224,6 +224,39 @@ function isKnownEffectfulNativeCall(
   );
 }
 
+/**
+ * True when `expr` is a Map/Set point-mutation call (.set/.delete on
+ * Map; .add/.delete/.clear on Set). Used by mutating-body sub-expression
+ * builders to surface a specific "collection mutation outside statement
+ * position" reason instead of the generic mutating-body fallback when a
+ * mutation call is observed in value position (e.g., `a.q = a.p.set(k, v)`).
+ */
+export function isCollectionMutationCall(
+  expr: ts.CallExpression,
+  checker: ts.TypeChecker,
+): boolean {
+  const member = callMemberName(expr.expression);
+  if (member === null) {
+    return false;
+  }
+  const receiverType = checker.getTypeAtLocation(member.receiver);
+  if (
+    (member.methodName === "set" || member.methodName === "delete") &&
+    isMapType(receiverType)
+  ) {
+    return true;
+  }
+  if (
+    (member.methodName === "add" ||
+      member.methodName === "delete" ||
+      member.methodName === "clear") &&
+    isSetType(receiverType)
+  ) {
+    return true;
+  }
+  return false;
+}
+
 function isArrayOrTupleType(t: ts.Type, checker: ts.TypeChecker): boolean {
   return checker.isArrayType(t) || checker.isTupleType(t);
 }
@@ -422,18 +455,6 @@ export function tryBuildL1PureSubExpression(
       const methodName = member.methodName;
       const receiverNode = member.receiver;
       const receiverType = ctx.checker.getTypeAtLocation(receiverNode);
-      if (
-        ((methodName === "set" || methodName === "delete") &&
-          isMapType(receiverType)) ||
-        ((methodName === "add" ||
-          methodName === "delete" ||
-          methodName === "clear") &&
-          isSetType(receiverType))
-      ) {
-        return {
-          unsupported: "collection mutation outside statement position",
-        };
-      }
       if (
         (methodName === "includes" || methodName === "has") &&
         expr.arguments.length === 1

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -295,6 +295,32 @@ export function tryBuildL1PureSubExpression(
   ctx: L1BuildContext,
 ): L1BuildResult | null {
   expr = unwrapParens(expr) as ts.Expression;
+  // Handle `x!` explicitly before the transparent-strip recursion: under
+  // list-lift, a `!` on a nullable receiver lowers to singleton
+  // extraction `(x 1)`, mirroring `translateBodyExpr`'s NonNull branch.
+  // Stripping it via `unwrapTransparentExpression` would silently drop
+  // the singleton extraction and emit just `x`, which is the wrong Pant
+  // type ([T] vs T).
+  if (ts.isNonNullExpression(expr)) {
+    const innerExpr = expr.expression;
+    const inner = tryBuildL1PureSubExpression(innerExpr, ctx);
+    if (inner === null || isL1Unsupported(inner)) {
+      return inner;
+    }
+    const receiverTsType = getOperandDeclaredType(innerExpr, ctx.checker);
+    const innerUnwrapped = unwrapTransparentExpression(innerExpr);
+    const isMapGetCall =
+      ts.isCallExpression(innerUnwrapped) &&
+      ts.isPropertyAccessExpression(innerUnwrapped.expression) &&
+      innerUnwrapped.expression.name.text === "get" &&
+      isMapType(
+        ctx.checker.getTypeAtLocation(innerUnwrapped.expression.expression),
+      );
+    if (isNullableTsType(receiverTsType) && !isMapGetCall) {
+      return ir1App(inner, [ir1LitNat(1)]);
+    }
+    return inner;
+  }
   const transparent = unwrapTransparentExpression(expr);
   if (transparent !== expr && ts.isExpression(transparent)) {
     return tryBuildL1PureSubExpression(transparent, ctx);

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -275,6 +275,55 @@ function isArrayOrTupleUnionType(t: ts.Type, checker: ts.TypeChecker): boolean {
   );
 }
 
+/**
+ * True when `t` is `Set<T>` / `ReadonlySet<T>` or a union of them.
+ * Mirrors `isArrayOrTupleUnionType`'s `every`-based shape so a mixed
+ * union (`Set<T> | string`) rejects rather than silently picking the
+ * Set side. `Set<T> | ReadonlySet<T>` is the canonical case the
+ * reviewer flagged: both constituents are operationally one Set
+ * shape, so collapsing them is sound.
+ */
+function isSetUnionType(t: ts.Type): boolean {
+  if (isSetType(t)) {
+    return true;
+  }
+  return t.isUnion() && t.types.every((member) => isSetType(member));
+}
+
+/**
+ * True when `t` is `Map<K, V>` / `ReadonlyMap<K, V>` or a union of
+ * them. Same shape contract as `isSetUnionType` — mixed unions reject.
+ */
+function isMapUnionType(t: ts.Type): boolean {
+  if (isMapType(t)) {
+    return true;
+  }
+  return t.isUnion() && t.types.every((member) => isMapType(member));
+}
+
+/**
+ * Return a representative Map constituent for `getTypeArguments`
+ * extraction. For a single Map type, returns it directly; for a union
+ * of Maps, returns the first constituent. Caller must guarantee
+ * `isMapUnionType(t)` is true. Returns `null` if `t` is neither.
+ *
+ * Picking the first Map constituent is sound for the canonical case
+ * (`Map<K, V> | ReadonlyMap<K, V>`): both constituents share the
+ * same K/V, so any representative gives the same result. Pathological
+ * unions with diverging K/V (`Map<string, int> | Map<number, string>`)
+ * are unreachable in practice — TS's `.get` signature contraction
+ * would already reject them at the call site.
+ */
+function findMapRepresentative(t: ts.Type): ts.Type | null {
+  if (isMapType(t)) {
+    return t;
+  }
+  if (t.isUnion() && t.types.every((member) => isMapType(member))) {
+    return t.types[0] ?? null;
+  }
+  return null;
+}
+
 function isArrayChainCall(
   expr: ts.CallExpression,
   checker: ts.TypeChecker,
@@ -492,15 +541,17 @@ export function tryBuildL1PureSubExpression(
         (methodName === "includes" || methodName === "has") &&
         expr.arguments.length === 1
       ) {
-        // Use `isArrayOrTupleUnionType` so tuple receivers and array
-        // unions (`string[] | number[]`) take the same `x in xs`
-        // lowering as plain arrays, matching `isArrayChainCall`'s
-        // coverage. `checker.isArrayType` alone would miss tuples
-        // even though TS supports `.includes` on them.
+        // Use `isArrayOrTupleUnionType` / `isSetUnionType` so tuple
+        // receivers and union receivers (`string[] | number[]`,
+        // `Set<T> | ReadonlySet<T>`) take the same `x in xs`
+        // lowering as plain arrays/sets, matching `isArrayChainCall`'s
+        // coverage. `checker.isArrayType` / `isSetType` alone would
+        // miss the union case and let it fall through to a generic
+        // member-call lowering, silently changing semantics.
         const isArray =
           methodName === "includes" &&
           isArrayOrTupleUnionType(receiverType, ctx.checker);
-        const isSet = methodName === "has" && isSetType(receiverType);
+        const isSet = methodName === "has" && isSetUnionType(receiverType);
         if (isArray || isSet) {
           const elem = tryBuildL1PureSubExpression(expr.arguments[0]!, ctx);
           if (elem === null || isL1Unsupported(elem)) {
@@ -516,7 +567,7 @@ export function tryBuildL1PureSubExpression(
       if (
         (methodName === "get" || methodName === "has") &&
         expr.arguments.length === 1 &&
-        isMapType(receiverType)
+        isMapUnionType(receiverType)
       ) {
         const key = tryBuildL1PureSubExpression(expr.arguments[0]!, ctx);
         if (key === null || isL1Unsupported(key)) {
@@ -531,8 +582,21 @@ export function tryBuildL1PureSubExpression(
           const callee = methodName === "has" ? `${ruleName}-key` : ruleName;
           return ir1App(ir1Var(callee), [receiver.receiver, key]);
         }
+        // For union receivers (`Map<K, V> | ReadonlyMap<K, V>`), pick
+        // a representative Map constituent for K/V extraction —
+        // `getTypeArguments` only operates on `TypeReference`, not on
+        // union types directly. `findMapRepresentative` enforces the
+        // every-constituent-is-Map-like uniformity, so the union
+        // collapses cleanly to a single (K, V).
+        const mapRep = findMapRepresentative(receiverType);
+        if (mapRep === null) {
+          return {
+            unsupported:
+              "Map .get/.has receiver is not a uniform Map / ReadonlyMap shape",
+          };
+        }
         const typeArgs = ctx.checker.getTypeArguments(
-          receiverType as ts.TypeReference,
+          mapRep as ts.TypeReference,
         );
         if (typeArgs.length !== 2) {
           return { unsupported: "Map with unexpected arity" };

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -522,10 +522,13 @@ export function tryBuildL1PureSubExpression(
               "Map key or value type is unsupported in native call lowering",
           };
         }
-        let info = ctx.supply.synthCell
-          ? lookupMapKV(ctx.supply.synthCell.synth, kType, vType)
-          : undefined;
-        if (!info && ctx.supply.synthCell) {
+        // `cellRegisterMap` is idempotent (returns the cached entry on
+        // re-registration), so always-register-then-lookup is the
+        // simplest safe shape. `lookupMapKV` returns `undefined`
+        // (Map.get) rather than throwing, but the conditional-register
+        // form was conflating "missing" with "registration failure".
+        let info: ReturnType<typeof lookupMapKV>;
+        if (ctx.supply.synthCell) {
           cellRegisterMap(ctx.supply.synthCell, kType, vType);
           info = lookupMapKV(ctx.supply.synthCell.synth, kType, vType);
         }

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -226,11 +226,12 @@ function isKnownEffectfulNativeCall(
 }
 
 /**
- * True when `expr` is a Map/Set point-mutation call (.set/.delete on
+ * True when `expr` is a Map/Set mutation call (.set/.delete/.clear on
  * Map; .add/.delete/.clear on Set). Used by mutating-body sub-expression
  * builders to surface a specific "collection mutation outside statement
  * position" reason instead of the generic mutating-body fallback when a
  * mutation call is observed in value position (e.g., `a.q = a.p.set(k, v)`).
+ * Mirrors the Map/Set coverage in `isKnownEffectfulNativeCall`.
  */
 export function isCollectionMutationCall(
   expr: ts.CallExpression,
@@ -242,7 +243,9 @@ export function isCollectionMutationCall(
   }
   const receiverType = checker.getTypeAtLocation(member.receiver);
   if (
-    (member.methodName === "set" || member.methodName === "delete") &&
+    (member.methodName === "set" ||
+      member.methodName === "delete" ||
+      member.methodName === "clear") &&
     isMapType(receiverType)
   ) {
     return true;

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -1028,40 +1028,50 @@ export function buildL1MemberAccess(
         return nativeReceiver;
       }
       receiverL1 = nativeReceiver;
-    } else if (options.nativeReceiverLeaf === true || ctx.state !== undefined) {
+    } else if (ctx.state !== undefined) {
+      // Mutating-body path never falls back to the from-l2 escape
+      // hatch — non-pure receivers reject explicitly.
       return {
         unsupported: `unsupported property-access receiver: ${(receiverNode as ts.Expression).getText()}`,
       };
-    } else {
+    } else if (options.nativeReceiverLeaf === true) {
+      // Pure-path with the native-leaf flag: try the IR-returning
+      // leaf translator (covers array-chain receivers via
+      // `ir-build`'s `buildNativeReceiverLeafIR`). If it doesn't
+      // apply, refuse rather than fall back to `translateBodyExpr` —
+      // the flag's contract is "native L1 or explicit unsupported".
       const nativeReceiverIR = tryBuildNativeReceiverLeafIR(
         receiverNode as ts.Expression,
         ctx,
         options,
       );
-      if (nativeReceiverIR !== null) {
-        if (isL1Unsupported(nativeReceiverIR)) {
-          return nativeReceiverIR;
-        }
-        receiverL1 = nativeReceiverIR;
-      } else {
-        const r = translateBodyExpr(
-          receiverNode as ts.Expression,
-          ctx.checker,
-          ctx.strategy,
-          ctx.paramNames,
-          ctx.state,
-          ctx.supply,
-        );
-        if (isBodyUnsupported(r)) {
-          return { unsupported: r.unsupported };
-        }
-        if ("effect" in r) {
-          return {
-            unsupported: "collection mutation as property-access receiver",
-          };
-        }
-        receiverL1 = ir1FromL2(irWrap(bodyExpr(r)));
+      if (nativeReceiverIR === null) {
+        return {
+          unsupported: `unsupported property-access receiver: ${(receiverNode as ts.Expression).getText()}`,
+        };
       }
+      if (isL1Unsupported(nativeReceiverIR)) {
+        return nativeReceiverIR;
+      }
+      receiverL1 = nativeReceiverIR;
+    } else {
+      const r = translateBodyExpr(
+        receiverNode as ts.Expression,
+        ctx.checker,
+        ctx.strategy,
+        ctx.paramNames,
+        ctx.state,
+        ctx.supply,
+      );
+      if (isBodyUnsupported(r)) {
+        return { unsupported: r.unsupported };
+      }
+      if ("effect" in r) {
+        return {
+          unsupported: "collection mutation as property-access receiver",
+        };
+      }
+      receiverL1 = ir1FromL2(irWrap(bodyExpr(r)));
     }
   }
 

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -242,11 +242,17 @@ export function isCollectionMutationCall(
     return false;
   }
   const receiverType = checker.getTypeAtLocation(member.receiver);
+  // Use the union-aware predicates so receivers like
+  // `Map<K, V> | ReadonlyMap<K, V>` and `Set<T> | ReadonlySet<T>`
+  // surface the targeted "collection mutation outside statement
+  // position" diagnostic instead of falling through to the generic
+  // mutating-body fallback. Mirrors the union-aware checks the
+  // native call branches use.
   if (
     (member.methodName === "set" ||
       member.methodName === "delete" ||
       member.methodName === "clear") &&
-    isMapType(receiverType)
+    isMapUnionType(receiverType)
   ) {
     return true;
   }
@@ -254,7 +260,7 @@ export function isCollectionMutationCall(
     (member.methodName === "add" ||
       member.methodName === "delete" ||
       member.methodName === "clear") &&
-    isSetType(receiverType)
+    isSetUnionType(receiverType)
   ) {
     return true;
   }
@@ -304,24 +310,46 @@ function isMapUnionType(t: ts.Type): boolean {
 /**
  * Return a representative Map constituent for `getTypeArguments`
  * extraction. For a single Map type, returns it directly; for a union
- * of Maps, returns the first constituent. Caller must guarantee
- * `isMapUnionType(t)` is true. Returns `null` if `t` is neither.
+ * of Maps, returns the first constituent — but only after verifying
+ * every constituent has identical (K, V) type arguments. Returns
+ * `null` if `t` is not a Map (or a uniform Map union), or if any
+ * union constituent has different K or V from the first.
  *
- * Picking the first Map constituent is sound for the canonical case
- * (`Map<K, V> | ReadonlyMap<K, V>`): both constituents share the
- * same K/V, so any representative gives the same result. Pathological
- * unions with diverging K/V (`Map<string, int> | Map<number, string>`)
- * are unreachable in practice — TS's `.get` signature contraction
- * would already reject them at the call site.
+ * Validation guards against the pathological case
+ * `Map<string, int> | Map<number, string>` synthesizing a domain
+ * built only on the first constituent's K/V — using just one
+ * representative would produce incorrect Pantagruel for accesses
+ * that flow through the second branch. Caller treats `null` as the
+ * "non-uniform Map union" rejection.
  */
-function findMapRepresentative(t: ts.Type): ts.Type | null {
+function findMapRepresentative(
+  t: ts.Type,
+  checker: ts.TypeChecker,
+): ts.Type | null {
   if (isMapType(t)) {
     return t;
   }
-  if (t.isUnion() && t.types.every((member) => isMapType(member))) {
-    return t.types[0] ?? null;
+  if (!t.isUnion() || !t.types.every((member) => isMapType(member))) {
+    return null;
   }
-  return null;
+  const first = t.types[0];
+  if (first === undefined) {
+    return null;
+  }
+  const firstArgs = checker.getTypeArguments(first as ts.TypeReference);
+  if (firstArgs.length !== 2) {
+    return null;
+  }
+  for (let i = 1; i < t.types.length; i++) {
+    const args = checker.getTypeArguments(t.types[i]! as ts.TypeReference);
+    if (args.length !== 2) {
+      return null;
+    }
+    if (args[0] !== firstArgs[0] || args[1] !== firstArgs[1]) {
+      return null;
+    }
+  }
+  return first;
 }
 
 function isArrayChainCall(
@@ -368,9 +396,14 @@ export function tryBuildL1PureSubExpression(
     const innerMember = ts.isCallExpression(innerUnwrapped)
       ? callMemberName(innerUnwrapped.expression)
       : null;
+    // Use the union-aware `isMapUnionType` so receivers like
+    // `Map<K, V> | ReadonlyMap<K, V>` reach the same Map-get carve-out
+    // as a single Map. Without this, `m.get(k)!` for a union receiver
+    // would slip past and add a bogus singleton extraction around the
+    // already-unboxed Map lookup.
     const isMapGetCall =
       innerMember?.methodName === "get" &&
-      isMapType(ctx.checker.getTypeAtLocation(innerMember.receiver));
+      isMapUnionType(ctx.checker.getTypeAtLocation(innerMember.receiver));
     if (isNullableTsType(receiverTsType) && !isMapGetCall) {
       return ir1App(inner, [ir1LitNat(1)]);
     }
@@ -585,10 +618,12 @@ export function tryBuildL1PureSubExpression(
         // For union receivers (`Map<K, V> | ReadonlyMap<K, V>`), pick
         // a representative Map constituent for K/V extraction —
         // `getTypeArguments` only operates on `TypeReference`, not on
-        // union types directly. `findMapRepresentative` enforces the
-        // every-constituent-is-Map-like uniformity, so the union
-        // collapses cleanly to a single (K, V).
-        const mapRep = findMapRepresentative(receiverType);
+        // union types directly. `findMapRepresentative` enforces both
+        // every-constituent-is-Map-like AND identical (K, V) across
+        // constituents, so pathological unions like
+        // `Map<string, int> | Map<number, string>` reject instead of
+        // synthesizing a domain on just the first branch's K/V.
+        const mapRep = findMapRepresentative(receiverType, ctx.checker);
         if (mapRep === null) {
           return {
             unsupported:

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -83,9 +83,12 @@ import {
   translateBodyExpr,
 } from "./translate-body.js";
 import {
+  cellRegisterMap,
   cellRegisterName,
   isMapType,
   isSetType,
+  lookupMapKV,
+  mapTsType,
   type NumericStrategy,
   toPantTermName,
 } from "./translate-types.js";
@@ -258,6 +261,10 @@ export function tryBuildL1PureSubExpression(
   ctx: L1BuildContext,
 ): L1BuildResult | null {
   expr = unwrapParens(expr) as ts.Expression;
+  const transparent = unwrapTransparentExpression(expr);
+  if (transparent !== expr && ts.isExpression(transparent)) {
+    return tryBuildL1PureSubExpression(transparent, ctx);
+  }
 
   if (expr.kind === ts.SyntaxKind.TrueKeyword) {
     return ir1LitBool(true);
@@ -280,6 +287,9 @@ export function tryBuildL1PureSubExpression(
   }
   if (expr.kind === ts.SyntaxKind.ThisKeyword) {
     return ir1Var(ctx.paramNames.get("this") ?? "this");
+  }
+  if (isL1ConditionalForm(expr, ctx.checker)) {
+    return buildL1Conditional(expr, ctx);
   }
 
   if (
@@ -320,11 +330,18 @@ export function tryBuildL1PureSubExpression(
   }
 
   if (ts.isBinaryExpression(expr)) {
-    const nullishProbe = recognizeNullishForm(expr, ctx.checker, () =>
-      ir1Var("__nullish_probe"),
-    );
-    if (nullishProbe !== null) {
-      return null;
+    const nullishTranslate: NullishTranslate = (sub) => {
+      const built = tryBuildL1PureSubExpression(sub, ctx);
+      if (built === null) {
+        return {
+          unsupported: `unsupported nullish operand: ${sub.getText()}`,
+        };
+      }
+      return built;
+    };
+    const nullish = recognizeNullishForm(expr, ctx.checker, nullishTranslate);
+    if (nullish !== null) {
+      return nullish;
     }
     if (
       expr.operatorToken.kind === ts.SyntaxKind.EqualsEqualsToken ||
@@ -400,6 +417,94 @@ export function tryBuildL1PureSubExpression(
         expressionHasSideEffects(member.receiver, ctx.checker))
     ) {
       return null;
+    }
+    if (ts.isPropertyAccessExpression(expr.expression)) {
+      const methodName = expr.expression.name.text;
+      const receiverNode = expr.expression.expression;
+      const receiverType = ctx.checker.getTypeAtLocation(receiverNode);
+      if (
+        ((methodName === "set" || methodName === "delete") &&
+          isMapType(receiverType)) ||
+        ((methodName === "add" ||
+          methodName === "delete" ||
+          methodName === "clear") &&
+          isSetType(receiverType))
+      ) {
+        return {
+          unsupported: "collection mutation outside statement position",
+        };
+      }
+      if (
+        (methodName === "includes" || methodName === "has") &&
+        expr.arguments.length === 1
+      ) {
+        const isArray =
+          methodName === "includes" && ctx.checker.isArrayType(receiverType);
+        const isSet = methodName === "has" && isSetType(receiverType);
+        if (isArray || isSet) {
+          const elem = tryBuildL1PureSubExpression(expr.arguments[0]!, ctx);
+          if (elem === null || isL1Unsupported(elem)) {
+            return elem;
+          }
+          const source = tryBuildL1PureSubExpression(receiverNode, ctx);
+          if (source === null || isL1Unsupported(source)) {
+            return source;
+          }
+          return ir1Binop("in", elem, source);
+        }
+      }
+      if (
+        (methodName === "get" || methodName === "has") &&
+        expr.arguments.length === 1 &&
+        isMapType(receiverType)
+      ) {
+        const key = tryBuildL1PureSubExpression(expr.arguments[0]!, ctx);
+        if (key === null || isL1Unsupported(key)) {
+          return key;
+        }
+        const receiver = tryBuildL1PureSubExpression(receiverNode, ctx);
+        if (receiver === null || isL1Unsupported(receiver)) {
+          return receiver;
+        }
+        if (receiver.kind === "member") {
+          const ruleName = receiver.name;
+          const callee = methodName === "has" ? `${ruleName}-key` : ruleName;
+          return ir1App(ir1Var(callee), [receiver.receiver, key]);
+        }
+        const typeArgs = ctx.checker.getTypeArguments(
+          receiverType as ts.TypeReference,
+        );
+        if (typeArgs.length !== 2) {
+          return { unsupported: "Map with unexpected arity" };
+        }
+        const kType = mapTsType(
+          typeArgs[0]!,
+          ctx.checker,
+          ctx.strategy,
+          ctx.supply.synthCell,
+        );
+        const vType = mapTsType(
+          typeArgs[1]!,
+          ctx.checker,
+          ctx.strategy,
+          ctx.supply.synthCell,
+        );
+        let info = ctx.supply.synthCell
+          ? lookupMapKV(ctx.supply.synthCell.synth, kType, vType)
+          : undefined;
+        if (!info && ctx.supply.synthCell) {
+          cellRegisterMap(ctx.supply.synthCell, kType, vType);
+          info = lookupMapKV(ctx.supply.synthCell.synth, kType, vType);
+        }
+        if (!info) {
+          return {
+            unsupported: `Map<${kType}, ${vType}>: key or value type cannot be mangled into a synthesized domain name`,
+          };
+        }
+        const callee =
+          methodName === "has" ? info.names.keyPred : info.names.rule;
+        return ir1App(ir1Var(callee), [receiver, key]);
+      }
     }
     let callee: IR1Expr | null;
     let args: IR1Expr[];
@@ -546,14 +651,14 @@ export function tryBuildL1Cardinality(
     }
     return ir1Unop("card", ir1FromL2(irWrap(r.expr)));
   }
-  if (ctx.state === undefined && options.nativeReceiverLeaf === true) {
-    const nativeReceiver = tryBuildL1PureSubExpression(
-      receiverNode as ts.Expression,
-      ctx,
-    );
-    if (nativeReceiver !== null && !isL1Unsupported(nativeReceiver)) {
-      return ir1Unop("card", nativeReceiver);
-    }
+  const nativeReceiver = tryBuildL1PureSubExpression(
+    receiverNode as ts.Expression,
+    ctx,
+  );
+  if (nativeReceiver !== null && !isL1Unsupported(nativeReceiver)) {
+    return ir1Unop("card", nativeReceiver);
+  }
+  if (options.nativeReceiverLeaf === true) {
     const nativeReceiverIR = tryBuildNativeReceiverLeafIR(
       receiverNode as ts.Expression,
       ctx,
@@ -562,6 +667,7 @@ export function tryBuildL1Cardinality(
     if (nativeReceiverIR !== null && !isL1Unsupported(nativeReceiverIR)) {
       return ir1Unop("card", nativeReceiverIR);
     }
+    return null;
   }
   const r = translateBodyExpr(
     receiverNode as ts.Expression,
@@ -847,7 +953,7 @@ export function buildL1MemberAccess(
       return { unsupported: r.reason };
     }
     receiverL1 = ir1FromL2(irWrap(r.expr));
-  } else if (ctx.state === undefined && options.nativeReceiverLeaf === true) {
+  } else {
     const nativeReceiver = tryBuildL1PureSubExpression(
       receiverNode as ts.Expression,
       ctx,
@@ -857,6 +963,10 @@ export function buildL1MemberAccess(
         return nativeReceiver;
       }
       receiverL1 = nativeReceiver;
+    } else if (options.nativeReceiverLeaf === true || ctx.state !== undefined) {
+      return {
+        unsupported: `unsupported property-access receiver: ${(receiverNode as ts.Expression).getText()}`,
+      };
     } else {
       const nativeReceiverIR = tryBuildNativeReceiverLeafIR(
         receiverNode as ts.Expression,
@@ -888,24 +998,6 @@ export function buildL1MemberAccess(
         receiverL1 = ir1FromL2(irWrap(bodyExpr(r)));
       }
     }
-  } else {
-    const r = translateBodyExpr(
-      receiverNode as ts.Expression,
-      ctx.checker,
-      ctx.strategy,
-      ctx.paramNames,
-      ctx.state,
-      ctx.supply,
-    );
-    if (isBodyUnsupported(r)) {
-      return { unsupported: r.unsupported };
-    }
-    if ("effect" in r) {
-      return {
-        unsupported: "collection mutation as property-access receiver",
-      };
-    }
-    receiverL1 = ir1FromL2(irWrap(bodyExpr(r)));
   }
 
   // Symbolic-state lookup at the outer level (mirrors
@@ -969,18 +1061,15 @@ export function isL1ConditionalForm(
 }
 
 // ---------------------------------------------------------------------------
-// Sub-expression delegation: translate via legacy, wrap into L1 via from-l2
+// Sub-expression delegation: native L1 or explicit unsupported
 // ---------------------------------------------------------------------------
 
 /**
- * Translate a non-conditional sub-expression via the legacy pipeline and
- * wrap as L1. Used for guards, values, and switch discriminants inside
- * an L1 conditional during M1 — those positions receive arbitrary TS
- * expressions whose normalization isn't M1's concern.
+ * Translate a non-conditional sub-expression as native L1. Used for
+ * guards, values, and switch discriminants inside L1 conditionals.
  *
- * Rejects collection-mutation sub-expressions (the legacy result type
- * `BodyResult` admits an "effect" variant that's only valid in
- * statement position; an L1 expression cannot host one).
+ * Rejects unsupported shapes with an explicit reason instead of routing
+ * through the legacy opaque expression fallback.
  */
 function buildSubExpr(expr: ts.Expression, ctx: L1BuildContext): L1BuildResult {
   expr = unwrapParens(expr) as ts.Expression;
@@ -991,26 +1080,14 @@ function buildSubExpr(expr: ts.Expression, ctx: L1BuildContext): L1BuildResult {
   if (ts.isObjectLiteralExpression(expr)) {
     return { unsupported: "object literal in conditional arm" };
   }
-  const result = translateBodyExpr(
-    expr,
-    ctx.checker,
-    ctx.strategy,
-    ctx.paramNames,
-    ctx.state,
-    ctx.supply,
-  );
-  if (isBodyUnsupported(result)) {
-    return { unsupported: result.unsupported };
+  if (isL1ConditionalForm(expr, ctx.checker)) {
+    return buildL1Conditional(expr, ctx);
   }
-  if ("effect" in result) {
-    return {
-      unsupported: "collection mutation cannot appear in a conditional arm",
-    };
+  const native = tryBuildL1PureSubExpression(expr, ctx);
+  if (native !== null) {
+    return native;
   }
-  // Materialize any deferred .filter()/.map() chain into a flat each(...)
-  // before wrapping — using result.expr directly would drop the traversal
-  // and lower the bare projection body instead.
-  return ir1FromL2(irWrap(bodyExpr(result)));
+  return { unsupported: `unsupported L1 sub-expression: ${expr.getText()}` };
 }
 
 // ---------------------------------------------------------------------------

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -312,13 +312,16 @@ export function tryBuildL1PureSubExpression(
     }
     const receiverTsType = getOperandDeclaredType(innerExpr, ctx.checker);
     const innerUnwrapped = unwrapTransparentExpression(innerExpr);
+    // Use `callMemberName` so string-literal element-access spellings
+    // (`m["get"](k)!`) follow the same Map-get carve-out as the dotted
+    // form (`m.get(k)!`) — both forms are operationally equivalent and
+    // should emit identical L1 (M5 property-access equivalence class).
+    const innerMember = ts.isCallExpression(innerUnwrapped)
+      ? callMemberName(innerUnwrapped.expression)
+      : null;
     const isMapGetCall =
-      ts.isCallExpression(innerUnwrapped) &&
-      ts.isPropertyAccessExpression(innerUnwrapped.expression) &&
-      innerUnwrapped.expression.name.text === "get" &&
-      isMapType(
-        ctx.checker.getTypeAtLocation(innerUnwrapped.expression.expression),
-      );
+      innerMember?.methodName === "get" &&
+      isMapType(ctx.checker.getTypeAtLocation(innerMember.receiver));
     if (isNullableTsType(receiverTsType) && !isMapGetCall) {
       return ir1App(inner, [ir1LitNat(1)]);
     }
@@ -489,8 +492,14 @@ export function tryBuildL1PureSubExpression(
         (methodName === "includes" || methodName === "has") &&
         expr.arguments.length === 1
       ) {
+        // Use `isArrayOrTupleUnionType` so tuple receivers and array
+        // unions (`string[] | number[]`) take the same `x in xs`
+        // lowering as plain arrays, matching `isArrayChainCall`'s
+        // coverage. `checker.isArrayType` alone would miss tuples
+        // even though TS supports `.includes` on them.
         const isArray =
-          methodName === "includes" && ctx.checker.isArrayType(receiverType);
+          methodName === "includes" &&
+          isArrayOrTupleUnionType(receiverType, ctx.checker);
         const isSet = methodName === "has" && isSetType(receiverType);
         if (isArray || isSet) {
           const elem = tryBuildL1PureSubExpression(expr.arguments[0]!, ctx);

--- a/tools/ts2pant/src/ir1-lower.ts
+++ b/tools/ts2pant/src/ir1-lower.ts
@@ -213,14 +213,6 @@ export interface MuSearchLowerCtx {
 }
 
 /**
- * Extract the L2 IRExpr from an L1 `from-l2` wrap, or return null if
- * the L1 expression is not a `from-l2`.
- */
-function extractFromL2(e: IR1Expr): IRExpr | null {
-  return e.kind === "from-l2" ? e.expr : null;
-}
-
-/**
  * Lower an L1 μ-search-shaped form to an L2 `comb-typed`. Validates
  * canonical shape, predicate-references-counter, and strategy.
  *
@@ -263,22 +255,8 @@ export function lowerL1MuSearch(
   if (letStmt.kind !== "let" || whileStmt.kind !== "while") {
     return { unsupported: "μ-search prelude shape changed unexpectedly" };
   }
-  // The init and predicate are wrapped in `from-l2` by
-  // `buildL1LetWhile` because their internal structure is not L1's
-  // concern (M1 / M2 architectural commitment). Unwrap them here.
-  const initL2 = extractFromL2(letStmt.value);
-  if (initL2 === null) {
-    return {
-      unsupported: "μ-search init is not a from-l2 wrap (build pipeline error)",
-    };
-  }
-  const predicateL2 = extractFromL2(whileStmt.cond);
-  if (predicateL2 === null) {
-    return {
-      unsupported:
-        "μ-search predicate is not a from-l2 wrap (build pipeline error)",
-    };
-  }
+  const initL2 = lowerL1Expr(letStmt.value);
+  const predicateL2 = lowerL1Expr(whileStmt.cond);
   // Predicate-references-counter is a precondition checked at L1
   // build time (see `buildL1LetWhile` in `ir1-build.ts`). Skipping
   // here — the lowering trusts that the L1 form represents a

--- a/tools/ts2pant/src/translate-signature.ts
+++ b/tools/ts2pant/src/translate-signature.ts
@@ -1018,13 +1018,37 @@ export function translateExpr(
     // resolved-`undefined` — verify the `undefined` identifier
     // resolves to the global symbol, not a shadowed local.
     const translate: NullishTranslate = (sub) => {
-      const subResult = tryBuildL1PureSubExpression(sub, {
+      const l1Ctx: L1BuildContext = {
         checker,
         strategy: _strategy,
         paramNames,
         state: undefined,
         supply: { n: 0, synthCell },
-      });
+      };
+      // Route property/element access operands through the same
+      // signature-side cardinality + Member dispatch that
+      // `translateExpr` uses for top-level accesses, so nullish
+      // operands like `account.owner === undefined` or
+      // `xs.length === 0` preserve signature semantics end-to-end
+      // (`ambiguousOwnerFallback: "bare-kebab"` for guard tolerance,
+      // `nativeReceiverLeaf: true` for the receiver leaf).
+      const strippedSub = unwrapParens(sub) as ts.Expression;
+      if (
+        (ts.isPropertyAccessExpression(strippedSub) ||
+          ts.isElementAccessExpression(strippedSub)) &&
+        (strippedSub.flags & ts.NodeFlags.OptionalChain) === 0
+      ) {
+        const sigOptions: BuildL1MemberAccessOptions = {
+          ambiguousOwnerFallback: "bare-kebab",
+          nativeReceiverLeaf: true,
+        };
+        const card = tryBuildL1Cardinality(strippedSub, l1Ctx, sigOptions);
+        if (card !== null) {
+          return card;
+        }
+        return buildL1MemberAccess(strippedSub, l1Ctx, sigOptions);
+      }
+      const subResult = tryBuildL1PureSubExpression(sub, l1Ctx);
       if (subResult === null) {
         return {
           unsupported: `unsupported signature nullish operand: ${sub.getText()}`,

--- a/tools/ts2pant/src/translate-signature.ts
+++ b/tools/ts2pant/src/translate-signature.ts
@@ -523,7 +523,8 @@ export function isPureExpression(expr: ts.Expression): boolean {
   if (
     ts.isParenthesizedExpression(expr) ||
     ts.isAsExpression(expr) ||
-    ts.isNonNullExpression(expr)
+    ts.isNonNullExpression(expr) ||
+    ts.isSatisfiesExpression(expr)
   ) {
     return isPureExpression(expr.expression);
   }

--- a/tools/ts2pant/src/translate-signature.ts
+++ b/tools/ts2pant/src/translate-signature.ts
@@ -14,6 +14,7 @@ import { lowerL1Expr } from "./ir1-lower.js";
 import {
   type NullishTranslate,
   recognizeNullishForm,
+  unwrapTransparentExpression,
 } from "./nullish-recognizer.js";
 import type { OpaqueBinop, OpaqueExpr } from "./pant-ast.js";
 import { getAst } from "./pant-wasm.js";
@@ -1038,12 +1039,18 @@ export function translateExpr(
       // equality (`==` / `!=`) is unsupported on the signature path
       // (`containsUnsupportedOperator` rejects it; CLAUDE.md § M4
       // documents the asymmetry against the body path). Walk up
-      // through parens / `typeof` to find the binary expression that
-      // claimed this operand and reject if loose.
+      // through transparent wrappers — parens, `as`, non-null `!`,
+      // `satisfies` — and `typeof` to find the binary expression
+      // that claimed this operand. Symmetric with `translateExpr`
+      // and `containsUnsupportedOperator` so wrapped operands like
+      // `(x as T) == null` route through the same rejection.
       let owner: ts.Node = sub;
       while (
         owner.parent &&
         (ts.isParenthesizedExpression(owner.parent) ||
+          ts.isAsExpression(owner.parent) ||
+          ts.isNonNullExpression(owner.parent) ||
+          ts.isSatisfiesExpression(owner.parent) ||
           ts.isTypeOfExpression(owner.parent))
       ) {
         owner = owner.parent;
@@ -1059,7 +1066,13 @@ export function translateExpr(
           unsupported: "loose equality (== / !=) is unsupported; use === / !==",
         };
       }
-      const strippedSub = unwrapParens(sub) as ts.Expression;
+      // Strip the same transparent wrappers (parens + `as` + `!` +
+      // `satisfies`) before classifying as Member surface. Without
+      // this, a wrapped property-access operand like
+      // `(account.owner as T) === null` would skip the signature-side
+      // bare-kebab fallback applied below and regress to a generic
+      // unsupported on ambiguous-owner shapes.
+      const strippedSub = unwrapTransparentExpression(sub);
       if (
         (ts.isPropertyAccessExpression(strippedSub) ||
           ts.isElementAccessExpression(strippedSub)) &&

--- a/tools/ts2pant/src/translate-signature.ts
+++ b/tools/ts2pant/src/translate-signature.ts
@@ -1,13 +1,13 @@
 import type { SourceFile } from "ts-morph";
 import ts from "typescript";
-import { irWrap } from "./ir.js";
 import { lowerExpr } from "./ir-emit.js";
-import { ir1FromL2 } from "./ir1.js";
 import {
   type BuildL1MemberAccessOptions,
   buildL1MemberAccess,
+  isL1Unsupported,
   type L1BuildContext,
   tryBuildL1Cardinality,
+  tryBuildL1PureSubExpression,
   unwrapParens,
 } from "./ir1-build.js";
 import { lowerL1Expr } from "./ir1-lower.js";
@@ -973,13 +973,7 @@ export function translateExpr(
     //   optional-chain functor lift) inappropriate inside guards.
     const sigOptions: BuildL1MemberAccessOptions = {
       ambiguousOwnerFallback: "bare-kebab",
-      translateReceiverLeaf: (e) => {
-        const r = translateExpr(e, checker, _strategy, paramNames, synthCell);
-        if (isTranslateExprUnsupported(r)) {
-          return { kind: "unsupported", reason: r.unsupported };
-        }
-        return { kind: "expr", expr: r };
-      },
+      nativeReceiverLeaf: true,
     };
     const card = tryBuildL1Cardinality(expr, l1Ctx, sigOptions);
     if (card !== null) {
@@ -1024,17 +1018,22 @@ export function translateExpr(
     // resolved-`undefined` — verify the `undefined` identifier
     // resolves to the global symbol, not a shadowed local.
     const translate: NullishTranslate = (sub) => {
-      const subResult = translateExpr(
-        sub,
+      const subResult = tryBuildL1PureSubExpression(sub, {
         checker,
-        _strategy,
+        strategy: _strategy,
         paramNames,
-        synthCell,
-      );
-      if (isTranslateExprUnsupported(subResult)) {
+        state: undefined,
+        supply: { n: 0, synthCell },
+      });
+      if (subResult === null) {
+        return {
+          unsupported: `unsupported signature nullish operand: ${sub.getText()}`,
+        };
+      }
+      if (isL1Unsupported(subResult)) {
         return subResult;
       }
-      return ir1FromL2(irWrap(subResult));
+      return subResult;
     };
     const recognized = recognizeNullishForm(expr, checker, translate);
     if (recognized !== null && !("unsupported" in recognized)) {

--- a/tools/ts2pant/src/translate-signature.ts
+++ b/tools/ts2pant/src/translate-signature.ts
@@ -471,7 +471,8 @@ export function containsUnsupportedOperator(expr: ts.Expression): boolean {
     ts.isParenthesizedExpression(expr) ||
     ts.isAsExpression(expr) ||
     ts.isNonNullExpression(expr) ||
-    ts.isSatisfiesExpression(expr)
+    ts.isSatisfiesExpression(expr) ||
+    ts.isTypeOfExpression(expr)
   ) {
     return containsUnsupportedOperator(expr.expression);
   }
@@ -524,7 +525,8 @@ export function isPureExpression(expr: ts.Expression): boolean {
     ts.isParenthesizedExpression(expr) ||
     ts.isAsExpression(expr) ||
     ts.isNonNullExpression(expr) ||
-    ts.isSatisfiesExpression(expr)
+    ts.isSatisfiesExpression(expr) ||
+    ts.isTypeOfExpression(expr)
   ) {
     return isPureExpression(expr.expression);
   }

--- a/tools/ts2pant/src/translate-signature.ts
+++ b/tools/ts2pant/src/translate-signature.ts
@@ -1100,7 +1100,15 @@ export function translateExpr(
       return subResult;
     };
     const recognized = recognizeNullishForm(expr, checker, translate);
-    if (recognized !== null && !("unsupported" in recognized)) {
+    if (recognized !== null) {
+      // Recognizer fired. Propagate either the lowered L1 expression
+      // or the operand's `{ unsupported }` rejection — falling through
+      // to the binary-fallback below would silently swallow a real
+      // rejection (e.g., the strict-only gate's loose-equality refusal
+      // emitted by the translate callback for wrapped operands).
+      if ("unsupported" in recognized) {
+        return recognized;
+      }
       return lowerExpr(lowerL1Expr(recognized));
     }
     // M4 P3: reject any surviving loose equality (== / !=). The

--- a/tools/ts2pant/src/translate-signature.ts
+++ b/tools/ts2pant/src/translate-signature.ts
@@ -1032,6 +1032,33 @@ export function translateExpr(
       // `xs.length === 0` preserve signature semantics end-to-end
       // (`ambiguousOwnerFallback: "bare-kebab"` for guard tolerance,
       // `nativeReceiverLeaf: true` for the receiver leaf).
+      //
+      // Strict-only gate: signature-side nullish operands must come
+      // from `===` / `!==` (or `typeof x === 'undefined'`). Loose
+      // equality (`==` / `!=`) is unsupported on the signature path
+      // (`containsUnsupportedOperator` rejects it; CLAUDE.md § M4
+      // documents the asymmetry against the body path). Walk up
+      // through parens / `typeof` to find the binary expression that
+      // claimed this operand and reject if loose.
+      let owner: ts.Node = sub;
+      while (
+        owner.parent &&
+        (ts.isParenthesizedExpression(owner.parent) ||
+          ts.isTypeOfExpression(owner.parent))
+      ) {
+        owner = owner.parent;
+      }
+      if (
+        owner.parent &&
+        ts.isBinaryExpression(owner.parent) &&
+        (owner.parent.operatorToken.kind === ts.SyntaxKind.EqualsEqualsToken ||
+          owner.parent.operatorToken.kind ===
+            ts.SyntaxKind.ExclamationEqualsToken)
+      ) {
+        return {
+          unsupported: "loose equality (== / !=) is unsupported; use === / !==",
+        };
+      }
       const strippedSub = unwrapParens(sub) as ts.Expression;
       if (
         (ts.isPropertyAccessExpression(strippedSub) ||

--- a/tools/ts2pant/tests/ir1-build-no-from-l2.test.mts
+++ b/tools/ts2pant/tests/ir1-build-no-from-l2.test.mts
@@ -167,7 +167,7 @@ function expectNoFromL2(stmt: IR1Stmt): void {
 describe("ir1-build-body M6 no-from-l2 stubs", () => {
   // M6 Patch 4 unskips this after mutating if guards use native L1
   // builders or return targeted unsupported results.
-  it.skip("builds if guards without from-l2", () => {
+  it("builds if guards without from-l2", () => {
     const { stmt, ctx } = firstStatement(
       `
       interface Account { balance: number; }
@@ -188,7 +188,7 @@ describe("ir1-build-body M6 no-from-l2 stubs", () => {
 
   // M6 Patch 4 unskips this after foreach sources build as native L1
   // expressions instead of `from-l2(ir-wrap(...))`.
-  it.skip("builds foreach sources without from-l2", () => {
+  it("builds foreach sources without from-l2", () => {
     const { stmt, ctx } = firstStatement(
       `
       interface Item { value: number; }
@@ -210,7 +210,7 @@ describe("ir1-build-body M6 no-from-l2 stubs", () => {
 
   // M6 Patch 4 unskips this after Shape B rhs/guard sub-expressions
   // build natively under the per-iteration L1 context.
-  it.skip("builds Shape B rhs and guard without from-l2", () => {
+  it("builds Shape B rhs and guard without from-l2", () => {
     const { stmt, ctx } = firstStatement(
       `
       interface Item { value: number; active: boolean; }
@@ -235,7 +235,7 @@ describe("ir1-build-body M6 no-from-l2 stubs", () => {
 
   // M6 Patch 4 unskips this after assignment RHS construction stops
   // delegating through `translateBodyExpr` for supported expressions.
-  it.skip("builds Shape A rhs without from-l2", () => {
+  it("builds Shape A rhs without from-l2", () => {
     const { stmt, ctx } = firstStatement(
       `
       interface Account { balance: number; }
@@ -254,7 +254,7 @@ describe("ir1-build-body M6 no-from-l2 stubs", () => {
 
   // M6 Patch 4 unskips this after Map mutation object/key/value
   // payloads build as native L1 forms or reject explicitly.
-  it.skip("builds map object/key/value payloads without from-l2", () => {
+  it("builds map object/key/value payloads without from-l2", () => {
     const { stmt, ctx } = firstStatement(
       `
       function f(m: Map<string, number>, suffix: string, value: number): void {
@@ -274,12 +274,13 @@ describe("ir1-build-body M6 no-from-l2 stubs", () => {
 
   // M6 Patch 4 unskips this after Set mutation object/element payloads
   // build as native L1 forms or reject explicitly.
-  it.skip("builds set object/element payloads without from-l2", () => {
+  it("builds set object/element payloads without from-l2", () => {
     const { stmt, ctx } = firstStatement(
       `
-      function f(s: Set<string>, suffix: string): void {
+      interface Bag { tags: Set<string>; }
+      function f(bag: Bag, suffix: string): void {
         if (suffix !== "") {
-          s.add("k" + suffix);
+          bag.tags.add("k" + suffix);
         }
       }
       `,

--- a/tools/ts2pant/tests/ir1-build-property.test.mts
+++ b/tools/ts2pant/tests/ir1-build-property.test.mts
@@ -131,9 +131,8 @@ describe("ir1-build-property", () => {
     const result = buildL1MemberAccess(node, ctx);
     const { receiver, name } = expectMember(result);
     assert.equal(name, "user--name");
-    // Receiver bottoms out at a non-property node, translated through
-    // legacy and wrapped via from-l2.
-    assert.equal(receiver.kind, "from-l2");
+    assert.equal(receiver.kind, "var");
+    assert.equal(receiver.name, "u");
   });
 
   it("nested PropertyAccess chain builds nested Member", () => {
@@ -151,7 +150,8 @@ describe("ir1-build-property", () => {
     // nested Member trees rather than a single flat from-l2 wrap.
     const inner = expectMember(outer.receiver);
     assert.equal(inner.name, "document--owner");
-    assert.equal(inner.receiver.kind, "from-l2");
+    assert.equal(inner.receiver.kind, "var");
+    assert.equal(inner.receiver.name, "d");
   });
 
   it("ambiguous receiver returns unsupported", () => {
@@ -299,8 +299,8 @@ describe("ir1-build-property", () => {
     assert.equal(calls, 1, "translateReceiverLeaf should fire exactly once");
     const { receiver, name } = expectMember(result);
     assert.equal(name, "account--balance");
-    // The receiver is the from-l2-wrapped opaque produced by the
-    // callback. Lower and check the marker name.
+    // The receiver is the callback-produced expression. Lower and
+    // check the marker name.
     const lowered = ast.strExpr(
       lowerExpr(lowerL1Expr(receiver as IR1Expr)),
     );
@@ -349,8 +349,8 @@ describe("ir1-build-property", () => {
     const { receiver, name } = expectMember(result);
     assert.equal(name, "user--name");
     // Mirrors the dotted-access bottom-out: receiver is a non-property
-    // node translated through legacy and wrapped via from-l2.
-    assert.equal(receiver.kind, "from-l2");
+    assert.equal(receiver.kind, "var");
+    assert.equal(receiver.name, "u");
   });
 
   it("nested string-literal ElementAccess composes", () => {
@@ -368,7 +368,8 @@ describe("ir1-build-property", () => {
     // string-literal recursion gate, not flattens to one from-l2 wrap.
     const inner = expectMember(outer.receiver);
     assert.equal(inner.name, "document--owner");
-    assert.equal(inner.receiver.kind, "from-l2");
+    assert.equal(inner.receiver.kind, "var");
+    assert.equal(inner.receiver.name, "d");
   });
 
   it("computed Identifier ElementAccess rejects with reason", () => {
@@ -450,7 +451,8 @@ describe("ir1-build-property", () => {
     const result = buildL1MemberAccess(node, ctx);
     const { receiver, name } = expectMember(result);
     assert.equal(name, "user--name");
-    assert.equal(receiver.kind, "from-l2");
+    assert.equal(receiver.kind, "var");
+    assert.equal(receiver.name, "u");
 
     const dotted = setupAccess(
       `interface User { readonly name: string; }


### PR DESCRIPTION
## Patch 4: Remove remaining mutating-body from-l2 dependencies

- Replace each `ir1FromL2(irWrap(...))` construction in `ir1-build-body.ts`, `ir1-build.ts`, and `translate-signature.ts` with native L1 expression construction or a specific unsupported reason.
- Update μ-search init/predicate handling so it consumes native L1 expressions and relies on lowering to produce the same `comb-typed` result.
- Reject expression shapes that still require opaque inspection with actionable messages rather than wrapping them.
- Unskip Patch 4 no-`from-l2` tests.

## Changes
- Replace each `ir1FromL2(irWrap(...))` construction in `ir1-build-body.ts`, `ir1-build.ts`, and `translate-signature.ts` with native L1 expression construction or a specific unsupported reason.
- Update μ-search init/predicate handling so it consumes native L1 expressions and relies on lowering to produce the same `comb-typed` result.
- Reject expression shapes that still require opaque inspection with actionable messages rather than wrapping them.
- Unskip Patch 4 no-`from-l2` tests.

## Files to Modify
- tools/ts2pant/src/ir1-build-body.ts (modify): Route guards, foreach sources, fold leaves, map/set payloads, and assignment values through native L1 expression builders.
- tools/ts2pant/src/ir1-build.ts (modify): Make the reusable sub-expression builder total over supported L1 expression classes and precise about unsupported classes.
- tools/ts2pant/src/translate-signature.ts (modify): Remove signature-position `from-l2` fallback and share native L1 sub-expression construction.
- tools/ts2pant/tests/ir1-build-no-from-l2.test.mts (modify): Unskip and implement Patch 4 no-`from-l2` tests.

## Gameplan Specification

```
module TS2PANT_M6_LEGACY_CLEANUP.

PureReturn.
L1SubExpression.
IRNode.
DocumentedArchitecture.

expression-terminal? r: PureReturn => Bool.
uses-ir? r: PureReturn => Bool.
uses-env-flag? r: PureReturn => Bool.

supported-l1? e: L1SubExpression => Bool.
native-l1? e: L1SubExpression => Bool.
unsupported-l1? e: L1SubExpression => Bool.

escape-hatch? n: IRNode => Bool.
reachable? n: IRNode => Bool.
native-node? n: IRNode => Bool.

final? a: DocumentedArchitecture => Bool.
mentions-migration-flag? a: DocumentedArchitecture => Bool.
mentions-escape-hatch? a: DocumentedArchitecture => Bool.

---

all r: PureReturn | expression-terminal? r -> uses-ir? r.
all r: PureReturn | uses-ir? r -> ~uses-env-flag? r.

all e: L1SubExpression | supported-l1? e -> native-l1? e.
all e: L1SubExpression | ~supported-l1? e -> unsupported-l1? e.
all e: L1SubExpression | native-l1? e -> ~unsupported-l1? e.

all n: IRNode | escape-hatch? n -> ~reachable? n.
all n: IRNode | reachable? n -> native-node? n.

all a: DocumentedArchitecture | final? a -> ~mentions-migration-flag? a.
all a: DocumentedArchitecture | final? a -> ~mentions-escape-hatch? a.

```

## Patch Specification

```
module TS2PANT_M6_LEGACY_CLEANUP_PATCH_4.

L1SubExpression.
supported? e: L1SubExpression => Bool.
native-l1? e: L1SubExpression => Bool.
unsupported? e: L1SubExpression => Bool.

---

all e: L1SubExpression | supported? e -> native-l1? e.
all e: L1SubExpression | ~supported? e -> unsupported? e.
all e: L1SubExpression | native-l1? e -> ~unsupported? e.

```


## Implementation Notes

- The new native sub-expression path is intentionally shared between body and signature translation. Signature translation still lowers the L1 expression immediately back to opaque Pant AST, but it no longer constructs signature-position `from-l2` wrappers.
- Unsupported expressions now fail at the L1 build boundary with the TS source text in the reason. This is deliberate: the mutating-body paths no longer try to preserve behavior for arbitrary calls, spreads, computed access, or unsupported literal shapes by hiding them behind opaque L2.
- Collection mutation effects still use `translateCallExpr` to classify Map/Set operations and recover synthesized rule/type metadata, then rebuild the receiver/key/value payloads from the original TS arguments as native L1. That keeps the existing Map/Set type machinery while removing the opaque payload fallback.
- Compound property assignments are desugared before native value building (`a.p += x` becomes `a.p = a.p + x`), so reviewers should expect added native `binop` structure rather than a dedicated compound-assignment node.