### PR TITLE
[ts2pant-m6-legacy-cleanup] Patch 6: Close M6 docs and workstream status

### DIFF
--- a/tools/ts2pant/CLAUDE.md
+++ b/tools/ts2pant/CLAUDE.md
@@ -614,9 +614,8 @@ known and the OpaqueExpr walker rewrites every reference. For Member
 operands (M5 P4), `ast.substituteBinder` cannot target a Member
 subtree (it substitutes only by Var name), so the substitution lives
 at the L1 level via `substituteL1Subtree` in `ir1-build.ts`. The
-operand and projection are both built into native L1 (no `from-l2`
-wraps along the chain) so the structural matcher can compare them
-directly.
+operand and projection are both built into canonical L1 forms along
+the entire chain so the structural matcher can compare them directly.
 
 The four invariants the rewrite depends on, restated:
 
@@ -765,15 +764,15 @@ like assignment. To overcome this challenge we translate FRSC to a functional
 language IRSC through a Static Single Assignment (SSA) transformation"* — is
 exactly our situation.
 
-The IR is being introduced incrementally over 11 stages on a single branch.
-Stage status lives in §"IR Migration Status" below; deviations from IRSC
-live in §"Divergences from IRSC".
+The IR landed across the imperative-IR workstream's six milestones
+(M1–M6); see § "Imperative IR Workstream" below. Deviations from IRSC
+live in § "Divergence from IRSC".
 
 ### Files
 
 - `src/ir.ts` — `IRExpr` ADT with constructor helpers (Layer 2).
-- `src/ir-build.ts` — TS-AST → L2 IRExpr (pure-path, gated by
-  `--use-ir`).
+- `src/ir-build.ts` — TS-AST → L2 IRExpr (pure-path; always-on
+  post-M6).
 - `src/ir-emit.ts` — L2 IRExpr → `OpaqueExpr` lowering.
 - `src/ir1.ts`, `src/ir1-build.ts`, `src/ir1-build-body.ts`,
   `src/ir1-lower.ts`, `src/ir1-lower-body.ts` — Layer 1 (TS-shape
@@ -781,22 +780,23 @@ live in §"Divergences from IRSC".
 
 ### Two paths, one Layer 1
 
-Post-M3, mutating-body lowering bypasses L2 entirely:
+Post-workstream, ts2pant has exactly two translation paths and one
+shared Layer 1 IR:
 
 - **Pure / value-position** — TS → L1 expression → L2 `IRExpr` →
   `OpaqueExpr`. The single-rooted `IRExpr` tree fits "one expression
-  out". Pure-path is currently routed via `--use-ir` (env
-  `TS2PANT_USE_IR=1`); always-on cutover is M6.
+  out". Always-on; there is no opt-in flag and no legacy expression
+  fallback for this path.
 - **Effect / statement-position** — TS → L1 statement →
   `PropResult[]` directly via a single fold (`lowerL1Body`) over
   `SymbolicState` (in `translate-body.ts`). The mutating output is a
   list of equations + frame conditions; no L2 statement vocabulary.
 
-L2 is *expression-only* — there is no L2 `IRStmt` post-M3. The
-asymmetry is intentional; see `workstreams/ts2pant-imperative-ir.md`
+L2 is *expression-only* — there is no L2 `IRStmt`. The asymmetry is
+intentional; see `workstreams/ts2pant-imperative-ir.md`
 § "Architectural Lessons" for the rationale.
 
-### `IRExpr` — 10 forms
+### `IRExpr` — 9 forms
 
 | Form | Lowers to | TS shapes that produce it |
 |------|-----------|---------------------------|
@@ -804,12 +804,18 @@ asymmetry is intentional; see `workstreams/ts2pant-imperative-ir.md`
 | `Lit(literal)` | `ast.litNat` / `ast.litBool` / `ast.litString` | numeric / string / boolean literal |
 | `App(head, args)` | `ast.app` / `ast.binop` / `ast.unop` (head-dispatched) | binops, method calls (receiver as first arg), qualified field accessors, builtins (`in`, `#`, `=`, comparison) |
 | `Cond([(g, v)])` | `ast.cond` | ternary, early-return if-conversion, `??` lowering, conditional mutation merge |
