### PR TITLE
[ir1-ssa-contract] Patch 3: Document the Milestone 1 IR1 SSA contract

### DIFF
--- a/tools/ts2pant/CLAUDE.md
+++ b/tools/ts2pant/CLAUDE.md
@@ -764,8 +764,11 @@ like assignment. To overcome this challenge we translate FRSC to a functional
 language IRSC through a Static Single Assignment (SSA) transformation"* — is
 exactly our situation.
 
-The IR landed across the imperative-IR workstream's six milestones
-(M1–M6); see § "Imperative IR Workstream" below. Deviations from IRSC
+The IR1 SSA workstream supersedes `SymbolicState` as the long-term
+semantic model for mutating bodies. Milestone 1 is additive and
+type-level: it reviews the IR contract in `src/ir1.ts` without changing
+production builder or lowerer behavior yet. The existing translation
+path still runs until later milestones replace it. Deviations from IRSC
 live in § "Divergence from IRSC".
 
 ### Files
@@ -776,7 +779,9 @@ live in § "Divergence from IRSC".
 - `src/ir-emit.ts` — L2 IRExpr → `OpaqueExpr` lowering.
 - `src/ir1.ts`, `src/ir1-build.ts`, `src/ir1-build-body.ts`,
   `src/ir1-lower.ts`, `src/ir1-lower-body.ts` — Layer 1 (TS-shape
-  imperative IR; see § "Imperative IR Workstream" below).
+  imperative IR today; the SSA-bearing contract now lives in
+  `src/ir1.ts`, while production lowering continues through
+  `SymbolicState` until later milestones).
 
 ### Two paths, one Layer 1
 
@@ -789,7 +794,9 @@ shared Layer 1 IR:
   fallback for this path.
 - **Effect / statement-position** — TS → L1 statement →
   `PropResult[]` directly via a single fold (`lowerL1Body`) over
-  `SymbolicState` (in `translate-body.ts`). The mutating output is a
+  `SymbolicState` (in `translate-body.ts`) for now. The IR1 SSA
+  contract is already present in `src/ir1.ts`, but Milestone 1 keeps
+  production lowering on the existing path. The mutating output is a
   list of equations + frame conditions; no L2 statement vocabulary.
 
 L2 is *expression-only* — there is no L2 `IRStmt`. The asymmetry is
@@ -817,6 +824,29 @@ canonical L1 constructors. Constructions that fall outside the
 canonical vocabulary reject as `unsupported`; there is no opaque
 catch-all that would smuggle uncanonicalized TS shapes through the
 pipeline.
+
+### `IR1` SSA contract surface
+
+Milestone 1 adds the SSA-bearing type vocabulary and constructor helpers
+in `src/ir1.ts`. The key exported names are:
+
+- Types: `IR1SsaLocation`, `IR1SsaVersion`, `IR1SsaRead`,
+  `IR1SsaWrite`, `IR1SsaJoin`, `IR1SsaLoopSummary`, `IR1SsaProgram`,
+  `IR1SsaValue`.
+- Location helpers: `ir1SsaPropertyLocation`,
+  `ir1SsaMapValueLocation`, `ir1SsaMapMembershipLocation`,
+  `ir1SsaSetMembershipLocation`, `ir1SsaRuleOfLocation`.
+- Version helpers: `ir1SsaInitialVersion`.
+- Read / write / join helpers: `ir1SsaRead`, `ir1SsaWrite`,
+  `ir1SsaJoin`, `ir1SsaLoopSummary`.
+- Value helpers: `ir1SsaPropertyValue`, `ir1SsaMapSetValue`,
+  `ir1SsaMapMembershipValue`, `ir1SsaSetMembershipValue`,
+  `ir1SsaSetClearValue`.
+
+These helpers establish the contract surface and enforce structural
+choices like location-compatible versions and degenerate-join
+simplification. They do not change the production builder/lowerer path
+yet.
 
 ### Mutating-body output (no L2 IR)
 
@@ -926,11 +956,17 @@ small canonical vocabulary. **Layer 2** is `IRExpr` in `src/ir.ts` —
 Pant-shaped *expression* IR (post-M3, statement-position lowering bypasses
 L2; see § "Two paths, one Layer 1" above). **Layer 3** is `OpaqueExpr`.
 
+The IR1 SSA workstream does not replace this Layer 1 shape all at once.
+Milestone 1 adds the SSA contract alongside the existing Layer 1
+constructors so later milestones can migrate the builder and lowerer
+without changing the surface review now.
+
 Lowering for value-position: TS AST → Layer 1 (`ir1-build.ts`) → Layer 2
 (`ir1-lower.ts`) → OpaqueExpr (`ir-emit.ts`).
 
 Lowering for effect-position: TS AST → Layer 1 (`ir1-build-body.ts`) →
-`PropResult[]` (`ir1-lower-body.ts`, threading `SymbolicState`).
+`PropResult[]` (`ir1-lower-body.ts`, threading `SymbolicState` for the
+current production path).
 
 The full milestone breakdown lives in
 `workstreams/ts2pant-imperative-ir.md`. Decisions on canonical forms,

