### PR TITLE
[ir1-ssa-map-set] Patch 2: Introduce shared collection SSA state

### DIFF
--- a/tools/ts2pant/src/ir1-ssa-collections.ts
+++ b/tools/ts2pant/src/ir1-ssa-collections.ts
@@ -1,0 +1,772 @@
+import {
+  type IR1Expr,
+  type IR1SsaJoin,
+  type IR1SsaLocation,
+  type IR1SsaProgram,
+  type IR1SsaRead,
+  type IR1SsaRuleName,
+  type IR1SsaVersion,
+  type IR1SsaWrite,
+  type IR1Stmt,
+  ir1SsaInitialVersion,
+  ir1SsaJoin,
+  ir1SsaMapMembershipLocation,
+  ir1SsaMapMembershipValue,
+  ir1SsaMapSetValue,
+  ir1SsaMapValueLocation,
+  ir1SsaRead,
+  ir1SsaRuleOfLocation,
+  ir1SsaSetClearValue,
+  ir1SsaSetMembershipLocation,
+  ir1SsaSetMembershipValue,
+  ir1SsaWrite,
+} from "./ir1.js";
+import type { PropResult } from "./types.js";
+
+export type CollectionSsaLocation =
+  | Extract<IR1SsaLocation, { kind: "map-value" }>
+  | Extract<IR1SsaLocation, { kind: "map-membership" }>
+  | Extract<IR1SsaLocation, { kind: "set-membership" }>;
+
+export interface CollectionSsaState {
+  currentVersions: Map<string, IR1SsaVersion>;
+  initialVersions: Map<string, IR1SsaVersion>;
+  locations: Map<string, CollectionSsaLocation>;
+  reads: IR1SsaRead[];
+  writes: IR1SsaWrite[];
+  joins: IR1SsaJoin[];
+  writtenKeys: Set<string>;
+  declaredRules: Set<string>;
+  modifiedRules: Set<string>;
+  canonicalize: (e: IR1Expr) => IR1Expr;
+}
+
+export interface CollectionSsaBuildOptions {
+  declaredRules?: Iterable<string>;
+  canonicalize?: (e: IR1Expr) => IR1Expr;
+}
+
+export interface CollectionSsaFinalMapValueEntry {
+  kind: "map-value";
+  location: Extract<IR1SsaLocation, { kind: "map-value" }>;
+  version: IR1SsaVersion;
+}
+
+export interface CollectionSsaFinalMapMembershipEntry {
+  kind: "map-membership";
+  location: Extract<IR1SsaLocation, { kind: "map-membership" }>;
+  version: IR1SsaVersion;
+}
+
+export interface CollectionSsaFinalSetMembershipEntry {
+  kind: "set-membership";
+  location: Extract<IR1SsaLocation, { kind: "set-membership" }>;
+  version: IR1SsaVersion;
+}
+
+export type CollectionSsaFinalEntry =
+  | CollectionSsaFinalMapValueEntry
+  | CollectionSsaFinalMapMembershipEntry
+  | CollectionSsaFinalSetMembershipEntry;
+
+export interface CollectionSsaLowerResult {
+  program: IR1SsaProgram;
+  finalEntries: CollectionSsaFinalEntry[];
+  propositions: PropResult[];
+  modifiedRules: IR1SsaRuleName[];
+  diagnostics: Array<Extract<PropResult, { kind: "unsupported" }>>;
+}
+
+interface CollectionSsaLocationState {
+  locations: Map<string, CollectionSsaLocation>;
+  declaredRules?: Set<string>;
+  canonicalize: (e: IR1Expr) => IR1Expr;
+}
+
+interface CollectionSsaInitialVersionState {
+  initialVersions: Map<string, IR1SsaVersion>;
+}
+
+export function makeCollectionSsaState(
+  options: CollectionSsaBuildOptions = {},
+): CollectionSsaState {
+  return {
+    currentVersions: new Map(),
+    initialVersions: new Map(),
+    locations: new Map(),
+    reads: [],
+    writes: [],
+    joins: [],
+    writtenKeys: new Set(),
+    declaredRules: new Set(options.declaredRules ?? []),
+    modifiedRules: new Set(),
+    canonicalize: options.canonicalize ?? ((e) => e),
+  };
+}
+
+export function buildCollectionSsaProgram(
+  stmt: IR1Stmt,
+  options: CollectionSsaBuildOptions = {},
+): IR1SsaProgram {
+  const state = makeCollectionSsaState(options);
+  lowerCollectionSsaL1Body(stmt, state);
+  const declaredRules = new Set(state.declaredRules);
+  for (const rule of state.modifiedRules) {
+    declaredRules.add(rule);
+  }
+  const framedRules = [...declaredRules].filter(
+    (rule) => !state.modifiedRules.has(rule),
+  );
+  return {
+    reads: state.reads,
+    writes: state.writes,
+    joins: state.joins,
+    loopSummaries: [],
+    declaredRules: [...declaredRules],
+    modifiedRules: [...state.modifiedRules],
+    framedRules,
+  };
+}
+
+export function collectionSsaFinalEntries(
+  state: Pick<CollectionSsaState, "currentVersions" | "locations">,
+): CollectionSsaFinalEntry[] {
+  const entries: CollectionSsaFinalEntry[] = [];
+  for (const [key, version] of state.currentVersions) {
+    const location = state.locations.get(key);
+    if (location === undefined) {
+      continue;
+    }
+    entries.push({
+      kind: location.kind,
+      location,
+      version,
+    } as CollectionSsaFinalEntry);
+  }
+  return entries;
+}
+
+export function isCollectionSsaL1Body(stmt: IR1Stmt): boolean {
+  switch (stmt.kind) {
+    case "assign":
+      return (
+        stmt.target.kind === "member" &&
+        isCollectionSsaExpr(stmt.target.receiver) &&
+        isCollectionSsaExpr(stmt.value)
+      );
+    case "map-effect":
+      return (
+        isCollectionSsaExpr(stmt.objExpr) &&
+        isCollectionSsaExpr(stmt.keyExpr) &&
+        (stmt.valueExpr === null || isCollectionSsaExpr(stmt.valueExpr))
+      );
+    case "set-effect":
+      return (
+        isCollectionSsaExpr(stmt.objExpr) &&
+        (stmt.elemExpr === null || isCollectionSsaExpr(stmt.elemExpr))
+      );
+    case "block":
+      return stmt.stmts.every(isCollectionSsaL1Body);
+    case "cond-stmt":
+      return (
+        stmt.arms.length === 1 &&
+        stmt.arms.every(
+          ([guard, body]) =>
+            isCollectionSsaExpr(guard) && isCollectionSsaL1Body(body),
+        ) &&
+        (stmt.otherwise === null || isCollectionSsaL1Body(stmt.otherwise))
+      );
+    case "foreach":
+    case "for":
+    case "while":
+    case "return":
+    case "throw":
+    case "let":
+    case "expr-stmt":
+      return false;
+    default: {
+      const _exhaustive: never = stmt;
+      void _exhaustive;
+      return false;
+    }
+  }
+}
+
+export function lowerCollectionSsaL1Body(
+  stmt: IR1Stmt,
+  state: CollectionSsaState,
+): void {
+  switch (stmt.kind) {
+    case "assign":
+      if (stmt.target.kind !== "member") {
+        throw new Error(
+          "collection SSA assignment target must be a property member",
+        );
+      }
+      collectionSsaReadExpr(stmt.target.receiver, state);
+      collectionSsaReadExpr(stmt.value, state);
+      return;
+    case "map-effect":
+      lowerCollectionMapEffect(stmt, state);
+      return;
+    case "set-effect":
+      lowerCollectionSetEffect(stmt, state);
+      return;
+    case "block":
+      for (const child of stmt.stmts) {
+        lowerCollectionSsaL1Body(child, state);
+      }
+      return;
+    case "cond-stmt":
+      lowerCollectionCondStmt(stmt, state);
+      return;
+    case "foreach":
+    case "for":
+    case "while":
+    case "return":
+    case "throw":
+    case "let":
+    case "expr-stmt":
+      throw new Error(`${stmt.kind} is not supported by collection SSA`);
+    default: {
+      const _exhaustive: never = stmt;
+      void _exhaustive;
+      throw new Error("unsupported IR1 statement in collection SSA lowering");
+    }
+  }
+}
+
+export function collectionSsaReadExpr(
+  expr: IR1Expr,
+  state: CollectionSsaState,
+): IR1Expr {
+  switch (expr.kind) {
+    case "map-read":
+      collectionSsaReadMap(expr, state);
+      collectionSsaReadExpr(expr.receiver, state);
+      collectionSsaReadExpr(expr.key, state);
+      return expr;
+    case "set-read":
+      collectionSsaReadSet(expr, state);
+      collectionSsaReadExpr(expr.receiver, state);
+      collectionSsaReadExpr(expr.elem, state);
+      return expr;
+    case "member":
+      collectionSsaReadExpr(expr.receiver, state);
+      return expr;
+    case "binop":
+      collectionSsaReadExpr(expr.lhs, state);
+      collectionSsaReadExpr(expr.rhs, state);
+      return expr;
+    case "unop":
+      collectionSsaReadExpr(expr.arg, state);
+      return expr;
+    case "app":
+      collectionSsaReadExpr(expr.callee, state);
+      for (const arg of expr.args) {
+        collectionSsaReadExpr(arg, state);
+      }
+      return expr;
+    case "cond":
+      for (const [guard, value] of expr.arms) {
+        collectionSsaReadExpr(guard, state);
+        collectionSsaReadExpr(value, state);
+      }
+      collectionSsaReadExpr(expr.otherwise, state);
+      return expr;
+    case "is-nullish":
+      collectionSsaReadExpr(expr.operand, state);
+      return expr;
+    case "each":
+      collectionSsaReadExpr(expr.src, state);
+      for (const guard of expr.guards) {
+        collectionSsaReadExpr(guard, state);
+      }
+      collectionSsaReadExpr(expr.proj, state);
+      return expr;
+    case "var":
+    case "lit":
+      return expr;
+    default: {
+      const _exhaustive: never = expr;
+      void _exhaustive;
+      return expr;
+    }
+  }
+}
+
+export function mapValueLocationForReadOrWrite(
+  input: {
+    ruleName: string;
+    keyPredName: string;
+    ownerType: string;
+    keyType: string;
+    receiver: IR1Expr;
+    key: IR1Expr;
+  },
+  state: CollectionSsaLocationState,
+): { key: string; location: Extract<IR1SsaLocation, { kind: "map-value" }> } {
+  return mapLocationForInput("map-value", input, state);
+}
+
+export function mapMembershipLocationForReadOrWrite(
+  input: {
+    ruleName: string;
+    keyPredName: string;
+    ownerType: string;
+    keyType: string;
+    receiver: IR1Expr;
+    key: IR1Expr;
+  },
+  state: CollectionSsaLocationState,
+): {
+  key: string;
+  location: Extract<IR1SsaLocation, { kind: "map-membership" }>;
+} {
+  return mapLocationForInput("map-membership", input, state);
+}
+
+export function setMembershipLocationForReadOrWrite(
+  input: {
+    ruleName: string;
+    ownerType: string;
+    elemType: string;
+    receiver: IR1Expr;
+  },
+  state: CollectionSsaLocationState,
+): {
+  key: string;
+  location: Extract<IR1SsaLocation, { kind: "set-membership" }>;
+} {
+  const receiverKey = collectionSsaCanonicalExprKey(input.receiver, state);
+  const key = setMembershipLocationKey(
+    input.ruleName,
+    input.ownerType,
+    input.elemType,
+    receiverKey,
+  );
+  const existing = state.locations.get(key);
+  if (existing !== undefined) {
+    if (existing.kind !== "set-membership") {
+      throw new Error("collection SSA location key kind mismatch");
+    }
+    return { key, location: existing };
+  }
+  const location = ir1SsaSetMembershipLocation(
+    input.ruleName,
+    input.ownerType,
+    input.elemType,
+    input.receiver,
+  ) as Extract<IR1SsaLocation, { kind: "set-membership" }>;
+  state.locations.set(key, location);
+  state.declaredRules?.add(ir1SsaRuleOfLocation(location));
+  return { key, location };
+}
+
+function lowerCollectionMapEffect(
+  stmt: Extract<IR1Stmt, { kind: "map-effect" }>,
+  state: CollectionSsaState,
+): void {
+  collectionSsaReadExpr(stmt.objExpr, state);
+  collectionSsaReadExpr(stmt.keyExpr, state);
+  const input = {
+    ruleName: stmt.ruleName,
+    keyPredName: stmt.keyPredName,
+    ownerType: stmt.ownerType,
+    keyType: stmt.keyType,
+    receiver: stmt.objExpr,
+    key: stmt.keyExpr,
+  };
+
+  if (stmt.op === "set") {
+    collectionSsaReadExpr(stmt.valueExpr, state);
+    const valueLocation = mapValueLocationForReadOrWrite(input, state);
+    const valueWrite = ir1SsaWrite(
+      valueLocation.location,
+      ir1SsaMapSetValue(stmt.valueExpr),
+    );
+    recordCollectionWrite(valueLocation.key, valueWrite, state);
+  }
+
+  const membershipLocation = mapMembershipLocationForReadOrWrite(input, state);
+  const membershipWrite = ir1SsaWrite(
+    membershipLocation.location,
+    ir1SsaMapMembershipValue(stmt.op),
+  );
+  recordCollectionWrite(membershipLocation.key, membershipWrite, state);
+}
+
+function lowerCollectionSetEffect(
+  stmt: Extract<IR1Stmt, { kind: "set-effect" }>,
+  state: CollectionSsaState,
+): void {
+  collectionSsaReadExpr(stmt.objExpr, state);
+  const location = setMembershipLocationForReadOrWrite(
+    {
+      ruleName: stmt.ruleName,
+      ownerType: stmt.ownerType,
+      elemType: stmt.elemType,
+      receiver: stmt.objExpr,
+    },
+    state,
+  );
+  const value =
+    stmt.op === "clear"
+      ? ir1SsaSetClearValue()
+      : ir1SsaSetMembershipValue(stmt.op, stmt.elemExpr);
+  if (stmt.op !== "clear") {
+    collectionSsaReadExpr(stmt.elemExpr, state);
+  }
+  const write = ir1SsaWrite(location.location, value);
+  recordCollectionWrite(location.key, write, state);
+}
+
+function recordCollectionWrite(
+  key: string,
+  write: IR1SsaWrite,
+  state: CollectionSsaState,
+): void {
+  state.writes.push(write);
+  state.currentVersions.set(key, write.version);
+  state.writtenKeys.add(key);
+  state.modifiedRules.add(ir1SsaRuleOfLocation(write.location));
+}
+
+function collectionSsaReadMap(
+  expr: Extract<IR1Expr, { kind: "map-read" }>,
+  state: CollectionSsaState,
+): IR1SsaRead {
+  const input = {
+    ruleName: expr.ruleName,
+    keyPredName: expr.keyPredName,
+    ownerType: expr.ownerType,
+    keyType: expr.keyType,
+    receiver: expr.receiver,
+    key: expr.key,
+  };
+  const { key, location } =
+    expr.op === "has"
+      ? mapMembershipLocationForReadOrWrite(input, state)
+      : mapValueLocationForReadOrWrite(input, state);
+  const version =
+    state.currentVersions.get(key) ??
+    initialCollectionVersionFor(key, location, state);
+  const read = ir1SsaRead(location, version, true);
+  state.reads.push(read);
+  return read;
+}
+
+function collectionSsaReadSet(
+  expr: Extract<IR1Expr, { kind: "set-read" }>,
+  state: CollectionSsaState,
+): IR1SsaRead {
+  const { key, location } = setMembershipLocationForReadOrWrite(
+    {
+      ruleName: expr.ruleName,
+      ownerType: expr.ownerType,
+      elemType: expr.elemType,
+      receiver: expr.receiver,
+    },
+    state,
+  );
+  const version =
+    state.currentVersions.get(key) ??
+    initialCollectionVersionFor(key, location, state);
+  const read = ir1SsaRead(location, version, true);
+  state.reads.push(read);
+  return read;
+}
+
+function lowerCollectionCondStmt(
+  stmt: Extract<IR1Stmt, { kind: "cond-stmt" }>,
+  state: CollectionSsaState,
+): void {
+  if (stmt.arms.length !== 1) {
+    throw new Error("multi-armed cond-stmt is not supported by collection SSA");
+  }
+  const [guard, thenBody] = stmt.arms[0]!;
+  collectionSsaReadExpr(guard, state);
+
+  const thenState = cloneCollectionSsaStateForBranch(state);
+  lowerCollectionSsaL1Body(thenBody, thenState);
+
+  const elseState = cloneCollectionSsaStateForBranch(state);
+  if (stmt.otherwise !== null) {
+    lowerCollectionSsaL1Body(stmt.otherwise, elseState);
+  }
+
+  state.reads.push(...thenState.reads, ...elseState.reads);
+  state.writes.push(...thenState.writes, ...elseState.writes);
+  state.joins.push(...thenState.joins, ...elseState.joins);
+  mergeBranchLocations(thenState, state);
+  mergeBranchLocations(elseState, state);
+  mergeBranchRules(thenState, state);
+  mergeBranchRules(elseState, state);
+
+  const touched = new Set([...thenState.writtenKeys, ...elseState.writtenKeys]);
+  for (const key of touched) {
+    const location =
+      thenState.locations.get(key) ??
+      elseState.locations.get(key) ??
+      state.locations.get(key);
+    if (location === undefined) {
+      throw new Error("collection SSA branch touched an unknown location");
+    }
+    const thenVersion =
+      thenState.currentVersions.get(key) ??
+      initialCollectionVersionFor(key, location, state);
+    const elseVersion =
+      elseState.currentVersions.get(key) ??
+      initialCollectionVersionFor(key, location, state);
+    const join = ir1SsaJoin(location, thenVersion, elseVersion);
+    if (join.kind === "ssa-join") {
+      state.joins.push(join);
+      state.currentVersions.set(key, join.joinVersion);
+    } else {
+      state.currentVersions.set(key, join);
+    }
+    state.writtenKeys.add(key);
+  }
+}
+
+function cloneCollectionSsaStateForBranch(
+  state: CollectionSsaState,
+): CollectionSsaState {
+  return {
+    currentVersions: new Map(state.currentVersions),
+    initialVersions: state.initialVersions,
+    locations: new Map(state.locations),
+    reads: [],
+    writes: [],
+    joins: [],
+    writtenKeys: new Set(),
+    declaredRules: new Set(state.declaredRules),
+    modifiedRules: new Set(),
+    canonicalize: state.canonicalize,
+  };
+}
+
+function mergeBranchLocations(
+  branch: CollectionSsaState,
+  target: CollectionSsaState,
+): void {
+  for (const [key, location] of branch.locations) {
+    if (!target.locations.has(key)) {
+      target.locations.set(key, location);
+    }
+  }
+}
+
+function mergeBranchRules(
+  branch: CollectionSsaState,
+  target: CollectionSsaState,
+): void {
+  for (const rule of branch.declaredRules) {
+    target.declaredRules.add(rule);
+  }
+  for (const rule of branch.modifiedRules) {
+    target.modifiedRules.add(rule);
+  }
+}
+
+function initialCollectionVersionFor(
+  key: string,
+  location: CollectionSsaLocation,
+  state: CollectionSsaInitialVersionState,
+): IR1SsaVersion {
+  const existing = state.initialVersions.get(key);
+  if (existing !== undefined) {
+    return existing;
+  }
+  const initial = ir1SsaInitialVersion(location);
+  state.initialVersions.set(key, initial);
+  return initial;
+}
+
+function mapLocationForInput<K extends "map-value" | "map-membership">(
+  kind: K,
+  input: {
+    ruleName: string;
+    keyPredName: string;
+    ownerType: string;
+    keyType: string;
+    receiver: IR1Expr;
+    key: IR1Expr;
+  },
+  state: CollectionSsaLocationState,
+): {
+  key: string;
+  location: Extract<IR1SsaLocation, { kind: K }>;
+} {
+  const receiverKey = collectionSsaCanonicalExprKey(input.receiver, state);
+  const elementKey = collectionSsaCanonicalExprKey(input.key, state);
+  const key = mapLocationKey(
+    kind,
+    input.ruleName,
+    input.keyPredName,
+    input.ownerType,
+    input.keyType,
+    receiverKey,
+    elementKey,
+  );
+  const existing = state.locations.get(key);
+  if (existing !== undefined) {
+    if (existing.kind !== kind) {
+      throw new Error("collection SSA location key kind mismatch");
+    }
+    return { key, location: existing as Extract<IR1SsaLocation, { kind: K }> };
+  }
+  const location =
+    kind === "map-value"
+      ? ir1SsaMapValueLocation(
+          input.ruleName,
+          input.keyPredName,
+          input.ownerType,
+          input.keyType,
+          input.receiver,
+          input.key,
+        )
+      : ir1SsaMapMembershipLocation(
+          input.ruleName,
+          input.keyPredName,
+          input.ownerType,
+          input.keyType,
+          input.receiver,
+          input.key,
+        );
+  state.locations.set(key, location as CollectionSsaLocation);
+  state.declaredRules?.add(ir1SsaRuleOfLocation(location));
+  return { key, location: location as Extract<IR1SsaLocation, { kind: K }> };
+}
+
+function mapLocationKey(
+  kind: "map-value" | "map-membership",
+  ruleName: string,
+  keyPredName: string,
+  ownerType: string,
+  keyType: string,
+  receiverKey: string,
+  keyExprKey: string,
+): string {
+  return [
+    kind,
+    ruleName,
+    keyPredName,
+    ownerType,
+    keyType,
+    receiverKey,
+    keyExprKey,
+  ].join("::");
+}
+
+function setMembershipLocationKey(
+  ruleName: string,
+  ownerType: string,
+  elemType: string,
+  receiverKey: string,
+): string {
+  return ["set-membership", ruleName, ownerType, elemType, receiverKey].join(
+    "::",
+  );
+}
+
+function collectionSsaCanonicalExprKey(
+  expr: IR1Expr,
+  state: Pick<CollectionSsaLocationState, "canonicalize">,
+): string {
+  try {
+    return collectionSsaExprKey(state.canonicalize(expr));
+  } catch (err) {
+    if (err instanceof Error) {
+      return collectionSsaExprKey(expr);
+    }
+    throw err;
+  }
+}
+
+function collectionSsaExprKey(expr: IR1Expr): string {
+  switch (expr.kind) {
+    case "var":
+      return `var:${expr.name}:${expr.primed ?? false}`;
+    case "lit":
+      return `lit:${expr.value.kind}:${"value" in expr.value ? expr.value.value : ""}`;
+    case "member":
+      return `member:${collectionSsaExprKey(expr.receiver)}:${expr.name}`;
+    case "binop":
+      return `binop:${expr.op}:${collectionSsaExprKey(expr.lhs)}:${collectionSsaExprKey(expr.rhs)}`;
+    case "unop":
+      return `unop:${expr.op}:${collectionSsaExprKey(expr.arg)}`;
+    case "app":
+      return `app:${collectionSsaExprKey(expr.callee)}(${expr.args
+        .map(collectionSsaExprKey)
+        .join(",")})`;
+    case "cond":
+      return `cond:${expr.arms
+        .map(
+          ([guard, value]) =>
+            `${collectionSsaExprKey(guard)}=>${collectionSsaExprKey(value)}`,
+        )
+        .join("|")}:${collectionSsaExprKey(expr.otherwise)}`;
+    case "is-nullish":
+      return `is-nullish:${collectionSsaExprKey(expr.operand)}`;
+    case "each":
+      return `each:${expr.binder}:${collectionSsaExprKey(expr.src)}:${expr.guards
+        .map(collectionSsaExprKey)
+        .join(",")}:${collectionSsaExprKey(expr.proj)}`;
+    case "map-read":
+      return `map-read:${expr.op}:${expr.ruleName}:${expr.keyPredName}:${expr.ownerType}:${expr.keyType}:${collectionSsaExprKey(expr.receiver)}:${collectionSsaExprKey(expr.key)}`;
+    case "set-read":
+      return `set-read:${expr.ruleName}:${expr.ownerType}:${expr.elemType}:${collectionSsaExprKey(expr.receiver)}:${collectionSsaExprKey(expr.elem)}`;
+    default: {
+      const _exhaustive: never = expr;
+      void _exhaustive;
+      return "";
+    }
+  }
+}
+
+function isCollectionSsaExpr(expr: IR1Expr): boolean {
+  switch (expr.kind) {
+    case "var":
+    case "lit":
+      return true;
+    case "member":
+      return isCollectionSsaExpr(expr.receiver);
+    case "binop":
+      return isCollectionSsaExpr(expr.lhs) && isCollectionSsaExpr(expr.rhs);
+    case "unop":
+      return isCollectionSsaExpr(expr.arg);
+    case "app":
+      return (
+        isCollectionSsaExpr(expr.callee) && expr.args.every(isCollectionSsaExpr)
+      );
+    case "cond":
+      return (
+        expr.arms.every(
+          ([guard, value]) =>
+            isCollectionSsaExpr(guard) && isCollectionSsaExpr(value),
+        ) && isCollectionSsaExpr(expr.otherwise)
+      );
+    case "is-nullish":
+      return isCollectionSsaExpr(expr.operand);
+    case "each":
+      return (
+        isCollectionSsaExpr(expr.src) &&
+        expr.guards.every(isCollectionSsaExpr) &&
+        isCollectionSsaExpr(expr.proj)
+      );
+    case "map-read":
+      return (
+        isCollectionSsaExpr(expr.receiver) && isCollectionSsaExpr(expr.key)
+      );
+    case "set-read":
+      return (
+        isCollectionSsaExpr(expr.receiver) && isCollectionSsaExpr(expr.elem)
+      );
+    default: {
+      const _exhaustive: never = expr;
+      void _exhaustive;
+      return false;
+    }
+  }
+}

