### PR TITLE
ts2pant: thread state through L1 Map/Set reads in branched bodies

### DIFF
--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -50,7 +50,9 @@ import {
   ir1LitBool,
   ir1LitNat,
   ir1LitString,
+  ir1MapRead,
   ir1Member,
+  ir1SetRead,
   ir1Unop,
   ir1Var,
   ir1While,
@@ -363,6 +365,97 @@ export function isArrayChainCall(
 }
 
 /**
+ * Resolve the `(ownerType, elemType)` strings for a Stage A Set read
+ * (`c.tags.has(x)`) so the L1 build pass can emit `set-read` carrying
+ * the type info `readSetThroughWrites` needs at lower time. Mirrors
+ * the Stage A lookup in `translateCallExpr`'s Set-effect arm — the
+ * inner TS receiver becomes the owner; the Set's element type comes
+ * from `getTypeArguments(receiverType)`. Returns `null` if the
+ * receiver shape isn't a recognizable property/element-access (so the
+ * caller falls back to the bare `Binop(in, ...)` form, which is
+ * sound for non-Stage-A receivers — only Stage A Sets accumulate
+ * staged writes).
+ */
+function resolveStageASetReadType(
+  receiverNode: ts.Expression,
+  ctx: L1BuildContext,
+): { ownerType: string; elemType: string } | null {
+  const unwrapped = unwrapTransparentExpression(receiverNode);
+  if (
+    !ts.isPropertyAccessExpression(unwrapped) &&
+    !ts.isElementAccessExpression(unwrapped)
+  ) {
+    return null;
+  }
+  const innerObj = unwrapped.expression;
+  const ownerType = mapTsType(
+    ctx.checker.getTypeAtLocation(innerObj),
+    ctx.checker,
+    ctx.strategy,
+    ctx.supply.synthCell,
+  );
+  const setType = ctx.checker.getTypeAtLocation(unwrapped);
+  const setTypeArgs = ctx.checker.getTypeArguments(setType as ts.TypeReference);
+  if (setTypeArgs.length !== 1) {
+    return null;
+  }
+  const elemType = mapTsType(
+    setTypeArgs[0]!,
+    ctx.checker,
+    ctx.strategy,
+    ctx.supply.synthCell,
+  );
+  if (isUnsupportedUnknown(ownerType) || isUnsupportedUnknown(elemType)) {
+    return null;
+  }
+  return { ownerType, elemType };
+}
+
+/**
+ * Resolve the `(ownerType, keyType)` strings for a Stage A Map read.
+ * Stage A receivers are property accesses on a declared interface
+ * field; the inner TS receiver supplies the owner sort, and the
+ * Map's K type arg supplies the key sort. Stage B has its own
+ * synthesized owner/key resolution at the call site.
+ */
+function resolveStageAMapReadType(
+  receiverNode: ts.Expression,
+  receiverType: ts.Type,
+  ctx: L1BuildContext,
+): { ownerType: string; keyType: string } | null {
+  const unwrapped = unwrapTransparentExpression(receiverNode);
+  if (
+    !ts.isPropertyAccessExpression(unwrapped) &&
+    !ts.isElementAccessExpression(unwrapped)
+  ) {
+    return null;
+  }
+  const innerObj = unwrapped.expression;
+  const typeArgs = ctx.checker.getTypeArguments(
+    receiverType as ts.TypeReference,
+  );
+  if (typeArgs.length !== 2) {
+    return null;
+  }
+  const ownerType = mapTsType(
+    ctx.checker.getTypeAtLocation(innerObj),
+    ctx.checker,
+    ctx.strategy,
+    ctx.supply.synthCell,
+  );
+  const keyType = mapTsType(
+    typeArgs[0]!,
+    ctx.checker,
+    ctx.strategy,
+    ctx.supply.synthCell,
+  );
+  if (isUnsupportedUnknown(ownerType) || isUnsupportedUnknown(keyType)) {
+    return null;
+  }
+  return { ownerType, keyType };
+}
+
+/**
  * Native L1 construction for ordinary pure sub-expressions. Returns
  * `null` when the expression is outside this cleanup patch's native
  * coverage and should continue to the temporary legacy safety net.
@@ -592,6 +685,26 @@ export function tryBuildL1PureSubExpression(
           if (source === null || isL1Unsupported(source)) {
             return source;
           }
+          // State-aware Stage A: `c.tags.has(x)` inside a mutating body
+          // must observe prior `.add` / `.delete` / `.clear` writes
+          // staged on the same receiver (issue #168). Emit a
+          // `set-read` form so the body lower path dispatches to
+          // `readSetThroughWrites`. Pure-path callers keep the bare
+          // `Binop(in, elem, source)` shape — there is no state to
+          // thread, and `set-read` lowers byte-identically on the
+          // read-only path.
+          if (isSet && ctx.state !== undefined && source.kind === "member") {
+            const setStageInfo = resolveStageASetReadType(receiverNode, ctx);
+            if (setStageInfo !== null) {
+              return ir1SetRead(
+                source.name,
+                setStageInfo.ownerType,
+                setStageInfo.elemType,
+                source.receiver,
+                elem,
+              );
+            }
+          }
           return ir1Binop("in", elem, source);
         }
       }
@@ -610,7 +723,30 @@ export function tryBuildL1PureSubExpression(
         }
         if (receiver.kind === "member") {
           const ruleName = receiver.name;
-          const callee = methodName === "has" ? `${ruleName}-key` : ruleName;
+          const keyPredName = `${ruleName}-key`;
+          // State-aware Stage A Map read: emit `map-read` so the body
+          // lower path dispatches to `readMapThroughWrites` and observes
+          // prior staged `.set` / `.delete` (issue #168). Pure-path keeps
+          // the bare `App` form.
+          if (ctx.state !== undefined) {
+            const stageInfo = resolveStageAMapReadType(
+              receiverNode,
+              receiverType,
+              ctx,
+            );
+            if (stageInfo !== null) {
+              return ir1MapRead(
+                methodName as "get" | "has",
+                ruleName,
+                keyPredName,
+                stageInfo.ownerType,
+                stageInfo.keyType,
+                receiver.receiver,
+                key,
+              );
+            }
+          }
+          const callee = methodName === "has" ? keyPredName : ruleName;
           return ir1App(ir1Var(callee), [receiver.receiver, key]);
         }
         // For union receivers (`Map<K, V> | ReadonlyMap<K, V>`), pick
@@ -671,6 +807,21 @@ export function tryBuildL1PureSubExpression(
           return {
             unsupported: `Map<${kType}, ${vType}>: key or value type cannot be mangled into a synthesized domain name`,
           };
+        }
+        // State-aware Stage B Map read: emit `map-read` so the body
+        // lower path observes prior staged writes through the
+        // synthesized rule (issue #168). The bare `App` form is kept on
+        // the pure read-only path.
+        if (ctx.state !== undefined) {
+          return ir1MapRead(
+            methodName as "get" | "has",
+            info.names.rule,
+            info.names.keyPred,
+            info.names.domain,
+            kType,
+            receiver,
+            key,
+          );
         }
         const callee =
           methodName === "has" ? info.names.keyPred : info.names.rule;
@@ -1606,6 +1757,42 @@ function substituteL1Subtree(
         },
         changed: true,
       };
+    }
+    case "map-read": {
+      const recv = substituteL1Subtree(root.receiver, needle, replacement);
+      const key = substituteL1Subtree(root.key, needle, replacement);
+      const changed = recv.changed || key.changed;
+      return changed
+        ? {
+            result: ir1MapRead(
+              root.op,
+              root.ruleName,
+              root.keyPredName,
+              root.ownerType,
+              root.keyType,
+              recv.result,
+              key.result,
+            ),
+            changed: true,
+          }
+        : { result: root, changed: false };
+    }
+    case "set-read": {
+      const recv = substituteL1Subtree(root.receiver, needle, replacement);
+      const elem = substituteL1Subtree(root.elem, needle, replacement);
+      const changed = recv.changed || elem.changed;
+      return changed
+        ? {
+            result: ir1SetRead(
+              root.ruleName,
+              root.ownerType,
+              root.elemType,
+              recv.result,
+              elem.result,
+            ),
+            changed: true,
+          }
+        : { result: root, changed: false };
     }
     default: {
       const _exhaustive: never = root;

--- a/tools/ts2pant/src/ir1-lower-body.ts
+++ b/tools/ts2pant/src/ir1-lower-body.ts
@@ -43,6 +43,8 @@ import {
   mergeOverrides,
   type PropertyWriteEntry,
   putWrite,
+  readMapThroughWrites,
+  readSetThroughWrites,
   type SetOverride,
   type SetRuleWriteEntry,
   type SymbolicState,
@@ -54,9 +56,151 @@ export interface LowerBodyCtx {
   applyConst: (e: OpaqueExpr) => OpaqueExpr;
 }
 
-/** Lower an L1 expression all the way to OpaqueExpr (L1 → L2 → Opaque). */
-function lowerL1ExprToOpaque(e: IR1Expr): OpaqueExpr {
-  return lowerExpr(lowerL1Expr(e));
+/**
+ * Quick syntactic predicate: does the L1 expression contain a
+ * `map-read` / `set-read` form? Drives the fast-path in
+ * `lowerL1ExprToOpaque` — a tree without state-aware reads can take
+ * the standard `lowerExpr(lowerL1Expr(e))` pipeline unchanged.
+ */
+function containsStateAwareRead(e: IR1Expr): boolean {
+  switch (e.kind) {
+    case "map-read":
+    case "set-read":
+      return true;
+    case "var":
+    case "lit":
+      return false;
+    case "binop":
+      return containsStateAwareRead(e.lhs) || containsStateAwareRead(e.rhs);
+    case "unop":
+      return containsStateAwareRead(e.arg);
+    case "app":
+      return (
+        containsStateAwareRead(e.callee) || e.args.some(containsStateAwareRead)
+      );
+    case "member":
+      return containsStateAwareRead(e.receiver);
+    case "cond":
+      return (
+        containsStateAwareRead(e.otherwise) ||
+        e.arms.some(
+          ([g, v]) => containsStateAwareRead(g) || containsStateAwareRead(v),
+        )
+      );
+    case "is-nullish":
+      return containsStateAwareRead(e.operand);
+    case "each":
+      return (
+        containsStateAwareRead(e.src) ||
+        e.guards.some(containsStateAwareRead) ||
+        containsStateAwareRead(e.proj)
+      );
+    default: {
+      const _exhaustive: never = e;
+      void _exhaustive;
+      return false;
+    }
+  }
+}
+
+/**
+ * Lower an L1 expression to OpaqueExpr with state awareness for
+ * `map-read` / `set-read`. The body lower path uses this so a Map/Set
+ * `.get` / `.has` inside a branched body observes prior staged writes
+ * accumulated through the same path (issue #168). For trees without
+ * state-aware reads, defers to the standard `lowerExpr(lowerL1Expr)`
+ * pipeline — byte-identical to the pre-existing fast-path output.
+ */
+function lowerL1ExprToOpaque(
+  e: IR1Expr,
+  state: SymbolicState | undefined,
+): OpaqueExpr {
+  if (!containsStateAwareRead(e)) {
+    return lowerExpr(lowerL1Expr(e));
+  }
+  const ast = getAst();
+  switch (e.kind) {
+    case "map-read":
+      return readMapThroughWrites(
+        state,
+        e.op,
+        e.ruleName,
+        e.keyPredName,
+        e.ownerType,
+        e.keyType,
+        lowerL1ExprToOpaque(e.receiver, state),
+        lowerL1ExprToOpaque(e.key, state),
+      );
+    case "set-read":
+      return readSetThroughWrites(
+        state,
+        e.ruleName,
+        e.ownerType,
+        e.elemType,
+        lowerL1ExprToOpaque(e.receiver, state),
+        lowerL1ExprToOpaque(e.elem, state),
+      );
+    case "binop":
+      return ast.binop(
+        lowerBinop(e.op),
+        lowerL1ExprToOpaque(e.lhs, state),
+        lowerL1ExprToOpaque(e.rhs, state),
+      );
+    case "unop": {
+      const op =
+        e.op === "not"
+          ? ast.opNot()
+          : e.op === "neg"
+            ? ast.opNeg()
+            : ast.opCard();
+      return ast.unop(op, lowerL1ExprToOpaque(e.arg, state));
+    }
+    case "app": {
+      const args = e.args.map((a) => lowerL1ExprToOpaque(a, state));
+      if (e.callee.kind === "var" && !e.callee.primed) {
+        return ast.app(ast.var(e.callee.name), args);
+      }
+      return ast.app(lowerL1ExprToOpaque(e.callee, state), args);
+    }
+    case "member":
+      // Member already-qualified at L1 build; lowers to `App(name,
+      // [receiver])` — symmetric to `lowerL1Expr`'s member arm but
+      // built in OpaqueExpr layer here so the receiver may carry a
+      // state-aware sub-tree.
+      return ast.app(ast.var(e.name), [lowerL1ExprToOpaque(e.receiver, state)]);
+    case "cond": {
+      const arms: Array<[OpaqueExpr, OpaqueExpr]> = e.arms.map(([g, v]) => [
+        lowerL1ExprToOpaque(g, state),
+        lowerL1ExprToOpaque(v, state),
+      ]);
+      arms.push([ast.litBool(true), lowerL1ExprToOpaque(e.otherwise, state)]);
+      return ast.cond(arms);
+    }
+    case "is-nullish":
+      // Mirrors `lowerL1Expr`'s lowering: `#x = 0` under list-lift.
+      return ast.binop(
+        ast.opEq(),
+        ast.unop(ast.opCard(), lowerL1ExprToOpaque(e.operand, state)),
+        ast.litNat(0),
+      );
+    case "each": {
+      const guards = [
+        ast.gIn(e.binder, lowerL1ExprToOpaque(e.src, state)),
+        ...e.guards.map((g) => ast.gExpr(lowerL1ExprToOpaque(g, state))),
+      ];
+      return ast.each([], guards, lowerL1ExprToOpaque(e.proj, state));
+    }
+    case "var":
+    case "lit":
+      // Unreachable — `containsStateAwareRead` returned false above
+      // would have taken the fast-path. Defensive fallthrough.
+      return lowerExpr(lowerL1Expr(e));
+    default: {
+      const _exhaustive: never = e;
+      void _exhaustive;
+      throw new Error("unreachable: IR1Expr in lowerL1ExprToOpaque");
+    }
+  }
 }
 
 /**
@@ -127,8 +271,10 @@ function lowerAssign(
     });
     return false;
   }
-  const objExpr = ctx.applyConst(lowerL1ExprToOpaque(stmt.target.receiver));
-  const value = ctx.applyConst(lowerL1ExprToOpaque(stmt.value));
+  const objExpr = ctx.applyConst(
+    lowerL1ExprToOpaque(stmt.target.receiver, state),
+  );
+  const value = ctx.applyConst(lowerL1ExprToOpaque(stmt.value, state));
   const prop = stmt.target.name;
   const key = symbolicKey(prop, objExpr);
   state.writes = putWrite(state.writes, key, {
@@ -146,8 +292,8 @@ function lowerMapEffect(
   state: SymbolicState,
   ctx: LowerBodyCtx,
 ): boolean {
-  const objExpr = lowerL1ExprToOpaque(stmt.objExpr);
-  const keyExpr = lowerL1ExprToOpaque(stmt.keyExpr);
+  const objExpr = lowerL1ExprToOpaque(stmt.objExpr, state);
+  const keyExpr = lowerL1ExprToOpaque(stmt.keyExpr, state);
   // The discriminated union encodes the op/payload invariant: `set`
   // carries a value, `delete` is value-less.
   if (stmt.op === "set") {
@@ -161,7 +307,7 @@ function lowerMapEffect(
         keyType: stmt.keyType,
         objExpr,
         keyExpr,
-        valueExpr: lowerL1ExprToOpaque(stmt.valueExpr),
+        valueExpr: lowerL1ExprToOpaque(stmt.valueExpr, state),
       },
       ctx.applyConst,
     );
@@ -189,7 +335,7 @@ function lowerSetEffect(
   state: SymbolicState,
   ctx: LowerBodyCtx,
 ): boolean {
-  const objExpr = lowerL1ExprToOpaque(stmt.objExpr);
+  const objExpr = lowerL1ExprToOpaque(stmt.objExpr, state);
   // Discriminated: `add`/`delete` carry an element, `clear` is element-less.
   if (stmt.op === "clear") {
     installSetWrite(
@@ -213,7 +359,7 @@ function lowerSetEffect(
         ownerType: stmt.ownerType,
         elemType: stmt.elemType,
         objExpr,
-        elemExpr: lowerL1ExprToOpaque(stmt.elemExpr),
+        elemExpr: lowerL1ExprToOpaque(stmt.elemExpr, state),
       },
       ctx.applyConst,
     );
@@ -228,7 +374,7 @@ function lowerForeach(
   ctx: LowerBodyCtx,
 ): boolean {
   const ast = getAst();
-  const arrExpr = ctx.applyConst(lowerL1ExprToOpaque(stmt.source));
+  const arrExpr = ctx.applyConst(lowerL1ExprToOpaque(stmt.source, state));
 
   // Shape A: Sub-state captures the body's per-iteration writes so they
   // don't leak into the outer state. Skipped when body is null (pure
@@ -298,11 +444,13 @@ function lowerFoldLeaf(
   ctx: LowerBodyCtx,
 ): boolean {
   const ast = getAst();
-  const target = ctx.applyConst(lowerL1ExprToOpaque(leaf.target));
-  const rhs = ctx.applyConst(lowerL1ExprToOpaque(leaf.rhs));
+  const target = ctx.applyConst(lowerL1ExprToOpaque(leaf.target, state));
+  const rhs = ctx.applyConst(lowerL1ExprToOpaque(leaf.rhs, state));
   const guards = [ast.gIn(binder, arrExpr)];
   if (leaf.guard !== null) {
-    guards.push(ast.gExpr(ctx.applyConst(lowerL1ExprToOpaque(leaf.guard))));
+    guards.push(
+      ast.gExpr(ctx.applyConst(lowerL1ExprToOpaque(leaf.guard, state))),
+    );
   }
   const comb =
     leaf.combiner === "add"
@@ -364,7 +512,7 @@ function lowerCondStmt(
   }
   const ast = getAst();
   const [guard, thenBody] = stmt.arms[0]!;
-  const gExpr = ctx.applyConst(lowerL1ExprToOpaque(guard));
+  const gExpr = ctx.applyConst(lowerL1ExprToOpaque(guard, state));
 
   // Each branch lowers into its own `PropResult[]` buffer so a Shape A
   // `foreach` inside the branch (which emits `all $N in src | …`

--- a/tools/ts2pant/src/ir1-lower.ts
+++ b/tools/ts2pant/src/ir1-lower.ts
@@ -106,6 +106,28 @@ export function lowerL1Expr(e: IR1Expr): IRExpr {
       );
     }
 
+    case "map-read": {
+      // Pure / read-only path: emit the bare `App(callee, [receiver,
+      // key])` form — byte-identical to the legacy fast-path output
+      // when no symbolic state is in play. The body lower path
+      // (`ir1-lower-body.ts`) intercepts `map-read` before reaching
+      // here and dispatches to `readMapThroughWrites` so prior staged
+      // writes are observed.
+      const callee = e.op === "has" ? e.keyPredName : e.ruleName;
+      return irAppName(callee, [lowerL1Expr(e.receiver), lowerL1Expr(e.key)]);
+    }
+
+    case "set-read": {
+      // Pure / read-only path: emit the bare `Binop(in, elem,
+      // App(rule, [receiver]))` form. The body lower path dispatches
+      // this form to `readSetThroughWrites` before reaching here.
+      return irBinop(
+        "in",
+        lowerL1Expr(e.elem),
+        irAppName(e.ruleName, [lowerL1Expr(e.receiver)]),
+      );
+    }
+
     default: {
       const _exhaustive: never = e;
       void _exhaustive;

--- a/tools/ts2pant/src/ir1.ts
+++ b/tools/ts2pant/src/ir1.ts
@@ -45,7 +45,7 @@ export type IR1Unop = IRUnop;
 // --------------------------------------------------------------------------
 
 /**
- * Layer 1 expressions. Nine forms preserve TS-shape canonicalization:
+ * Layer 1 expressions. Eleven forms preserve TS-shape canonicalization:
  *
  * - `var`, `lit` — literal references
  * - `binop`, `unop` — arithmetic/logical/comparison operators
@@ -62,6 +62,14 @@ export type IR1Unop = IRUnop;
  * - `each` — list comprehension. Canonical form for the functor-lift
  *   recognizer's `each n in operand | projection` output. Mirrors L2
  *   `each` and lowers structurally.
+ * - `map-read`, `set-read` — state-aware Map/Set reads (`.get`/`.has`
+ *   on a Map, `.has` on a Set). Symmetric to the write-side
+ *   `map-effect` / `set-effect` statement forms; the body lower path
+ *   dispatches them to `readMapThroughWrites` /
+ *   `readSetThroughWrites` so prior staged writes in the same path
+ *   are observed inline. Pure / read-only callers lower these forms
+ *   to the bare `App` / `Binop(in, ...)` shapes the legacy fast-path
+ *   used to emit (issue #168).
  */
 export type IR1Expr =
   /** Variable / parameter reference. `primed = true` means next-state. */
@@ -114,6 +122,46 @@ export type IR1Expr =
       src: IR1Expr;
       guards: IR1Expr[];
       proj: IR1Expr;
+    }
+  /**
+   * State-aware Map read: `m.get(k)` (`op = "get"`) or `m.has(k)`
+   * (`op = "has"`). Symmetric to the write-side `map-effect` form —
+   * carries the Stage A / Stage B descriptor (`ruleName`,
+   * `keyPredName`, `ownerType`, `keyType`) so the body lower path can
+   * dispatch to `readMapThroughWrites`, observing prior staged writes
+   * inside the same path. The pure / read-only lower path (`lowerL1Expr`
+   * in `ir1-lower.ts`) emits the bare `App(rule, [receiver, key])`
+   * form — byte-identical to the pre-existing fast-path output when
+   * no state is in play.
+   *
+   * Built only when `ctx.state !== undefined` in
+   * `tryBuildL1PureSubExpression`; pure callers keep emitting the bare
+   * `App` form because there is no state to thread.
+   */
+  | {
+      kind: "map-read";
+      op: "get" | "has";
+      ruleName: string;
+      keyPredName: string;
+      ownerType: string;
+      keyType: string;
+      receiver: IR1Expr;
+      key: IR1Expr;
+    }
+  /**
+   * State-aware Set read: `s.has(x)`. Symmetric to the write-side
+   * `set-effect` form — body lower dispatches to
+   * `readSetThroughWrites` so prior `.add` / `.delete` / `.clear` in
+   * the same path are observed. Pure lower emits the bare
+   * `Binop(in, elem, App(rule, [receiver]))` form.
+   */
+  | {
+      kind: "set-read";
+      ruleName: string;
+      ownerType: string;
+      elemType: string;
+      receiver: IR1Expr;
+      elem: IR1Expr;
     };
 
 // --------------------------------------------------------------------------
@@ -434,6 +482,52 @@ export const ir1Each = (
   src,
   guards,
   proj,
+});
+
+/**
+ * State-aware Map read. The body lower path (`ir1-lower-body.ts`)
+ * dispatches this form to `readMapThroughWrites`; the pure /
+ * read-only lower path (`ir1-lower.ts`) emits the bare
+ * `App(callee, [receiver, key])` form (`callee = ruleName` for `get`,
+ * `keyPredName` for `has`).
+ */
+export const ir1MapRead = (
+  op: "get" | "has",
+  ruleName: string,
+  keyPredName: string,
+  ownerType: string,
+  keyType: string,
+  receiver: IR1Expr,
+  key: IR1Expr,
+): IR1Expr => ({
+  kind: "map-read",
+  op,
+  ruleName,
+  keyPredName,
+  ownerType,
+  keyType,
+  receiver,
+  key,
+});
+
+/**
+ * State-aware Set read. The body lower path dispatches this form to
+ * `readSetThroughWrites`; the pure / read-only lower path emits the
+ * bare `Binop(in, elem, App(ruleName, [receiver]))` form.
+ */
+export const ir1SetRead = (
+  ruleName: string,
+  ownerType: string,
+  elemType: string,
+  receiver: IR1Expr,
+  elem: IR1Expr,
+): IR1Expr => ({
+  kind: "set-read",
+  ruleName,
+  ownerType,
+  elemType,
+  receiver,
+  elem,
 });
 
 // --------------------------------------------------------------------------

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -806,7 +806,7 @@ export function installMapWrite(
  * partial function), but an inline override application has no such guard,
  * so the filter is explicit at the read site.
  */
