### PR TITLE
[ir1-ssa-contract] Patch 2: Implement the IR1 SSA type and constructor contract

### DIFF
--- a/tools/ts2pant/src/ir1.ts
+++ b/tools/ts2pant/src/ir1.ts
@@ -588,12 +588,15 @@ export const ir1SsaInitialVersion = (location: IR1SsaLocation): IR1SsaVersion =>
 export const ir1SsaWrite = (
   location: IR1SsaLocation,
   value: IR1SsaValue,
-): IR1SsaWrite => ({
-  kind: "ssa-write",
-  location,
-  version: ir1SsaVersion(location, "write"),
-  value,
-});
+): IR1SsaWrite => {
+  ir1SsaAssertWriteValueCompatible(location, value);
+  return {
+    kind: "ssa-write",
+    location,
+    version: ir1SsaVersion(location, "write"),
+    value,
+  };
+};
 
 export const ir1SsaRead = (
   location: IR1SsaLocation,
@@ -677,6 +680,17 @@ const ir1SsaAssertLocationCompatible = (
 
 const ir1SsaLocationEquals = (a: IR1SsaLocation, b: IR1SsaLocation): boolean =>
   JSON.stringify(a) === JSON.stringify(b);
+
+const ir1SsaAssertWriteValueCompatible = (
+  location: IR1SsaLocation,
+  value: IR1SsaValue,
+): void => {
+  if (location.kind !== value.kind) {
+    throw new Error(
+      `IR1 SSA write value/location kind mismatch: location=${location.kind}, value=${value.kind}`,
+    );
+  }
+};
 
 // --------------------------------------------------------------------------
 // Expression constructors

--- a/tools/ts2pant/src/ir1.ts
+++ b/tools/ts2pant/src/ir1.ts
@@ -730,8 +730,10 @@ const ir1SsaLocationEquals = (
         ir1SsaExprEquals(a.receiver, b.receiver)
       );
     }
-    default:
-      return false;
+    default: {
+      const _exhaustive: never = a;
+      return _exhaustive;
+    }
   }
 };
 
@@ -832,8 +834,10 @@ const ir1SsaExprEquals = (a: IR1Expr, b: IR1Expr): boolean => {
         ir1SsaExprEquals(a.elem, b.elem)
       );
     }
-    default:
-      return false;
+    default: {
+      const _exhaustive: never = a;
+      return _exhaustive;
+    }
   }
 };
 

--- a/tools/ts2pant/src/ir1.ts
+++ b/tools/ts2pant/src/ir1.ts
@@ -678,8 +678,185 @@ const ir1SsaAssertLocationCompatible = (
   }
 };
 
