### PR TITLE
[ir1-ssa-loop-summaries] Patch 5: Route foreach Shape B through loop summaries

### DIFF
--- a/tools/ts2pant/src/ir1-lower-body.ts
+++ b/tools/ts2pant/src/ir1-lower-body.ts
@@ -25,13 +25,17 @@
  */
 
 import { lowerBinop, lowerExpr } from "./ir-emit.js";
-import type { IR1Expr, IR1FoldLeaf, IR1Stmt } from "./ir1.js";
+import type { IR1Expr, IR1Stmt } from "./ir1.js";
 import { lowerL1Expr } from "./ir1-lower.js";
 import {
   isCollectionSsaL1Body,
   lowerCollectionSsaToProps,
 } from "./ir1-ssa-collections.js";
-import { lowerForeachShapeASummaries } from "./ir1-ssa-loops.js";
+import {
+  foreachShapeBAccumulatorKey,
+  lowerForeachShapeASummaries,
+  lowerForeachShapeBSummaries,
+} from "./ir1-ssa-loops.js";
 import { isScalarSsaL1Body, lowerScalarSsaToProps } from "./ir1-ssa-scalars.js";
 import type { OpaqueExpr } from "./pant-ast.js";
 import { getAst } from "./pant-wasm.js";
@@ -636,14 +640,60 @@ function lowerForeach(
     }
   }
 
