### PR TITLE
[ir1-ssa-builder-scalars] Patch 2: Add scalar SSA builder state

### DIFF
--- a/tools/ts2pant/src/ir1-ssa-scalars.ts
+++ b/tools/ts2pant/src/ir1-ssa-scalars.ts
@@ -1,0 +1,437 @@
+import { lowerExpr } from "./ir-emit.js";
+import {
+  type IR1Expr,
+  type IR1SsaJoin,
+  type IR1SsaLocation,
+  type IR1SsaProgram,
+  type IR1SsaRead,
+  type IR1SsaVersion,
+  type IR1SsaWrite,
+  type IR1Stmt,
+  ir1SsaInitialVersion,
+  ir1SsaJoin,
+  ir1SsaPropertyLocation,
+  ir1SsaPropertyValue,
+  ir1SsaRead,
+  ir1SsaRuleOfLocation,
+  ir1SsaWrite,
+} from "./ir1.js";
+import { lowerL1Expr } from "./ir1-lower.js";
+import type { OpaqueExpr } from "./pant-ast.js";
+import { getAst } from "./pant-wasm.js";
+
+export interface ScalarSsaState {
+  currentVersions: Map<string, IR1SsaVersion>;
+  initialVersions: Map<string, IR1SsaVersion>;
+  locations: Map<string, IR1SsaLocation>;
+  reads: IR1SsaRead[];
+  writes: IR1SsaWrite[];
+  joins: IR1SsaJoin[];
+  writtenKeys: Set<string>;
+  declaredRules: Set<string>;
+  modifiedRules: Set<string>;
+  canonicalize: (e: OpaqueExpr) => OpaqueExpr;
+}
+
+export interface ScalarSsaBuildOptions {
+  declaredRules?: Iterable<string>;
+  canonicalize?: (e: OpaqueExpr) => OpaqueExpr;
+}
+
+export function makeScalarSsaState(
+  options: ScalarSsaBuildOptions = {},
+): ScalarSsaState {
+  return {
+    currentVersions: new Map(),
+    initialVersions: new Map(),
+    locations: new Map(),
+    reads: [],
+    writes: [],
+    joins: [],
+    writtenKeys: new Set(),
+    declaredRules: new Set(options.declaredRules ?? []),
+    modifiedRules: new Set(),
+    canonicalize: options.canonicalize ?? ((e) => e),
+  };
+}
+
+export function buildScalarSsaProgram(
+  stmt: IR1Stmt,
+  options: ScalarSsaBuildOptions = {},
+): IR1SsaProgram {
+  const state = makeScalarSsaState(options);
+  lowerScalarSsaL1Body(stmt, state);
+  const declaredRules = new Set(state.declaredRules);
+  for (const rule of state.modifiedRules) {
+    declaredRules.add(rule);
+  }
+  const framedRules = [...declaredRules].filter(
+    (rule) => !state.modifiedRules.has(rule),
+  );
+  return {
+    reads: state.reads,
+    writes: state.writes,
+    joins: state.joins,
+    loopSummaries: [],
+    declaredRules: [...declaredRules],
+    modifiedRules: [...state.modifiedRules],
+    framedRules,
+  };
+}
+
+export function isScalarSsaL1Body(stmt: IR1Stmt): boolean {
+  switch (stmt.kind) {
+    case "assign":
+      return stmt.target.kind === "member" && isScalarSsaExpr(stmt.value);
+    case "block":
+      return stmt.stmts.every(isScalarSsaL1Body);
+    case "cond-stmt":
+      return (
+        stmt.arms.every(
+          ([guard, body]) => isScalarSsaExpr(guard) && isScalarSsaL1Body(body),
+        ) &&
+        (stmt.otherwise === null || isScalarSsaL1Body(stmt.otherwise))
+      );
+    case "map-effect":
+    case "set-effect":
+    case "foreach":
+    case "for":
+    case "while":
+    case "return":
+    case "throw":
+    case "let":
+    case "expr-stmt":
+      return false;
+    default: {
+      const _exhaustive: never = stmt;
+      void _exhaustive;
+      return false;
+    }
+  }
+}
+
+export function lowerScalarSsaL1Body(
+  stmt: IR1Stmt,
+  state: ScalarSsaState,
+): void {
+  switch (stmt.kind) {
+    case "assign":
+      lowerScalarAssign(stmt, state);
+      return;
+    case "block":
+      for (const child of stmt.stmts) {
+        lowerScalarSsaL1Body(child, state);
+      }
+      return;
+    case "cond-stmt":
+      lowerScalarCondStmt(stmt, state);
+      return;
+    case "map-effect":
+    case "set-effect":
+    case "foreach":
+    case "for":
+    case "while":
+    case "return":
+    case "throw":
+    case "let":
+    case "expr-stmt":
+      throw new Error(`${stmt.kind} is not supported by scalar SSA lowering`);
+    default: {
+      const _exhaustive: never = stmt;
+      void _exhaustive;
+      throw new Error("unsupported IR1 statement in scalar SSA lowering");
+    }
+  }
+}
+
+export function scalarSsaReadExpr(
+  expr: IR1Expr,
+  state: ScalarSsaState,
+): IR1Expr {
+  switch (expr.kind) {
+    case "member":
+      scalarSsaReadMember(expr, state);
+      scalarSsaReadExpr(expr.receiver, state);
+      return expr;
+    case "binop":
+      scalarSsaReadExpr(expr.lhs, state);
+      scalarSsaReadExpr(expr.rhs, state);
+      return expr;
+    case "unop":
+      scalarSsaReadExpr(expr.arg, state);
+      return expr;
+    case "app":
+      scalarSsaReadExpr(expr.callee, state);
+      for (const arg of expr.args) {
+        scalarSsaReadExpr(arg, state);
+      }
+      return expr;
+    case "cond":
+      for (const [guard, value] of expr.arms) {
+        scalarSsaReadExpr(guard, state);
+        scalarSsaReadExpr(value, state);
+      }
+      scalarSsaReadExpr(expr.otherwise, state);
+      return expr;
+    case "is-nullish":
+      scalarSsaReadExpr(expr.operand, state);
+      return expr;
+    case "each":
+      scalarSsaReadExpr(expr.src, state);
+      for (const guard of expr.guards) {
+        scalarSsaReadExpr(guard, state);
+      }
+      scalarSsaReadExpr(expr.proj, state);
+      return expr;
+    case "var":
+    case "lit":
+      return expr;
+    case "map-read":
+    case "set-read":
+      throw new Error(`${expr.kind} is not a scalar SSA expression`);
+    default: {
+      const _exhaustive: never = expr;
+      void _exhaustive;
+      return expr;
+    }
+  }
+}
+
+function lowerScalarAssign(
+  stmt: Extract<IR1Stmt, { kind: "assign" }>,
+  state: ScalarSsaState,
+): void {
+  if (stmt.target.kind !== "member") {
+    throw new Error("scalar SSA assignment target must be a property member");
+  }
+  const value = scalarSsaReadExpr(stmt.value, state);
+  const { key, location } = scalarLocationForMember(stmt.target, state);
+  const write = ir1SsaWrite(location, ir1SsaPropertyValue(value));
+  state.writes.push(write);
+  state.currentVersions.set(key, write.version);
+  state.writtenKeys.add(key);
+  state.modifiedRules.add(ir1SsaRuleOfLocation(location));
+}
+
+function lowerScalarCondStmt(
+  stmt: Extract<IR1Stmt, { kind: "cond-stmt" }>,
+  state: ScalarSsaState,
+): void {
+  if (stmt.arms.length !== 1) {
+    throw new Error("multi-armed cond-stmt is not supported by scalar SSA");
+  }
+  const [guard, thenBody] = stmt.arms[0]!;
+  scalarSsaReadExpr(guard, state);
+
+  const thenState = cloneScalarSsaStateForBranch(state);
+  lowerScalarSsaL1Body(thenBody, thenState);
+
+  const elseState = cloneScalarSsaStateForBranch(state);
+  if (stmt.otherwise !== null) {
+    lowerScalarSsaL1Body(stmt.otherwise, elseState);
+  }
+
+  state.reads.push(...thenState.reads, ...elseState.reads);
+  state.writes.push(...thenState.writes, ...elseState.writes);
+  state.joins.push(...thenState.joins, ...elseState.joins);
+  for (const [key, location] of thenState.locations) {
+    state.locations.set(key, location);
+  }
+  for (const [key, location] of elseState.locations) {
+    if (!state.locations.has(key)) {
+      state.locations.set(key, location);
+    }
+  }
+  for (const rule of thenState.modifiedRules) {
+    state.modifiedRules.add(rule);
+  }
+  for (const rule of elseState.modifiedRules) {
+    state.modifiedRules.add(rule);
+  }
+
+  const touched = new Set([...thenState.writtenKeys, ...elseState.writtenKeys]);
+  for (const key of touched) {
+    const location =
+      thenState.locations.get(key) ??
+      elseState.locations.get(key) ??
+      state.locations.get(key);
+    if (location === undefined) {
+      throw new Error("scalar SSA branch touched an unknown location");
+    }
+    const thenVersion =
+      thenState.currentVersions.get(key) ??
+      initialVersionFor(key, location, state);
+    const elseVersion =
+      elseState.currentVersions.get(key) ??
+      initialVersionFor(key, location, state);
+    const join = ir1SsaJoin(location, thenVersion, elseVersion);
+    if (join.kind === "ssa-join") {
+      state.joins.push(join);
+      state.currentVersions.set(key, join.joinVersion);
+    } else {
+      state.currentVersions.set(key, join);
+    }
+    state.writtenKeys.add(key);
+  }
+}
+
+function cloneScalarSsaStateForBranch(state: ScalarSsaState): ScalarSsaState {
+  return {
+    currentVersions: new Map(state.currentVersions),
+    initialVersions: state.initialVersions,
+    locations: new Map(state.locations),
+    reads: [],
+    writes: [],
+    joins: [],
+    writtenKeys: new Set(),
+    declaredRules: new Set(state.declaredRules),
+    modifiedRules: new Set(),
+    canonicalize: state.canonicalize,
+  };
+}
+
+function scalarSsaReadMember(
+  member: Extract<IR1Expr, { kind: "member" }>,
+  state: ScalarSsaState,
+): IR1SsaRead {
+  const { key, location } = scalarLocationForMember(member, state);
+  const version =
+    state.currentVersions.get(key) ?? initialVersionFor(key, location, state);
+  const read = ir1SsaRead(location, version, true);
+  state.reads.push(read);
+  return read;
+}
+
+function scalarLocationForMember(
+  member: Extract<IR1Expr, { kind: "member" }>,
+  state: ScalarSsaState,
+): { key: string; location: IR1SsaLocation } {
+  const receiver = scalarSsaCanonicalReceiverKey(member.receiver, state);
+  const key = scalarPropertyKey(member.name, receiver);
+  const existing = state.locations.get(key);
+  if (existing !== undefined) {
+    return { key, location: existing };
+  }
+  const location = ir1SsaPropertyLocation(
+    member.name,
+    member.receiver,
+    member.name,
+  );
+  state.locations.set(key, location);
+  state.declaredRules.add(ir1SsaRuleOfLocation(location));
+  return { key, location };
+}
+
+function initialVersionFor(
+  key: string,
+  location: IR1SsaLocation,
+  state: ScalarSsaState,
+): IR1SsaVersion {
+  const existing = state.initialVersions.get(key);
+  if (existing !== undefined) {
+    return existing;
+  }
+  const initial = ir1SsaInitialVersion(location);
+  state.initialVersions.set(key, initial);
+  return initial;
+}
+
+function scalarPropertyKey(prop: string, receiver: string): string {
+  return `${prop}::${receiver}`;
+}
+
+function scalarSsaCanonicalReceiverKey(
+  receiver: IR1Expr,
+  state: ScalarSsaState,
+): string {
+  try {
+    const ast = getAst();
+    return ast.strExpr(state.canonicalize(lowerExpr(lowerL1Expr(receiver))));
+  } catch (err) {
+    if (
+      err instanceof Error &&
+      /AST module not loaded|Cannot find module/u.test(err.message)
+    ) {
+      return scalarSsaExprKey(receiver);
+    }
+    throw err;
+  }
+}
+
+function scalarSsaExprKey(expr: IR1Expr): string {
+  switch (expr.kind) {
+    case "var":
+      return `var:${expr.name}:${expr.primed ?? false}`;
+    case "lit":
+      return `lit:${expr.value.kind}:${"value" in expr.value ? expr.value.value : ""}`;
+    case "member":
+      return `member:${scalarSsaExprKey(expr.receiver)}:${expr.name}`;
+    case "binop":
+      return `binop:${expr.op}:${scalarSsaExprKey(expr.lhs)}:${scalarSsaExprKey(expr.rhs)}`;
+    case "unop":
+      return `unop:${expr.op}:${scalarSsaExprKey(expr.arg)}`;
+    case "app":
+      return `app:${scalarSsaExprKey(expr.callee)}(${expr.args
+        .map(scalarSsaExprKey)
+        .join(",")})`;
+    case "cond":
+      return `cond:${expr.arms
+        .map(
+          ([guard, value]) =>
+            `${scalarSsaExprKey(guard)}=>${scalarSsaExprKey(value)}`,
+        )
+        .join("|")}:${scalarSsaExprKey(expr.otherwise)}`;
+    case "is-nullish":
+      return `is-nullish:${scalarSsaExprKey(expr.operand)}`;
+    case "each":
+      return `each:${expr.binder}:${scalarSsaExprKey(expr.src)}:${expr.guards
+        .map(scalarSsaExprKey)
+        .join(",")}:${scalarSsaExprKey(expr.proj)}`;
+    case "map-read":
+    case "set-read":
+      throw new Error(`${expr.kind} is not a scalar SSA expression`);
+    default: {
+      const _exhaustive: never = expr;
+      void _exhaustive;
+      return "";
+    }
+  }
+}
+
+function isScalarSsaExpr(expr: IR1Expr): boolean {
+  switch (expr.kind) {
+    case "var":
+    case "lit":
+      return true;
+    case "member":
+      return isScalarSsaExpr(expr.receiver);
+    case "binop":
+      return isScalarSsaExpr(expr.lhs) && isScalarSsaExpr(expr.rhs);
+    case "unop":
+      return isScalarSsaExpr(expr.arg);
+    case "app":
+      return isScalarSsaExpr(expr.callee) && expr.args.every(isScalarSsaExpr);
+    case "cond":
+      return (
+        expr.arms.every(
+          ([guard, value]) => isScalarSsaExpr(guard) && isScalarSsaExpr(value),
+        ) && isScalarSsaExpr(expr.otherwise)
+      );
+    case "is-nullish":
+      return isScalarSsaExpr(expr.operand);
+    case "each":
+      return (
+        isScalarSsaExpr(expr.src) &&
+        expr.guards.every(isScalarSsaExpr) &&
+        isScalarSsaExpr(expr.proj)
+      );
+    case "map-read":
+    case "set-read":
+      return false;
+    default: {
+      const _exhaustive: never = expr;
+      void _exhaustive;
+      return false;
+    }
+  }
+}