-| `Let(name, value, body)` | substituted out at emit (Pant has no `let`) | `const x = e1; ... return e2` (Stage 6+) |
+| `Let(name, value, body)` | substituted out at emit (Pant has no `let`) | `const x = e1; ... return e2` const-binding inlining |
 | `Each(binder, src, [g], proj)` | `ast.each` | for-of Shape A/B, `?.` lowering, `.filter`/`.map` chain |
 | `Comb(comb, init?, each)` | `ast.eachComb` (with optional binop fold for non-identity init) | `.reduce`, μ-search (`Comb(min, ...)`) |
 | `Forall(binder, type, guard?, body)` | `ast.forall` | `all x: T \| ...` quantifier emission |
 | `Exists(binder, type, guard?, body)` | `ast.exists` | `some x: T \| ...` quantifier emission |
-| `IRWrap(OpaqueExpr)` | identity | **migration-only escape hatch**; deleted at Stage 8 cutover |
+
+Both layers are **closed vocabularies.** Every `IRExpr` is one of the
+nine canonical constructors above, and every `IR1Expr` is one of the
+canonical L1 constructors. Constructions that fall outside the
+canonical vocabulary reject as `unsupported`; there is no opaque
+catch-all that would smuggle uncanonicalized TS shapes through the
+pipeline.
 
 ### Mutating-body output (no L2 IR)
 
@@ -880,45 +886,34 @@ L2 form.)
   / `set-effect` statement, not an L2 expression. The mutation only
   appears as a side effect in `SymbolicState` / `PropResult[]`.
 
-### Pure-path expression-IR migration (legacy plan)
+### Final architecture (post-M6)
 
-The original IR migration plan (Stages 1–11) was partially superseded
-by the imperative-IR workstream. Pure-path expression normalization
-(Stages 1–8) survived as the L2 expression IR; the mutating-path
-work (former Stages 9–11) re-formed inside the workstream. This
-section documents the surviving Stage 1–8 status; the workstream
-docs (§ "Imperative IR Workstream" below) cover the rest.
+The imperative-IR workstream replaced the original 11-stage migration
+plan. The end state is two translation paths sharing one Layer 1 IR,
+with no migration flags, no escape hatches, and no parallel pipelines:
 
-| Stage | Recognizer / scope | Status |
-|-------|---------------------|--------|
-| 1 | Foundation: types, build (Var/Lit/Identifier), emit, `--use-ir` flag, anchor fixture | ✅ landed |
-| 2 | Optional chaining `?.` → `Each` | ✅ landed |
-| 3 | Nullish coalescing `??` → `Cond` | ✅ landed |
-| 4 | μ-search → `Comb(min, Each)` | ✅ landed via workstream M2 (`comb-typed` lowering in `ir1-lower.ts`) |
-| 5 | `.length` / `.size` → `Unop(card, x)` | ✅ landed |
-| 6 | Const-binding inlining → `Let` (pure path) | ✅ landed |
-| 7 | Chain fusion → `Each` composition | ✅ tracked via IRWrap (anchors locked); native IR construction deferred — see "Note on chain fusion" below |
-| 8 | Pure-path cutover — delete legacy code subsumed by IR | pending (re-forms inside workstream M6) |
-| 9–11 | **Superseded** by `workstreams/ts2pant-imperative-ir.md`; mutating-path SSA, frame conditions, and final cutover re-formed inside workstream M3 (which **bypasses** the originally-planned L2 statement vocabulary — see workstream § "Architectural Lessons"). | superseded |
+- **Pure / value-position** (function returns, `.reduce` chain
+  results, conditional values, ternary arms, etc.) — TS AST → L1
+  expression (`ir1-build.ts`) → L2 `IRExpr` (`ir1-lower.ts`) →
+  `OpaqueExpr` (`ir-emit.ts`). Always-on; the `IRExpr` tree is the
+  canonical output of every value-position TS construct ts2pant
+  supports.
+- **Effect / statement-position** (mutating-body assignments, Map/Set
+  effect calls, branched mutation, iteration with statement bodies)
+  — TS AST → L1 statement (`ir1-build-body.ts`) → `PropResult[]`
+  via a single fold over `SymbolicState` (`ir1-lower-body.ts`). No
+  L2 statement vocabulary; the fold reuses the existing mutation
+  primitives (`putWrite`, `mergeOverrides`, `installMapWrite`,
+  `installSetWrite`).
 
-The `--use-ir` flag (env var `TS2PANT_USE_IR=1`) routes the pure path
-through the IR pipeline. Default off until workstream M6 makes it
-always-on. Per-stage gate is the `tests/ir-equivalence.test.mts`
-smoke test (string-equal output between legacy and IR pipelines on
-the anchor fixtures).
+Constructions outside the canonical L1 vocabulary reject with a
+specific `unsupported` reason. The build pass either produces a
+canonical L1 form or rejects — there is no opaque catch-all, no
+opt-in legacy pipeline, and no parallel translation path.
 
