### PR TITLE
[ts2pant-ir1-ssa-propresult-lowering] Patch 4: Route loop summaries through unified lowering

### DIFF
--- a/tools/ts2pant/src/ir1-lower-body.ts
+++ b/tools/ts2pant/src/ir1-lower-body.ts
@@ -35,6 +35,7 @@ import {
   foreachShapeBAccumulatorKey,
   lowerForeachShapeASummaries,
   lowerForeachShapeBSummaries,
+  type MuSearchSummaryLowerResult,
 } from "./ir1-ssa-loops.js";
 import {
   collectionSsaBodyLowerResult,
@@ -90,9 +91,13 @@ export function adaptLoopSummaryLowerResult(
   result: ReturnType<typeof lowerForeachShapeBSummaries>,
 ): IR1SsaBodyLowerResult;
 export function adaptLoopSummaryLowerResult(
+  result: MuSearchSummaryLowerResult,
+): IR1SsaBodyLowerResult;
+export function adaptLoopSummaryLowerResult(
   result:
     | ReturnType<typeof lowerForeachShapeASummaries>
-    | ReturnType<typeof lowerForeachShapeBSummaries>,
+    | ReturnType<typeof lowerForeachShapeBSummaries>
+    | MuSearchSummaryLowerResult,
 ): IR1SsaBodyLowerResult {
   return loopSsaBodyLowerResult(result);
 }
@@ -662,12 +667,13 @@ function lowerForeach(
       lowerOpaque: ctx.applyConst,
       initialPropertyValues: shapeAInitialPropertyValues(state),
     });
-    if (result.diagnostics.length > 0) {
-      propositions.push(...result.diagnostics);
+    const lowered = adaptLoopSummaryLowerResult(result);
+    if (lowered.diagnostics.length > 0) {
+      propositions.push(...lowered.diagnostics);
       return false;
     }
-    propositions.push(...result.propositions);
-    for (const rule of result.modifiedRules) {
+    propositions.push(...lowered.propositions);
+    for (const rule of lowered.modifiedRules) {
       state.modifiedProps = addModifiedProp(state.modifiedProps, rule);
     }
   }
@@ -701,16 +707,17 @@ function lowerForeach(
         ctx.applyConst(lowerL1ExprToOpaque(expr, state)),
       priorAccumulatorValues,
     });