-const ir1SsaLocationEquals = (a: IR1SsaLocation, b: IR1SsaLocation): boolean =>
-  JSON.stringify(a) === JSON.stringify(b);
+const ir1SsaLocationEquals = (
+  a: IR1SsaLocation,
+  b: IR1SsaLocation,
+): boolean => {
+  switch (a.kind) {
+    case "property": {
+      if (b.kind !== "property") {
+        return false;
+      }
+      return (
+        a.ruleName === b.ruleName &&
+        a.property === b.property &&
+        ir1SsaExprEquals(a.receiver, b.receiver)
+      );
+    }
+    case "map-value": {
+      if (b.kind !== "map-value") {
+        return false;
+      }
+      return (
+        a.ruleName === b.ruleName &&
+        a.keyPredName === b.keyPredName &&
+        a.ownerType === b.ownerType &&
+        a.keyType === b.keyType &&
+        ir1SsaExprEquals(a.receiver, b.receiver) &&
+        ir1SsaExprEquals(a.key, b.key)
+      );
+    }
+    case "map-membership": {
+      if (b.kind !== "map-membership") {
+        return false;
+      }
+      return (
+        a.ruleName === b.ruleName &&
+        a.keyPredName === b.keyPredName &&
+        a.ownerType === b.ownerType &&
+        a.keyType === b.keyType &&
+        ir1SsaExprEquals(a.receiver, b.receiver) &&
+        ir1SsaExprEquals(a.key, b.key)
+      );
+    }
+    case "set-membership": {
+      if (b.kind !== "set-membership") {
+        return false;
+      }
+      return (
+        a.ruleName === b.ruleName &&
+        a.ownerType === b.ownerType &&
+        a.elemType === b.elemType &&
+        ir1SsaExprEquals(a.receiver, b.receiver)
+      );
+    }
+    default:
+      return false;
+  }
+};
+
+const ir1SsaExprEquals = (a: IR1Expr, b: IR1Expr): boolean => {
+  switch (a.kind) {
+    case "var": {
+      if (b.kind !== "var") {
+        return false;
+      }
+      return a.name === b.name && (a.primed ?? false) === (b.primed ?? false);
+    }
+    case "lit": {
+      if (b.kind !== "lit") {
+        return false;
+      }
+      return a.value.kind === b.value.kind && a.value.value === b.value.value;
+    }
+    case "binop": {
+      if (b.kind !== "binop") {
+        return false;
+      }
+      return (
+        a.op === b.op &&
+        ir1SsaExprEquals(a.lhs, b.lhs) &&
+        ir1SsaExprEquals(a.rhs, b.rhs)
+      );
+    }
+    case "unop": {
+      if (b.kind !== "unop") {
+        return false;
+      }
+      return a.op === b.op && ir1SsaExprEquals(a.arg, b.arg);
+    }
+    case "app": {
+      if (b.kind !== "app") {
+        return false;
+      }
+      return (
+        ir1SsaExprEquals(a.callee, b.callee) &&
+        ir1SsaArrayEquals(a.args, b.args, ir1SsaExprEquals)
+      );
+    }
+    case "member": {
+      if (b.kind !== "member") {
+        return false;
+      }
+      return a.name === b.name && ir1SsaExprEquals(a.receiver, b.receiver);
+    }
+    case "cond": {
+      if (b.kind !== "cond") {
+        return false;
+      }
+      return (
+        ir1SsaArrayEquals(a.arms, b.arms, ir1SsaCondArmEquals) &&
+        ir1SsaExprEquals(a.otherwise, b.otherwise)
+      );
+    }
+    case "is-nullish": {
+      if (b.kind !== "is-nullish") {
+        return false;
+      }
+      return ir1SsaExprEquals(a.operand, b.operand);
+    }
+    case "each": {
+      if (b.kind !== "each") {
+        return false;
+      }
+      return (
+        a.binder === b.binder &&
+        ir1SsaExprEquals(a.src, b.src) &&
+        ir1SsaArrayEquals(a.guards, b.guards, ir1SsaExprEquals) &&
+        ir1SsaExprEquals(a.proj, b.proj)
+      );
+    }
+    case "map-read": {
+      if (b.kind !== "map-read") {
+        return false;
+      }
+      return (
+        a.op === b.op &&
+        a.ruleName === b.ruleName &&
+        a.keyPredName === b.keyPredName &&
+        a.ownerType === b.ownerType &&
+        a.keyType === b.keyType &&
+        ir1SsaExprEquals(a.receiver, b.receiver) &&
+        ir1SsaExprEquals(a.key, b.key)
+      );
+    }
+    case "set-read": {
+      if (b.kind !== "set-read") {
+        return false;
+      }
+      return (
+        a.ruleName === b.ruleName &&
+        a.ownerType === b.ownerType &&
+        a.elemType === b.elemType &&
+        ir1SsaExprEquals(a.receiver, b.receiver) &&
+        ir1SsaExprEquals(a.elem, b.elem)
+      );
+    }
+    default:
+      return false;
+  }
+};
+
+const ir1SsaCondArmEquals = (
+  a: readonly [IR1Expr, IR1Expr],
+  b: readonly [IR1Expr, IR1Expr],
+): boolean => ir1SsaExprEquals(a[0], b[0]) && ir1SsaExprEquals(a[1], b[1]);
+
+const ir1SsaArrayEquals = <T>(
+  a: ReadonlyArray<T>,
+  b: ReadonlyArray<T>,
+  eq: (a: T, b: T) => boolean,
+): boolean => {
+  if (a.length !== b.length) {
+    return false;
+  }
+  for (let i = 0; i < a.length; i += 1) {
+    if (!eq(a[i] as T, b[i] as T)) {
+      return false;
+    }
+  }
+  return true;
+};
 
 const ir1SsaAssertWriteValueCompatible = (
   location: IR1SsaLocation,

--- a/tools/ts2pant/src/ir1.ts
+++ b/tools/ts2pant/src/ir1.ts
@@ -382,6 +382,303 @@ export type IR1ForeachBody =
     };
 
 // --------------------------------------------------------------------------