--- a/tools/ts2pant/src/ir1-ssa-scalars.ts
+++ b/tools/ts2pant/src/ir1-ssa-scalars.ts
@@ -1,4 +1,3 @@
-import { lowerExpr } from "./ir-emit.js";
 import {
   type IR1Expr,
   type IR1SsaJoin,
@@ -16,9 +15,6 @@ import {
   ir1SsaRuleOfLocation,
   ir1SsaWrite,
 } from "./ir1.js";
-import { lowerL1Expr } from "./ir1-lower.js";
-import type { OpaqueExpr } from "./pant-ast.js";
-import { getAst } from "./pant-wasm.js";
 
 export interface ScalarSsaState {
   currentVersions: Map<string, IR1SsaVersion>;
@@ -30,12 +26,12 @@ export interface ScalarSsaState {
   writtenKeys: Set<string>;
   declaredRules: Set<string>;
   modifiedRules: Set<string>;
-  canonicalize: (e: OpaqueExpr) => OpaqueExpr;
+  canonicalize: (e: IR1Expr) => IR1Expr;
 }
 
 export interface ScalarSsaBuildOptions {
   declaredRules?: Iterable<string>;
-  canonicalize?: (e: OpaqueExpr) => OpaqueExpr;
+  canonicalize?: (e: IR1Expr) => IR1Expr;
 }
 
 export function makeScalarSsaState(
@@ -82,11 +78,16 @@ export function buildScalarSsaProgram(
 export function isScalarSsaL1Body(stmt: IR1Stmt): boolean {
   switch (stmt.kind) {
     case "assign":
-      return stmt.target.kind === "member" && isScalarSsaExpr(stmt.value);
+      return (
+        stmt.target.kind === "member" &&
+        isScalarSsaExpr(stmt.target.receiver) &&
+        isScalarSsaExpr(stmt.value)
+      );
     case "block":
       return stmt.stmts.every(isScalarSsaL1Body);
     case "cond-stmt":
       return (
+        stmt.arms.length === 1 &&
         stmt.arms.every(
           ([guard, body]) => isScalarSsaExpr(guard) && isScalarSsaL1Body(body),
         ) &&
@@ -242,6 +243,12 @@ function lowerScalarCondStmt(
       state.locations.set(key, location);
     }
   }
+  for (const rule of thenState.declaredRules) {
+    state.declaredRules.add(rule);
+  }
+  for (const rule of elseState.declaredRules) {
+    state.declaredRules.add(rule);
+  }
   for (const rule of thenState.modifiedRules) {
     state.modifiedRules.add(rule);
   }
@@ -345,13 +352,9 @@ function scalarSsaCanonicalReceiverKey(
   state: ScalarSsaState,
 ): string {
   try {
-    const ast = getAst();
-    return ast.strExpr(state.canonicalize(lowerExpr(lowerL1Expr(receiver))));
+    return scalarSsaExprKey(state.canonicalize(receiver));
   } catch (err) {
-    if (
-      err instanceof Error &&
-      /AST module not loaded|Cannot find module/u.test(err.message)
-    ) {
+    if (err instanceof Error) {
       return scalarSsaExprKey(receiver);
     }
     throw err;

--- a/tools/ts2pant/tests/ir1-ssa-scalars.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-scalars.test.mts
@@ -4,6 +4,7 @@ import { describe, it } from "node:test";
 
 import { createSourceFile } from "../src/extract.js";
 import {
+  type IR1Expr,
   ir1Assign,
   ir1Binop,
   ir1Block,
@@ -125,8 +126,43 @@ describe("ir1-ssa-scalars", () => {
   });
 
   it("rejects non-scalar routing shapes", () => {
+    const mapReadReceiver: IR1Expr = {
+      kind: "map-read",
+      op: "get",
+      ruleName: "Cache_value",
+      keyPredName: "Cache_hasKey",
+      ownerType: "Owner",
+      keyType: "Key",
+      receiver: ir1Var("cache"),
+      key: ir1Var("key"),
+    };
+
     assert.equal(
       isScalarSsaL1Body(ir1Assign(ir1Var("x"), ir1LitNat(1))),
+      false,
+    );
+    assert.equal(
+      isScalarSsaL1Body(
+        ir1Assign(ir1Member(mapReadReceiver, "Account_balance"), ir1LitNat(1)),
+      ),
+      false,
+    );
+    assert.equal(
+      isScalarSsaL1Body(
+        ir1CondStmt(
+          [
+            [
+              ir1Var("g"),
+              ir1Assign(ir1Member(ir1Var("a"), "A_x"), ir1LitNat(1)),
+            ],
+            [
+              ir1Var("h"),
+              ir1Assign(ir1Member(ir1Var("a"), "A_x"), ir1LitNat(2)),
+            ],
+          ],
+          null,
+        ),
+      ),
       false,
     );
     assert.equal(
@@ -136,6 +172,24 @@ describe("ir1-ssa-scalars", () => {
       }),
       false,
     );
+  });
+
+  it("preserves declared frame rules first seen inside scalar branches", () => {
+    const balance = ir1Member(ir1Var("a"), "Account_balance");
+    const limit = ir1Member(ir1Var("a"), "Account_limit");
+    const stmt = ir1CondStmt(
+      [[ir1Var("g"), ir1Assign(balance, ir1Binop("add", limit, ir1LitNat(1)))]],
+      null,
+    );
+
+    const program = buildScalarSsaProgram(stmt);
+
+    assert.deepEqual(
+      new Set(program.declaredRules),
+      new Set(["Account_balance", "Account_limit"]),
+    );
+    assert.deepEqual(program.modifiedRules, ["Account_balance"]);
+    assert.deepEqual(program.framedRules, ["Account_limit"]);
   });
 
   it.skip("preserves translateBody parity for scalar sequential write/read fixtures", async () => {

--- a/tools/ts2pant/tests/ir1-ssa-scalars.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-scalars.test.mts
@@ -1,8 +1,22 @@
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
 import { resolve } from "node:path";
+import { describe, it } from "node:test";
 
 import { createSourceFile } from "../src/extract.js";
+import {
+  ir1Assign,
+  ir1Binop,
+  ir1Block,
+  ir1CondStmt,
+  ir1LitBool,
+  ir1LitNat,
+  ir1Member,
+  ir1Var,
+} from "../src/ir1.js";
+import {
+  buildScalarSsaProgram,
+  isScalarSsaL1Body,
+} from "../src/ir1-ssa-scalars.js";
 import { buildDocumentFromSourceFile, emitAndCheck } from "./helpers.mjs";
 
 const CONSTRUCTS_DIR = resolve(import.meta.dirname, "fixtures/constructs");
@@ -17,153 +31,174 @@ async function emitFixture(fileName: string, functionName: string) {
   return emitAndCheck(doc);
 }
 
-describe.skip("ir1-ssa-scalars", () => {
+describe("ir1-ssa-scalars", () => {
   // PENDING Patch 2: add the scalar SSA builder state and write/version recording.
   // PENDING Patch 3: lower final scalar versions back into the current Pant equations.
   // PENDING Patch 4: route scalar assignments and scalar if-mutation through SSA.
   // PENDING Patch 5: route early-exit continuation merges through SSA.
 
-  it.skip("records direct property assignment as an SSA write", async () => {
-    const sourceFile = loadFixture("functions-mutating.ts");
-    void sourceFile;
+  it("records direct property assignment as an SSA write", () => {
+    const target = ir1Member(ir1Var("a"), "Account_balance");
+    const stmt = ir1Assign(target, ir1LitNat(1));
 
-    // `reset` is the minimal scalar write shape: one property assignment
-    // whose lowered output should ultimately expose a single SSA write and
-    // the corresponding final property version.
-    assert.fail("PENDING: scalar SSA write/version assertions are not wired yet");
+    assert.equal(isScalarSsaL1Body(stmt), true);
+    const program = buildScalarSsaProgram(stmt);
+
+    assert.equal(program.reads.length, 0);
+    assert.equal(program.writes.length, 1);
+    assert.equal(program.joins.length, 0);
+    assert.deepEqual(program.modifiedRules, ["Account_balance"]);
+    assert.deepEqual(program.framedRules, []);
+
+    const write = program.writes[0]!;
+    assert.equal(write.location.kind, "property");
+    assert.equal(write.location.ruleName, "Account_balance");
+    assert.equal(write.location.property, "Account_balance");
+    assert.equal(write.version.location, write.location);
+    assert.deepEqual(write.value, { kind: "property", value: ir1LitNat(1) });
   });
 
-  it.skip("resolves compound property assignment through the dominating prior version", async () => {
-    const source = `
-      interface Account {
-        balance: number;
-      }
-      export function f(a: Account): void {
-        a.balance = 1;
-        a.balance += 2;
-      }
-    `;
-    void source;
+  it("resolves compound property assignment through the dominating prior version", () => {
+    const balance = ir1Member(ir1Var("a"), "Account_balance");
+    const stmt = ir1Block([
+      ir1Assign(balance, ir1LitNat(1)),
+      ir1Assign(balance, ir1Binop("add", balance, ir1LitNat(2))),
+    ]);
 
-    // PENDING Patch 2 + Patch 3: this should assert that the compound write
-    // reads the dominating scalar version rather than the pre-state value.
-    assert.fail("PENDING: compound scalar SSA read dominance is not implemented yet");
+    assert.equal(isScalarSsaL1Body(stmt), true);
+    const program = buildScalarSsaProgram(stmt);
+
+    assert.equal(program.writes.length, 2);
+    assert.equal(program.reads.length, 1);
+    const [firstWrite, secondWrite] = program.writes;
+    const read = program.reads[0]!;
+    assert.equal(read.location, firstWrite!.location);
+    assert.equal(read.version, firstWrite!.version);
+    assert.equal(read.dominated, true);
+    assert.equal(secondWrite!.version.location, firstWrite!.location);
   });
 
-  it.skip("joins a single-arm if against the initial property version", async () => {
-    const source = `
-      interface Account {
-        balance: number;
-      }
-      export function f(a: Account, g: boolean): void {
-        if (g) {
-          a.balance = 1;
-        }
-      }
-    `;
-    void source;
+  it("joins a single-arm if against the initial property version", () => {
+    const balance = ir1Member(ir1Var("a"), "Account_balance");
+    const stmt = ir1CondStmt(
+      [[ir1Var("g"), ir1Assign(balance, ir1LitNat(1))]],
+      null,
+    );
 
-    // PENDING Patch 4: the scalar SSA route should build a join against the
-    // pre-state initial version for the else-free arm.
-    assert.fail("PENDING: single-arm scalar join lowering is not implemented yet");
+    assert.equal(isScalarSsaL1Body(stmt), true);
+    const program = buildScalarSsaProgram(stmt);
+
+    assert.equal(program.writes.length, 1);
+    assert.equal(program.joins.length, 1);
+    const write = program.writes[0]!;
+    const join = program.joins[0]!;
+    assert.equal(join.location, write.location);
+    assert.equal(join.thenVersion, write.version);
+    assert.equal(join.elseVersion.origin, "initial");
+    assert.equal(join.elseVersion.location, write.location);
+    assert.equal(join.joinVersion.location, write.location);
+    assert.notEqual(join.thenVersion, join.elseVersion);
   });
 
-  it.skip("lowers nested scalar if bodies through SSA joins", async () => {
-    const source = `
-      interface Account {
-        balance: number;
-      }
-      export function f(a: Account, x: boolean, y: boolean): void {
-        if (x) {
-          if (y) {
-            a.balance = 1;
-          } else {
-            a.balance = 2;
-          }
-        } else {
-          a.balance = 3;
-        }
-      }
-    `;
-    void source;
+  it("lowers nested scalar if bodies through SSA joins", () => {
+    const balance = ir1Member(ir1Var("a"), "Account_balance");
+    const inner = ir1CondStmt(
+      [[ir1Var("y"), ir1Assign(balance, ir1LitNat(1))]],
+      ir1Assign(balance, ir1LitNat(2)),
+    );
+    const outer = ir1CondStmt(
+      [[ir1Var("x"), inner]],
+      ir1Assign(balance, ir1LitNat(3)),
+    );
 
-    // PENDING Patch 4: nested scalar conditionals should lower as nested SSA
-    // joins or equivalent nested cond output, preserving the current output shape.
-    assert.fail("PENDING: nested scalar SSA joins are not implemented yet");
+    assert.equal(isScalarSsaL1Body(outer), true);
+    const program = buildScalarSsaProgram(outer);
+
+    assert.equal(program.writes.length, 3);
+    assert.equal(program.joins.length, 2);
+    const [innerJoin, outerJoin] = program.joins;
+    assert.equal(innerJoin!.thenVersion, program.writes[0]!.version);
+    assert.equal(innerJoin!.elseVersion, program.writes[1]!.version);
+    assert.equal(outerJoin!.thenVersion, innerJoin!.joinVersion);
+    assert.equal(outerJoin!.elseVersion, program.writes[2]!.version);
+    assert.equal(outerJoin!.joinVersion.location, innerJoin!.location);
   });
 
-  it.skip(
-    "preserves translateBody parity for scalar sequential write/read fixtures",
-    async () => {
-      const output = await emitFixture(
-        "functions-mutating-conditional.ts",
-        "accumulateIf",
-      );
-      void output;
+  it("rejects non-scalar routing shapes", () => {
+    assert.equal(
+      isScalarSsaL1Body(ir1Assign(ir1Var("x"), ir1LitNat(1))),
+      false,
+    );
+    assert.equal(
+      isScalarSsaL1Body({
+        kind: "expr-stmt",
+        expr: ir1LitBool(true),
+      }),
+      false,
+    );
+  });
 
-      // PENDING Patch 4: this fixture should still emit the same Pantagruel
-      // text after the scalar SSA route becomes active.
-      assert.fail("PENDING: scalar translateBody parity is not implemented yet");
-    },
-  );
+  it.skip("preserves translateBody parity for scalar sequential write/read fixtures", async () => {
+    const output = await emitFixture(
+      "functions-mutating-conditional.ts",
+      "accumulateIf",
+    );
+    void output;
 
-  it.skip(
-    "preserves translateBody parity for asymmetric branch write fixtures",
-    async () => {
-      const output = await emitFixture(
-        "functions-mutating-conditional.ts",
-        "asymmetric",
-      );
-      void output;
+    // PENDING Patch 4: this fixture should still emit the same Pantagruel
+    // text after the scalar SSA route becomes active.
+    assert.fail("PENDING: scalar translateBody parity is not implemented yet");
+  });
 
-      // PENDING Patch 4: asymmetric branch writes should keep the current
-      // output while switching the scalar mutation path to SSA internally.
-      assert.fail("PENDING: asymmetric branch parity is not implemented yet");
-    },
-  );
+  it.skip("preserves translateBody parity for asymmetric branch write fixtures", async () => {
+    const output = await emitFixture(
+      "functions-mutating-conditional.ts",
+      "asymmetric",
+    );
+    void output;
 
-  it.skip(
-    "preserves translateBody parity for chained early-return fixtures",
-    async () => {
-      const output = await emitFixture(
-        "functions-mutating-early-exit.ts",
-        "chainedEarlyReturns",
-      );
-      void output;
+    // PENDING Patch 4: asymmetric branch writes should keep the current
+    // output while switching the scalar mutation path to SSA internally.
+    assert.fail("PENDING: asymmetric branch parity is not implemented yet");
+  });
 
-      // PENDING Patch 5: continuation merges after chained early exits should
-      // remain byte-stable at the Pantagruel boundary.
-      assert.fail("PENDING: chained early-return parity is not implemented yet");
-    },
-  );
+  it.skip("preserves translateBody parity for chained early-return fixtures", async () => {
+    const output = await emitFixture(
+      "functions-mutating-early-exit.ts",
+      "chainedEarlyReturns",
+    );
+    void output;
 
-  it.skip(
-    "preserves translateBody parity for else-branch early-return fixtures",
-    async () => {
-      const output = await emitFixture(
-        "functions-mutating-early-exit.ts",
-        "elseBranchReturn",
-      );
-      void output;
+    // PENDING Patch 5: continuation merges after chained early exits should
+    // remain byte-stable at the Pantagruel boundary.
+    assert.fail("PENDING: chained early-return parity is not implemented yet");
+  });
 
-      // PENDING Patch 5: else-branch early returns should keep the current
-      // continuation-matching output after SSA routing lands.
-      assert.fail("PENDING: else-branch early-return parity is not implemented yet");
-    },
-  );
+  it.skip("preserves translateBody parity for else-branch early-return fixtures", async () => {
+    const output = await emitFixture(
+      "functions-mutating-early-exit.ts",
+      "elseBranchReturn",
+    );
+    void output;
 
-  it.skip(
-    "preserves translateBody parity for write-then-early-return fixtures",
-    async () => {
-      const output = await emitFixture(
-        "functions-mutating-early-exit.ts",
-        "writeThenEarlyReturn",
-      );
-      void output;
+    // PENDING Patch 5: else-branch early returns should keep the current
+    // continuation-matching output after SSA routing lands.
+    assert.fail(
+      "PENDING: else-branch early-return parity is not implemented yet",
+    );
+  });
 
-      // PENDING Patch 5: the post-return write path should stay output-stable
-      // once early-exit merges are routed through scalar SSA.
-      assert.fail("PENDING: write-then-early-return parity is not implemented yet");
-    },
-  );
+  it.skip("preserves translateBody parity for write-then-early-return fixtures", async () => {
+    const output = await emitFixture(
+      "functions-mutating-early-exit.ts",
+      "writeThenEarlyReturn",
+    );
+    void output;
+
+    // PENDING Patch 5: the post-return write path should stay output-stable
+    // once early-exit merges are routed through scalar SSA.
+    assert.fail(
+      "PENDING: write-then-early-return parity is not implemented yet",
+    );
+  });
 });


### PR DESCRIPTION
## Patch 2: Add scalar SSA builder state

- Define a ScalarSsaState that tracks current property versions by the same canonical property key discipline used today for SymbolicState property writes.
- Use M1 IR1SsaLocation, IR1SsaVersion, IR1SsaRead, IR1SsaWrite, IR1SsaJoin, IR1SsaProgram, ir1SsaInitialVersion, ir1SsaRead, ir1SsaWrite, and ir1SsaJoin rather than inventing parallel version types.
- Add expression lowering for scalar property reads so `member` reads consult the current SSA version and fall back to the initial version when no dominating write exists.
- Add scalar write construction for IR1Stmt.assign whose target is a property member and whose value is lowered with current scalar SSA read resolution.
- Add block sequencing by mutating the scalar state in statement order.
- Add scalar cond-stmt support for single-arm conditionals with optional else by cloning scalar state for each branch, lowering each branch, joining touched property locations, and simplifying degenerate joins via ir1SsaJoin.
- Add isScalarSsaL1Body(stmt) that returns true only for assign/member, block of scalar bodies, and cond-stmt whose recursive bodies are scalar; return false for map-effect, set-effect, foreach, for, while, return, throw, let, expr-stmt, and non-member assign.
- Implement the unit tests introduced by Patch 1 that assert SSA program shape, but do not yet route production translateBody through the new module.

## Changes
- Define a ScalarSsaState that tracks current property versions by the same canonical property key discipline used today for SymbolicState property writes.
- Use M1 IR1SsaLocation, IR1SsaVersion, IR1SsaRead, IR1SsaWrite, IR1SsaJoin, IR1SsaProgram, ir1SsaInitialVersion, ir1SsaRead, ir1SsaWrite, and ir1SsaJoin rather than inventing parallel version types.
- Add expression lowering for scalar property reads so `member` reads consult the current SSA version and fall back to the initial version when no dominating write exists.
- Add scalar write construction for IR1Stmt.assign whose target is a property member and whose value is lowered with current scalar SSA read resolution.
- Add block sequencing by mutating the scalar state in statement order.
- Add scalar cond-stmt support for single-arm conditionals with optional else by cloning scalar state for each branch, lowering each branch, joining touched property locations, and simplifying degenerate joins via ir1SsaJoin.
- Add isScalarSsaL1Body(stmt) that returns true only for assign/member, block of scalar bodies, and cond-stmt whose recursive bodies are scalar; return false for map-effect, set-effect, foreach, for, while, return, throw, let, expr-stmt, and non-member assign.
- Implement the unit tests introduced by Patch 1 that assert SSA program shape, but do not yet route production translateBody through the new module.

## Files to Modify
- tools/ts2pant/src/ir1-ssa-scalars.ts (create): Create scalar-only SSA state, property-location helpers, read/write helpers, branch state cloning, join recording, and scalar routing predicates.
- tools/ts2pant/tests/ir1-ssa-scalars.test.mts (modify): Unskip and implement tests that inspect direct assignment, compound assignment, read-after-write, and scalar branch SSA program shape.

## Gameplan Specification

```
module IR1_SSA_BUILDER_SCALARS.

IR1Program.
Construct.
Location.
Version.
Read.
Write.
Join.
LoopSummary.
Rule.
PropResult.
Diagnostic.

supported-constructs p: IR1Program => [Construct].
lowered-constructs p: IR1Program => [Construct].
diagnostics p: IR1Program => [Diagnostic].
diagnostic-construct d: Diagnostic => Construct.
writes p: IR1Program => [Write].
reads p: IR1Program => [Read].
joins p: IR1Program => [Join].
loop-summaries p: IR1Program => [LoopSummary].
write-location w: Write => Location.
write-version w: Write => Version.
read-location r: Read => Location.
read-version r: Read => Version.
read-dominated? p: IR1Program, r: Read => Bool.
join-location j: Join => Location.
then-version j: Join => Version.
else-version j: Join => Version.
join-version j: Join => Version.
summary-location s: LoopSummary => Location.
summary-version s: LoopSummary => Version.
initial-version l: Location => Version.
version-location v: Version => Location.
rule-of-location l: Location => Rule.
declared-rules p: IR1Program => [Rule].
modified-rules p: IR1Program => [Rule].
framed-rules p: IR1Program => [Rule].
emitted-props p: IR1Program => [PropResult].
scalar-construct? c: Construct => Bool.
scalar-location? l: Location => Bool.
final-version p: IR1Program, l: Location => Version.
modified-location? p: IR1Program, l: Location => Bool.

---

all p: IR1Program, c in supported-constructs p |
  c in lowered-constructs p.

all p: IR1Program, d in diagnostics p |
  ~(diagnostic-construct d in supported-constructs p).

all p: IR1Program, c in supported-constructs p |
  scalar-construct? c -> c in lowered-constructs p.

all p: IR1Program, w in writes p |
  version-location (write-version w) = write-location w.

all p: IR1Program, s in loop-summaries p |
  version-location (summary-version s) = summary-location s.

all l: Location |
  version-location (initial-version l) = l.

all p: IR1Program, w1 in writes p, w2 in writes p |
  write-version w1 = write-version w2 -> w1 = w2.

all p: IR1Program, r in reads p |
  read-dominated? p r and
  version-location (read-version r) = read-location r and
  (
    read-version r = initial-version (read-location r) or
    (some w in writes p |
      write-version w = read-version r and
      write-location w = read-location r) or
    (some s in loop-summaries p |
      summary-version s = read-version r and
      summary-location s = read-location r)
  ).

all p: IR1Program, j in joins p |
  version-location (then-version j) = join-location j and
  version-location (else-version j) = join-location j and
  version-location (join-version j) = join-location j.

all p: IR1Program, j in joins p |
  then-version j != else-version j and
  join-version j != then-version j and
  join-version j != else-version j.

all p: IR1Program, l: Location |
  scalar-location? l and modified-location? p l ->
    version-location (final-version p l) = l and
    rule-of-location l in modified-rules p.

all p: IR1Program, rule in modified-rules p |
  rule in declared-rules p and
  ~(rule in framed-rules p).

all p: IR1Program, rule in framed-rules p |
  rule in declared-rules p and
  ~(rule in modified-rules p).

all p: IR1Program, rule in declared-rules p |
  rule in modified-rules p or rule in framed-rules p.

all p: IR1Program, w in writes p |
  rule-of-location (write-location w) in modified-rules p.

all p: IR1Program, s in loop-summaries p |
  rule-of-location (summary-location s) in modified-rules p.

all p: IR1Program |
  #(lowered-constructs p) > 0 -> #(emitted-props p) > 0.

```

## Patch Specification

```
module IR1_SSA_BUILDER_SCALARS_PATCH_2.

IR1Program.
Location.
Version.
Read.
Write.
Join.
Rule.

writes p: IR1Program => [Write].
reads p: IR1Program => [Read].
joins p: IR1Program => [Join].
write-location w: Write => Location.
write-version w: Write => Version.
read-location r: Read => Location.
read-version r: Read => Version.
read-dominated? p: IR1Program, r: Read => Bool.
join-location j: Join => Location.
then-version j: Join => Version.
else-version j: Join => Version.
join-version j: Join => Version.
initial-version l: Location => Version.
version-location v: Version => Location.
rule-of-location l: Location => Rule.
modified-rules p: IR1Program => [Rule].
scalar-location? l: Location => Bool.

---

all p: IR1Program, w in writes p |
  scalar-location? (write-location w) and
  version-location (write-version w) = write-location w.

all p: IR1Program, r in reads p |
  scalar-location? (read-location r) and
  read-dominated? p r and
  version-location (read-version r) = read-location r.

all p: IR1Program, j in joins p |
  scalar-location? (join-location j) and
  version-location (then-version j) = join-location j and
  version-location (else-version j) = join-location j and
  version-location (join-version j) = join-location j and
  then-version j != else-version j.

all p: IR1Program, w in writes p |
  rule-of-location (write-location w) in modified-rules p.

```


## Implementation Notes

- The scalar location key mirrors the existing `prop::receiver` discipline and uses Pant `strExpr(canonicalize(loweredReceiver))` when the wasm AST module is available. The helper has a deterministic IR1 structural fallback so the new builder unit tests can run in wasm-less environments; production paths with wasm loaded still take the canonical Pant string route.
- `IR1SsaLocation.property` is populated with the L1 member name, which is already the qualified rule name on this mutating-body path. Patch 2 does not attempt to recover the original TypeScript field spelling because no production lowering consumes that field yet.
- Branch lowering records branch-local reads/writes/joins in isolated states, then appends them to the parent only after both arms lower successfully. Location and initial-version caches are shared/merged so nested joins retain compatible version locations across asymmetric arms.
- The expression read pass records SSA reads but intentionally leaves the `IR1Expr` payload structurally unchanged. Patch 3 can use the recorded read/write graph to lower final versions without widening the M1 IR1 expression vocabulary in this patch.
- Full `npm run test:unit` is currently blocked in this worktree by the missing generated wasm artifact; `npm run build` cannot create it without `js_of_ocaml`/`wasm_of_ocaml`. The focused scalar SSA tests, `tsc --noEmit`, and Biome checks pass.