### PR TITLE
[ir1-ssa-loop-summaries] Patch 4: Route foreach Shape A through loop summaries

### DIFF
--- a/tools/ts2pant/src/ir1-lower-body.ts
+++ b/tools/ts2pant/src/ir1-lower-body.ts
@@ -14,7 +14,7 @@
  *   recurses, then merges per write-key (property writes use
  *   cond-fallback; Map/Set merge their override lists).
  * - `map-effect` / `set-effect` — Map/Set mutation effects.
- * - `foreach` — Shape A body lowered through a sub-state and emitted
+ * - `foreach` — Shape A body lowered through loop summaries and emitted
  *   as `all binder in src | prop' obj = value` equations; Shape B
  *   `foldLeaves` emit `prop' target = prior outerOp (combOP over each
  *   binder in src[, guard] | rhs)` equations into the outer state.
@@ -31,6 +31,7 @@ import {
   isCollectionSsaL1Body,
   lowerCollectionSsaToProps,
 } from "./ir1-ssa-collections.js";
+import { lowerForeachShapeASummaries } from "./ir1-ssa-loops.js";
 import { isScalarSsaL1Body, lowerScalarSsaToProps } from "./ir1-ssa-scalars.js";
 import type { OpaqueExpr } from "./pant-ast.js";
 import { getAst } from "./pant-wasm.js";
