### PR TITLE
[ir1-ssa-loop-summaries] Patch 1: Add skipped loop-summary acceptance tests

### DIFF
--- a/tools/ts2pant/tests/ir1-ssa-loops.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-loops.test.mts
@@ -1,0 +1,60 @@
+import { describe, it } from "node:test";
+
+describe("ir1-ssa-loops", () => {
+  // PENDING Patch 2: introduce the dedicated loop-summary SSA helper and
+  // summary/version bookkeeping for supported loop-like constructs.
+  // PENDING Patch 3: route canonical mu-search lowering through loop summaries.
+  // PENDING Patch 4: route foreach Shape A lowering through loop summaries.
+  // PENDING Patch 5: route foreach Shape B lowering through loop summaries.
+
+  it.skip("records canonical mu-search as a loop summary", async () => {
+    // PENDING Patch 3: cover a canonical let/while/increment recognizer path
+    // and assert it records a `mu-search` loop summary before lowering to the
+    // same `min over each` expression emitted today.
+  });
+
+  it.skip(
+    "records foreach Shape A quantified writes as loop summaries",
+    async () => {
+      // PENDING Patch 4: cover a foreach iterator-write fixture and assert the
+      // helper records a `foreach-shape-a` summary whose lowering still emits
+      // the current quantified write proposition shape.
+    },
+  );
+
+  it.skip(
+    "records foreach Shape B accumulator folds as loop summaries",
+    async () => {
+      // PENDING Patch 5: cover a foreach accumulator fixture and assert the
+      // helper records a `foreach-shape-b` summary whose lowering still emits
+      // the current accumulator-fold proposition shape.
+    },
+  );
+
+  it.skip(
+    "represents supported in-iteration read-after-write without subState mutation",
+    async () => {
+      // PENDING Patch 4: cover the currently supported loop-body read semantics
+      // so the helper proves read-after-write behavior without executing the
+      // body inside a SymbolicState subState.
+    },
+  );
+
+  it.skip(
+    "preserves unsupported diagnostics for out-of-scope loops",
+    async () => {
+      // PENDING Patch 2: pin current unsupported boundaries for general loops,
+      // proposition-emitting nested loop bodies, and unsupported in-loop
+      // collection mutation with clear diagnostic reasons.
+    },
+  );
+
+  it.skip("preserves production parity for foreach and mu-search fixtures", async () => {
+    // PENDING Patch 4: pin parity for `functions-mutating-loop.ts`
+    // (for example `forEachActivate`, `forEachSum`, or `mixedUpdates`) once
+    // foreach lowering routes through the loop-summary helper.
+    // PENDING Patch 3: pin parity for `expressions-while-mu-search.ts`
+    // (for example `firstUnusedSuffix`) once mu-search lowering routes through
+    // the loop-summary helper.
+  });
+});


### PR DESCRIPTION
## Patch 1: Add skipped loop-summary acceptance tests

- Create describe("ir1-ssa-loops", ...) with skipped tests and PENDING comments naming the implementation patches.
- Stub a μ-search test proving canonical let/while/increment builds a loop summary and lowers to min over each.
- Stub a foreach Shape A test proving quantified writes are represented by foreach-shape-a loop summaries.
- Stub a foreach Shape B test proving accumulator fold leaves are represented by foreach-shape-b loop summaries.
- Stub an in-iteration read-after-write test proving the summary helper captures the currently supported loop-body read semantics without a SymbolicState subState.
- Stub a diagnostics test proving unsupported loop forms remain unsupported with clear reasons.
- Stub production parity tests for functions-mutating-loop.ts and expressions-while-mu-search.ts fixtures.

## Changes
- Create describe("ir1-ssa-loops", ...) with skipped tests and PENDING comments naming the implementation patches.
- Stub a μ-search test proving canonical let/while/increment builds a loop summary and lowers to min over each.
- Stub a foreach Shape A test proving quantified writes are represented by foreach-shape-a loop summaries.
- Stub a foreach Shape B test proving accumulator fold leaves are represented by foreach-shape-b loop summaries.
- Stub an in-iteration read-after-write test proving the summary helper captures the currently supported loop-body read semantics without a SymbolicState subState.
- Stub a diagnostics test proving unsupported loop forms remain unsupported with clear reasons.
- Stub production parity tests for functions-mutating-loop.ts and expressions-while-mu-search.ts fixtures.

## Files to Modify
- tools/ts2pant/tests/ir1-ssa-loops.test.mts (create): Add node:test stubs with skip markers for loop-summary build/lower behavior and production parity.

## Gameplan Specification

