### PR TITLE
[ir1-ssa-map-set] Patch 3: Implement Map SSA writes reads and lowering

### DIFF
--- a/tools/ts2pant/src/ir1-ssa-collections.ts
+++ b/tools/ts2pant/src/ir1-ssa-collections.ts
@@ -1,3 +1,4 @@
+import { lowerBinop, lowerExpr } from "./ir-emit.js";
 import {
   type IR1Expr,
   type IR1SsaJoin,
@@ -21,6 +22,9 @@ import {
   ir1SsaSetMembershipValue,
   ir1SsaWrite,
 } from "./ir1.js";
+import { lowerL1Expr } from "./ir1-lower.js";
+import type { OpaqueExpr, OpaqueParam } from "./pant-ast.js";
+import { getAst } from "./pant-wasm.js";
 import type { PropResult } from "./types.js";
 
 export type CollectionSsaLocation =
@@ -45,18 +49,23 @@ export interface CollectionSsaState {
 export interface CollectionSsaBuildOptions {
   declaredRules?: Iterable<string>;
   canonicalize?: (e: IR1Expr) => IR1Expr;
+  lowerOpaque?: (e: OpaqueExpr) => OpaqueExpr;
 }
 
 export interface CollectionSsaFinalMapValueEntry {
   kind: "map-value";
   location: Extract<IR1SsaLocation, { kind: "map-value" }>;
   version: IR1SsaVersion;
+  keyTuple?: OpaqueExpr;
+  value?: OpaqueExpr;
 }
 
 export interface CollectionSsaFinalMapMembershipEntry {
   kind: "map-membership";
   location: Extract<IR1SsaLocation, { kind: "map-membership" }>;
   version: IR1SsaVersion;
+  keyTuple?: OpaqueExpr;
+  value?: OpaqueExpr;
 }
 
 export interface CollectionSsaFinalSetMembershipEntry {
@@ -137,12 +146,31 @@ export function lowerCollectionSsaToResult(
   const state = makeCollectionSsaState(options);
   lowerCollectionSsaL1Body(stmt, state);
   const program = collectionSsaProgramFromState(state);
+  if (state.diagnostics.length > 0) {
+    return {
+      program,
+      finalEntries: collectionSsaFinalEntries(state),
+      propositions: [],
+      modifiedRules: [...program.modifiedRules],
+      diagnostics: state.diagnostics,
+    };
+  }
+
+  const lowerState = makeCollectionSsaLowerState(
+    program,
+    options.canonicalize,
+    options.lowerOpaque,
+  );
+  lowerState.initialVersions = new Map(state.initialVersions);
+  lowerCollectionSsaStmtToVersions(stmt, lowerState);
+  const finalEntries = collectionSsaLowerFinalEntries(lowerState);
+
   return {
     program,
-    finalEntries: collectionSsaFinalEntries(state),
-    propositions: [],
+    finalEntries,
+    propositions: lowerMapFinalEntriesToProps(finalEntries),
     modifiedRules: [...program.modifiedRules],
-    diagnostics: state.diagnostics,
+    diagnostics: [],
   };
 }
 
@@ -165,6 +193,13 @@ function collectionSsaProgramFromState(
     modifiedRules: [...state.modifiedRules],
     framedRules,
   };
+}
+
+export function lowerCollectionSsaToProps(
+  stmt: IR1Stmt,
+  options: CollectionSsaBuildOptions = {},
+): CollectionSsaLowerResult {
+  return lowerCollectionSsaToResult(stmt, options);
 }
 
 export function collectionSsaFinalEntries(
@@ -506,6 +541,633 @@ function recordCollectionWrite(
   state.modifiedRules.add(ir1SsaRuleOfLocation(write.location));
 }
 
+interface CollectionSsaLowerState {
+  writes: readonly IR1SsaWrite[];
+  joins: readonly IR1SsaJoin[];
+  writeIndex: number;
+  joinIndex: number;
+  currentVersions: Map<string, IR1SsaVersion>;
+  initialVersions: Map<string, IR1SsaVersion>;
+  locations: Map<string, CollectionSsaLocation>;
+  versionExprs: Map<IR1SsaVersion, OpaqueExpr>;
+  writtenKeys: Set<string>;
+  canonicalize: (e: IR1Expr) => IR1Expr;
+  lowerOpaque: (e: OpaqueExpr) => OpaqueExpr;
+}
+
+function makeCollectionSsaLowerState(
+  program: IR1SsaProgram,
+  canonicalize?: (e: IR1Expr) => IR1Expr,
+  lowerOpaque?: (e: OpaqueExpr) => OpaqueExpr,
+): CollectionSsaLowerState {
+  return {
+    writes: program.writes,
+    joins: program.joins,
+    writeIndex: 0,
+    joinIndex: 0,
+    currentVersions: new Map(),
+    initialVersions: new Map(),
+    locations: new Map(),
+    versionExprs: new Map(),
+    writtenKeys: new Set(),
+    canonicalize: canonicalize ?? ((e) => e),
+    lowerOpaque: lowerOpaque ?? ((e) => e),
+  };
+}
+
+function lowerCollectionSsaStmtToVersions(
+  stmt: IR1Stmt,
+  state: CollectionSsaLowerState,
+): void {
+  switch (stmt.kind) {
+    case "assign":
+      if (stmt.target.kind !== "member") {
+        throw new Error(
+          "collection SSA assignment target must be a property member",
+        );
+      }
+      lowerCollectionSsaExprToOpaque(stmt.target.receiver, state);
+      lowerCollectionSsaExprToOpaque(stmt.value, state);
+      return;
+    case "map-effect":
+      lowerCollectionSsaMapEffectToVersions(stmt, state);
+      return;
+    case "set-effect":
+      lowerCollectionSsaSetEffectToVersions(stmt, state);
+      return;
+    case "block":
+      for (const child of stmt.stmts) {
+        lowerCollectionSsaStmtToVersions(child, state);
+      }
+      return;
+    case "cond-stmt":
+      lowerCollectionSsaCondToVersions(stmt, state);
+      return;
+    case "foreach":
+    case "for":
+    case "while":
+    case "return":
+    case "throw":
+    case "let":
+    case "expr-stmt":
+      throw new Error(`${stmt.kind} is not supported by collection SSA`);
+    default: {
+      const _exhaustive: never = stmt;
+      void _exhaustive;
+      throw new Error("unsupported IR1 statement in collection SSA lowering");
+    }
+  }
+}
+
+function lowerCollectionSsaMapEffectToVersions(
+  stmt: Extract<IR1Stmt, { kind: "map-effect" }>,
+  state: CollectionSsaLowerState,
+): void {
+  lowerCollectionSsaExprToOpaque(stmt.objExpr, state);
+  lowerCollectionSsaExprToOpaque(stmt.keyExpr, state);
+  const input = {
+    ruleName: stmt.ruleName,
+    keyPredName: stmt.keyPredName,
+    ownerType: stmt.ownerType,
+    keyType: stmt.keyType,
+    receiver: stmt.objExpr,
+    key: stmt.keyExpr,
+  };
+
+  if (stmt.op === "set") {
+    const valueWrite = nextCollectionSsaWrite(state, "map-value");
+    const { key, location } = mapValueLocationForReadOrWrite(input, state);
+    if (!sameCollectionSsaLocation(valueWrite.location, location, state)) {
+      throw new Error("collection SSA map-value write order mismatch");
+    }
+    const valueExpr = lowerCollectionSsaExprToOpaque(stmt.valueExpr, state);
+    state.currentVersions.set(key, valueWrite.version);
+    state.locations.set(key, location);
+    state.versionExprs.set(valueWrite.version, valueExpr);
+    state.writtenKeys.add(key);
+  }
+
+  const membershipWrite = nextCollectionSsaWrite(state, "map-membership");
+  const { key, location } = mapMembershipLocationForReadOrWrite(input, state);
+  if (!sameCollectionSsaLocation(membershipWrite.location, location, state)) {
+    throw new Error("collection SSA map-membership write order mismatch");
+  }
+  const ast = getAst();
+  state.currentVersions.set(key, membershipWrite.version);
+  state.locations.set(key, location);
+  state.versionExprs.set(
+    membershipWrite.version,
+    ast.litBool(stmt.op === "set"),
+  );
+  state.writtenKeys.add(key);
+}
+
+function lowerCollectionSsaSetEffectToVersions(
+  stmt: Extract<IR1Stmt, { kind: "set-effect" }>,
+  state: CollectionSsaLowerState,
+): void {
+  lowerCollectionSsaExprToOpaque(stmt.objExpr, state);
+  if (stmt.op !== "clear") {
+    lowerCollectionSsaExprToOpaque(stmt.elemExpr, state);
+  }
+  const write = nextCollectionSsaWrite(state, "set-membership");
+  const { key, location } = setMembershipLocationForReadOrWrite(
+    {
+      ruleName: stmt.ruleName,
+      ownerType: stmt.ownerType,
+      elemType: stmt.elemType,
+      receiver: stmt.objExpr,
+    },
+    state,
+  );
+  if (!sameCollectionSsaLocation(write.location, location, state)) {
+    throw new Error("collection SSA set-membership write order mismatch");
+  }
+  state.currentVersions.set(key, write.version);
+  state.locations.set(key, location);
+  state.versionExprs.set(write.version, setMembershipWriteExpr(stmt));
+  state.writtenKeys.add(key);
+}
+
+function lowerCollectionSsaCondToVersions(
+  stmt: Extract<IR1Stmt, { kind: "cond-stmt" }>,
+  state: CollectionSsaLowerState,
+): void {
+  if (stmt.arms.length !== 1) {
+    throw new Error("multi-armed cond-stmt is not supported by collection SSA");
+  }
+  const ast = getAst();
+  const [guard, thenBody] = stmt.arms[0]!;
+  const guardExpr = lowerCollectionSsaExprToOpaque(guard, state);
+
+  const thenState = cloneCollectionSsaLowerStateForBranch(state);
+  lowerCollectionSsaStmtToVersions(thenBody, thenState);
+
+  const elseState = cloneCollectionSsaLowerStateForBranch(state);
+  elseState.writeIndex = thenState.writeIndex;
+  elseState.joinIndex = thenState.joinIndex;
+  if (stmt.otherwise !== null) {
+    lowerCollectionSsaStmtToVersions(stmt.otherwise, elseState);
+  }
+
+  state.writeIndex = elseState.writeIndex;
+  state.joinIndex = elseState.joinIndex;
+
+  const touched = new Set([...thenState.writtenKeys, ...elseState.writtenKeys]);
+  for (const key of touched) {
+    const location =
+      thenState.locations.get(key) ??
+      elseState.locations.get(key) ??
+      state.locations.get(key);
+    if (location === undefined) {
+      throw new Error("collection SSA branch touched an unknown location");
+    }
+    const thenVersion =
+      thenState.currentVersions.get(key) ??
+      initialCollectionVersionFor(key, location, thenState);
+    const elseVersion =
+      elseState.currentVersions.get(key) ??
+      initialCollectionVersionFor(key, location, elseState);
+    if (thenVersion === elseVersion) {
+      state.currentVersions.set(key, thenVersion);
+      state.locations.set(key, location);
+      state.writtenKeys.add(key);
+      continue;
+    }
+    const join = nextCollectionSsaJoin(state, location);
+    if (
+      !sameCollectionSsaVersion(join.thenVersion, thenVersion, state) ||
+      !sameCollectionSsaVersion(join.elseVersion, elseVersion, state) ||
+      !sameCollectionSsaLocation(join.location, location, state)
+    ) {
+      throw new Error(
+        "collection SSA join order did not match branch versions",
+      );
+    }
+    const thenExpr = resolveCollectionSsaVersionExpr(thenVersion, thenState);
+    const elseExpr = resolveCollectionSsaVersionExpr(elseVersion, elseState);
+    const joinExpr = state.lowerOpaque(
+      ast.cond([
+        [guardExpr, thenExpr],
+        [ast.litBool(true), elseExpr],
+      ]),
+    );
+    state.currentVersions.set(key, join.joinVersion);
+    state.locations.set(key, location);
+    state.versionExprs.set(join.joinVersion, joinExpr);
+    state.writtenKeys.add(key);
+  }
+}
+
+function lowerCollectionSsaExprToOpaque(
+  expr: IR1Expr,
+  state: CollectionSsaLowerState,
+): OpaqueExpr {
+  const ast = getAst();
+  switch (expr.kind) {
+    case "map-read":
+      return lowerCollectionSsaMapReadToOpaque(expr, state);
+    case "set-read":
+      return lowerCollectionSsaSetReadToOpaque(expr, state);
+    case "var":
+    case "lit":
+      return state.lowerOpaque(lowerCollectionOpaqueExpr(expr, state));
+    case "member":
+      return state.lowerOpaque(
+        ast.app(ast.var(expr.name), [
+          lowerCollectionSsaExprToOpaque(expr.receiver, state),
+        ]),
+      );
+    case "binop":
+      return state.lowerOpaque(
+        ast.binop(
+          lowerBinop(expr.op),
+          lowerCollectionSsaExprToOpaque(expr.lhs, state),
+          lowerCollectionSsaExprToOpaque(expr.rhs, state),
+        ),
+      );
+    case "unop": {
+      const op =
+        expr.op === "not"
+          ? ast.opNot()
+          : expr.op === "neg"
+            ? ast.opNeg()
+            : ast.opCard();
+      return state.lowerOpaque(
+        ast.unop(op, lowerCollectionSsaExprToOpaque(expr.arg, state)),
+      );
+    }
+    case "app": {
+      const args = expr.args.map((arg) =>
+        lowerCollectionSsaExprToOpaque(arg, state),
+      );
+      if (expr.callee.kind === "var" && !expr.callee.primed) {
+        return state.lowerOpaque(ast.app(ast.var(expr.callee.name), args));
+      }
+      return state.lowerOpaque(
+        ast.app(lowerCollectionSsaExprToOpaque(expr.callee, state), args),
+      );
+    }
+    case "cond": {
+      const arms: Array<[OpaqueExpr, OpaqueExpr]> = expr.arms.map(
+        ([guard, value]) => [
+          lowerCollectionSsaExprToOpaque(guard, state),
+          lowerCollectionSsaExprToOpaque(value, state),
+        ],
+      );
+      arms.push([
+        ast.litBool(true),
+        lowerCollectionSsaExprToOpaque(expr.otherwise, state),
+      ]);
+      return state.lowerOpaque(ast.cond(arms));
+    }
+    case "is-nullish":
+      return state.lowerOpaque(
+        ast.binop(
+          ast.opEq(),
+          ast.unop(
+            ast.opCard(),
+            lowerCollectionSsaExprToOpaque(expr.operand, state),
+          ),
+          ast.litNat(0),
+        ),
+      );
+    case "each":
+      return state.lowerOpaque(
+        ast.each(
+          [],
+          [
+            ast.gIn(
+              expr.binder,
+              lowerCollectionSsaExprToOpaque(expr.src, state),
+            ),
+            ...expr.guards.map((guard) =>
+              ast.gExpr(lowerCollectionSsaExprToOpaque(guard, state)),
+            ),
+          ],
+          lowerCollectionSsaExprToOpaque(expr.proj, state),
+        ),
+      );
+    default: {
+      const _exhaustive: never = expr;
+      void _exhaustive;
+      throw new Error("unsupported IR1 expression in collection SSA lowering");
+    }
+  }
+}
+
+function lowerCollectionSsaMapReadToOpaque(
+  expr: Extract<IR1Expr, { kind: "map-read" }>,
+  state: CollectionSsaLowerState,
+): OpaqueExpr {
+  const ast = getAst();
+  const input = {
+    ruleName: expr.ruleName,
+    keyPredName: expr.keyPredName,
+    ownerType: expr.ownerType,
+    keyType: expr.keyType,
+    receiver: expr.receiver,
+    key: expr.key,
+  };
+  const receiver = lowerCollectionSsaExprToOpaque(expr.receiver, state);
+  const keyExpr = lowerCollectionSsaExprToOpaque(expr.key, state);
+  const keyTuple = ast.tuple([receiver, keyExpr]);
+  if (expr.op === "has") {
+    const loc = mapMembershipLocationForReadOrWrite(input, state);
+    const version =
+      state.currentVersions.get(loc.key) ??
+      initialCollectionVersionFor(loc.key, loc.location, state);
+    const value = resolveCollectionSsaVersionExpr(version, state);
+    return mapOverrideApp(expr.keyPredName, keyTuple, value, receiver, keyExpr);
+  }
+
+  const valueLoc = mapValueLocationForReadOrWrite(input, state);
+  const valueVersion =
+    state.currentVersions.get(valueLoc.key) ??
+    initialCollectionVersionFor(valueLoc.key, valueLoc.location, state);
+  if (valueVersion.origin === "initial") {
+    return state.lowerOpaque(
+      ast.app(ast.var(expr.ruleName), [receiver, keyExpr]),
+    );
+  }
+
+  const membershipLoc = mapMembershipLocationForReadOrWrite(input, state);
+  const membershipVersion =
+    state.currentVersions.get(membershipLoc.key) ??
+    initialCollectionVersionFor(
+      membershipLoc.key,
+      membershipLoc.location,
+      state,
+    );
+  if (
+    isOpaqueLiteralFalse(
+      resolveCollectionSsaVersionExpr(membershipVersion, state),
+    )
+  ) {
+    return state.lowerOpaque(
+      ast.app(ast.var(expr.ruleName), [receiver, keyExpr]),
+    );
+  }
+  const value = resolveCollectionSsaVersionExpr(valueVersion, state);
+  return mapOverrideApp(expr.ruleName, keyTuple, value, receiver, keyExpr);
+}
+
+function lowerCollectionSsaSetReadToOpaque(
+  expr: Extract<IR1Expr, { kind: "set-read" }>,
+  state: CollectionSsaLowerState,
+): OpaqueExpr {
+  const ast = getAst();
+  const receiver = lowerCollectionSsaExprToOpaque(expr.receiver, state);
+  const elem = lowerCollectionSsaExprToOpaque(expr.elem, state);
+  return state.lowerOpaque(
+    ast.binop(ast.opIn(), elem, ast.app(ast.var(expr.ruleName), [receiver])),
+  );
+}
+
+function mapOverrideApp(
+  ruleName: string,
+  keyTuple: OpaqueExpr,
+  value: OpaqueExpr,
+  receiver: OpaqueExpr,
+  keyExpr: OpaqueExpr,
+): OpaqueExpr {
+  const ast = getAst();
+  return ast.app(ast.override(ruleName, [[keyTuple, value]]), [
+    receiver,
+    keyExpr,
+  ]);
+}
+
+function setMembershipWriteExpr(
+  stmt: Extract<IR1Stmt, { kind: "set-effect" }>,
+): OpaqueExpr {
+  const ast = getAst();
+  if (stmt.op === "clear") {
+    return ast.litBool(false);
+  }
+  return ast.litBool(stmt.op === "add");
+}
+
+function resolveCollectionSsaVersionExpr(
+  version: IR1SsaVersion,
+  state: Pick<
+    CollectionSsaLowerState,
+    "versionExprs" | "canonicalize" | "lowerOpaque"
+  >,
+): OpaqueExpr {
+  const existing = state.versionExprs.get(version);
+  if (existing !== undefined) {
+    return existing;
+  }
+  if (version.origin !== "initial") {
+    throw new Error("collection SSA lowering expected an initial version");
+  }
+  const ast = getAst();
+  const location = version.location;
+  let identity: OpaqueExpr;
+  switch (location.kind) {
+    case "map-value": {
+      const receiver = state.lowerOpaque(
+        lowerCollectionOpaqueExpr(location.receiver, state),
+      );
+      const key = state.lowerOpaque(
+        lowerCollectionOpaqueExpr(location.key, state),
+      );
+      identity = ast.app(ast.var(location.ruleName), [receiver, key]);
+      break;
+    }
+    case "map-membership": {
+      const receiver = state.lowerOpaque(
+        lowerCollectionOpaqueExpr(location.receiver, state),
+      );
+      const key = state.lowerOpaque(
+        lowerCollectionOpaqueExpr(location.key, state),
+      );
+      identity = ast.app(ast.var(location.keyPredName), [receiver, key]);
+      break;
+    }
+    case "set-membership": {
+      identity = ast.litBool(false);
+      break;
+    }
+    case "property":
+      throw new Error("collection SSA cannot resolve property versions");
+    default: {
+      const _exhaustive: never = location;
+      void _exhaustive;
+      throw new Error("unsupported collection SSA location");
+    }
+  }
+  const lowered = state.lowerOpaque(identity);
+  state.versionExprs.set(version, lowered);
+  return lowered;
+}
+
+function cloneCollectionSsaLowerStateForBranch(
+  state: CollectionSsaLowerState,
+): CollectionSsaLowerState {
+  return {
+    writes: state.writes,
+    joins: state.joins,
+    writeIndex: state.writeIndex,
+    joinIndex: state.joinIndex,
+    currentVersions: new Map(state.currentVersions),
+    initialVersions: state.initialVersions,
+    locations: new Map(state.locations),
+    versionExprs: new Map(state.versionExprs),
+    writtenKeys: new Set(),
+    canonicalize: state.canonicalize,
+    lowerOpaque: state.lowerOpaque,
+  };
+}
+
+function nextCollectionSsaWrite(
+  state: CollectionSsaLowerState,
+  expectedKind: CollectionSsaLocation["kind"],
+): IR1SsaWrite {
+  const write = state.writes[state.writeIndex];
+  if (write === undefined) {
+    throw new Error("collection SSA lowering ran out of writes");
+  }
+  state.writeIndex += 1;
+  if (write.location.kind !== expectedKind) {
+    throw new Error("collection SSA write sequence did not match source order");
+  }
+  return write;
+}
+
+function nextCollectionSsaJoin(
+  state: CollectionSsaLowerState,
+  location: CollectionSsaLocation,
+): IR1SsaJoin {
+  const join = state.joins[state.joinIndex];
+  if (join === undefined) {
+    throw new Error("collection SSA lowering ran out of joins");
+  }
+  state.joinIndex += 1;
+  if (!sameCollectionSsaLocation(join.location, location, state)) {
+    throw new Error("collection SSA join sequence did not match source order");
+  }
+  return join;
+}
+
+function collectionSsaLowerFinalEntries(
+  state: CollectionSsaLowerState,
+): CollectionSsaFinalEntry[] {
+  const entries: CollectionSsaFinalEntry[] = [];
+  const ast = getAst();
+  for (const [key, location] of state.locations) {
+    const version =
+      state.currentVersions.get(key) ?? state.initialVersions.get(key);
+    if (version === undefined) {
+      continue;
+    }
+    if (location.kind === "map-value" || location.kind === "map-membership") {
+      const receiver = state.lowerOpaque(
+        lowerCollectionOpaqueExpr(location.receiver, state),
+      );
+      const keyExpr = state.lowerOpaque(
+        lowerCollectionOpaqueExpr(location.key, state),
+      );
+      entries.push({
+        kind: location.kind,
+        location,
+        version,
+        keyTuple: ast.tuple([receiver, keyExpr]),
+        value: resolveCollectionSsaVersionExpr(version, state),
+      } as CollectionSsaFinalEntry);
+      continue;
+    }
+    entries.push({ kind: "set-membership", location, version });
+  }
+  return entries;
+}
+
+function lowerMapFinalEntriesToProps(
+  entries: readonly CollectionSsaFinalEntry[],
+): PropResult[] {
+  const ast = getAst();
+  const props: PropResult[] = [];
+  const groups = new Map<
+    string,
+    {
+      ruleName: string;
+      keyPredName: string;
+      ownerType: string;
+      keyType: string;
+      valueOverrides: Array<[OpaqueExpr, OpaqueExpr]>;
+      membershipOverrides: Array<[OpaqueExpr, OpaqueExpr]>;
+    }
+  >();
+  for (const entry of entries) {
+    if (entry.kind !== "map-value" && entry.kind !== "map-membership") {
+      continue;
+    }
+    if (entry.keyTuple === undefined || entry.value === undefined) {
+      throw new Error("lowered map SSA entry is missing override data");
+    }
+    const groupKey = [
+      entry.location.ruleName,
+      entry.location.keyPredName,
+      entry.location.ownerType,
+      entry.location.keyType,
+    ].join("::");
+    let group = groups.get(groupKey);
+    if (group === undefined) {
+      group = {
+        ruleName: entry.location.ruleName,
+        keyPredName: entry.location.keyPredName,
+        ownerType: entry.location.ownerType,
+        keyType: entry.location.keyType,
+        valueOverrides: [],
+        membershipOverrides: [],
+      };
+      groups.set(groupKey, group);
+    }
+    if (entry.kind === "map-value") {
+      group.valueOverrides.push([entry.keyTuple, entry.value]);
+    } else {
+      group.membershipOverrides.push([entry.keyTuple, entry.value]);
+    }
+  }
+
+  for (const group of groups.values()) {
+    if (group.valueOverrides.length > 0) {
+      const m = "m";
+      const k = "k";
+      props.push({
+        kind: "equation",
+        quantifiers: [
+          ast.param(m, ast.tName(group.ownerType)),
+          ast.param(k, ast.tName(group.keyType)),
+        ] as OpaqueParam[],
+        lhs: ast.app(ast.primed(group.ruleName), [ast.var(m), ast.var(k)]),
+        rhs: ast.app(ast.override(group.ruleName, group.valueOverrides), [
+          ast.var(m),
+          ast.var(k),
+        ]),
+      });
+    }
+    if (group.membershipOverrides.length > 0) {
+      const m = "m";
+      const k = "k";
+      props.push({
+        kind: "equation",
+        quantifiers: [
+          ast.param(m, ast.tName(group.ownerType)),
+          ast.param(k, ast.tName(group.keyType)),
+        ] as OpaqueParam[],
+        lhs: ast.app(ast.primed(group.keyPredName), [ast.var(m), ast.var(k)]),
+        rhs: ast.app(
+          ast.override(group.keyPredName, group.membershipOverrides),
+          [ast.var(m), ast.var(k)],
+        ),
+      });
+    }
+  }
+  return props;
+}
+
 function collectionSsaReadMap(
   expr: Extract<IR1Expr, { kind: "map-read" }>,
   state: CollectionSsaState,
@@ -523,7 +1185,15 @@ function collectionSsaReadMap(
     return recordCollectionRead(membership.key, membership.location, state);
   }
   const value = mapValueLocationForReadOrWrite(input, state);
-  const valueRead = recordCollectionRead(value.key, value.location, state);
+  const valueVersion = currentMapMembershipIsDelete(input, state)
+    ? initialCollectionVersionFor(value.key, value.location, state)
+    : undefined;
+  const valueRead = recordCollectionRead(
+    value.key,
+    value.location,
+    state,
+    valueVersion,
+  );
   const membership = mapMembershipLocationForReadOrWrite(input, state);
   recordCollectionRead(membership.key, membership.location, state);
   return valueRead;
@@ -533,13 +1203,35 @@ function recordCollectionRead(
   key: string,
   location: CollectionSsaLocation,
   state: CollectionSsaState,
+  versionOverride?: IR1SsaVersion,
 ): IR1SsaRead {
   const version =
+    versionOverride ??
     state.currentVersions.get(key) ??
     initialCollectionVersionFor(key, location, state);
   const read = ir1SsaRead(location, version, true);
   state.reads.push(read);
   return read;
+}
+
+function currentMapMembershipIsDelete(
+  input: {
+    ruleName: string;
+    keyPredName: string;
+    ownerType: string;
+    keyType: string;
+    receiver: IR1Expr;
+    key: IR1Expr;
+  },
+  state: CollectionSsaState,
+): boolean {
+  const membership = mapMembershipLocationForReadOrWrite(input, state);
+  const version = state.currentVersions.get(membership.key);
+  if (version === undefined) {
+    return false;
+  }
+  const write = state.writes.find((w) => w.version === version);
+  return write?.value.kind === "map-membership" && write.value.op === "delete";
 }
 
 function collectionSsaReadSet(
@@ -680,6 +1372,96 @@ function initialCollectionVersionFor(
   const initial = ir1SsaInitialVersion(location);
   state.initialVersions.set(key, initial);
   return initial;
+}
+
+function lowerCollectionOpaqueExpr(
+  expr: IR1Expr,
+  state: Pick<CollectionSsaLocationState, "canonicalize">,
+): OpaqueExpr {
+  return lowerExpr(lowerL1Expr(state.canonicalize(expr)));
+}
+
+function isOpaqueLiteralFalse(expr: OpaqueExpr): boolean {
+  const ast = getAst();
+  return ast.strExpr(expr) === ast.strExpr(ast.litBool(false));
+}
+
+function sameCollectionSsaLocation(
+  left: IR1SsaLocation,
+  right: IR1SsaLocation,
+  state: Pick<CollectionSsaLocationState, "canonicalize">,
+): boolean {
+  if (left.kind !== right.kind) {
+    return false;
+  }
+  switch (left.kind) {
+    case "map-value":
+      return (
+        right.kind === "map-value" &&
+        left.ruleName === right.ruleName &&
+        left.keyPredName === right.keyPredName &&
+        left.ownerType === right.ownerType &&
+        left.keyType === right.keyType &&
+        collectionSsaExprKey(
+          collectionSsaCanonicalExpr(left.receiver, state),
+        ) ===
+          collectionSsaExprKey(
+            collectionSsaCanonicalExpr(right.receiver, state),
+          ) &&
+        collectionSsaExprKey(collectionSsaCanonicalExpr(left.key, state)) ===
+          collectionSsaExprKey(collectionSsaCanonicalExpr(right.key, state))
+      );
+    case "map-membership":
+      return (
+        right.kind === "map-membership" &&
+        left.ruleName === right.ruleName &&
+        left.keyPredName === right.keyPredName &&
+        left.ownerType === right.ownerType &&
+        left.keyType === right.keyType &&
+        collectionSsaExprKey(
+          collectionSsaCanonicalExpr(left.receiver, state),
+        ) ===
+          collectionSsaExprKey(
+            collectionSsaCanonicalExpr(right.receiver, state),
+          ) &&
+        collectionSsaExprKey(collectionSsaCanonicalExpr(left.key, state)) ===
+          collectionSsaExprKey(collectionSsaCanonicalExpr(right.key, state))
+      );
+    case "set-membership":
+      return (
+        right.kind === "set-membership" &&
+        left.ruleName === right.ruleName &&
+        left.ownerType === right.ownerType &&
+        left.elemType === right.elemType &&
+        collectionSsaExprKey(
+          collectionSsaCanonicalExpr(left.receiver, state),
+        ) ===
+          collectionSsaExprKey(
+            collectionSsaCanonicalExpr(right.receiver, state),
+          )
+      );
+    case "property":
+      return false;
+    default: {
+      const _exhaustive: never = left;
+      void _exhaustive;
+      return false;
+    }
+  }
+}
+
+function sameCollectionSsaVersion(
+  left: IR1SsaVersion,
+  right: IR1SsaVersion,
+  state: Pick<CollectionSsaLocationState, "canonicalize">,
+): boolean {
+  if (left === right) {
+    return true;
+  }
+  if (left.origin !== "initial" || right.origin !== "initial") {
+    return false;
+  }
+  return sameCollectionSsaLocation(left.location, right.location, state);
 }
 
 function mapLocationForInput<K extends "map-value" | "map-membership">(

--- a/tools/ts2pant/tests/ir1-ssa-collections.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-collections.test.mts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import { before, describe, it } from "node:test";
 import {
   type IR1SsaProgram,
   ir1Assign,
@@ -22,6 +22,11 @@ import {
   isCollectionSsaL1Body,
   lowerCollectionSsaToResult,
 } from "../src/ir1-ssa-collections.js";
+import { getAst, loadAst } from "../src/pant-wasm.js";
+
+before(async () => {
+  await loadAst();
+});
 
 function mustBuildCollectionSsaProgram(
   ...args: Parameters<typeof buildCollectionSsaProgram>
@@ -179,9 +184,96 @@ describe("ir1-ssa-collections", () => {
     const [valueWrite, , membershipDeleteWrite] = program.writes;
     const [valueRead, membershipRead] = program.reads;
     assert.equal(valueRead!.location, valueWrite!.location);
-    assert.equal(valueRead!.version, valueWrite!.version);
+    assert.equal(valueRead!.version.origin, "initial");
+    assert.notEqual(valueRead!.version, valueWrite!.version);
     assert.equal(membershipRead!.location, membershipDeleteWrite!.location);
     assert.equal(membershipRead!.version, membershipDeleteWrite!.version);
+  });
+
+  it("records Map.delete as membership-only SSA write", () => {
+    const stmt = ir1MapDelete(
+      "Cache_value",
+      "Cache_hasKey",
+      "Owner",
+      "Key",
+      ir1Var("cache"),
+      ir1Var("key"),
+    );
+
+    const program = mustBuildCollectionSsaProgram(stmt);
+
+    assert.equal(program.writes.length, 1);
+    const [membershipWrite] = program.writes;
+    assert.equal(membershipWrite!.location.kind, "map-membership");
+    assert.deepEqual(
+      membershipWrite!.value,
+      ir1SsaMapMembershipValue("delete"),
+    );
+    assert.deepEqual(
+      new Set(program.modifiedRules),
+      new Set(["Cache_hasKey"]),
+    );
+  });
+
+  it("filters Map.get value reads after literal delete membership", () => {
+    const stmt = ir1Block([
+      ir1MapSet(
+        "Cache_value",
+        "Cache_hasKey",
+        "Owner",
+        "Key",
+        ir1Var("cache"),
+        ir1Var("key"),
+        ir1LitNat(7),
+      ),
+      ir1MapDelete(
+        "Cache_value",
+        "Cache_hasKey",
+        "Owner",
+        "Key",
+        ir1Var("cache"),
+        ir1Var("key"),
+      ),
+      ir1Assign(
+        ir1Member(ir1Var("owner"), "Owner_seen"),
+        ir1MapRead(
+          "get",
+          "Cache_value",
+          "Cache_hasKey",
+          "Owner",
+          "Key",
+          ir1Var("cache"),
+          ir1Var("key"),
+        ),
+      ),
+      ir1Assign(
+        ir1Member(ir1Var("owner"), "Owner_has"),
+        ir1MapRead(
+          "has",
+          "Cache_value",
+          "Cache_hasKey",
+          "Owner",
+          "Key",
+          ir1Var("cache"),
+          ir1Var("key"),
+        ),
+      ),
+    ]);
+
+    const program = mustBuildCollectionSsaProgram(stmt);
+
+    assert.equal(program.writes.length, 3);
+    assert.equal(program.reads.length, 3);
+    const [valueWrite, , membershipDeleteWrite] = program.writes;
+    const [valueRead, getMembershipRead, hasMembershipRead] = program.reads;
+    assert.equal(valueWrite!.location.kind, "map-value");
+    assert.equal(valueRead!.location, valueWrite!.location);
+    assert.equal(valueRead!.version.origin, "initial");
+    assert.notEqual(valueRead!.version, valueWrite!.version);
+    assert.equal(getMembershipRead!.location, membershipDeleteWrite!.location);
+    assert.equal(getMembershipRead!.version, membershipDeleteWrite!.version);
+    assert.equal(hasMembershipRead!.location, membershipDeleteWrite!.location);
+    assert.equal(hasMembershipRead!.version, membershipDeleteWrite!.version);
   });
 
   it("joins Map value and membership versions across branches", () => {
@@ -286,6 +378,87 @@ describe("ir1-ssa-collections", () => {
     assert.equal(valueRead!.version, program.writes[0]!.version);
     assert.equal(membershipRead!.location, membershipJoin.location);
     assert.equal(membershipRead!.version, membershipJoin.joinVersion);
+  });
+
+  it("lowers final Map versions to value and membership override equations", () => {
+    const stmt = ir1Block([
+      ir1MapSet(
+        "Cache_value",
+        "Cache_hasKey",
+        "Owner",
+        "Key",
+        ir1Var("cache"),
+        ir1Var("key"),
+        ir1LitNat(7),
+      ),
+      ir1MapDelete(
+        "Cache_value",
+        "Cache_hasKey",
+        "Owner",
+        "Key",
+        ir1Var("cache"),
+        ir1Var("otherKey"),
+      ),
+    ]);
+
+    const result = lowerCollectionSsaToResult(stmt);
+    const ast = getAst();
+
+    assert.equal(result.diagnostics.length, 0);
+    assert.equal(result.propositions.length, 2);
+    const valueEq = result.propositions.find(
+      (p) => p.kind === "equation" && ast.strExpr(p.lhs).startsWith("Cache_value'"),
+    );
+    const membershipEq = result.propositions.find(
+      (p) =>
+        p.kind === "equation" && ast.strExpr(p.lhs).startsWith("Cache_hasKey'"),
+    );
+    assert.ok(valueEq);
+    assert.ok(membershipEq);
+    assert.match(ast.strExpr(valueEq.rhs), /Cache_value.*->\s*7/u);
+    assert.match(ast.strExpr(membershipEq.rhs), /Cache_hasKey.*->\s*true/u);
+    assert.match(ast.strExpr(membershipEq.rhs), /Cache_hasKey.*->\s*false/u);
+  });
+
+  it("lowers Map branch joins to conditional override values", () => {
+    const stmt = ir1CondStmt(
+      [
+        [
+          ir1Var("gate"),
+          ir1MapSet(
+            "Cache_value",
+            "Cache_hasKey",
+            "Owner",
+            "Key",
+            ir1Var("cache"),
+            ir1Var("key"),
+            ir1LitNat(7),
+          ),
+        ],
+      ],
+      null,
+    );
+
+    const result = lowerCollectionSsaToResult(stmt);
+    const ast = getAst();
+    const valueEq = result.propositions.find(
+      (p) => p.kind === "equation" && ast.strExpr(p.lhs).startsWith("Cache_value'"),
+    );
+    const membershipEq = result.propositions.find(
+      (p) =>
+        p.kind === "equation" && ast.strExpr(p.lhs).startsWith("Cache_hasKey'"),
+    );
+
+    assert.ok(valueEq);
+    assert.ok(membershipEq);
+    assert.match(
+      ast.strExpr(valueEq.rhs),
+      /cond gate => 7, true => Cache_value cache key/u,
+    );
+    assert.match(
+      ast.strExpr(membershipEq.rhs),
+      /cond gate => true, true => Cache_hasKey cache key/u,
+    );
   });
 
   it("resolves Set.has through the current membership version", () => {


### PR DESCRIPTION
## Patch 3: Implement Map SSA writes reads and lowering

- For each Map.set, create a map-value write carrying ir1SsaMapSetValue(value) and a map-membership write carrying ir1SsaMapMembershipValue("set").
- For each Map.delete, create a map-membership write carrying ir1SsaMapMembershipValue("delete") and avoid creating a redundant value write.
- Resolve Map.get through the dominating map-value version, filtering literal-false latest membership in the same way readMapThroughWrites does today.
- Resolve Map.has through the dominating map-membership version.
- Lower final map-value and map-membership versions to the same value and membership override equations currently emitted for MapRuleWriteEntry.
- Lower Map branch joins as conditional override values derived from IR1SsaJoin nodes, preserving asymmetric branch fallback to pre-state rule applications.
- Unskip and implement Map-specific tests from Patch 1.

## Changes
- For each Map.set, create a map-value write carrying ir1SsaMapSetValue(value) and a map-membership write carrying ir1SsaMapMembershipValue("set").
- For each Map.delete, create a map-membership write carrying ir1SsaMapMembershipValue("delete") and avoid creating a redundant value write.
- Resolve Map.get through the dominating map-value version, filtering literal-false latest membership in the same way readMapThroughWrites does today.
- Resolve Map.has through the dominating map-membership version.
- Lower final map-value and map-membership versions to the same value and membership override equations currently emitted for MapRuleWriteEntry.
- Lower Map branch joins as conditional override values derived from IR1SsaJoin nodes, preserving asymmetric branch fallback to pre-state rule applications.
- Unskip and implement Map-specific tests from Patch 1.

## Files to Modify
- tools/ts2pant/src/ir1-ssa-collections.ts (modify): Implement Map.set, Map.delete, Map.get, Map.has, branch join lowering, and final Map override emission through IR1 SSA.
- tools/ts2pant/tests/ir1-ssa-collections.test.mts (modify): Unskip and implement Map SSA tests.

## Gameplan Specification

```
module IR1_SSA_MAP_SET.

Program.
Construct.
Location.
Version.
Read.
Write.
Join.
Rule.
PropResult.
Diagnostic.
Element.
Operation.

map-set => Operation.
map-delete => Operation.
set-add => Operation.
set-delete => Operation.
set-clear => Operation.
supported-constructs p: Program => [Construct].
lowered-constructs p: Program => [Construct].
diagnostics p: Program => [Diagnostic].
diagnostic-construct d: Diagnostic => Construct.
map-or-set? c: Construct => Bool.
loop-like? c: Construct => Bool.

writes p: Program => [Write].
reads p: Program => [Read].
joins p: Program => [Join].
write-location w: Write => Location.
write-version w: Write => Version.
write-op w: Write => Operation.
write-element w: Write => [Element].
read-location r: Read => Location.
read-version r: Read => Version.
join-location j: Join => Location.
then-version j: Join => Version.
else-version j: Join => Version.
join-version j: Join => Version.
version-location v: Version => Location.
rule-of-location l: Location => Rule.
paired-membership-location l: Location => Location.

map-value? l: Location => Bool.
map-membership? l: Location => Bool.
set-membership? l: Location => Bool.
collection-location? l: Location => Bool.

declared-rules p: Program => [Rule].
modified-rules p: Program => [Rule].
framed-rules p: Program => [Rule].
emitted-props p: Program => [PropResult].

---

all p: Program, c in supported-constructs p |
  map-or-set? c and ~loop-like? c -> c in lowered-constructs p.

all p: Program, d in diagnostics p |
  ~(diagnostic-construct d in supported-constructs p).

all p: Program, w in writes p |
  collection-location? (write-location w) ->
    version-location (write-version w) = write-location w and
    rule-of-location (write-location w) in modified-rules p.

all p: Program, r in reads p |
  collection-location? (read-location r) ->
    version-location (read-version r) = read-location r.

all p: Program, j in joins p |
  collection-location? (join-location j) ->
    version-location (then-version j) = join-location j and
    version-location (else-version j) = join-location j and
    version-location (join-version j) = join-location j and
    then-version j != else-version j and
    join-version j != then-version j and
    join-version j != else-version j.

all p: Program, w in writes p |
  map-value? (write-location w) ->
    write-op w = map-set and
    map-membership? (paired-membership-location (write-location w)) and
    (some m in writes p |
      write-location m = paired-membership-location (write-location w) and
      write-op m = map-set).

all p: Program, w in writes p |
  map-membership? (write-location w) ->
    (write-op w = map-set or write-op w = map-delete).

all p: Program, w in writes p |
  set-membership? (write-location w) ->
    (write-op w = set-add or write-op w = set-delete or write-op w = set-clear).

all p: Program, w in writes p |
  set-membership? (write-location w) and write-op w = set-clear ->
    #(write-element w) = 0.

all p: Program, w in writes p |
  set-membership? (write-location w) and (write-op w = set-add or write-op w = set-delete) ->
    #(write-element w) = 1.

all p: Program, rule in modified-rules p |
  rule in declared-rules p and ~(rule in framed-rules p).

all p: Program, rule in framed-rules p |
  rule in declared-rules p and ~(rule in modified-rules p).

all p: Program, rule in declared-rules p |
  rule in modified-rules p or rule in framed-rules p.

all p: Program |
  #(lowered-constructs p) > 0 -> #(emitted-props p) > 0.

```

## Patch Specification

```
module IR1_SSA_MAP_SET_PATCH_3.

Program.
Location.
Version.
Write.
Read.
Rule.
Operation.

map-set => Operation.
map-delete => Operation.
map-value? l: Location => Bool.
map-membership? l: Location => Bool.
paired-membership-location l: Location, map-value? l => Location.
write-location w: Write => Location.
write-version w: Write => Version.
write-op w: Write => Operation.
read-location r: Read => Location.
read-version r: Read => Version.
version-location v: Version => Location.
writes p: Program => [Write].
reads p: Program => [Read].
modified-rules p: Program => [Rule].
rule-of-location l: Location => Rule.

---

all p: Program, w in writes p |
  map-value? (write-location w) ->
    write-op w = map-set and
    version-location (write-version w) = write-location w and
    rule-of-location (write-location w) in modified-rules p.

all p: Program, w in writes p |
  map-membership? (write-location w) ->
    (write-op w = map-set or write-op w = map-delete) and
    version-location (write-version w) = write-location w and
    rule-of-location (write-location w) in modified-rules p.

all p: Program, r in reads p |
  (map-value? (read-location r) or map-membership? (read-location r)) ->
    version-location (read-version r) = read-location r.

all p: Program, w in writes p |
  map-value? (write-location w) ->
    (some m in writes p |
      write-location m = paired-membership-location (write-location w) and
      write-op m = map-set).

```


## Implementation Notes

- The prop-lowering replay rebuilds locations from the source statement and consumes the already-built SSA write/join sequence in order. For initial branch fallbacks, it compares initial versions structurally by location instead of by object identity because replay creates fresh initial-version objects while the recorded joins came from the build pass.
- Map `.get` after a literal delete records an initial-version read for the value location. This mirrors the old `readMapThroughWrites` behavior: only literal-false membership suppresses the staged value; conditional membership joins still flow through the joined value expression.
- The final override emitter groups map value and membership locations by rule pair and emits separate quantified equations only for groups that have final writes. Pure deletes therefore emit only the membership equation.
- The collection SSA test file now loads the Pant AST wasm module itself because the new lowering assertions render Pant expressions directly; the previous tests only inspected IR objects and did not need that setup.