### PR TITLE
[ts2pant-ir1-ssa-propresult-lowering] Patch 1: Add pending unified SSA lowering tests

### DIFF
--- a/tools/ts2pant/tests/ir1-ssa-propresult-lowering.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-propresult-lowering.test.mts
@@ -1,0 +1,277 @@
+import assert from "node:assert/strict";
+import { before, describe, it } from "node:test";
+
+import {
+  ir1Assign,
+  ir1Block,
+  ir1LitNat,
+  ir1MapDelete,
+  ir1MapSet,
+  ir1Member,
+  ir1SetAddOrDelete,
+  ir1SetClear,
+  ir1SsaPropertyLocation,
+  ir1Var,
+} from "../src/ir1.js";
+import { lowerCollectionSsaToResult } from "../src/ir1-ssa-collections.js";
+import { lowerForeachSummary } from "../src/ir1-ssa-loops.js";
+import { lowerScalarSsaToProps } from "../src/ir1-ssa-scalars.js";
+import { getAst, loadAst } from "../src/pant-wasm.js";
+import type { PropResult } from "../src/types.js";
+
+type UnsupportedDiagnostic = Extract<PropResult, { kind: "unsupported" }>;
+
+interface PendingUnifiedLowerResult {
+  propositions: PropResult[];
+  modifiedRules: string[];
+  framedRules: string[];
+  diagnostics: UnsupportedDiagnostic[];
+}
+
+function pendingUnifiedLowerResult(input: {
+  declaredRules?: readonly string[];
+  propositions?: readonly PropResult[];
+  modifiedRules?: readonly string[];
+  diagnostics?: readonly UnsupportedDiagnostic[];
+}): PendingUnifiedLowerResult {
+  const diagnostics = [...(input.diagnostics ?? [])];
+  const modifiedRules = [...new Set(input.modifiedRules ?? [])];
+  const declaredRules = [...new Set(input.declaredRules ?? [])];
+  const modifiedRuleSet = new Set(modifiedRules);
+  const framedRules =
+    diagnostics.length > 0
+      ? []
+      : declaredRules.filter((rule) => !modifiedRuleSet.has(rule));
+  return {
+    propositions: [...(input.propositions ?? [])],
+    modifiedRules,
+    framedRules,
+    diagnostics,
+  };
+}
+
+function findEquation(
+  propositions: readonly PropResult[],
+  prefix: string,
+): Extract<PropResult, { kind: "equation" }> | undefined {
+  const ast = getAst();
+  return propositions.find(
+    (p): p is Extract<PropResult, { kind: "equation" }> =>
+      p.kind === "equation" && ast.strExpr(p.lhs).startsWith(prefix),
+  );
+}
+
+before(async () => {
+  await loadAst();
+});
+
+describe("ir1-ssa-propresult-lowering", () => {
+  it.skip("scalar properties lower through one result", () => {
+    const balance = ir1Member(ir1Var("a"), "Account_balance");
+    const scalar = lowerScalarSsaToProps(
+      ir1Block([
+        ir1Assign(balance, ir1LitNat(1)),
+        ir1Assign(balance, ir1LitNat(3)),
+      ]),
+      { declaredRules: ["Account_balance", "Account_limit"] },
+    );
+    const result = pendingUnifiedLowerResult({
+      declaredRules: scalar.program.declaredRules,
+      propositions: scalar.propositions,
+      modifiedRules: scalar.modifiedRules,
+      diagnostics: scalar.diagnostics,
+    });
+    const ast = getAst();
+    const equation = findEquation(result.propositions, "Account_balance'");
+
+    assert.deepEqual(result.diagnostics, []);
+    assert.deepEqual(result.modifiedRules, ["Account_balance"]);
+    assert.deepEqual(result.framedRules, ["Account_limit"]);
+    assert.equal(scalar.finalProperties.length, 1);
+    assert.ok(equation, "expected the unified result to carry the final write");
+    if (equation !== undefined) {
+      assert.equal(ast.strExpr(equation.lhs), "Account_balance' a");
+      assert.equal(ast.strExpr(equation.rhs), "3");
+    }
+  });
+
+  it.skip(
+    "collections lower value and membership props through one result",
+    () => {
+      const stmt = ir1Block([
+        ir1MapSet(
+          "Cache_value",
+          "Cache_hasKey",
+          "Owner",
+          "Key",
+          ir1Var("cache"),
+          ir1Var("key"),
+          ir1LitNat(7),
+        ),
+        ir1MapDelete(
+          "Cache_value",
+          "Cache_hasKey",
+          "Owner",
+          "Key",
+          ir1Var("cache"),
+          ir1Var("otherKey"),
+        ),
+        ir1SetAddOrDelete(
+          "add",
+          "Owner_tags",
+          "Owner",
+          "Tag",
+          ir1Var("owner"),
+          ir1Var("x"),
+        ),
+        ir1SetAddOrDelete(
+          "delete",
+          "Owner_tags",
+          "Owner",
+          "Tag",
+          ir1Var("owner"),
+          ir1Var("x"),
+        ),
+        ir1SetClear("Owner_tags", "Owner", "Tag", ir1Var("owner")),
+        ir1SetAddOrDelete(
+          "add",
+          "Owner_tags",
+          "Owner",
+          "Tag",
+          ir1Var("owner"),
+          ir1Var("y"),
+        ),
+      ]);
+
+      const lowered = lowerCollectionSsaToResult(stmt, {
+        declaredRules: ["Owner_name"],
+      });
+      const result = pendingUnifiedLowerResult({
+        declaredRules: lowered.program.declaredRules,
+        propositions: lowered.propositions,
+        modifiedRules: lowered.modifiedRules,
+        diagnostics: lowered.diagnostics,
+      });
+      const ast = getAst();
+      const valueEq = findEquation(result.propositions, "Cache_value'");
+      const membershipEq = findEquation(result.propositions, "Cache_hasKey'");
+      const setAssertion = result.propositions.find(
+        (p): p is Extract<PropResult, { kind: "assertion" }> =>
+          p.kind === "assertion",
+      );
+
+      assert.deepEqual(result.diagnostics, []);
+      assert.deepEqual(
+        new Set(result.modifiedRules),
+        new Set(["Cache_value", "Cache_hasKey", "Owner_tags"]),
+      );
+      assert.deepEqual(result.framedRules, ["Owner_name"]);
+      assert.ok(valueEq, "expected a final Map value proposition");
+      assert.ok(membershipEq, "expected a final Map membership proposition");
+      assert.ok(setAssertion, "expected a final Set membership proposition");
+      if (valueEq !== undefined) {
+        assert.match(ast.strExpr(valueEq.rhs), /Cache_value.*->\s*7/u);
+      }
+      if (membershipEq !== undefined) {
+        assert.match(ast.strExpr(membershipEq.rhs), /Cache_hasKey.*->\s*true/u);
+        assert.match(ast.strExpr(membershipEq.rhs), /Cache_hasKey.*->\s*false/u);
+      }
+      if (setAssertion !== undefined) {
+        assert.equal(
+          ast.strExpr(setAssertion.body),
+          "y1 in Owner_tags' owner <-> (cond y1 = y => true, true => false)",
+        );
+      }
+    },
+  );
+
+  it.skip(
+    "loop summaries report propositions and modified rules through one result",
+    () => {
+      const shapeA = lowerForeachSummary({
+        input: {
+          kind: "foreach-shape-a",
+          location: ir1SsaPropertyLocation(
+            "Item_seen",
+            ir1Var("$item"),
+            "seen",
+          ),
+          propositions: [{ kind: "raw", text: "quantified-write" }],
+        },
+      });
+      const shapeB = lowerForeachSummary({
+        input: {
+          kind: "foreach-shape-b",
+          location: ir1SsaPropertyLocation(
+            "Account_total",
+            ir1Var("account"),
+            "total",
+          ),
+          propositions: [{ kind: "raw", text: "accumulator-fold" }],
+        },
+        declaredRules: ["Account_limit"],
+      });
+      const result = pendingUnifiedLowerResult({
+        declaredRules: [
+          ...shapeA.program.declaredRules,
+          ...shapeB.program.declaredRules,
+        ],
+        propositions: [...shapeA.propositions, ...shapeB.propositions],
+        modifiedRules: [...shapeA.modifiedRules, ...shapeB.modifiedRules],
+        diagnostics: [...shapeA.diagnostics, ...shapeB.diagnostics],
+      });
+
+      assert.deepEqual(result.diagnostics, []);
+      assert.deepEqual(
+        [shapeA.summary?.shape, shapeB.summary?.shape],
+        ["foreach-shape-a", "foreach-shape-b"],
+      );
+      assert.deepEqual(
+        new Set(result.modifiedRules),
+        new Set(["Item_seen", "Account_total"]),
+      );
+      assert.deepEqual(result.framedRules, ["Account_limit"]);
+      assert.deepEqual(result.propositions, [
+        { kind: "raw", text: "quantified-write" },
+        { kind: "raw", text: "accumulator-fold" },
+      ]);
+    },
+  );
+
+  it.skip("frames derive from result modified rules", () => {
+    const result = pendingUnifiedLowerResult({
+      declaredRules: ["Account_balance", "Account_limit", "Account_limit"],
+      modifiedRules: ["Account_balance", "Account_balance"],
+      diagnostics: [],
+    });
+
+    assert.deepEqual(result.modifiedRules, ["Account_balance"]);
+    assert.deepEqual(result.framedRules, ["Account_limit"]);
+    assert.equal(
+      result.framedRules.filter((rule) => rule === "Account_limit").length,
+      1,
+    );
+  });
+
+  it.skip("unsupported diagnostics suppress frame emission", () => {
+    const unsupported = lowerCollectionSsaToResult(
+      ir1Assign(ir1Var("x"), ir1LitNat(1)),
+      { declaredRules: ["Account_balance", "Account_limit"] },
+    );
+    const result = pendingUnifiedLowerResult({
+      declaredRules: unsupported.program.declaredRules,
+      propositions: unsupported.propositions,
+      modifiedRules: unsupported.modifiedRules,
+      diagnostics: unsupported.diagnostics,
+    });
+
+    assert.equal(result.diagnostics.length, 1);
+    assert.deepEqual(result.modifiedRules, []);
+    assert.deepEqual(result.propositions, []);
+    assert.deepEqual(result.framedRules, []);
+    assert.equal(
+      result.diagnostics[0]?.reason,
+      "statement is not supported by collection SSA lowering",
+    );
+  });
+});