-    if (result.diagnostics.length > 0) {
-      propositions.push(...result.diagnostics);
+    const lowered = adaptLoopSummaryLowerResult(result);
+    if (lowered.diagnostics.length > 0) {
+      propositions.push(...lowered.diagnostics);
       return false;
     }
-    for (const rule of result.modifiedRules) {
+    for (const rule of lowered.modifiedRules) {
       state.modifiedProps = addModifiedProp(state.modifiedProps, rule);
     }
     for (let i = 0; i < stmt.foldLeaves.length; i++) {
       const leaf = stmt.foldLeaves[i]!;
-      const prop = result.propositions[i];
+      const prop = lowered.propositions[i];
       if (prop?.kind !== "equation") {
         propositions.push({
           kind: "unsupported",

--- a/tools/ts2pant/src/ir1-ssa-lower.ts
+++ b/tools/ts2pant/src/ir1-ssa-lower.ts
@@ -7,6 +7,7 @@ import type {
   ForeachShapeASummaryResult,
   ForeachShapeBSummaryResult,
   ForeachSummaryLowerResult,
+  MuSearchSummaryLowerResult,
 } from "./ir1-ssa-loops.js";
 import type {
   ScalarSsaFinalPropertyEntry,
@@ -176,10 +177,11 @@ export function loopSsaBodyLowerResult(
   result:
     | ForeachSummaryLowerResult
     | ForeachShapeASummaryResult
-    | ForeachShapeBSummaryResult,
+    | ForeachShapeBSummaryResult
+    | MuSearchSummaryLowerResult,
 ): IR1SsaBodyLowerResult {
   return ir1SsaBodyLowerResult({
-    propositions: result.propositions,
+    propositions: "propositions" in result ? result.propositions : [],
     modifiedRules: result.modifiedRules,
     diagnostics: result.diagnostics,
     programs: [result.program],

--- a/tools/ts2pant/tests/ir1-ssa-loops.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-loops.test.mts
@@ -312,9 +312,39 @@ describe("ir1-ssa-loops", () => {
     }
   });
 
-  it.skip("preserves production parity for foreach fixtures", async () => {
-    // PENDING Patch 4: pin parity for `functions-mutating-loop.ts`
-    // (for example `forEachActivate`, `forEachSum`, or `mixedUpdates`) once
-    // foreach lowering routes through the loop-summary helper.
+  it("preserves production parity for foreach fixtures", async () => {
+    const filePath = resolve(
+      import.meta.dirname,
+      "fixtures/constructs/functions-mutating-loop.ts",
+    );
+    const sourceFile = createSourceFile(filePath);
+    const funcs = ["forEachActivate", "forEachSum", "mixedUpdates"];
+
+    const outputs = await Promise.all(
+      funcs.map(async (funcName) => {
+        const doc = await buildDocumentFromSourceFile(sourceFile, funcName);
+        return emitDocument(doc);
+      }),
+    );
+
+    for (const output of outputs) {
+      assert.doesNotMatch(output, /UNSUPPORTED/u);
+    }
+    assert.match(
+      outputs[0]!,
+      /all ([\w$]+) in users \| user--active' \1 = true/u,
+    );
+    assert.match(
+      outputs[1]!,
+      /account--total' a = account--total a \+ \(\+ over each ([\w$]+) in items \| item--value \1\)/u,
+    );
+    assert.match(
+      outputs[2]!,
+      /all ([\w$]+) in items \| item--tagged' \1 = true/u,
+    );
+    assert.match(
+      outputs[2]!,
+      /account--total' a = account--total a \+ \(\+ over each ([\w$]+) in items \| item--value \1\)/u,
+    );
   });
 });

--- a/tools/ts2pant/tests/ir1-ssa-lower.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-lower.test.mts
@@ -3,6 +3,7 @@ import { before, describe, it } from "node:test";
 
 import {
   ir1Assign,
+  ir1Binop,
   ir1LitBool,
   ir1LitNat,
   ir1MapSet,
@@ -10,7 +11,11 @@ import {
   ir1SsaPropertyLocation,
   ir1Var,
 } from "../src/ir1.js";
-import { adaptCollectionSsaLowerResult, adaptLoopSummaryLowerResult, adaptScalarSsaLowerResult } from "../src/ir1-lower-body.js";
+import {
+  adaptCollectionSsaLowerResult,
+  adaptLoopSummaryLowerResult,
+  adaptScalarSsaLowerResult,
+} from "../src/ir1-lower-body.js";
 import {
   appendFramesForUnmodifiedRules,
   combineIR1SsaBodyLowerResults,
@@ -18,7 +23,11 @@ import {
   ir1SsaBodyLowerUnsupported,
 } from "../src/ir1-ssa-lower.js";
 import { lowerCollectionSsaToProps } from "../src/ir1-ssa-collections.js";
-import { lowerForeachShapeASummaries } from "../src/ir1-ssa-loops.js";
+import {
+  lowerForeachShapeASummaries,
+  lowerForeachShapeBSummaries,
+  lowerMuSearchSummary,
+} from "../src/ir1-ssa-loops.js";
 import { lowerScalarSsaToProps } from "../src/ir1-ssa-scalars.js";
 import { getAst, loadAst } from "../src/pant-wasm.js";
 
@@ -235,5 +244,85 @@ describe("ir1-ssa-lower", () => {
     assert.deepEqual(loop.diagnostics, [
       { kind: "unsupported", reason: "general loops are not supported" },
     ]);
+  });
+
+  it("loop summaries report propositions and modified rules through one result", () => {
+    const ast = getAst();
+    const shapeA = adaptLoopSummaryLowerResult(
+      lowerForeachShapeASummaries({
+        binder: "item0",
+        source: ast.var("items"),
+        body: ir1Assign(
+          ir1Member(ir1Var("item0"), "Item_seen"),
+          ir1LitBool(true),
+        ),
+      }),
+    );
+    const shapeB = adaptLoopSummaryLowerResult(
+      lowerForeachShapeBSummaries({
+        binder: "item0",
+        source: ast.var("items"),
+        foldLeaves: [
+          {
+            target: ir1Var("account"),
+            prop: "Account_total",
+            combiner: "add",
+            outerOp: "add",
+            rhs: ir1Member(ir1Var("item0"), "Item_value"),
+            guard: ir1Binop(
+              "gt",
+              ir1Member(ir1Var("item0"), "Item_value"),
+              ir1LitNat(0),
+            ),
+          },
+        ],
+      }),
+    );
+    const muSearch = adaptLoopSummaryLowerResult(
+      lowerMuSearchSummary({
+        location: ir1SsaPropertyLocation(
+          "Name_firstUnusedSuffix",
+          ir1Var("name"),
+          "firstUnusedSuffix",
+        ),
+        counterType: "Int",
+        counterPantName: "i",
+        binder: "j1",
+        initExpr: ast.litNat(1),
+        predicateExpr: ast.binop(ast.opIn(), ast.var("i"), ast.var("used")),
+      }),
+    );
+    const result = combineIR1SsaBodyLowerResults(shapeA, shapeB, muSearch);
+
+    assert.equal(result.diagnostics.length, 0);
+    assert.equal(result.propositions.length, 2);
+    assert.deepEqual(
+      new Set(result.modifiedRules),
+      new Set(["Item_seen", "Account_total", "Name_firstUnusedSuffix"]),
+    );
+    assert.equal(result.programs.length, 3);
+    assert.deepEqual(
+      result.programs.flatMap((program) =>
+        program.loopSummaries.map((summary) => summary.shape),
+      ),
+      ["foreach-shape-a", "foreach-shape-b", "mu-search"],
+    );
+
+    const shapeAProp = result.propositions[0];
+    assert.equal(shapeAProp?.kind, "equation");
+    if (shapeAProp?.kind === "equation") {
+      assert.equal(ast.strExpr(shapeAProp.lhs), "Item_seen' item0");
+      assert.equal(ast.strExpr(shapeAProp.rhs), "true");
+    }
+
+    const shapeBProp = result.propositions[1];
+    assert.equal(shapeBProp?.kind, "equation");
+    if (shapeBProp?.kind === "equation") {
+      assert.equal(ast.strExpr(shapeBProp.lhs), "Account_total' account");
+      assert.equal(
+        ast.strExpr(shapeBProp.rhs),
+        "Account_total account + (+ over each item0 in items, Item_value item0 > 0 | Item_value item0)",
+      );
+    }
   });
 });


### PR DESCRIPTION
## Patch 4: Route loop summaries through unified lowering

- Adapt `lowerForeachShapeASummaries` and `lowerForeachShapeBSummaries` to produce or wrap `IR1SsaBodyLowerResult` entries.
- Ensure Shape A quantified equations and Shape B accumulator equations preserve current emitted Pantagruel semantics.
- Ensure μ-search summary metadata reports modified rules through the same result contract where the mutating-body path consumes it.
- Keep general `for` / `while` loops unsupported unless they match existing μ-search recognition.
- Enable the Patch 1 loop-summary test.

## Changes
- Adapt `lowerForeachShapeASummaries` and `lowerForeachShapeBSummaries` to produce or wrap `IR1SsaBodyLowerResult` entries.
- Ensure Shape A quantified equations and Shape B accumulator equations preserve current emitted Pantagruel semantics.
- Ensure μ-search summary metadata reports modified rules through the same result contract where the mutating-body path consumes it.
- Keep general `for` / `while` loops unsupported unless they match existing μ-search recognition.
- Enable the Patch 1 loop-summary test.

## Files to Modify
- tools/ts2pant/src/ir1-lower-body.ts (modify): Adapts foreach Shape A and Shape B summary results into the unified SSA body-lowering result.
- tools/ts2pant/src/ir1-ssa-loops.ts (modify): Expose loop-summary propositions, summary versions, and modified-rule metadata in a shape consumable by the unified result.
- tools/ts2pant/src/ir1-lower.ts (modify): If needed, expose μ-search summary lowering metadata through the same result contract or a compatible adapter.
- tools/ts2pant/tests/ir1-ssa-propresult-lowering.test.mts (modify): Enable and implement loop-summary unified-lowering tests.

## Gameplan Specification

```
module TS2PANT_IR1_SSA_PROPRESULT_LOWERING.

LowerResult.
Rule.
Location.
Version.
LoopSummary.
PropResult.

successful? r: LowerResult => Bool.
has-diagnostic? r: LowerResult => Bool.
declared? r: LowerResult, rule: Rule => Bool.
modified? r: LowerResult, rule: Rule => Bool.
framed? r: LowerResult, rule: Rule => Bool.
property-location? l: Location => Bool.
collection-location? l: Location => Bool.
final-version? r: LowerResult, l: Location, v: Version => Bool.
lowered-final? r: LowerResult, l: Location => Bool.
rule-of l: Location => Rule.
summary-of? r: LowerResult, s: LoopSummary => Bool.
lowered-summary? r: LowerResult, s: LoopSummary => Bool.
summary-modifies? s: LoopSummary, rule: Rule => Bool.
general-loop-summary? s: LoopSummary => Bool.
emits? r: LowerResult, p: PropResult => Bool.
translate-body-final-emitter? r: LowerResult => Bool.
---
> Every supported final scalar or collection SSA version is lowered.
all r: LowerResult, l: Location, v: Version, successful? r, final-version? r l v, property-location? l | lowered-final? r l.
all r: LowerResult, l: Location, v: Version, successful? r, final-version? r l v, collection-location? l | lowered-final? r l.

> Every supported loop summary is lowered by the same result boundary.
all r: LowerResult, s: LoopSummary, successful? r, summary-of? r s | lowered-summary? r s.

> Final locations and loop summaries drive the modified-rule set used for frames.
all r: LowerResult, l: Location, successful? r, lowered-final? r l | modified? r (rule-of l).
all r: LowerResult, s: LoopSummary, rule: Rule, successful? r, summary-of? r s, summary-modifies? s rule | modified? r rule.

> Successful results frame exactly declared rules that were not modified.
all r: LowerResult, rule: Rule, successful? r, declared? r rule, modified? r rule | ~framed? r rule.
all r: LowerResult, rule: Rule, successful? r, declared? r rule, ~modified? r rule | framed? r rule.

> Unsupported diagnostics suppress frame emission.
all r: LowerResult, has-diagnostic? r | all rule: Rule | ~framed? r rule.

> M5 does not introduce general loop SSA.
all s: LoopSummary | ~general-loop-summary? s.

> Supported SSA-backed final emission is no longer owned by translate-body.
all r: LowerResult, successful? r | ~translate-body-final-emitter? r.

```

## Patch Specification

```
module TS2PANT_IR1_SSA_PROPRESULT_LOWERING_PATCH_4.

LowerResult.
LoopSummary.
Rule.
PropResult.

summary-of? r: LowerResult, s: LoopSummary => Bool.
lowered-summary? r: LowerResult, s: LoopSummary => Bool.
summary-modifies? s: LoopSummary, rule: Rule => Bool.
modified? r: LowerResult, rule: Rule => Bool.
emits? r: LowerResult, p: PropResult => Bool.
general-loop-summary? s: LoopSummary => Bool.
---
> Every supported loop summary in the result is lowered.
all r: LowerResult, s: LoopSummary, summary-of? r s | lowered-summary? r s.

> Summary-modified rules are visible to frame derivation.
all r: LowerResult, s: LoopSummary, rule: Rule, summary-of? r s, summary-modifies? s rule | modified? r rule.

> This milestone does not introduce general loop summaries.
all s: LoopSummary | ~general-loop-summary? s.

```


## Implementation Notes

- The foreach production path still updates `SymbolicState` after adapting Shape A/B summaries into `IR1SsaBodyLowerResult`; this is intentional compatibility glue for Patch 5, not a second semantic lowering path.
- `loopSsaBodyLowerResult` accepts μ-search summary results even though μ-search emits an expression rather than body propositions, so its modified-rule/program metadata can travel through the same result contract.
- The enabled foreach fixture test asserts emitted Pantagruel shapes rather than exact binder names, because production binder allocation uses hygienic source-derived names.
- `npm run build` was not a reliable verifier in this worktree because `build:wasm` hit a corrupted shared opam `ppxlib.cmi`; `npx tsc --noEmit`, lint, focused loop tests, full `npm test`, and the pre-commit hook all passed.