### PR TITLE
[ir1-ssa-loop-summaries] Patch 2: Introduce loop-summary SSA helper

### DIFF
--- a/tools/ts2pant/src/ir1-ssa-loops.ts
+++ b/tools/ts2pant/src/ir1-ssa-loops.ts
@@ -1,0 +1,136 @@
+import {
+  type IR1SsaLocation,
+  type IR1SsaLoopSummary,
+  type IR1SsaProgram,
+  type IR1SsaRuleName,
+  ir1SsaLoopSummary,
+  ir1SsaRuleOfLocation,
+} from "./ir1.js";
+import type { OpaqueExpr } from "./pant-ast.js";
+import type { PropResult } from "./types.js";
+
+export type LoopSsaShape = IR1SsaLoopSummary["shape"];
+
+type UnsupportedDiagnostic = Extract<PropResult, { kind: "unsupported" }>;
+
+interface LoopSummaryInputBase {
+  location: IR1SsaLocation;
+}
+
+export interface MuSearchSummaryInput extends LoopSummaryInputBase {
+  kind: "mu-search";
+  loweredExpr?: OpaqueExpr;
+}
+
+export interface ForeachShapeASummaryInput extends LoopSummaryInputBase {
+  kind: "foreach-shape-a";
+  propositions?: readonly PropResult[];
+}
+
+export interface ForeachShapeBSummaryInput extends LoopSummaryInputBase {
+  kind: "foreach-shape-b";
+  propositions?: readonly PropResult[];
+}
+
+export interface UnsupportedLoopSummaryInput {
+  kind: "unsupported";
+  reason: string;
+}
+
+export type IR1LoopSsaInput =
+  | MuSearchSummaryInput
+  | ForeachShapeASummaryInput
+  | ForeachShapeBSummaryInput
+  | UnsupportedLoopSummaryInput;
+
+export interface LoopSsaBuildOptions {
+  declaredRules?: Iterable<IR1SsaRuleName>;
+}
+
+export interface ForeachSummaryLowerOptions extends LoopSsaBuildOptions {
+  input: ForeachShapeASummaryInput | ForeachShapeBSummaryInput;
+}
+
+export interface ForeachSummaryLowerResult {
+  program: IR1SsaProgram;
+  summary: IR1SsaLoopSummary | null;
+  propositions: PropResult[];
+  modifiedRules: IR1SsaRuleName[];
+  diagnostics: UnsupportedDiagnostic[];
+}
+
+export interface LoopSsaBuildResult {
+  program: IR1SsaProgram;
+  loweredExpr: OpaqueExpr[];
+  propositions: PropResult[];
+  diagnostics: UnsupportedDiagnostic[];
+}
+
+export function buildLoopSsaProgram(
+  inputs: IR1LoopSsaInput | readonly IR1LoopSsaInput[],
+  options: LoopSsaBuildOptions = {},
+): LoopSsaBuildResult {
+  const normalizedInputs = Array.isArray(inputs) ? inputs : [inputs];
+  const loopSummaries: IR1SsaLoopSummary[] = [];
+  const modifiedRules = new Set<IR1SsaRuleName>();
+  const declaredRules = new Set<IR1SsaRuleName>(options.declaredRules ?? []);
+  const loweredExpr: OpaqueExpr[] = [];
+  const propositions: PropResult[] = [];
+  const diagnostics: UnsupportedDiagnostic[] = [];
+
+  for (const input of normalizedInputs) {
+    if (input.kind === "unsupported") {
+      diagnostics.push({ kind: "unsupported", reason: input.reason });
+      continue;
+    }
+
+    const summary = ir1SsaLoopSummary(input.kind, input.location);
+    loopSummaries.push(summary);
+
+    const modifiedRule = ir1SsaRuleOfLocation(input.location);
+    modifiedRules.add(modifiedRule);
+    declaredRules.add(modifiedRule);
+
+    if (input.kind === "mu-search") {
+      if (input.loweredExpr !== undefined) {
+        loweredExpr.push(input.loweredExpr);
+      }
+      continue;
+    }
+
+    if (input.propositions !== undefined) {
+      propositions.push(...input.propositions);
+    }
+  }
+
+  const framedRules = [...declaredRules].filter(
+    (rule) => !modifiedRules.has(rule),
+  );
+  return {
+    program: {
+      reads: [],
+      writes: [],
+      joins: [],
+      loopSummaries,
+      declaredRules: [...declaredRules],
+      modifiedRules: [...modifiedRules],
+      framedRules,
+    },
+    loweredExpr,
+    propositions,
+    diagnostics,
+  };
+}
+
+export function lowerForeachSummary(
+  options: ForeachSummaryLowerOptions,
+): ForeachSummaryLowerResult {
+  const result = buildLoopSsaProgram(options.input, options);
+  return {
+    program: result.program,
+    summary: result.program.loopSummaries[0] ?? null,
+    propositions: result.propositions,
+    modifiedRules: result.program.modifiedRules,
+    diagnostics: result.diagnostics,
+  };
+}