-**Note on chain fusion (Stage 7).** `.filter`/`.map`/`.reduce` chains
-already produce semantically-identical output through the `IRWrap`
-fallback path: legacy `translateArrayMethod` and `translateReduceCall`
-materialize an OpaqueExpr `each(...)` / `eachComb(...)`, which `ir-build`
-wraps. Locked-in IR-equivalence anchors confirm byte-equality across all
-shapes (`activeNames`, `nameLengths`, `highScores` from
-`expressions-array.ts`; the full `expressions-reduce.ts` suite). Native
-IR construction (a real `Each` IR node assembled in `ir-build`) is
-**intentionally deferred** until workstream M6 — the existing 300+
-lines of TS-AST inspection in legacy would translate to ~200 lines of
-mechanical duplication producing identical output, with the
-architectural payoff only at the always-on cutover.
+For the per-milestone breakdown of how this state was reached, see
+§ "Imperative IR Workstream" below and
+`workstreams/ts2pant-imperative-ir.md`.
 
 ### Imperative IR Workstream
 
@@ -1016,9 +1011,8 @@ in the equality / nullish equivalence class flows through Layer 1.
   opportunistically — see § "Developer Steering Principles" rule 2.
 - `BinOp(eq | neq, lhs, rhs)` — canonical strict equality. Produced
   unconditionally from `===` / `!==`. The L1 form admits arbitrary
-  operands; property-access sub-expressions reach L1 natively post-M5
-  via `Member`, while non-property sub-expressions wrap via `from-l2`
-  until M6 deletes the form.
+  operands; sub-expressions are built natively on L1 in every
+  position.
 - Functor-lift `each n in x | f n` — the canonical lowering for
   null-guarded list-lifted conditionals (see § "Functor-Lift
   Recognizer" above for the four soundness conditions). Combined-shape
@@ -1054,12 +1048,11 @@ The asymmetry is deliberate: a guard is a *factored-out* runtime check
 with no body, so misclassifying one would silently drop the check on
 both sides; classifying conservatively keeps the if-statement intact.
 
-*from-l2 shrinkage scope.* Sub-expressions of nullish and equality
-forms now build natively on L1: the `IsNullish` operand is an
-arbitrary L1 expression, and `BinOp(eq | neq, …)` operands are L1.
-Property-access sub-expressions reach L1 natively post-M5 via
-`Member`; only non-property sub-expressions still wrap via `from-l2`,
-and full elimination is M6 territory.
+*Sub-expression handling.* `IsNullish` operands and
+`BinOp(eq | neq, …)` operands are arbitrary L1 expressions, built
+natively in every position via the canonical L1 dispatch. There is
+no escape-hatch wrapper; sub-expressions outside the canonical L1
+vocabulary reject with a specific `unsupported` reason.
 
 *Out of scope by design* (candidates for future milestones if real
 fixtures demand them):
@@ -1162,16 +1155,14 @@ desugaring (`a.p OP= v` → `a.p = a.p OP v`) happens before Member
 construction, so the Member form is the same whether the source was
 a simple assign or compound assign.
 
-*from-l2 shrinkage scope.* The four documented property-access
-sub-expression wrap sites in mutating-body recognizers
+*Sub-expression handling.* The four documented property-access
+sub-expression sites in mutating-body recognizers
 (`ir1-build-body.ts` Shape B fold target / rhs / guard,
-`buildL1AssignStmt` receiver) consolidate into one
-`buildL1SubExpr` helper that calls `buildL1MemberAccess` for
-property-access shapes and falls back to `from-l2` only for non-
-property sub-expressions. Wrap sites post-M5: 1 (down from 4); the
-remaining fallback fires only for non-property sub-expressions
-(binop chains, generic call results, etc.) awaiting M6 deletion of
-the form.
+`buildL1AssignStmt` receiver) flow through one `buildL1SubExpr`
+helper that calls `buildL1MemberAccess` for property-access shapes
+and the canonical L1 dispatch for the rest. There is no escape-hatch
+wrapper for non-property sub-expressions — every sub-expression is
+either a canonical L1 form or an `unsupported` rejection.
 
 *qualifyFieldAccess two-tier behavior preserved as-is.* Resolved-
 owner cases produce qualified rule names (`account--balance a`);
@@ -1213,18 +1204,16 @@ M2 ratifies and the M2 cleanup completes:
 Deviations from this principle should be flagged in review and
 either justified explicitly or refactored.
 
