### PR TITLE
[ir1-ssa-loop-summaries] Patch 3: Route mu-search through loop summaries

### DIFF
--- a/tools/ts2pant/src/ir1-lower.ts
+++ b/tools/ts2pant/src/ir1-lower.ts
@@ -41,7 +41,10 @@ import {
   type IR1Stmt,
   ir1Var,
 } from "./ir1.js";
-import { lowerMuSearchSummary } from "./ir1-ssa-loops.js";
+import {
+  lowerMuSearchSummary,
+  type MuSearchCounterType,
+} from "./ir1-ssa-loops.js";
 import type { OpaqueExpr } from "./pant-ast.js";
 import type { NumericStrategy } from "./translate-types.js";
 
@@ -285,6 +288,7 @@ export function lowerL1MuSearch(
         "μ-search is only supported for discrete numeric strategies (got Real)",
     };
   }
+  const discreteCounterType: MuSearchCounterType = "Int";
   // After `isCanonicalMuSearchForm` has validated, we know the form
   // shape: Block([Let(c, init), While(p, Assign(c, c + 1))]).
   // Re-destructure to extract the init and predicate sub-expressions.
@@ -325,7 +329,7 @@ export function lowerL1MuSearch(
       receiver: ir1Var(ctx.counterPantName),
       property: ctx.counterPantName,
     },
-    counterType,
+    counterType: discreteCounterType,
     counterPantName: ctx.counterPantName,
     binder,
     initExpr: lowerExpr(initL2),

--- a/tools/ts2pant/src/ir1-lower.ts
+++ b/tools/ts2pant/src/ir1-lower.ts
@@ -35,9 +35,14 @@ import {
   irVar,
 } from "./ir.js";
 import { lowerExpr } from "./ir-emit.js";
-import type { IR1Expr, IR1Stmt } from "./ir1.js";
+import {
+  type IR1Expr,
+  type IR1SsaLocation,
+  type IR1Stmt,
+  ir1Var,
+} from "./ir1.js";
+import { lowerMuSearchSummary } from "./ir1-ssa-loops.js";
 import type { OpaqueExpr } from "./pant-ast.js";
-import { getAst } from "./pant-wasm.js";
 import type { NumericStrategy } from "./translate-types.js";
 
 /**
@@ -241,6 +246,8 @@ export interface MuSearchLowerCtx {
   counterPantName: string;
   /** Allocate a fresh binder name (e.g., `j`, `j1`, …). */
   allocateBinder: (hint: string) => string;
