### PR TITLE
[ir1-ssa-map-set] Patch 1: Add skipped collection SSA acceptance tests

### DIFF
--- a/tools/ts2pant/tests/ir1-ssa-collections.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-collections.test.mts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  ir1LitNat,
+  ir1SsaMapMembershipValue,
+  ir1SsaMapSetValue,
+  ir1SsaSetClearValue,
+} from "../src/ir1.js";
+
+describe("ir1-ssa-collections", () => {
+  // PENDING Patch 2: introduce shared collection SSA state for coordinated
+  // Map value/membership and Set membership versions.
+  // PENDING Patch 3: implement Map SSA writes, staged reads, and lowering.
+  // PENDING Patch 4: implement Set SSA writes, staged reads, clear, and lowering.
+  // PENDING Patch 5: route non-looping Map/Set bodies through collection SSA.
+  // PENDING Patch 6: keep production parity fixtures pinned while the old
+  // SymbolicState-only path is narrowed.
+
+  it.skip("records Map.set as coordinated value and membership SSA writes", () => {
+    const value = ir1SsaMapSetValue(ir1LitNat(7));
+    const membership = ir1SsaMapMembershipValue("set");
+
+    assert.equal(value.kind, "map-value");
+    assert.equal(membership.kind, "map-membership");
+    // PENDING Patch 3: build collection SSA for a `Map.set(k, v)` body and
+    // assert it records one map-value write plus one paired map-membership
+    // write for the same receiver/key location.
+  });
+
+  it.skip("resolves Map.get and Map.has through staged SSA writes", () => {
+    // PENDING Patch 3: lower a non-looping `set -> get/has` body and assert
+    // both reads resolve against the dominating staged versions rather than
+    // the pre-state rule helpers from `readMapThroughWrites`.
+  });
+
+  it.skip("joins Map value and membership versions across branches", () => {
+    // PENDING Patch 3: cover `if (gate) m.set(...)` / `else m.delete(...)`
+    // and assert collection SSA emits IR1SsaJoin nodes for both map-value and
+    // map-membership locations instead of relying on `mergeOverrides`.
+  });
+
+  it.skip("records Set.add delete and clear as membership SSA writes", () => {
+    const clear = ir1SsaSetClearValue();
+
+    assert.equal(clear.kind, "set-membership");
+    assert.equal(clear.op, "clear");
+    // PENDING Patch 4: build collection SSA for `.add`, `.delete`, and
+    // `.clear()` and assert all writes target set-membership locations, with
+    // clear represented by `ir1SsaSetClearValue()`.
+  });
+
+  it.skip("resolves Set.has through staged membership and clear versions", () => {
+    // PENDING Patch 4: lower `add/delete/clear -> has` bodies and assert
+    // reads observe later-wins membership versions plus clear fallthrough,
+    // matching the existing `readSetThroughWrites` semantics.
+  });
+
+  it.skip("preserves production parity for Map and Set mutation fixtures", async () => {
+    const mapCases = [
+      ["expressions-map-mutation.ts", "put"],
+      ["expressions-map-mutation.ts", "remove"],
+      ["expressions-map-mutation.ts", "setAndCopy"],
+      ["expressions-state-aware-reads.ts", "entrySetThenCheck"],
+      ["expressions-state-aware-reads.ts", "bumpInBranch"],
+    ] as const;
+
+    const setCases = [
+      ["expressions-set-mutation-field.ts", "tagAddThenRemove"],
+      ["expressions-set-mutation-field.ts", "tagClearAndAdd"],
+      ["expressions-state-aware-reads.ts", "tagThenCheck"],
+    ] as const;
+
+    void mapCases;
+    void setCases;
+    // PENDING Patch 5: route the non-looping production path through
+    // collection SSA and keep these existing Map/Set mutation and staged-read
+    // fixtures byte-equivalent at emit time.
+  });
+});


### PR DESCRIPTION
## Patch 1: Add skipped collection SSA acceptance tests

- Create describe("ir1-ssa-collections", ...) with skipped tests and PENDING comments naming the implementation patches.
- Stub a Map test proving Map.set records both map-value and map-membership writes.
- Stub a Map test proving Map.get and Map.has read through staged writes.
- Stub a Map branch test proving branch merges create IR1SsaJoin nodes instead of relying on mergeOverrides.
- Stub a Set test proving Set.add/Delete/Clear record set-membership writes, with clear represented by ir1SsaSetClearValue.
- Stub a Set read test proving Set.has observes staged add/delete/clear writes.
- Stub production parity tests using existing Map/Set mutation and state-aware-read fixtures.

## Changes
- Create describe("ir1-ssa-collections", ...) with skipped tests and PENDING comments naming the implementation patches.
- Stub a Map test proving Map.set records both map-value and map-membership writes.
- Stub a Map test proving Map.get and Map.has read through staged writes.
- Stub a Map branch test proving branch merges create IR1SsaJoin nodes instead of relying on mergeOverrides.
- Stub a Set test proving Set.add/Delete/Clear record set-membership writes, with clear represented by ir1SsaSetClearValue.
- Stub a Set read test proving Set.has observes staged add/delete/clear writes.
- Stub production parity tests using existing Map/Set mutation and state-aware-read fixtures.

