### PR TITLE
[ir1-ssa-map-set] Patch 4: Implement Set SSA writes reads and clear lowering

### DIFF
--- a/tools/ts2pant/src/ir1-ssa-collections.ts
+++ b/tools/ts2pant/src/ir1-ssa-collections.ts
@@ -106,6 +106,21 @@ interface CollectionSsaInitialVersionState {
   initialVersions: Map<string, IR1SsaVersion>;
 }
 
+interface SetMembershipOverride {
+  elemExpr: OpaqueExpr;
+  value: OpaqueExpr;
+}
+
+interface LoweredSetMembershipVersion {
+  kind: "set-membership";
+  ruleName: string;
+  ownerType: string;
+  elemType: string;
+  receiver: OpaqueExpr;
+  memberOverrides: SetMembershipOverride[];
+  cleared: OpaqueExpr;
+}
+
 export function makeCollectionSsaState(
   options: CollectionSsaBuildOptions = {},
 ): CollectionSsaState {
@@ -164,11 +179,18 @@ export function lowerCollectionSsaToResult(
   lowerState.initialVersions = new Map(state.initialVersions);
   lowerCollectionSsaStmtToVersions(stmt, lowerState);
   const finalEntries = collectionSsaLowerFinalEntries(lowerState);
+  const propositions = lowerMapFinalEntriesToProps(finalEntries);
+  for (const entry of finalEntries) {
+    if (entry.kind === "set-membership") {
+      const value = resolveSetMembershipVersion(entry.version, lowerState);
+      emitSetMembershipSsaEquation(value, propositions);
+    }
+  }
 
   return {
     program,
     finalEntries,
-    propositions: lowerMapFinalEntriesToProps(finalEntries),
+    propositions,
     modifiedRules: [...program.modifiedRules],
     diagnostics: [],
   };
@@ -530,6 +552,279 @@ function lowerCollectionSetEffect(
   recordCollectionWrite(location.key, write, state);
 }
 
+function lowerSetMembershipElementWrite(
+  value: Extract<
+    IR1SsaWrite["value"],
+    { kind: "set-membership"; op: "add" | "delete" }
+  >,
+  previous: LoweredSetMembershipVersion,
+  state: CollectionSsaLowerState,
+): LoweredSetMembershipVersion {
+  const ast = getAst();
+  const elemExpr = lowerCollectionSsaExprToOpaque(value.elem, state);
+  const elemText = ast.strExpr(elemExpr);
+  const memberOverrides = previous.memberOverrides.filter(
+    (o) => ast.strExpr(o.elemExpr) !== elemText,
+  );
+  memberOverrides.push({
+    elemExpr,
+    value: ast.litBool(value.op === "add"),
+  });
+  return {
+    ...previous,
+    memberOverrides,
+  };
+}
+
+function joinSetMembershipVersions(
+  guardExpr: OpaqueExpr,
+  thenValue: LoweredSetMembershipVersion,
+  elseValue: LoweredSetMembershipVersion,
+): LoweredSetMembershipVersion {
+  const ast = getAst();
+  const combine = (a: OpaqueExpr, b: OpaqueExpr): OpaqueExpr =>
+    ast.cond([
+      [guardExpr, a],
+      [ast.litBool(true), b],
+    ]);
+  const baseIn = (o: SetMembershipOverride): OpaqueExpr =>
+    ast.binop(
+      ast.opIn(),
+      o.elemExpr,
+      ast.app(ast.var(thenValue.ruleName), [thenValue.receiver]),
+    );
+  const thenCleared = thenValue.cleared;
+  const elseCleared = elseValue.cleared;
+  const mergedOverrides = mergeSetMembershipOverrides(
+    thenValue.memberOverrides,
+    elseValue.memberOverrides,
+    (o) => clearedSetFallback(elseCleared, baseIn(o)),
+    combine,
+    (o) => clearedSetFallback(thenCleared, baseIn(o)),
+  );
+  return {
+    ...thenValue,
+    memberOverrides: mergedOverrides,
+    cleared: mergeSetClearedCond(guardExpr, thenCleared, elseCleared),
+  };
+}
+
+function mergeSetMembershipOverrides(
+  aSide: readonly SetMembershipOverride[],
+  bSide: readonly SetMembershipOverride[],
+  fallbackForMissingB: (o: SetMembershipOverride) => OpaqueExpr,
+  combine: (vA: OpaqueExpr, vB: OpaqueExpr) => OpaqueExpr,
+  fallbackForMissingA: (o: SetMembershipOverride) => OpaqueExpr,
+): SetMembershipOverride[] {
+  const ast = getAst();
+  const canonical = (t: OpaqueExpr) => ast.strExpr(t);
+  const bByKey = new Map<string, OpaqueExpr>();
+  for (const o of bSide) {
+    bByKey.set(canonical(o.elemExpr), o.value);
+  }
+  const seen = new Set<string>();
+  const out: SetMembershipOverride[] = [];
+  for (const o of aSide) {
+    const key = canonical(o.elemExpr);
+    seen.add(key);
+    out.push({
+      ...o,
+      value: combine(o.value, bByKey.get(key) ?? fallbackForMissingB(o)),
+    });
+  }
+  for (const o of bSide) {
+    const key = canonical(o.elemExpr);
+    if (seen.has(key)) {
+      continue;
+    }
+    out.push({
+      ...o,
+      value: combine(fallbackForMissingA(o), o.value),
+    });
+  }
+  return out;
+}
+
+function readSetMembershipVersion(
+  version: IR1SsaVersion,
+  queryExpr: OpaqueExpr,
+  state: CollectionSsaLowerState,
+): OpaqueExpr {
+  const value = resolveSetMembershipVersion(version, state);
+  return projectSetMembershipValue(value, queryExpr);
+}
+
+function projectSetMembershipValue(
+  value: LoweredSetMembershipVersion,
+  queryExpr: OpaqueExpr,
+): OpaqueExpr {
+  const ast = getAst();
+  const preState = ast.binop(
+    ast.opIn(),
+    queryExpr,
+    ast.app(ast.var(value.ruleName), [value.receiver]),
+  );
+  const tail = clearedSetFallback(value.cleared, preState);
+  if (value.memberOverrides.length === 0) {
+    return tail;
+  }
+  return ast.cond([
+    ...value.memberOverrides.map(
+      (o) =>
+        [ast.binop(ast.opEq(), queryExpr, o.elemExpr), o.value] as [
+          OpaqueExpr,
+          OpaqueExpr,
+        ],
+    ),
+    [ast.litBool(true), tail],
+  ]);
+}
+
+function resolveSetMembershipVersion(
+  version: IR1SsaVersion,
+  state: CollectionSsaLowerState,
+): LoweredSetMembershipVersion {
+  const existing = state.versionValues.get(version);
+  if (existing !== undefined) {
+    return existing;
+  }
+  if (
+    version.origin !== "initial" ||
+    version.location.kind !== "set-membership"
+  ) {
+    throw new Error(
+      "collection SSA lowering expected a Set membership version",
+    );
+  }
+  const initial: LoweredSetMembershipVersion = {
+    kind: "set-membership",
+    ruleName: version.location.ruleName,
+    ownerType: version.location.ownerType,
+    elemType: version.location.elemType,
+    receiver: state.lowerOpaque(
+      lowerExpr(lowerL1Expr(state.canonicalize(version.location.receiver))),
+    ),
+    memberOverrides: [],
+    cleared: getAst().litBool(false),
+  };
+  state.versionValues.set(version, initial);
+  return initial;
+}
+
+function emitSetMembershipSsaEquation(
+  value: LoweredSetMembershipVersion,
+  propositions: PropResult[],
+): void {
+  if (
+    value.memberOverrides.length === 0 &&
+    isStaticBoolLit(value.cleared, false)
+  ) {
+    return;
+  }
+  const ast = getAst();
+  const y = freshSetMembershipBinder(value, "y");
+  const yVar = ast.var(y);
+  const memberIn = (rule: OpaqueExpr) => ast.binop(ast.opIn(), yVar, rule);
+  const primedApp = ast.app(ast.primed(value.ruleName), [value.receiver]);
+  const preApp = ast.app(ast.var(value.ruleName), [value.receiver]);
+  const tail = clearedSetFallback(value.cleared, memberIn(preApp));
+  const condArms = value.memberOverrides.map(
+    (o) =>
+      [ast.binop(ast.opEq(), yVar, o.elemExpr), o.value] as [
+        OpaqueExpr,
+        OpaqueExpr,
+      ],
+  );
+  const rhs =
+    condArms.length === 0
+      ? tail
+      : ast.cond([...condArms, [ast.litBool(true), tail]]);
+  propositions.push({
+    kind: "assertion",
+    quantifiers: [ast.param(y, ast.tName(value.elemType))] as OpaqueParam[],
+    body: ast.binop(ast.opIff(), memberIn(primedApp), rhs),
+  });
+}
+
+function freshSetMembershipBinder(
+  value: LoweredSetMembershipVersion,
+  hint: string,
+): string {
+  const ast = getAst();
+  const usedText = [
+    ast.strExpr(value.receiver),
+    ast.strExpr(value.cleared),
+    ...value.memberOverrides.flatMap((o) => [
+      ast.strExpr(o.elemExpr),
+      ast.strExpr(o.value),
+    ]),
+  ].join("\n");
+  let candidate = hint;
+  let i = 1;
+  while (nameAppearsInOpaqueText(candidate, usedText)) {
+    candidate = `${hint}${i}`;
+    i += 1;
+  }
+  return candidate;
+}
+
+function nameAppearsInOpaqueText(name: string, text: string): boolean {
+  return new RegExp(
+    `(^|[^A-Za-z0-9_])${escapeRegExp(name)}([^A-Za-z0-9_]|$)`,
+    "u",
+  ).test(text);
+}
+
+function escapeRegExp(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
+function clearedSetFallback(cleared: OpaqueExpr, pre: OpaqueExpr): OpaqueExpr {
+  const ast = getAst();
+  if (isStaticBoolLit(cleared, false)) {
+    return pre;
+  }
+  if (isStaticBoolLit(cleared, true)) {
+    return ast.litBool(false);
+  }
+  return ast.cond([
+    [cleared, ast.litBool(false)],
+    [ast.litBool(true), pre],
+  ]);
+}
+
+function mergeSetClearedCond(
+  guardExpr: OpaqueExpr,
+  thenCleared: OpaqueExpr,
+  elseCleared: OpaqueExpr,
+): OpaqueExpr {
+  const ast = getAst();
+  if (ast.strExpr(thenCleared) === ast.strExpr(elseCleared)) {
+    return thenCleared;
+  }
+  if (
+    isStaticBoolLit(thenCleared, true) &&
+    isStaticBoolLit(elseCleared, false)
+  ) {
+    return guardExpr;
+  }
+  if (
+    isStaticBoolLit(thenCleared, false) &&
+    isStaticBoolLit(elseCleared, true)
+  ) {
+    return ast.unop(ast.opNot(), guardExpr);
+  }
+  return ast.cond([
+    [guardExpr, thenCleared],
+    [ast.litBool(true), elseCleared],
+  ]);
+}
+
+function isStaticBoolLit(expr: OpaqueExpr, value: boolean): boolean {
+  const ast = getAst();
+  return ast.strExpr(expr) === ast.strExpr(ast.litBool(value));
+}
+
 function recordCollectionWrite(
   key: string,
   write: IR1SsaWrite,
@@ -550,6 +845,7 @@ interface CollectionSsaLowerState {
   initialVersions: Map<string, IR1SsaVersion>;
   locations: Map<string, CollectionSsaLocation>;
   versionExprs: Map<IR1SsaVersion, OpaqueExpr>;
+  versionValues: Map<IR1SsaVersion, LoweredSetMembershipVersion>;
   writtenKeys: Set<string>;
   canonicalize: (e: IR1Expr) => IR1Expr;
   lowerOpaque: (e: OpaqueExpr) => OpaqueExpr;
@@ -569,6 +865,7 @@ function makeCollectionSsaLowerState(
     initialVersions: new Map(),
     locations: new Map(),
     versionExprs: new Map(),
+    versionValues: new Map(),
     writtenKeys: new Set(),
     canonicalize: canonicalize ?? ((e) => e),
     lowerOpaque: lowerOpaque ?? ((e) => e),
@@ -667,9 +964,6 @@ function lowerCollectionSsaSetEffectToVersions(
   state: CollectionSsaLowerState,
 ): void {
   lowerCollectionSsaExprToOpaque(stmt.objExpr, state);
-  if (stmt.op !== "clear") {
-    lowerCollectionSsaExprToOpaque(stmt.elemExpr, state);
-  }
   const write = nextCollectionSsaWrite(state, "set-membership");
   const { key, location } = setMembershipLocationForReadOrWrite(
     {
@@ -683,9 +977,24 @@ function lowerCollectionSsaSetEffectToVersions(
   if (!sameCollectionSsaLocation(write.location, location, state)) {
     throw new Error("collection SSA set-membership write order mismatch");
   }
+  if (write.value.kind !== "set-membership") {
+    throw new Error("collection SSA Set effect lowered to a non-Set write");
+  }
+  const previous =
+    state.currentVersions.get(key) ??
+    initialCollectionVersionFor(key, location, state);
+  const previousValue = resolveSetMembershipVersion(previous, state);
+  const nextValue: LoweredSetMembershipVersion =
+    write.value.op === "clear"
+      ? {
+          ...previousValue,
+          memberOverrides: [],
+          cleared: getAst().litBool(true),
+        }
+      : lowerSetMembershipElementWrite(write.value, previousValue, state);
   state.currentVersions.set(key, write.version);
   state.locations.set(key, location);
-  state.versionExprs.set(write.version, setMembershipWriteExpr(stmt));
+  state.versionValues.set(write.version, nextValue);
   state.writtenKeys.add(key);
 }
 
@@ -744,17 +1053,26 @@ function lowerCollectionSsaCondToVersions(
         "collection SSA join order did not match branch versions",
       );
     }
-    const thenExpr = resolveCollectionSsaVersionExpr(thenVersion, thenState);
-    const elseExpr = resolveCollectionSsaVersionExpr(elseVersion, elseState);
-    const joinExpr = state.lowerOpaque(
-      ast.cond([
-        [guardExpr, thenExpr],
-        [ast.litBool(true), elseExpr],
-      ]),
-    );
+    if (location.kind === "set-membership") {
+      const thenValue = resolveSetMembershipVersion(thenVersion, thenState);
+      const elseValue = resolveSetMembershipVersion(elseVersion, elseState);
+      state.versionValues.set(
+        join.joinVersion,
+        joinSetMembershipVersions(guardExpr, thenValue, elseValue),
+      );
+    } else {
+      const thenExpr = resolveCollectionSsaVersionExpr(thenVersion, thenState);
+      const elseExpr = resolveCollectionSsaVersionExpr(elseVersion, elseState);
+      const joinExpr = state.lowerOpaque(
+        ast.cond([
+          [guardExpr, thenExpr],
+          [ast.litBool(true), elseExpr],
+        ]),
+      );
+      state.versionExprs.set(join.joinVersion, joinExpr);
+    }
     state.currentVersions.set(key, join.joinVersion);
     state.locations.set(key, location);
-    state.versionExprs.set(join.joinVersion, joinExpr);
     state.writtenKeys.add(key);
   }
 }
@@ -916,12 +1234,21 @@ function lowerCollectionSsaSetReadToOpaque(
   expr: Extract<IR1Expr, { kind: "set-read" }>,
   state: CollectionSsaLowerState,
 ): OpaqueExpr {
-  const ast = getAst();
-  const receiver = lowerCollectionSsaExprToOpaque(expr.receiver, state);
+  lowerCollectionSsaExprToOpaque(expr.receiver, state);
   const elem = lowerCollectionSsaExprToOpaque(expr.elem, state);
-  return state.lowerOpaque(
-    ast.binop(ast.opIn(), elem, ast.app(ast.var(expr.ruleName), [receiver])),
+  const loc = setMembershipLocationForReadOrWrite(
+    {
+      ruleName: expr.ruleName,
+      ownerType: expr.ownerType,
+      elemType: expr.elemType,
+      receiver: expr.receiver,
+    },
+    state,
   );
+  const version =
+    state.currentVersions.get(loc.key) ??
+    initialCollectionVersionFor(loc.key, loc.location, state);
+  return readSetMembershipVersion(version, elem, state);
 }
 
 function mapOverrideApp(
@@ -936,16 +1263,6 @@ function mapOverrideApp(
     receiver,
     keyExpr,
   ]);
-}
-
-function setMembershipWriteExpr(
-  stmt: Extract<IR1Stmt, { kind: "set-effect" }>,
-): OpaqueExpr {
-  const ast = getAst();
-  if (stmt.op === "clear") {
-    return ast.litBool(false);
-  }
-  return ast.litBool(stmt.op === "add");
 }
 
 function resolveCollectionSsaVersionExpr(
@@ -1015,6 +1332,7 @@ function cloneCollectionSsaLowerStateForBranch(
     initialVersions: state.initialVersions,
     locations: new Map(state.locations),
     versionExprs: new Map(state.versionExprs),
+    versionValues: new Map(state.versionValues),
     writtenKeys: new Set(),
     canonicalize: state.canonicalize,
     lowerOpaque: state.lowerOpaque,

--- a/tools/ts2pant/tests/ir1-ssa-collections.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-collections.test.mts
@@ -11,16 +11,19 @@ import {
   ir1MapSet,
   ir1Member,
   ir1SetAddOrDelete,
+  ir1SetClear,
   ir1SetRead,
   ir1SsaMapMembershipValue,
   ir1SsaMapSetValue,
   ir1SsaSetClearValue,
+  ir1SsaSetMembershipValue,
   ir1Var,
 } from "../src/ir1.js";
 import {
   buildCollectionSsaProgram,
   isCollectionSsaL1Body,
   lowerCollectionSsaToResult,
+  lowerCollectionSsaToProps,
 } from "../src/ir1-ssa-collections.js";
 import { getAst, loadAst } from "../src/pant-wasm.js";
 
@@ -717,20 +720,158 @@ describe("ir1-ssa-collections", () => {
     );
   });
 
-  it.skip("records Set.add delete and clear as membership SSA writes", () => {
+  it("records Set.add delete and clear as membership SSA writes", () => {
     const clear = ir1SsaSetClearValue();
+    const add = ir1SsaSetMembershipValue("add", ir1Var("x"));
+    const del = ir1SsaSetMembershipValue("delete", ir1Var("y"));
+    const stmt = ir1Block([
+      ir1SetAddOrDelete(
+        "add",
+        "Owner_tags",
+        "Owner",
+        "Tag",
+        ir1Var("owner"),
+        ir1Var("x"),
+      ),
+      ir1SetAddOrDelete(
+        "delete",
+        "Owner_tags",
+        "Owner",
+        "Tag",
+        ir1Var("owner"),
+        ir1Var("y"),
+      ),
+      ir1SetClear("Owner_tags", "Owner", "Tag", ir1Var("owner")),
+    ]);
 
+    assert.equal(add.kind, "set-membership");
+    assert.equal(add.op, "add");
+    assert.deepEqual(add.elem, ir1Var("x"));
+    assert.equal(del.kind, "set-membership");
+    assert.equal(del.op, "delete");
+    assert.deepEqual(del.elem, ir1Var("y"));
     assert.equal(clear.kind, "set-membership");
     assert.equal(clear.op, "clear");
-    // PENDING Patch 4: build collection SSA for `.add`, `.delete`, and
-    // `.clear()` and assert all writes target set-membership locations, with
-    // clear represented by `ir1SsaSetClearValue()`.
+    assert.equal(clear.elem, null);
+
+    const program = mustBuildCollectionSsaProgram(stmt);
+
+    assert.equal(program.writes.length, 3);
+    assert.equal(program.reads.length, 0);
+    assert.deepEqual(program.modifiedRules, ["Owner_tags"]);
+    assert.deepEqual(
+      program.writes.map((w) => w.location.kind),
+      ["set-membership", "set-membership", "set-membership"],
+    );
+    assert.deepEqual(
+      program.writes.map((w) => w.value),
+      [add, del, clear],
+    );
+    for (const write of program.writes) {
+      assert.equal(write.version.location, write.location);
+      if (write.value.kind === "set-membership" && write.value.op === "clear") {
+        assert.equal(write.value.elem, null);
+      } else if (write.value.kind === "set-membership") {
+        assert.notEqual(write.value.elem, null);
+      }
+    }
   });
 
-  it.skip("resolves Set.has through staged membership and clear versions", () => {
-    // PENDING Patch 4: lower `add/delete/clear -> has` bodies and assert
-    // reads observe later-wins membership versions plus clear fallthrough,
-    // matching the existing `readSetThroughWrites` semantics.
+  it("resolves Set.has through staged membership and clear versions", () => {
+    const ast = getAst();
+    const stmt = ir1Block([
+      ir1SetAddOrDelete(
+        "add",
+        "Owner_tags",
+        "Owner",
+        "Tag",
+        ir1Var("owner"),
+        ir1Var("x"),
+      ),
+      ir1SetAddOrDelete(
+        "delete",
+        "Owner_tags",
+        "Owner",
+        "Tag",
+        ir1Var("owner"),
+        ir1Var("x"),
+      ),
+      ir1SetClear("Owner_tags", "Owner", "Tag", ir1Var("owner")),
+      ir1SetAddOrDelete(
+        "add",
+        "Owner_tags",
+        "Owner",
+        "Tag",
+        ir1Var("owner"),
+        ir1Var("y"),
+      ),
+      ir1Assign(
+        ir1Member(ir1Var("owner"), "Owner_hasTag"),
+        ir1SetRead("Owner_tags", "Owner", "Tag", ir1Var("owner"), ir1Var("x")),
+      ),
+      ir1Assign(
+        ir1Member(ir1Var("owner"), "Owner_hasTag"),
+        ir1SetRead("Owner_tags", "Owner", "Tag", ir1Var("owner"), ir1Var("y")),
+      ),
+    ]);
+
+    const result = lowerCollectionSsaToProps(stmt);
+
+    assert.equal(result.program.writes.length, 4);
+    assert.equal(result.program.reads.length, 2);
+    assert.equal(
+      result.program.reads[0]!.version,
+      result.program.writes[3]!.version,
+    );
+    assert.equal(
+      result.program.reads[1]!.version,
+      result.program.writes[3]!.version,
+    );
+    assert.equal(result.propositions.length, 1);
+    const assertion = result.propositions[0]!;
+    assert.equal(assertion.kind, "assertion");
+    if (assertion.kind !== "assertion") {
+      return;
+    }
+    assert.equal(
+      ast.strExpr(assertion.body),
+      "y1 in Owner_tags' owner <-> (cond y1 = y => true, true => false)",
+    );
+  });
+
+  it("lowers Set branch joins with asymmetric clear fallbacks", () => {
+    const ast = getAst();
+    const stmt = ir1CondStmt(
+      [
+        [
+          ir1Var("gate"),
+          ir1SetClear("Owner_tags", "Owner", "Tag", ir1Var("owner")),
+        ],
+      ],
+      ir1SetAddOrDelete(
+        "add",
+        "Owner_tags",
+        "Owner",
+        "Tag",
+        ir1Var("owner"),
+        ir1Var("x"),
+      ),
+    );
+
+    const result = lowerCollectionSsaToProps(stmt);
+
+    assert.equal(result.program.writes.length, 2);
+    assert.equal(result.program.joins.length, 1);
+    assert.equal(result.propositions.length, 1);
+    const assertion = result.propositions[0]!;
+    assert.equal(assertion.kind, "assertion");
+    if (assertion.kind !== "assertion") {
+      return;
+    }
+    assert.equal(
+      ast.strExpr(assertion.body),
+      "y in Owner_tags' owner <-> (cond y = x => (cond gate => false, true => true), true => (cond gate => false, true => y in Owner_tags owner))",
+    );
   });
 
   it.skip("preserves production parity for Map and Set mutation fixtures", async () => {


### PR DESCRIPTION
## Patch 4: Implement Set SSA writes reads and clear lowering

- For Set.add and Set.delete, create set-membership writes carrying ir1SsaSetMembershipValue(op, elem).
- For Set.clear, create a set-membership write carrying ir1SsaSetClearValue and reset lower-time member overrides over that receiver.
- Resolve Set.has through the dominating set-membership version, lowering element overrides to the existing cond-over-equality shape.
- Represent clear fallthrough in the set-membership version value so cleared versions lower to literal false or guarded clearedFallback semantics.
- Lower Set branch joins from IR1SsaJoin nodes, preserving asymmetric cleared fallbacks and mergeClearedCond behavior.
- Unskip and implement Set-specific tests from Patch 1.

## Changes
- For Set.add and Set.delete, create set-membership writes carrying ir1SsaSetMembershipValue(op, elem).
- For Set.clear, create a set-membership write carrying ir1SsaSetClearValue and reset lower-time member overrides over that receiver.
- Resolve Set.has through the dominating set-membership version, lowering element overrides to the existing cond-over-equality shape.
- Represent clear fallthrough in the set-membership version value so cleared versions lower to literal false or guarded clearedFallback semantics.
- Lower Set branch joins from IR1SsaJoin nodes, preserving asymmetric cleared fallbacks and mergeClearedCond behavior.
- Unskip and implement Set-specific tests from Patch 1.

## Files to Modify
- tools/ts2pant/src/ir1-ssa-collections.ts (modify): Implement Set.add, Set.delete, Set.clear, Set.has, branch join lowering, and final Set membership equation emission through IR1 SSA.
- tools/ts2pant/tests/ir1-ssa-collections.test.mts (modify): Unskip and implement Set SSA tests.

## Gameplan Specification

```
module IR1_SSA_MAP_SET.

Program.
Construct.
Location.
Version.
Read.
Write.
Join.
Rule.
PropResult.
Diagnostic.
Element.
Operation.

map-set => Operation.
map-delete => Operation.
set-add => Operation.
set-delete => Operation.
set-clear => Operation.
supported-constructs p: Program => [Construct].
lowered-constructs p: Program => [Construct].
diagnostics p: Program => [Diagnostic].
diagnostic-construct d: Diagnostic => Construct.
map-or-set? c: Construct => Bool.
loop-like? c: Construct => Bool.

writes p: Program => [Write].
reads p: Program => [Read].
joins p: Program => [Join].
write-location w: Write => Location.
write-version w: Write => Version.
write-op w: Write => Operation.
write-element w: Write => [Element].
read-location r: Read => Location.
read-version r: Read => Version.
join-location j: Join => Location.
then-version j: Join => Version.
else-version j: Join => Version.
join-version j: Join => Version.
version-location v: Version => Location.
rule-of-location l: Location => Rule.
paired-membership-location l: Location => Location.

map-value? l: Location => Bool.
map-membership? l: Location => Bool.
set-membership? l: Location => Bool.
collection-location? l: Location => Bool.

declared-rules p: Program => [Rule].
modified-rules p: Program => [Rule].
framed-rules p: Program => [Rule].
emitted-props p: Program => [PropResult].

---

all p: Program, c in supported-constructs p |
  map-or-set? c and ~loop-like? c -> c in lowered-constructs p.

all p: Program, d in diagnostics p |
  ~(diagnostic-construct d in supported-constructs p).

all p: Program, w in writes p |
  collection-location? (write-location w) ->
    version-location (write-version w) = write-location w and
    rule-of-location (write-location w) in modified-rules p.

all p: Program, r in reads p |
  collection-location? (read-location r) ->
    version-location (read-version r) = read-location r.

all p: Program, j in joins p |
  collection-location? (join-location j) ->
    version-location (then-version j) = join-location j and
    version-location (else-version j) = join-location j and
    version-location (join-version j) = join-location j and
    then-version j != else-version j and
    join-version j != then-version j and
    join-version j != else-version j.

all p: Program, w in writes p |
  map-value? (write-location w) ->
    write-op w = map-set and
    map-membership? (paired-membership-location (write-location w)) and
    (some m in writes p |
      write-location m = paired-membership-location (write-location w) and
      write-op m = map-set).

all p: Program, w in writes p |
  map-membership? (write-location w) ->
    (write-op w = map-set or write-op w = map-delete).

all p: Program, w in writes p |
  set-membership? (write-location w) ->
    (write-op w = set-add or write-op w = set-delete or write-op w = set-clear).

all p: Program, w in writes p |
  set-membership? (write-location w) and write-op w = set-clear ->
    #(write-element w) = 0.

all p: Program, w in writes p |
  set-membership? (write-location w) and (write-op w = set-add or write-op w = set-delete) ->
    #(write-element w) = 1.

all p: Program, rule in modified-rules p |
  rule in declared-rules p and ~(rule in framed-rules p).

all p: Program, rule in framed-rules p |
  rule in declared-rules p and ~(rule in modified-rules p).

all p: Program, rule in declared-rules p |
  rule in modified-rules p or rule in framed-rules p.

all p: Program |
  #(lowered-constructs p) > 0 -> #(emitted-props p) > 0.

```

## Patch Specification

```
module IR1_SSA_MAP_SET_PATCH_4.

Program.
Location.
Version.
Write.
Read.
Rule.
Element.
Operation.

set-add => Operation.
set-delete => Operation.
set-clear => Operation.
set-membership? l: Location => Bool.
write-location w: Write => Location.
write-version w: Write => Version.
write-op w: Write => Operation.
write-element w: Write => [Element].
read-location r: Read => Location.
read-version r: Read => Version.
version-location v: Version => Location.
writes p: Program => [Write].
reads p: Program => [Read].
modified-rules p: Program => [Rule].
rule-of-location l: Location => Rule.

---

all p: Program, w in writes p |
  set-membership? (write-location w) ->
    (write-op w = set-add or write-op w = set-delete or write-op w = set-clear) and
    version-location (write-version w) = write-location w and
    rule-of-location (write-location w) in modified-rules p.

all p: Program, w in writes p |
  set-membership? (write-location w) and write-op w = set-clear ->
    #(write-element w) = 0.

all p: Program, w in writes p |
  set-membership? (write-location w) and (write-op w = set-add or write-op w = set-delete) ->
    #(write-element w) = 1.

all p: Program, r in reads p |
  set-membership? (read-location r) ->
    version-location (read-version r) = read-location r.

```


## Implementation Notes

- Set lowering is implemented as a second pass over the already-built IR1 SSA program so the emitted equations consume the same write and join nodes that the builder records, rather than rebuilding branch state independently.
- Map writes are only advanced through the lower-time write stream in this patch. Their emission remains for the Map patch/routing work, which keeps this change focused on Set semantics while preserving source-order alignment for mixed Map/Set bodies.
- The Set version value mirrors the old symbolic representation: element overrides plus a `cleared` predicate. This keeps unconditional clear as literal `false` fallthrough, and branch-only clear as a guarded fallback expression.
- Final Set membership equations allocate a fresh quantified element binder against the lowered receiver, clear predicate, and override expressions. This avoids accidental capture in cases where a staged element is already named `y`.
- Full `npm run build` and integration tests require the local Pantagruel/wasm toolchain and binary; the patch was verified with lint, `tsc --noEmit`, the focused collection SSA test, and the full ts2pant unit suite.