```
module IR1_SSA_LOOP_SUMMARIES.

Program.
Construct.
Location.
Version.
Read.
LoopSummary.
Shape.
Rule.
PropResult.
Diagnostic.
Expr.

mu-search => Shape.
foreach-shape-a => Shape.
foreach-shape-b => Shape.
supported-constructs p: Program => [Construct].
lowered-constructs p: Program => [Construct].
diagnostics p: Program => [Diagnostic].
diagnostic-construct d: Diagnostic => Construct.
mu-search? c: Construct => Bool.
foreach-shape-a? c: Construct => Bool.
foreach-shape-b? c: Construct => Bool.
general-loop? c: Construct => Bool.
loop-summaries p: Program => [LoopSummary].
summary-shape s: LoopSummary => Shape.
summary-location s: LoopSummary => Location.
summary-version s: LoopSummary => Version.
version-location v: Version => Location.
reads p: Program => [Read].
read-location r: Read => Location.
read-version r: Read => Version.
read-dominated? p: Program, r: Read => Bool.
rule-of-location l: Location => Rule.
declared-rules p: Program => [Rule].
modified-rules p: Program => [Rule].
framed-rules p: Program => [Rule].
emitted-props p: Program => [PropResult].
lowered-expr p: Program => [Expr].
min-over-each? e: Expr => Bool.
quantified-write? pr: PropResult => Bool.
accumulator-fold? pr: PropResult => Bool.

---

all p: Program, c in supported-constructs p |
  (mu-search? c or foreach-shape-a? c or foreach-shape-b? c) -> c in lowered-constructs p.

all p: Program, c in supported-constructs p |
  ~(general-loop? c).

all p: Program, d in diagnostics p |
  ~(diagnostic-construct d in supported-constructs p).

all p: Program, s in loop-summaries p |
  version-location (summary-version s) = summary-location s and
  rule-of-location (summary-location s) in modified-rules p.

all p: Program, s in loop-summaries p |
  summary-shape s = mu-search or
  summary-shape s = foreach-shape-a or
  summary-shape s = foreach-shape-b.

all p: Program, s1 in loop-summaries p, s2 in loop-summaries p |
  summary-version s1 = summary-version s2 -> s1 = s2.

all p: Program, r in reads p |
  read-dominated? p r and
  version-location (read-version r) = read-location r and
  (
    (some s in loop-summaries p |
      summary-version s = read-version r and
      summary-location s = read-location r) or
    ~(some s in loop-summaries p | summary-location s = read-location r)
  ).

all p: Program, c in supported-constructs p |
  mu-search? c ->
    (some s in loop-summaries p | summary-shape s = mu-search) and
    (some e in lowered-expr p | min-over-each? e).

all p: Program, c in supported-constructs p |
  foreach-shape-a? c ->
    (some s in loop-summaries p | summary-shape s = foreach-shape-a) and
    (some pr in emitted-props p | quantified-write? pr).

all p: Program, c in supported-constructs p |
  foreach-shape-b? c ->
    (some s in loop-summaries p | summary-shape s = foreach-shape-b) and
    (some pr in emitted-props p | accumulator-fold? pr).

all p: Program, rule in modified-rules p |
  rule in declared-rules p and ~(rule in framed-rules p).

all p: Program, rule in framed-rules p |
  rule in declared-rules p and ~(rule in modified-rules p).

all p: Program, rule in declared-rules p |
  rule in modified-rules p or rule in framed-rules p.

all p: Program |
  #(lowered-constructs p) > 0 -> (#(emitted-props p) > 0 or #(lowered-expr p) > 0).

```

## Patch Specification

```
module IR1_SSA_LOOP_SUMMARIES_PATCH_1.

Test.
Construct.

stubbed? t: Test => Bool.
covered-constructs t: Test => [Construct].
mu-search => Construct.
foreach-shape-a => Construct.
foreach-shape-b => Construct.
read-after-write => Construct.
unsupported-loop => Construct.

---

some t: Test |
  stubbed? t and
  mu-search in covered-constructs t and
  foreach-shape-a in covered-constructs t and
  foreach-shape-b in covered-constructs t and
  read-after-write in covered-constructs t and
  unsupported-loop in covered-constructs t.

```


## Implementation Notes

- The new suite is intentionally all-`skip` and import-light: it only brings in `node:test` so Patch 1 cannot fail on helper/module churn before the loop-summary helper exists.
- The parity coverage for `functions-mutating-loop.ts` and `expressions-while-mu-search.ts` is pinned as one combined stub rather than two separate tests. That keeps the public test inventory aligned with the gameplan while still naming the concrete fixture families future patches should activate.
- No behavior or existing snapshots changed in this patch; the only artifact is the new scaffold file under `tests/`.