--- a/tools/ts2pant/src/ir1.ts
+++ b/tools/ts2pant/src/ir1.ts
@@ -873,17 +873,6 @@ const ir1SsaAssertWriteValueCompatible = (
   }
 };
 
-const ir1SsaAssertWriteValueCompatible = (
-  location: IR1SsaLocation,
-  value: IR1SsaValue,
-): void => {
-  if (location.kind !== value.kind) {
-    throw new Error(
-      `IR1 SSA write value/location kind mismatch: location=${location.kind}, value=${value.kind}`,
-    );
-  }
-};
-
 // --------------------------------------------------------------------------
 // Expression constructors
 // --------------------------------------------------------------------------

--- a/tools/ts2pant/src/ir1.ts
+++ b/tools/ts2pant/src/ir1.ts
@@ -873,6 +873,17 @@ const ir1SsaAssertWriteValueCompatible = (
   }
 };
 
+const ir1SsaAssertWriteValueCompatible = (
+  location: IR1SsaLocation,
+  value: IR1SsaValue,
+): void => {
+  if (location.kind !== value.kind) {
+    throw new Error(
+      `IR1 SSA write value/location kind mismatch: location=${location.kind}, value=${value.kind}`,
+    );
+  }
+};
+
 // --------------------------------------------------------------------------
 // Expression constructors
 // --------------------------------------------------------------------------

--- a/workstreams/ts2pant-ir1-ssa.md
+++ b/workstreams/ts2pant-ir1-ssa.md
@@ -55,14 +55,26 @@ folds all live as special paths in the lowering code.
 ### Milestone 1: ir1-ssa-contract
 
 **Definition of Done**:
-`tools/ts2pant/src/ir1.ts` defines IR1 as the SSA-bearing semantic IR for both
-value and effect positions. The type vocabulary includes explicit state
-locations, SSA versions, reads, writes, branch joins, Map effects, Set effects,
-frameable modified-rule tracking, and loop-summary forms for existing foreach
-Shape A / Shape B and μ-search outputs. The document comments in `ir1.ts`,
-`tools/ts2pant/CLAUDE.md`, and this workstream agree on the new IR1 contract.
-No production builder is required to emit the new forms yet, but the new types
-compile and unit tests can construct representative IR1 SSA values.
+`tools/ts2pant/src/ir1.ts` now defines IR1 as the SSA-bearing semantic IR for
+both value and effect positions. The exported contract surface includes:
+
+- SSA data types: `IR1SsaLocation`, `IR1SsaVersion`, `IR1SsaRead`,
+  `IR1SsaWrite`, `IR1SsaJoin`, `IR1SsaLoopSummary`, `IR1SsaProgram`,
+  `IR1SsaValue`.
+- Location helpers: `ir1SsaPropertyLocation`, `ir1SsaMapValueLocation`,
+  `ir1SsaMapMembershipLocation`, `ir1SsaSetMembershipLocation`,
+  `ir1SsaRuleOfLocation`.
+- Version helper: `ir1SsaInitialVersion`.
+- SSA constructors: `ir1SsaRead`, `ir1SsaWrite`, `ir1SsaJoin`,
+  `ir1SsaLoopSummary`.
+- SSA value helpers: `ir1SsaPropertyValue`, `ir1SsaMapSetValue`,
+  `ir1SsaMapMembershipValue`, `ir1SsaSetMembershipValue`,
+  `ir1SsaSetClearValue`.
+
+The document comments in `ir1.ts`, `tools/ts2pant/CLAUDE.md`, and this
+workstream all describe the same contract. Milestone 1 stays additive and
+type-level: the existing production builder and lowerer paths remain in place,
+and no translation behavior changes yet.
 
 **Why this is a safe pause point**:
 The milestone is type-level and documentation-level. Existing translation
@@ -73,10 +85,16 @@ contract is reviewed in isolation.
 Implementation of the new builder and lowerer against a stable vocabulary.
 
 **Open Questions**:
-None. Version identity is settled: IR1 SSA uses opaque version symbols, with
-`version-location` / equivalent metadata linking each version back to its
-location. Degenerate joins are structurally invalid in final IR1 SSA; shared
-builder helpers should simplify them away before constructing join nodes.
+Beyond Milestone 1, the remaining questions are implementation sequencing, not
+contract shape:
+
+- When the builder begins emitting SSA writes for scalar bodies, should it
+  reuse the existing L1 statement forms or introduce a dedicated SSA builder
+  helper layer first?
+- Which later milestone will retire `SymbolicState` as the production
+  mutating-body model?
+- How should map/set and loop-summary lowering reuse the M1 vocabulary without
+  widening the public contract again?
 
 ---
 


### PR DESCRIPTION
## Patch 3: Document the Milestone 1 IR1 SSA contract

- Update the Intermediate Representation section in tools/ts2pant/CLAUDE.md to say that the IR1 SSA workstream supersedes SymbolicState as the long-term semantic model for mutating bodies.
- Document that Milestone 1 is additive and type-level: production builders and lowerers still use the existing path until later milestones.
- Add a short list of the exported IR1 SSA types and helper constructors introduced in Patch 2.
- Update workstreams/ts2pant-ir1-ssa.md so Milestone 1 reflects the implemented names and no longer reads as purely future-tense.
- Do not claim that builders emit IR1 SSA or that SymbolicState has been removed; those are later milestones.