-function readMapThroughWrites(
+export function readMapThroughWrites(
   state: SymbolicState | undefined,
   methodName: "get" | "has",
   ruleName: string,
@@ -983,7 +983,7 @@ export function installSetWrite(
  * with `ast.opIn` and a cond over equality arms. `ast.override` would be
  * invalid on a list-valued field accessor.
  */
-function readSetThroughWrites(
+export function readSetThroughWrites(
   state: SymbolicState | undefined,
   ruleName: string,
   ownerType: string,

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -678,6 +678,22 @@ exports[`expressions-set.ts > contains 1`] = `
 "module Contains.\\n\\ncontains xs: [String], x: String => Bool.\\n\\n---\\n\\ncontains xs x = (x in xs).\\n"
 `;
 
+exports[`expressions-state-aware-reads.ts > bumpInBranch 1`] = `
+"module BumpInBranch.\\n\\nStringToIntMap.\\nstring-to-int-map-key m1: StringToIntMap, k1: String => Bool.\\nstring-to-int-map m1: StringToIntMap, k1: String, string-to-int-map-key m1 k1 => Int.\\n~> Bump-in-branch @ m: StringToIntMap, k: String, v: Int, gate: Bool.\\n\\n---\\n\\nall m2: StringToIntMap, k2: String | string-to-int-map' m2 k2 = string-to-int-map[(m, k) |-> cond gate => string-to-int-map[(m, k) |-> v] m k + 1, true => string-to-int-map m k] m2 k2.\\nall m3: StringToIntMap, k3: String | string-to-int-map-key' m3 k3 = string-to-int-map-key[(m, k) |-> cond gate => true, true => string-to-int-map-key m k] m3 k3.\\n"
+`;
+
+exports[`expressions-state-aware-reads.ts > entrySetThenCheck 1`] = `
+"module EntrySetThenCheck.\\n\\nCache.\\ncache--entries-key c1: Cache, k1: String => Bool.\\ncache--entries c1: Cache, k1: String, cache--entries-key c1 k1 => Int.\\ncache--hits c1: Cache => Int.\\n~> Entry-set-then-check @ c: Cache, k: String, v: Int, gate: Bool.\\n\\n---\\n\\nall m: Cache, k2: String | cache--entries' m k2 = cache--entries[(c, k) |-> cond gate => v, true => cache--entries c k] m k2.\\nall m1: Cache, k3: String | cache--entries-key' m1 k3 = cache--entries-key[(c, k) |-> cond gate => true, true => cache--entries-key c k] m1 k3.\\ncache--hits' c = (cond gate => (cond cache--entries-key[(c, k) |-> true] c k => cache--hits c + 1, true => cache--hits c), true => cache--hits c).\\n"
+`;
+
+exports[`expressions-state-aware-reads.ts > setIfThenBump 1`] = `
+"module SetIfThenBump.\\n\\nStringToIntMap.\\nstring-to-int-map-key m1: StringToIntMap, k1: String => Bool.\\nstring-to-int-map m1: StringToIntMap, k1: String, string-to-int-map-key m1 k1 => Int.\\n~> Set-if-then-bump @ m: StringToIntMap, k: String, v: Int, gate: Bool.\\n\\n---\\n\\nall m2: StringToIntMap, k2: String | string-to-int-map' m2 k2 = string-to-int-map[(m, k) |-> cond gate => (cond string-to-int-map-key[(m, k) |-> true] m k => string-to-int-map[(m, k) |-> v] m k + 1, true => v), true => string-to-int-map m k] m2 k2.\\nall m3: StringToIntMap, k3: String | string-to-int-map-key' m3 k3 = string-to-int-map-key[(m, k) |-> cond gate => (cond string-to-int-map-key[(m, k) |-> true] m k => true, true => true), true => string-to-int-map-key m k] m3 k3.\\n"
+`;
+
+exports[`expressions-state-aware-reads.ts > tagThenCheck 1`] = `
+"module TagThenCheck.\\n\\nTagged.\\ntagged--tags t: Tagged => [String].\\ntagged--flag t: Tagged => Bool.\\n~> Tag-then-check @ c: Tagged, x: String, gate: Bool.\\n\\n---\\n\\nall y: String | y in tagged--tags' c <-> (cond y = x => (cond gate => true, true => x in tagged--tags c), true => y in tagged--tags c).\\ntagged--flag' c = (cond gate => (cond (cond x = x => true, true => x in tagged--tags c) => true, true => tagged--flag c), true => tagged--flag c).\\n"
+`;
+
 exports[`expressions-while-mu-search.ts > compoundIncrementStep 1`] = `
 "module CompoundIncrementStep.\\n\\ncompound-increment-step used: [Int] => Int.\\n\\n---\\n\\ncompound-increment-step used = (min over each j: Int, j >= 1, ~(j in used) | j).\\n"
 `;

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-state-aware-reads.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-state-aware-reads.ts
@@ -1,0 +1,107 @@
+// State-aware Map/Set reads inside *branched* mutating bodies.
+//
+// These shapes flow through the L1 build pass (`buildL1IfMutation` →
+// `buildL1EffectCall` → `buildL1SubExpr` → `tryBuildL1PureSubExpression`).
+// Pre-fix, the `.has` / `.get` fast-paths in `tryBuildL1PureSubExpression`
+// emitted bare `Binop(in, ...)` / `App(rule, [...])` forms that ignored
+// staged `MapRuleWriteEntry` / `SetRuleWriteEntry` overrides accumulated
+// from earlier statements in the same path. The resulting reads missed
+// prior `.add` / `.set` and emitted Pantagruel that referenced only the
+// pre-state of the rule.
+//
+// Post-fix, these fast-paths emit `map-read` / `set-read` L1 forms when
+// `ctx.state !== undefined`. The body lower path dispatches those forms
+// to `readMapThroughWrites` / `readSetThroughWrites` so prior staged
+// writes flow into the read inline (override application for Map values,
+// `cond` over equality arms for Set membership). The pure / read-only
+// path lowers `map-read` / `set-read` mechanically to the same bare
+// shapes the fast-path used to emit, so existing pure fixtures stay
+// byte-identical. See issue #168.
+
+interface Tagged {
+  tags: Set<string>;
+  flag: boolean;
+}
+
+interface Cache {
+  entries: Map<string, number>;
+  hits: number;
+}
+
+/**
+ * Stage A Set: branched `c.tags.add(x)` followed by branched
+ * `c.tags.has(x)`. The inner `if`'s guard is built as a `set-read`
+ * (state-aware) and lowers via `readSetThroughWrites` to a cond with
+ * an `x = x => true` arm — observing the staged `.add`. Pre-fix this
+ * lowered to bare `x in (tagged--tags c)`, missing the add.
+ */
+export function tagThenCheck(c: Tagged, x: string, gate: boolean): void {
+  if (gate) {
+    c.tags.add(x);
+    if (c.tags.has(x)) {
+      c.flag = true;
+    }
+  }
+}
+
+/**
+ * Stage A Map: branched `c.entries.set(k, v)` followed by branched
+ * `c.entries.has(k)`. The inner guard's `map-read` lowers via
+ * `readMapThroughWrites` and observes the prior `.set` through the
+ * `entries-key` membership predicate's override list.
+ */
+export function entrySetThenCheck(
+  c: Cache,
+  k: string,
+  v: number,
+  gate: boolean,
+): void {
+  if (gate) {
+    c.entries.set(k, v);
+    if (c.entries.has(k)) {
+      c.hits = c.hits + 1;
+    }
+  }
+}
+
+/**
+ * Stage B Map: read-after-write inside a branch. The second `.set`'s
+ * value sub-expression `m.get(k)! + 1` contains a `map-read` that the
+ * body lower threads through `readMapThroughWrites` against the
+ * current state (which has the first `.set` staged). Pre-fix this
+ * silently emitted `stringToIntMap m k + 1` — reading the pre-state
+ * rule rather than the just-written `v`.
+ */
+export function bumpInBranch(
+  m: Map<string, number>,
+  k: string,
+  v: number,
+  gate: boolean,
+): void {
+  if (gate) {
+    m.set(k, v);
+    m.set(k, m.get(k)! + 1);
+  }
+}
+
+/**
+ * Stage B Map: branched `m.has(k)` after a staged `.set` — the
+ * inner-if guard's `map-read` observes the staged write through the
+ * synthesized `stringToIntMap-key` override list. Combines the
+ * `.has`-membership and `.get`-value paths into one shape: the inner
+ * branch's `m.set(k, m.get(k)! + 1)` re-exercises the value-side
+ * `map-read` from inside a doubly-nested branch.
+ */
+export function setIfThenBump(
+  m: Map<string, number>,
+  k: string,
+  v: number,
+  gate: boolean,
+): void {
+  if (gate) {
+    m.set(k, v);
+    if (m.has(k)) {
+      m.set(k, m.get(k)! + 1);
+    }
+  }
+}

--- a/tools/ts2pant/tests/ir1-build-state-aware-reads.test.mts
+++ b/tools/ts2pant/tests/ir1-build-state-aware-reads.test.mts
@@ -1,0 +1,333 @@
+/**
+ * Unit tests for the state-aware Map/Set read forms (`map-read`,
+ * `set-read`) that the L1 build pass emits inside mutating bodies
+ * when `ctx.state !== undefined`. The forms exist so the body lower
+ * path can dispatch to `readMapThroughWrites` /
+ * `readSetThroughWrites`, observing prior staged writes from the
+ * same path. Pure-path callers (no state) keep emitting the bare
+ * `App` / `Binop(in, ...)` shapes via the legacy fast-path. See
+ * issue #168.
+ */
+
+import assert from "node:assert/strict";
+import { before, describe, it } from "node:test";
+import ts from "typescript";
+import { createSourceFileFromSource, getChecker } from "../src/extract.js";
+import {
+  type L1BuildContext,
+  tryBuildL1PureSubExpression,
+} from "../src/ir1-build.js";
+import type { IR1Expr } from "../src/ir1.js";
+import { getAst, loadAst } from "../src/pant-wasm.js";
+import {
+  makeSymbolicState,
+  translateBody,
+  type UniqueSupply,
+} from "../src/translate-body.js";
+import { translateSignature } from "../src/translate-signature.js";
+import {
+  cellRegisterName,
+  IntStrategy,
+  newSynthCell,
+  toPantTermName,
+} from "../src/translate-types.js";
+import type { PropResult } from "../src/types.js";
+
+before(async () => {
+  await loadAst();
+});
+
+interface ExprSetup {
+  expr: ts.Expression;
+  ctx: L1BuildContext;
+}
+
+/** Parse a single `return EXPR;` body and hand back the expression + a build ctx. */
+function setupReturn(source: string, withState: boolean): ExprSetup {
+  const sourceFile = createSourceFileFromSource(source);
+  const checker = getChecker(sourceFile);
+  const fn = sourceFile.compilerNode.statements.find(ts.isFunctionDeclaration);
+  if (!fn || !fn.body) {
+    throw new Error("setup: expected a function declaration with a body");
+  }
+  const synthCell = newSynthCell();
+  const paramNames = new Map<string, string>();
+  for (const p of fn.parameters) {
+    if (ts.isIdentifier(p.name)) {
+      const pantName = cellRegisterName(synthCell, toPantTermName(p.name.text));
+      paramNames.set(p.name.text, pantName);
+    }
+  }
+  const supply: UniqueSupply = { n: 0, synthCell };
+  const ctx: L1BuildContext = {
+    checker,
+    strategy: IntStrategy,
+    paramNames,
+    state: withState ? makeSymbolicState() : undefined,
+    supply,
+  };
+  const stmt = fn.body.statements[0];
+  if (!stmt || !ts.isReturnStatement(stmt) || !stmt.expression) {
+    throw new Error("setup: expected a return statement with an expression");
+  }
+  return { expr: stmt.expression, ctx };
+}
+
+function expectIR(r: IR1Expr | { unsupported: string } | null): IR1Expr {
+  if (r === null) {
+    throw new Error("expected an IR1Expr, got null");
+  }
+  if ("unsupported" in r) {
+    throw new Error(`expected an IR1Expr, got unsupported: ${r.unsupported}`);
+  }
+  return r;
+}
+
+describe("ir1-build state-aware Map/Set reads", () => {
+  describe("Set.has", () => {
+    it("Stage A receiver builds set-read when ctx.state is defined", () => {
+      const { expr, ctx } = setupReturn(
+        `interface Tagged { readonly tags: Set<string>; }
+         function f(c: Tagged, x: string): boolean {
+           return c.tags.has(x);
+         }`,
+        true,
+      );
+      const built = expectIR(tryBuildL1PureSubExpression(expr, ctx));
+      assert.equal(
+        built.kind,
+        "set-read",
+        `expected set-read, got ${built.kind}`,
+      );
+      if (built.kind !== "set-read") return;
+      assert.equal(built.ruleName, "tagged--tags");
+      assert.equal(built.ownerType, "Tagged");
+      assert.equal(built.elemType, "String");
+    });
+
+    it("Stage A receiver builds bare Binop(in, ...) when ctx.state is undefined", () => {
+      const { expr, ctx } = setupReturn(
+        `interface Tagged { readonly tags: Set<string>; }
+         function f(c: Tagged, x: string): boolean {
+           return c.tags.has(x);
+         }`,
+        false,
+      );
+      const built = expectIR(tryBuildL1PureSubExpression(expr, ctx));
+      assert.equal(
+        built.kind,
+        "binop",
+        `expected binop (bare path), got ${built.kind}`,
+      );
+      if (built.kind !== "binop") return;
+      assert.equal(built.op, "in");
+    });
+
+    it("parameter-level Set receiver keeps the bare Binop(in, ...) form", () => {
+      // No staged Set writes can exist on a parameter receiver
+      // (parameter-level Set mutation is rejected at translate time),
+      // so the bare form is sound and the build pass keeps it for
+      // byte-equivalent output with the pure path.
+      const { expr, ctx } = setupReturn(
+        `function f(s: Set<string>, x: string): boolean {
+           return s.has(x);
+         }`,
+        true,
+      );
+      const built = expectIR(tryBuildL1PureSubExpression(expr, ctx));
+      assert.equal(built.kind, "binop");
+    });
+  });
+
+  describe("Map.has / Map.get", () => {
+    it("Stage A `.has` builds map-read with op=has when ctx.state is defined", () => {
+      const { expr, ctx } = setupReturn(
+        `interface Cache { readonly entries: Map<string, number>; }
+         function f(c: Cache, k: string): boolean {
+           return c.entries.has(k);
+         }`,
+        true,
+      );
+      const built = expectIR(tryBuildL1PureSubExpression(expr, ctx));
+      assert.equal(built.kind, "map-read");
+      if (built.kind !== "map-read") return;
+      assert.equal(built.op, "has");
+      assert.equal(built.ruleName, "cache--entries");
+      assert.equal(built.keyPredName, "cache--entries-key");
+      assert.equal(built.ownerType, "Cache");
+      assert.equal(built.keyType, "String");
+    });
+
+    it("Stage A `.get` builds map-read with op=get when ctx.state is defined", () => {
+      const { expr, ctx } = setupReturn(
+        `interface Cache { readonly entries: Map<string, number>; }
+         function f(c: Cache, k: string): number {
+           return c.entries.get(k)!;
+         }`,
+        true,
+      );
+      const built = expectIR(tryBuildL1PureSubExpression(expr, ctx));
+      assert.equal(built.kind, "map-read");
+      if (built.kind !== "map-read") return;
+      assert.equal(built.op, "get");
+    });
+
+    it("Stage B `.get` builds map-read against the synthesized rule", () => {
+      const { expr, ctx } = setupReturn(
+        `function f(m: Map<string, number>, k: string): number {
+           return m.get(k)!;
+         }`,
+        true,
+      );
+      const built = expectIR(tryBuildL1PureSubExpression(expr, ctx));
+      assert.equal(built.kind, "map-read");
+      if (built.kind !== "map-read") return;
+      assert.equal(built.op, "get");
+      // Synth names: `domain` is CamelCase (`StringToIntMap`); `rule`
+      // is the kebab-cased term form (`string-to-int-map`); `keyPred`
+      // appends `-key`.
+      assert.equal(built.ruleName, "string-to-int-map");
+      assert.equal(built.keyPredName, "string-to-int-map-key");
+      assert.equal(built.ownerType, "StringToIntMap");
+    });
+
+    it("Stage A Map receiver keeps bare App when ctx.state is undefined", () => {
+      const { expr, ctx } = setupReturn(
+        `interface Cache { readonly entries: Map<string, number>; }
+         function f(c: Cache, k: string): boolean {
+           return c.entries.has(k);
+         }`,
+        false,
+      );
+      const built = expectIR(tryBuildL1PureSubExpression(expr, ctx));
+      assert.equal(built.kind, "app", `expected bare app, got ${built.kind}`);
+    });
+  });
+});
+
+/**
+ * Translate `functionName` from `source` with synth + paramNameMap
+ * threaded through signature translation — needed for Map/Set bodies
+ * (which allocate domains and binders against the document-wide
+ * `NameRegistry`) and for emit-time binder allocation.
+ */
+function translateBodyWithSynth(source: string, functionName: string): PropResult[] {
+  const sf = createSourceFileFromSource(source);
+  const synthCell = newSynthCell();
+  const { paramNameMap } = translateSignature(
+    sf,
+    functionName,
+    IntStrategy,
+    synthCell,
+  );
+  return translateBody({
+    sourceFile: sf,
+    functionName,
+    strategy: IntStrategy,
+    synthCell,
+    paramNameMap,
+  });
+}
+
+describe("end-to-end: branched Map/Set read observes prior staged write", () => {
+  it("Stage A Set: branched .add then branched .has observes the staged add", () => {
+    const props = translateBodyWithSynth(
+      `interface Tagged { tags: Set<string>; flag: boolean; }
+       export function f(c: Tagged, x: string, gate: boolean): void {
+         if (gate) {
+           c.tags.add(x);
+           if (c.tags.has(x)) {
+             c.flag = true;
+           }
+         }
+       }`,
+      "f",
+    );
+    const unsupported = props.filter((p) => p.kind === "unsupported");
+    assert.equal(
+      unsupported.length,
+      0,
+      `unexpected unsupported props: ${JSON.stringify(unsupported)}`,
+    );
+    // Find the flag' equation. Its rhs (a cond merging the gate with
+    // the identity fall-through) must reference `true` — the inner
+    // guard `c.tags.has(x)` reduced to `true` because the staged `.add`
+    // was visible. With the pre-fix bare read, the rhs would have
+    // instead carried `cond x in (tagged--tags c) => true, ...`.
+    const ast = getAst();
+    const flagEq = props.find((p) => {
+      if (p.kind !== "equation") return false;
+      const lhsStr = ast.strExpr(
+        (p as { lhs: import("../src/pant-ast.js").OpaqueExpr }).lhs,
+      );
+      return /flag'\s*c/u.test(lhsStr);
+    });
+    assert.ok(flagEq, "expected a `flag' c` equation");
+    if (flagEq && flagEq.kind === "equation") {
+      const rhsStr = ast.strExpr(
+        (flagEq as { rhs: import("../src/pant-ast.js").OpaqueExpr }).rhs,
+      );
+      // The inner guard's `c.tags.has(x)` lowered through
+      // `readSetThroughWrites` should resolve to a cond that, given
+      // the prior `.add(x)`, has at least one `=> true` arm — even if
+      // the outer merge folds it, the inline equality on the staged
+      // element appears in the produced text.
+      assert.ok(
+        /=\s*x/u.test(rhsStr) || /true/u.test(rhsStr),
+        `flag' rhs should contain the staged add equality or a true arm: ${rhsStr}`,
+      );
+    }
+  });
+
+  it("Stage B Map: branched .set followed by branched .has + .get observes the prior write", () => {
+    const props = translateBodyWithSynth(
+      `export function f(m: Map<string, number>, k: string, v: number, gate: boolean): void {
+         if (gate) {
+           m.set(k, v);
+           if (m.has(k)) {
+             m.set(k, m.get(k)! + 1);
+           }
+         }
+       }`,
+      "f",
+    );
+    const unsupported = props.filter((p) => p.kind === "unsupported");
+    assert.equal(
+      unsupported.length,
+      0,
+      `unexpected unsupported props: ${JSON.stringify(unsupported)}`,
+    );
+    const equations = props.filter((p) => p.kind === "equation");
+    assert.ok(
+      equations.length > 0,
+      "expected emitted equations for the branched body",
+    );
+    // The merged value-rule equation must reference `v` — the inner
+    // `m.get(k)!` saw the staged `.set(k, v)` through
+    // `readMapThroughWrites` and inlined `v` rather than reading the
+    // pre-state rule.
+    const ast = getAst();
+    const valueEq = props.find((p) => {
+      if (p.kind !== "equation") return false;
+      const lhsStr = ast.strExpr(
+        (p as { lhs: import("../src/pant-ast.js").OpaqueExpr }).lhs,
+      );
+      // The Stage B value rule's primed form. Match either kebab or
+      // CamelCase to avoid coupling to current name format.
+      return /string-to-int-map'/u.test(lhsStr);
+    });
+    assert.ok(
+      valueEq,
+      "expected a primed Stage B Map value-rule equation",
+    );
+    if (valueEq && valueEq.kind === "equation") {
+      const rhsStr = ast.strExpr(
+        (valueEq as { rhs: import("../src/pant-ast.js").OpaqueExpr }).rhs,
+      );
+      assert.ok(
+        /\bv\b/u.test(rhsStr),
+        `Map value-rule rhs should reference the staged \`v\`: ${rhsStr}`,
+      );
+    }
+  });
+});

--- a/tools/ts2pant/tests/ir1-build-state-aware-reads.test.mts
+++ b/tools/ts2pant/tests/ir1-build-state-aware-reads.test.mts
@@ -268,13 +268,20 @@ describe("end-to-end: branched Map/Set read observes prior staged write", () => 
         (flagEq as { rhs: import("../src/pant-ast.js").OpaqueExpr }).rhs,
       );
       // The inner guard's `c.tags.has(x)` lowered through
-      // `readSetThroughWrites` should resolve to a cond that, given
-      // the prior `.add(x)`, has at least one `=> true` arm — even if
-      // the outer merge folds it, the inline equality on the staged
-      // element appears in the produced text.
-      assert.ok(
-        /=\s*x/u.test(rhsStr) || /true/u.test(rhsStr),
-        `flag' rhs should contain the staged add equality or a true arm: ${rhsStr}`,
+      // `readSetThroughWrites` resolves to a cond whose first arm is
+      // the equality `x = x => true` produced by the prior staged
+      // `.add(x)`. With the pre-fix bare read, the guard would have
+      // been the bare pre-state membership `x in tagged--tags c`
+      // rather than the staged equality arm.
+      assert.match(
+        rhsStr,
+        /cond\s+x\s*=\s*x\s*=>\s*true/u,
+        `flag' rhs should include the staged Set-read equality arm: ${rhsStr}`,
+      );
+      assert.doesNotMatch(
+        rhsStr,
+        /cond\s+x\s+in\s+tagged--tags\s+c\s*=>\s*true/u,
+        `flag' rhs should not be guarded by bare pre-state membership: ${rhsStr}`,
       );
     }
   });
@@ -324,9 +331,19 @@ describe("end-to-end: branched Map/Set read observes prior staged write", () => 
       const rhsStr = ast.strExpr(
         (valueEq as { rhs: import("../src/pant-ast.js").OpaqueExpr }).rhs,
       );
-      assert.ok(
-        /\bv\b/u.test(rhsStr),
-        `Map value-rule rhs should reference the staged \`v\`: ${rhsStr}`,
+      // The inner `m.get(k)!` lowered through `readMapThroughWrites`
+      // sees the prior staged `.set(k, v)`, so it reads through the
+      // override `string-to-int-map[(m, k) |-> v] m k + 1` rather
+      // than the bare pre-state rule `string-to-int-map m k + 1`.
+      assert.match(
+        rhsStr,
+        /string-to-int-map\[\(m,\s*k\)\s*\|->\s*v\]\s*m\s*k\s*\+\s*1/u,
+        `Map value-rule rhs should read through the staged override: ${rhsStr}`,
+      );
+      assert.doesNotMatch(
+        rhsStr,
+        /string-to-int-map\s+m\s+k\s*\+\s*1/u,
+        `Map value-rule rhs should not use bare pre-state \`m.get(k)\`: ${rhsStr}`,
       );
     }
   });

--- a/tools/ts2pant/tests/ir1-build-state-aware-reads.test.mts
+++ b/tools/ts2pant/tests/ir1-build-state-aware-reads.test.mts
@@ -191,6 +191,22 @@ describe("ir1-build state-aware Map/Set reads", () => {
       assert.equal(built.ownerType, "StringToIntMap");
     });
 
+    it("Stage B `.has` builds map-read with op=has against the synthesized rule", () => {
+      const { expr, ctx } = setupReturn(
+        `function f(m: Map<string, number>, k: string): boolean {
+           return m.has(k);
+         }`,
+        true,
+      );
+      const built = expectIR(tryBuildL1PureSubExpression(expr, ctx));
+      assert.equal(built.kind, "map-read");
+      if (built.kind !== "map-read") return;
+      assert.equal(built.op, "has");
+      assert.equal(built.ruleName, "string-to-int-map");
+      assert.equal(built.keyPredName, "string-to-int-map-key");
+      assert.equal(built.ownerType, "StringToIntMap");
+    });
+
     it("Stage A Map receiver keeps bare App when ctx.state is undefined", () => {
       const { expr, ctx } = setupReturn(
         `interface Cache { readonly entries: Map<string, number>; }
@@ -321,7 +337,7 @@ describe("end-to-end: branched Map/Set read observes prior staged write", () => 
       );
       // The Stage B value rule's primed form. Match either kebab or
       // CamelCase to avoid coupling to current name format.
-      return /string-to-int-map'/u.test(lhsStr);
+      return /(?:string-to-int-map|StringToIntMap)'/u.test(lhsStr);
     });
     assert.ok(
       valueEq,


### PR DESCRIPTION
## Summary

Fixes #168. The Set.has / Map.get / Map.has fast-paths in `tryBuildL1PureSubExpression` were emitting bare `Binop(in, ...)` / `App(rule, [...])` forms that ignored staged `MapRuleWriteEntry` / `SetRuleWriteEntry` overrides accumulated earlier in the same path. Inside a *branched* mutating body, this caused `.has` / `.get` to silently miss prior `.add` / `.set` on the same receiver.

The fix follows the architecturally-clean approach proposed in the issue (rather than the inline `readSet/MapThroughWrites` short-circuit, which would have imported body-translator state into the L1 build pass).

## What changed

- **L1 vocabulary** — added `map-read` and `set-read` forms to `IR1Expr`, symmetric to the existing write-side `map-effect` / `set-effect`. Each carries the `(ruleName, keyPredName, ownerType, keyType)` descriptor (or `(ruleName, ownerType, elemType)` for Set) so the body lower can dispatch without re-resolving Stage A/B at lower time.
- **Build pass** (`ir1-build.ts`) — the Set.has / Map.get / Map.has fast-paths now emit the new forms when `ctx.state !== undefined`. Pure callers (state undefined) keep emitting the bare shapes, and Stage B Set parameter receivers (where staged writes can't exist) keep the bare form too.
- **Pure / read-only lower** (`ir1-lower.ts`) — `map-read` lowers to `App(callee, [receiver, key])`, `set-read` to `Binop(in, elem, App(rule, [receiver]))`. Byte-identical to the legacy fast-path output, so existing read-only snapshots stay unchanged.
- **Body / state-threaded lower** (`ir1-lower-body.ts`) — `lowerL1ExprToOpaque` now takes `state` and uses a syntactic `containsStateAwareRead` predicate to fast-path trees without state-aware reads. Trees that contain them walk structurally and dispatch to `readMapThroughWrites` / `readSetThroughWrites`.
- **Layering** — the L1 pass stays Pant-target-agnostic. "Read with state" is just a discriminator on the L1 ADT (same shape as every other M2/M3/M5 invariant). The body-translator-specific `MapRuleWriteEntry` / override composition lives only in the body lower path.

## Test plan

- [x] New fixture `tests/fixtures/constructs/expressions-state-aware-reads.ts` covering all four shapes: Stage A Set, Stage A Map, Stage B Map read-after-write inside a branch, Stage B Map with nested if. The wasm typechecker validates the emitted Pantagruel.
- [x] New unit tests in `tests/ir1-build-state-aware-reads.test.mts` covering both directions:
  - `tryBuildL1PureSubExpression` emits the new forms when `ctx.state` is defined and the bare forms when it isn't.
  - End-to-end branched bodies emit the override-application form inline (`stringToIntMap[(m, k) |-> v] m k + 1`) — proves the staged write is observed.
- [x] No existing snapshots changed (purely additive snapshot diff). Pure-path callers — `expressions-set.ts`, `expressions-map.ts`, `expressions-map-params.ts` — stay byte-identical.
- [x] All 796 unit tests pass, all 22 integration tests pass.
- [x] `just ts2pant-precommit` clean (biome + tsc + tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)