### PR DESCRIPTION
## Patch 1: Add pending unified SSA lowering tests

- Add skipped test `ir1-ssa-propresult-lowering > scalar properties lower through one result` that expects final property equations and modified rules without a `SymbolicState` final-emission step.
- Add skipped test `ir1-ssa-propresult-lowering > collections lower value and membership props through one result` that covers Map.set/Delete and Set.add/Delete/Clear final propositions.
- Add skipped test `ir1-ssa-propresult-lowering > loop summaries report propositions and modified rules through one result` that covers foreach Shape A and Shape B summaries.
- Add skipped test `ir1-ssa-propresult-lowering > frames derive from result modified rules` that asserts modified rules suppress frames exactly once.
- Add skipped test `ir1-ssa-propresult-lowering > unsupported diagnostics suppress frame emission` that pins all-or-nothing failure behavior.

## Changes
- Add skipped test `ir1-ssa-propresult-lowering > scalar properties lower through one result` that expects final property equations and modified rules without a `SymbolicState` final-emission step.
- Add skipped test `ir1-ssa-propresult-lowering > collections lower value and membership props through one result` that covers Map.set/Delete and Set.add/Delete/Clear final propositions.
- Add skipped test `ir1-ssa-propresult-lowering > loop summaries report propositions and modified rules through one result` that covers foreach Shape A and Shape B summaries.
- Add skipped test `ir1-ssa-propresult-lowering > frames derive from result modified rules` that asserts modified rules suppress frames exactly once.
- Add skipped test `ir1-ssa-propresult-lowering > unsupported diagnostics suppress frame emission` that pins all-or-nothing failure behavior.