+// SSA contract forms
+// --------------------------------------------------------------------------
+//
+// Milestone 1 exposes the IR1 SSA vocabulary without wiring production
+// builders or lowerers to emit it yet. Versions are opaque identities that
+// carry their location metadata; callers compare version objects by identity
+// and inspect `location` when checking structural compatibility.
+
+const IR1_SSA_VERSION: unique symbol = Symbol("IR1_SSA_VERSION");
+
+export type IR1SsaRuleName = string;
+
+export type IR1SsaLocation =
+  | {
+      kind: "property";
+      ruleName: IR1SsaRuleName;
+      receiver: IR1Expr;
+      property: string;
+    }
+  | {
+      kind: "map-value";
+      ruleName: IR1SsaRuleName;
+      keyPredName: string;
+      ownerType: string;
+      keyType: string;
+      receiver: IR1Expr;
+      key: IR1Expr;
+    }
+  | {
+      kind: "map-membership";
+      ruleName: IR1SsaRuleName;
+      keyPredName: string;
+      ownerType: string;
+      keyType: string;
+      receiver: IR1Expr;
+      key: IR1Expr;
+    }
+  | {
+      kind: "set-membership";
+      ruleName: IR1SsaRuleName;
+      ownerType: string;
+      elemType: string;
+      receiver: IR1Expr;
+    };
+
+export interface IR1SsaVersion {
+  readonly kind: "ssa-version";
+  readonly id: symbol;
+  readonly location: IR1SsaLocation;
+  readonly origin: "initial" | "write" | "join" | "loop-summary";
+  readonly [IR1_SSA_VERSION]: true;
+}
+
+export type IR1SsaMapValue = {
+  kind: "map-value";
+  op: "set";
+  value: IR1Expr;
+};
+
+export type IR1SsaMapMembershipValue = {
+  kind: "map-membership";
+  op: "set" | "delete";
+};
+
+export type IR1SsaSetMembershipValue =
+  | {
+      kind: "set-membership";
+      op: "add" | "delete";
+      elem: IR1Expr;
+    }
+  | {
+      kind: "set-membership";
+      op: "clear";
+      elem: null;
+    };
+
+export type IR1SsaPropertyValue = {
+  kind: "property";
+  value: IR1Expr;
+};
+
+export type IR1SsaValue =
+  | IR1SsaPropertyValue
+  | IR1SsaMapValue
+  | IR1SsaMapMembershipValue
+  | IR1SsaSetMembershipValue;
+
+export interface IR1SsaRead {
+  readonly kind: "ssa-read";
+  readonly location: IR1SsaLocation;
+  readonly version: IR1SsaVersion;
+  readonly dominated: boolean;
+}
+
+export interface IR1SsaWrite {
+  readonly kind: "ssa-write";
+  readonly location: IR1SsaLocation;
+  readonly version: IR1SsaVersion;
+  readonly value: IR1SsaValue;
+}
+
+export interface IR1SsaJoin {
+  readonly kind: "ssa-join";
+  readonly location: IR1SsaLocation;
+  readonly thenVersion: IR1SsaVersion;
+  readonly elseVersion: IR1SsaVersion;
+  readonly joinVersion: IR1SsaVersion;
+}
+
+export interface IR1SsaLoopSummary {
+  readonly kind: "ssa-loop-summary";
+  readonly shape: "foreach-shape-a" | "foreach-shape-b";
+  readonly location: IR1SsaLocation;
+  readonly summaryVersion: IR1SsaVersion;
+}
+
+export interface IR1SsaProgram {
+  readonly reads: IR1SsaRead[];
+  readonly writes: IR1SsaWrite[];
+  readonly joins: IR1SsaJoin[];
+  readonly loopSummaries: IR1SsaLoopSummary[];
+  readonly declaredRules: IR1SsaRuleName[];
+  readonly modifiedRules: IR1SsaRuleName[];
+  readonly framedRules: IR1SsaRuleName[];
+}
+
+export const ir1SsaPropertyLocation = (
+  ruleName: IR1SsaRuleName,
+  receiver: IR1Expr,
+  property: string,
+): IR1SsaLocation => ({
+  kind: "property",
+  ruleName,
+  receiver,
+  property,
+});
+
+export const ir1SsaMapValueLocation = (
+  ruleName: IR1SsaRuleName,
+  keyPredName: string,
+  ownerType: string,
+  keyType: string,
+  receiver: IR1Expr,
+  key: IR1Expr,
+): IR1SsaLocation => ({
+  kind: "map-value",
+  ruleName,
+  keyPredName,
+  ownerType,
+  keyType,
+  receiver,
+  key,
+});
+
+export const ir1SsaMapMembershipLocation = (
+  ruleName: IR1SsaRuleName,
+  keyPredName: string,
+  ownerType: string,
+  keyType: string,
+  receiver: IR1Expr,
+  key: IR1Expr,
+): IR1SsaLocation => ({
+  kind: "map-membership",
+  ruleName,
+  keyPredName,
+  ownerType,
+  keyType,
+  receiver,
+  key,
+});
+
+export const ir1SsaSetMembershipLocation = (
+  ruleName: IR1SsaRuleName,
+  ownerType: string,
+  elemType: string,
+  receiver: IR1Expr,
+): IR1SsaLocation => ({
+  kind: "set-membership",
+  ruleName,
+  ownerType,
+  elemType,
+  receiver,
+});
+
+export const ir1SsaRuleOfLocation = (
+  location: IR1SsaLocation,
+): IR1SsaRuleName =>
+  location.kind === "map-membership" ? location.keyPredName : location.ruleName;
+
+const ir1SsaVersion = (
+  location: IR1SsaLocation,
+  origin: IR1SsaVersion["origin"],
+): IR1SsaVersion => ({
+  kind: "ssa-version",
+  id: Symbol(`ir1-ssa:${origin}`),
+  location,
+  origin,
+  [IR1_SSA_VERSION]: true,
+});
+
+export const ir1SsaInitialVersion = (location: IR1SsaLocation): IR1SsaVersion =>
+  ir1SsaVersion(location, "initial");
+
+export const ir1SsaWrite = (
+  location: IR1SsaLocation,
+  value: IR1SsaValue,
+): IR1SsaWrite => ({
+  kind: "ssa-write",
+  location,
+  version: ir1SsaVersion(location, "write"),
+  value,
+});
+
+export const ir1SsaRead = (
+  location: IR1SsaLocation,
+  version: IR1SsaVersion,
+  dominated = true,
+): IR1SsaRead => {
+  ir1SsaAssertLocationCompatible(location, version.location);
+  return { kind: "ssa-read", location, version, dominated };
+};
+
+export const ir1SsaJoin = (
+  location: IR1SsaLocation,
+  thenVersion: IR1SsaVersion,
+  elseVersion: IR1SsaVersion,
+): IR1SsaJoin | IR1SsaVersion => {
+  ir1SsaAssertLocationCompatible(location, thenVersion.location);
+  ir1SsaAssertLocationCompatible(location, elseVersion.location);
+  if (thenVersion === elseVersion) {
+    return thenVersion;
+  }
+  return {
+    kind: "ssa-join",
+    location,
+    thenVersion,
+    elseVersion,
+    joinVersion: ir1SsaVersion(location, "join"),
+  };
+};
+
+export const ir1SsaLoopSummary = (
+  shape: IR1SsaLoopSummary["shape"],
+  location: IR1SsaLocation,
+): IR1SsaLoopSummary => ({
+  kind: "ssa-loop-summary",
+  shape,
+  location,
+  summaryVersion: ir1SsaVersion(location, "loop-summary"),
+});
+
+export const ir1SsaPropertyValue = (value: IR1Expr): IR1SsaPropertyValue => ({
+  kind: "property",
+  value,
+});
+
+export const ir1SsaMapSetValue = (value: IR1Expr): IR1SsaMapValue => ({
+  kind: "map-value",
+  op: "set",
+  value,
+});
+
+export const ir1SsaMapMembershipValue = (
+  op: "set" | "delete",
+): IR1SsaMapMembershipValue => ({
+  kind: "map-membership",
+  op,
+});
+
+export const ir1SsaSetMembershipValue = (
+  op: "add" | "delete",
+  elem: IR1Expr,
+): IR1SsaSetMembershipValue => ({
+  kind: "set-membership",
+  op,
+  elem,
+});
+
+export const ir1SsaSetClearValue = (): IR1SsaSetMembershipValue => ({
+  kind: "set-membership",
+  op: "clear",
+  elem: null,
+});
+
+const ir1SsaAssertLocationCompatible = (
+  expected: IR1SsaLocation,
+  actual: IR1SsaLocation,
+): void => {
+  if (!ir1SsaLocationEquals(expected, actual)) {
+    throw new Error("IR1 SSA version location mismatch");
+  }
+};
+
+const ir1SsaLocationEquals = (a: IR1SsaLocation, b: IR1SsaLocation): boolean =>
+  JSON.stringify(a) === JSON.stringify(b);
+
+// --------------------------------------------------------------------------
 // Expression constructors
 // --------------------------------------------------------------------------
 