--- a/tools/ts2pant/src/ir1.ts
+++ b/tools/ts2pant/src/ir1.ts
@@ -493,7 +493,7 @@ export interface IR1SsaJoin {
 
 export interface IR1SsaLoopSummary {
   readonly kind: "ssa-loop-summary";
-  readonly shape: "foreach-shape-a" | "foreach-shape-b";
+  readonly shape: "mu-search" | "foreach-shape-a" | "foreach-shape-b";
   readonly location: IR1SsaLocation;
   readonly summaryVersion: IR1SsaVersion;
 }

--- a/tools/ts2pant/tests/ir1-ssa-loops.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-loops.test.mts
@@ -1,4 +1,15 @@
+import assert from "node:assert/strict";
 import { describe, it } from "node:test";
+
+import {
+  ir1SsaPropertyLocation,
+  ir1SsaRuleOfLocation,
+  ir1Var,
+} from "../src/ir1.js";
+import {
+  buildLoopSsaProgram,
+  lowerForeachSummary,
+} from "../src/ir1-ssa-loops.js";
 
 describe("ir1-ssa-loops", () => {
   // PENDING Patch 2: introduce the dedicated loop-summary SSA helper and
@@ -7,47 +18,156 @@ describe("ir1-ssa-loops", () => {
   // PENDING Patch 4: route foreach Shape A lowering through loop summaries.
   // PENDING Patch 5: route foreach Shape B lowering through loop summaries.
 
-  it.skip("records canonical mu-search as a loop summary", async () => {
-    // PENDING Patch 3: cover a canonical let/while/increment recognizer path
-    // and assert it records a `mu-search` loop summary before lowering to the
-    // same `min over each` expression emitted today.
+  it("records canonical mu-search as a loop summary", () => {
+    const location = ir1SsaPropertyLocation(
+      "Name_firstUnusedSuffix",
+      ir1Var("name"),
+      "firstUnusedSuffix",
+    );
+
+    const result = buildLoopSsaProgram({
+      kind: "mu-search",
+      location,
+    });
+
+    assert.deepEqual(result.diagnostics, []);
+    assert.equal(result.program.loopSummaries.length, 1);
+    assert.deepEqual(result.program.modifiedRules, [
+      ir1SsaRuleOfLocation(location),
+    ]);
+
+    const [summary] = result.program.loopSummaries;
+    assert.equal(summary!.shape, "mu-search");
+    assert.equal(summary!.location, location);
+    assert.equal(summary!.summaryVersion.origin, "loop-summary");
+    assert.equal(summary!.summaryVersion.location, location);
   });
 
-  it.skip(
-    "records foreach Shape A quantified writes as loop summaries",
-    async () => {
-      // PENDING Patch 4: cover a foreach iterator-write fixture and assert the
-      // helper records a `foreach-shape-a` summary whose lowering still emits
-      // the current quantified write proposition shape.
-    },
-  );
+  it("records foreach Shape A quantified writes as loop summaries", () => {
+    const location = ir1SsaPropertyLocation(
+      "Item_seen",
+      ir1Var("$item"),
+      "seen",
+    );
+    const proposition = { kind: "raw" as const, text: "quantified-write" };
 
-  it.skip(
-    "records foreach Shape B accumulator folds as loop summaries",
-    async () => {
-      // PENDING Patch 5: cover a foreach accumulator fixture and assert the
-      // helper records a `foreach-shape-b` summary whose lowering still emits
-      // the current accumulator-fold proposition shape.
-    },
-  );
+    const result = lowerForeachSummary({
+      input: {
+        kind: "foreach-shape-a",
+        location,
+        propositions: [proposition],
+      },
+    });
 
-  it.skip(
-    "represents supported in-iteration read-after-write without subState mutation",
-    async () => {
-      // PENDING Patch 4: cover the currently supported loop-body read semantics
-      // so the helper proves read-after-write behavior without executing the
-      // body inside a SymbolicState subState.
-    },
-  );
+    assert.deepEqual(result.diagnostics, []);
+    assert.equal(result.summary?.shape, "foreach-shape-a");
+    assert.equal(result.summary?.location, location);
+    assert.equal(result.summary?.summaryVersion.origin, "loop-summary");
+    assert.equal(result.summary?.summaryVersion.location, location);
+    assert.deepEqual(result.propositions, [proposition]);
+    assert.deepEqual(result.modifiedRules, [ir1SsaRuleOfLocation(location)]);
+  });
 
-  it.skip(
-    "preserves unsupported diagnostics for out-of-scope loops",
-    async () => {
-      // PENDING Patch 2: pin current unsupported boundaries for general loops,
-      // proposition-emitting nested loop bodies, and unsupported in-loop
-      // collection mutation with clear diagnostic reasons.
-    },
-  );
+  it("records foreach Shape B accumulator folds as loop summaries", () => {
+    const location = ir1SsaPropertyLocation(
+      "Account_total",
+      ir1Var("account"),
+      "total",
+    );
+    const proposition = { kind: "raw" as const, text: "accumulator-fold" };
+
+    const result = lowerForeachSummary({
+      input: {
+        kind: "foreach-shape-b",
+        location,
+        propositions: [proposition],
+      },
+      declaredRules: ["Account_limit"],
+    });
+
+    assert.deepEqual(result.diagnostics, []);
+    assert.equal(result.summary?.shape, "foreach-shape-b");
+    assert.equal(result.summary?.location, location);
+    assert.equal(result.summary?.summaryVersion.origin, "loop-summary");
+    assert.equal(result.summary?.summaryVersion.location, location);
+    assert.deepEqual(result.propositions, [proposition]);
+    assert.deepEqual(result.program.modifiedRules, [
+      ir1SsaRuleOfLocation(location),
+    ]);
+    assert.deepEqual(
+      new Set(result.program.declaredRules),
+      new Set(["Account_total", "Account_limit"]),
+    );
+    assert.deepEqual(result.program.framedRules, ["Account_limit"]);
+  });
+
+  it("creates distinct summary versions and tracks modified rules", () => {
+    const shapeALocation = ir1SsaPropertyLocation(
+      "Item_seen",
+      ir1Var("$item"),
+      "seen",
+    );
+    const shapeBLocation = ir1SsaPropertyLocation(
+      "Account_total",
+      ir1Var("account"),
+      "total",
+    );
+
+    const result = buildLoopSsaProgram(
+      [
+        { kind: "foreach-shape-a", location: shapeALocation },
+        { kind: "foreach-shape-b", location: shapeBLocation },
+      ],
+      { declaredRules: ["Account_limit"] },
+    );
+
+    const [shapeA, shapeB] = result.program.loopSummaries;
+    assert.notEqual(shapeA!.summaryVersion, shapeB!.summaryVersion);
+    assert.notEqual(shapeA!.summaryVersion.id, shapeB!.summaryVersion.id);
+    assert.equal(shapeA!.summaryVersion.location, shapeALocation);
+    assert.equal(shapeB!.summaryVersion.location, shapeBLocation);
+    assert.deepEqual(
+      new Set(result.program.modifiedRules),
+      new Set(["Item_seen", "Account_total"]),
+    );
+    assert.deepEqual(
+      new Set(result.program.declaredRules),
+      new Set(["Item_seen", "Account_total", "Account_limit"]),
+    );
+    assert.deepEqual(result.program.framedRules, ["Account_limit"]);
+  });
+
+  it("reports unsupported loop summary inputs without summaries", () => {
+    const result = buildLoopSsaProgram(
+      {
+        kind: "unsupported",
+        reason: "general loops are not supported by loop-summary SSA",
+      },
+      { declaredRules: ["Account_total"] },
+    );
+
+    assert.equal(result.program.loopSummaries.length, 0);
+    assert.deepEqual(result.program.modifiedRules, []);
+    assert.deepEqual(result.program.framedRules, ["Account_total"]);
+    assert.deepEqual(result.diagnostics, [
+      {
+        kind: "unsupported",
+        reason: "general loops are not supported by loop-summary SSA",
+      },
+    ]);
+  });
+
+  it.skip("represents supported in-iteration read-after-write without subState mutation", async () => {
+    // PENDING Patch 4: cover the currently supported loop-body read semantics
+    // so the helper proves read-after-write behavior without executing the
+    // body inside a SymbolicState subState.
+  });
+
+  it.skip("preserves unsupported diagnostics for out-of-scope loops", async () => {
+    // PENDING Patch 2: pin current unsupported boundaries for general loops,
+    // proposition-emitting nested loop bodies, and unsupported in-loop
+    // collection mutation with clear diagnostic reasons.
+  });
 
   it.skip("preserves production parity for foreach and mu-search fixtures", async () => {
     // PENDING Patch 4: pin parity for `functions-mutating-loop.ts`


### PR DESCRIPTION
## Patch 2: Introduce loop-summary SSA helper

- Define IR1LoopSsaInput, LoopSsaBuildOptions, MuSearchSummaryInput, ForeachSummaryLowerOptions, and ForeachSummaryLowerResult.
- Build IR1SsaProgram objects whose loopSummaries contain ir1SsaLoopSummary("mu-search"), ir1SsaLoopSummary("foreach-shape-a"), or ir1SsaLoopSummary("foreach-shape-b") entries.
- Ensure each summary version has origin "loop-summary" and its location matches summary-location.
- Track declaredRules, modifiedRules, and framedRules from summary locations through ir1SsaRuleOfLocation.
- Provide diagnostics for unsupported loop summary inputs without changing production lowering.
- Implement helper tests for distinct summary versions and modified-rule tracking.

## Changes
- Define IR1LoopSsaInput, LoopSsaBuildOptions, MuSearchSummaryInput, ForeachSummaryLowerOptions, and ForeachSummaryLowerResult.
- Build IR1SsaProgram objects whose loopSummaries contain ir1SsaLoopSummary("mu-search"), ir1SsaLoopSummary("foreach-shape-a"), or ir1SsaLoopSummary("foreach-shape-b") entries.
- Ensure each summary version has origin "loop-summary" and its location matches summary-location.
- Track declaredRules, modifiedRules, and framedRules from summary locations through ir1SsaRuleOfLocation.
- Provide diagnostics for unsupported loop summary inputs without changing production lowering.
- Implement helper tests for distinct summary versions and modified-rule tracking.

## Files to Modify
- tools/ts2pant/src/ir1-ssa-loops.ts (create): Add loop-summary input types, summary-state construction, summary version tracking, diagnostics, and helper-level lowering result types.
- tools/ts2pant/tests/ir1-ssa-loops.test.mts (modify): Implement helper-level summary construction tests that do not require production routing.

## Gameplan Specification

```
module IR1_SSA_LOOP_SUMMARIES.

Program.
Construct.
Location.
Version.
Read.
LoopSummary.
Shape.
Rule.
PropResult.
Diagnostic.
Expr.

mu-search => Shape.
foreach-shape-a => Shape.
foreach-shape-b => Shape.
supported-constructs p: Program => [Construct].
lowered-constructs p: Program => [Construct].
diagnostics p: Program => [Diagnostic].
diagnostic-construct d: Diagnostic => Construct.
mu-search? c: Construct => Bool.
foreach-shape-a? c: Construct => Bool.
foreach-shape-b? c: Construct => Bool.
general-loop? c: Construct => Bool.
loop-summaries p: Program => [LoopSummary].
summary-shape s: LoopSummary => Shape.
summary-location s: LoopSummary => Location.
summary-version s: LoopSummary => Version.
version-location v: Version => Location.
reads p: Program => [Read].
read-location r: Read => Location.
read-version r: Read => Version.
read-dominated? p: Program, r: Read => Bool.
rule-of-location l: Location => Rule.
declared-rules p: Program => [Rule].
modified-rules p: Program => [Rule].
framed-rules p: Program => [Rule].
emitted-props p: Program => [PropResult].
lowered-expr p: Program => [Expr].
min-over-each? e: Expr => Bool.
quantified-write? pr: PropResult => Bool.
accumulator-fold? pr: PropResult => Bool.

---

all p: Program, c in supported-constructs p |
  (mu-search? c or foreach-shape-a? c or foreach-shape-b? c) -> c in lowered-constructs p.

all p: Program, c in supported-constructs p |
  ~(general-loop? c).

all p: Program, d in diagnostics p |
  ~(diagnostic-construct d in supported-constructs p).

all p: Program, s in loop-summaries p |
  version-location (summary-version s) = summary-location s and
  rule-of-location (summary-location s) in modified-rules p.

all p: Program, s in loop-summaries p |
  summary-shape s = mu-search or
  summary-shape s = foreach-shape-a or
  summary-shape s = foreach-shape-b.

all p: Program, s1 in loop-summaries p, s2 in loop-summaries p |
  summary-version s1 = summary-version s2 -> s1 = s2.

all p: Program, r in reads p |
  read-dominated? p r and
  version-location (read-version r) = read-location r and
  (
    (some s in loop-summaries p |
      summary-version s = read-version r and
      summary-location s = read-location r) or
    ~(some s in loop-summaries p | summary-location s = read-location r)
  ).

all p: Program, c in supported-constructs p |
  mu-search? c ->
    (some s in loop-summaries p | summary-shape s = mu-search) and
    (some e in lowered-expr p | min-over-each? e).

all p: Program, c in supported-constructs p |
  foreach-shape-a? c ->
    (some s in loop-summaries p | summary-shape s = foreach-shape-a) and
    (some pr in emitted-props p | quantified-write? pr).

all p: Program, c in supported-constructs p |
  foreach-shape-b? c ->
    (some s in loop-summaries p | summary-shape s = foreach-shape-b) and
    (some pr in emitted-props p | accumulator-fold? pr).

all p: Program, rule in modified-rules p |
  rule in declared-rules p and ~(rule in framed-rules p).

all p: Program, rule in framed-rules p |
  rule in declared-rules p and ~(rule in modified-rules p).

all p: Program, rule in declared-rules p |
  rule in modified-rules p or rule in framed-rules p.

all p: Program |
  #(lowered-constructs p) > 0 -> (#(emitted-props p) > 0 or #(lowered-expr p) > 0).

```

## Patch Specification

```
module IR1_SSA_LOOP_SUMMARIES_PATCH_2.

Program.
Location.
Version.
LoopSummary.
Rule.
Shape.

mu-search => Shape.
foreach-shape-a => Shape.
foreach-shape-b => Shape.
loop-summaries p: Program => [LoopSummary].
summary-location s: LoopSummary => Location.
summary-version s: LoopSummary => Version.
summary-shape s: LoopSummary => Shape.
version-location v: Version => Location.
rule-of-location l: Location => Rule.
modified-rules p: Program => [Rule].

---

all p: Program, s in loop-summaries p |
  version-location (summary-version s) = summary-location s and
  rule-of-location (summary-location s) in modified-rules p.

all p: Program, s in loop-summaries p |
  summary-shape s = mu-search or
  summary-shape s = foreach-shape-a or
  summary-shape s = foreach-shape-b.

all p: Program, s1 in loop-summaries p, s2 in loop-summaries p |
  summary-version s1 = summary-version s2 -> s1 = s2.

```


## Implementation Notes

- The helper is intentionally metadata-first: it records loop summaries, summary versions, diagnostics, and pass-through lowered artifacts, but it does not route production foreach or mu-search lowering yet.
- `IR1SsaLoopSummary["shape"]` was widened to include `"mu-search"` because the existing IR1 constructor is the single source of loop-summary version allocation; this keeps `summaryVersion.origin` and location compatibility centralized.
- Unsupported loop inputs are represented as explicit helper inputs that return diagnostics with an otherwise empty SSA program, so current production unsupported behavior remains untouched.
- Full unit tests could not be completed in this environment because the generated wasm bridge is absent and `npm run build:wasm` requires missing OCaml tools (`js_of_ocaml` / `wasm_of_ocaml`). Patch-specific tests, SSA contract tests, Biome, and `tsc --noEmit` passed.