## Files to Modify
- tools/ts2pant/tests/ir1-ssa-propresult-lowering.test.mts (create): Skipped unit tests for scalar, collection, loop-summary, frame, and unsupported-diagnostic behavior through the unified lowering boundary.

## Gameplan Specification

```
module TS2PANT_IR1_SSA_PROPRESULT_LOWERING.

LowerResult.
Rule.
Location.
Version.
LoopSummary.
PropResult.

successful? r: LowerResult => Bool.
has-diagnostic? r: LowerResult => Bool.
declared? r: LowerResult, rule: Rule => Bool.
modified? r: LowerResult, rule: Rule => Bool.
framed? r: LowerResult, rule: Rule => Bool.
property-location? l: Location => Bool.
collection-location? l: Location => Bool.
final-version? r: LowerResult, l: Location, v: Version => Bool.
lowered-final? r: LowerResult, l: Location => Bool.
rule-of l: Location => Rule.
summary-of? r: LowerResult, s: LoopSummary => Bool.
lowered-summary? r: LowerResult, s: LoopSummary => Bool.
summary-modifies? s: LoopSummary, rule: Rule => Bool.
general-loop-summary? s: LoopSummary => Bool.
emits? r: LowerResult, p: PropResult => Bool.
translate-body-final-emitter? r: LowerResult => Bool.
---
> Every supported final scalar or collection SSA version is lowered.
all r: LowerResult, l: Location, v: Version, successful? r, final-version? r l v, property-location? l | lowered-final? r l.
all r: LowerResult, l: Location, v: Version, successful? r, final-version? r l v, collection-location? l | lowered-final? r l.

> Every supported loop summary is lowered by the same result boundary.
all r: LowerResult, s: LoopSummary, successful? r, summary-of? r s | lowered-summary? r s.

> Final locations and loop summaries drive the modified-rule set used for frames.
all r: LowerResult, l: Location, successful? r, lowered-final? r l | modified? r (rule-of l).
all r: LowerResult, s: LoopSummary, rule: Rule, successful? r, summary-of? r s, summary-modifies? s rule | modified? r rule.

> Successful results frame exactly declared rules that were not modified.
all r: LowerResult, rule: Rule, successful? r, declared? r rule, modified? r rule | ~framed? r rule.
all r: LowerResult, rule: Rule, successful? r, declared? r rule, ~modified? r rule | framed? r rule.

> Unsupported diagnostics suppress frame emission.
all r: LowerResult, has-diagnostic? r | all rule: Rule | ~framed? r rule.

> M5 does not introduce general loop SSA.
all s: LoopSummary | ~general-loop-summary? s.

> Supported SSA-backed final emission is no longer owned by translate-body.
all r: LowerResult, successful? r | ~translate-body-final-emitter? r.

```

