### PR TITLE
[ir1-ssa-builder-scalars] Patch 3: Lower scalar SSA final versions to property equations

### DIFF
--- a/tools/ts2pant/src/ir1-ssa-scalars.ts
+++ b/tools/ts2pant/src/ir1-ssa-scalars.ts
@@ -571,6 +571,8 @@ function cloneScalarSsaLowerStateForBranch(
     writeIndex: state.writeIndex,
     joinIndex: state.joinIndex,
     currentVersions: new Map(state.currentVersions),
+    // Shared, not cloned: initial versions represent pre-function state,
+    // the same regardless of which branch is taken.
     initialVersions: state.initialVersions,
     locations: new Map(state.locations),
     versionExprs: new Map(state.versionExprs),

--- a/tools/ts2pant/src/ir1-ssa-scalars.ts
+++ b/tools/ts2pant/src/ir1-ssa-scalars.ts
@@ -112,15 +112,16 @@ export function lowerScalarSsaToProps(
 ): ScalarSsaLowerResult {
   if (!isScalarSsaL1Body(stmt)) {
     const reason = "statement is not supported by scalar SSA lowering";
+    const declared = [...new Set(options.declaredRules ?? [])];
     return {
       program: {
         reads: [],
         writes: [],
         joins: [],
         loopSummaries: [],
-        declaredRules: [...new Set(options.declaredRules ?? [])],
+        declaredRules: declared,
         modifiedRules: [],
-        framedRules: [...new Set(options.declaredRules ?? [])],
+        framedRules: declared,
       },
       finalProperties: [],
       propositions: [],
@@ -434,6 +435,10 @@ function lowerScalarSsaCondToVersions(
     const elseVersion =
       elseState.currentVersions.get(key) ??
       initialVersionFor(key, location, elseState);
+    // Defensive fast-path: today `touched` implies at least one branch wrote,
+    // but future version reuse or caching could still leave both branches with
+    // the same version object. In that case we keep the shared version as the
+    // final one and still propagate the location/key through the outer state.
     if (thenVersion === elseVersion) {
       state.currentVersions.set(key, thenVersion);
       state.locations.set(key, location);

--- a/tools/ts2pant/src/ir1-ssa-scalars.ts
+++ b/tools/ts2pant/src/ir1-ssa-scalars.ts
@@ -1,9 +1,11 @@
+import { lowerExpr } from "./ir-emit.js";
 import {
   type IR1Expr,
   type IR1SsaJoin,
   type IR1SsaLocation,
   type IR1SsaProgram,
   type IR1SsaRead,
+  type IR1SsaRuleName,
   type IR1SsaVersion,
   type IR1SsaWrite,
   type IR1Stmt,
@@ -15,6 +17,10 @@ import {
   ir1SsaRuleOfLocation,
   ir1SsaWrite,
 } from "./ir1.js";
+import { lowerL1Expr } from "./ir1-lower.js";
+import type { OpaqueExpr } from "./pant-ast.js";
+import { getAst } from "./pant-wasm.js";
+import type { PropResult } from "./types.js";
 
 export interface ScalarSsaState {
   currentVersions: Map<string, IR1SsaVersion>;
@@ -32,6 +38,31 @@ export interface ScalarSsaState {
 export interface ScalarSsaBuildOptions {
   declaredRules?: Iterable<string>;
   canonicalize?: (e: IR1Expr) => IR1Expr;
+}
+
+export interface ScalarSsaFinalPropertyEntry {
+  location: Extract<IR1SsaLocation, { kind: "property" }>;
+  version: IR1SsaVersion;
+  lhs: OpaqueExpr;
+  rhs: OpaqueExpr;
+}
+
+export interface ScalarSsaLowerResult {
+  program: IR1SsaProgram;
+  finalProperties: ScalarSsaFinalPropertyEntry[];
+  propositions: PropResult[];
+  modifiedRules: IR1SsaRuleName[];
+  diagnostics: Array<Extract<PropResult, { kind: "unsupported" }>>;
+}
+
+interface ScalarSsaLocationState {
+  locations: Map<string, IR1SsaLocation>;
+  declaredRules?: Set<string>;
+  canonicalize: (e: IR1Expr) => IR1Expr;
+}
+
+interface ScalarSsaInitialVersionState {
+  initialVersions: Map<string, IR1SsaVersion>;
 }
 
 export function makeScalarSsaState(
@@ -72,6 +103,67 @@ export function buildScalarSsaProgram(
     declaredRules: [...declaredRules],
     modifiedRules: [...state.modifiedRules],
     framedRules,
+  };
+}
+
+export function lowerScalarSsaToProps(
+  stmt: IR1Stmt,
+  options: ScalarSsaBuildOptions = {},
+): ScalarSsaLowerResult {
+  if (!isScalarSsaL1Body(stmt)) {
+    const reason = "statement is not supported by scalar SSA lowering";
+    return {
+      program: {
+        reads: [],
+        writes: [],
+        joins: [],
+        loopSummaries: [],
+        declaredRules: [...new Set(options.declaredRules ?? [])],
+        modifiedRules: [],
+        framedRules: [...new Set(options.declaredRules ?? [])],
+      },
+      finalProperties: [],
+      propositions: [],
+      modifiedRules: [],
+      diagnostics: [{ kind: "unsupported", reason }],
+    };
+  }
+
+  const program = buildScalarSsaProgram(stmt, options);
+  const lowerState = makeScalarSsaLowerState(program, options.canonicalize);
+  lowerScalarSsaStmtToVersions(stmt, lowerState);
+
+  const ast = getAst();
+  const finalProperties: ScalarSsaFinalPropertyEntry[] = [];
+  const propositions: PropResult[] = [];
+  for (const [key, version] of lowerState.currentVersions) {
+    const location = lowerState.locations.get(key);
+    if (location === undefined || location.kind !== "property") {
+      continue;
+    }
+    const rhs = lowerState.versionExprs.get(version);
+    if (rhs === undefined) {
+      throw new Error("missing lowered expression for final scalar SSA version");
+    }
+    const lhs = ast.app(
+      ast.primed(location.ruleName),
+      [lowerScalarOpaqueExpr(location.receiver, lowerState.canonicalize)],
+    );
+    finalProperties.push({ location, version, lhs, rhs });
+    propositions.push({
+      kind: "equation",
+      quantifiers: [],
+      lhs,
+      rhs,
+    });
+  }
+
+  return {
+    program,
+    finalProperties,
+    propositions,
+    modifiedRules: [...program.modifiedRules],
+    diagnostics: [],
   };
 }
 
@@ -214,6 +306,425 @@ function lowerScalarAssign(
   state.modifiedRules.add(ir1SsaRuleOfLocation(location));
 }
 
+interface ScalarSsaLowerState {
+  writes: readonly IR1SsaWrite[];
+  joins: readonly IR1SsaJoin[];
+  writeIndex: number;
+  joinIndex: number;
+  currentVersions: Map<string, IR1SsaVersion>;
+  initialVersions: Map<string, IR1SsaVersion>;
+  locations: Map<string, IR1SsaLocation>;
+  versionExprs: Map<IR1SsaVersion, OpaqueExpr>;
+  writtenKeys: Set<string>;
+  canonicalize: (e: IR1Expr) => IR1Expr;
+}
+
+function makeScalarSsaLowerState(
+  program: IR1SsaProgram,
+  canonicalize?: (e: IR1Expr) => IR1Expr,
+): ScalarSsaLowerState {
+  return {
+    writes: program.writes,
+    joins: program.joins,
+    writeIndex: 0,
+    joinIndex: 0,
+    currentVersions: new Map(),
+    initialVersions: new Map(),
+    locations: new Map(),
+    versionExprs: new Map(),
+    writtenKeys: new Set(),
+    canonicalize: canonicalize ?? ((e) => e),
+  };
+}
+
+function lowerScalarSsaStmtToVersions(
+  stmt: IR1Stmt,
+  state: ScalarSsaLowerState,
+): void {
+  switch (stmt.kind) {
+    case "assign":
+      lowerScalarSsaAssignToVersions(stmt, state);
+      return;
+    case "block":
+      for (const child of stmt.stmts) {
+        lowerScalarSsaStmtToVersions(child, state);
+      }
+      return;
+    case "cond-stmt":
+      lowerScalarSsaCondToVersions(stmt, state);
+      return;
+    case "map-effect":
+    case "set-effect":
+    case "foreach":
+    case "for":
+    case "while":
+    case "return":
+    case "throw":
+    case "let":
+    case "expr-stmt":
+      throw new Error(`${stmt.kind} is not supported by scalar SSA lowering`);
+    default: {
+      const _exhaustive: never = stmt;
+      void _exhaustive;
+      throw new Error("unsupported IR1 statement in scalar SSA lowering");
+    }
+  }
+}
+
+function lowerScalarSsaAssignToVersions(
+  stmt: Extract<IR1Stmt, { kind: "assign" }>,
+  state: ScalarSsaLowerState,
+): void {
+  if (stmt.target.kind !== "member") {
+    throw new Error("scalar SSA assignment target must be a property member");
+  }
+  const write = nextScalarSsaWrite(state, stmt.target.name);
+  if (write.location.kind !== "property") {
+    throw new Error("scalar SSA write lowered to a non-property location");
+  }
+  const { key, location } = scalarLocationForMember(stmt.target, state);
+  if (!sameScalarSsaLocation(write.location, location, state.canonicalize)) {
+    throw new Error("scalar SSA write order did not match its property location");
+  }
+  const rhs = lowerScalarSsaExprToOpaque(stmt.value, state);
+  state.currentVersions.set(key, write.version);
+  state.locations.set(key, location);
+  state.versionExprs.set(write.version, rhs);
+  state.writtenKeys.add(key);
+}
+
+function lowerScalarSsaCondToVersions(
+  stmt: Extract<IR1Stmt, { kind: "cond-stmt" }>,
+  state: ScalarSsaLowerState,
+): void {
+  if (stmt.arms.length !== 1) {
+    throw new Error("multi-armed cond-stmt is not supported by scalar SSA");
+  }
+  const ast = getAst();
+  const [guard, thenBody] = stmt.arms[0]!;
+  const guardExpr = lowerScalarSsaExprToOpaque(guard, state);
+  const thenState = cloneScalarSsaLowerStateForBranch(state);
+  lowerScalarSsaStmtToVersions(thenBody, thenState);
+
+  const elseState = cloneScalarSsaLowerStateForBranch(state);
+  elseState.writeIndex = thenState.writeIndex;
+  elseState.joinIndex = thenState.joinIndex;
+  if (stmt.otherwise !== null) {
+    lowerScalarSsaStmtToVersions(stmt.otherwise, elseState);
+  }
+
+  state.writeIndex = elseState.writeIndex;
+  state.joinIndex = elseState.joinIndex;
+
+  const touched = new Set([...thenState.writtenKeys, ...elseState.writtenKeys]);
+  for (const key of touched) {
+    const location =
+      thenState.locations.get(key) ??
+      elseState.locations.get(key) ??
+      state.locations.get(key);
+    if (location === undefined) {
+      throw new Error("scalar SSA branch touched an unknown location");
+    }
+    const thenVersion =
+      thenState.currentVersions.get(key) ??
+      initialVersionFor(key, location, thenState);
+    const elseVersion =
+      elseState.currentVersions.get(key) ??
+      initialVersionFor(key, location, elseState);
+    if (thenVersion === elseVersion) {
+      state.currentVersions.set(key, thenVersion);
+      state.locations.set(key, location);
+      state.writtenKeys.add(key);
+      continue;
+    }
+    const join = nextScalarSsaJoin(state, location);
+    if (
+      !sameScalarSsaVersion(join.thenVersion, thenVersion, state.canonicalize) ||
+      !sameScalarSsaVersion(join.elseVersion, elseVersion, state.canonicalize) ||
+      !sameScalarSsaLocation(join.location, location, state.canonicalize)
+    ) {
+      throw new Error("scalar SSA join order did not match branch versions");
+    }
+    const thenExpr = resolveScalarSsaVersionExpr(thenVersion, thenState);
+    const elseExpr = resolveScalarSsaVersionExpr(elseVersion, elseState);
+    const joinExpr = ast.cond([
+      [guardExpr, thenExpr],
+      [ast.litBool(true), elseExpr],
+    ]);
+    state.currentVersions.set(key, join.joinVersion);
+    state.locations.set(key, location);
+    state.versionExprs.set(join.joinVersion, joinExpr);
+    state.writtenKeys.add(key);
+  }
+}
+
+function lowerScalarSsaExprToOpaque(
+  expr: IR1Expr,
+  state: ScalarSsaLowerState,
+): OpaqueExpr {
+  const ast = getAst();
+  switch (expr.kind) {
+    case "member": {
+      const { key, location } = scalarLocationForMember(expr, state);
+      const version =
+        state.currentVersions.get(key) ?? initialVersionFor(key, location, state);
+      return resolveScalarSsaVersionExpr(version, state);
+    }
+    case "var":
+    case "lit":
+      return lowerScalarOpaqueExpr(expr, state.canonicalize);
+    case "binop":
+      return ast.binop(
+        lowerScalarBinop(expr.op),
+        lowerScalarSsaExprToOpaque(expr.lhs, state),
+        lowerScalarSsaExprToOpaque(expr.rhs, state),
+      );
+    case "unop":
+      return ast.unop(
+        lowerScalarUnop(expr.op),
+        lowerScalarSsaExprToOpaque(expr.arg, state),
+      );
+    case "app": {
+      const callee = lowerScalarSsaExprToOpaque(expr.callee, state);
+      const args = expr.args.map((arg) => lowerScalarSsaExprToOpaque(arg, state));
+      return ast.app(callee, args);
+    }
+    case "cond": {
+      const arms: Array<[OpaqueExpr, OpaqueExpr]> = expr.arms.map(
+        ([armGuard, value]) => [
+          lowerScalarSsaExprToOpaque(armGuard, state),
+          lowerScalarSsaExprToOpaque(value, state),
+        ],
+      );
+      return ast.cond([
+        ...arms,
+        [ast.litBool(true), lowerScalarSsaExprToOpaque(expr.otherwise, state)],
+      ]);
+    }
+    case "is-nullish":
+      return ast.binop(
+        ast.opEq(),
+        ast.unop(
+          ast.opCard(),
+          lowerScalarSsaExprToOpaque(expr.operand, state),
+        ),
+        ast.litNat(0),
+      );
+    case "each":
+      return ast.each(
+        [],
+        [
+          ast.gIn(expr.binder, lowerScalarSsaExprToOpaque(expr.src, state)),
+          ...expr.guards.map((guard) =>
+            ast.gExpr(lowerScalarSsaExprToOpaque(guard, state)),
+          ),
+        ],
+        lowerScalarSsaExprToOpaque(expr.proj, state),
+      );
+    case "map-read":
+    case "set-read":
+      throw new Error(`${expr.kind} is not a scalar SSA expression`);
+    default: {
+      const _exhaustive: never = expr;
+      void _exhaustive;
+      throw new Error("unsupported IR1 expression in scalar SSA lowering");
+    }
+  }
+}
+
+function resolveScalarSsaVersionExpr(
+  version: IR1SsaVersion,
+  state: Pick<
+    ScalarSsaLowerState,
+    "versionExprs" | "canonicalize"
+  >,
+): OpaqueExpr {
+  const existing = state.versionExprs.get(version);
+  if (existing !== undefined) {
+    return existing;
+  }
+  if (version.origin !== "initial" || version.location.kind !== "property") {
+    throw new Error("scalar SSA lowering expected a property initial version");
+  }
+  const ast = getAst();
+  const identity = ast.app(
+    ast.var(version.location.ruleName),
+    [lowerScalarOpaqueExpr(version.location.receiver, state.canonicalize)],
+  );
+  state.versionExprs.set(version, identity);
+  return identity;
+}
+
+function cloneScalarSsaLowerStateForBranch(
+  state: ScalarSsaLowerState,
+): ScalarSsaLowerState {
+  return {
+    writes: state.writes,
+    joins: state.joins,
+    writeIndex: state.writeIndex,
+    joinIndex: state.joinIndex,
+    currentVersions: new Map(state.currentVersions),
+    initialVersions: state.initialVersions,
+    locations: new Map(state.locations),
+    versionExprs: new Map(state.versionExprs),
+    writtenKeys: new Set(),
+    canonicalize: state.canonicalize,
+  };
+}
+
+function nextScalarSsaWrite(
+  state: ScalarSsaLowerState,
+  expectedRule?: string,
+): IR1SsaWrite {
+  const write = state.writes[state.writeIndex];
+  if (write === undefined) {
+    throw new Error("scalar SSA lowering ran out of writes");
+  }
+  state.writeIndex += 1;
+  if (expectedRule !== undefined && ir1SsaRuleOfLocation(write.location) !== expectedRule) {
+    throw new Error("scalar SSA write sequence did not match the source order");
+  }
+  return write;
+}
+
+function nextScalarSsaJoin(
+  state: ScalarSsaLowerState,
+  location: IR1SsaLocation,
+): IR1SsaJoin {
+  const join = state.joins[state.joinIndex];
+  if (join === undefined) {
+    throw new Error("scalar SSA lowering ran out of joins");
+  }
+  state.joinIndex += 1;
+  if (!sameScalarSsaLocation(join.location, location, state.canonicalize)) {
+    throw new Error("scalar SSA join sequence did not match the source order");
+  }
+  return join;
+}
+
+function lowerScalarOpaqueExpr(
+  expr: IR1Expr,
+  canonicalize: (e: IR1Expr) => IR1Expr,
+): OpaqueExpr {
+  return lowerExpr(lowerL1Expr(canonicalize(expr)));
+}
+
+function sameScalarSsaLocation(
+  left: IR1SsaLocation,
+  right: IR1SsaLocation,
+  canonicalize: (e: IR1Expr) => IR1Expr,
+): boolean {
+  if (left.kind !== right.kind) {
+    return false;
+  }
+  switch (left.kind) {
+    case "property":
+      return (
+        right.kind === "property" &&
+        left.ruleName === right.ruleName &&
+        left.property === right.property &&
+        scalarSsaCanonicalReceiverKey(left.receiver, { canonicalize }) ===
+          scalarSsaCanonicalReceiverKey(right.receiver, { canonicalize })
+      );
+    case "map-value":
+      return (
+        right.kind === "map-value" &&
+        left.ruleName === right.ruleName &&
+        left.ownerType === right.ownerType &&
+        left.keyType === right.keyType &&
+        scalarSsaCanonicalReceiverKey(left.receiver, { canonicalize }) ===
+          scalarSsaCanonicalReceiverKey(right.receiver, { canonicalize }) &&
+        scalarSsaCanonicalReceiverKey(left.key, { canonicalize }) ===
+          scalarSsaCanonicalReceiverKey(right.key, { canonicalize })
+      );
+    case "map-membership":
+      return (
+        right.kind === "map-membership" &&
+        left.ruleName === right.ruleName &&
+        left.keyPredName === right.keyPredName &&
+        left.ownerType === right.ownerType &&
+        left.keyType === right.keyType &&
+        scalarSsaCanonicalReceiverKey(left.receiver, { canonicalize }) ===
+          scalarSsaCanonicalReceiverKey(right.receiver, { canonicalize }) &&
+        scalarSsaCanonicalReceiverKey(left.key, { canonicalize }) ===
+          scalarSsaCanonicalReceiverKey(right.key, { canonicalize })
+      );
+    case "set-membership":
+      return (
+        right.kind === "set-membership" &&
+        left.ruleName === right.ruleName &&
+        left.ownerType === right.ownerType &&
+        left.elemType === right.elemType &&
+        scalarSsaCanonicalReceiverKey(left.receiver, { canonicalize }) ===
+          scalarSsaCanonicalReceiverKey(right.receiver, { canonicalize })
+      );
+    default: {
+      const _exhaustive: never = left;
+      void _exhaustive;
+      return false;
+    }
+  }
+}
+
+function sameScalarSsaVersion(
+  left: IR1SsaVersion,
+  right: IR1SsaVersion,
+  canonicalize: (e: IR1Expr) => IR1Expr,
+): boolean {
+  return (
+    left.origin === right.origin &&
+    sameScalarSsaLocation(left.location, right.location, canonicalize)
+  );
+}
+
+function lowerScalarBinop(op: Extract<IR1Expr, { kind: "binop" }>["op"]) {
+  const ast = getAst();
+  switch (op) {
+    case "add":
+      return ast.opAdd();
+    case "sub":
+      return ast.opSub();
+    case "mul":
+      return ast.opMul();
+    case "div":
+      return ast.opDiv();
+    case "eq":
+      return ast.opEq();
+    case "neq":
+      return ast.opNeq();
+    case "lt":
+      return ast.opLt();
+    case "le":
+      return ast.opLe();
+    case "gt":
+      return ast.opGt();
+    case "ge":
+      return ast.opGe();
+    case "and":
+      return ast.opAnd();
+    case "or":
+      return ast.opOr();
+    case "in":
+      return ast.opIn();
+    default:
+      throw new Error(`unsupported scalar SSA binop: ${String(op)}`);
+  }
+}
+
+function lowerScalarUnop(op: Extract<IR1Expr, { kind: "unop" }>["op"]) {
+  const ast = getAst();
+  switch (op) {
+    case "not":
+      return ast.opNot();
+    case "neg":
+      return ast.opNeg();
+    case "card":
+      return ast.opCard();
+    default:
+      throw new Error(`unsupported scalar SSA unop: ${String(op)}`);
+  }
+}
+
 function lowerScalarCondStmt(
   stmt: Extract<IR1Stmt, { kind: "cond-stmt" }>,
   state: ScalarSsaState,
@@ -311,7 +822,7 @@ function scalarSsaReadMember(
 
 function scalarLocationForMember(
   member: Extract<IR1Expr, { kind: "member" }>,
-  state: ScalarSsaState,
+  state: ScalarSsaLocationState,
 ): { key: string; location: IR1SsaLocation } {
   const receiver = scalarSsaCanonicalReceiverKey(member.receiver, state);
   const key = scalarPropertyKey(member.name, receiver);
@@ -325,14 +836,14 @@ function scalarLocationForMember(
     member.name,
   );
   state.locations.set(key, location);
-  state.declaredRules.add(ir1SsaRuleOfLocation(location));
+  state.declaredRules?.add(ir1SsaRuleOfLocation(location));
   return { key, location };
 }
 
 function initialVersionFor(
   key: string,
   location: IR1SsaLocation,
-  state: ScalarSsaState,
+  state: ScalarSsaInitialVersionState,
 ): IR1SsaVersion {
   const existing = state.initialVersions.get(key);
   if (existing !== undefined) {
@@ -349,7 +860,7 @@ function scalarPropertyKey(prop: string, receiver: string): string {
 
 function scalarSsaCanonicalReceiverKey(
   receiver: IR1Expr,
-  state: ScalarSsaState,
+  state: Pick<ScalarSsaLocationState, "canonicalize">,
 ): string {
   try {
     return scalarSsaExprKey(state.canonicalize(receiver));

--- a/tools/ts2pant/src/ir1-ssa-scalars.ts
+++ b/tools/ts2pant/src/ir1-ssa-scalars.ts
@@ -143,12 +143,13 @@ export function lowerScalarSsaToProps(
     }
     const rhs = lowerState.versionExprs.get(version);
     if (rhs === undefined) {
-      throw new Error("missing lowered expression for final scalar SSA version");
+      throw new Error(
+        "missing lowered expression for final scalar SSA version",
+      );
     }
-    const lhs = ast.app(
-      ast.primed(location.ruleName),
-      [lowerScalarOpaqueExpr(location.receiver, lowerState.canonicalize)],
-    );
+    const lhs = ast.app(ast.primed(location.ruleName), [
+      lowerScalarOpaqueExpr(location.receiver, lowerState.canonicalize),
+    ]);
     finalProperties.push({ location, version, lhs, rhs });
     propositions.push({
       kind: "equation",
@@ -384,7 +385,9 @@ function lowerScalarSsaAssignToVersions(
   }
   const { key, location } = scalarLocationForMember(stmt.target, state);
   if (!sameScalarSsaLocation(write.location, location, state.canonicalize)) {
-    throw new Error("scalar SSA write order did not match its property location");
+    throw new Error(
+      "scalar SSA write order did not match its property location",
+    );
   }
   const rhs = lowerScalarSsaExprToOpaque(stmt.value, state);
   state.currentVersions.set(key, write.version);
@@ -439,8 +442,16 @@ function lowerScalarSsaCondToVersions(
     }
     const join = nextScalarSsaJoin(state, location);
     if (
-      !sameScalarSsaVersion(join.thenVersion, thenVersion, state.canonicalize) ||
-      !sameScalarSsaVersion(join.elseVersion, elseVersion, state.canonicalize) ||
+      !sameScalarSsaVersion(
+        join.thenVersion,
+        thenVersion,
+        state.canonicalize,
+      ) ||
+      !sameScalarSsaVersion(
+        join.elseVersion,
+        elseVersion,
+        state.canonicalize,
+      ) ||
       !sameScalarSsaLocation(join.location, location, state.canonicalize)
     ) {
       throw new Error("scalar SSA join order did not match branch versions");
@@ -467,7 +478,8 @@ function lowerScalarSsaExprToOpaque(
     case "member": {
       const { key, location } = scalarLocationForMember(expr, state);
       const version =
-        state.currentVersions.get(key) ?? initialVersionFor(key, location, state);
+        state.currentVersions.get(key) ??
+        initialVersionFor(key, location, state);
       return resolveScalarSsaVersionExpr(version, state);
     }
     case "var":
@@ -486,7 +498,9 @@ function lowerScalarSsaExprToOpaque(
       );
     case "app": {
       const callee = lowerScalarSsaExprToOpaque(expr.callee, state);
-      const args = expr.args.map((arg) => lowerScalarSsaExprToOpaque(arg, state));
+      const args = expr.args.map((arg) =>
+        lowerScalarSsaExprToOpaque(arg, state),
+      );
       return ast.app(callee, args);
     }
     case "cond": {
@@ -504,10 +518,7 @@ function lowerScalarSsaExprToOpaque(
     case "is-nullish":
       return ast.binop(
         ast.opEq(),
-        ast.unop(
-          ast.opCard(),
-          lowerScalarSsaExprToOpaque(expr.operand, state),
-        ),
+        ast.unop(ast.opCard(), lowerScalarSsaExprToOpaque(expr.operand, state)),
         ast.litNat(0),
       );
     case "each":
@@ -534,10 +545,7 @@ function lowerScalarSsaExprToOpaque(
 
 function resolveScalarSsaVersionExpr(
   version: IR1SsaVersion,
-  state: Pick<
-    ScalarSsaLowerState,
-    "versionExprs" | "canonicalize"
-  >,
+  state: Pick<ScalarSsaLowerState, "versionExprs" | "canonicalize">,
 ): OpaqueExpr {
   const existing = state.versionExprs.get(version);
   if (existing !== undefined) {
@@ -547,10 +555,9 @@ function resolveScalarSsaVersionExpr(
     throw new Error("scalar SSA lowering expected a property initial version");
   }
   const ast = getAst();
-  const identity = ast.app(
-    ast.var(version.location.ruleName),
-    [lowerScalarOpaqueExpr(version.location.receiver, state.canonicalize)],
-  );
+  const identity = ast.app(ast.var(version.location.ruleName), [
+    lowerScalarOpaqueExpr(version.location.receiver, state.canonicalize),
+  ]);
   state.versionExprs.set(version, identity);
   return identity;
 }
@@ -581,7 +588,10 @@ function nextScalarSsaWrite(
     throw new Error("scalar SSA lowering ran out of writes");
   }
   state.writeIndex += 1;
-  if (expectedRule !== undefined && ir1SsaRuleOfLocation(write.location) !== expectedRule) {
+  if (
+    expectedRule !== undefined &&
+    ir1SsaRuleOfLocation(write.location) !== expectedRule
+  ) {
     throw new Error("scalar SSA write sequence did not match the source order");
   }
   return write;

--- a/tools/ts2pant/tests/ir1-ssa-scalars.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-scalars.test.mts
@@ -149,7 +149,7 @@ describe("ir1-ssa-scalars", () => {
     assert.equal(outerJoin!.joinVersion.location, innerJoin!.location);
     assert.equal(
       scalarEquationRhs(outer),
-      "cond x => cond y => 1, true => 2, true => 3",
+      "cond x => (cond y => 1, true => 2), true => 3",
     );
   });
 

--- a/tools/ts2pant/tests/ir1-ssa-scalars.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-scalars.test.mts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { resolve } from "node:path";
-import { describe, it } from "node:test";
+import { before, describe, it } from "node:test";
 
 import { createSourceFile } from "../src/extract.js";
 import {
@@ -17,7 +17,9 @@ import {
 import {
   buildScalarSsaProgram,
   isScalarSsaL1Body,
+  lowerScalarSsaToProps,
 } from "../src/ir1-ssa-scalars.js";
+import { getAst, loadAst } from "../src/pant-wasm.js";
 import { buildDocumentFromSourceFile, emitAndCheck } from "./helpers.mjs";
 
 const CONSTRUCTS_DIR = resolve(import.meta.dirname, "fixtures/constructs");
@@ -31,6 +33,22 @@ async function emitFixture(fileName: string, functionName: string) {
   const doc = await buildDocumentFromSourceFile(sourceFile, functionName);
   return emitAndCheck(doc);
 }
+
+function scalarEquationRhs(stmt: Parameters<typeof lowerScalarSsaToProps>[0]) {
+  const result = lowerScalarSsaToProps(stmt);
+  assert.deepEqual(result.diagnostics, []);
+  assert.equal(result.propositions.length, 1);
+  const [eq] = result.propositions;
+  assert.equal(eq?.kind, "equation");
+  if (eq?.kind !== "equation") {
+    assert.fail("expected a scalar SSA equation");
+  }
+  return getAst().strExpr(eq.rhs);
+}
+
+before(async () => {
+  await loadAst();
+});
 
 describe("ir1-ssa-scalars", () => {
   // PENDING Patch 2: add the scalar SSA builder state and write/version recording.
@@ -57,6 +75,7 @@ describe("ir1-ssa-scalars", () => {
     assert.equal(write.location.property, "Account_balance");
     assert.equal(write.version.location, write.location);
     assert.deepEqual(write.value, { kind: "property", value: ir1LitNat(1) });
+    assert.equal(scalarEquationRhs(stmt), "1");
   });
 
   it("resolves compound property assignment through the dominating prior version", () => {
@@ -77,6 +96,7 @@ describe("ir1-ssa-scalars", () => {
     assert.equal(read.version, firstWrite!.version);
     assert.equal(read.dominated, true);
     assert.equal(secondWrite!.version.location, firstWrite!.location);
+    assert.equal(scalarEquationRhs(stmt), "1 + 2");
   });
 
   it("joins a single-arm if against the initial property version", () => {
@@ -99,6 +119,10 @@ describe("ir1-ssa-scalars", () => {
     assert.equal(join.elseVersion.location, write.location);
     assert.equal(join.joinVersion.location, write.location);
     assert.notEqual(join.thenVersion, join.elseVersion);
+    assert.equal(
+      scalarEquationRhs(stmt),
+      "cond g => 1, true => Account_balance a",
+    );
   });
 
   it("lowers nested scalar if bodies through SSA joins", () => {
@@ -123,6 +147,10 @@ describe("ir1-ssa-scalars", () => {
     assert.equal(outerJoin!.thenVersion, innerJoin!.joinVersion);
     assert.equal(outerJoin!.elseVersion, program.writes[2]!.version);
     assert.equal(outerJoin!.joinVersion.location, innerJoin!.location);
+    assert.equal(
+      scalarEquationRhs(outer),
+      "cond x => cond y => 1, true => 2, true => 3",
+    );
   });
 
   it("rejects non-scalar routing shapes", () => {


### PR DESCRIPTION
## Patch 3: Lower scalar SSA final versions to property equations

- Add ScalarSsaLowerResult containing the IR1SsaProgram, final property entries, generated PropResult equations, modified rule set, and unsupported diagnostics.
- Lower final property versions to `prop' receiver = value` equations using the same OpaqueExpr construction discipline currently used by lowerAssign and translateMutatingBody.
- Represent join versions as cond expressions with the branch guard and the else/identity fallback used today for SymbolicState property merges.
- Ensure asymmetric branch writes emit one final property equation per touched property, using the pre-state property read for untouched branch arms.
- Ensure degenerate joins reuse the existing version and do not emit redundant join records.
- Do not lower Map/Set or foreach in this module; return unsupported or false from the scalar route predicate before those forms reach scalar lowering.
- Implement equation-level assertions for the direct assignment, read-after-write, single-arm branch, and nested branch tests introduced by Patch 1.

## Changes
- Add ScalarSsaLowerResult containing the IR1SsaProgram, final property entries, generated PropResult equations, modified rule set, and unsupported diagnostics.
- Lower final property versions to `prop' receiver = value` equations using the same OpaqueExpr construction discipline currently used by lowerAssign and translateMutatingBody.
- Represent join versions as cond expressions with the branch guard and the else/identity fallback used today for SymbolicState property merges.
- Ensure asymmetric branch writes emit one final property equation per touched property, using the pre-state property read for untouched branch arms.
- Ensure degenerate joins reuse the existing version and do not emit redundant join records.
- Do not lower Map/Set or foreach in this module; return unsupported or false from the scalar route predicate before those forms reach scalar lowering.
- Implement equation-level assertions for the direct assignment, read-after-write, single-arm branch, and nested branch tests introduced by Patch 1.

## Files to Modify
- tools/ts2pant/src/ir1-ssa-scalars.ts (modify): Add final-version lowering from scalar IR1 SSA into PropResult equations and modified-rule tracking.
- tools/ts2pant/tests/ir1-ssa-scalars.test.mts (modify): Extend implemented unit tests to assert final equation RHS strings for direct writes, read-after-write, and branches.

## Gameplan Specification

```
module IR1_SSA_BUILDER_SCALARS.

IR1Program.
Construct.
Location.
Version.
Read.
Write.
Join.
LoopSummary.
Rule.
PropResult.
Diagnostic.

supported-constructs p: IR1Program => [Construct].
lowered-constructs p: IR1Program => [Construct].
diagnostics p: IR1Program => [Diagnostic].
diagnostic-construct d: Diagnostic => Construct.
writes p: IR1Program => [Write].
reads p: IR1Program => [Read].
joins p: IR1Program => [Join].
loop-summaries p: IR1Program => [LoopSummary].
write-location w: Write => Location.
write-version w: Write => Version.
read-location r: Read => Location.
read-version r: Read => Version.
read-dominated? p: IR1Program, r: Read => Bool.
join-location j: Join => Location.
then-version j: Join => Version.
else-version j: Join => Version.
join-version j: Join => Version.
summary-location s: LoopSummary => Location.
summary-version s: LoopSummary => Version.
initial-version l: Location => Version.
version-location v: Version => Location.
rule-of-location l: Location => Rule.
declared-rules p: IR1Program => [Rule].
modified-rules p: IR1Program => [Rule].
framed-rules p: IR1Program => [Rule].
emitted-props p: IR1Program => [PropResult].
scalar-construct? c: Construct => Bool.
scalar-location? l: Location => Bool.
final-version p: IR1Program, l: Location => Version.
modified-location? p: IR1Program, l: Location => Bool.

---

all p: IR1Program, c in supported-constructs p |
  c in lowered-constructs p.

all p: IR1Program, d in diagnostics p |
  ~(diagnostic-construct d in supported-constructs p).

all p: IR1Program, c in supported-constructs p |
  scalar-construct? c -> c in lowered-constructs p.

all p: IR1Program, w in writes p |
  version-location (write-version w) = write-location w.

all p: IR1Program, s in loop-summaries p |
  version-location (summary-version s) = summary-location s.

all l: Location |
  version-location (initial-version l) = l.

all p: IR1Program, w1 in writes p, w2 in writes p |
  write-version w1 = write-version w2 -> w1 = w2.

all p: IR1Program, r in reads p |
  read-dominated? p r and
  version-location (read-version r) = read-location r and
  (
    read-version r = initial-version (read-location r) or
    (some w in writes p |
      write-version w = read-version r and
      write-location w = read-location r) or
    (some s in loop-summaries p |
      summary-version s = read-version r and
      summary-location s = read-location r)
  ).

all p: IR1Program, j in joins p |
  version-location (then-version j) = join-location j and
  version-location (else-version j) = join-location j and
  version-location (join-version j) = join-location j.

all p: IR1Program, j in joins p |
  then-version j != else-version j and
  join-version j != then-version j and
  join-version j != else-version j.

all p: IR1Program, l: Location |
  scalar-location? l and modified-location? p l ->
    version-location (final-version p l) = l and
    rule-of-location l in modified-rules p.

all p: IR1Program, rule in modified-rules p |
  rule in declared-rules p and
  ~(rule in framed-rules p).

all p: IR1Program, rule in framed-rules p |
  rule in declared-rules p and
  ~(rule in modified-rules p).

all p: IR1Program, rule in declared-rules p |
  rule in modified-rules p or rule in framed-rules p.

all p: IR1Program, w in writes p |
  rule-of-location (write-location w) in modified-rules p.

all p: IR1Program, s in loop-summaries p |
  rule-of-location (summary-location s) in modified-rules p.

all p: IR1Program |
  #(lowered-constructs p) > 0 -> #(emitted-props p) > 0.

```

## Patch Specification

```
module IR1_SSA_BUILDER_SCALARS_PATCH_3.

IR1Program.
Location.
Version.
Write.
Join.
Rule.
PropResult.

writes p: IR1Program => [Write].
joins p: IR1Program => [Join].
write-location w: Write => Location.
write-version w: Write => Version.
join-location j: Join => Location.
join-version j: Join => Version.
version-location v: Version => Location.
rule-of-location l: Location => Rule.
modified-rules p: IR1Program => [Rule].
emitted-props p: IR1Program => [PropResult].
final-version p: IR1Program, l: Location => Version.
modified-location? p: IR1Program, l: Location => Bool.

---

all p: IR1Program, l: Location |
  modified-location? p l ->
    rule-of-location l in modified-rules p and
    version-location (final-version p l) = l.

all p: IR1Program, w in writes p |
  modified-location? p (write-location w).

all p: IR1Program, j in joins p |
  modified-location? p (join-location j) and
  version-location (join-version j) = join-location j.

all p: IR1Program |
  #(writes p) > 0 -> #(emitted-props p) > 0.

```


## Implementation Notes

- The lowerer is a second pass over the original scalar `IR1Stmt`, not a direct fold over `IR1SsaProgram`. Patch 2’s SSA program records writes/joins/reads, but it does not retain branch guards, so reconstructing final `cond` equations requires replaying the source statement while consuming the recorded SSA write/join sequence.
- The replay pass tracks `IR1SsaVersion -> OpaqueExpr` and `property-key -> current version`. That keeps read-after-write lowering exact without widening the public IR1 SSA vocabulary with expression-bearing version nodes.
- The builder and replay pass both recreate `Location` objects, so the lowering pass matches writes/joins by semantic location equality rather than object identity. That is the main non-obvious piece in the implementation; otherwise initial-version fallbacks on asymmetric branches would spuriously fail when validating replay order.
- Unsupported routing is surfaced as `diagnostics` on `ScalarSsaLowerResult` and returns an empty SSA program/result shape, instead of throwing, when the entry statement fails the scalar-only syntactic predicate. Once inside the scalar route, unsupported forms still reject hard because reaching them is an internal invariant violation.
- Verification note: `pnpm exec tsc -p tsconfig.json --noEmit` passed. The new scalar SSA test file was exercised locally, but only with a temporary wasm stub because this environment does not have the `js_of_ocaml` / `wasm_of_ocaml` toolchain needed to build or load the real `pant-wasm` bundle.