### PR TITLE
[ir1-ssa-builder-scalars] Patch 1: Add skipped scalar SSA acceptance tests

### DIFF
--- a/tools/ts2pant/tests/ir1-ssa-scalars.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-scalars.test.mts
@@ -1,0 +1,169 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { resolve } from "node:path";
+
+import { createSourceFile } from "../src/extract.js";
+import { buildDocumentFromSourceFile, emitAndCheck } from "./helpers.mjs";
+
+const CONSTRUCTS_DIR = resolve(import.meta.dirname, "fixtures/constructs");
+
+function loadFixture(fileName: string) {
+  return createSourceFile(resolve(CONSTRUCTS_DIR, fileName));
+}
+
+async function emitFixture(fileName: string, functionName: string) {
+  const sourceFile = loadFixture(fileName);
+  const doc = await buildDocumentFromSourceFile(sourceFile, functionName);
+  return emitAndCheck(doc);
+}
+
+describe.skip("ir1-ssa-scalars", () => {
+  // PENDING Patch 2: add the scalar SSA builder state and write/version recording.
+  // PENDING Patch 3: lower final scalar versions back into the current Pant equations.
+  // PENDING Patch 4: route scalar assignments and scalar if-mutation through SSA.
+  // PENDING Patch 5: route early-exit continuation merges through SSA.
+
+  it.skip("records direct property assignment as an SSA write", async () => {
+    const sourceFile = loadFixture("functions-mutating.ts");
+    void sourceFile;
+
+    // `reset` is the minimal scalar write shape: one property assignment
+    // whose lowered output should ultimately expose a single SSA write and
+    // the corresponding final property version.
+    assert.fail("PENDING: scalar SSA write/version assertions are not wired yet");
+  });
+
+  it.skip("resolves compound property assignment through the dominating prior version", async () => {
+    const source = `
+      interface Account {
+        balance: number;
+      }
+      export function f(a: Account): void {
+        a.balance = 1;
+        a.balance += 2;
+      }
+    `;
+    void source;
+
+    // PENDING Patch 2 + Patch 3: this should assert that the compound write
+    // reads the dominating scalar version rather than the pre-state value.
+    assert.fail("PENDING: compound scalar SSA read dominance is not implemented yet");
+  });
+
+  it.skip("joins a single-arm if against the initial property version", async () => {
+    const source = `
+      interface Account {
+        balance: number;
+      }
+      export function f(a: Account, g: boolean): void {
+        if (g) {
+          a.balance = 1;
+        }
+      }
+    `;
+    void source;
+
+    // PENDING Patch 4: the scalar SSA route should build a join against the
+    // pre-state initial version for the else-free arm.
+    assert.fail("PENDING: single-arm scalar join lowering is not implemented yet");
+  });
+
+  it.skip("lowers nested scalar if bodies through SSA joins", async () => {
+    const source = `
+      interface Account {
+        balance: number;
+      }
+      export function f(a: Account, x: boolean, y: boolean): void {
+        if (x) {
+          if (y) {
+            a.balance = 1;
+          } else {
+            a.balance = 2;
+          }
+        } else {
+          a.balance = 3;
+        }
+      }
+    `;
+    void source;
+
+    // PENDING Patch 4: nested scalar conditionals should lower as nested SSA
+    // joins or equivalent nested cond output, preserving the current output shape.
+    assert.fail("PENDING: nested scalar SSA joins are not implemented yet");
+  });
+
+  it.skip(
+    "preserves translateBody parity for scalar sequential write/read fixtures",
+    async () => {
+      const output = await emitFixture(
+        "functions-mutating-conditional.ts",
+        "accumulateIf",
+      );
+      void output;
+
+      // PENDING Patch 4: this fixture should still emit the same Pantagruel
+      // text after the scalar SSA route becomes active.
+      assert.fail("PENDING: scalar translateBody parity is not implemented yet");
+    },
+  );
+
+  it.skip(
+    "preserves translateBody parity for asymmetric branch write fixtures",
+    async () => {
+      const output = await emitFixture(
+        "functions-mutating-conditional.ts",
+        "asymmetric",
+      );
+      void output;
+
+      // PENDING Patch 4: asymmetric branch writes should keep the current
+      // output while switching the scalar mutation path to SSA internally.
+      assert.fail("PENDING: asymmetric branch parity is not implemented yet");
+    },
+  );
+
+  it.skip(
+    "preserves translateBody parity for chained early-return fixtures",
+    async () => {
+      const output = await emitFixture(
+        "functions-mutating-early-exit.ts",
+        "chainedEarlyReturns",
+      );
+      void output;
+
+      // PENDING Patch 5: continuation merges after chained early exits should
+      // remain byte-stable at the Pantagruel boundary.
+      assert.fail("PENDING: chained early-return parity is not implemented yet");
+    },
+  );
+
+  it.skip(
+    "preserves translateBody parity for else-branch early-return fixtures",
+    async () => {
+      const output = await emitFixture(
+        "functions-mutating-early-exit.ts",
+        "elseBranchReturn",
+      );
+      void output;
+
+      // PENDING Patch 5: else-branch early returns should keep the current
+      // continuation-matching output after SSA routing lands.
+      assert.fail("PENDING: else-branch early-return parity is not implemented yet");
+    },
+  );
+
+  it.skip(
+    "preserves translateBody parity for write-then-early-return fixtures",
+    async () => {
+      const output = await emitFixture(
+        "functions-mutating-early-exit.ts",
+        "writeThenEarlyReturn",
+      );
+      void output;
+
+      // PENDING Patch 5: the post-return write path should stay output-stable
+      // once early-exit merges are routed through scalar SSA.
+      assert.fail("PENDING: write-then-early-return parity is not implemented yet");
+    },
+  );
+});