--- a/tools/ts2pant/tests/ir1-ssa-contract.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-contract.test.mts
@@ -125,6 +125,10 @@ describe("ir1-ssa-contract", () => {
     assert.equal(valueWrite.version.location, valueLocation);
     assert.equal(membershipWrite.version.location, membershipLocation);
     assert.deepEqual(program.modifiedRules, ["Score_value", "Score_hasKey"]);
+    assert.throws(
+      () => ir1SsaWrite(valueLocation, ir1SsaMapMembershipValue("delete")),
+      /write value\/location kind mismatch: location=map-value, value=map-membership/u,
+    );
   });
 
   it("models Set clear inside membership SSA value", () => {

--- a/tools/ts2pant/tests/ir1-ssa-contract.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-contract.test.mts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import {
+  type IR1Expr,
   type IR1SsaProgram,
   ir1LitBool,
   ir1LitNat,
@@ -76,6 +77,22 @@ describe("ir1-ssa-contract", () => {
         ir1SsaJoin(location, left.version, ir1SsaInitialVersion(otherLocation)),
       /location mismatch/u,
     );
+
+    const receiverWithoutDefaultPrimed: IR1Expr = {
+      kind: "var",
+      name: "account",
+    };
+    const equivalentLocation = ir1SsaPropertyLocation(
+      "Account_balance",
+      receiverWithoutDefaultPrimed,
+      "balance",
+    );
+    const compatibleJoin = ir1SsaJoin(
+      equivalentLocation,
+      left.version,
+      right.version,
+    );
+    assert.equal(compatibleJoin.kind, "ssa-join");
   });
 
   it("models Map state as coordinated value and membership locations", () => {

--- a/tools/ts2pant/tests/ir1-ssa-contract.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-contract.test.mts
@@ -1,29 +1,171 @@
+import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
+import {
+  type IR1SsaProgram,
+  ir1LitBool,
+  ir1LitNat,
+  ir1SsaInitialVersion,
+  ir1SsaJoin,
+  ir1SsaLoopSummary,
+  ir1SsaMapMembershipLocation,
+  ir1SsaMapMembershipValue,
+  ir1SsaMapSetValue,
+  ir1SsaMapValueLocation,
+  ir1SsaPropertyLocation,
+  ir1SsaPropertyValue,
+  ir1SsaRuleOfLocation,
+  ir1SsaSetClearValue,
+  ir1SsaSetMembershipLocation,
+  ir1SsaWrite,
+  ir1Var,
+} from "../src/ir1.js";
+
 describe("ir1-ssa-contract", () => {
-  it.skip("allocates opaque versions with location metadata", () => {
-    // PENDING: Patch 2 implements opaque version allocation + location metadata.
+  it("allocates opaque versions with location metadata", () => {
+    const location = ir1SsaPropertyLocation(
+      "Account_balance",
+      ir1Var("account"),
+      "balance",
+    );
+
+    const initial = ir1SsaInitialVersion(location);
+    const write = ir1SsaWrite(location, ir1SsaPropertyValue(ir1LitNat(10)));
+
+    assert.equal(initial.kind, "ssa-version");
+    assert.equal(typeof initial.id, "symbol");
+    assert.equal(typeof write.version.id, "symbol");
+    assert.equal(initial.location, location);
+    assert.equal(write.location, location);
+    assert.equal(write.version.location, location);
+    assert.notEqual(initial.id, write.version.id);
+    assert.equal(ir1SsaRuleOfLocation(location), "Account_balance");
   });
 
-  it.skip(
-    "simplifies degenerate joins before constructing join nodes",
-    () => {
-      // PENDING: Patch 2 implements join construction and simplification.
-    },
-  );
+  it("simplifies degenerate joins before constructing join nodes", () => {
+    const location = ir1SsaPropertyLocation(
+      "Account_balance",
+      ir1Var("account"),
+      "balance",
+    );
+    const left = ir1SsaWrite(location, ir1SsaPropertyValue(ir1LitNat(1)));
+    const right = ir1SsaWrite(location, ir1SsaPropertyValue(ir1LitNat(2)));
 
-  it.skip(
-    "models Map state as coordinated value and membership locations",
-    () => {
-      // PENDING: Patch 2 implements coordinated Map SSA locations.
-    },
-  );
+    const degenerate = ir1SsaJoin(location, left.version, left.version);
+    assert.equal(degenerate, left.version);
 
-  it.skip("models Set clear inside membership SSA value", () => {
-    // PENDING: Patch 2 implements Set membership SSA value construction.
+    const join = ir1SsaJoin(location, left.version, right.version);
+    assert.equal(join.kind, "ssa-join");
+    if (join.kind !== "ssa-join") {
+      assert.fail("expected a non-degenerate join node");
+    }
+    assert.equal(join.location, location);
+    assert.equal(join.thenVersion, left.version);
+    assert.equal(join.elseVersion, right.version);
+    assert.equal(join.joinVersion.location, location);
+    assert.notEqual(join.joinVersion, left.version);
+    assert.notEqual(join.joinVersion, right.version);
+
+    const otherLocation = ir1SsaPropertyLocation(
+      "Account_limit",
+      ir1Var("account"),
+      "limit",
+    );
+    assert.throws(
+      () =>
+        ir1SsaJoin(location, left.version, ir1SsaInitialVersion(otherLocation)),
+      /location mismatch/u,
+    );
   });
 
-  it.skip("exposes distinct loop-summary versions", () => {
-    // PENDING: Patch 2 implements loop-summary SSA version allocation.
+  it("models Map state as coordinated value and membership locations", () => {
+    const receiver = ir1Var("scores");
+    const key = ir1Var("player");
+    const valueLocation = ir1SsaMapValueLocation(
+      "Score_value",
+      "Score_hasKey",
+      "Scoreboard",
+      "Player",
+      receiver,
+      key,
+    );
+    const membershipLocation = ir1SsaMapMembershipLocation(
+      "Score_value",
+      "Score_hasKey",
+      "Scoreboard",
+      "Player",
+      receiver,
+      key,
+    );
+
+    const valueWrite = ir1SsaWrite(
+      valueLocation,
+      ir1SsaMapSetValue(ir1LitNat(7)),
+    );
+    const membershipWrite = ir1SsaWrite(
+      membershipLocation,
+      ir1SsaMapMembershipValue("set"),
+    );
+    const program: IR1SsaProgram = {
+      reads: [],
+      writes: [valueWrite, membershipWrite],
+      joins: [],
+      loopSummaries: [],
+      declaredRules: ["Score_value", "Score_hasKey"],
+      modifiedRules: [
+        ir1SsaRuleOfLocation(valueLocation),
+        ir1SsaRuleOfLocation(membershipLocation),
+      ],
+      framedRules: [],
+    };
+
+    assert.equal(valueLocation.kind, "map-value");
+    assert.equal(membershipLocation.kind, "map-membership");
+    assert.equal(valueLocation.keyPredName, membershipLocation.keyPredName);
+    assert.equal(valueWrite.version.location, valueLocation);
+    assert.equal(membershipWrite.version.location, membershipLocation);
+    assert.deepEqual(program.modifiedRules, ["Score_value", "Score_hasKey"]);
+  });
+
+  it("models Set clear inside membership SSA value", () => {
+    const location = ir1SsaSetMembershipLocation(
+      "Group_members",
+      "Group",
+      "User",
+      ir1Var("group"),
+    );
+    const write = ir1SsaWrite(location, ir1SsaSetClearValue());
+
+    assert.equal(location.kind, "set-membership");
+    assert.equal(write.location, location);
+    assert.equal(write.value.kind, "set-membership");
+    assert.equal(write.value.op, "clear");
+    assert.equal(write.value.elem, null);
+  });
+
+  it("exposes distinct loop-summary versions", () => {
+    const shapeALocation = ir1SsaPropertyLocation(
+      "Item_seen",
+      ir1Var("$item"),
+      "seen",
+    );
+    const shapeBLocation = ir1SsaPropertyLocation(
+      "Account_total",
+      ir1Var("account"),
+      "total",
+    );
+    const ordinaryWrite = ir1SsaWrite(
+      shapeALocation,
+      ir1SsaPropertyValue(ir1LitBool(true)),
+    );
+    const shapeASummary = ir1SsaLoopSummary("foreach-shape-a", shapeALocation);
+    const shapeBSummary = ir1SsaLoopSummary("foreach-shape-b", shapeBLocation);
+
+    assert.equal(shapeASummary.summaryVersion.location, shapeALocation);
+    assert.equal(shapeBSummary.summaryVersion.location, shapeBLocation);
+    assert.equal(shapeASummary.summaryVersion.origin, "loop-summary");
+    assert.equal(shapeBSummary.summaryVersion.origin, "loop-summary");
+    assert.notEqual(shapeASummary.summaryVersion, ordinaryWrite.version);
+    assert.notEqual(shapeASummary.summaryVersion.id, ordinaryWrite.version.id);
   });
 });


### PR DESCRIPTION
## Patch 2: Implement the IR1 SSA type and constructor contract

- Add an IR1 SSA section to ir1.ts without deleting existing IR1Expr or IR1Stmt forms.
- Define IR1SsaLocation variants for property locations, Map value locations, Map membership locations, and Set membership locations.
- Define IR1SsaVersion as an opaque identity carrying its IR1SsaLocation.
- Define IR1SsaRead, IR1SsaWrite, IR1SsaJoin, IR1SsaLoopSummary, and IR1SsaProgram types sufficient to express the workstream spec's structural invariants.
- Provide constructor helpers for locations and versions; helpers should allocate opaque version ids and should not expose numeric counter semantics as the public contract.
- Provide a join helper that enforces location compatibility and simplifies degenerate joins by returning the existing version instead of constructing an IR1SsaJoin.
- Represent Set clear as data inside the Set membership SSA value rather than a separate IR1SsaLocation variant.
- Represent foreach Shape A/B effects using IR1SsaLoopSummary with summaryVersion distinct from ordinary IR1SsaWrite versions.
- Unskip and implement all tests introduced by Patch 1.
- Run npm test for ts2pant unit tests or at minimum npx tsx --test --test-timeout=300000 tests/ir1-ssa-contract.test.mts from tools/ts2pant.

## Changes
- Add an IR1 SSA section to ir1.ts without deleting existing IR1Expr or IR1Stmt forms.
- Define IR1SsaLocation variants for property locations, Map value locations, Map membership locations, and Set membership locations.
- Define IR1SsaVersion as an opaque identity carrying its IR1SsaLocation.
- Define IR1SsaRead, IR1SsaWrite, IR1SsaJoin, IR1SsaLoopSummary, and IR1SsaProgram types sufficient to express the workstream spec's structural invariants.
- Provide constructor helpers for locations and versions; helpers should allocate opaque version ids and should not expose numeric counter semantics as the public contract.
- Provide a join helper that enforces location compatibility and simplifies degenerate joins by returning the existing version instead of constructing an IR1SsaJoin.
- Represent Set clear as data inside the Set membership SSA value rather than a separate IR1SsaLocation variant.
- Represent foreach Shape A/B effects using IR1SsaLoopSummary with summaryVersion distinct from ordinary IR1SsaWrite versions.
- Unskip and implement all tests introduced by Patch 1.
- Run npm test for ts2pant unit tests or at minimum npx tsx --test --test-timeout=300000 tests/ir1-ssa-contract.test.mts from tools/ts2pant.

## Files to Modify
- tools/ts2pant/src/ir1.ts (modify): Add IR1 SSA location/version/read/write/join/summary/program types and helper constructors directly in the IR1 module.
- tools/ts2pant/tests/ir1-ssa-contract.test.mts (modify): Remove skip markers and implement the contract tests against the new IR1 SSA exports.

## Gameplan Specification

```
module IR1_SSA_CONTRACT.

IR1Program.
Construct.
Location.
Version.
Read.
Write.
Join.
LoopSummary.
Rule.
PropResult.
Diagnostic.

supported-constructs p: IR1Program => [Construct].
lowered-constructs p: IR1Program => [Construct].
diagnostics p: IR1Program => [Diagnostic].
diagnostic-construct d: Diagnostic => Construct.
writes p: IR1Program => [Write].
reads p: IR1Program => [Read].
joins p: IR1Program => [Join].
loop-summaries p: IR1Program => [LoopSummary].
write-location w: Write => Location.
write-version w: Write => Version.
read-location r: Read => Location.
read-version r: Read => Version.
read-dominated? p: IR1Program, r: Read => Bool.
join-location j: Join => Location.
then-version j: Join => Version.
else-version j: Join => Version.
join-version j: Join => Version.
summary-location s: LoopSummary => Location.
summary-version s: LoopSummary => Version.
initial-version l: Location => Version.
version-location v: Version => Location.
rule-of-location l: Location => Rule.
declared-rules p: IR1Program => [Rule].
modified-rules p: IR1Program => [Rule].
framed-rules p: IR1Program => [Rule].
emitted-props p: IR1Program => [PropResult].

---

all p: IR1Program, c in supported-constructs p |
  c in lowered-constructs p.

all p: IR1Program, d in diagnostics p |
  ~(diagnostic-construct d in supported-constructs p).

all p: IR1Program, w in writes p |
  version-location (write-version w) = write-location w.

all p: IR1Program, s in loop-summaries p |
  version-location (summary-version s) = summary-location s.

all l: Location |
  version-location (initial-version l) = l.

all p: IR1Program, w1 in writes p, w2 in writes p |
  write-version w1 = write-version w2 -> w1 = w2.

all p: IR1Program, r in reads p |
  read-dominated? p r and
  version-location (read-version r) = read-location r and
  (
    read-version r = initial-version (read-location r) or
    (some w in writes p |
      write-version w = read-version r and
      write-location w = read-location r) or
    (some s in loop-summaries p |
      summary-version s = read-version r and
      summary-location s = read-location r)
  ).

all p: IR1Program, j in joins p |
  version-location (then-version j) = join-location j and
  version-location (else-version j) = join-location j and
  version-location (join-version j) = join-location j.

all p: IR1Program, j in joins p |
  then-version j != else-version j and
  join-version j != then-version j and
  join-version j != else-version j.

all p: IR1Program, rule in modified-rules p |
  rule in declared-rules p and
  ~(rule in framed-rules p).

all p: IR1Program, rule in framed-rules p |
  rule in declared-rules p and
  ~(rule in modified-rules p).

all p: IR1Program, rule in declared-rules p |
  rule in modified-rules p or rule in framed-rules p.

all p: IR1Program, w in writes p |
  rule-of-location (write-location w) in modified-rules p.

all p: IR1Program, s in loop-summaries p |
  rule-of-location (summary-location s) in modified-rules p.

all p: IR1Program |
  #(lowered-constructs p) > 0 -> #(emitted-props p) > 0.

```

## Patch Specification

```
module IR1_SSA_CONTRACT_PATCH_2.

IR1Program.
Location.
Version.
Write.
Join.
LoopSummary.
Rule.

writes p: IR1Program => [Write].
joins p: IR1Program => [Join].
loop-summaries p: IR1Program => [LoopSummary].
write-location w: Write => Location.
write-version w: Write => Version.
join-location j: Join => Location.
then-version j: Join => Version.
else-version j: Join => Version.
join-version j: Join => Version.
summary-location s: LoopSummary => Location.
summary-version s: LoopSummary => Version.
version-location v: Version => Location.
rule-of-location l: Location => Rule.
modified-rules p: IR1Program => [Rule].

---

> Opaque versions always carry the location they version.
all p: IR1Program, w in writes p |
  version-location (write-version w) = write-location w.

all p: IR1Program, s in loop-summaries p |
  version-location (summary-version s) = summary-location s.

> Final IR1 SSA contains no degenerate joins.
all p: IR1Program, j in joins p |
  version-location (then-version j) = join-location j and
  version-location (else-version j) = join-location j and
  version-location (join-version j) = join-location j and
  then-version j != else-version j and
  join-version j != then-version j and
  join-version j != else-version j.

> Writes and summaries mark their underlying rules modified.
all p: IR1Program, w in writes p |
  rule-of-location (write-location w) in modified-rules p.

all p: IR1Program, s in loop-summaries p |
  rule-of-location (summary-location s) in modified-rules p.

```


## Implementation Notes

- Version identities are symbol-backed and branded in the type surface; the exported contract exposes identity comparison and `location` metadata, but no numeric allocation sequence.
- Location compatibility is checked structurally, so separately constructed locations with the same IR1 payload can be joined/read together. Map membership locations report `keyPredName` from `ir1SsaRuleOfLocation`, while Map value locations report the value rule.
- `ir1SsaJoin` intentionally returns a union: a degenerate join returns the existing `IR1SsaVersion`, while a non-degenerate join returns an `IR1SsaJoin` carrying a fresh `joinVersion`.
- Full `npm run test:unit` is still blocked in this environment by the missing generated wasm loader and missing local OCaml wasm toolchain; the focused contract test, `tsc --noEmit`, and Biome checks on the touched files pass.