## Files to Modify
- tools/ts2pant/tests/ir1-ssa-collections.test.mts (create): Add node:test stubs with skip markers for Map and Set SSA build/lower behavior and production translateBody parity.

## Gameplan Specification

```
module IR1_SSA_MAP_SET.

Program.
Construct.
Location.
Version.
Read.
Write.
Join.
Rule.
PropResult.
Diagnostic.
Element.
Operation.

map-set => Operation.
map-delete => Operation.
set-add => Operation.
set-delete => Operation.
set-clear => Operation.
supported-constructs p: Program => [Construct].
lowered-constructs p: Program => [Construct].
diagnostics p: Program => [Diagnostic].
diagnostic-construct d: Diagnostic => Construct.
map-or-set? c: Construct => Bool.
loop-like? c: Construct => Bool.

writes p: Program => [Write].
reads p: Program => [Read].
joins p: Program => [Join].
write-location w: Write => Location.
write-version w: Write => Version.
write-op w: Write => Operation.
write-element w: Write => [Element].
read-location r: Read => Location.
read-version r: Read => Version.
join-location j: Join => Location.
then-version j: Join => Version.
else-version j: Join => Version.
join-version j: Join => Version.
version-location v: Version => Location.
rule-of-location l: Location => Rule.
paired-membership-location l: Location => Location.

map-value? l: Location => Bool.
map-membership? l: Location => Bool.
set-membership? l: Location => Bool.
collection-location? l: Location => Bool.

declared-rules p: Program => [Rule].
modified-rules p: Program => [Rule].
framed-rules p: Program => [Rule].
emitted-props p: Program => [PropResult].

---

all p: Program, c in supported-constructs p |
  map-or-set? c and ~loop-like? c -> c in lowered-constructs p.

all p: Program, d in diagnostics p |
  ~(diagnostic-construct d in supported-constructs p).

all p: Program, w in writes p |
  collection-location? (write-location w) ->
    version-location (write-version w) = write-location w and
    rule-of-location (write-location w) in modified-rules p.

all p: Program, r in reads p |
  collection-location? (read-location r) ->
    version-location (read-version r) = read-location r.

all p: Program, j in joins p |
  collection-location? (join-location j) ->
    version-location (then-version j) = join-location j and
    version-location (else-version j) = join-location j and
    version-location (join-version j) = join-location j and
    then-version j != else-version j and
    join-version j != then-version j and
    join-version j != else-version j.

all p: Program, w in writes p |
  map-value? (write-location w) ->
    write-op w = map-set and
    map-membership? (paired-membership-location (write-location w)) and
    (some m in writes p |
      write-location m = paired-membership-location (write-location w) and
      write-op m = map-set).

all p: Program, w in writes p |
  map-membership? (write-location w) ->
    (write-op w = map-set or write-op w = map-delete).

all p: Program, w in writes p |
  set-membership? (write-location w) ->
    (write-op w = set-add or write-op w = set-delete or write-op w = set-clear).

all p: Program, w in writes p |
  set-membership? (write-location w) and write-op w = set-clear ->
    #(write-element w) = 0.

all p: Program, w in writes p |
  set-membership? (write-location w) and (write-op w = set-add or write-op w = set-delete) ->
    #(write-element w) = 1.

all p: Program, rule in modified-rules p |
  rule in declared-rules p and ~(rule in framed-rules p).

all p: Program, rule in framed-rules p |
  rule in declared-rules p and ~(rule in modified-rules p).

all p: Program, rule in declared-rules p |
  rule in modified-rules p or rule in framed-rules p.

all p: Program |
  #(lowered-constructs p) > 0 -> #(emitted-props p) > 0.

```

## Patch Specification

```
module IR1_SSA_MAP_SET_PATCH_1.

Test.
Construct.

stubbed? t: Test => Bool.
covered-constructs t: Test => [Construct].
map-set => Construct.
map-delete => Construct.
map-get => Construct.
map-has => Construct.
set-add => Construct.
set-delete => Construct.
set-clear => Construct.
set-has => Construct.
branch-join => Construct.

---

some t: Test |
  stubbed? t and
  map-set in covered-constructs t and
  map-delete in covered-constructs t and
  map-get in covered-constructs t and
  map-has in covered-constructs t and
  set-add in covered-constructs t and
  set-delete in covered-constructs t and
  set-clear in covered-constructs t and
  set-has in covered-constructs t and
  branch-join in covered-constructs t.

```


## Implementation Notes

- The new test file is intentionally lightweight: I removed `translateBody`, fixture-loading, and wasm setup imports from the stub file so the skipped tests do not pull in `ts-morph` or built wasm artifacts before the later implementation patches need them.
- The parity stub names concrete existing fixture/functions for both mutation and staged-read paths, including `expressions-set-mutation-field.ts` in addition to the state-aware-read fixture, so reviewers can see the intended production coverage boundary up front.
- No behavioral code changed in this patch; the only deviation from the initial sketch was keeping the stubs self-contained enough to execute as skipped tests in a partially provisioned local environment.