## Patch Specification

```
module TS2PANT_IR1_SSA_PROPRESULT_LOWERING_PATCH_1.

TestStub.
scalar-lowering-stub => TestStub.
collection-lowering-stub => TestStub.
loop-summary-lowering-stub => TestStub.
frame-lowering-stub => TestStub.
unsupported-diagnostic-stub => TestStub.
---
true.

```


## Implementation Notes

- The new test file stays intentionally self-contained and skipped: it does not import or name a not-yet-existing unified M5 production API, so Patch 1 remains green while still pinning the target result semantics.
- I reused current scalar, collection, and loop-summary helpers inside the skipped bodies to anchor expectations to today's emitted propositions and modified-rule behavior rather than duplicating synthetic Pant fragments by hand.
- A small local `pendingUnifiedLowerResult(...)` helper models only the reviewer-relevant contract for M5: deduped `modifiedRules`, frame derivation from declared-minus-modified rules, and all-or-nothing frame suppression when diagnostics are present.
- The collection stub intentionally covers both Map and Set final emission in one case because the milestone boundary is shared; this makes the future cutover expectation explicit without forcing a premature production abstraction in Patch 1.
- No behavioral code changed in `src/`; this patch is test scaffolding only, and the skipped assertions are meant to become direct consumers of the real unified lowering result in later patches.