+  /** Optional SSA summary location for the μ-search result. */
+  summaryLocation?: IR1SsaLocation;
 }
 
 /**
@@ -311,22 +318,23 @@ export function lowerL1MuSearch(
   // `binder` never collides with predicate-internal binders, but
   // this layer enforces it independently).
   const binder = ctx.allocateBinder("j");
-  const ast = getAst();
-  const predicateOpaque = ast.substituteBinder(
-    lowerExpr(predicateL2),
-    ctx.counterPantName,
-    ast.var(binder),
-  );
-  const initOpaque = lowerExpr(initL2);
-  // Emit `min over each binder: T, binder >= INIT, ~P | binder`
-  // directly at the OpaqueExpr layer.
-  return ast.eachComb(
-    [ast.param(binder, ast.tName(counterType))],
-    [
-      ast.gExpr(ast.binop(ast.opGe(), ast.var(binder), initOpaque)),
-      ast.gExpr(ast.unop(ast.opNot(), predicateOpaque)),
-    ],
-    ast.combMin(),
-    ast.var(binder),
-  );
+  const lowered = lowerMuSearchSummary({
+    location: ctx.summaryLocation ?? {
+      kind: "property",
+      ruleName: ctx.counterPantName,
+      receiver: ir1Var(ctx.counterPantName),
+      property: ctx.counterPantName,
+    },
+    counterType,
+    counterPantName: ctx.counterPantName,
+    binder,
+    initExpr: lowerExpr(initL2),
+    predicateExpr: lowerExpr(predicateL2),
+  });
+  if (lowered.loweredExpr === null) {
+    return {
+      unsupported: "μ-search summary lowering did not produce an expression",
+    };
+  }
+  return lowered.loweredExpr;
 }

--- a/tools/ts2pant/src/ir1-ssa-loops.ts
+++ b/tools/ts2pant/src/ir1-ssa-loops.ts
@@ -99,6 +99,23 @@ export interface ForeachShapeBSummaryResult {
   accumulatorKeys: string[];
 }
 
+export interface MuSearchSummaryLowerOptions extends LoopSsaBuildOptions {
+  location: IR1SsaLocation;
+  counterType: string;
+  counterPantName: string;
+  binder: string;
+  initExpr: OpaqueExpr;
+  predicateExpr: OpaqueExpr;
+}
+
+export interface MuSearchSummaryLowerResult {
+  program: IR1SsaProgram;
+  summary: IR1SsaLoopSummary | null;
+  loweredExpr: OpaqueExpr | null;
+  modifiedRules: IR1SsaRuleName[];
+  diagnostics: UnsupportedDiagnostic[];
+}
+
 export interface LoopSsaBuildResult {
   program: IR1SsaProgram;
   loweredExpr: OpaqueExpr[];
@@ -518,4 +535,42 @@ export function foreachShapeBAccumulatorKey(
   objExpr: OpaqueExpr,
 ): string {
   return `${prop}::${getAst().strExpr(objExpr)}`;
+}
+
+export function lowerMuSearchSummary(
+  options: MuSearchSummaryLowerOptions,
+): MuSearchSummaryLowerResult {
+  const result = buildLoopSsaProgram(
+    {
+      kind: "mu-search",
+      location: options.location,
+    },
+    options,
+  );
+
+  const ast = getAst();
+  const predicateOpaque = ast.substituteBinder(
+    options.predicateExpr,
+    options.counterPantName,
+    ast.var(options.binder),
+  );
+  const loweredExpr = ast.eachComb(
+    [ast.param(options.binder, ast.tName(options.counterType))],
+    [
+      ast.gExpr(
+        ast.binop(ast.opGe(), ast.var(options.binder), options.initExpr),
+      ),
+      ast.gExpr(ast.unop(ast.opNot(), predicateOpaque)),
+    ],
+    ast.combMin(),
+    ast.var(options.binder),
+  );
+
+  return {
+    program: result.program,
+    summary: result.program.loopSummaries[0] ?? null,
+    loweredExpr,
+    modifiedRules: result.program.modifiedRules,
+    diagnostics: result.diagnostics,
+  };
 }

--- a/tools/ts2pant/src/ir1-ssa-loops.ts
+++ b/tools/ts2pant/src/ir1-ssa-loops.ts
@@ -99,9 +99,17 @@ export interface ForeachShapeBSummaryResult {
   accumulatorKeys: string[];
 }
 
+export type MuSearchCounterType = "Int";
+
+/**
+ * Preconditions:
+ * - caller already validated canonical μ-search form
+ * - `binder` is fresh with respect to `predicateExpr`
+ * - `counterType` is a discrete well-ordered numeric type
+ */
 export interface MuSearchSummaryLowerOptions extends LoopSsaBuildOptions {
   location: IR1SsaLocation;
-  counterType: string;
+  counterType: MuSearchCounterType;
   counterPantName: string;
   binder: string;
   initExpr: OpaqueExpr;

--- a/tools/ts2pant/tests/ir1-ssa-loops.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-loops.test.mts
@@ -3,6 +3,7 @@ import { resolve } from "node:path";
 import { before, describe, it } from "node:test";
 
 import { createSourceFile } from "../src/extract.js";
+import { lowerExpr } from "../src/ir-emit.js";
 import {
   ir1Assign,
   ir1Binop,
@@ -13,18 +14,20 @@ import {
   ir1SsaRuleOfLocation,
   ir1Var,
 } from "../src/ir1.js";
+import { lowerL1Expr } from "../src/ir1-lower.js";
 import {
   buildLoopSsaProgram,
   lowerForeachShapeASummaries,
   lowerForeachShapeBSummaries,
   lowerForeachSummary,
+  lowerMuSearchSummary,
 } from "../src/ir1-ssa-loops.js";
 import { assertWasmTypeChecks, getAst, loadAst } from "../src/pant-wasm.js";
 import {
   buildDocumentFromSourceFile,
   containsUnsupportedLine,
   emitDocument,
-} from "./helpers.mjs";
+} from "./helpers.mts";
 
 before(async () => {
   await loadAst();
@@ -60,6 +63,35 @@ describe("ir1-ssa-loops", () => {
     assert.equal(summary!.location, location);
     assert.equal(summary!.summaryVersion.origin, "loop-summary");
     assert.equal(summary!.summaryVersion.location, location);
+  });
+
+  it("lowers mu-search summaries to the existing min-over-each shape", () => {
+    const location = ir1SsaPropertyLocation(
+      "Name_firstUnusedSuffix",
+      ir1Var("name"),
+      "firstUnusedSuffix",
+    );
+
+    const result = lowerMuSearchSummary({
+      location,
+      counterType: "Int",
+      counterPantName: "i",
+      binder: "j1",
+      initExpr: lowerExpr(lowerL1Expr(ir1LitNat(1))),
+      predicateExpr: lowerExpr(
+        lowerL1Expr(ir1Binop("in", ir1Var("i"), ir1Var("used"))),
+      ),
+    });
+
+    assert.deepEqual(result.diagnostics, []);
+    assert.equal(result.summary?.shape, "mu-search");
+    assert.equal(result.summary?.location, location);
+    assert.equal(result.summary?.summaryVersion.location, location);
+    assert.ok(result.loweredExpr !== null);
+    assert.equal(
+      getAst().strExpr(result.loweredExpr!),
+      "min over each j1: Int, j1 >= 1, ~(j1 in used) | j1",
+    );
   });
 
   it("records foreach Shape A quantified writes as loop summaries", () => {

--- a/tools/ts2pant/tests/m2-musearch-l1.test.mts
+++ b/tools/ts2pant/tests/m2-musearch-l1.test.mts
@@ -33,11 +33,11 @@ before(async () => {
   await loadAst();
 });
 
-function extractEquationRhs(output: string): string {
+function extractEquationRhs(output: string, entryName: string): string {
   const equationLine = output
     .trim()
     .split("\n")
-    .findLast((line) => line.includes(" = "));
+    .find((line) => line.startsWith(`${entryName} `) && line.includes(" = "));
   assert.ok(equationLine, "expected an emitted equation line");
   return equationLine.slice(equationLine.indexOf(" = ") + 3);
 }
@@ -158,14 +158,20 @@ describe("M2 μ-search L1: all five +1 spellings produce identical Pant", () => 
       "explicitIncrementStep",
       "explicitIncrementStepFlipped",
     ];
-    const outputs = await Promise.all(
-      funcs.map(async (funcName) => {
-        const doc = await buildDocumentFromSourceFile(sourceFile, funcName);
-        return emitDocument(doc);
-      }),
-    );
+    const outputs: Array<{ funcName: string; output: string }> = [];
+    for (const funcName of funcs) {
+      const doc = await buildDocumentFromSourceFile(sourceFile, funcName);
+      outputs.push({ funcName, output: emitDocument(doc) });
+    }
 
-    const rhsOutputs = outputs.map(extractEquationRhs);
+    const rhsOutputs = outputs.map(({ funcName, output }) =>
+      extractEquationRhs(
+        output,
+        funcName
+          .replace(/[A-Z]/gu, (c) => `-${c.toLowerCase()}`)
+          .replace(/^-/, ""),
+      ),
+    );
     for (const rhs of rhsOutputs) {
       assert.match(rhs, /min over each j\d*: Int/u);
     }

--- a/tools/ts2pant/tests/m2-musearch-l1.test.mts
+++ b/tools/ts2pant/tests/m2-musearch-l1.test.mts
@@ -17,15 +17,30 @@
  */
 
 import assert from "node:assert/strict";
+import { resolve } from "node:path";
 import { before, describe, it } from "node:test";
-import { createSourceFileFromSource } from "../src/extract.js";
+import { emitDocument } from "../src/emit.js";
+import {
+  createSourceFile,
+  createSourceFileFromSource,
+} from "../src/extract.js";
 import { getAst, loadAst } from "../src/pant-wasm.js";
 import { translateBody } from "../src/translate-body.js";
 import { IntStrategy } from "../src/translate-types.js";
+import { buildDocumentFromSourceFile } from "./helpers.mts";
 
 before(async () => {
   await loadAst();
 });
+
+function extractEquationRhs(output: string): string {
+  const equationLine = output
+    .trim()
+    .split("\n")
+    .findLast((line) => line.includes(" = "));
+  assert.ok(equationLine, "expected an emitted equation line");
+  return equationLine.slice(equationLine.indexOf(" = ") + 3);
+}
 
 function translate(
   source: string,
@@ -65,7 +80,7 @@ describe("M2 μ-search L1: existing shapes translate", () => {
     `;
     const { unsupported, pant } = translate(source, "firstUnused");
     assert.equal(unsupported, null);
-    assert.match(pant!, /min over each j\d*: Int/);
+    assert.match(pant!, /min over each j\d*: Int/u);
   });
 
   it("μ-search counter referenced post-loop", () => {
@@ -78,8 +93,8 @@ describe("M2 μ-search L1: existing shapes translate", () => {
     `;
     const { unsupported, pant } = translate(source, "nextSlotPlusOne");
     assert.equal(unsupported, null);
-    assert.match(pant!, /min over each j\d*: Int/);
-    assert.match(pant!, /\+ 1/);
+    assert.match(pant!, /min over each j\d*: Int/u);
+    assert.match(pant!, /\+ 1/u);
   });
 
   it("μ-search interleaved with const binding", () => {
@@ -121,13 +136,42 @@ describe("M2 μ-search L1: all five +1 spellings produce identical Pant", () => 
     // binder allocation is deterministic per call. The five spellings
     // must produce byte-identical Pant — the M2 architectural promise.
     const baseline = translateForm("i++");
-    assert.match(baseline, /min over each j\d*: Int/);
-    assert.match(baseline, /~\(j\d* in used\)/);
+    assert.match(baseline, /min over each j\d*: Int/u);
+    assert.match(baseline, /~\(j\d* in used\)/u);
 
     assert.equal(translateForm("++i"), baseline);
     assert.equal(translateForm("i += 1"), baseline);
     assert.equal(translateForm("i = i + 1"), baseline);
     assert.equal(translateForm("i = 1 + i"), baseline);
+  });
+
+  it("fixture spellings still emit identical Pant through loop summaries", async () => {
+    const filePath = resolve(
+      import.meta.dirname,
+      "fixtures/constructs/expressions-while-mu-search.ts",
+    );
+    const sourceFile = createSourceFile(filePath);
+    const funcs = [
+      "firstUnusedSuffix",
+      "unbracedWhileBody",
+      "compoundIncrementStep",
+      "explicitIncrementStep",
+      "explicitIncrementStepFlipped",
+    ];
+    const outputs = await Promise.all(
+      funcs.map(async (funcName) => {
+        const doc = await buildDocumentFromSourceFile(sourceFile, funcName);
+        return emitDocument(doc);
+      }),
+    );
+
+    const rhsOutputs = outputs.map(extractEquationRhs);
+    for (const rhs of rhsOutputs) {
+      assert.match(rhs, /min over each j\d*: Int/u);
+    }
+    for (const rhs of rhsOutputs.slice(1)) {
+      assert.equal(rhs, rhsOutputs[0]);
+    }
   });
 });
 
@@ -163,7 +207,7 @@ describe("M2 μ-search L1: rejection cases", () => {
     `;
     const { unsupported } = translate(source, "nonUnit");
     assert.notEqual(unsupported, null);
-    assert.match(unsupported!, /canonical|step/);
+    assert.match(unsupported!, /canonical|step/u);
   });
 
   it("predicate not referencing counter rejects", () => {


### PR DESCRIPTION
## Patch 3: Route mu-search through loop summaries

- Represent canonical μ-search as a loop summary with shape "mu-search" and a summary location tied to the counter result.
- Lower the μ-search summary to the same min over each expression currently produced by lowerL1MuSearch.
- Preserve isCanonicalMuSearchForm as the rejection boundary for compound bodies, invalid counters, and predicates that do not reference the counter.
- Assert all five supported +1 spellings still produce identical Pant output.
- Ensure μ-search summary tests can inspect the IR1SsaProgram before lower-time expression emission.

## Changes
- Represent canonical μ-search as a loop summary with shape "mu-search" and a summary location tied to the counter result.
- Lower the μ-search summary to the same min over each expression currently produced by lowerL1MuSearch.
- Preserve isCanonicalMuSearchForm as the rejection boundary for compound bodies, invalid counters, and predicates that do not reference the counter.
- Assert all five supported +1 spellings still produce identical Pant output.
- Ensure μ-search summary tests can inspect the IR1SsaProgram before lower-time expression emission.

## Files to Modify
- tools/ts2pant/src/ir1-ssa-loops.ts (modify): Implement μ-search summary lowering to the existing min-over-each expression shape.
- tools/ts2pant/src/ir1-lower.ts (modify): Call the loop-summary helper from lowerL1MuSearch after canonical-form validation.
- tools/ts2pant/tests/ir1-ssa-loops.test.mts (modify): Unskip and implement μ-search summary tests.
- tools/ts2pant/tests/m2-musearch-l1.test.mts (modify): Keep parity assertions for canonical μ-search output and rejection diagnostics.

## Gameplan Specification

```
module IR1_SSA_LOOP_SUMMARIES.

Program.
Construct.
Location.
Version.
Read.
LoopSummary.
Shape.
Rule.
PropResult.
Diagnostic.
Expr.

mu-search => Shape.
foreach-shape-a => Shape.
foreach-shape-b => Shape.
supported-constructs p: Program => [Construct].
lowered-constructs p: Program => [Construct].
diagnostics p: Program => [Diagnostic].
diagnostic-construct d: Diagnostic => Construct.
mu-search? c: Construct => Bool.
foreach-shape-a? c: Construct => Bool.
foreach-shape-b? c: Construct => Bool.
general-loop? c: Construct => Bool.
loop-summaries p: Program => [LoopSummary].
summary-shape s: LoopSummary => Shape.
summary-location s: LoopSummary => Location.
summary-version s: LoopSummary => Version.
version-location v: Version => Location.
reads p: Program => [Read].
read-location r: Read => Location.
read-version r: Read => Version.
read-dominated? p: Program, r: Read => Bool.
rule-of-location l: Location => Rule.
declared-rules p: Program => [Rule].
modified-rules p: Program => [Rule].
framed-rules p: Program => [Rule].
emitted-props p: Program => [PropResult].
lowered-expr p: Program => [Expr].
min-over-each? e: Expr => Bool.
quantified-write? pr: PropResult => Bool.
accumulator-fold? pr: PropResult => Bool.

---

all p: Program, c in supported-constructs p |
  (mu-search? c or foreach-shape-a? c or foreach-shape-b? c) -> c in lowered-constructs p.

all p: Program, c in supported-constructs p |
  ~(general-loop? c).

all p: Program, d in diagnostics p |
  ~(diagnostic-construct d in supported-constructs p).

all p: Program, s in loop-summaries p |
  version-location (summary-version s) = summary-location s and
  rule-of-location (summary-location s) in modified-rules p.

all p: Program, s in loop-summaries p |
  summary-shape s = mu-search or
  summary-shape s = foreach-shape-a or
  summary-shape s = foreach-shape-b.

all p: Program, s1 in loop-summaries p, s2 in loop-summaries p |
  summary-version s1 = summary-version s2 -> s1 = s2.

all p: Program, r in reads p |
  read-dominated? p r and
  version-location (read-version r) = read-location r and
  (
    (some s in loop-summaries p |
      summary-version s = read-version r and
      summary-location s = read-location r) or
    ~(some s in loop-summaries p | summary-location s = read-location r)
  ).

all p: Program, c in supported-constructs p |
  mu-search? c ->
    (some s in loop-summaries p | summary-shape s = mu-search) and
    (some e in lowered-expr p | min-over-each? e).

all p: Program, c in supported-constructs p |
  foreach-shape-a? c ->
    (some s in loop-summaries p | summary-shape s = foreach-shape-a) and
    (some pr in emitted-props p | quantified-write? pr).

all p: Program, c in supported-constructs p |
  foreach-shape-b? c ->
    (some s in loop-summaries p | summary-shape s = foreach-shape-b) and
    (some pr in emitted-props p | accumulator-fold? pr).

all p: Program, rule in modified-rules p |
  rule in declared-rules p and ~(rule in framed-rules p).

all p: Program, rule in framed-rules p |
  rule in declared-rules p and ~(rule in modified-rules p).

all p: Program, rule in declared-rules p |
  rule in modified-rules p or rule in framed-rules p.

all p: Program |
  #(lowered-constructs p) > 0 -> (#(emitted-props p) > 0 or #(lowered-expr p) > 0).

```

## Patch Specification

```
module IR1_SSA_LOOP_SUMMARIES_PATCH_3.

Program.
Construct.
Location.
Version.
LoopSummary.
Shape.
Diagnostic.
Expr.

mu-search => Shape.
supported-constructs p: Program => [Construct].
lowered-constructs p: Program => [Construct].
diagnostics p: Program => [Diagnostic].
diagnostic-construct d: Diagnostic => Construct.
loop-summaries p: Program => [LoopSummary].
summary-shape s: LoopSummary => Shape.
summary-location s: LoopSummary => Location.
summary-version s: LoopSummary => Version.
version-location v: Version => Location.
lowered-expr p: Program => [Expr].
min-over-each? e: Expr => Bool.
mu-search? c: Construct => Bool.

---

all p: Program, c in supported-constructs p |
  mu-search? c -> c in lowered-constructs p.

all p: Program, d in diagnostics p |
  ~(diagnostic-construct d in supported-constructs p).

all p: Program, s in loop-summaries p |
  summary-shape s = mu-search ->
    version-location (summary-version s) = summary-location s.

all p: Program, c in supported-constructs p |
  mu-search? c ->
    (some s in loop-summaries p | summary-shape s = mu-search) and
    (some e in lowered-expr p | min-over-each? e).

```


## Implementation Notes

- `lowerMuSearchSummary` builds the SSA program and emits the final `OpaqueExpr` in one helper, but the tests still exercise `buildLoopSsaProgram` directly so reviewers can see the summary artifact exists independently of emission. That split is intentional: production gets a single cutover point, while tests can inspect the pre-emission IR1 SSA state.
- The summary location for the production μ-search path is a synthetic property location derived from the lowered counter name when the caller does not provide one. This keeps the summary-version/location invariant aligned with the existing IR1 SSA location vocabulary without widening SSA location types in this patch.
- I added an optional `summaryLocation` field to `MuSearchLowerCtx` for forward compatibility, but this patch does not need a custom caller-provided location yet.
- Fixture parity assertions compare the emitted equation RHS rather than whole documents. The full documents differ in module/rule names across fixtures even when the μ-search lowering is identical, so whole-document equality would overconstrain the test for the wrong reason.
- No behavioral expansion was introduced: the rejection surface is still owned by the existing recognizer, and the helper only runs after canonical-form validation has succeeded.