### PR TITLE
[ts2pant-ir1-ssa-propresult-lowering] Patch 2: Introduce unified SSA body-lowering result

### DIFF
--- a/tools/ts2pant/src/ir1-lower-body.ts
+++ b/tools/ts2pant/src/ir1-lower-body.ts
@@ -36,6 +36,12 @@ import {
   lowerForeachShapeASummaries,
   lowerForeachShapeBSummaries,
 } from "./ir1-ssa-loops.js";
+import {
+  collectionSsaBodyLowerResult,
+  type IR1SsaBodyLowerResult,
+  loopSsaBodyLowerResult,
+  scalarSsaBodyLowerResult,
+} from "./ir1-ssa-lower.js";
 import { isScalarSsaL1Body, lowerScalarSsaToProps } from "./ir1-ssa-scalars.js";
 import type { OpaqueExpr } from "./pant-ast.js";
 import { getAst } from "./pant-wasm.js";
@@ -63,6 +69,32 @@ import type { PropResult } from "./types.js";
 
 export interface LowerBodyCtx {
   applyConst: (e: OpaqueExpr) => OpaqueExpr;
+}
+
+export function adaptCollectionSsaLowerResult(
+  result: ReturnType<typeof lowerCollectionSsaToProps>,
+): IR1SsaBodyLowerResult {
+  return collectionSsaBodyLowerResult(result);
+}
+
+export function adaptScalarSsaLowerResult(
+  result: ReturnType<typeof lowerScalarSsaToProps>,
+): IR1SsaBodyLowerResult {
+  return scalarSsaBodyLowerResult(result);
+}
+
+export function adaptLoopSummaryLowerResult(
+  result: ReturnType<typeof lowerForeachShapeASummaries>,
+): IR1SsaBodyLowerResult;
+export function adaptLoopSummaryLowerResult(
+  result: ReturnType<typeof lowerForeachShapeBSummaries>,
+): IR1SsaBodyLowerResult;
+export function adaptLoopSummaryLowerResult(
+  result:
+    | ReturnType<typeof lowerForeachShapeASummaries>
+    | ReturnType<typeof lowerForeachShapeBSummaries>,
+): IR1SsaBodyLowerResult {
+  return loopSsaBodyLowerResult(result);
 }
 
 /**

--- a/tools/ts2pant/src/ir1-ssa-lower.ts
+++ b/tools/ts2pant/src/ir1-ssa-lower.ts
@@ -1,0 +1,207 @@
+import type { IR1SsaProgram, IR1SsaRuleName } from "./ir1.js";
+import type {
+  CollectionSsaFinalPropertyEntry,
+  CollectionSsaLowerResult,
+} from "./ir1-ssa-collections.js";
+import type {
+  ForeachShapeASummaryResult,
+  ForeachShapeBSummaryResult,
+  ForeachSummaryLowerResult,
+} from "./ir1-ssa-loops.js";
+import type {
+  ScalarSsaFinalPropertyEntry,
+  ScalarSsaLowerResult,
+} from "./ir1-ssa-scalars.js";
+import type { OpaqueParam } from "./pant-ast.js";
+import { getAst } from "./pant-wasm.js";
+import type { PantDeclaration, PropResult } from "./types.js";
+
+type UnsupportedDiagnostic = Extract<PropResult, { kind: "unsupported" }>;
+
+export type IR1SsaFinalProperty =
+  | ScalarSsaFinalPropertyEntry
+  | CollectionSsaFinalPropertyEntry;
+
+export interface IR1SsaBodyLowerResult {
+  propositions: PropResult[];
+  modifiedRules: IR1SsaRuleName[];
+  diagnostics: UnsupportedDiagnostic[];
+  programs: IR1SsaProgram[];
+  finalProperties?: IR1SsaFinalProperty[];
+}
+
+export interface IR1SsaBodyLowerSuccessOptions {
+  propositions?: Iterable<PropResult>;
+  modifiedRules?: Iterable<IR1SsaRuleName>;
+  programs?: Iterable<IR1SsaProgram>;
+  finalProperties?: Iterable<IR1SsaFinalProperty>;
+}
+
+export interface IR1SsaBodyLowerUnsupportedOptions {
+  diagnostics?: Iterable<UnsupportedDiagnostic>;
+  programs?: Iterable<IR1SsaProgram>;
+  propositions?: Iterable<PropResult>;
+  modifiedRules?: Iterable<IR1SsaRuleName>;
+  finalProperties?: Iterable<IR1SsaFinalProperty>;
+}
+
+export function ir1SsaBodyLowerSuccess(
+  options: IR1SsaBodyLowerSuccessOptions = {},
+): IR1SsaBodyLowerResult {
+  return {
+    propositions: [...(options.propositions ?? [])],
+    modifiedRules: dedupeRules(options.modifiedRules),
+    diagnostics: [],
+    programs: [...(options.programs ?? [])],
+    ...(options.finalProperties === undefined
+      ? {}
+      : { finalProperties: [...options.finalProperties] }),
+  };
+}
+
+export function ir1SsaBodyLowerUnsupported(
+  reason: string,
+  options: IR1SsaBodyLowerUnsupportedOptions = {},
+): IR1SsaBodyLowerResult {
+  return ir1SsaBodyLowerResult({
+    diagnostics: [
+      { kind: "unsupported", reason },
+      ...(options.diagnostics ?? []),
+    ],
+    ...(options.propositions === undefined
+      ? {}
+      : { propositions: options.propositions }),
+    ...(options.modifiedRules === undefined
+      ? {}
+      : { modifiedRules: options.modifiedRules }),
+    ...(options.programs === undefined ? {} : { programs: options.programs }),
+    ...(options.finalProperties === undefined
+      ? {}
+      : { finalProperties: options.finalProperties }),
+  });
+}
+
+export function combineIR1SsaBodyLowerResults(
+  ...results: readonly IR1SsaBodyLowerResult[]
+): IR1SsaBodyLowerResult {
+  const propositions: PropResult[] = [];
+  const modifiedRules = new Set<IR1SsaRuleName>();
+  const diagnostics: UnsupportedDiagnostic[] = [];
+  const programs: IR1SsaProgram[] = [];
+  const finalProperties: IR1SsaFinalProperty[] = [];
+  let hasFinalProperties = false;
+
+  for (const result of results) {
+    propositions.push(...result.propositions);
+    diagnostics.push(...result.diagnostics);
+    programs.push(...result.programs);
+    for (const rule of result.modifiedRules) {
+      modifiedRules.add(rule);
+    }
+    if (result.finalProperties !== undefined) {
+      hasFinalProperties = true;
+      finalProperties.push(...result.finalProperties);
+    }
+  }
+
+  return {
+    propositions,
+    modifiedRules: [...modifiedRules],
+    diagnostics,
+    programs,
+    ...(hasFinalProperties ? { finalProperties } : {}),
+  };
+}
+
+export function appendFramesForUnmodifiedRules(
+  result: IR1SsaBodyLowerResult,
+  declarations: readonly PantDeclaration[],
+): IR1SsaBodyLowerResult {
+  if (result.diagnostics.length > 0) {
+    return result;
+  }
+
+  const ast = getAst();
+  const frames: PropResult[] = [];
+  const modifiedRules = new Set(result.modifiedRules);
+
+  for (const decl of declarations) {
+    if (decl.kind !== "rule" || modifiedRules.has(decl.name)) {
+      continue;
+    }
+    const paramArgs = decl.params.map((p) => ast.var(p.name));
+    frames.push({
+      kind: "equation",
+      quantifiers: [] as OpaqueParam[],
+      lhs: ast.app(ast.primed(decl.name), paramArgs),
+      rhs: ast.app(ast.var(decl.name), paramArgs),
+    });
+  }
+
+  if (frames.length === 0) {
+    return result;
+  }
+
+  return {
+    ...result,
+    propositions: [...result.propositions, ...frames],
+  };
+}
+
+export function scalarSsaBodyLowerResult(
+  result: ScalarSsaLowerResult,
+): IR1SsaBodyLowerResult {
+  return ir1SsaBodyLowerResult({
+    propositions: result.propositions,
+    modifiedRules: result.modifiedRules,
+    diagnostics: result.diagnostics,
+    programs: [result.program],
+    finalProperties: result.finalProperties,
+  });
+}
+
+export function collectionSsaBodyLowerResult(
+  result: CollectionSsaLowerResult,
+): IR1SsaBodyLowerResult {
+  return ir1SsaBodyLowerResult({
+    propositions: result.propositions,
+    modifiedRules: result.modifiedRules,
+    diagnostics: result.diagnostics,
+    programs: [result.program],
+    finalProperties: result.finalProperties,
+  });
+}
+
+export function loopSsaBodyLowerResult(
+  result:
+    | ForeachSummaryLowerResult
+    | ForeachShapeASummaryResult
+    | ForeachShapeBSummaryResult,
+): IR1SsaBodyLowerResult {
+  return ir1SsaBodyLowerResult({
+    propositions: result.propositions,
+    modifiedRules: result.modifiedRules,
+    diagnostics: result.diagnostics,
+    programs: [result.program],
+  });
+}
+
+function ir1SsaBodyLowerResult(
+  options: IR1SsaBodyLowerUnsupportedOptions,
+): IR1SsaBodyLowerResult {
+  return {
+    propositions: [...(options.propositions ?? [])],
+    modifiedRules: dedupeRules(options.modifiedRules),
+    diagnostics: [...(options.diagnostics ?? [])],
+    programs: [...(options.programs ?? [])],
+    ...(options.finalProperties === undefined
+      ? {}
+      : { finalProperties: [...options.finalProperties] }),
+  };
+}
+
+function dedupeRules(
+  rules: Iterable<IR1SsaRuleName> | undefined,
+): IR1SsaRuleName[] {
+  return rules === undefined ? [] : [...new Set(rules)];
+}

--- a/tools/ts2pant/tests/ir1-ssa-lower.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-lower.test.mts
@@ -1,0 +1,239 @@
+import assert from "node:assert/strict";
+import { before, describe, it } from "node:test";
+
+import {
+  ir1Assign,
+  ir1LitBool,
+  ir1LitNat,
+  ir1MapSet,
+  ir1Member,
+  ir1SsaPropertyLocation,
+  ir1Var,
+} from "../src/ir1.js";
+import { adaptCollectionSsaLowerResult, adaptLoopSummaryLowerResult, adaptScalarSsaLowerResult } from "../src/ir1-lower-body.js";
+import {
+  appendFramesForUnmodifiedRules,
+  combineIR1SsaBodyLowerResults,
+  ir1SsaBodyLowerSuccess,
+  ir1SsaBodyLowerUnsupported,
+} from "../src/ir1-ssa-lower.js";
+import { lowerCollectionSsaToProps } from "../src/ir1-ssa-collections.js";
+import { lowerForeachShapeASummaries } from "../src/ir1-ssa-loops.js";
+import { lowerScalarSsaToProps } from "../src/ir1-ssa-scalars.js";
+import { getAst, loadAst } from "../src/pant-wasm.js";
+
+before(async () => {
+  await loadAst();
+});
+
+describe("ir1-ssa-lower", () => {
+  it("combines body-lowering results with proposition order and deduped modified rules", () => {
+    const programA = {
+      reads: [],
+      writes: [],
+      joins: [],
+      loopSummaries: [],
+      declaredRules: ["Account_balance", "Account_limit"],
+      modifiedRules: ["Account_balance"],
+      framedRules: ["Account_limit"],
+    };
+    const programB = {
+      reads: [],
+      writes: [],
+      joins: [],
+      loopSummaries: [],
+      declaredRules: ["Account_balance", "Account_seen"],
+      modifiedRules: ["Account_seen", "Account_balance"],
+      framedRules: [],
+    };
+    const result = combineIR1SsaBodyLowerResults(
+      ir1SsaBodyLowerSuccess({
+        propositions: [
+          { kind: "raw", text: "first" },
+          { kind: "raw", text: "second" },
+        ],
+        modifiedRules: ["Account_balance"],
+        programs: [programA],
+        finalProperties: [
+          {
+            kind: "property",
+            prop: "Account_balance",
+            objExpr: getAst().var("a"),
+            rhs: getAst().litNat(1),
+          },
+        ],
+      }),
+      ir1SsaBodyLowerUnsupported("unsupported loop", {
+        diagnostics: [{ kind: "unsupported", reason: "unsupported map" }],
+        propositions: [{ kind: "raw", text: "third" }],
+        modifiedRules: ["Account_seen", "Account_balance"],
+        programs: [programB],
+      }),
+    );
+
+    assert.deepEqual(
+      result.propositions.map((prop) =>
+        prop.kind === "raw" ? prop.text : prop.kind,
+      ),
+      ["first", "second", "third"],
+    );
+    assert.deepEqual(result.modifiedRules, [
+      "Account_balance",
+      "Account_seen",
+    ]);
+    assert.deepEqual(result.diagnostics, [
+      { kind: "unsupported", reason: "unsupported loop" },
+      { kind: "unsupported", reason: "unsupported map" },
+    ]);
+    assert.deepEqual(result.programs, [programA, programB]);
+    assert.equal(result.finalProperties?.length, 1);
+  });
+
+  it("appends frames only for unmodified rules when diagnostics are absent", () => {
+    const ast = getAst();
+    const result = appendFramesForUnmodifiedRules(
+      ir1SsaBodyLowerSuccess({
+        propositions: [{ kind: "raw", text: "body" }],
+        modifiedRules: ["Account_balance"],
+      }),
+      [
+        {
+          kind: "rule",
+          name: "Account_balance",
+          params: [{ name: "a", type: "Account" }],
+          returnType: "Nat",
+        },
+        {
+          kind: "rule",
+          name: "Account_limit",
+          params: [{ name: "a", type: "Account" }],
+          returnType: "Nat",
+        },
+      ],
+    );
+
+    assert.equal(result.propositions.length, 2);
+    const frame = result.propositions[1];
+    assert.equal(frame?.kind, "equation");
+    if (frame?.kind !== "equation") {
+      assert.fail("expected a frame equation");
+    }
+    assert.equal(ast.strExpr(frame.lhs), "Account_limit' a");
+    assert.equal(ast.strExpr(frame.rhs), "Account_limit a");
+    assert.ok(!result.modifiedRules.includes("Account_limit"));
+  });
+
+  it("suppresses frame emission when diagnostics are present", () => {
+    const result = appendFramesForUnmodifiedRules(
+      ir1SsaBodyLowerUnsupported("unsupported path", {
+        propositions: [{ kind: "raw", text: "body" }],
+      }),
+      [
+        {
+          kind: "rule",
+          name: "Account_limit",
+          params: [{ name: "a", type: "Account" }],
+          returnType: "Nat",
+        },
+      ],
+    );
+
+    assert.deepEqual(result.propositions, [{ kind: "raw", text: "body" }]);
+  });
+
+  it("adapts scalar, collection, and loop summary helpers into the unified shape", () => {
+    const scalar = adaptScalarSsaLowerResult(
+      lowerScalarSsaToProps(
+        ir1Assign(
+          ir1Member(ir1Var("a"), "Account_balance"),
+          ir1LitNat(1),
+        ),
+      ),
+    );
+    const collection = adaptCollectionSsaLowerResult(
+      lowerCollectionSsaToProps(
+        ir1MapSet(
+          "Cache_value",
+          "Cache_hasKey",
+          "Owner",
+          "Key",
+          ir1Var("cache"),
+          ir1Var("key"),
+          ir1LitNat(7),
+        ),
+      ),
+    );
+    const loop = adaptLoopSummaryLowerResult(
+      lowerForeachShapeASummaries({
+        binder: "$item",
+        source: getAst().var("items"),
+        body: ir1Assign(
+          ir1Member(ir1Var("$item"), "Item_seen"),
+          ir1LitBool(true),
+        ),
+      }),
+    );
+
+    assert.equal(scalar.programs.length, 1);
+    assert.deepEqual(scalar.modifiedRules, ["Account_balance"]);
+    assert.equal(scalar.finalProperties?.length, 1);
+    assert.equal(scalar.diagnostics.length, 0);
+
+    assert.equal(collection.programs.length, 1);
+    assert.deepEqual(
+      new Set(collection.modifiedRules),
+      new Set(["Cache_value", "Cache_hasKey"]),
+    );
+    assert.equal(collection.finalProperties?.length, 0);
+    assert.equal(collection.diagnostics.length, 0);
+
+    assert.equal(loop.programs.length, 1);
+    assert.deepEqual(loop.modifiedRules, ["Item_seen"]);
+    assert.equal(loop.finalProperties, undefined);
+    assert.equal(loop.diagnostics.length, 0);
+  });
+
+  it("preserves helper diagnostics through adapters", () => {
+    const scalar = adaptScalarSsaLowerResult(
+      lowerScalarSsaToProps({
+        kind: "expr-stmt",
+        expr: ir1LitBool(true),
+      }),
+    );
+    const location = ir1SsaPropertyLocation(
+      "Account_balance",
+      ir1Var("a"),
+      "balance",
+    );
+    const loop = adaptLoopSummaryLowerResult(
+      {
+        program: {
+          reads: [],
+          writes: [],
+          joins: [],
+          loopSummaries: [],
+          declaredRules: ["Account_balance"],
+          modifiedRules: [],
+          framedRules: ["Account_balance"],
+        },
+        summary: null,
+        propositions: [],
+        modifiedRules: [],
+        diagnostics: [
+          { kind: "unsupported", reason: "general loops are not supported" },
+        ],
+      },
+    );
+
+    assert.deepEqual(scalar.diagnostics, [
+      {
+        kind: "unsupported",
+        reason: "statement is not supported by scalar SSA lowering",
+      },
+    ]);
+    assert.equal(location.kind, "property");
+    assert.deepEqual(loop.diagnostics, [
+      { kind: "unsupported", reason: "general loops are not supported" },
+    ]);
+  });
+});

--- a/tools/ts2pant/tests/ir1-ssa-lower.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-lower.test.mts
@@ -165,10 +165,10 @@ describe("ir1-ssa-lower", () => {
     );
     const loop = adaptLoopSummaryLowerResult(
       lowerForeachShapeASummaries({
-        binder: "$item",
+        binder: "item0",
         source: getAst().var("items"),
         body: ir1Assign(
-          ir1Member(ir1Var("$item"), "Item_seen"),
+          ir1Member(ir1Var("item0"), "Item_seen"),
           ir1LitBool(true),
         ),
       }),


### PR DESCRIPTION
## Patch 2: Introduce unified SSA body-lowering result

- Define `IR1SsaBodyLowerResult` with `propositions`, `modifiedRules`, `diagnostics`, `programs`, and optional `finalProperties` fields.
- Add constructors for successful, unsupported, and combined results; combining results must dedupe `modifiedRules` while preserving proposition order.
- Add `appendFramesForUnmodifiedRules(result, declarations)` or equivalent helper that adds frames only when `diagnostics` is empty.
- Add adapter functions that can wrap existing scalar, collection, and loop-summary helper outputs into the unified result shape without changing behavior yet.

## Changes
- Define `IR1SsaBodyLowerResult` with `propositions`, `modifiedRules`, `diagnostics`, `programs`, and optional `finalProperties` fields.
- Add constructors for successful, unsupported, and combined results; combining results must dedupe `modifiedRules` while preserving proposition order.
- Add `appendFramesForUnmodifiedRules(result, declarations)` or equivalent helper that adds frames only when `diagnostics` is empty.
- Add adapter functions that can wrap existing scalar, collection, and loop-summary helper outputs into the unified result shape without changing behavior yet.

## Files to Modify
- tools/ts2pant/src/ir1-ssa-lower.ts (create): Defines the unified result type, result constructors/combinators, diagnostic handling, modified-rule tracking, and frame generation helper.
- tools/ts2pant/src/ir1-lower-body.ts (modify): Imports the new result type and adds adapter signatures without changing production dispatch.

## Gameplan Specification

```
module TS2PANT_IR1_SSA_PROPRESULT_LOWERING.

LowerResult.
Rule.
Location.
Version.
LoopSummary.
PropResult.

successful? r: LowerResult => Bool.
has-diagnostic? r: LowerResult => Bool.
declared? r: LowerResult, rule: Rule => Bool.
modified? r: LowerResult, rule: Rule => Bool.
framed? r: LowerResult, rule: Rule => Bool.
property-location? l: Location => Bool.
collection-location? l: Location => Bool.
final-version? r: LowerResult, l: Location, v: Version => Bool.
lowered-final? r: LowerResult, l: Location => Bool.
rule-of l: Location => Rule.
summary-of? r: LowerResult, s: LoopSummary => Bool.
lowered-summary? r: LowerResult, s: LoopSummary => Bool.
summary-modifies? s: LoopSummary, rule: Rule => Bool.
general-loop-summary? s: LoopSummary => Bool.
emits? r: LowerResult, p: PropResult => Bool.
translate-body-final-emitter? r: LowerResult => Bool.
---
> Every supported final scalar or collection SSA version is lowered.
all r: LowerResult, l: Location, v: Version, successful? r, final-version? r l v, property-location? l | lowered-final? r l.
all r: LowerResult, l: Location, v: Version, successful? r, final-version? r l v, collection-location? l | lowered-final? r l.

> Every supported loop summary is lowered by the same result boundary.
all r: LowerResult, s: LoopSummary, successful? r, summary-of? r s | lowered-summary? r s.

> Final locations and loop summaries drive the modified-rule set used for frames.
all r: LowerResult, l: Location, successful? r, lowered-final? r l | modified? r (rule-of l).
all r: LowerResult, s: LoopSummary, rule: Rule, successful? r, summary-of? r s, summary-modifies? s rule | modified? r rule.

> Successful results frame exactly declared rules that were not modified.
all r: LowerResult, rule: Rule, successful? r, declared? r rule, modified? r rule | ~framed? r rule.
all r: LowerResult, rule: Rule, successful? r, declared? r rule, ~modified? r rule | framed? r rule.

> Unsupported diagnostics suppress frame emission.
all r: LowerResult, has-diagnostic? r | all rule: Rule | ~framed? r rule.

> M5 does not introduce general loop SSA.
all s: LoopSummary | ~general-loop-summary? s.

> Supported SSA-backed final emission is no longer owned by translate-body.
all r: LowerResult, successful? r | ~translate-body-final-emitter? r.

```

## Patch Specification

```
module TS2PANT_IR1_SSA_PROPRESULT_LOWERING_PATCH_2.

LowerResult.
Rule.
PropResult.
Diagnostic.

modified? r: LowerResult, rule: Rule => Bool.
framed? r: LowerResult, rule: Rule => Bool.
emits? r: LowerResult, p: PropResult => Bool.
has-diagnostic? r: LowerResult => Bool.
---
> A diagnostic result is not frameable; callers must not emit partial frames.
all r: LowerResult, has-diagnostic? r | all rule: Rule | ~framed? r rule.

> Modified rules and framed rules are disjoint in every result.
all r: LowerResult, rule: Rule, modified? r rule | ~framed? r rule.

```


## Implementation Notes

- The new result module is intentionally additive in Patch 2: production dispatch in `ir1-lower-body.ts` still uses the old helper return types, and the new adapters are exported but not yet threaded into the main lowering path. That keeps this patch architecture-only and avoids mixing the result-boundary introduction with behavior changes reserved for later patches.
- `programs` is modeled as `IR1SsaProgram[]` rather than a single program because the target M5 boundary needs to combine scalar, collection, and loop-summary lowerings without re-wrapping or losing provenance. Patch 2 does not consume multiple programs yet, but the combiner is shaped for that follow-on work.
- `appendFramesForUnmodifiedRules` mirrors the existing frame emission logic from `translate-body.ts` instead of trying to infer declarations from `programs`. That keeps the helper byte-compatible with current frame equations and avoids introducing a second notion of declared-rule ownership in this patch.
- The unsupported constructor and frame helper are written to satisfy `exactOptionalPropertyTypes`: optional fields are omitted rather than passed through as `undefined`. This mattered at pre-commit typecheck time and is easy to miss in review because the runtime behavior is unchanged.
- I added a dedicated `ir1-ssa-lower.test.mts` instead of extending the existing scalar/collection/loop suites so the result-boundary invariants are tested directly in one place: proposition-order preservation, modified-rule dedupe, frame suppression on diagnostics, and adapter preservation of helper outputs.