-  // Shape B: Each fold leaf becomes one accumulator equation
-  //   prop' target = prior outerOp (combOP over each binder in src[, guard] | rhs)
-  // The leaf carries pre-translated `target`, `rhs`, `guard` (with `rhs`/
-  // `guard` already observing in-iter Shape A writes via the build-time
-  // subState).
-  for (const leaf of stmt.foldLeaves) {
-    if (!lowerFoldLeaf(leaf, stmt.binder, arrExpr, state, propositions, ctx)) {
+  // Shape B: summarize each fold leaf as an accumulator equation with
+  // the prior accumulator value supplied explicitly to the helper.
+  if (stmt.foldLeaves.length > 0) {
+    const priorAccumulatorValues = new Map<string, OpaqueExpr>();
+    for (const leaf of stmt.foldLeaves) {
+      const target = ctx.applyConst(lowerL1ExprToOpaque(leaf.target, state));
+      const key = foreachShapeBAccumulatorKey(leaf.prop, target);
+      const priorEntry = state.writes.get(key);
+      if (priorEntry !== undefined && priorEntry.kind !== "property") {
+        propositions.push({
+          kind: "unsupported",
+          reason: "loop-fold accumulator over a non-property prior write",
+        });
+        return false;
+      }
+      priorAccumulatorValues.set(
+        key,
+        priorEntry?.value ?? getAst().app(getAst().var(leaf.prop), [target]),
+      );
+    }
+
+    const result = lowerForeachShapeBSummaries({
+      binder: stmt.binder,
+      source: arrExpr,
+      foldLeaves: stmt.foldLeaves,
+      lowerExpr: (expr) => ctx.applyConst(lowerL1ExprToOpaque(expr, state)),
+      priorAccumulatorValues,
+    });
+    if (result.diagnostics.length > 0) {
+      propositions.push(...result.diagnostics);
       return false;
+    }
+    for (const rule of result.modifiedRules) {
+      state.modifiedProps = addModifiedProp(state.modifiedProps, rule);
+    }
+    for (let i = 0; i < stmt.foldLeaves.length; i++) {
+      const leaf = stmt.foldLeaves[i]!;
+      const prop = result.propositions[i];
+      if (prop?.kind !== "equation") {
+        propositions.push({
+          kind: "unsupported",
+          reason: "foreach Shape B summary did not lower to an equation",
+        });
+        return false;
+      }
+      const target = ctx.applyConst(lowerL1ExprToOpaque(leaf.target, state));
+      const key = foreachShapeBAccumulatorKey(leaf.prop, target);
+      state.writes = putWrite(state.writes, key, {
+        kind: "property",
+        prop: leaf.prop,
+        objExpr: target,
+        value: prop.rhs,
+      });
+      state.writtenKeys = addWrittenKey(state.writtenKeys, key);
     }
   }
   return true;
@@ -659,65 +709,6 @@ function shapeAInitialPropertyValues(
     }
   }
   return initialValues;
-}
-
-function lowerFoldLeaf(
-  leaf: IR1FoldLeaf,
-  binder: string,
-  arrExpr: OpaqueExpr,
-  state: SymbolicState,
-  propositions: PropResult[],
-  ctx: LowerBodyCtx,
-): boolean {
-  const ast = getAst();
-  const target = ctx.applyConst(lowerL1ExprToOpaque(leaf.target, state));
-  const rhs = ctx.applyConst(lowerL1ExprToOpaque(leaf.rhs, state));
-  const guards = [ast.gIn(binder, arrExpr)];
-  if (leaf.guard !== null) {
-    guards.push(
-      ast.gExpr(ctx.applyConst(lowerL1ExprToOpaque(leaf.guard, state))),
-    );
-  }
-  const comb =
-    leaf.combiner === "add"
-      ? ast.combAdd()
-      : leaf.combiner === "mul"
-        ? ast.combMul()
-        : leaf.combiner === "and"
-          ? ast.combAnd()
-          : ast.combOr();
-  const folded = ast.eachComb([], guards, comb, rhs);
-
-  const outerOp = lowerBinop(leaf.outerOp);
-  const key = symbolicKey(leaf.prop, target);
-  const priorEntry = state.writes.get(key);
-  if (priorEntry !== undefined && priorEntry.kind !== "property") {
-    propositions.push({
-      kind: "unsupported",
-      reason: "loop-fold accumulator over a non-property prior write",
-    });
-    return false;
-  }
-  const priorVal = priorEntry?.value ?? ast.app(ast.var(leaf.prop), [target]);
-  const newVal = ast.binop(outerOp, priorVal, folded);
-
-  state.writes = putWrite(state.writes, key, {
-    kind: "property",
-    prop: leaf.prop,
-    objExpr: target,
-    value: newVal,
-  });
-  state.writtenKeys = addWrittenKey(state.writtenKeys, key);
-  // Mirror `lowerForeach`'s Shape A path so Shape B accumulator folds
-  // also flag their target rule as modified. The downstream
-  // `state.writes` → equation emission loop in `symbolicExecute` adds
-  // the same prop to `modifiedProps` after `lowerL1Body` returns, so
-  // this is idempotent in the standard top-level flow — but updating
-  // here prevents a future refactor from inadvertently letting an
-  // identity equation slip through `generateFrameConditions` for the
-  // accumulator rule.
-  state.modifiedProps = addModifiedProp(state.modifiedProps, leaf.prop);
-  return true;
 }
 
 function lowerCondStmt(

--- a/tools/ts2pant/src/ir1-ssa-loops.ts
+++ b/tools/ts2pant/src/ir1-ssa-loops.ts
@@ -1,6 +1,7 @@
 import { lowerBinop, lowerExpr } from "./ir-emit.js";
 import {
   type IR1Expr,
+  type IR1FoldLeaf,
   type IR1ForeachBody,
   type IR1SsaLocation,
   type IR1SsaLoopSummary,
@@ -65,6 +66,14 @@ export interface ForeachShapeASummaryOptions extends LoopSsaBuildOptions {
   initialPropertyValues?: ReadonlyMap<string, OpaqueExpr>;
 }
 
+export interface ForeachShapeBSummaryOptions extends LoopSsaBuildOptions {
+  binder: string;
+  source: OpaqueExpr;
+  foldLeaves: readonly IR1FoldLeaf[];
+  lowerExpr?: (e: IR1Expr) => OpaqueExpr;
+  priorAccumulatorValues?: ReadonlyMap<string, OpaqueExpr>;
+}
+
 export interface ForeachSummaryLowerResult {
   program: IR1SsaProgram;
   summary: IR1SsaLoopSummary | null;
@@ -79,6 +88,15 @@ export interface ForeachShapeASummaryResult {
   propositions: PropResult[];
   modifiedRules: IR1SsaRuleName[];
   diagnostics: UnsupportedDiagnostic[];
+}
+
+export interface ForeachShapeBSummaryResult {
+  program: IR1SsaProgram;
+  summaries: IR1SsaLoopSummary[];
+  propositions: PropResult[];
+  modifiedRules: IR1SsaRuleName[];
+  diagnostics: UnsupportedDiagnostic[];
+  accumulatorKeys: string[];
 }
 
 export interface LoopSsaBuildResult {
@@ -217,6 +235,61 @@ export function lowerForeachShapeASummaries(
     propositions: result.propositions,
     modifiedRules: result.program.modifiedRules,
     diagnostics: result.diagnostics,
+  };
+}
+
+export function lowerForeachShapeBSummaries(
+  options: ForeachShapeBSummaryOptions,
+): ForeachShapeBSummaryResult {
+  const ast = getAst();
+  const lower = options.lowerExpr ?? ((e) => lowerExpr(lowerL1Expr(e)));
+  const accumulatorKeys: string[] = [];
+  const inputs: ForeachShapeBSummaryInput[] = options.foldLeaves.map((leaf) => {
+    const target = lower(leaf.target);
+    const rhs = lower(leaf.rhs);
+    const guards = [ast.gIn(options.binder, options.source)];
+    if (leaf.guard !== null) {
+      guards.push(ast.gExpr(lower(leaf.guard)));
+    }
+
+    const comb =
+      leaf.combiner === "add"
+        ? ast.combAdd()
+        : leaf.combiner === "mul"
+          ? ast.combMul()
+          : leaf.combiner === "and"
+            ? ast.combAnd()
+            : ast.combOr();
+    const folded = ast.eachComb([], guards, comb, rhs);
+    const key = foreachShapeBAccumulatorKey(leaf.prop, target);
+    accumulatorKeys.push(key);
+    const prior =
+      options.priorAccumulatorValues?.get(key) ??
+      ast.app(ast.var(leaf.prop), [target]);
+
+    const location = ir1SsaPropertyLocation(leaf.prop, leaf.target, leaf.prop);
+    return {
+      kind: "foreach-shape-b",
+      location,
+      propositions: [
+        {
+          kind: "equation",
+          quantifiers: [],
+          lhs: ast.app(ast.primed(leaf.prop), [target]),
+          rhs: ast.binop(lowerBinop(leaf.outerOp), prior, folded),
+        },
+      ],
+    };
+  });
+
+  const result = buildLoopSsaProgram(inputs, options);
+  return {
+    program: result.program,
+    summaries: result.program.loopSummaries,
+    propositions: result.propositions,
+    modifiedRules: result.program.modifiedRules,
+    diagnostics: result.diagnostics,
+    accumulatorKeys,
   };
 }
 
@@ -437,5 +510,12 @@ function lowerShapeAExpr(expr: IR1Expr, state: ShapeASummaryState): OpaqueExpr {
 }
 
 function shapeAKey(prop: string, objExpr: OpaqueExpr): string {
+  return `${prop}::${getAst().strExpr(objExpr)}`;
+}
+
+export function foreachShapeBAccumulatorKey(
+  prop: string,
+  objExpr: OpaqueExpr,
+): string {
   return `${prop}::${getAst().strExpr(objExpr)}`;
 }

--- a/tools/ts2pant/tests/ir1-ssa-loops.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-loops.test.mts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
+import { resolve } from "node:path";
 import { before, describe, it } from "node:test";
 
+import { createSourceFile } from "../src/extract.js";
 import {
   ir1Assign,
   ir1Binop,
@@ -14,9 +16,15 @@ import {
 import {
   buildLoopSsaProgram,
   lowerForeachShapeASummaries,
+  lowerForeachShapeBSummaries,
   lowerForeachSummary,
 } from "../src/ir1-ssa-loops.js";
-import { getAst, loadAst } from "../src/pant-wasm.js";
+import { assertWasmTypeChecks, getAst, loadAst } from "../src/pant-wasm.js";
+import {
+  buildDocumentFromSourceFile,
+  containsUnsupportedLine,
+  emitDocument,
+} from "./helpers.mjs";
 
 before(async () => {
   await loadAst();
@@ -80,31 +88,47 @@ describe("ir1-ssa-loops", () => {
   });
 
   it("records foreach Shape B accumulator folds as loop summaries", () => {
-    const location = ir1SsaPropertyLocation(
-      "Account_total",
-      ir1Var("account"),
-      "total",
-    );
-    const proposition = { kind: "raw" as const, text: "accumulator-fold" };
-
-    const result = lowerForeachSummary({
-      input: {
-        kind: "foreach-shape-b",
-        location,
-        propositions: [proposition],
-      },
+    const ast = getAst();
+    const account = ir1Var("account");
+    const item = ir1Var("$item");
+    const value = ir1Member(item, "Item_value");
+    const result = lowerForeachShapeBSummaries({
+      binder: "$item",
+      source: ast.var("items"),
+      foldLeaves: [
+        {
+          target: account,
+          prop: "Account_total",
+          combiner: "add",
+          outerOp: "add",
+          rhs: value,
+          guard: ir1Binop("gt", value, ir1LitNat(0)),
+        },
+      ],
+      priorAccumulatorValues: new Map([
+        ["Account_total::account", ast.litNat(10)],
+      ]),
       declaredRules: ["Account_limit"],
     });
 
     assert.deepEqual(result.diagnostics, []);
-    assert.equal(result.summary?.shape, "foreach-shape-b");
-    assert.equal(result.summary?.location, location);
-    assert.equal(result.summary?.summaryVersion.origin, "loop-summary");
-    assert.equal(result.summary?.summaryVersion.location, location);
-    assert.deepEqual(result.propositions, [proposition]);
-    assert.deepEqual(result.program.modifiedRules, [
-      ir1SsaRuleOfLocation(location),
-    ]);
+    assert.equal(result.summaries.length, 1);
+    const [summary] = result.summaries;
+    assert.equal(summary!.shape, "foreach-shape-b");
+    assert.equal(summary!.location.ruleName, "Account_total");
+    assert.equal(summary!.summaryVersion.origin, "loop-summary");
+    assert.equal(summary!.summaryVersion.location, summary!.location);
+    assert.equal(result.propositions.length, 1);
+    const [prop] = result.propositions;
+    assert.equal(prop!.kind, "equation");
+    if (prop?.kind === "equation") {
+      assert.equal(ast.strExpr(prop.lhs), "Account_total' account");
+      assert.match(
+        ast.strExpr(prop.rhs),
+        /^10 \+ \(\+ over each \$item in items, Item_value \$item > 0 \| Item_value \$item\)$/u,
+      );
+    }
+    assert.deepEqual(result.program.modifiedRules, ["Account_total"]);
     assert.deepEqual(
       new Set(result.program.declaredRules),
       new Set(["Account_total", "Account_limit"]),
@@ -237,12 +261,55 @@ describe("ir1-ssa-loops", () => {
     );
   });
 
-  it.skip("preserves production parity for foreach and mu-search fixtures", async () => {
-    // PENDING Patch 4: pin parity for `functions-mutating-loop.ts`
-    // (for example `forEachActivate`, `forEachSum`, or `mixedUpdates`) once
-    // foreach lowering routes through the loop-summary helper.
-    // PENDING Patch 3: pin parity for `expressions-while-mu-search.ts`
-    // (for example `firstUnusedSuffix`) once mu-search lowering routes through
-    // the loop-summary helper.
+  it("preserves production parity for foreach and mu-search fixtures", async () => {
+    const constructsDir = resolve(import.meta.dirname, "fixtures/constructs");
+    const cases = [
+      {
+        file: "functions-mutating-loop.ts",
+        functionName: "sumAmounts",
+        expected:
+          /account--total' a = account--total a \+ \(\+ over each \w+ in items \| item--value \w+\)\./u,
+      },
+      {
+        file: "functions-mutating-loop.ts",
+        functionName: "sumPositive",
+        expected:
+          /account--total' a = account--total a \+ \(\+ over each \w+ in items, item--value \w+ > 0 \| item--value \w+\)\./u,
+      },
+      {
+        file: "functions-mutating-loop.ts",
+        functionName: "mixedUpdates",
+        expected: /item--tagged' \w+ = true\./u,
+      },
+      {
+        file: "functions-mutating-loop.ts",
+        functionName: "forEachSum",
+        expected:
+          /account--total' a = account--total a \+ \(\+ over each \w+ in items \| item--value \w+\)\./u,
+      },
+      {
+        file: "functions-mutating-loop.ts",
+        functionName: "sumIntoAnon",
+        expected:
+          /total-rec--total' acc = total-rec--total acc \+ \(\+ over each \w+ in items \| \w+\)\./u,
+      },
+      {
+        file: "expressions-while-mu-search.ts",
+        functionName: "firstUnusedSuffix",
+        expected: /min over each/u,
+      },
+    ];
+
+    for (const { file, functionName, expected } of cases) {
+      const sourceFile = createSourceFile(resolve(constructsDir, file));
+      const doc = await buildDocumentFromSourceFile(sourceFile, functionName);
+      const output = emitDocument(doc);
+      assert.ok(
+        !containsUnsupportedLine(output),
+        `${file} > ${functionName} should stay supported`,
+      );
+      assert.match(output, expected, `${file} > ${functionName}`);
+      await assertWasmTypeChecks(output, doc.bundleModules);
+    }
   });
 });


### PR DESCRIPTION
## Patch 5: Route foreach Shape B through loop summaries

- Build one foreach-shape-b summary per IR1FoldLeaf and ensure each summary version is distinct from ordinary scalar writes.
- Lower each Shape B summary to prop' target = prior outerOp (comb over each binder in source and optional guard | rhs), preserving current combiner and outerOp behavior.
- Thread prior accumulator values through explicit summary inputs rather than reading and writing state.writes inside lowerFoldLeaf.
- Support mixed Shape A + Shape B foreach by emitting both summary families and marking all summary rules modified.
- Preserve for-of and .forEach fixture parity, including guarded folds and anonymous record accumulator rules.
- Unskip Shape B and production parity tests.

## Changes
- Build one foreach-shape-b summary per IR1FoldLeaf and ensure each summary version is distinct from ordinary scalar writes.
- Lower each Shape B summary to prop' target = prior outerOp (comb over each binder in source and optional guard | rhs), preserving current combiner and outerOp behavior.
- Thread prior accumulator values through explicit summary inputs rather than reading and writing state.writes inside lowerFoldLeaf.
- Support mixed Shape A + Shape B foreach by emitting both summary families and marking all summary rules modified.
- Preserve for-of and .forEach fixture parity, including guarded folds and anonymous record accumulator rules.
- Unskip Shape B and production parity tests.

## Files to Modify
- tools/ts2pant/src/ir1-ssa-loops.ts (modify): Implement foreach Shape B accumulator summary construction, fold lowering, and mixed Shape A/B summary composition.
- tools/ts2pant/src/ir1-lower-body.ts (modify): Replace lowerFoldLeaf direct outer-state mutation with foreach-shape-b summary lowering.
- tools/ts2pant/tests/ir1-ssa-loops.test.mts (modify): Unskip and implement Shape B and production fixture parity tests.
- tools/ts2pant/tests/constructs.test.mts.snapshot (modify): Update snapshots only if output ordering changes; emitted semantics must remain wasm-checkable.

## Gameplan Specification

```
module IR1_SSA_LOOP_SUMMARIES.

Program.
Construct.
Location.
Version.
Read.
LoopSummary.
Shape.
Rule.
PropResult.
Diagnostic.
Expr.

mu-search => Shape.
foreach-shape-a => Shape.
foreach-shape-b => Shape.
supported-constructs p: Program => [Construct].
lowered-constructs p: Program => [Construct].
diagnostics p: Program => [Diagnostic].
diagnostic-construct d: Diagnostic => Construct.
mu-search? c: Construct => Bool.
foreach-shape-a? c: Construct => Bool.
foreach-shape-b? c: Construct => Bool.
general-loop? c: Construct => Bool.
loop-summaries p: Program => [LoopSummary].
summary-shape s: LoopSummary => Shape.
summary-location s: LoopSummary => Location.
summary-version s: LoopSummary => Version.
version-location v: Version => Location.
reads p: Program => [Read].
read-location r: Read => Location.
read-version r: Read => Version.
read-dominated? p: Program, r: Read => Bool.
rule-of-location l: Location => Rule.
declared-rules p: Program => [Rule].
modified-rules p: Program => [Rule].
framed-rules p: Program => [Rule].
emitted-props p: Program => [PropResult].
lowered-expr p: Program => [Expr].
min-over-each? e: Expr => Bool.
quantified-write? pr: PropResult => Bool.
accumulator-fold? pr: PropResult => Bool.

---

all p: Program, c in supported-constructs p |
  (mu-search? c or foreach-shape-a? c or foreach-shape-b? c) -> c in lowered-constructs p.

all p: Program, c in supported-constructs p |
  ~(general-loop? c).

all p: Program, d in diagnostics p |
  ~(diagnostic-construct d in supported-constructs p).

all p: Program, s in loop-summaries p |
  version-location (summary-version s) = summary-location s and
  rule-of-location (summary-location s) in modified-rules p.

all p: Program, s in loop-summaries p |
  summary-shape s = mu-search or
  summary-shape s = foreach-shape-a or
  summary-shape s = foreach-shape-b.

all p: Program, s1 in loop-summaries p, s2 in loop-summaries p |
  summary-version s1 = summary-version s2 -> s1 = s2.

all p: Program, r in reads p |
  read-dominated? p r and
  version-location (read-version r) = read-location r and
  (
    (some s in loop-summaries p |
      summary-version s = read-version r and
      summary-location s = read-location r) or
    ~(some s in loop-summaries p | summary-location s = read-location r)
  ).

all p: Program, c in supported-constructs p |
  mu-search? c ->
    (some s in loop-summaries p | summary-shape s = mu-search) and
    (some e in lowered-expr p | min-over-each? e).

all p: Program, c in supported-constructs p |
  foreach-shape-a? c ->
    (some s in loop-summaries p | summary-shape s = foreach-shape-a) and
    (some pr in emitted-props p | quantified-write? pr).

all p: Program, c in supported-constructs p |
  foreach-shape-b? c ->
    (some s in loop-summaries p | summary-shape s = foreach-shape-b) and
    (some pr in emitted-props p | accumulator-fold? pr).

all p: Program, rule in modified-rules p |
  rule in declared-rules p and ~(rule in framed-rules p).

all p: Program, rule in framed-rules p |
  rule in declared-rules p and ~(rule in modified-rules p).

all p: Program, rule in declared-rules p |
  rule in modified-rules p or rule in framed-rules p.

all p: Program |
  #(lowered-constructs p) > 0 -> (#(emitted-props p) > 0 or #(lowered-expr p) > 0).

```

## Patch Specification

```
module IR1_SSA_LOOP_SUMMARIES_PATCH_5.

Program.
Construct.
Location.
Version.
LoopSummary.
Shape.
Rule.
PropResult.

foreach-shape-b => Shape.
supported-constructs p: Program => [Construct].
lowered-constructs p: Program => [Construct].
foreach-shape-b? c: Construct => Bool.
loop-summaries p: Program => [LoopSummary].
summary-shape s: LoopSummary => Shape.
summary-location s: LoopSummary => Location.
summary-version s: LoopSummary => Version.
version-location v: Version => Location.
rule-of-location l: Location => Rule.
modified-rules p: Program => [Rule].
emitted-props p: Program => [PropResult].
accumulator-fold? pr: PropResult => Bool.

---

all p: Program, c in supported-constructs p |
  foreach-shape-b? c -> c in lowered-constructs p.

all p: Program, s in loop-summaries p |
  summary-shape s = foreach-shape-b ->
    version-location (summary-version s) = summary-location s and
    rule-of-location (summary-location s) in modified-rules p.

all p: Program, c in supported-constructs p |
  foreach-shape-b? c ->
    (some s in loop-summaries p | summary-shape s = foreach-shape-b) and
    (some pr in emitted-props p | accumulator-fold? pr).

```


## Implementation Notes

- Production lowering still stages the Shape B summary result back into the symbolic write state after constructing it through the helper. That preserves post-loop read behavior and branch merge behavior while avoiding the old `lowerFoldLeaf` path that computed the fold directly from `state.writes`.
- The helper returns emitted accumulator equations for helper-level/spec coverage; the production path uses those equations as the source of truth for the staged accumulator value, so final Pant output stays byte-compatible with existing fixture snapshots.
- Prior accumulator values are collected once before Shape B summary construction and passed into the helper explicitly. The only remaining `state.writes` access in foreach Shape B routing is this outer prior collection plus normal symbolic-state staging after summary lowering.
- The integration suite was attempted, but dogfood/e2e checks require the external `pant` binary at `_build/default/bin/main.exe` or `PANT_BIN`; that binary was not present in this worktree. Unit, focused loop/body tests, and construct snapshots passed.