--- a/tools/ts2pant/src/ir1-ssa-collections.ts
+++ b/tools/ts2pant/src/ir1-ssa-collections.ts
@@ -394,8 +394,8 @@ export function setMembershipLocationForReadOrWrite(
   key: string;
   location: Extract<IR1SsaLocation, { kind: "set-membership" }>;
 } {
-  const receiverKey = collectionSsaCanonicalExprKey(input.receiver, state);
   const receiver = collectionSsaCanonicalExpr(input.receiver, state);
+  const receiverKey = collectionSsaExprKey(receiver);
   const key = setMembershipLocationKey(
     input.ruleName,
     input.ownerType,
@@ -744,13 +744,6 @@ function setMembershipLocationKey(
     elemType,
     receiverKey,
   ]);
-}
-
-function collectionSsaCanonicalExprKey(
-  expr: IR1Expr,
-  state: Pick<CollectionSsaLocationState, "canonicalize">,
-): string {
-  return collectionSsaExprKey(collectionSsaCanonicalExpr(expr, state));
 }
 
 function collectionSsaCanonicalExpr(

--- a/tools/ts2pant/src/ir1-ssa-collections.ts
+++ b/tools/ts2pant/src/ir1-ssa-collections.ts
@@ -249,6 +249,9 @@ export function lowerCollectionSsaL1Body(
         return;
       }
       collectionSsaReadExpr(stmt.target.receiver, state);
+      if (state.diagnostics.length > 0) {
+        return;
+      }
       collectionSsaReadExpr(stmt.value, state);
       return;
     case "map-effect":
@@ -318,17 +321,16 @@ export function collectionSsaReadExpr(
       collectionSsaReadExpr(expr.arg, state);
       return expr;
     case "app":
-      collectionSsaReadExpr(expr.callee, state);
-      for (const arg of expr.args) {
-        collectionSsaReadExpr(arg, state);
-      }
+      collectionSsaUnsupported(
+        state,
+        "collection SSA does not support call expressions in this pass",
+      );
       return expr;
     case "cond":
-      for (const [guard, value] of expr.arms) {
-        collectionSsaReadExpr(guard, state);
-        collectionSsaReadExpr(value, state);
-      }
-      collectionSsaReadExpr(expr.otherwise, state);
+      collectionSsaUnsupported(
+        state,
+        "collection SSA does not support value-position conditionals in this pass",
+      );
       return expr;
     case "is-nullish":
       collectionSsaReadExpr(expr.operand, state);
@@ -425,7 +427,13 @@ function lowerCollectionMapEffect(
   state: CollectionSsaState,
 ): void {
   collectionSsaReadExpr(stmt.objExpr, state);
+  if (state.diagnostics.length > 0) {
+    return;
+  }
   collectionSsaReadExpr(stmt.keyExpr, state);
+  if (state.diagnostics.length > 0) {
+    return;
+  }
   const input = {
     ruleName: stmt.ruleName,
     keyPredName: stmt.keyPredName,
@@ -437,6 +445,9 @@ function lowerCollectionMapEffect(
 
   if (stmt.op === "set") {
     collectionSsaReadExpr(stmt.valueExpr, state);
+    if (state.diagnostics.length > 0) {
+      return;
+    }
     const valueLocation = mapValueLocationForReadOrWrite(input, state);
     const valueWrite = ir1SsaWrite(
       valueLocation.location,
@@ -458,6 +469,9 @@ function lowerCollectionSetEffect(
   state: CollectionSsaState,
 ): void {
   collectionSsaReadExpr(stmt.objExpr, state);
+  if (state.diagnostics.length > 0) {
+    return;
+  }
   const location = setMembershipLocationForReadOrWrite(
     {
       ruleName: stmt.ruleName,
@@ -473,6 +487,9 @@ function lowerCollectionSetEffect(
       : ir1SsaSetMembershipValue(stmt.op, stmt.elemExpr);
   if (stmt.op !== "clear") {
     collectionSsaReadExpr(stmt.elemExpr, state);
+    if (state.diagnostics.length > 0) {
+      return;
+    }
   }
   const write = ir1SsaWrite(location.location, value);
   recordCollectionWrite(location.key, write, state);
@@ -862,16 +879,8 @@ function isCollectionSsaExpr(expr: IR1Expr): boolean {
     case "unop":
       return isCollectionSsaExpr(expr.arg);
     case "app":
-      return (
-        isCollectionSsaExpr(expr.callee) && expr.args.every(isCollectionSsaExpr)
-      );
     case "cond":
-      return (
-        expr.arms.every(
-          ([guard, value]) =>
-            isCollectionSsaExpr(guard) && isCollectionSsaExpr(value),
-        ) && isCollectionSsaExpr(expr.otherwise)
-      );
+      return false;
     case "is-nullish":
       return isCollectionSsaExpr(expr.operand);
     case "each":

--- a/tools/ts2pant/src/ir1-ssa-collections.ts
+++ b/tools/ts2pant/src/ir1-ssa-collections.ts
@@ -501,10 +501,22 @@ function collectionSsaReadMap(
     receiver: expr.receiver,
     key: expr.key,
   };
-  const { key, location } =
-    expr.op === "has"
-      ? mapMembershipLocationForReadOrWrite(input, state)
-      : mapValueLocationForReadOrWrite(input, state);
+  if (expr.op === "has") {
+    const membership = mapMembershipLocationForReadOrWrite(input, state);
+    return recordCollectionRead(membership.key, membership.location, state);
+  }
+  const value = mapValueLocationForReadOrWrite(input, state);
+  const valueRead = recordCollectionRead(value.key, value.location, state);
+  const membership = mapMembershipLocationForReadOrWrite(input, state);
+  recordCollectionRead(membership.key, membership.location, state);
+  return valueRead;
+}
+
+function recordCollectionRead(
+  key: string,
+  location: CollectionSsaLocation,
+  state: CollectionSsaState,
+): IR1SsaRead {
   const version =
     state.currentVersions.get(key) ??
     initialCollectionVersionFor(key, location, state);

--- a/tools/ts2pant/src/ir1-ssa-collections.ts
+++ b/tools/ts2pant/src/ir1-ssa-collections.ts
@@ -78,6 +78,15 @@ export interface CollectionSsaLowerResult {
   diagnostics: Array<Extract<PropResult, { kind: "unsupported" }>>;
 }
 
+export interface CollectionSsaUnsupportedResult {
+  unsupported: string;
+  diagnostics: Array<Extract<PropResult, { kind: "unsupported" }>>;
+}
+
+export type CollectionSsaProgramBuildResult =
+  | IR1SsaProgram
+  | CollectionSsaUnsupportedResult;
+
 interface CollectionSsaLocationState {
   locations: Map<string, CollectionSsaLocation>;
   declaredRules?: Set<string>;
@@ -109,9 +118,15 @@ export function makeCollectionSsaState(
 export function buildCollectionSsaProgram(
   stmt: IR1Stmt,
   options: CollectionSsaBuildOptions = {},
-): IR1SsaProgram {
+): CollectionSsaProgramBuildResult {
   const state = makeCollectionSsaState(options);
   lowerCollectionSsaL1Body(stmt, state);
+  if (state.diagnostics.length > 0) {
+    return {
+      unsupported: state.diagnostics[0]!.reason,
+      diagnostics: state.diagnostics,
+    };
+  }
   return collectionSsaProgramFromState(state);
 }
 
@@ -153,12 +168,16 @@ function collectionSsaProgramFromState(
 }
 
 export function collectionSsaFinalEntries(
-  state: Pick<CollectionSsaState, "currentVersions" | "locations">,
+  state: Pick<
+    CollectionSsaState,
+    "currentVersions" | "initialVersions" | "locations"
+  >,
 ): CollectionSsaFinalEntry[] {
   const entries: CollectionSsaFinalEntry[] = [];
-  for (const [key, version] of state.currentVersions) {
-    const location = state.locations.get(key);
-    if (location === undefined) {
+  for (const [key, location] of state.locations) {
+    const version =
+      state.currentVersions.get(key) ?? state.initialVersions.get(key);
+    if (version === undefined) {
       continue;
     }
     entries.push({
@@ -738,14 +757,7 @@ function collectionSsaCanonicalExpr(
   expr: IR1Expr,
   state: Pick<CollectionSsaLocationState, "canonicalize">,
 ): IR1Expr {
-  try {
-    return state.canonicalize(expr);
-  } catch (err) {
-    if (err instanceof Error) {
-      return expr;
-    }
-    throw err;
-  }
+  return state.canonicalize(expr);
 }
 
 function collectionSsaExprKey(expr: IR1Expr): string {

--- a/tools/ts2pant/src/ir1-ssa-collections.ts
+++ b/tools/ts2pant/src/ir1-ssa-collections.ts
@@ -35,6 +35,7 @@ export interface CollectionSsaState {
   reads: IR1SsaRead[];
   writes: IR1SsaWrite[];
   joins: IR1SsaJoin[];
+  diagnostics: Array<Extract<PropResult, { kind: "unsupported" }>>;
   writtenKeys: Set<string>;
   declaredRules: Set<string>;
   modifiedRules: Set<string>;
@@ -97,6 +98,7 @@ export function makeCollectionSsaState(
     reads: [],
     writes: [],
     joins: [],
+    diagnostics: [],
     writtenKeys: new Set(),
     declaredRules: new Set(options.declaredRules ?? []),
     modifiedRules: new Set(),
@@ -110,6 +112,28 @@ export function buildCollectionSsaProgram(
 ): IR1SsaProgram {
   const state = makeCollectionSsaState(options);
   lowerCollectionSsaL1Body(stmt, state);
+  return collectionSsaProgramFromState(state);
+}
+
+export function lowerCollectionSsaToResult(
+  stmt: IR1Stmt,
+  options: CollectionSsaBuildOptions = {},
+): CollectionSsaLowerResult {
+  const state = makeCollectionSsaState(options);
+  lowerCollectionSsaL1Body(stmt, state);
+  const program = collectionSsaProgramFromState(state);
+  return {
+    program,
+    finalEntries: collectionSsaFinalEntries(state),
+    propositions: [],
+    modifiedRules: [...program.modifiedRules],
+    diagnostics: state.diagnostics,
+  };
+}
+
+function collectionSsaProgramFromState(
+  state: CollectionSsaState,
+): IR1SsaProgram {
   const declaredRules = new Set(state.declaredRules);
   for (const rule of state.modifiedRules) {
     declaredRules.add(rule);
@@ -199,9 +223,11 @@ export function lowerCollectionSsaL1Body(
   switch (stmt.kind) {
     case "assign":
       if (stmt.target.kind !== "member") {
-        throw new Error(
+        collectionSsaUnsupported(
+          state,
           "collection SSA assignment target must be a property member",
         );
+        return;
       }
       collectionSsaReadExpr(stmt.target.receiver, state);
       collectionSsaReadExpr(stmt.value, state);
@@ -215,6 +241,9 @@ export function lowerCollectionSsaL1Body(
     case "block":
       for (const child of stmt.stmts) {
         lowerCollectionSsaL1Body(child, state);
+        if (state.diagnostics.length > 0) {
+          return;
+        }
       }
       return;
     case "cond-stmt":
@@ -227,11 +256,19 @@ export function lowerCollectionSsaL1Body(
     case "throw":
     case "let":
     case "expr-stmt":
-      throw new Error(`${stmt.kind} is not supported by collection SSA`);
+      collectionSsaUnsupported(
+        state,
+        `collection SSA does not support ${stmt.kind} in this pass`,
+      );
+      return;
     default: {
       const _exhaustive: never = stmt;
       void _exhaustive;
-      throw new Error("unsupported IR1 statement in collection SSA lowering");
+      collectionSsaUnsupported(
+        state,
+        "collection SSA does not support this IR1 statement in this pass",
+      );
+      return;
     }
   }
 }
@@ -339,6 +376,7 @@ export function setMembershipLocationForReadOrWrite(
   location: Extract<IR1SsaLocation, { kind: "set-membership" }>;
 } {
   const receiverKey = collectionSsaCanonicalExprKey(input.receiver, state);
+  const receiver = collectionSsaCanonicalExpr(input.receiver, state);
   const key = setMembershipLocationKey(
     input.ruleName,
     input.ownerType,
@@ -356,7 +394,7 @@ export function setMembershipLocationForReadOrWrite(
     input.ruleName,
     input.ownerType,
     input.elemType,
-    input.receiver,
+    receiver,
   ) as Extract<IR1SsaLocation, { kind: "set-membership" }>;
   state.locations.set(key, location);
   state.declaredRules?.add(ir1SsaRuleOfLocation(location));
@@ -482,17 +520,29 @@ function lowerCollectionCondStmt(
   state: CollectionSsaState,
 ): void {
   if (stmt.arms.length !== 1) {
-    throw new Error("multi-armed cond-stmt is not supported by collection SSA");
+    collectionSsaUnsupported(
+      state,
+      "collection SSA does not support multi-armed cond-stmt in this pass",
+    );
+    return;
   }
   const [guard, thenBody] = stmt.arms[0]!;
   collectionSsaReadExpr(guard, state);
 
   const thenState = cloneCollectionSsaStateForBranch(state);
   lowerCollectionSsaL1Body(thenBody, thenState);
+  if (thenState.diagnostics.length > 0) {
+    state.diagnostics.push(...thenState.diagnostics);
+    return;
+  }
 
   const elseState = cloneCollectionSsaStateForBranch(state);
   if (stmt.otherwise !== null) {
     lowerCollectionSsaL1Body(stmt.otherwise, elseState);
+    if (elseState.diagnostics.length > 0) {
+      state.diagnostics.push(...elseState.diagnostics);
+      return;
+    }
   }
 
   state.reads.push(...thenState.reads, ...elseState.reads);
@@ -539,6 +589,7 @@ function cloneCollectionSsaStateForBranch(
     reads: [],
     writes: [],
     joins: [],
+    diagnostics: [],
     writtenKeys: new Set(),
     declaredRules: new Set(state.declaredRules),
     modifiedRules: new Set(),
@@ -598,8 +649,10 @@ function mapLocationForInput<K extends "map-value" | "map-membership">(
   key: string;
   location: Extract<IR1SsaLocation, { kind: K }>;
 } {
-  const receiverKey = collectionSsaCanonicalExprKey(input.receiver, state);
-  const elementKey = collectionSsaCanonicalExprKey(input.key, state);
+  const receiver = collectionSsaCanonicalExpr(input.receiver, state);
+  const element = collectionSsaCanonicalExpr(input.key, state);
+  const receiverKey = collectionSsaExprKey(receiver);
+  const elementKey = collectionSsaExprKey(element);
   const key = mapLocationKey(
     kind,
     input.ruleName,
@@ -623,16 +676,16 @@ function mapLocationForInput<K extends "map-value" | "map-membership">(
           input.keyPredName,
           input.ownerType,
           input.keyType,
-          input.receiver,
-          input.key,
+          receiver,
+          element,
         )
       : ir1SsaMapMembershipLocation(
           input.ruleName,
           input.keyPredName,
           input.ownerType,
           input.keyType,
-          input.receiver,
-          input.key,
+          receiver,
+          element,
         );
   state.locations.set(key, location as CollectionSsaLocation);
   state.declaredRules?.add(ir1SsaRuleOfLocation(location));
@@ -648,7 +701,7 @@ function mapLocationKey(
   receiverKey: string,
   keyExprKey: string,
 ): string {
-  return [
+  return JSON.stringify([
     kind,
     ruleName,
     keyPredName,
@@ -656,7 +709,7 @@ function mapLocationKey(
     keyType,
     receiverKey,
     keyExprKey,
-  ].join("::");
+  ]);
 }
 
 function setMembershipLocationKey(
@@ -665,64 +718,119 @@ function setMembershipLocationKey(
   elemType: string,
   receiverKey: string,
 ): string {
-  return ["set-membership", ruleName, ownerType, elemType, receiverKey].join(
-    "::",
-  );
+  return JSON.stringify([
+    "set-membership",
+    ruleName,
+    ownerType,
+    elemType,
+    receiverKey,
+  ]);
 }
 
 function collectionSsaCanonicalExprKey(
   expr: IR1Expr,
   state: Pick<CollectionSsaLocationState, "canonicalize">,
 ): string {
+  return collectionSsaExprKey(collectionSsaCanonicalExpr(expr, state));
+}
+
+function collectionSsaCanonicalExpr(
+  expr: IR1Expr,
+  state: Pick<CollectionSsaLocationState, "canonicalize">,
+): IR1Expr {
   try {
-    return collectionSsaExprKey(state.canonicalize(expr));
+    return state.canonicalize(expr);
   } catch (err) {
     if (err instanceof Error) {
-      return collectionSsaExprKey(expr);
+      return expr;
     }
     throw err;
   }
 }
 
 function collectionSsaExprKey(expr: IR1Expr): string {
+  return JSON.stringify(collectionSsaExprKeyData(expr));
+}
+
+function collectionSsaExprKeyData(expr: IR1Expr): unknown {
   switch (expr.kind) {
     case "var":
-      return `var:${expr.name}:${expr.primed ?? false}`;
+      return ["var", expr.name, expr.primed ?? false];
     case "lit":
-      return `lit:${expr.value.kind}:${"value" in expr.value ? expr.value.value : ""}`;
+      return [
+        "lit",
+        expr.value.kind,
+        "value" in expr.value ? expr.value.value : null,
+      ];
     case "member":
-      return `member:${collectionSsaExprKey(expr.receiver)}:${expr.name}`;
+      return ["member", collectionSsaExprKeyData(expr.receiver), expr.name];
     case "binop":
-      return `binop:${expr.op}:${collectionSsaExprKey(expr.lhs)}:${collectionSsaExprKey(expr.rhs)}`;
+      return [
+        "binop",
+        expr.op,
+        collectionSsaExprKeyData(expr.lhs),
+        collectionSsaExprKeyData(expr.rhs),
+      ];
     case "unop":
-      return `unop:${expr.op}:${collectionSsaExprKey(expr.arg)}`;
+      return ["unop", expr.op, collectionSsaExprKeyData(expr.arg)];
     case "app":
-      return `app:${collectionSsaExprKey(expr.callee)}(${expr.args
-        .map(collectionSsaExprKey)
-        .join(",")})`;
+      return [
+        "app",
+        collectionSsaExprKeyData(expr.callee),
+        expr.args.map(collectionSsaExprKeyData),
+      ];
     case "cond":
-      return `cond:${expr.arms
-        .map(
-          ([guard, value]) =>
-            `${collectionSsaExprKey(guard)}=>${collectionSsaExprKey(value)}`,
-        )
-        .join("|")}:${collectionSsaExprKey(expr.otherwise)}`;
+      return [
+        "cond",
+        expr.arms.map(([guard, value]) => [
+          collectionSsaExprKeyData(guard),
+          collectionSsaExprKeyData(value),
+        ]),
+        collectionSsaExprKeyData(expr.otherwise),
+      ];
     case "is-nullish":
-      return `is-nullish:${collectionSsaExprKey(expr.operand)}`;
+      return ["is-nullish", collectionSsaExprKeyData(expr.operand)];
     case "each":
-      return `each:${expr.binder}:${collectionSsaExprKey(expr.src)}:${expr.guards
-        .map(collectionSsaExprKey)
-        .join(",")}:${collectionSsaExprKey(expr.proj)}`;
+      return [
+        "each",
+        expr.binder,
+        collectionSsaExprKeyData(expr.src),
+        expr.guards.map(collectionSsaExprKeyData),
+        collectionSsaExprKeyData(expr.proj),
+      ];
     case "map-read":
-      return `map-read:${expr.op}:${expr.ruleName}:${expr.keyPredName}:${expr.ownerType}:${expr.keyType}:${collectionSsaExprKey(expr.receiver)}:${collectionSsaExprKey(expr.key)}`;
+      return [
+        "map-read",
+        expr.op,
+        expr.ruleName,
+        expr.keyPredName,
+        expr.ownerType,
+        expr.keyType,
+        collectionSsaExprKeyData(expr.receiver),
+        collectionSsaExprKeyData(expr.key),
+      ];
     case "set-read":
-      return `set-read:${expr.ruleName}:${expr.ownerType}:${expr.elemType}:${collectionSsaExprKey(expr.receiver)}:${collectionSsaExprKey(expr.elem)}`;
+      return [
+        "set-read",
+        expr.ruleName,
+        expr.ownerType,
+        expr.elemType,
+        collectionSsaExprKeyData(expr.receiver),
+        collectionSsaExprKeyData(expr.elem),
+      ];
     default: {
       const _exhaustive: never = expr;
       void _exhaustive;
-      return "";
+      return ["unknown"];
     }
   }
+}
+
+function collectionSsaUnsupported(
+  state: CollectionSsaState,
+  reason: string,
+): void {
+  state.diagnostics.push({ kind: "unsupported", reason });
 }
 
 function isCollectionSsaExpr(expr: IR1Expr): boolean {

--- a/tools/ts2pant/tests/ir1-ssa-collections.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-collections.test.mts
@@ -444,6 +444,57 @@ describe("ir1-ssa-collections", () => {
     ]);
   });
 
+  it("rejects call and value-position conditional expressions", () => {
+    const target = ir1Member(ir1Var("owner"), "Owner_seen");
+    const callAssign = ir1Assign(target, {
+      kind: "app",
+      callee: ir1Var("maybeMutates"),
+      args: [ir1Var("cache")],
+    });
+    const condAssign = ir1Assign(target, {
+      kind: "cond",
+      arms: [
+        [
+          ir1Var("gate"),
+          ir1MapRead(
+            "get",
+            "Cache_value",
+            "Cache_hasKey",
+            "Owner",
+            "Key",
+            ir1Var("cache"),
+            ir1Var("a"),
+          ),
+        ],
+      ],
+      otherwise: ir1MapRead(
+        "get",
+        "Cache_value",
+        "Cache_hasKey",
+        "Owner",
+        "Key",
+        ir1Var("cache"),
+        ir1Var("b"),
+      ),
+    });
+
+    assert.equal(isCollectionSsaL1Body(callAssign), false);
+    assert.deepEqual(lowerCollectionSsaToResult(callAssign).diagnostics, [
+      {
+        kind: "unsupported",
+        reason: "collection SSA does not support call expressions in this pass",
+      },
+    ]);
+    assert.equal(isCollectionSsaL1Body(condAssign), false);
+    assert.deepEqual(lowerCollectionSsaToResult(condAssign).diagnostics, [
+      {
+        kind: "unsupported",
+        reason:
+          "collection SSA does not support value-position conditionals in this pass",
+      },
+    ]);
+  });
+
   it("includes read-only collection locations in final entries", () => {
     const result = lowerCollectionSsaToResult(
       ir1Assign(

--- a/tools/ts2pant/tests/ir1-ssa-collections.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-collections.test.mts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
+  type IR1SsaProgram,
   ir1Assign,
   ir1Block,
   ir1CondStmt,
@@ -21,6 +22,16 @@ import {
   isCollectionSsaL1Body,
   lowerCollectionSsaToResult,
 } from "../src/ir1-ssa-collections.js";
+
+function mustBuildCollectionSsaProgram(
+  ...args: Parameters<typeof buildCollectionSsaProgram>
+): IR1SsaProgram {
+  const result = buildCollectionSsaProgram(...args);
+  if ("unsupported" in result) {
+    assert.fail(result.unsupported);
+  }
+  return result;
+}
 
 describe("ir1-ssa-collections", () => {
   // PENDING Patch 2: introduce shared collection SSA state for coordinated
@@ -48,7 +59,7 @@ describe("ir1-ssa-collections", () => {
     assert.equal(membership.kind, "map-membership");
     assert.equal(isCollectionSsaL1Body(stmt), true);
 
-    const program = buildCollectionSsaProgram(stmt);
+    const program = mustBuildCollectionSsaProgram(stmt);
 
     assert.equal(program.writes.length, 2);
     assert.equal(program.reads.length, 0);
@@ -106,7 +117,7 @@ describe("ir1-ssa-collections", () => {
       ),
     ]);
 
-    const program = buildCollectionSsaProgram(stmt, {
+    const program = mustBuildCollectionSsaProgram(stmt, {
       canonicalize: (expr) =>
         expr.kind === "var" && expr.name === "alias" ? ir1Var("cache") : expr,
     });
@@ -151,7 +162,7 @@ describe("ir1-ssa-collections", () => {
       ),
     );
 
-    const program = buildCollectionSsaProgram(stmt);
+    const program = mustBuildCollectionSsaProgram(stmt);
 
     assert.equal(program.writes.length, 3);
     assert.equal(program.joins.length, 2);
@@ -197,7 +208,7 @@ describe("ir1-ssa-collections", () => {
       ),
     ]);
 
-    const program = buildCollectionSsaProgram(stmt);
+    const program = mustBuildCollectionSsaProgram(stmt);
 
     assert.equal(program.writes.length, 1);
     assert.equal(program.reads.length, 1);
@@ -229,7 +240,7 @@ describe("ir1-ssa-collections", () => {
       ),
     ]);
 
-    const program = buildCollectionSsaProgram(stmt);
+    const program = mustBuildCollectionSsaProgram(stmt);
     const valueRules = program.writes
       .filter((write) => write.location.kind === "map-value")
       .map((write) => write.location.ruleName);
@@ -275,6 +286,20 @@ describe("ir1-ssa-collections", () => {
         reason: "collection SSA does not support expr-stmt in this pass",
       },
     ]);
+
+    const buildResult = buildCollectionSsaProgram({
+      kind: "expr-stmt",
+      expr: ir1Var("x"),
+    });
+    assert.deepEqual(buildResult, {
+      unsupported: "collection SSA does not support expr-stmt in this pass",
+      diagnostics: [
+        {
+          kind: "unsupported",
+          reason: "collection SSA does not support expr-stmt in this pass",
+        },
+      ],
+    });
   });
 
   it("reports unsupported multi-arm conditionals as diagnostics", () => {
@@ -315,6 +340,55 @@ describe("ir1-ssa-collections", () => {
           "collection SSA does not support multi-armed cond-stmt in this pass",
       },
     ]);
+  });
+
+  it("includes read-only collection locations in final entries", () => {
+    const result = lowerCollectionSsaToResult(
+      ir1Assign(
+        ir1Member(ir1Var("owner"), "Owner_has"),
+        ir1MapRead(
+          "has",
+          "Cache_value",
+          "Cache_hasKey",
+          "Owner",
+          "Key",
+          ir1Var("cache"),
+          ir1Var("key"),
+        ),
+      ),
+    );
+
+    assert.deepEqual(result.diagnostics, []);
+    assert.equal(result.program.reads.length, 1);
+    assert.equal(result.program.writes.length, 0);
+    assert.equal(result.finalEntries.length, 1);
+    assert.equal(result.finalEntries[0]!.kind, "map-membership");
+    assert.equal(result.finalEntries[0]!.version.origin, "initial");
+    assert.equal(
+      result.finalEntries[0]!.version,
+      result.program.reads[0]!.version,
+    );
+  });
+
+  it("propagates canonicalizer failures", () => {
+    const stmt = ir1MapDelete(
+      "Cache_value",
+      "Cache_hasKey",
+      "Owner",
+      "Key",
+      ir1Var("cache"),
+      ir1Var("key"),
+    );
+
+    assert.throws(
+      () =>
+        buildCollectionSsaProgram(stmt, {
+          canonicalize: () => {
+            throw new Error("canonicalize failed");
+          },
+        }),
+      /canonicalize failed/,
+    );
   });
 
   it.skip("records Set.add delete and clear as membership SSA writes", () => {

--- a/tools/ts2pant/tests/ir1-ssa-collections.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-collections.test.mts
@@ -1,11 +1,25 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
+  ir1Assign,
+  ir1Block,
+  ir1CondStmt,
   ir1LitNat,
+  ir1MapDelete,
+  ir1MapRead,
+  ir1MapSet,
+  ir1Member,
+  ir1SetAddOrDelete,
+  ir1SetRead,
   ir1SsaMapMembershipValue,
   ir1SsaMapSetValue,
   ir1SsaSetClearValue,
+  ir1Var,
 } from "../src/ir1.js";
+import {
+  buildCollectionSsaProgram,
+  isCollectionSsaL1Body,
+} from "../src/ir1-ssa-collections.js";
 
 describe("ir1-ssa-collections", () => {
   // PENDING Patch 2: introduce shared collection SSA state for coordinated
@@ -16,27 +30,203 @@ describe("ir1-ssa-collections", () => {
   // PENDING Patch 6: keep production parity fixtures pinned while the old
   // SymbolicState-only path is narrowed.
 
-  it.skip("records Map.set as coordinated value and membership SSA writes", () => {
+  it("records Map.set as coordinated value and membership SSA writes", () => {
     const value = ir1SsaMapSetValue(ir1LitNat(7));
     const membership = ir1SsaMapMembershipValue("set");
+    const stmt = ir1MapSet(
+      "Cache_value",
+      "Cache_hasKey",
+      "Owner",
+      "Key",
+      ir1Var("cache"),
+      ir1Var("key"),
+      ir1LitNat(7),
+    );
 
     assert.equal(value.kind, "map-value");
     assert.equal(membership.kind, "map-membership");
-    // PENDING Patch 3: build collection SSA for a `Map.set(k, v)` body and
-    // assert it records one map-value write plus one paired map-membership
-    // write for the same receiver/key location.
+    assert.equal(isCollectionSsaL1Body(stmt), true);
+
+    const program = buildCollectionSsaProgram(stmt);
+
+    assert.equal(program.writes.length, 2);
+    assert.equal(program.reads.length, 0);
+    assert.equal(program.joins.length, 0);
+    assert.deepEqual(
+      new Set(program.modifiedRules),
+      new Set(["Cache_value", "Cache_hasKey"]),
+    );
+
+    const [valueWrite, membershipWrite] = program.writes;
+    assert.equal(valueWrite!.location.kind, "map-value");
+    assert.equal(valueWrite!.location.ruleName, "Cache_value");
+    assert.equal(valueWrite!.version.location, valueWrite!.location);
+    assert.deepEqual(valueWrite!.value, value);
+    assert.equal(membershipWrite!.location.kind, "map-membership");
+    assert.equal(membershipWrite!.location.keyPredName, "Cache_hasKey");
+    assert.equal(membershipWrite!.version.location, membershipWrite!.location);
+    assert.deepEqual(membershipWrite!.value, membership);
   });
 
-  it.skip("resolves Map.get and Map.has through staged SSA writes", () => {
-    // PENDING Patch 3: lower a non-looping `set -> get/has` body and assert
-    // both reads resolve against the dominating staged versions rather than
-    // the pre-state rule helpers from `readMapThroughWrites`.
+  it("resolves Map.get and Map.has through staged SSA writes", () => {
+    const stmt = ir1Block([
+      ir1MapSet(
+        "Cache_value",
+        "Cache_hasKey",
+        "Owner",
+        "Key",
+        ir1Var("alias"),
+        ir1Var("key"),
+        ir1LitNat(7),
+      ),
+      ir1Assign(
+        ir1Member(ir1Var("owner"), "Owner_seen"),
+        ir1MapRead(
+          "get",
+          "Cache_value",
+          "Cache_hasKey",
+          "Owner",
+          "Key",
+          ir1Var("cache"),
+          ir1Var("key"),
+        ),
+      ),
+      ir1Assign(
+        ir1Member(ir1Var("owner"), "Owner_has"),
+        ir1MapRead(
+          "has",
+          "Cache_value",
+          "Cache_hasKey",
+          "Owner",
+          "Key",
+          ir1Var("cache"),
+          ir1Var("key"),
+        ),
+      ),
+    ]);
+
+    const program = buildCollectionSsaProgram(stmt, {
+      canonicalize: (expr) =>
+        expr.kind === "var" && expr.name === "alias" ? ir1Var("cache") : expr,
+    });
+
+    assert.equal(program.writes.length, 2);
+    assert.equal(program.reads.length, 2);
+    const [valueWrite, membershipWrite] = program.writes;
+    const [valueRead, membershipRead] = program.reads;
+    assert.equal(valueRead!.location, valueWrite!.location);
+    assert.equal(valueRead!.version, valueWrite!.version);
+    assert.equal(valueRead!.dominated, true);
+    assert.equal(membershipRead!.location, membershipWrite!.location);
+    assert.equal(membershipRead!.version, membershipWrite!.version);
+    assert.equal(membershipRead!.dominated, true);
   });
 
-  it.skip("joins Map value and membership versions across branches", () => {
-    // PENDING Patch 3: cover `if (gate) m.set(...)` / `else m.delete(...)`
-    // and assert collection SSA emits IR1SsaJoin nodes for both map-value and
-    // map-membership locations instead of relying on `mergeOverrides`.
+  it("joins Map value and membership versions across branches", () => {
+    const stmt = ir1CondStmt(
+      [
+        [
+          ir1Var("gate"),
+          ir1MapSet(
+            "Cache_value",
+            "Cache_hasKey",
+            "Owner",
+            "Key",
+            ir1Var("cache"),
+            ir1Var("key"),
+            ir1LitNat(7),
+          ),
+        ],
+      ],
+      ir1MapDelete(
+        "Cache_value",
+        "Cache_hasKey",
+        "Owner",
+        "Key",
+        ir1Var("cache"),
+        ir1Var("key"),
+      ),
+    );
+
+    const program = buildCollectionSsaProgram(stmt);
+
+    assert.equal(program.writes.length, 3);
+    assert.equal(program.joins.length, 2);
+    const [valueWrite, membershipSetWrite, membershipDeleteWrite] =
+      program.writes;
+    const valueJoin = program.joins.find(
+      (j) => j.location.kind === "map-value",
+    );
+    const membershipJoin = program.joins.find(
+      (j) => j.location.kind === "map-membership",
+    );
+    assert.ok(valueJoin);
+    assert.equal(valueJoin.location, valueWrite!.location);
+    assert.equal(valueJoin.thenVersion, valueWrite!.version);
+    assert.equal(valueJoin.elseVersion.origin, "initial");
+    assert.equal(valueJoin.joinVersion.location, valueJoin.location);
+    assert.ok(membershipJoin);
+    assert.equal(membershipJoin.location, membershipSetWrite!.location);
+    assert.equal(membershipJoin.thenVersion, membershipSetWrite!.version);
+    assert.equal(membershipJoin.elseVersion, membershipDeleteWrite!.version);
+    assert.equal(membershipJoin.joinVersion.location, membershipJoin.location);
+  });
+
+  it("resolves Set.has through the current membership version", () => {
+    const stmt = ir1Block([
+      ir1SetAddOrDelete(
+        "add",
+        "Owner_tags",
+        "Owner",
+        "Tag",
+        ir1Var("owner"),
+        ir1Var("tag"),
+      ),
+      ir1Assign(
+        ir1Member(ir1Var("owner"), "Owner_hasTag"),
+        ir1SetRead(
+          "Owner_tags",
+          "Owner",
+          "Tag",
+          ir1Var("owner"),
+          ir1Var("tag"),
+        ),
+      ),
+    ]);
+
+    const program = buildCollectionSsaProgram(stmt);
+
+    assert.equal(program.writes.length, 1);
+    assert.equal(program.reads.length, 1);
+    assert.equal(program.writes[0]!.location.kind, "set-membership");
+    assert.equal(program.reads[0]!.location, program.writes[0]!.location);
+    assert.equal(program.reads[0]!.version, program.writes[0]!.version);
+    assert.equal(program.reads[0]!.dominated, true);
+  });
+
+  it("rejects loop and expression statement routing shapes", () => {
+    assert.equal(
+      isCollectionSsaL1Body({
+        kind: "expr-stmt",
+        expr: ir1Var("x"),
+      }),
+      false,
+    );
+    assert.equal(
+      isCollectionSsaL1Body({
+        kind: "while",
+        cond: ir1Var("keepGoing"),
+        body: ir1MapDelete(
+          "Cache_value",
+          "Cache_hasKey",
+          "Owner",
+          "Key",
+          ir1Var("cache"),
+          ir1Var("key"),
+        ),
+      }),
+      false,
+    );
   });
 
   it.skip("records Set.add delete and clear as membership SSA writes", () => {

--- a/tools/ts2pant/tests/ir1-ssa-collections.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-collections.test.mts
@@ -123,17 +123,65 @@ describe("ir1-ssa-collections", () => {
     });
 
     assert.equal(program.writes.length, 2);
-    assert.equal(program.reads.length, 2);
+    assert.equal(program.reads.length, 3);
     const [valueWrite, membershipWrite] = program.writes;
-    const [valueRead, membershipRead] = program.reads;
+    const [valueRead, getMembershipRead, hasMembershipRead] = program.reads;
     assert.deepEqual(valueWrite!.location.receiver, ir1Var("cache"));
     assert.deepEqual(membershipWrite!.location.receiver, ir1Var("cache"));
     assert.equal(valueRead!.location, valueWrite!.location);
     assert.equal(valueRead!.version, valueWrite!.version);
     assert.equal(valueRead!.dominated, true);
-    assert.equal(membershipRead!.location, membershipWrite!.location);
-    assert.equal(membershipRead!.version, membershipWrite!.version);
-    assert.equal(membershipRead!.dominated, true);
+    assert.equal(getMembershipRead!.location, membershipWrite!.location);
+    assert.equal(getMembershipRead!.version, membershipWrite!.version);
+    assert.equal(getMembershipRead!.dominated, true);
+    assert.equal(hasMembershipRead!.location, membershipWrite!.location);
+    assert.equal(hasMembershipRead!.version, membershipWrite!.version);
+    assert.equal(hasMembershipRead!.dominated, true);
+  });
+
+  it("tracks Map.get membership after delete-like effects", () => {
+    const stmt = ir1Block([
+      ir1MapSet(
+        "Cache_value",
+        "Cache_hasKey",
+        "Owner",
+        "Key",
+        ir1Var("cache"),
+        ir1Var("key"),
+        ir1LitNat(7),
+      ),
+      ir1MapDelete(
+        "Cache_value",
+        "Cache_hasKey",
+        "Owner",
+        "Key",
+        ir1Var("cache"),
+        ir1Var("key"),
+      ),
+      ir1Assign(
+        ir1Member(ir1Var("owner"), "Owner_seen"),
+        ir1MapRead(
+          "get",
+          "Cache_value",
+          "Cache_hasKey",
+          "Owner",
+          "Key",
+          ir1Var("cache"),
+          ir1Var("key"),
+        ),
+      ),
+    ]);
+
+    const program = mustBuildCollectionSsaProgram(stmt);
+
+    assert.equal(program.writes.length, 3);
+    assert.equal(program.reads.length, 2);
+    const [valueWrite, , membershipDeleteWrite] = program.writes;
+    const [valueRead, membershipRead] = program.reads;
+    assert.equal(valueRead!.location, valueWrite!.location);
+    assert.equal(valueRead!.version, valueWrite!.version);
+    assert.equal(membershipRead!.location, membershipDeleteWrite!.location);
+    assert.equal(membershipRead!.version, membershipDeleteWrite!.version);
   });
 
   it("joins Map value and membership versions across branches", () => {
@@ -184,6 +232,60 @@ describe("ir1-ssa-collections", () => {
     assert.equal(membershipJoin.thenVersion, membershipSetWrite!.version);
     assert.equal(membershipJoin.elseVersion, membershipDeleteWrite!.version);
     assert.equal(membershipJoin.joinVersion.location, membershipJoin.location);
+  });
+
+  it("tracks Map.get membership joins after branch-local delete", () => {
+    const stmt = ir1Block([
+      ir1MapSet(
+        "Cache_value",
+        "Cache_hasKey",
+        "Owner",
+        "Key",
+        ir1Var("cache"),
+        ir1Var("key"),
+        ir1LitNat(7),
+      ),
+      ir1CondStmt(
+        [
+          [
+            ir1Var("gate"),
+            ir1MapDelete(
+              "Cache_value",
+              "Cache_hasKey",
+              "Owner",
+              "Key",
+              ir1Var("cache"),
+              ir1Var("key"),
+            ),
+          ],
+        ],
+        null,
+      ),
+      ir1Assign(
+        ir1Member(ir1Var("owner"), "Owner_seen"),
+        ir1MapRead(
+          "get",
+          "Cache_value",
+          "Cache_hasKey",
+          "Owner",
+          "Key",
+          ir1Var("cache"),
+          ir1Var("key"),
+        ),
+      ),
+    ]);
+
+    const program = mustBuildCollectionSsaProgram(stmt);
+
+    assert.equal(program.joins.length, 1);
+    const membershipJoin = program.joins[0]!;
+    assert.equal(membershipJoin.location.kind, "map-membership");
+    assert.equal(program.reads.length, 2);
+    const [valueRead, membershipRead] = program.reads;
+    assert.equal(valueRead!.location.kind, "map-value");
+    assert.equal(valueRead!.version, program.writes[0]!.version);
+    assert.equal(membershipRead!.location, membershipJoin.location);
+    assert.equal(membershipRead!.version, membershipJoin.joinVersion);
   });
 
   it("resolves Set.has through the current membership version", () => {

--- a/tools/ts2pant/tests/ir1-ssa-collections.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-collections.test.mts
@@ -19,6 +19,7 @@ import {
 import {
   buildCollectionSsaProgram,
   isCollectionSsaL1Body,
+  lowerCollectionSsaToResult,
 } from "../src/ir1-ssa-collections.js";
 
 describe("ir1-ssa-collections", () => {
@@ -114,6 +115,8 @@ describe("ir1-ssa-collections", () => {
     assert.equal(program.reads.length, 2);
     const [valueWrite, membershipWrite] = program.writes;
     const [valueRead, membershipRead] = program.reads;
+    assert.deepEqual(valueWrite!.location.receiver, ir1Var("cache"));
+    assert.deepEqual(membershipWrite!.location.receiver, ir1Var("cache"));
     assert.equal(valueRead!.location, valueWrite!.location);
     assert.equal(valueRead!.version, valueWrite!.version);
     assert.equal(valueRead!.dominated, true);
@@ -204,6 +207,40 @@ describe("ir1-ssa-collections", () => {
     assert.equal(program.reads[0]!.dominated, true);
   });
 
+  it("keeps collection location keys unambiguous for delimiter-bearing names", () => {
+    const stmt = ir1Block([
+      ir1MapSet(
+        "Cache",
+        "Has::Key",
+        "Owner",
+        "Key",
+        ir1Var("cache"),
+        ir1Var("key"),
+        ir1LitNat(1),
+      ),
+      ir1MapSet(
+        "Cache::Has",
+        "Key",
+        "Owner",
+        "Key",
+        ir1Var("cache"),
+        ir1Var("key"),
+        ir1LitNat(2),
+      ),
+    ]);
+
+    const program = buildCollectionSsaProgram(stmt);
+    const valueRules = program.writes
+      .filter((write) => write.location.kind === "map-value")
+      .map((write) => write.location.ruleName);
+    const membershipRules = program.writes
+      .filter((write) => write.location.kind === "map-membership")
+      .map((write) => write.location.keyPredName);
+
+    assert.deepEqual(valueRules, ["Cache", "Cache::Has"]);
+    assert.deepEqual(membershipRules, ["Has::Key", "Key"]);
+  });
+
   it("rejects loop and expression statement routing shapes", () => {
     assert.equal(
       isCollectionSsaL1Body({
@@ -227,6 +264,57 @@ describe("ir1-ssa-collections", () => {
       }),
       false,
     );
+
+    const result = lowerCollectionSsaToResult({
+      kind: "expr-stmt",
+      expr: ir1Var("x"),
+    });
+    assert.deepEqual(result.diagnostics, [
+      {
+        kind: "unsupported",
+        reason: "collection SSA does not support expr-stmt in this pass",
+      },
+    ]);
+  });
+
+  it("reports unsupported multi-arm conditionals as diagnostics", () => {
+    const result = lowerCollectionSsaToResult(
+      ir1CondStmt(
+        [
+          [
+            ir1Var("g"),
+            ir1MapDelete(
+              "Cache_value",
+              "Cache_hasKey",
+              "Owner",
+              "Key",
+              ir1Var("cache"),
+              ir1Var("key"),
+            ),
+          ],
+          [
+            ir1Var("h"),
+            ir1MapDelete(
+              "Cache_value",
+              "Cache_hasKey",
+              "Owner",
+              "Key",
+              ir1Var("cache"),
+              ir1Var("key"),
+            ),
+          ],
+        ],
+        null,
+      ),
+    );
+
+    assert.deepEqual(result.diagnostics, [
+      {
+        kind: "unsupported",
+        reason:
+          "collection SSA does not support multi-armed cond-stmt in this pass",
+      },
+    ]);
   });
 
   it.skip("records Set.add delete and clear as membership SSA writes", () => {


### PR DESCRIPTION
## Patch 2: Introduce shared collection SSA state

- Define CollectionSsaState, CollectionSsaBuildOptions, CollectionSsaLowerResult, and final entry types for map-value, map-membership, and set-membership locations.
- Implement stable location keys for map value, map membership, and set membership using the same canonical receiver/key discipline as the old helper path.
- Implement isCollectionSsaL1Body for block, single-arm cond-stmt, scalar assign, map-effect, and set-effect forms while rejecting foreach, loops, returns, throws, let, and expr-stmt.
- Implement common read tracking for map-read and set-read expressions so reads resolve to initial or current versions with dominated=true.
- Implement branch state cloning and join allocation over collection locations, reusing ir1SsaJoin and preserving degenerate join simplification.
- Keep production lowerL1Body unchanged in this patch.

## Changes
- Define CollectionSsaState, CollectionSsaBuildOptions, CollectionSsaLowerResult, and final entry types for map-value, map-membership, and set-membership locations.
- Implement stable location keys for map value, map membership, and set membership using the same canonical receiver/key discipline as the old helper path.
- Implement isCollectionSsaL1Body for block, single-arm cond-stmt, scalar assign, map-effect, and set-effect forms while rejecting foreach, loops, returns, throws, let, and expr-stmt.
- Implement common read tracking for map-read and set-read expressions so reads resolve to initial or current versions with dominated=true.
- Implement branch state cloning and join allocation over collection locations, reusing ir1SsaJoin and preserving degenerate join simplification.
- Keep production lowerL1Body unchanged in this patch.

## Files to Modify
- tools/ts2pant/src/ir1-ssa-collections.ts (create): Add collection SSA state, location keying, read/write/join helpers, lowering result types, and a routing predicate without production cutover.
- tools/ts2pant/tests/ir1-ssa-collections.test.mts (modify): Implement the helper-level tests that can pass before production routing.

## Gameplan Specification

```
module IR1_SSA_MAP_SET.

Program.
Construct.
Location.
Version.
Read.
Write.
Join.
Rule.
PropResult.
Diagnostic.
Element.
Operation.

map-set => Operation.
map-delete => Operation.
set-add => Operation.
set-delete => Operation.
set-clear => Operation.
supported-constructs p: Program => [Construct].
lowered-constructs p: Program => [Construct].
diagnostics p: Program => [Diagnostic].
diagnostic-construct d: Diagnostic => Construct.
map-or-set? c: Construct => Bool.
loop-like? c: Construct => Bool.

writes p: Program => [Write].
reads p: Program => [Read].
joins p: Program => [Join].
write-location w: Write => Location.
write-version w: Write => Version.
write-op w: Write => Operation.
write-element w: Write => [Element].
read-location r: Read => Location.
read-version r: Read => Version.
join-location j: Join => Location.
then-version j: Join => Version.
else-version j: Join => Version.
join-version j: Join => Version.
version-location v: Version => Location.
rule-of-location l: Location => Rule.
paired-membership-location l: Location => Location.

map-value? l: Location => Bool.
map-membership? l: Location => Bool.
set-membership? l: Location => Bool.
collection-location? l: Location => Bool.

declared-rules p: Program => [Rule].
modified-rules p: Program => [Rule].
framed-rules p: Program => [Rule].
emitted-props p: Program => [PropResult].

---

all p: Program, c in supported-constructs p |
  map-or-set? c and ~loop-like? c -> c in lowered-constructs p.

all p: Program, d in diagnostics p |
  ~(diagnostic-construct d in supported-constructs p).

all p: Program, w in writes p |
  collection-location? (write-location w) ->
    version-location (write-version w) = write-location w and
    rule-of-location (write-location w) in modified-rules p.

all p: Program, r in reads p |
  collection-location? (read-location r) ->
    version-location (read-version r) = read-location r.

all p: Program, j in joins p |
  collection-location? (join-location j) ->
    version-location (then-version j) = join-location j and
    version-location (else-version j) = join-location j and
    version-location (join-version j) = join-location j and
    then-version j != else-version j and
    join-version j != then-version j and
    join-version j != else-version j.

all p: Program, w in writes p |
  map-value? (write-location w) ->
    write-op w = map-set and
    map-membership? (paired-membership-location (write-location w)) and
    (some m in writes p |
      write-location m = paired-membership-location (write-location w) and
      write-op m = map-set).

all p: Program, w in writes p |
  map-membership? (write-location w) ->
    (write-op w = map-set or write-op w = map-delete).

all p: Program, w in writes p |
  set-membership? (write-location w) ->
    (write-op w = set-add or write-op w = set-delete or write-op w = set-clear).

all p: Program, w in writes p |
  set-membership? (write-location w) and write-op w = set-clear ->
    #(write-element w) = 0.

all p: Program, w in writes p |
  set-membership? (write-location w) and (write-op w = set-add or write-op w = set-delete) ->
    #(write-element w) = 1.

all p: Program, rule in modified-rules p |
  rule in declared-rules p and ~(rule in framed-rules p).

all p: Program, rule in framed-rules p |
  rule in declared-rules p and ~(rule in modified-rules p).

all p: Program, rule in declared-rules p |
  rule in modified-rules p or rule in framed-rules p.

all p: Program |
  #(lowered-constructs p) > 0 -> #(emitted-props p) > 0.

```

## Patch Specification

```
module IR1_SSA_MAP_SET_PATCH_2.

Program.
Location.
Version.
Read.
Write.
Join.
Rule.

version-location v: Version => Location.
read-location r: Read => Location.
read-version r: Read => Version.
write-location w: Write => Location.
write-version w: Write => Version.
join-location j: Join => Location.
then-version j: Join => Version.
else-version j: Join => Version.
join-version j: Join => Version.
writes p: Program => [Write].
reads p: Program => [Read].
joins p: Program => [Join].
modified-rules p: Program => [Rule].
rule-of-location l: Location => Rule.
collection-location? l: Location => Bool.

---

all p: Program, w in writes p |
  collection-location? (write-location w) ->
    version-location (write-version w) = write-location w and
    rule-of-location (write-location w) in modified-rules p.

all p: Program, r in reads p |
  collection-location? (read-location r) ->
    version-location (read-version r) = read-location r.

all p: Program, j in joins p |
  collection-location? (join-location j) ->
    version-location (then-version j) = join-location j and
    version-location (else-version j) = join-location j and
    version-location (join-version j) = join-location j and
    then-version j != else-version j and
    join-version j != then-version j and
    join-version j != else-version j.

```


## Implementation Notes

- Collection SSA intentionally records collection reads while walking otherwise-scalar assignments, but does not emit scalar property writes. That keeps this patch focused on Map/Set version state and avoids introducing a second scalar lowering path.
- Map SSA keys include canonicalized receiver and key expressions, while Set SSA keys include the canonicalized receiver only. This mirrors the old helper split: Map overrides are tuple-keyed by receiver/key, and Set membership state is per receiver with element operations stored in the write value.
- Branch joins are allocated only for locations touched by either branch. If `ir1SsaJoin` returns an existing version for a degenerate merge, no join node is appended.
- Production lowering is deliberately untouched; the new tests exercise the helper-level builder API only, so later patches can wire it in without changing the existing fixture path in this PR.