### PR TITLE
[ir1-ssa-map-set] Patch 6: Document M3 landed status

### DIFF
--- a/tools/ts2pant/CLAUDE.md
+++ b/tools/ts2pant/CLAUDE.md
@@ -779,10 +779,11 @@ live in § "Divergence from IRSC".
 - `src/ir-emit.ts` — L2 IRExpr → `OpaqueExpr` lowering.
 - `src/ir1.ts`, `src/ir1-build.ts`, `src/ir1-build-body.ts`,
   `src/ir1-lower.ts`, `src/ir1-lower-body.ts`,
-  `src/ir1-ssa-scalars.ts` — Layer 1 (TS-shape imperative IR today;
+  `src/ir1-ssa-scalars.ts`, `src/ir1-ssa-collections.ts` — Layer 1 (TS-shape imperative IR today;
   the SSA-bearing contract now lives in `src/ir1.ts`, while the
   scalar SSA builder/lowerer helper owns scalar property mutation and
-  the production fallback still routes Map/Set and foreach through
+  the collection SSA helper owns Map/Set mutation; the production
+  fallback still routes foreach and loop-summary shapes through
   `SymbolicState` until later milestones).
 
 ### Two paths, one Layer 1
@@ -800,10 +801,10 @@ shared Layer 1 IR:
   contract is already present in `src/ir1.ts`, and Milestone 2 routes
   scalar property mutation, read-after-write, branch joins, and
   scalar early-exit merges through `src/ir1-ssa-scalars.ts`. Map/Set
-  mutation stays on the existing `SymbolicState` path until M3, and
-  foreach / loop-summary lowering stays there until M4. The mutating
-  output is a list of equations + frame conditions; no L2 statement
-  vocabulary.
+  mutation now routes through `src/ir1-ssa-collections.ts`, while
+  foreach / loop-summary lowering stays on the `SymbolicState` fallback
+  path until M4. The mutating output is a list of equations + frame
+  conditions; no L2 statement vocabulary.
 
 L2 is *expression-only* — there is no L2 `IRStmt`. The asymmetry is
 intentional; see `workstreams/ts2pant-imperative-ir.md`
@@ -939,9 +940,8 @@ scalar-only cases that now execute in production:
 - scalar early-exit continuation merges
 
 Those cases lower through IR1 SSA and then emit the same primed
-equations as before. Map/Set mutation still uses `SymbolicState` until
-M3, and foreach / loop-summary lowering still uses `SymbolicState`
-until M4.
+equations as before. Map/Set mutation now uses `src/ir1-ssa-collections.ts`;
+foreach / loop-summary lowering still uses `SymbolicState` until M4.
 
 ### Final architecture (post-M6)
 
@@ -959,10 +959,11 @@ with no migration flags, no escape hatches, and no parallel pipelines:
   effect calls, branched mutation, iteration with statement bodies)
   — TS AST → L1 statement (`ir1-build-body.ts`) → `PropResult[]`.
   Scalar property mutation now routes through the dedicated SSA helper