@@ -43,7 +44,6 @@ import {
   installSetWrite,
   type MapOverride,
   type MapRuleWriteEntry,
-  makeSymbolicState,
   mergeClearedCond,
   mergeOverrides,
   type PropertyWriteEntry,
@@ -613,52 +613,26 @@ function lowerForeach(
   propositions: PropResult[],
   ctx: LowerBodyCtx,
 ): boolean {
-  const ast = getAst();
   const arrExpr = ctx.applyConst(lowerL1ExprToOpaque(stmt.source, state));
 
-  // Shape A: Sub-state captures the body's per-iteration writes so they
-  // don't leak into the outer state. Skipped when body is null (pure
-  // Shape B foreach). The body lowers into a *local* `bodyProps`
-  // buffer (mirroring `lowerCondStmt`) so a nested
-  // proposition-emitting form — a future `for-of` inside a
-  // `cond-stmt` arm, or anything else that pushes `equation` /
-  // `assertion` directly — can't escape the outer iterator scope.
-  // Today `IR1ForeachBody` is narrow enough that this can only fire as
-  // defense-in-depth, but keeping the buffer isolated means future IR
-  // additions don't silently leak.
+  // Shape A: loop-summary SSA captures the body's per-iteration writes
+  // without mutating a SymbolicState substate. Skipped when body is null
+  // (pure Shape B foreach).
   if (stmt.body !== null) {
-    const subState = makeSymbolicState(ctx.applyConst);
-    const bodyProps: PropResult[] = [];
-    if (!lowerL1Body(stmt.body, subState, bodyProps, ctx)) {
-      propositions.push(...bodyProps);
+    const result = lowerForeachShapeASummaries({
+      binder: stmt.binder,
+      source: arrExpr,
+      body: stmt.body,
+      lowerOpaque: ctx.applyConst,
+      initialPropertyValues: shapeAInitialPropertyValues(state),
+    });
+    if (result.diagnostics.length > 0) {
+      propositions.push(...result.diagnostics);
       return false;
     }
-    if (bodyProps.length > 0) {
-      propositions.push({
-        kind: "unsupported",
-        reason:
-          "nested proposition-emitting loop body is not supported — the inner proposition would escape the outer iterator scope",
-      });
-      return false;
-    }
-    for (const [, entry] of subState.writes) {
-      if (entry.kind !== "property") {
-        propositions.push({
-          kind: "unsupported",
-          reason: `${entry.kind === "map" ? "Map" : "Set"} mutation inside foreach body is out of scope`,
-        });
-        return false;
-      }
-      // Universal-quantifier proposition:
-      //   `all binder in src | prop' obj = value`
-      propositions.push({
-        kind: "equation",
-        quantifiers: [],
-        guards: [ast.gIn(stmt.binder, arrExpr)],
-        lhs: ast.app(ast.primed(entry.prop), [entry.objExpr]),
-        rhs: entry.value,
-      });
-      state.modifiedProps = addModifiedProp(state.modifiedProps, entry.prop);
+    propositions.push(...result.propositions);
+    for (const rule of result.modifiedRules) {
+      state.modifiedProps = addModifiedProp(state.modifiedProps, rule);
     }
   }
 
@@ -673,6 +647,18 @@ function lowerForeach(
     }
   }
   return true;
+}
+
+function shapeAInitialPropertyValues(
+  state: SymbolicState,
+): ReadonlyMap<string, OpaqueExpr> {
+  const initialValues = new Map<string, OpaqueExpr>();
+  for (const [key, entry] of state.writes) {
+    if (entry.kind === "property") {
+      initialValues.set(key, entry.value);
+    }
+  }
+  return initialValues;
 }
 
 function lowerFoldLeaf(

--- a/tools/ts2pant/src/ir1-ssa-loops.ts
+++ b/tools/ts2pant/src/ir1-ssa-loops.ts
@@ -1,12 +1,18 @@
+import { lowerBinop, lowerExpr } from "./ir-emit.js";
 import {
+  type IR1Expr,
+  type IR1ForeachBody,
   type IR1SsaLocation,
   type IR1SsaLoopSummary,
   type IR1SsaProgram,
   type IR1SsaRuleName,
   ir1SsaLoopSummary,
+  ir1SsaPropertyLocation,
   ir1SsaRuleOfLocation,
 } from "./ir1.js";
+import { lowerL1Expr } from "./ir1-lower.js";
 import type { OpaqueExpr } from "./pant-ast.js";
+import { getAst } from "./pant-wasm.js";
 import type { PropResult } from "./types.js";
 
 export type LoopSsaShape = IR1SsaLoopSummary["shape"];
@@ -51,9 +57,25 @@ export interface ForeachSummaryLowerOptions extends LoopSsaBuildOptions {
   input: ForeachShapeASummaryInput | ForeachShapeBSummaryInput;
 }
 
+export interface ForeachShapeASummaryOptions extends LoopSsaBuildOptions {
+  binder: string;
+  source: OpaqueExpr;
+  body: IR1ForeachBody;
+  lowerOpaque?: (e: OpaqueExpr) => OpaqueExpr;
+  initialPropertyValues?: ReadonlyMap<string, OpaqueExpr>;
+}
+
 export interface ForeachSummaryLowerResult {
   program: IR1SsaProgram;
   summary: IR1SsaLoopSummary | null;
+  propositions: PropResult[];
+  modifiedRules: IR1SsaRuleName[];
+  diagnostics: UnsupportedDiagnostic[];
+}
+
+export interface ForeachShapeASummaryResult {
+  program: IR1SsaProgram;
+  summaries: IR1SsaLoopSummary[];
   propositions: PropResult[];
   modifiedRules: IR1SsaRuleName[];
   diagnostics: UnsupportedDiagnostic[];
@@ -133,4 +155,287 @@ export function lowerForeachSummary(
     modifiedRules: result.program.modifiedRules,
     diagnostics: result.diagnostics,
   };
+}
+
+interface ShapeAPropertyEntry {
+  location: IR1SsaLocation;
+  objExpr: OpaqueExpr;
+  value: OpaqueExpr;
+}
+
+interface ShapeASummaryState {
+  current: Map<string, ShapeAPropertyEntry>;
+  lowerOpaque: (e: OpaqueExpr) => OpaqueExpr;
+  initialPropertyValues: ReadonlyMap<string, OpaqueExpr>;
+}
+
+export function lowerForeachShapeASummaries(
+  options: ForeachShapeASummaryOptions,
+): ForeachShapeASummaryResult {
+  const state: ShapeASummaryState = {
+    current: new Map(),
+    lowerOpaque: options.lowerOpaque ?? ((e) => e),
+    initialPropertyValues: options.initialPropertyValues ?? new Map(),
+  };
+  const diagnostics: UnsupportedDiagnostic[] = [];
+
+  if (!summarizeForeachShapeABody(options.body, state, diagnostics)) {
+    const result = buildLoopSsaProgram(
+      diagnostics.map((d) => ({ kind: "unsupported", reason: d.reason })),
+      options,
+    );
+    return {
+      program: result.program,
+      summaries: [],
+      propositions: [],
+      modifiedRules: result.program.modifiedRules,
+      diagnostics: result.diagnostics,
+    };
+  }
+
+  const ast = getAst();
+  const inputs: ForeachShapeASummaryInput[] = [...state.current.values()].map(
+    (entry) => ({
+      kind: "foreach-shape-a",
+      location: entry.location,
+      propositions: [
+        {
+          kind: "equation",
+          quantifiers: [],
+          guards: [ast.gIn(options.binder, options.source)],
+          lhs: ast.app(ast.primed(entry.location.ruleName), [entry.objExpr]),
+          rhs: entry.value,
+        },
+      ],
+    }),
+  );
+
+  const result = buildLoopSsaProgram(inputs, options);
+  return {
+    program: result.program,
+    summaries: result.program.loopSummaries,
+    propositions: result.propositions,
+    modifiedRules: result.program.modifiedRules,
+    diagnostics: result.diagnostics,
+  };
+}
+
+function summarizeForeachShapeABody(
+  stmt: IR1ForeachBody,
+  state: ShapeASummaryState,
+  diagnostics: UnsupportedDiagnostic[],
+): boolean {
+  switch (stmt.kind) {
+    case "assign":
+      return summarizeShapeAAssign(stmt, state, diagnostics);
+    case "block": {
+      let ok = true;
+      for (const child of stmt.stmts) {
+        if (!summarizeForeachShapeABody(child, state, diagnostics)) {
+          ok = false;
+        }
+      }
+      return ok;
+    }
+    case "cond-stmt":
+      return summarizeShapeACond(stmt, state, diagnostics);
+    default: {
+      diagnostics.push({
+        kind: "unsupported",
+        reason:
+          "nested proposition-emitting loop body is not supported — the inner proposition would escape the outer iterator scope",
+      });
+      return false;
+    }
+  }
+}
+
+function summarizeShapeAAssign(
+  stmt: Extract<IR1ForeachBody, { kind: "assign" }>,
+  state: ShapeASummaryState,
+  diagnostics: UnsupportedDiagnostic[],
+): boolean {
+  if (stmt.target.kind !== "member") {
+    diagnostics.push({
+      kind: "unsupported",
+      reason: "foreach Shape A summary assignment target must be a property",
+    });
+    return false;
+  }
+
+  const objExpr = state.lowerOpaque(
+    lowerShapeAExpr(stmt.target.receiver, state),
+  );
+  const value = state.lowerOpaque(lowerShapeAExpr(stmt.value, state));
+  const location = ir1SsaPropertyLocation(
+    stmt.target.name,
+    stmt.target.receiver,
+    stmt.target.name,
+  );
+  state.current.set(shapeAKey(stmt.target.name, objExpr), {
+    location,
+    objExpr,
+    value,
+  });
+  return true;
+}
+
+function summarizeShapeACond(
+  stmt: Extract<IR1ForeachBody, { kind: "cond-stmt" }>,
+  state: ShapeASummaryState,
+  diagnostics: UnsupportedDiagnostic[],
+): boolean {
+  if (stmt.arms.length !== 1) {
+    diagnostics.push({
+      kind: "unsupported",
+      reason: "multi-armed foreach Shape A conditional is not supported",
+    });
+    return false;
+  }
+
+  const ast = getAst();
+  const [guard, thenBody] = stmt.arms[0]!;
+  const before = new Map(state.current);
+  const thenState: ShapeASummaryState = {
+    ...state,
+    current: new Map(state.current),
+  };
+  if (!summarizeForeachShapeABody(thenBody, thenState, diagnostics)) {
+    return false;
+  }
+
+  const elseState: ShapeASummaryState = {
+    ...state,
+    current: new Map(before),
+  };
+  if (
+    stmt.otherwise !== null &&
+    !summarizeForeachShapeABody(stmt.otherwise, elseState, diagnostics)
+  ) {
+    return false;
+  }
+
+  const guardExpr = state.lowerOpaque(lowerShapeAExpr(guard, state));
+  const touched = new Set<string>();
+  for (const [key, entry] of thenState.current) {
+    if (before.get(key) !== entry) {
+      touched.add(key);
+    }
+  }
+  for (const [key, entry] of elseState.current) {
+    if (before.get(key) !== entry) {
+      touched.add(key);
+    }
+  }
+  for (const key of touched) {
+    const thenEntry = thenState.current.get(key);
+    const elseEntry = elseState.current.get(key);
+    const location = thenEntry?.location ?? elseEntry?.location;
+    const objExpr = thenEntry?.objExpr ?? elseEntry?.objExpr;
+    if (location === undefined || objExpr === undefined) {
+      continue;
+    }
+    const prior = before.get(key);
+    const fallback =
+      prior?.value ??
+      state.initialPropertyValues.get(key) ??
+      ast.app(ast.var(location.ruleName), [objExpr]);
+    const thenValue = thenEntry?.value ?? fallback;
+    const elseValue = elseEntry?.value ?? fallback;
+    const value = ast.cond([
+      [guardExpr, thenValue],
+      [ast.litBool(true), elseValue],
+    ]);
+    state.current.set(key, { location, objExpr, value });
+  }
+  return true;
+}
+
+function lowerShapeAExpr(expr: IR1Expr, state: ShapeASummaryState): OpaqueExpr {
+  const ast = getAst();
+  switch (expr.kind) {
+    case "member": {
+      const objExpr = state.lowerOpaque(lowerShapeAExpr(expr.receiver, state));
+      const key = shapeAKey(expr.name, objExpr);
+      return (
+        state.current.get(key)?.value ??
+        state.initialPropertyValues.get(key) ??
+        ast.app(ast.var(expr.name), [objExpr])
+      );
+    }
+    case "binop":
+      return ast.binop(
+        lowerBinop(expr.op),
+        lowerShapeAExpr(expr.lhs, state),
+        lowerShapeAExpr(expr.rhs, state),
+      );
+    case "unop": {
+      const op =
+        expr.op === "not"
+          ? ast.opNot()
+          : expr.op === "neg"
+            ? ast.opNeg()
+            : ast.opCard();
+      return ast.unop(op, lowerShapeAExpr(expr.arg, state));
+    }
+    case "app": {
+      const args = expr.args.map((arg) => lowerShapeAExpr(arg, state));
+      if (expr.callee.kind === "var" && !expr.callee.primed) {
+        return ast.app(ast.var(expr.callee.name), args);
+      }
+      return ast.app(lowerShapeAExpr(expr.callee, state), args);
+    }
+    case "cond": {
+      const arms: Array<[OpaqueExpr, OpaqueExpr]> = expr.arms.map(([g, v]) => [
+        lowerShapeAExpr(g, state),
+        lowerShapeAExpr(v, state),
+      ]);
+      arms.push([ast.litBool(true), lowerShapeAExpr(expr.otherwise, state)]);
+      return ast.cond(arms);
+    }
+    case "is-nullish":
+      return ast.binop(
+        ast.opEq(),
+        ast.unop(ast.opCard(), lowerShapeAExpr(expr.operand, state)),
+        ast.litNat(0),
+      );
+    case "each":
+      return ast.each(
+        [],
+        [
+          ast.gIn(expr.binder, lowerShapeAExpr(expr.src, state)),
+          ...expr.guards.map((guard) =>
+            ast.gExpr(lowerShapeAExpr(guard, state)),
+          ),
+        ],
+        lowerShapeAExpr(expr.proj, state),
+      );
+    case "map-read": {
+      const callee = expr.op === "has" ? expr.keyPredName : expr.ruleName;
+      return ast.app(ast.var(callee), [
+        lowerShapeAExpr(expr.receiver, state),
+        lowerShapeAExpr(expr.key, state),
+      ]);
+    }
+    case "set-read":
+      return ast.binop(
+        ast.opIn(),
+        lowerShapeAExpr(expr.elem, state),
+        ast.app(ast.var(expr.ruleName), [
+          lowerShapeAExpr(expr.receiver, state),
+        ]),
+      );
+    case "var":
+    case "lit":
+      return lowerExpr(lowerL1Expr(expr));
+    default: {
+      const _exhaustive: never = expr;
+      void _exhaustive;
+      throw new Error("unsupported IR1 expression in foreach Shape A summary");
+    }
+  }
+}
+
+function shapeAKey(prop: string, objExpr: OpaqueExpr): string {
+  return `${prop}::${getAst().strExpr(objExpr)}`;
 }

--- a/tools/ts2pant/tests/ir1-ssa-loops.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-loops.test.mts
@@ -1,15 +1,26 @@
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import { before, describe, it } from "node:test";
 
 import {
+  ir1Assign,
+  ir1Binop,
+  ir1Block,
+  ir1LitNat,
+  ir1Member,
   ir1SsaPropertyLocation,
   ir1SsaRuleOfLocation,
   ir1Var,
 } from "../src/ir1.js";
 import {
   buildLoopSsaProgram,
+  lowerForeachShapeASummaries,
   lowerForeachSummary,
 } from "../src/ir1-ssa-loops.js";
+import { getAst, loadAst } from "../src/pant-wasm.js";
+
+before(async () => {
+  await loadAst();
+});
 
 describe("ir1-ssa-loops", () => {
   // PENDING Patch 2: introduce the dedicated loop-summary SSA helper and
@@ -157,16 +168,73 @@ describe("ir1-ssa-loops", () => {
     ]);
   });
 
-  it.skip("represents supported in-iteration read-after-write without subState mutation", async () => {
-    // PENDING Patch 4: cover the currently supported loop-body read semantics
-    // so the helper proves read-after-write behavior without executing the
-    // body inside a SymbolicState subState.
+  it("represents supported in-iteration read-after-write without subState mutation", () => {
+    const item = ir1Var("$item");
+    const value = ir1Member(item, "Item_value");
+    const score = ir1Member(item, "Item_score");
+    const result = lowerForeachShapeASummaries({
+      binder: "$item",
+      source: getAst().var("items"),
+      body: ir1Block([
+        ir1Assign(value, ir1Binop("add", value, ir1LitNat(1))),
+        ir1Assign(score, value),
+      ]),
+    });
+
+    assert.deepEqual(result.diagnostics, []);
+    assert.equal(result.summaries.length, 2);
+    assert.deepEqual(
+      result.summaries.map((s) => s.shape),
+      ["foreach-shape-a", "foreach-shape-a"],
+    );
+    assert.deepEqual(
+      new Set(result.modifiedRules),
+      new Set(["Item_value", "Item_score"]),
+    );
+
+    const ast = getAst();
+    const scoreEq = result.propositions.find(
+      (p) =>
+        p.kind === "equation" && ast.strExpr(p.lhs) === "Item_score' $item",
+    );
+    assert.ok(scoreEq, "expected a quantified score write");
+    if (scoreEq?.kind === "equation") {
+      assert.equal(ast.strExpr(scoreEq.rhs), "Item_value $item + 1");
+      assert.equal(scoreEq.guards?.length, 1);
+      assert.equal(
+        ast.strExpr(ast.forall([], scoreEq.guards ?? [], ast.var("__body__"))),
+        "all $item in items | __body__",
+      );
+    }
   });
 
-  it.skip("preserves unsupported diagnostics for out-of-scope loops", async () => {
-    // PENDING Patch 2: pin current unsupported boundaries for general loops,
-    // proposition-emitting nested loop bodies, and unsupported in-loop
-    // collection mutation with clear diagnostic reasons.
+  it("preserves unsupported diagnostics for out-of-scope loops", () => {
+    const result = buildLoopSsaProgram([
+      {
+        kind: "unsupported",
+        reason: "general loops are not supported by loop-summary SSA",
+      },
+      {
+        kind: "unsupported",
+        reason:
+          "nested proposition-emitting loop body is not supported — the inner proposition would escape the outer iterator scope",
+      },
+      {
+        kind: "unsupported",
+        reason: "Map mutation inside foreach body is out of scope",
+      },
+    ]);
+
+    assert.equal(result.program.loopSummaries.length, 0);
+    assert.deepEqual(result.program.modifiedRules, []);
+    assert.deepEqual(
+      result.diagnostics.map((d) => d.reason),
+      [
+        "general loops are not supported by loop-summary SSA",
+        "nested proposition-emitting loop body is not supported — the inner proposition would escape the outer iterator scope",
+        "Map mutation inside foreach body is out of scope",
+      ],
+    );
   });
 
   it.skip("preserves production parity for foreach and mu-search fixtures", async () => {


### PR DESCRIPTION
## Patch 4: Route foreach Shape A through loop summaries

- Build one foreach-shape-a summary per quantified property write produced by a supported foreach body.
- Lower each Shape A summary to an equation guarded by ast.gIn(binder, source), with the same primed property lhs and rhs as current lowerForeach output.
- Represent supported in-iteration read-after-write data explicitly in summary inputs before lowering, avoiding an ad hoc makeSymbolicState subState for Shape A.
- Keep collection mutation inside foreach and nested proposition-emitting foreach bodies unsupported with current or clearer reasons.
- Mark summary rules modified so frame generation suppresses identity equations for Shape A targets.
- Unskip Shape A and unsupported-diagnostics tests.

## Changes
- Build one foreach-shape-a summary per quantified property write produced by a supported foreach body.
- Lower each Shape A summary to an equation guarded by ast.gIn(binder, source), with the same primed property lhs and rhs as current lowerForeach output.
- Represent supported in-iteration read-after-write data explicitly in summary inputs before lowering, avoiding an ad hoc makeSymbolicState subState for Shape A.
- Keep collection mutation inside foreach and nested proposition-emitting foreach bodies unsupported with current or clearer reasons.
- Mark summary rules modified so frame generation suppresses identity equations for Shape A targets.
- Unskip Shape A and unsupported-diagnostics tests.

## Files to Modify
- tools/ts2pant/src/ir1-ssa-loops.ts (modify): Implement foreach Shape A summary construction and quantified equation lowering.
- tools/ts2pant/src/ir1-lower-body.ts (modify): Replace Shape A subState-based quantified write emission with loop-summary lowering for supported foreach bodies.
- tools/ts2pant/tests/ir1-ssa-loops.test.mts (modify): Unskip and implement Shape A routing and diagnostics tests.
- tools/ts2pant/tests/translate-body.test.mts (modify): Keep Shape A foreach/forEach fixture parity covered.

## Gameplan Specification

```
module IR1_SSA_LOOP_SUMMARIES.

Program.
Construct.
Location.
Version.
Read.
LoopSummary.
Shape.
Rule.
PropResult.
Diagnostic.
Expr.

mu-search => Shape.
foreach-shape-a => Shape.
foreach-shape-b => Shape.
supported-constructs p: Program => [Construct].
lowered-constructs p: Program => [Construct].
diagnostics p: Program => [Diagnostic].
diagnostic-construct d: Diagnostic => Construct.
mu-search? c: Construct => Bool.
foreach-shape-a? c: Construct => Bool.
foreach-shape-b? c: Construct => Bool.
general-loop? c: Construct => Bool.
loop-summaries p: Program => [LoopSummary].
summary-shape s: LoopSummary => Shape.
summary-location s: LoopSummary => Location.
summary-version s: LoopSummary => Version.
version-location v: Version => Location.
reads p: Program => [Read].
read-location r: Read => Location.
read-version r: Read => Version.
read-dominated? p: Program, r: Read => Bool.
rule-of-location l: Location => Rule.
declared-rules p: Program => [Rule].
modified-rules p: Program => [Rule].
framed-rules p: Program => [Rule].
emitted-props p: Program => [PropResult].
lowered-expr p: Program => [Expr].
min-over-each? e: Expr => Bool.
quantified-write? pr: PropResult => Bool.
accumulator-fold? pr: PropResult => Bool.

---

all p: Program, c in supported-constructs p |
  (mu-search? c or foreach-shape-a? c or foreach-shape-b? c) -> c in lowered-constructs p.

all p: Program, c in supported-constructs p |
  ~(general-loop? c).

all p: Program, d in diagnostics p |
  ~(diagnostic-construct d in supported-constructs p).

all p: Program, s in loop-summaries p |
  version-location (summary-version s) = summary-location s and
  rule-of-location (summary-location s) in modified-rules p.

all p: Program, s in loop-summaries p |
  summary-shape s = mu-search or
  summary-shape s = foreach-shape-a or
  summary-shape s = foreach-shape-b.

all p: Program, s1 in loop-summaries p, s2 in loop-summaries p |
  summary-version s1 = summary-version s2 -> s1 = s2.

all p: Program, r in reads p |
  read-dominated? p r and
  version-location (read-version r) = read-location r and
  (
    (some s in loop-summaries p |
      summary-version s = read-version r and
      summary-location s = read-location r) or
    ~(some s in loop-summaries p | summary-location s = read-location r)
  ).

all p: Program, c in supported-constructs p |
  mu-search? c ->
    (some s in loop-summaries p | summary-shape s = mu-search) and
    (some e in lowered-expr p | min-over-each? e).

all p: Program, c in supported-constructs p |
  foreach-shape-a? c ->
    (some s in loop-summaries p | summary-shape s = foreach-shape-a) and
    (some pr in emitted-props p | quantified-write? pr).

all p: Program, c in supported-constructs p |
  foreach-shape-b? c ->
    (some s in loop-summaries p | summary-shape s = foreach-shape-b) and
    (some pr in emitted-props p | accumulator-fold? pr).

all p: Program, rule in modified-rules p |
  rule in declared-rules p and ~(rule in framed-rules p).

all p: Program, rule in framed-rules p |
  rule in declared-rules p and ~(rule in modified-rules p).

all p: Program, rule in declared-rules p |
  rule in modified-rules p or rule in framed-rules p.

all p: Program |
  #(lowered-constructs p) > 0 -> (#(emitted-props p) > 0 or #(lowered-expr p) > 0).

```

## Patch Specification

```
module IR1_SSA_LOOP_SUMMARIES_PATCH_4.

Program.
Construct.
Location.
Version.
LoopSummary.
Shape.
Rule.
PropResult.

foreach-shape-a => Shape.
supported-constructs p: Program => [Construct].
lowered-constructs p: Program => [Construct].
foreach-shape-a? c: Construct => Bool.
loop-summaries p: Program => [LoopSummary].
summary-shape s: LoopSummary => Shape.
summary-location s: LoopSummary => Location.
summary-version s: LoopSummary => Version.
version-location v: Version => Location.
rule-of-location l: Location => Rule.
modified-rules p: Program => [Rule].
emitted-props p: Program => [PropResult].
quantified-write? pr: PropResult => Bool.

---

all p: Program, c in supported-constructs p |
  foreach-shape-a? c -> c in lowered-constructs p.

all p: Program, s in loop-summaries p |
  summary-shape s = foreach-shape-a ->
    version-location (summary-version s) = summary-location s and
    rule-of-location (summary-location s) in modified-rules p.

all p: Program, c in supported-constructs p |
  foreach-shape-a? c ->
    (some s in loop-summaries p | summary-shape s = foreach-shape-a) and
    (some pr in emitted-props p | quantified-write? pr).

```


## Implementation Notes

- Shape A now uses a small summary-local property state rather than `SymbolicState`; it tracks only per-iteration property writes plus explicit initial property values copied from the outer state for reads that happened before the loop.
- Conditional Shape A writes are merged inside the helper with the same `cond guard => write, true => fallback` shape as the old substate path, so existing output parity stays intact while still creating loop-summary versions.
- The helper preserves the previous nested proposition-emitting diagnostic text for hand-built unsupported IR, because existing lower-level tests assert that boundary explicitly.
- Local full `npm test` still requires a Pant binary and OCaml deps not present in this environment; verification used an existing `PANT_BIN` from a sibling worktree for integration tests.