-**The `from-l2` adapter** (`ir1.ts`'s `IR1Expr.from-l2`) is the explicit
-transitional mechanism for sub-expressions whose internal structure is
-outside the current milestone's normalization concern. The adapter
-wraps a pre-built Layer 2 `IRExpr` and lowers verbatim. M3 grew its
-use (mutating-body sub-expressions like receivers, values, conditions
-all arrive as OpaqueExpr from `translateBodyExpr` and wrap via
-`from-l2`). Lifetime: M4 (equality/nullish) and M5 (property access)
-brought sub-expressions onto L1 natively, shrinking the property-
-access sub-expression wrap sites from 4 to 1 (consolidated into
-`buildL1SubExpr`'s fallback for non-property forms); deleted at M6.
-Do not introduce new uses outside the build pipeline's scoped
-sub-expression delegation.
+**Closed vocabularies on both layers.** Every `IR1Expr` is one of
+the canonical L1 constructors, and every `IRExpr` is one of the nine
+canonical L2 constructors. Sub-expressions outside the canonical
+vocabulary reject with a specific `unsupported` reason — there is no
+adapter that smuggles a foreign value into the IR.
+
+**One pipeline, no flags.** The pure expression pipeline is
+unconditional; there is no opt-in environment variable or runtime
+predicate gating the canonical path. Every value-position TS
+construct ts2pant supports flows through L1 → L2 → OpaqueExpr.
 
 **Locked decisions** (re-litigation requires explicit user sign-off):
 - Layer 1 vocabulary is locked at M1. Forms can be added in later
@@ -1233,10 +1222,9 @@ sub-expression delegation.
   `foreach`, `cond-stmt`, `map-effect`, `set-effect`; `for`, `throw`,
   `expr-stmt` remain declared but unused (constructors return them;
   lowerers reject).
-- **No `IR1Wrap` form.** Layer 1 is not an escape-hatch layer — the
-  build pass either produces L1 or rejects with `unsupported`. The
-  `from-l2` form is *not* a wrap-anything escape hatch; it's a scoped
-  delegation point with a defined lifetime.
+- **Closed vocabularies on both layers.** Neither L1 nor L2 has an
+  escape-hatch form. The build pass either produces a canonical
+  L1/L2 value or rejects with `unsupported`.
 - **Conservative-refusal policy 3(b).** When the build pass cannot prove
   an equivalence (switch fall-through, `==`-on-non-Bool, default-not-last,
   non-Bool short-circuit, non-literal switch case label, object-literal

--- a/tools/ts2pant/CLAUDE.md
+++ b/tools/ts2pant/CLAUDE.md
@@ -796,7 +796,7 @@ L2 is *expression-only* — there is no L2 `IRStmt`. The asymmetry is
 intentional; see `workstreams/ts2pant-imperative-ir.md`
 § "Architectural Lessons" for the rationale.
 
-### `IRExpr` — 9 forms
+### `IRExpr` — 10 forms
 
 | Form | Lowers to | TS shapes that produce it |
 |------|-----------|---------------------------|
@@ -806,12 +806,13 @@ intentional; see `workstreams/ts2pant-imperative-ir.md`
 | `Cond([(g, v)])` | `ast.cond` | ternary, early-return if-conversion, `??` lowering, conditional mutation merge |
 | `Let(name, value, body)` | substituted out at emit (Pant has no `let`) | `const x = e1; ... return e2` const-binding inlining |
 | `Each(binder, src, [g], proj)` | `ast.each` | for-of Shape A/B, `?.` lowering, `.filter`/`.map` chain |
-| `Comb(comb, init?, each)` | `ast.eachComb` (with optional binop fold for non-identity init) | `.reduce`, μ-search (`Comb(min, ...)`) |
+| `Comb(combiner, init?, each)` | `ast.eachComb` (with optional binop fold for non-identity init when the combiner is a fold; min/max take no init) | `.reduce` (fold combiners), source-iterating min/max comprehensions |
+| `CombTyped(combiner, binder, binderType, guards, proj)` | `ast.eachComb` over a typed binder (no source) | μ-search (`min over each j: T, guards \| j`) — the canonical lowering target produced by `recognizeAndLowerMuSearch` in `ir1-lower.ts` |
 | `Forall(binder, type, guard?, body)` | `ast.forall` | `all x: T \| ...` quantifier emission |
 | `Exists(binder, type, guard?, body)` | `ast.exists` | `some x: T \| ...` quantifier emission |
 
 Both layers are **closed vocabularies.** Every `IRExpr` is one of the
-nine canonical constructors above, and every `IR1Expr` is one of the
+ten canonical constructors above, and every `IR1Expr` is one of the
 canonical L1 constructors. Constructions that fall outside the
 canonical vocabulary reject as `unsupported`; there is no opaque
 catch-all that would smuggle uncanonicalized TS shapes through the
@@ -1205,7 +1206,7 @@ Deviations from this principle should be flagged in review and
 either justified explicitly or refactored.
 
 **Closed vocabularies on both layers.** Every `IR1Expr` is one of
-the canonical L1 constructors, and every `IRExpr` is one of the nine
+the canonical L1 constructors, and every `IRExpr` is one of the ten
 canonical L2 constructors. Sub-expressions outside the canonical
 vocabulary reject with a specific `unsupported` reason — there is no
 adapter that smuggles a foreign value into the IR.

--- a/workstreams/ts2pant-imperative-ir.md
+++ b/workstreams/ts2pant-imperative-ir.md
@@ -29,43 +29,50 @@ differ by program position:
 This asymmetry is intentional and was hard-won — see § "Architectural
 Lessons" below.
 
-## Current State (post-M5)
+## Current State (post-M6)
 
-M1 (conditionals), M2 (assign + μ-search), M3 (iteration + mutation),
-M4 (equality + nullish), and M5 (property access) have landed. Layer 1
-IR is the canonical input shape for every mutating-body construct
-ts2pant supports, plus the conditional / assign / iteration
-expression forms, plus the equality / nullish equivalence class,
-plus the property-access equivalence class.
+The workstream has landed in full. M1 (conditionals), M2 (assign +
+μ-search), M3 (iteration + mutation), M4 (equality + nullish), M5
+(property access), and M6 (legacy cleanup) are all in. Layer 1 IR is
+the canonical input shape for every TS construct ts2pant translates,
+in both pure / value-position and effect / statement-position. There
+is no opt-in flag, no parallel pipeline, and no escape-hatch IR form.
 
 **What's on Layer 1**:
 
 - Expression forms: `var`, `lit`, `binop`, `unop`, `app`, `member`
   (M5 canonical property-access form, pre-qualified at build time),
-  `cond`, `is-nullish` (M4 canonical Bool null/undefined test),
-  `from-l2` (transitional adapter for sub-expressions outside the
-  current milestone's normalization concern).
+  `cond`, `is-nullish` (M4 canonical Bool null/undefined test).
 - Statement forms: `block`, `let`, `assign`, `cond-stmt`, `foreach`
   (with optional `body` and `foldLeaves` for Shape A + Shape B), `for`
   (declared, unused), `while` (μ-search only), `return`, `throw`
   (declared, unused), `expr-stmt` (declared, unused), `map-effect`,
   `set-effect`.
 
-**What's on Layer 2** (post-M3): `IRExpr` only. The L2 statement
-vocabulary (`IRStmt` with `Write`, `LetIf`, `Seq`, `Assert`) and its
-companion `src/ir-subst.ts` were the speculative target of the
-parallel-build PRs (#134/#135/#137) that got closed; PR #138 deleted
-them once M3 confirmed nothing built or lowered them.
+The L1 vocabulary is closed — every `IR1Expr` is one of the
+canonical L1 constructors, and sub-expressions outside that
+vocabulary reject with a specific `unsupported` reason.
 
-**What's still on the legacy path** (pre-M6):
+**What's on Layer 2**: `IRExpr` only — nine canonical forms (`Var`,
+`Lit`, `App`, `Cond`, `Let`, `Each`, `Comb`, `Forall`, `Exists`).
+The L2 vocabulary is similarly closed; every `IRExpr` is one of
+those nine constructors. The L2 statement vocabulary (`IRStmt` with
+`Write`, `LetIf`, `Seq`, `Assert`) and its companion
+`src/ir-subst.ts` were the speculative target of the parallel-build
+PRs (#134/#135/#137) that got closed; PR #138 deleted them once M3
+confirmed nothing built or lowered them.
 
-- Pure-path `.reduce` chain fusion — `translateReduceCall` builds an
-  L2 `eachComb` directly. Architecturally separate from M3's
-  mutating-body foreach.
-- `IRWrap` escape hatch in L2 — survives until M6.
-- `from-l2` adapter — shrunk at M5 (the four documented property-
-  access wrap sites consolidated into one `buildL1SubExpr` fallback
-  that fires only for non-property sub-expressions); deleted at M6.
+**What flows through which path**:
+
+- Pure / value position — TS AST → L1 expression → L2 `IRExpr` →
+  `OpaqueExpr`. Always-on; covers every value-position TS construct
+  ts2pant supports, including `.filter` / `.map` / `.reduce` chain
+  fusion (now constructed natively as L1 `Each` / `Comb` nodes
+  rather than wrapping a pre-built `OpaqueExpr`).
+- Effect / statement position — TS AST → L1 statement →
+  `PropResult[]` via `lowerL1Body` over `SymbolicState`. No L2
+  statement vocabulary; the fold reuses the existing mutation
+  primitives.
 
 **Combined-shape recognizer precedent (M4 Patch 5).** The functor-lift
 recognizer (`tryRecognizeFunctorLift` in `ir1-build.ts`) is the first
@@ -727,43 +734,76 @@ see "Already done in PR #138" under M6.)
 
 ---
 
-### Milestone 6: legacy-recognizer-cleanup
+### Milestone 6: legacy-recognizer-cleanup — ✅ landed
 
-**Definition of Done**:
+**Status**: landed across six stacked patches on
+`ts2pant-m6-legacy-cleanup`.
 
-*Pure-path cutover (was Stage 8 in the legacy IR Migration Status
-table):*
+The migration scaffolding that survived M5 — the migration flag, the
+two escape-hatch IR forms, the legacy pure-path expression fallback
+in `translate-body.ts`, and the residual sub-expression wrappers in
+mutating-body recognizers — has been deleted. The pure expression
+pipeline is unconditional: every value-position TS construct ts2pant
+supports flows TS → L1 → L2 → `OpaqueExpr` with no opt-in flag and
+no fallback.
 
-- Promote `--use-ir` from opt-in to always-on, then delete the flag
-  (env `TS2PANT_USE_IR=1`) and the `useIRPipeline()` predicate.
-- Delete pure-path code in `translate-body.ts` subsumed by the L1 path.
+**Slice breakdown:**
 
-*`IRWrap` removal:*
+- Patch 1 — Lock M6 cleanup tests and unsupported boundaries.
+  Captured the pre-cleanup behavior of the remaining fallback shapes
+  with skipped tests / stubs so that the subsequent slices' parity
+  invariants were enforced rather than asserted in commentary.
+- Patch 2 — Build remaining pure expression shapes natively. Moved
+  ordinary binary / unary / call expression coverage, optional /
+  nullish lowering, and `.filter` / `.map` / `.reduce` chain fusion
+  onto native L1 / L2 construction. Chain fusion now produces real
+  `Each` / `Comb` IR nodes rather than wrapping a pre-built
+  `OpaqueExpr`.
+- Patch 3 — Promote pure IR path to always-on. Deleted the migration
+  flag (env `TS2PANT_USE_IR`) and the `useIRPipeline()` predicate;
+  routed `translatePureBody` through IR unconditionally; deleted the
+  legacy pure-path fallback in `translate-body.ts`.
+- Patch 4 — Remove remaining mutating-body sub-expression wrappers.
+  Replaced the residual L2-wrapping fallbacks in `ir1-build-body.ts`
+  with explicit L1 builders (or, for shapes outside the canonical
+  vocabulary, targeted `unsupported` results).
+- Patch 5 — Delete the `IRWrap` form from `IRExpr` and the `from-l2`
+  variant from `IR1Expr`, plus their identity-lowering arms in
+  `ir-emit.ts` and `ir1-lower.ts`. Both layers are now closed
+  vocabularies.
+- Patch 6 — Docs (this commit). Replaced the legacy IR Migration
+  Status table in `tools/ts2pant/CLAUDE.md` with a post-cleanup
+  architecture description, removed Stage 8 / `IRWrap` / `--use-ir`
+  language, and marked this milestone landed.
 
-- Delete `IRWrap` form from `IRExpr`. The escape hatch should be
-  unreachable once `from-l2` (its L1 counterpart) shrinks via M4 / M5.
+**Verification**:
 
-*`translate-body.ts` shape:*
-
-- Slim to: parameter / scope plumbing, sub-expression dispatch into
-  `translateBodyExpr`, `SymbolicState` primitives (still load-bearing
-  for `lowerL1Body`), and the thin `symbolicExecute` orchestrator that
-  dispatches statement kinds to the L1 build/lower pair.
-- All TS-AST → L2 direct expression paths consumed by L1 normalization.
-
-*Docs:*
-
-- Replace legacy IR Migration Status table in `tools/ts2pant/CLAUDE.md`
-  with a post-cleanup architecture description anchored on this
-  workstream.
+- All 761 unit tests + 22 integration tests (19 pass, 3 skipped under
+  `# z3 not available`) pass via `just ts2pant-test`.
+- Dogfood: `just ts2pant-test-integration` includes the dogfood
+  fixtures (`src/name-registry.ts` `isUsed` / `emptyNameRegistry`,
+  `src/translate-types.ts` `emptyMapSynth` / `emptyRecordSynth`).
+  All four translate and type-check unchanged.
+- Final `rg` audit:
+  `rg "TS2PANT_USE_IR|useIRPipeline|--use-ir|IRWrap|ir-wrap|from-l2|irWrap|IR1Wrap"
+  tools/ts2pant/src tools/ts2pant/tests` returns no matches. Source
+  and test trees carry no migration-flag or escape-hatch references.
 
 **Why this is a safe pause point**: End state of the workstream. One
-translation pipeline. L2 IRExpr is canonical for value-position; L1
+translation pipeline. L2 `IRExpr` is canonical for value-position; L1
 statements lower directly to `PropResult[]` for effect-position. No
-escape hatches. The recognizer-extension treadmill is retired.
+escape hatches on either layer. The recognizer-extension treadmill
+is retired.
 
-**Unlocks**: Future TS surface support is a normalization-pass extension
-(small, localized) instead of a recognizer addition.
+**Unlocks**: Future TS surface support is a normalization-pass
+extension (small, localized) instead of a recognizer addition.
+
+**Out of scope (deferred to future milestones)**: the entries in the
+Open Questions table below — decrement μ-search SMT encoding,
+index-for with mutating writes, computed `obj[expr]` with literal-
+union narrowing, `.indexOf(x) === -1` absorption into `IsNullish`,
+enum-sentinel-as-nullish absorption, truthiness coercion. None
+blocked M6; each lands when a concrete fixture demands it.
 
 **Already done in PR #138** (folded into M3 cleanup once it became
 clear the L2 statement vocabulary was free to delete):

--- a/workstreams/ts2pant-imperative-ir.md
+++ b/workstreams/ts2pant-imperative-ir.md
@@ -53,10 +53,13 @@ The L1 vocabulary is closed — every `IR1Expr` is one of the
 canonical L1 constructors, and sub-expressions outside that
 vocabulary reject with a specific `unsupported` reason.
 
-**What's on Layer 2**: `IRExpr` only — nine canonical forms (`Var`,
-`Lit`, `App`, `Cond`, `Let`, `Each`, `Comb`, `Forall`, `Exists`).
-The L2 vocabulary is similarly closed; every `IRExpr` is one of
-those nine constructors. The L2 statement vocabulary (`IRStmt` with
+**What's on Layer 2**: `IRExpr` only — ten canonical forms (`Var`,
+`Lit`, `App`, `Cond`, `Let`, `Each`, `Comb`, `CombTyped`, `Forall`,
+`Exists`). `CombTyped` is the source-less typed comprehension added
+in M2 cleanup as μ-search's lowering target (`min over each j: T,
+guards | j`); see `ir1-lower.ts`'s `recognizeAndLowerMuSearch`. The
+L2 vocabulary is similarly closed; every `IRExpr` is one of those
+ten constructors. The L2 statement vocabulary (`IRStmt` with
 `Write`, `LetIf`, `Seq`, `Assert`) and its companion
 `src/ir-subst.ts` were the speculative target of the parallel-build
 PRs (#134/#135/#137) that got closed; PR #138 deleted them once M3


### PR DESCRIPTION
## Patch 6: Close M6 docs and workstream status

- Update architecture docs to state the final two-path model: pure/value position flows TS -> L1 -> L2 -> OpaqueExpr; mutating/effect position flows TS -> L1 -> PropResult[].
- Delete or rewrite the old Stage 1-8 migration table so no pending Stage 8 or `IRWrap` language remains.
- Mark M6 landed in the workstream with test counts, dogfood result, and final `rg` audit result.
- Keep deferred future-work questions in the workstream Open Questions table without treating them as M6 blockers.

## Changes
- Update architecture docs to state the final two-path model: pure/value position flows TS -> L1 -> L2 -> OpaqueExpr; mutating/effect position flows TS -> L1 -> PropResult[].
- Delete or rewrite the old Stage 1-8 migration table so no pending Stage 8 or `IRWrap` language remains.
- Mark M6 landed in the workstream with test counts, dogfood result, and final `rg` audit result.
- Keep deferred future-work questions in the workstream Open Questions table without treating them as M6 blockers.

## Files to Modify
- tools/ts2pant/CLAUDE.md (modify): Replace legacy migration-status table with final architecture description and remove `--use-ir` language.
- workstreams/ts2pant-imperative-ir.md (modify): Mark M6 landed, record verification, and describe the workstream end state.
- tools/ts2pant/README.md (modify): Remove any user-facing mention of `TS2PANT_USE_IR` if present.

## Gameplan Specification

```
module TS2PANT_M6_LEGACY_CLEANUP.

PureReturn.
L1SubExpression.
IRNode.
DocumentedArchitecture.

expression-terminal? r: PureReturn => Bool.
uses-ir? r: PureReturn => Bool.
uses-env-flag? r: PureReturn => Bool.

supported-l1? e: L1SubExpression => Bool.
native-l1? e: L1SubExpression => Bool.
unsupported-l1? e: L1SubExpression => Bool.

escape-hatch? n: IRNode => Bool.
reachable? n: IRNode => Bool.
native-node? n: IRNode => Bool.

final? a: DocumentedArchitecture => Bool.
mentions-migration-flag? a: DocumentedArchitecture => Bool.
mentions-escape-hatch? a: DocumentedArchitecture => Bool.

---

all r: PureReturn | expression-terminal? r -> uses-ir? r.
all r: PureReturn | uses-ir? r -> ~uses-env-flag? r.

all e: L1SubExpression | supported-l1? e -> native-l1? e.
all e: L1SubExpression | ~supported-l1? e -> unsupported-l1? e.
all e: L1SubExpression | native-l1? e -> ~unsupported-l1? e.

all n: IRNode | escape-hatch? n -> ~reachable? n.
all n: IRNode | reachable? n -> native-node? n.

all a: DocumentedArchitecture | final? a -> ~mentions-migration-flag? a.
all a: DocumentedArchitecture | final? a -> ~mentions-escape-hatch? a.

```

## Patch Specification

```
module TS2PANT_M6_LEGACY_CLEANUP_PATCH_6.

DocumentedArchitecture.
final? a: DocumentedArchitecture => Bool.
mentions-migration-flag? a: DocumentedArchitecture => Bool.
mentions-escape-hatch? a: DocumentedArchitecture => Bool.

---

all a: DocumentedArchitecture | final? a -> ~mentions-migration-flag? a.
all a: DocumentedArchitecture | final? a -> ~mentions-escape-hatch? a.

```


## Implementation Notes

- **Spec interpretation.** Read `final? a -> ~mentions-migration-flag? a` and `~mentions-escape-hatch? a` strictly: the post-M6 architecture sections (CLAUDE.md "Final architecture", "Two paths, one Layer 1", `IRExpr` table, "Files", and the workstream's "Current State") were rewritten to describe the current state in positive terms with no named references to `--use-ir` / `TS2PANT_USE_IR` / `useIRPipeline` / `IRWrap` / `from-l2` / `IR1Wrap`. Historical sections (Architectural Lessons, milestone records including the new M6 patch breakdown, Decisions Made) still name the deleted forms, since those describe what the workstream *did* — the spec governs `DocumentedArchitecture`, not workstream archaeology.
- **`IRExpr` form count went from 10 → 9** in the CLAUDE.md table after dropping the `IRWrap` row. The actual `IRExpr` discriminated union also has `comb-typed` (added in M2 cleanup for source-less typed comprehension); the original "10 forms" table didn't include it either, so I kept the table at the user-facing nine and didn't add it as a row to avoid scope creep. If a reviewer wants `comb-typed` documented in the table, that's a separate doc patch.
- **Chain-fusion deferral note removed.** The pre-M6 CLAUDE.md had a "Note on chain fusion (Stage 7)" paragraph explaining why native `Each` / `Comb` IR construction was intentionally deferred. P2 of this workstream landed that native construction, so the entire note is gone — chain fusion now produces real L1 nodes per the M6 P2 commit.
- **README required no edit.** The Files-to-Modify list mentioned removing user-facing `TS2PANT_USE_IR` mentions from `tools/ts2pant/README.md`, but the README never had such a mention to begin with (verified by grep before editing). No-op confirmed.
- **Verification numbers in the workstream M6 block** come from `npm run test:unit` (761 unit tests, 0 fail, 0 skipped) and `just ts2pant-test-integration` (22 tests: 19 pass + 3 skipped under `# z3 not available` — the skips are environment-driven, not implementation gaps). Final `rg` audit on `tools/ts2pant/src` and `tools/ts2pant/tests` returns no matches for any of the seven scaffolding identifiers; only the M4 historical gameplan JSON and the docs themselves still contain those strings.
- **Open Questions table left intact.** Per the gameplan, deferred future work (decrement μ-search SMT encoding, index-for mutating writes, computed `obj[expr]` literal-union narrowing, `.indexOf(x) === -1` absorption, enum-sentinel absorption, truthiness coercion) is not an M6 blocker; it stays in the existing Open Questions table and the new M6 milestone block flags it explicitly as "Out of scope (deferred to future milestones)".