### PR DESCRIPTION
## Patch 1: Add skipped scalar SSA acceptance tests

- Create describe("ir1-ssa-scalars", ...) with skip markers and PENDING comments naming the implementation patches.
- Add a pending unit test proving direct property assignment creates an IR1 SSA property write and final property version.
- Add a pending unit test proving compound property assignment reads the dominating prior property version.
- Add a pending unit test proving a single-arm if creates a join against the pre-state initial version.
- Add a pending unit test proving nested if/else scalar mutation creates nested joins or equivalent nested cond output.
- Add pending translateBody parity tests for existing scalar fixtures: sequential write/read, asymmetric branch writes, chained early returns, else-branch early return, and write-then-early-return.
- Keep the tests skipped so this patch is non-functional and independently mergeable.

## Changes
- Create describe("ir1-ssa-scalars", ...) with skip markers and PENDING comments naming the implementation patches.
- Add a pending unit test proving direct property assignment creates an IR1 SSA property write and final property version.
- Add a pending unit test proving compound property assignment reads the dominating prior property version.
- Add a pending unit test proving a single-arm if creates a join against the pre-state initial version.
- Add a pending unit test proving nested if/else scalar mutation creates nested joins or equivalent nested cond output.
- Add pending translateBody parity tests for existing scalar fixtures: sequential write/read, asymmetric branch writes, chained early returns, else-branch early return, and write-then-early-return.
- Keep the tests skipped so this patch is non-functional and independently mergeable.

## Files to Modify
- tools/ts2pant/tests/ir1-ssa-scalars.test.mts (create): Create node:test stubs for scalar property SSA builder/lowerer behavior and production translateBody parity.

## Gameplan Specification