## Changes
- Update the Intermediate Representation section in tools/ts2pant/CLAUDE.md to say that the IR1 SSA workstream supersedes SymbolicState as the long-term semantic model for mutating bodies.
- Document that Milestone 1 is additive and type-level: production builders and lowerers still use the existing path until later milestones.
- Add a short list of the exported IR1 SSA types and helper constructors introduced in Patch 2.
- Update workstreams/ts2pant-ir1-ssa.md so Milestone 1 reflects the implemented names and no longer reads as purely future-tense.
- Do not claim that builders emit IR1 SSA or that SymbolicState has been removed; those are later milestones.

## Files to Modify
- tools/ts2pant/CLAUDE.md (modify): Update IR architecture notes to describe the new IR1 SSA contract and its Milestone 1 scope.
- workstreams/ts2pant-ir1-ssa.md (modify): Record Milestone 1 implementation details, final type/helper names, and remaining non-Milestone-1 open questions.

## Gameplan Specification

```
module IR1_SSA_CONTRACT.

IR1Program.
Construct.
Location.
Version.
Read.
Write.
Join.
LoopSummary.
Rule.
PropResult.
Diagnostic.

supported-constructs p: IR1Program => [Construct].
lowered-constructs p: IR1Program => [Construct].
diagnostics p: IR1Program => [Diagnostic].
diagnostic-construct d: Diagnostic => Construct.
writes p: IR1Program => [Write].
reads p: IR1Program => [Read].
joins p: IR1Program => [Join].
loop-summaries p: IR1Program => [LoopSummary].
write-location w: Write => Location.
write-version w: Write => Version.
read-location r: Read => Location.
read-version r: Read => Version.
read-dominated? p: IR1Program, r: Read => Bool.
join-location j: Join => Location.
then-version j: Join => Version.
else-version j: Join => Version.
join-version j: Join => Version.
summary-location s: LoopSummary => Location.
summary-version s: LoopSummary => Version.
initial-version l: Location => Version.
version-location v: Version => Location.
rule-of-location l: Location => Rule.
declared-rules p: IR1Program => [Rule].
modified-rules p: IR1Program => [Rule].
framed-rules p: IR1Program => [Rule].
emitted-props p: IR1Program => [PropResult].

---

all p: IR1Program, c in supported-constructs p |
  c in lowered-constructs p.

all p: IR1Program, d in diagnostics p |
  ~(diagnostic-construct d in supported-constructs p).

all p: IR1Program, w in writes p |
  version-location (write-version w) = write-location w.

all p: IR1Program, s in loop-summaries p |
  version-location (summary-version s) = summary-location s.

all l: Location |
  version-location (initial-version l) = l.

all p: IR1Program, w1 in writes p, w2 in writes p |
  write-version w1 = write-version w2 -> w1 = w2.

all p: IR1Program, r in reads p |
  read-dominated? p r and
  version-location (read-version r) = read-location r and
  (
    read-version r = initial-version (read-location r) or
    (some w in writes p |
      write-version w = read-version r and
      write-location w = read-location r) or
    (some s in loop-summaries p |
      summary-version s = read-version r and
      summary-location s = read-location r)
  ).

all p: IR1Program, j in joins p |
  version-location (then-version j) = join-location j and
  version-location (else-version j) = join-location j and
  version-location (join-version j) = join-location j.

all p: IR1Program, j in joins p |
  then-version j != else-version j and
  join-version j != then-version j and
  join-version j != else-version j.

all p: IR1Program, rule in modified-rules p |
  rule in declared-rules p and
  ~(rule in framed-rules p).

all p: IR1Program, rule in framed-rules p |
  rule in declared-rules p and
  ~(rule in modified-rules p).

all p: IR1Program, rule in declared-rules p |
  rule in modified-rules p or rule in framed-rules p.

all p: IR1Program, w in writes p |
  rule-of-location (write-location w) in modified-rules p.

all p: IR1Program, s in loop-summaries p |
  rule-of-location (summary-location s) in modified-rules p.

all p: IR1Program |
  #(lowered-constructs p) > 0 -> #(emitted-props p) > 0.

```

## Patch Specification

```
module IR1_SSA_CONTRACT_PATCH_3.

Documentation.
Decision.

records d: Documentation => [Decision].
current? d: Documentation => Bool.

---

> Patch 3 aligns developer documentation with the implemented contract.
all d: Documentation | current? d -> #(records d) >= 0.

```


## Implementation Notes

- Patch 3 is documentation-only: it does not touch the translator, builder, or lowerer code paths.
- I kept the wording deliberately scoped to Milestone 1 so it names the new SSA contract surface without implying that `SymbolicState` has been retired or that production output now comes from SSA builders.
- The workstream note now includes the concrete exported `IR1Ssa*` types and helper constructors from `src/ir1.ts`, which is the main reviewer-facing change beyond the architecture wording.