-  (`src/ir1-ssa-scalars.ts`), while Map/Set and foreach still lower
-  through `SymbolicState` (`ir1-lower-body.ts`) until M3/M4. No L2
-  statement vocabulary; the fallback fold reuses the existing mutation
-  primitives (`putWrite`, `mergeOverrides`, `installMapWrite`,
+  (`src/ir1-ssa-scalars.ts`), while Map/Set now routes through the
+  collection SSA helper (`src/ir1-ssa-collections.ts`) and foreach
+  still lowers through `SymbolicState` (`ir1-lower-body.ts`) until M4.
+  No L2 statement vocabulary; the fallback fold reuses the existing
+  mutation primitives (`putWrite`, `mergeOverrides`, `installMapWrite`,
   `installSetWrite`).
 
 Constructions outside the canonical L1 vocabulary reject with a
@@ -1035,12 +1036,14 @@ and iteration flow through Layer 1. The build pass (`ir1-build-body.ts`)
 produces canonical L1 statement forms — `cond-stmt` for `if`-with-
 mutation, `foreach` for `for-of` / `forEach` — and the lower pass
 (`ir1-lower-body.ts`) does a single fold over the L1, threading the
-existing `SymbolicState` from `translate-body.ts` and emitting
-`PropResult[]`. No L2 statement vocabulary; the existing `SymbolicState`
-primitives (`putWrite`, `mergeOverrides`, `installMapWrite`,
-`installSetWrite`) are reused so frame-condition synthesis is
-unchanged. `Foreach.body` (Shape A — uniform iterator writes) emits
-one universally-quantified per-iteration equation per modified rule
+collection SSA from `src/ir1-ssa-collections.ts` for Map/Set effects,
+and the remaining `SymbolicState` fallback from `translate-body.ts` for
+foreach / loop-summary shapes, then emitting `PropResult[]`. No L2
+statement vocabulary; the retained `SymbolicState` primitives
+(`putWrite`, `mergeOverrides`, `installMapWrite`, `installSetWrite`)
+are fallback-only and remain in place for the M4 loop-summary pause
+point. `Foreach.body` (Shape A — uniform iterator writes) emits one
+universally-quantified per-iteration equation per modified rule
 (`all $N in src | prop' $N = …`), while `Foreach.foldLeaves` (Shape B
 — accumulator folds `a.p OP= f(x)`) emits one *aggregated* accumulator
 equation per leaf with a `comb over each $N in src[, guard] | rhs`

--- a/workstreams/ts2pant-ir1-ssa.md
+++ b/workstreams/ts2pant-ir1-ssa.md
@@ -17,16 +17,18 @@ IR1 is currently a TypeScript-shaped canonical layer. Value-position code
 lowers through `IR1Expr -> IRExpr -> OpaqueExpr`; mutating bodies lower
 directly through `lowerL1Body` in `tools/ts2pant/src/ir1-lower-body.ts`, with
 scalar property mutation routed through `tools/ts2pant/src/ir1-ssa-scalars.ts`
-and the remaining Map/Set and foreach paths still threading
-`SymbolicState` from `tools/ts2pant/src/translate-body.ts` to emit
+and collection mutation routed through `tools/ts2pant/src/ir1-ssa-collections.ts`.
+The remaining foreach and loop-summary paths still thread `SymbolicState`
+from `tools/ts2pant/src/translate-body.ts` as fallback-only helpers to emit
 `PropResult[]`.
 
 That design is now partially SSA. Scalar property mutation, read-after-write,
 branch joins, and supported early-exit continuation merges are represented by
 IR1 SSA. IR1 still contains `assign`, `while`, `for`, `foreach`, `cond-stmt`,
-`map-effect`, and `set-effect` statement forms. Map/Set semantics, `Set.clear()`,
-and foreach / loop-summary behavior still live as special paths in the
-lowering code until the later milestones take them over.
+`map-effect`, and `set-effect` statement forms. Map/Set semantics, including
+`Set.clear()`, now lower through the collection SSA module, while foreach /
+loop-summary behavior still lives in the fallback lowering code until the later
+milestones take them over.
 
 ## Key Challenges
 
@@ -113,9 +115,10 @@ simple branch mutation:
 - nested supported `if` bodies
 - early-exit guard patterns that are currently supported
 
-The old `SymbolicState` path remains available only as a fallback for Map/Set
-mutation until M3 and foreach / loop-summary constructs until M4. Property
-mutation fixtures are validated through snapshots and wasm typechecking.
+The old `SymbolicState` path remains available only as a fallback for foreach /
+loop-summary constructs until M4. Map/Set mutation is routed through the
+collection SSA module as of M3. Property mutation fixtures are validated
+through snapshots and wasm typechecking.
 
 **Why this is a safe pause point**:
 The codebase supports all previous scalar property-mutation behavior. The
@@ -145,12 +148,13 @@ Map and Set mutation semantics move into IR1 SSA:
 - Existing Map/Set mutating fixtures pass snapshots and wasm typechecking.
 
 The old Map/Set-specific mutation primitives in `translate-body.ts` are either
-deleted or reduced to pure helper functions used by IR1 lowering.
+deleted or reduced to pure fallback helper functions used only by the
+non-collection IR1 lowering path.
 
 **Why this is a safe pause point**:
-All currently supported non-looping mutation classes are represented in the new
-IR1 SSA architecture. Remaining old-path usage is limited to loop summaries and
-special forms.
+All currently supported non-looping Map/Set mutation classes are represented in
+the new IR1 SSA architecture. Remaining old-path usage is limited to foreach
+and loop summaries, which stay deferred until M4.
 
 **Unlocks**:
 A single SSA read/write/join model for scalar properties, Maps, and Sets.
@@ -183,9 +187,9 @@ Existing foreach, forEach, accumulator-fold, and μ-search fixtures pass
 snapshots and wasm typechecking.
 
 **Why this is a safe pause point**:
-All currently supported mutation and loop-summary behavior now flows through
-IR1 SSA. General `for` / `while` support remains explicitly out of scope, so
-the codebase does not imply support it cannot provide.
+All currently supported non-looping mutation now flows through IR1 SSA.
+General `for` / `while` support remains explicitly out of scope, so the
+codebase does not imply support it cannot provide.
 
 **Unlocks**:
 Full removal of `lowerL1Body`'s old `SymbolicState` execution model.


### PR DESCRIPTION
## Patch 6: Document M3 landed status

- Update the Current State section of workstreams/ts2pant-ir1-ssa.md so Map/Set mutation is no longer described as SymbolicState-backed after M3.
- Record that foreach and loop summaries remain deferred to M4 and that any retained old helpers are fallback-only.
- Update tools/ts2pant/CLAUDE.md IR guidance to mention ir1-ssa-collections.ts next to ir1-ssa-scalars.ts.
- Do not claim that SymbolicState is fully removed; that remains M5/M6 scope.

## Changes
- Update the Current State section of workstreams/ts2pant-ir1-ssa.md so Map/Set mutation is no longer described as SymbolicState-backed after M3.
- Record that foreach and loop summaries remain deferred to M4 and that any retained old helpers are fallback-only.
- Update tools/ts2pant/CLAUDE.md IR guidance to mention ir1-ssa-collections.ts next to ir1-ssa-scalars.ts.
- Do not claim that SymbolicState is fully removed; that remains M5/M6 scope.

## Files to Modify
- tools/ts2pant/CLAUDE.md (modify): Update developer architecture notes for collection SSA routing and remaining loop fallback scope.
- workstreams/ts2pant-ir1-ssa.md (modify): Mark Milestone 3 as landed and record the final collection SSA module names and helper boundary.
- gameplans/ir1-ssa-map-set.json (modify): Update gameplan status details if implementation discovers renamed functions or narrower helper retention.

## Gameplan Specification

```
module IR1_SSA_MAP_SET.

Program.
Construct.
Location.
Version.
Read.
Write.
Join.
Rule.
PropResult.
Diagnostic.
Element.
Operation.

map-set => Operation.
map-delete => Operation.
set-add => Operation.
set-delete => Operation.
set-clear => Operation.
supported-constructs p: Program => [Construct].
lowered-constructs p: Program => [Construct].
diagnostics p: Program => [Diagnostic].
diagnostic-construct d: Diagnostic => Construct.
map-or-set? c: Construct => Bool.
loop-like? c: Construct => Bool.

writes p: Program => [Write].
reads p: Program => [Read].
joins p: Program => [Join].
write-location w: Write => Location.
write-version w: Write => Version.
write-op w: Write => Operation.
write-element w: Write => [Element].
read-location r: Read => Location.
read-version r: Read => Version.
join-location j: Join => Location.
then-version j: Join => Version.
else-version j: Join => Version.
join-version j: Join => Version.
version-location v: Version => Location.
rule-of-location l: Location => Rule.
paired-membership-location l: Location => Location.

map-value? l: Location => Bool.
map-membership? l: Location => Bool.
set-membership? l: Location => Bool.
collection-location? l: Location => Bool.

declared-rules p: Program => [Rule].
modified-rules p: Program => [Rule].
framed-rules p: Program => [Rule].
emitted-props p: Program => [PropResult].

---

all p: Program, c in supported-constructs p |
  map-or-set? c and ~loop-like? c -> c in lowered-constructs p.

all p: Program, d in diagnostics p |
  ~(diagnostic-construct d in supported-constructs p).

all p: Program, w in writes p |
  collection-location? (write-location w) ->
    version-location (write-version w) = write-location w and
    rule-of-location (write-location w) in modified-rules p.

all p: Program, r in reads p |
  collection-location? (read-location r) ->
    version-location (read-version r) = read-location r.

all p: Program, j in joins p |
  collection-location? (join-location j) ->
    version-location (then-version j) = join-location j and
    version-location (else-version j) = join-location j and
    version-location (join-version j) = join-location j and
    then-version j != else-version j and
    join-version j != then-version j and
    join-version j != else-version j.

all p: Program, w in writes p |
  map-value? (write-location w) ->
    write-op w = map-set and
    map-membership? (paired-membership-location (write-location w)) and
    (some m in writes p |
      write-location m = paired-membership-location (write-location w) and
      write-op m = map-set).

all p: Program, w in writes p |
  map-membership? (write-location w) ->
    (write-op w = map-set or write-op w = map-delete).

all p: Program, w in writes p |
  set-membership? (write-location w) ->
    (write-op w = set-add or write-op w = set-delete or write-op w = set-clear).

all p: Program, w in writes p |
  set-membership? (write-location w) and write-op w = set-clear ->
    #(write-element w) = 0.

all p: Program, w in writes p |
  set-membership? (write-location w) and (write-op w = set-add or write-op w = set-delete) ->
    #(write-element w) = 1.

all p: Program, rule in modified-rules p |
  rule in declared-rules p and ~(rule in framed-rules p).

all p: Program, rule in framed-rules p |
  rule in declared-rules p and ~(rule in modified-rules p).

all p: Program, rule in declared-rules p |
  rule in modified-rules p or rule in framed-rules p.

all p: Program |
  #(lowered-constructs p) > 0 -> #(emitted-props p) > 0.

```

## Patch Specification

```
module IR1_SSA_MAP_SET_PATCH_6.

Doc.
Milestone.

records-landed? d: Doc, m: Milestone => Bool.
records-fallback-scope? d: Doc, m: Milestone => Bool.
ir1-ssa-map-set => Milestone.

---

all d: Doc |
  records-landed? d ir1-ssa-map-set -> records-fallback-scope? d ir1-ssa-map-set.

```


## Implementation Notes

- I updated the architecture docs to reflect the landed split between `ir1-ssa-scalars.ts` and `ir1-ssa-collections.ts`; Map/Set now reads as collection-SSA-backed, while the old `SymbolicState` helpers are described as fallback-only for foreach and loop-summary shapes.
- I kept the M5/M6 boundary intact: the docs stop short of saying `SymbolicState` is removed, and the remaining fallback helpers are still described as temporary until the later loop-summary ripout.
- The requested `gameplans/ir1-ssa-map-set.json` path was not present in this checkout, so no JSON gameplan file was updated in this patch.