```
module IR1_SSA_BUILDER_SCALARS.

IR1Program.
Construct.
Location.
Version.
Read.
Write.
Join.
LoopSummary.
Rule.
PropResult.
Diagnostic.

supported-constructs p: IR1Program => [Construct].
lowered-constructs p: IR1Program => [Construct].
diagnostics p: IR1Program => [Diagnostic].
diagnostic-construct d: Diagnostic => Construct.
writes p: IR1Program => [Write].
reads p: IR1Program => [Read].
joins p: IR1Program => [Join].
loop-summaries p: IR1Program => [LoopSummary].
write-location w: Write => Location.
write-version w: Write => Version.
read-location r: Read => Location.
read-version r: Read => Version.
read-dominated? p: IR1Program, r: Read => Bool.
join-location j: Join => Location.
then-version j: Join => Version.
else-version j: Join => Version.
join-version j: Join => Version.
summary-location s: LoopSummary => Location.
summary-version s: LoopSummary => Version.
initial-version l: Location => Version.
version-location v: Version => Location.
rule-of-location l: Location => Rule.
declared-rules p: IR1Program => [Rule].
modified-rules p: IR1Program => [Rule].
framed-rules p: IR1Program => [Rule].
emitted-props p: IR1Program => [PropResult].
scalar-construct? c: Construct => Bool.
scalar-location? l: Location => Bool.
final-version p: IR1Program, l: Location => Version.
modified-location? p: IR1Program, l: Location => Bool.

---

all p: IR1Program, c in supported-constructs p |
  c in lowered-constructs p.

all p: IR1Program, d in diagnostics p |
  ~(diagnostic-construct d in supported-constructs p).

all p: IR1Program, c in supported-constructs p |
  scalar-construct? c -> c in lowered-constructs p.

all p: IR1Program, w in writes p |
  version-location (write-version w) = write-location w.

all p: IR1Program, s in loop-summaries p |
  version-location (summary-version s) = summary-location s.

all l: Location |
  version-location (initial-version l) = l.

all p: IR1Program, w1 in writes p, w2 in writes p |
  write-version w1 = write-version w2 -> w1 = w2.

all p: IR1Program, r in reads p |
  read-dominated? p r and
  version-location (read-version r) = read-location r and
  (
    read-version r = initial-version (read-location r) or
    (some w in writes p |
      write-version w = read-version r and
      write-location w = read-location r) or
    (some s in loop-summaries p |
      summary-version s = read-version r and
      summary-location s = read-location r)
  ).

all p: IR1Program, j in joins p |
  version-location (then-version j) = join-location j and
  version-location (else-version j) = join-location j and
  version-location (join-version j) = join-location j.

all p: IR1Program, j in joins p |
  then-version j != else-version j and
  join-version j != then-version j and
  join-version j != else-version j.

all p: IR1Program, l: Location |
  scalar-location? l and modified-location? p l ->
    version-location (final-version p l) = l and
    rule-of-location l in modified-rules p.

all p: IR1Program, rule in modified-rules p |
  rule in declared-rules p and
  ~(rule in framed-rules p).

all p: IR1Program, rule in framed-rules p |
  rule in declared-rules p and
  ~(rule in modified-rules p).

all p: IR1Program, rule in declared-rules p |
  rule in modified-rules p or rule in framed-rules p.

all p: IR1Program, w in writes p |
  rule-of-location (write-location w) in modified-rules p.

all p: IR1Program, s in loop-summaries p |
  rule-of-location (summary-location s) in modified-rules p.

all p: IR1Program |
  #(lowered-constructs p) > 0 -> #(emitted-props p) > 0.

```

## Patch Specification

```
module IR1_SSA_BUILDER_SCALARS_PATCH_1.

ScalarSsaTest.
ScalarInvariant.

covers-invariant t: ScalarSsaTest => ScalarInvariant.
pending? t: ScalarSsaTest => Bool.

---

all t: ScalarSsaTest | pending? t.
all t: ScalarSsaTest | covers-invariant t = covers-invariant t.

```


## Implementation Notes

- This patch is intentionally scaffold-only: the new suite stays fully skipped, and the bodies are placeholders for the later SSA builder/lowerer patches.
- I verified the new test file loads on its own with `tsx --test`; the broader `test:unit` run in this workspace is blocked by the missing generated wasm loader (`src/wasm/pant_wasm.bc.wasm.js`), which depends on the repo's OCaml/js_of_ocaml build toolchain.