### PR TITLE
[ir1-ssa-builder-scalars] Patch 4: Route scalar assignments and if-mutation through SSA

### DIFF
--- a/tools/ts2pant/src/ir1-lower-body.ts
+++ b/tools/ts2pant/src/ir1-lower-body.ts
@@ -27,6 +27,10 @@
 import { lowerBinop, lowerExpr } from "./ir-emit.js";
 import type { IR1Expr, IR1FoldLeaf, IR1Stmt } from "./ir1.js";
 import { lowerL1Expr } from "./ir1-lower.js";
+import {
+  isScalarSsaL1Body,
+  lowerScalarSsaToProps,
+} from "./ir1-ssa-scalars.js";
 import type { OpaqueExpr } from "./pant-ast.js";
 import { getAst } from "./pant-wasm.js";
 import {
@@ -214,6 +218,10 @@ export function lowerL1Body(
   propositions: PropResult[],
   ctx: LowerBodyCtx,
 ): boolean {
+  if (isScalarSsaL1Body(stmt)) {
+    return lowerScalarL1BodyToSsa(stmt, state, propositions, ctx);
+  }
+
   switch (stmt.kind) {
     case "block": {
       let ok = true;
@@ -255,6 +263,62 @@ export function lowerL1Body(
       return false;
     }
   }
+}
+
+function lowerScalarL1BodyToSsa(
+  stmt: IR1Stmt,
+  state: SymbolicState,
+  propositions: PropResult[],
+  ctx: LowerBodyCtx,
+): boolean {
+  let result: ReturnType<typeof lowerScalarSsaToProps>;
+  try {
+    result = lowerScalarSsaToProps(stmt, {
+      lowerOpaque: ctx.applyConst,
+      initialPropertyValues: scalarInitialPropertyValues(state),
+    });
+  } catch (err) {
+    propositions.push({
+      kind: "unsupported",
+      reason:
+        err instanceof Error
+          ? err.message
+          : "scalar SSA lowering rejected the body",
+    });
+    return false;
+  }
+
+  if (result.diagnostics.length > 0) {
+    propositions.push(...result.diagnostics);
+    return false;
+  }
+
+  for (const entry of result.finalProperties) {
+    const prop = entry.location.ruleName;
+    const key = symbolicKey(prop, entry.objExpr);
+    state.writes = putWrite(state.writes, key, {
+      kind: "property",
+      prop,
+      objExpr: entry.objExpr,
+      value: entry.rhs,
+    });
+    state.writtenKeys = addWrittenKey(state.writtenKeys, key);
+    state.modifiedProps = addModifiedProp(state.modifiedProps, prop);
+  }
+
+  return true;
+}
+
+function scalarInitialPropertyValues(
+  state: SymbolicState,
+): ReadonlyMap<string, OpaqueExpr> {
+  const initialValues = new Map<string, OpaqueExpr>();
+  for (const [key, entry] of state.writes) {
+    if (entry.kind === "property") {
+      initialValues.set(key, entry.value);
+    }
+  }
+  return initialValues;
 }
 
 function lowerAssign(

--- a/tools/ts2pant/src/ir1-lower-body.ts
+++ b/tools/ts2pant/src/ir1-lower-body.ts
@@ -27,10 +27,7 @@
 import { lowerBinop, lowerExpr } from "./ir-emit.js";
 import type { IR1Expr, IR1FoldLeaf, IR1Stmt } from "./ir1.js";
 import { lowerL1Expr } from "./ir1-lower.js";
-import {
-  isScalarSsaL1Body,
-  lowerScalarSsaToProps,
-} from "./ir1-ssa-scalars.js";
+import { isScalarSsaL1Body, lowerScalarSsaToProps } from "./ir1-ssa-scalars.js";
 import type { OpaqueExpr } from "./pant-ast.js";
 import { getAst } from "./pant-wasm.js";
 import {

--- a/tools/ts2pant/src/ir1-ssa-scalars.ts
+++ b/tools/ts2pant/src/ir1-ssa-scalars.ts
@@ -38,11 +38,14 @@ export interface ScalarSsaState {
 export interface ScalarSsaBuildOptions {
   declaredRules?: Iterable<string>;
   canonicalize?: (e: IR1Expr) => IR1Expr;
+  lowerOpaque?: (e: OpaqueExpr) => OpaqueExpr;
+  initialPropertyValues?: ReadonlyMap<string, OpaqueExpr>;
 }
 
 export interface ScalarSsaFinalPropertyEntry {
   location: Extract<IR1SsaLocation, { kind: "property" }>;
   version: IR1SsaVersion;
+  objExpr: OpaqueExpr;
   lhs: OpaqueExpr;
   rhs: OpaqueExpr;
 }
@@ -131,7 +134,12 @@ export function lowerScalarSsaToProps(
   }
 
   const program = buildScalarSsaProgram(stmt, options);
-  const lowerState = makeScalarSsaLowerState(program, options.canonicalize);
+  const lowerState = makeScalarSsaLowerState(
+    program,
+    options.canonicalize,
+    options.lowerOpaque,
+    options.initialPropertyValues,
+  );
   lowerScalarSsaStmtToVersions(stmt, lowerState);
 
   const ast = getAst();
@@ -148,10 +156,14 @@ export function lowerScalarSsaToProps(
         "missing lowered expression for final scalar SSA version",
       );
     }
-    const lhs = ast.app(ast.primed(location.ruleName), [
-      lowerScalarOpaqueExpr(location.receiver, lowerState.canonicalize),
-    ]);
-    finalProperties.push({ location, version, lhs, rhs });
+    const objExpr = lowerState.lowerOpaque(
+      lowerScalarOpaqueExpr(
+        location.receiver,
+        lowerState.canonicalize,
+      ),
+    );
+    const lhs = ast.app(ast.primed(location.ruleName), [objExpr]);
+    finalProperties.push({ location, version, objExpr, lhs, rhs });
     propositions.push({
       kind: "equation",
       quantifiers: [],
@@ -319,11 +331,15 @@ interface ScalarSsaLowerState {
   versionExprs: Map<IR1SsaVersion, OpaqueExpr>;
   writtenKeys: Set<string>;
   canonicalize: (e: IR1Expr) => IR1Expr;
+  lowerOpaque: (e: OpaqueExpr) => OpaqueExpr;
+  initialPropertyValues: ReadonlyMap<string, OpaqueExpr>;
 }
 
 function makeScalarSsaLowerState(
   program: IR1SsaProgram,
   canonicalize?: (e: IR1Expr) => IR1Expr,
+  lowerOpaque?: (e: OpaqueExpr) => OpaqueExpr,
+  initialPropertyValues: ReadonlyMap<string, OpaqueExpr> = new Map(),
 ): ScalarSsaLowerState {
   return {
     writes: program.writes,
@@ -336,6 +352,8 @@ function makeScalarSsaLowerState(
     versionExprs: new Map(),
     writtenKeys: new Set(),
     canonicalize: canonicalize ?? ((e) => e),
+    lowerOpaque: lowerOpaque ?? ((e) => e),
+    initialPropertyValues,
   };
 }
 
@@ -463,10 +481,12 @@ function lowerScalarSsaCondToVersions(
     }
     const thenExpr = resolveScalarSsaVersionExpr(thenVersion, thenState);
     const elseExpr = resolveScalarSsaVersionExpr(elseVersion, elseState);
-    const joinExpr = ast.cond([
-      [guardExpr, thenExpr],
-      [ast.litBool(true), elseExpr],
-    ]);
+    const joinExpr = state.lowerOpaque(
+      ast.cond([
+        [guardExpr, thenExpr],
+        [ast.litBool(true), elseExpr],
+      ]),
+    );
     state.currentVersions.set(key, join.joinVersion);
     state.locations.set(key, location);
     state.versionExprs.set(join.joinVersion, joinExpr);
@@ -489,24 +509,26 @@ function lowerScalarSsaExprToOpaque(
     }
     case "var":
     case "lit":
-      return lowerScalarOpaqueExpr(expr, state.canonicalize);
+      return state.lowerOpaque(lowerScalarOpaqueExpr(expr, state.canonicalize));
     case "binop":
-      return ast.binop(
-        lowerScalarBinop(expr.op),
-        lowerScalarSsaExprToOpaque(expr.lhs, state),
-        lowerScalarSsaExprToOpaque(expr.rhs, state),
+      return state.lowerOpaque(
+        ast.binop(
+          lowerScalarBinop(expr.op),
+          lowerScalarSsaExprToOpaque(expr.lhs, state),
+          lowerScalarSsaExprToOpaque(expr.rhs, state),
+        ),
       );
     case "unop":
-      return ast.unop(
-        lowerScalarUnop(expr.op),
-        lowerScalarSsaExprToOpaque(expr.arg, state),
+      return state.lowerOpaque(
+        ast.unop(
+          lowerScalarUnop(expr.op),
+          lowerScalarSsaExprToOpaque(expr.arg, state),
+        ),
       );
     case "app": {
       const callee = lowerScalarSsaExprToOpaque(expr.callee, state);
-      const args = expr.args.map((arg) =>
-        lowerScalarSsaExprToOpaque(arg, state),
-      );
-      return ast.app(callee, args);
+      const args = expr.args.map((arg) => lowerScalarSsaExprToOpaque(arg, state));
+      return state.lowerOpaque(ast.app(callee, args));
     }
     case "cond": {
       const arms: Array<[OpaqueExpr, OpaqueExpr]> = expr.arms.map(
@@ -515,27 +537,36 @@ function lowerScalarSsaExprToOpaque(
           lowerScalarSsaExprToOpaque(value, state),
         ],
       );
-      return ast.cond([
-        ...arms,
-        [ast.litBool(true), lowerScalarSsaExprToOpaque(expr.otherwise, state)],
-      ]);
+      return state.lowerOpaque(
+        ast.cond([
+          ...arms,
+          [ast.litBool(true), lowerScalarSsaExprToOpaque(expr.otherwise, state)],
+        ]),
+      );
     }
     case "is-nullish":
-      return ast.binop(
-        ast.opEq(),
-        ast.unop(ast.opCard(), lowerScalarSsaExprToOpaque(expr.operand, state)),
-        ast.litNat(0),
+      return state.lowerOpaque(
+        ast.binop(
+          ast.opEq(),
+          ast.unop(
+            ast.opCard(),
+            lowerScalarSsaExprToOpaque(expr.operand, state),
+          ),
+          ast.litNat(0),
+        ),
       );
     case "each":
-      return ast.each(
-        [],
-        [
-          ast.gIn(expr.binder, lowerScalarSsaExprToOpaque(expr.src, state)),
-          ...expr.guards.map((guard) =>
-            ast.gExpr(lowerScalarSsaExprToOpaque(guard, state)),
-          ),
-        ],
-        lowerScalarSsaExprToOpaque(expr.proj, state),
+      return state.lowerOpaque(
+        ast.each(
+          [],
+          [
+            ast.gIn(expr.binder, lowerScalarSsaExprToOpaque(expr.src, state)),
+            ...expr.guards.map((guard) =>
+              ast.gExpr(lowerScalarSsaExprToOpaque(guard, state)),
+            ),
+          ],
+          lowerScalarSsaExprToOpaque(expr.proj, state),
+        ),
       );
     case "map-read":
     case "set-read":
@@ -550,7 +581,10 @@ function lowerScalarSsaExprToOpaque(
 
 function resolveScalarSsaVersionExpr(
   version: IR1SsaVersion,
-  state: Pick<ScalarSsaLowerState, "versionExprs" | "canonicalize">,
+  state: Pick<
+    ScalarSsaLowerState,
+    "versionExprs" | "canonicalize" | "lowerOpaque" | "initialPropertyValues"
+  >,
 ): OpaqueExpr {
   const existing = state.versionExprs.get(version);
   if (existing !== undefined) {
@@ -559,10 +593,23 @@ function resolveScalarSsaVersionExpr(
   if (version.origin !== "initial" || version.location.kind !== "property") {
     throw new Error("scalar SSA lowering expected a property initial version");
   }
-  const ast = getAst();
-  const identity = ast.app(ast.var(version.location.ruleName), [
+  const initialKey = scalarOpaquePropertyKey(
+    version.location.ruleName,
     lowerScalarOpaqueExpr(version.location.receiver, state.canonicalize),
-  ]);
+  );
+  const initialValue = state.initialPropertyValues.get(initialKey);
+  if (initialValue !== undefined) {
+    const loweredInitialValue = state.lowerOpaque(initialValue);
+    state.versionExprs.set(version, loweredInitialValue);
+    return loweredInitialValue;
+  }
+  const ast = getAst();
+  const identity = state.lowerOpaque(
+    ast.app(
+      ast.var(version.location.ruleName),
+      [lowerScalarOpaqueExpr(version.location.receiver, state.canonicalize)],
+    ),
+  );
   state.versionExprs.set(version, identity);
   return identity;
 }
@@ -583,6 +630,8 @@ function cloneScalarSsaLowerStateForBranch(
     versionExprs: new Map(state.versionExprs),
     writtenKeys: new Set(),
     canonicalize: state.canonicalize,
+    lowerOpaque: state.lowerOpaque,
+    initialPropertyValues: state.initialPropertyValues,
   };
 }
 
@@ -873,6 +922,10 @@ function initialVersionFor(
 
 function scalarPropertyKey(prop: string, receiver: string): string {
   return `${prop}::${receiver}`;
+}
+
+function scalarOpaquePropertyKey(prop: string, receiver: OpaqueExpr): string {
+  return `${prop}::${getAst().strExpr(receiver)}`;
 }
 
 function scalarSsaCanonicalReceiverKey(

--- a/tools/ts2pant/src/ir1-ssa-scalars.ts
+++ b/tools/ts2pant/src/ir1-ssa-scalars.ts
@@ -157,10 +157,7 @@ export function lowerScalarSsaToProps(
       );
     }
     const objExpr = lowerState.lowerOpaque(
-      lowerScalarOpaqueExpr(
-        location.receiver,
-        lowerState.canonicalize,
-      ),
+      lowerScalarOpaqueExpr(location.receiver, lowerState.canonicalize),
     );
     const lhs = ast.app(ast.primed(location.ruleName), [objExpr]);
     finalProperties.push({ location, version, objExpr, lhs, rhs });
@@ -527,7 +524,9 @@ function lowerScalarSsaExprToOpaque(
       );
     case "app": {
       const callee = lowerScalarSsaExprToOpaque(expr.callee, state);
-      const args = expr.args.map((arg) => lowerScalarSsaExprToOpaque(arg, state));
+      const args = expr.args.map((arg) =>
+        lowerScalarSsaExprToOpaque(arg, state),
+      );
       return state.lowerOpaque(ast.app(callee, args));
     }
     case "cond": {
@@ -540,7 +539,10 @@ function lowerScalarSsaExprToOpaque(
       return state.lowerOpaque(
         ast.cond([
           ...arms,
-          [ast.litBool(true), lowerScalarSsaExprToOpaque(expr.otherwise, state)],
+          [
+            ast.litBool(true),
+            lowerScalarSsaExprToOpaque(expr.otherwise, state),
+          ],
         ]),
       );
     }
@@ -605,10 +607,9 @@ function resolveScalarSsaVersionExpr(
   }
   const ast = getAst();
   const identity = state.lowerOpaque(
-    ast.app(
-      ast.var(version.location.ruleName),
-      [lowerScalarOpaqueExpr(version.location.receiver, state.canonicalize)],
-    ),
+    ast.app(ast.var(version.location.ruleName), [
+      lowerScalarOpaqueExpr(version.location.receiver, state.canonicalize),
+    ]),
   );
   state.versionExprs.set(version, identity);
   return identity;

--- a/tools/ts2pant/src/ir1-ssa-scalars.ts
+++ b/tools/ts2pant/src/ir1-ssa-scalars.ts
@@ -595,9 +595,12 @@ function resolveScalarSsaVersionExpr(
   if (version.origin !== "initial" || version.location.kind !== "property") {
     throw new Error("scalar SSA lowering expected a property initial version");
   }
+  const receiver = state.lowerOpaque(
+    lowerScalarOpaqueExpr(version.location.receiver, state.canonicalize),
+  );
   const initialKey = scalarOpaquePropertyKey(
     version.location.ruleName,
-    lowerScalarOpaqueExpr(version.location.receiver, state.canonicalize),
+    receiver,
   );
   const initialValue = state.initialPropertyValues.get(initialKey);
   if (initialValue !== undefined) {
@@ -607,9 +610,7 @@ function resolveScalarSsaVersionExpr(
   }
   const ast = getAst();
   const identity = state.lowerOpaque(
-    ast.app(ast.var(version.location.ruleName), [
-      lowerScalarOpaqueExpr(version.location.receiver, state.canonicalize),
-    ]),
+    ast.app(ast.var(version.location.ruleName), [receiver]),
   );
   state.versionExprs.set(version, identity);
   return identity;

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -23,6 +23,7 @@ import {
 } from "./ir1-build-body.js";
 import { lowerL1MuSearch, type MuSearchLowerCtx } from "./ir1-lower.js";
 import { lowerL1Body } from "./ir1-lower-body.js";
+import { isScalarSsaL1Body } from "./ir1-ssa-scalars.js";
 import {
   getOperandDeclaredType,
   type NullishTranslate,
@@ -4908,10 +4909,9 @@ function symbolicExecute(
 
     // Property assignment: obj.prop = rhs. Routes through L1: build
     // canonical `Assign(Member(receiver, name), value)` via
-    // `buildL1AssignStmt`, then `lowerL1Body` installs the write into
-    // `SymbolicState`. Output is byte-equal to the legacy direct
-    // construction (M5 hard-rule cutover for the property-access
-    // equivalence class — assignment targets are L1 Member).
+    // `buildL1AssignStmt`, then scalar-only bodies are resolved by IR1
+    // SSA inside `lowerL1Body` before installing final writes into
+    // `SymbolicState`. Non-scalar L1 forms still use the legacy lowerer.
     if (
       ts.isExpressionStatement(stmt) &&
       ts.isBinaryExpression(unwrapExpression(stmt.expression))
@@ -4938,6 +4938,12 @@ function symbolicExecute(
             kind: "unsupported",
             reason: built.unsupported,
           });
+          continue;
+        }
+        if (isScalarSsaL1Body(built)) {
+          if (!lowerL1Body(built, state, propositions, { applyConst })) {
+            ok = false;
+          }
           continue;
         }
         if (!lowerL1Body(built, state, propositions, { applyConst })) {
@@ -5067,11 +5073,9 @@ function symbolicExecute(
       continue;
     }
 
-    // Branched mutation: build L1 cond-stmt, lower via lowerL1Body
-    // (single-fold over L1 statements; threads SymbolicState).
-    // Slice 1 handles simple property assigns; richer branch shapes
-    // (Map/Set effects, compound assigns, etc.) reject from the build
-    // pass and fall through to the legacy unsupported below.
+    // Branched mutation: build L1 cond-stmt, lower via lowerL1Body. Scalar
+    // cond-stmts resolve through IR1 SSA; Map/Set and foreach-containing
+    // branches stay on the existing SymbolicState fallback.
     if (ts.isIfStatement(stmt)) {
       const built = buildL1IfMutation(stmt, {
         checker,
@@ -5087,6 +5091,12 @@ function symbolicExecute(
           reason: built.unsupported,
         });
         ok = false;
+        continue;
+      }
+      if (isScalarSsaL1Body(built)) {
+        if (!lowerL1Body(built, state, propositions, { applyConst })) {
+          ok = false;
+        }
         continue;
       }
       if (!lowerL1Body(built, state, propositions, { applyConst })) {

--- a/tools/ts2pant/tests/ir1-ssa-scalars.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-scalars.test.mts
@@ -220,28 +220,32 @@ describe("ir1-ssa-scalars", () => {
     assert.deepEqual(program.framedRules, ["Account_limit"]);
   });
 
-  it.skip("preserves translateBody parity for scalar sequential write/read fixtures", async () => {
+  it("preserves translateBody parity for scalar sequential write/read fixtures", async () => {
     const output = await emitFixture(
       "functions-mutating-conditional.ts",
       "accumulateIf",
     );
-    void output;
 
-    // PENDING Patch 4: this fixture should still emit the same Pantagruel
-    // text after the scalar SSA route becomes active.
-    assert.fail("PENDING: scalar translateBody parity is not implemented yet");
+    assert.match(
+      output,
+      /account--balance' a = \(cond g => 10 \+ 5, true => 10\)\./,
+    );
   });
 
-  it.skip("preserves translateBody parity for asymmetric branch write fixtures", async () => {
+  it("preserves translateBody parity for asymmetric branch write fixtures", async () => {
     const output = await emitFixture(
       "functions-mutating-conditional.ts",
       "asymmetric",
     );
-    void output;
 
-    // PENDING Patch 4: asymmetric branch writes should keep the current
-    // output while switching the scalar mutation path to SSA internally.
-    assert.fail("PENDING: asymmetric branch parity is not implemented yet");
+    assert.match(
+      output,
+      /account--balance' a = \(cond g => 0, true => account--balance a\)\./,
+    );
+    assert.match(
+      output,
+      /account--owner' a = \(cond g => account--owner a, true => new-owner\)\./,
+    );
   });
 
   it.skip("preserves translateBody parity for chained early-return fixtures", async () => {

--- a/tools/ts2pant/tests/ir1-ssa-scalars.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-scalars.test.mts
@@ -19,6 +19,7 @@ import {
   isScalarSsaL1Body,
   lowerScalarSsaToProps,
 } from "../src/ir1-ssa-scalars.js";
+import type { OpaqueExpr } from "../src/pant-ast.js";
 import { getAst, loadAst } from "../src/pant-wasm.js";
 import { buildDocumentFromSourceFile, emitAndCheck } from "./helpers.mjs";
 
@@ -97,6 +98,39 @@ describe("ir1-ssa-scalars", () => {
     assert.equal(read.dominated, true);
     assert.equal(secondWrite!.version.location, firstWrite!.location);
     assert.equal(scalarEquationRhs(stmt), "1 + 2");
+  });
+
+  it("resolves initial property values through normalized receivers", () => {
+    const ast = getAst();
+    const balance = ir1Member(ir1Var("x"), "Account_balance");
+    const lowerOpaque = (expr: OpaqueExpr): OpaqueExpr => {
+      switch (ast.strExpr(expr)) {
+        case "x":
+          return ast.var("a");
+        case "Account_balance x":
+          return ast.app(ast.var("Account_balance"), [ast.var("a")]);
+        default:
+          return expr;
+      }
+    };
+    const result = lowerScalarSsaToProps(
+      ir1Assign(balance, ir1Binop("add", balance, ir1LitNat(2))),
+      {
+        lowerOpaque,
+        initialPropertyValues: new Map([
+          ["Account_balance::a", ast.litNat(10)],
+        ]),
+      },
+    );
+
+    assert.deepEqual(result.diagnostics, []);
+    assert.equal(result.propositions.length, 1);
+    const [eq] = result.propositions;
+    assert.equal(eq?.kind, "equation");
+    if (eq?.kind !== "equation") {
+      assert.fail("expected a scalar SSA equation");
+    }
+    assert.equal(ast.strExpr(eq.rhs), "10 + 2");
   });
 
   it("joins a single-arm if against the initial property version", () => {
@@ -228,7 +262,7 @@ describe("ir1-ssa-scalars", () => {
 
     assert.match(
       output,
-      /account--balance' a = \(cond g => 10 \+ 5, true => 10\)\./,
+      /account--balance' a = \(cond g => 10 \+ 5, true => 10\)\./u,
     );
   });
 
@@ -240,11 +274,11 @@ describe("ir1-ssa-scalars", () => {
 
     assert.match(
       output,
-      /account--balance' a = \(cond g => 0, true => account--balance a\)\./,
+      /account--balance' a = \(cond g => 0, true => account--balance a\)\./u,
     );
     assert.match(
       output,
-      /account--owner' a = \(cond g => account--owner a, true => new-owner\)\./,
+      /account--owner' a = \(cond g => account--owner a, true => new-owner\)\./u,
     );
   });
 


### PR DESCRIPTION
## Patch 4: Route scalar assignments and if-mutation through SSA

- Update lowerL1Body so scalar property-only bodies are handled by lowerScalarL1BodyToSsa and their resulting property writes are reflected into the existing final emission flow or directly appended as equations according to the least invasive local design.
- Preserve the old lowerAssign/lowerCondStmt implementation for Map/Set-containing cond-stmt branches, foreach bodies, and any non-scalar form rejected by isScalarSsaL1Body.
- Update translate-body.ts top-level property assignment routing so direct assignments and compound assignments exercise scalar SSA rather than putting property writes directly through SymbolicState.
- Update translate-body.ts if-mutation routing so buildL1IfMutation results that satisfy isScalarSsaL1Body execute through scalar SSA, while Map/Set and foreach paths remain on lowerL1Body fallback.
- Maintain existing all-or-nothing unsupported behavior: if scalar SSA lowering rejects a scalar body, push the unsupported marker and do not emit partial frames.
- Ensure final frame conditions still suppress rules modified by scalar SSA property writes exactly once.
- Run focused unit tests for ir1-ssa-scalars, translate-body scalar branch tests, and ir1-lower tests.

## Changes
- Update lowerL1Body so scalar property-only bodies are handled by lowerScalarL1BodyToSsa and their resulting property writes are reflected into the existing final emission flow or directly appended as equations according to the least invasive local design.
- Preserve the old lowerAssign/lowerCondStmt implementation for Map/Set-containing cond-stmt branches, foreach bodies, and any non-scalar form rejected by isScalarSsaL1Body.
- Update translate-body.ts top-level property assignment routing so direct assignments and compound assignments exercise scalar SSA rather than putting property writes directly through SymbolicState.
- Update translate-body.ts if-mutation routing so buildL1IfMutation results that satisfy isScalarSsaL1Body execute through scalar SSA, while Map/Set and foreach paths remain on lowerL1Body fallback.
- Maintain existing all-or-nothing unsupported behavior: if scalar SSA lowering rejects a scalar body, push the unsupported marker and do not emit partial frames.
- Ensure final frame conditions still suppress rules modified by scalar SSA property writes exactly once.
- Run focused unit tests for ir1-ssa-scalars, translate-body scalar branch tests, and ir1-lower tests.

## Files to Modify
- tools/ts2pant/src/ir1-lower-body.ts (modify): Dispatch scalar property-only L1 bodies to the scalar SSA lowerer and keep the existing lowerer as fallback for non-scalar forms.
- tools/ts2pant/src/translate-body.ts (modify): Use the scalar SSA route for top-level property assignments and supported scalar if-mutation bodies before final frame generation.
- tools/ts2pant/tests/ir1-ssa-scalars.test.mts (modify): Unskip and implement production translateBody parity checks for scalar assignment and branch fixtures.

## Gameplan Specification

```
module IR1_SSA_BUILDER_SCALARS.

IR1Program.
Construct.
Location.
Version.
Read.
Write.
Join.
LoopSummary.
Rule.
PropResult.
Diagnostic.

supported-constructs p: IR1Program => [Construct].
lowered-constructs p: IR1Program => [Construct].
diagnostics p: IR1Program => [Diagnostic].
diagnostic-construct d: Diagnostic => Construct.
writes p: IR1Program => [Write].
reads p: IR1Program => [Read].
joins p: IR1Program => [Join].
loop-summaries p: IR1Program => [LoopSummary].
write-location w: Write => Location.
write-version w: Write => Version.
read-location r: Read => Location.
read-version r: Read => Version.
read-dominated? p: IR1Program, r: Read => Bool.
join-location j: Join => Location.
then-version j: Join => Version.
else-version j: Join => Version.
join-version j: Join => Version.
summary-location s: LoopSummary => Location.
summary-version s: LoopSummary => Version.
initial-version l: Location => Version.
version-location v: Version => Location.
rule-of-location l: Location => Rule.
declared-rules p: IR1Program => [Rule].
modified-rules p: IR1Program => [Rule].
framed-rules p: IR1Program => [Rule].
emitted-props p: IR1Program => [PropResult].
scalar-construct? c: Construct => Bool.
scalar-location? l: Location => Bool.
final-version p: IR1Program, l: Location => Version.
modified-location? p: IR1Program, l: Location => Bool.

---

all p: IR1Program, c in supported-constructs p |
  c in lowered-constructs p.

all p: IR1Program, d in diagnostics p |
  ~(diagnostic-construct d in supported-constructs p).

all p: IR1Program, c in supported-constructs p |
  scalar-construct? c -> c in lowered-constructs p.

all p: IR1Program, w in writes p |
  version-location (write-version w) = write-location w.

all p: IR1Program, s in loop-summaries p |
  version-location (summary-version s) = summary-location s.

all l: Location |
  version-location (initial-version l) = l.

all p: IR1Program, w1 in writes p, w2 in writes p |
  write-version w1 = write-version w2 -> w1 = w2.

all p: IR1Program, r in reads p |
  read-dominated? p r and
  version-location (read-version r) = read-location r and
  (
    read-version r = initial-version (read-location r) or
    (some w in writes p |
      write-version w = read-version r and
      write-location w = read-location r) or
    (some s in loop-summaries p |
      summary-version s = read-version r and
      summary-location s = read-location r)
  ).

all p: IR1Program, j in joins p |
  version-location (then-version j) = join-location j and
  version-location (else-version j) = join-location j and
  version-location (join-version j) = join-location j.

all p: IR1Program, j in joins p |
  then-version j != else-version j and
  join-version j != then-version j and
  join-version j != else-version j.

all p: IR1Program, l: Location |
  scalar-location? l and modified-location? p l ->
    version-location (final-version p l) = l and
    rule-of-location l in modified-rules p.

all p: IR1Program, rule in modified-rules p |
  rule in declared-rules p and
  ~(rule in framed-rules p).

all p: IR1Program, rule in framed-rules p |
  rule in declared-rules p and
  ~(rule in modified-rules p).

all p: IR1Program, rule in declared-rules p |
  rule in modified-rules p or rule in framed-rules p.

all p: IR1Program, w in writes p |
  rule-of-location (write-location w) in modified-rules p.

all p: IR1Program, s in loop-summaries p |
  rule-of-location (summary-location s) in modified-rules p.

all p: IR1Program |
  #(lowered-constructs p) > 0 -> #(emitted-props p) > 0.

```

## Patch Specification

```
module IR1_SSA_BUILDER_SCALARS_PATCH_4.

IR1Program.
Construct.
Location.
Version.
Read.
Write.
Join.
Rule.
PropResult.
Diagnostic.

supported-constructs p: IR1Program => [Construct].
lowered-constructs p: IR1Program => [Construct].
diagnostics p: IR1Program => [Diagnostic].
diagnostic-construct d: Diagnostic => Construct.
writes p: IR1Program => [Write].
reads p: IR1Program => [Read].
joins p: IR1Program => [Join].
write-location w: Write => Location.
write-version w: Write => Version.
read-location r: Read => Location.
read-version r: Read => Version.
read-dominated? p: IR1Program, r: Read => Bool.
join-location j: Join => Location.
then-version j: Join => Version.
else-version j: Join => Version.
join-version j: Join => Version.
version-location v: Version => Location.
rule-of-location l: Location => Rule.
modified-rules p: IR1Program => [Rule].
emitted-props p: IR1Program => [PropResult].
scalar-construct? c: Construct => Bool.

---

all p: IR1Program, c in supported-constructs p |
  scalar-construct? c -> c in lowered-constructs p.

all p: IR1Program, d in diagnostics p |
  ~(diagnostic-construct d in supported-constructs p).

all p: IR1Program, w in writes p |
  version-location (write-version w) = write-location w and
  rule-of-location (write-location w) in modified-rules p.

all p: IR1Program, r in reads p |
  read-dominated? p r and
  version-location (read-version r) = read-location r.

all p: IR1Program, j in joins p |
  version-location (then-version j) = join-location j and
  version-location (else-version j) = join-location j and
  version-location (join-version j) = join-location j and
  then-version j != else-version j.

all p: IR1Program |
  #(lowered-constructs p) > 0 -> #(emitted-props p) > 0.

```


## Implementation Notes

- Scalar SSA is integrated by reflecting `lowerScalarSsaToProps` final property entries back into `SymbolicState` rather than appending equations immediately. This keeps final equation emission and frame-condition suppression on the existing path.
- The scalar lowerer now accepts initial property values from existing symbolic writes. This is needed for sequential cases such as `write; if (...) read/write`, where SSA initial versions must resolve to the staged prior value rather than the pre-state accessor.
- `translate-body.ts` performs an explicit scalar predicate check before calling `lowerL1Body`, but the actual SSA/fallback split remains centralized in `ir1-lower-body.ts`. The duplicate-looking check is intentional routing documentation at the production call sites.
- Map/Set and foreach behavior is unchanged; non-scalar L1 bodies still fall through to the previous lowerer.
- Full verification required building the generated Pant wasm artifact and native `pant` binary locally before `npm test` could run end to end.