### PR TITLE
[ts2pant-ir1-ssa-propresult-lowering] Patch 5: Move supported final emission and frames to IR1 SSA lowering

### DIFF
--- a/tools/ts2pant/AGENTS.md
+++ b/tools/ts2pant/AGENTS.md
@@ -785,8 +785,11 @@ live in § "Divergence from IRSC".
   scalar SSA builder/lowerer helper owns scalar property mutation,
   the collection SSA helper owns Map/Set mutation, and the loop
   summary helper owns μ-search plus supported foreach summaries.
-  `SymbolicState` still exists for later cleanup, but it is no longer
-  the backing model for the supported loop-summary forms after M4).
+  `ir1-lower-body.ts` exposes `lowerL1BodyToSsaProps`, the M5
+  body-level boundary that returns final propositions plus frames from
+  SSA `modifiedRules`. `SymbolicState` still exists for M6 cleanup,
+  but supported SSA-backed final emission is no longer owned by
+  `translate-body.ts`).
 
 ### Two paths, one Layer 1
 
@@ -798,17 +801,16 @@ shared Layer 1 IR:
   out". Always-on; there is no opt-in flag and no legacy expression
   fallback for this path.
 - **Effect / statement-position** — TS → L1 statement →
-  `PropResult[]` directly via a single fold (`lowerL1Body`) over
-  `SymbolicState` (in `translate-body.ts`) for now. The IR1 SSA
-  contract is already present in `src/ir1.ts`, and Milestone 2 routes
-  scalar property mutation, read-after-write, branch joins, and
-  scalar early-exit merges through `src/ir1-ssa-scalars.ts`. Map/Set
-  mutation now routes through `src/ir1-ssa-collections.ts`, while
-  μ-search and supported foreach summaries route through
-  `src/ir1-ssa-loops.ts`. General loop SSA remains out of scope, and
-  the later M5 lowering pass owns the unified `PropResult[]`
-  emission for the supported summary forms. The mutating output is a
-  list of equations + frame conditions; no L2 statement vocabulary.
+  `lowerL1BodyToSsaProps` → `PropResult[]` for supported SSA-backed
+  bodies. Scalar property mutation, read-after-write, branch joins,
+  and scalar early-exit merges route through `src/ir1-ssa-scalars.ts`;
+  Map/Set mutation routes through `src/ir1-ssa-collections.ts`; and
+  μ-search plus supported foreach summaries route through
+  `src/ir1-ssa-loops.ts`. General loop SSA remains out of scope.
+  `translate-body.ts` orchestrates build/lower and keeps
+  `SymbolicState` fallback utilities only for M6 cleanup. The
+  mutating output is a list of equations + frame conditions; no L2
+  statement vocabulary.
 
 L2 is *expression-only* — there is no L2 `IRStmt`. The asymmetry is
 intentional; see `workstreams/ts2pant-imperative-ir.md`
@@ -871,14 +873,14 @@ The mutating path emits `PropResult[]` directly:
 - One frame `kind: "equation"` per unmodified-but-in-scope rule
   (identity equation `prop' obj = prop obj`).
 
-The fold is `lowerL1Body` in `ir1-lower-body.ts`, threading
-`SymbolicState` from `translate-body.ts`. Scalar property writes now
-flow through the dedicated SSA helper in `src/ir1-ssa-scalars.ts`,
-which records property reads, writes, joins, and final versions before
-lowering them back to the same primed equations the old path emitted.
-The legacy `SymbolicState` primitives (`putWrite`, `mergeOverrides`,
-`installMapWrite`, `installSetWrite`) remain in use for Map/Set and
-foreach until the later milestones that own those migrations.
+The supported path is `lowerL1BodyToSsaProps` in
+`ir1-lower-body.ts`. It combines scalar, collection, and supported
+loop-summary lowering results, carries final property writes and
+modified rules, and appends frames for declared rules that were not
+modified. The legacy `SymbolicState` primitives (`putWrite`,
+`mergeOverrides`, `installMapWrite`, `installSetWrite`,
+`readMapThroughWrites`, `readSetThroughWrites`) remain only as M6
+fallback cleanup scope.
 
 ### Divergence from IRSC
 
@@ -966,12 +968,10 @@ with no migration flags, no escape hatches, and no parallel pipelines:
   Scalar property mutation now routes through the dedicated SSA helper
   (`src/ir1-ssa-scalars.ts`), while Map/Set now routes through the
   collection SSA helper (`src/ir1-ssa-collections.ts`) and loop
-  summaries route through `src/ir1-ssa-loops.ts`. `SymbolicState`
-  still exists in `ir1-lower-body.ts` for later cleanup, but it is not
-  the semantic backing for the supported loop-summary forms after M4.
-  No L2 statement vocabulary; the fallback fold reuses the existing
-  mutation primitives (`putWrite`, `mergeOverrides`, `installMapWrite`,
-  `installSetWrite`).
+  summaries route through `src/ir1-ssa-loops.ts`.
+  `lowerL1BodyToSsaProps` is the M5 production boundary for final
+  emission and frame derivation. `SymbolicState` remains only as M6
+  fallback cleanup scope. No L2 statement vocabulary.
 
 Constructions outside the canonical L1 vocabulary reject with a
 specific `unsupported` reason. The build pass either produces a

--- a/tools/ts2pant/src/ir1-build-body.ts
+++ b/tools/ts2pant/src/ir1-build-body.ts
@@ -993,7 +993,7 @@ function buildL1MutationBody(
  * recognized `.set/.delete/.add/.delete/.clear` calls on Map/Set
  * receivers.
  */
-function buildL1EffectCall(
+export function buildL1EffectCall(
   call: ts.CallExpression,
   ctx: BuildBodyCtx,
 ): BuildResult<IR1Stmt> {

--- a/tools/ts2pant/src/ir1-lower-body.ts
+++ b/tools/ts2pant/src/ir1-lower-body.ts
@@ -27,7 +27,10 @@
 import { lowerBinop, lowerExpr } from "./ir-emit.js";
 import type { IR1Expr, IR1Stmt } from "./ir1.js";
 import { lowerL1Expr } from "./ir1-lower.js";
-import { lowerCollectionSsaToProps } from "./ir1-ssa-collections.js";
+import {
+  isCollectionSsaL1Body,
+  lowerCollectionSsaToProps,
+} from "./ir1-ssa-collections.js";
 import {
   foreachShapeBAccumulatorKey,
   lowerForeachShapeASummaries,
@@ -35,7 +38,9 @@ import {
   type MuSearchSummaryLowerResult,
 } from "./ir1-ssa-loops.js";
 import {
+  appendFramesForUnmodifiedRules,
   collectionSsaBodyLowerResult,
+  combineIR1SsaBodyLowerResults,
   type IR1SsaBodyLowerResult,
   ir1SsaBodyLowerUnsupported,
   loopSsaBodyLowerResult,
@@ -64,7 +69,7 @@ import {
   type SymbolicState,
   symbolicKey,
 } from "./translate-body.js";
-import type { PropResult } from "./types.js";
+import type { PantDeclaration, PropResult } from "./types.js";
 
 export interface LowerBodyCtx {
   applyConst: (e: OpaqueExpr) => OpaqueExpr;
@@ -103,6 +108,58 @@ export function adaptLoopSummaryLowerResult(
 
 export interface ScalarSsaBodyLowerOptions extends LowerBodyCtx {
   initialPropertyValues?: ReadonlyMap<string, OpaqueExpr>;
+}
+
+export interface SsaBodyLowerOptions extends LowerBodyCtx {
+  initialPropertyValues?: ReadonlyMap<string, OpaqueExpr>;
+}
+
+export function lowerL1BodyToSsaProps(
+  stmt: IR1Stmt,
+  declarations: readonly PantDeclaration[],
+  options: SsaBodyLowerOptions,
+): IR1SsaBodyLowerResult {
+  return appendFramesForUnmodifiedRules(
+    lowerL1BodyToSsaResult(stmt, options),
+    declarations,
+  );
+}
+
+function lowerL1BodyToSsaResult(
+  stmt: IR1Stmt,
+  options: SsaBodyLowerOptions,
+): IR1SsaBodyLowerResult {
+  if (isCollectionSsaL1Body(stmt)) {
+    return lowerCollectionL1BodyToSsaResult(stmt, options);
+  }
+  if (isScalarSsaL1Body(stmt)) {
+    return lowerScalarL1BodyToSsaResult(stmt, options);
+  }
+  if (stmt.kind === "foreach") {
+    return lowerForeachL1BodyToSsaResult(stmt, options);
+  }
+  if (stmt.kind === "block") {
+    const results: IR1SsaBodyLowerResult[] = [];
+    const initialPropertyValues = new Map(options.initialPropertyValues);
+    for (const child of stmt.stmts) {
+      const result = lowerL1BodyToSsaResult(child, {
+        ...options,
+        initialPropertyValues,
+      });
+      results.push(result);
+      if (result.diagnostics.length > 0) {
+        continue;
+      }
+      for (const entry of result.finalProperties ?? []) {
+        const prop = "location" in entry ? entry.location.ruleName : entry.prop;
+        initialPropertyValues.set(symbolicKey(prop, entry.objExpr), entry.rhs);
+      }
+    }
+    return combineIR1SsaBodyLowerResults(...results);
+  }
+  return ir1SsaBodyLowerUnsupported(
+    "statement is not supported by unified SSA body lowering",
+  );
 }
 
 export function lowerCollectionL1BodyToSsaResult(
@@ -144,6 +201,49 @@ export function lowerScalarL1BodyToSsaResult(
         : "scalar SSA lowering rejected the body",
     );
   }
+}
+
+function lowerForeachL1BodyToSsaResult(
+  stmt: Extract<IR1Stmt, { kind: "foreach" }>,
+  options: SsaBodyLowerOptions,
+): IR1SsaBodyLowerResult {
+  const arrExpr = options.applyConst(lowerExpr(lowerL1Expr(stmt.source)));
+  const results: IR1SsaBodyLowerResult[] = [];
+
+  if (stmt.body !== null) {
+    results.push(
+      adaptLoopSummaryLowerResult(
+        lowerForeachShapeASummaries({
+          binder: stmt.binder,
+          source: arrExpr,
+          body: stmt.body,
+          lowerOpaque: options.applyConst,
+          ...(options.initialPropertyValues === undefined
+            ? {}
+            : { initialPropertyValues: options.initialPropertyValues }),
+        }),
+      ),
+    );
+  }
+
+  if (stmt.foldLeaves.length > 0) {
+    results.push(
+      adaptLoopSummaryLowerResult(
+        lowerForeachShapeBSummaries({
+          binder: stmt.binder,
+          source: arrExpr,
+          foldLeaves: stmt.foldLeaves,
+          lowerExpr: (expr) => options.applyConst(lowerExpr(lowerL1Expr(expr))),
+          priorAccumulatorValues: new Map(),
+        }),
+      ),
+    );
+  }
+
+  if (results.length === 0) {
+    return ir1SsaBodyLowerUnsupported("empty foreach body");
+  }
+  return combineIR1SsaBodyLowerResults(...results);
 }
 
 /**

--- a/tools/ts2pant/src/ir1-ssa-lower.ts
+++ b/tools/ts2pant/src/ir1-ssa-lower.ts
@@ -125,11 +125,17 @@ export function appendFramesForUnmodifiedRules(
   const ast = getAst();
   const frames: PropResult[] = [];
   const modifiedRules = new Set(result.modifiedRules);
+  const framedRules = new Set<IR1SsaRuleName>();
 
   for (const decl of declarations) {
-    if (decl.kind !== "rule" || modifiedRules.has(decl.name)) {
+    if (
+      decl.kind !== "rule" ||
+      modifiedRules.has(decl.name) ||
+      framedRules.has(decl.name)
+    ) {
       continue;
     }
+    framedRules.add(decl.name);
     const paramArgs = decl.params.map((p) => ast.var(p.name));
     frames.push({
       kind: "equation",

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -2,6 +2,7 @@ import type { SourceFile } from "ts-morph";
 import ts from "typescript";
 import { buildIR, isBuildUnsupported } from "./ir-build.js";
 import { lowerExpr } from "./ir-emit.js";
+import { type IR1Expr, type IR1Stmt, ir1Block } from "./ir1.js";
 import {
   buildL1Conditional,
   buildL1LetWhile,
@@ -16,13 +17,14 @@ import {
 } from "./ir1-build.js";
 import {
   buildL1AssignStmt,
+  buildL1EffectCall,
   buildL1ForEachCall,
   buildL1ForOfMutation,
   buildL1IfMutation,
   isUnsupported,
 } from "./ir1-build-body.js";
 import { lowerL1MuSearch, type MuSearchLowerCtx } from "./ir1-lower.js";
-import { lowerL1Body } from "./ir1-lower-body.js";
+import { lowerL1Body, lowerL1BodyToSsaProps } from "./ir1-lower-body.js";
 import {
   isScalarSsaL1Body,
   lowerScalarSsaEarlyExitMerge,
@@ -4497,9 +4499,27 @@ function translateMutatingBody(
 
   const ast = getAst();
   const propositions: PropResult[] = [];
+  const ssaState = makeSymbolicState();
+  const ssaSupply = makeUniqueSupply(synthCell);
+  const ssaBody = buildSupportedSsaMutatingBody(
+    node.body,
+    checker,
+    strategy,
+    paramNames,
+    ssaState,
+    ssaSupply,
+  );
+  if (!isUnsupported(ssaBody) && !containsDeferredSsaFastPathShape(ssaBody)) {
+    const lowered = lowerL1BodyToSsaProps(ssaBody, declarations, {
+      applyConst: (e) => applyOpaqueAliases(e, ssaSupply),
+    });
+    if (lowered.diagnostics.length === 0) {
+      return lowered.propositions;
+    }
+  }
+
   const state = makeSymbolicState();
   const supply = makeUniqueSupply(synthCell);
-
   const ok = symbolicExecute(
     node.body,
     checker,
@@ -4556,6 +4576,188 @@ function translateMutatingBody(
   propositions.push(...frames);
 
   return propositions;
+}
+
+function containsDeferredSsaFastPathShape(stmt: IR1Stmt): boolean {
+  switch (stmt.kind) {
+    case "foreach":
+      return stmt.foldLeaves.length > 0 || containsStateAwareRead(stmt.source);
+    case "assign":
+      return (
+        containsStateAwareRead(stmt.target) ||
+        containsStateAwareRead(stmt.value)
+      );
+    case "map-effect":
+      return (
+        containsStateAwareRead(stmt.objExpr) ||
+        containsStateAwareRead(stmt.keyExpr) ||
+        (stmt.valueExpr !== null && containsStateAwareRead(stmt.valueExpr))
+      );
+    case "set-effect":
+      return (
+        containsStateAwareRead(stmt.objExpr) ||
+        (stmt.elemExpr !== null && containsStateAwareRead(stmt.elemExpr))
+      );
+    case "cond-stmt":
+      return (
+        stmt.arms.some(
+          ([guard, body]) =>
+            containsStateAwareRead(guard) ||
+            containsDeferredSsaFastPathShape(body),
+        ) ||
+        (stmt.otherwise !== null &&
+          containsDeferredSsaFastPathShape(stmt.otherwise))
+      );
+    case "block":
+      return stmt.stmts.some(containsDeferredSsaFastPathShape);
+    case "let":
+      return containsStateAwareRead(stmt.value);
+    case "return":
+    case "throw":
+    case "expr-stmt":
+      return stmt.expr !== null && containsStateAwareRead(stmt.expr);
+    case "while":
+    case "for":
+      return true;
+    default: {
+      const _exhaustive: never = stmt;
+      void _exhaustive;
+      return true;
+    }
+  }
+}
+
+function containsStateAwareRead(expr: IR1Expr): boolean {
+  switch (expr.kind) {
+    case "map-read":
+    case "set-read":
+      return true;
+    case "var":
+    case "lit":
+      return false;
+    case "member":
+      return containsStateAwareRead(expr.receiver);
+    case "binop":
+      return (
+        containsStateAwareRead(expr.lhs) || containsStateAwareRead(expr.rhs)
+      );
+    case "unop":
+      return containsStateAwareRead(expr.arg);
+    case "app":
+      return (
+        containsStateAwareRead(expr.callee) ||
+        expr.args.some(containsStateAwareRead)
+      );
+    case "cond":
+      return (
+        expr.arms.some(
+          ([guard, value]) =>
+            containsStateAwareRead(guard) || containsStateAwareRead(value),
+        ) || containsStateAwareRead(expr.otherwise)
+      );
+    case "is-nullish":
+      return containsStateAwareRead(expr.operand);
+    case "each":
+      return (
+        containsStateAwareRead(expr.src) ||
+        expr.guards.some(containsStateAwareRead) ||
+        containsStateAwareRead(expr.proj)
+      );
+    default: {
+      const _exhaustive: never = expr;
+      void _exhaustive;
+      return true;
+    }
+  }
+}
+
+function buildSupportedSsaMutatingBody(
+  body: ts.Block,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  paramNames: Map<string, string>,
+  state: SymbolicState,
+  supply: UniqueSupply,
+): IR1Stmt | { unsupported: string } {
+  const stmts: IR1Stmt[] = [];
+  const applyConst = (e: OpaqueExpr): OpaqueExpr =>
+    applyOpaqueAliases(e, supply);
+  for (const stmt of body.statements) {
+    if (isGuardStatement(stmt, checker)) {
+      continue;
+    }
+    if (ts.isReturnStatement(stmt) && !stmt.expression) {
+      continue;
+    }
+    const built = buildSupportedSsaStatement(stmt, {
+      checker,
+      strategy,
+      paramNames,
+      state,
+      supply,
+      applyConst,
+    });
+    if (isUnsupported(built)) {
+      return built;
+    }
+    stmts.push(built);
+  }
+  if (stmts.length === 0) {
+    return { unsupported: "empty mutating body" };
+  }
+  if (stmts.length === 1) {
+    return stmts[0]!;
+  }
+  return ir1Block(stmts as [IR1Stmt, ...IR1Stmt[]]);
+}
+
+function buildSupportedSsaStatement(
+  stmt: ts.Statement,
+  ctx: {
+    checker: ts.TypeChecker;
+    strategy: NumericStrategy;
+    paramNames: Map<string, string>;
+    state: SymbolicState;
+    supply: UniqueSupply;
+    applyConst: (e: OpaqueExpr) => OpaqueExpr;
+  },
+): IR1Stmt | { unsupported: string } {
+  if (ts.isBlock(stmt)) {
+    const body = buildSupportedSsaMutatingBody(
+      stmt,
+      ctx.checker,
+      ctx.strategy,
+      ctx.paramNames,
+      ctx.state,
+      ctx.supply,
+    );
+    return body;
+  }
+  if (ts.isIfStatement(stmt)) {
+    return buildL1IfMutation(stmt, ctx);
+  }
+  if (ts.isForOfStatement(stmt)) {
+    return buildL1ForOfMutation(stmt, ctx);
+  }
+  if (ts.isExpressionStatement(stmt)) {
+    const expr = unwrapExpression(stmt.expression);
+    if (
+      ts.isCallExpression(expr) &&
+      ts.isPropertyAccessExpression(expr.expression) &&
+      expr.expression.name.text === "forEach"
+    ) {
+      return buildL1ForEachCall(expr, ctx);
+    }
+    if (ts.isCallExpression(expr)) {
+      return buildL1EffectCall(expr, ctx);
+    }
+    if (ts.isBinaryExpression(expr)) {
+      return buildL1AssignStmt(stmt, ctx);
+    }
+  }
+  return {
+    unsupported: `statement is not supported by unified SSA body lowering: ${ts.SyntaxKind[stmt.kind]}`,
+  };
 }
 
 /**

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -359,19 +359,19 @@ exports[`expressions-literals.ts > yes 1`] = `
 `;
 
 exports[`expressions-map-mutation-field.ts > cacheEvict 1`] = `
-"module CACHE_EVICT.\\n\\nCache.\\ncache--entries-key c1: Cache, k1: String => Bool.\\ncache--entries c1: Cache, k1: String, cache--entries-key c1 k1 => Int.\\n~> Cache-evict @ c: Cache, k: String.\\n\\n---\\n\\nall m: Cache, k2: String | cache--entries-key' m k2 = cache--entries-key[(c, k) |-> false] m k2.\\n"
+"module CACHE_EVICT.\\n\\nCache.\\ncache--entries-key c1: Cache, k1: String => Bool.\\ncache--entries c1: Cache, k1: String, cache--entries-key c1 k1 => Int.\\n~> Cache-evict @ c: Cache, k: String.\\n\\n---\\n\\nall m: Cache, k1: String | cache--entries-key' m k1 = cache--entries-key[(c, k) |-> false] m k1.\\ncache--entries' c1 k1 = cache--entries c1 k1.\\n"
 `;
 
 exports[`expressions-map-mutation-field.ts > cacheEvictParen 1`] = `
-"module CACHE_EVICT_PAREN.\\n\\nCache.\\ncache--entries-key c1: Cache, k1: String => Bool.\\ncache--entries c1: Cache, k1: String, cache--entries-key c1 k1 => Int.\\n~> Cache-evict-paren @ c: Cache, k: String.\\n\\n---\\n\\nall m: Cache, k2: String | cache--entries-key' m k2 = cache--entries-key[(c, k) |-> false] m k2.\\n"
+"module CACHE_EVICT_PAREN.\\n\\nCache.\\ncache--entries-key c1: Cache, k1: String => Bool.\\ncache--entries c1: Cache, k1: String, cache--entries-key c1 k1 => Int.\\n~> Cache-evict-paren @ c: Cache, k: String.\\n\\n---\\n\\nall m: Cache, k1: String | cache--entries-key' m k1 = cache--entries-key[(c, k) |-> false] m k1.\\ncache--entries' c1 k1 = cache--entries c1 k1.\\n"
 `;
 
 exports[`expressions-map-mutation-field.ts > cachePut 1`] = `
-"module CACHE_PUT.\\n\\nCache.\\ncache--entries-key c1: Cache, k1: String => Bool.\\ncache--entries c1: Cache, k1: String, cache--entries-key c1 k1 => Int.\\n~> Cache-put @ c: Cache, k: String, v: Int.\\n\\n---\\n\\nall m: Cache, k2: String | cache--entries' m k2 = cache--entries[(c, k) |-> v] m k2.\\nall m1: Cache, k3: String | cache--entries-key' m1 k3 = cache--entries-key[(c, k) |-> true] m1 k3.\\n"
+"module CACHE_PUT.\\n\\nCache.\\ncache--entries-key c1: Cache, k1: String => Bool.\\ncache--entries c1: Cache, k1: String, cache--entries-key c1 k1 => Int.\\n~> Cache-put @ c: Cache, k: String, v: Int.\\n\\n---\\n\\nall m: Cache, k1: String | cache--entries' m k1 = cache--entries[(c, k) |-> v] m k1.\\nall m: Cache, k1: String | cache--entries-key' m k1 = cache--entries-key[(c, k) |-> true] m k1.\\n"
 `;
 
 exports[`expressions-map-mutation-field.ts > cachePutNonNull 1`] = `
-"module CACHE_PUT_NON_NULL.\\n\\nCache.\\ncache--entries-key c1: Cache, k1: String => Bool.\\ncache--entries c1: Cache, k1: String, cache--entries-key c1 k1 => Int.\\n~> Cache-put-non-null @ c: Cache, k: String, v: Int.\\n\\n---\\n\\nall m: Cache, k2: String | cache--entries' m k2 = cache--entries[(c, k) |-> v] m k2.\\nall m1: Cache, k3: String | cache--entries-key' m1 k3 = cache--entries-key[(c, k) |-> true] m1 k3.\\n"
+"module CACHE_PUT_NON_NULL.\\n\\nCache.\\ncache--entries-key c1: Cache, k1: String => Bool.\\ncache--entries c1: Cache, k1: String, cache--entries-key c1 k1 => Int.\\n~> Cache-put-non-null @ c: Cache, k: String, v: Int.\\n\\n---\\n\\nall m: Cache, k1: String | cache--entries' m k1 = cache--entries[(c, k) |-> v] m k1.\\nall m: Cache, k1: String | cache--entries-key' m k1 = cache--entries-key[(c, k) |-> true] m k1.\\n"
 `;
 
 exports[`expressions-map-mutation.ts > bump 1`] = `
@@ -383,7 +383,7 @@ exports[`expressions-map-mutation.ts > deleteThenCopy 1`] = `
 `;
 
 exports[`expressions-map-mutation.ts > put 1`] = `
-"module PUT.\\n\\nStringToIntMap.\\nstring-to-int-map-key m1: StringToIntMap, k1: String => Bool.\\nstring-to-int-map m1: StringToIntMap, k1: String, string-to-int-map-key m1 k1 => Int.\\n~> Put @ m: StringToIntMap, k: String, v: Int.\\n\\n---\\n\\nall m2: StringToIntMap, k2: String | string-to-int-map' m2 k2 = string-to-int-map[(m, k) |-> v] m2 k2.\\nall m3: StringToIntMap, k3: String | string-to-int-map-key' m3 k3 = string-to-int-map-key[(m, k) |-> true] m3 k3.\\n"
+"module PUT.\\n\\nStringToIntMap.\\nstring-to-int-map-key m1: StringToIntMap, k1: String => Bool.\\nstring-to-int-map m1: StringToIntMap, k1: String, string-to-int-map-key m1 k1 => Int.\\n~> Put @ m: StringToIntMap, k: String, v: Int.\\n\\n---\\n\\nall m1: StringToIntMap, k1: String | string-to-int-map' m1 k1 = string-to-int-map[(m, k) |-> v] m1 k1.\\nall m1: StringToIntMap, k1: String | string-to-int-map-key' m1 k1 = string-to-int-map-key[(m, k) |-> true] m1 k1.\\n"
 `;
 
 exports[`expressions-map-mutation.ts > putIfAbsent 1`] = `
@@ -391,11 +391,11 @@ exports[`expressions-map-mutation.ts > putIfAbsent 1`] = `
 `;
 
 exports[`expressions-map-mutation.ts > putPair 1`] = `
-"module PUT_PAIR.\\n\\nStringToIntMap.\\nstring-to-int-map-key m1: StringToIntMap, k: String => Bool.\\nstring-to-int-map m1: StringToIntMap, k: String, string-to-int-map-key m1 k => Int.\\n~> Put-pair @ m: StringToIntMap, k1: String, v1: Int, k2: String, v2: Int.\\n\\n---\\n\\nall m2: StringToIntMap, k3: String | string-to-int-map' m2 k3 = string-to-int-map[(m, k1) |-> v1, (m, k2) |-> v2] m2 k3.\\nall m3: StringToIntMap, k4: String | string-to-int-map-key' m3 k4 = string-to-int-map-key[(m, k1) |-> true, (m, k2) |-> true] m3 k4.\\n"
+"module PUT_PAIR.\\n\\nStringToIntMap.\\nstring-to-int-map-key m1: StringToIntMap, k: String => Bool.\\nstring-to-int-map m1: StringToIntMap, k: String, string-to-int-map-key m1 k => Int.\\n~> Put-pair @ m: StringToIntMap, k1: String, v1: Int, k2: String, v2: Int.\\n\\n---\\n\\nall m1: StringToIntMap, k: String | string-to-int-map' m1 k = string-to-int-map[(m, k1) |-> v1, (m, k2) |-> v2] m1 k.\\nall m1: StringToIntMap, k: String | string-to-int-map-key' m1 k = string-to-int-map-key[(m, k1) |-> true, (m, k2) |-> true] m1 k.\\n"
 `;
 
 exports[`expressions-map-mutation.ts > remove 1`] = `
-"module REMOVE.\\n\\nStringToIntMap.\\nstring-to-int-map-key m1: StringToIntMap, k1: String => Bool.\\nstring-to-int-map m1: StringToIntMap, k1: String, string-to-int-map-key m1 k1 => Int.\\n~> Remove @ m: StringToIntMap, k: String.\\n\\n---\\n\\nall m2: StringToIntMap, k2: String | string-to-int-map-key' m2 k2 = string-to-int-map-key[(m, k) |-> false] m2 k2.\\n"
+"module REMOVE.\\n\\nStringToIntMap.\\nstring-to-int-map-key m1: StringToIntMap, k1: String => Bool.\\nstring-to-int-map m1: StringToIntMap, k1: String, string-to-int-map-key m1 k1 => Int.\\n~> Remove @ m: StringToIntMap, k: String.\\n\\n---\\n\\nall m1: StringToIntMap, k1: String | string-to-int-map-key' m1 k1 = string-to-int-map-key[(m, k) |-> false] m1 k1.\\nstring-to-int-map' m1 k1 = string-to-int-map m1 k1.\\n"
 `;
 
 exports[`expressions-map-mutation.ts > setAndCopy 1`] = `
@@ -403,11 +403,11 @@ exports[`expressions-map-mutation.ts > setAndCopy 1`] = `
 `;
 
 exports[`expressions-map-mutation.ts > setThenDelete 1`] = `
-"module SET_THEN_DELETE.\\n\\nStringToIntMap.\\nstring-to-int-map-key m1: StringToIntMap, k1: String => Bool.\\nstring-to-int-map m1: StringToIntMap, k1: String, string-to-int-map-key m1 k1 => Int.\\n~> Set-then-delete @ m: StringToIntMap, k: String, v: Int.\\n\\n---\\n\\nall m2: StringToIntMap, k2: String | string-to-int-map-key' m2 k2 = string-to-int-map-key[(m, k) |-> false] m2 k2.\\n"
+"module SET_THEN_DELETE.\\n\\nStringToIntMap.\\nstring-to-int-map-key m1: StringToIntMap, k1: String => Bool.\\nstring-to-int-map m1: StringToIntMap, k1: String, string-to-int-map-key m1 k1 => Int.\\n~> Set-then-delete @ m: StringToIntMap, k: String, v: Int.\\n\\n---\\n\\nall m1: StringToIntMap, k1: String | string-to-int-map' m1 k1 = string-to-int-map[(m, k) |-> v] m1 k1.\\nall m1: StringToIntMap, k1: String | string-to-int-map-key' m1 k1 = string-to-int-map-key[(m, k) |-> false] m1 k1.\\n"
 `;
 
 exports[`expressions-map-mutation.ts > setTwice 1`] = `
-"module SET_TWICE.\\n\\nStringToIntMap.\\nstring-to-int-map-key m1: StringToIntMap, k1: String => Bool.\\nstring-to-int-map m1: StringToIntMap, k1: String, string-to-int-map-key m1 k1 => Int.\\n~> Set-twice @ m: StringToIntMap, k: String, v1: Int, v2: Int.\\n\\n---\\n\\nall m2: StringToIntMap, k2: String | string-to-int-map' m2 k2 = string-to-int-map[(m, k) |-> v2] m2 k2.\\nall m3: StringToIntMap, k3: String | string-to-int-map-key' m3 k3 = string-to-int-map-key[(m, k) |-> true] m3 k3.\\n"
+"module SET_TWICE.\\n\\nStringToIntMap.\\nstring-to-int-map-key m1: StringToIntMap, k1: String => Bool.\\nstring-to-int-map m1: StringToIntMap, k1: String, string-to-int-map-key m1 k1 => Int.\\n~> Set-twice @ m: StringToIntMap, k: String, v1: Int, v2: Int.\\n\\n---\\n\\nall m1: StringToIntMap, k1: String | string-to-int-map' m1 k1 = string-to-int-map[(m, k) |-> v2] m1 k1.\\nall m1: StringToIntMap, k1: String | string-to-int-map-key' m1 k1 = string-to-int-map-key[(m, k) |-> true] m1 k1.\\n"
 `;
 
 exports[`expressions-map-params.ts > contains 1`] = `
@@ -639,7 +639,7 @@ exports[`expressions-set-mutation-field.ts > tagAddTwo 1`] = `
 `;
 
 exports[`expressions-set-mutation-field.ts > tagAddTwoReceivers 1`] = `
-"module TAG_ADD_TWO_RECEIVERS.\\n\\nTagged.\\ntagged--tags t: Tagged => [String].\\n~> Tag-add-two-receivers @ c1: Tagged, c2: Tagged, x: String, y: String.\\n\\n---\\n\\nall y1: String | y1 in tagged--tags' c1 <-> (cond y1 = x => true, true => y1 in tagged--tags c1).\\nall y2: String | y2 in tagged--tags' c2 <-> (cond y2 = y => true, true => y2 in tagged--tags c2).\\n"
+"module TAG_ADD_TWO_RECEIVERS.\\n\\nTagged.\\ntagged--tags t: Tagged => [String].\\n~> Tag-add-two-receivers @ c1: Tagged, c2: Tagged, x: String, y: String.\\n\\n---\\n\\nall y: String | y in tagged--tags' c1 <-> (cond y = x => true, true => y in tagged--tags c1).\\nall y1: String | y1 in tagged--tags' c2 <-> (cond y1 = y => true, true => y1 in tagged--tags c2).\\n"
 `;
 
 exports[`expressions-set-mutation-field.ts > tagClear 1`] = `
@@ -883,7 +883,7 @@ exports[`functions-mutating-loop.ts > activateAll 1`] = `
 `;
 
 exports[`functions-mutating-loop.ts > deductFees 1`] = `
-"module DEDUCT_FEES.\\n\\nAccount.\\naccount--total a1: Account => Int.\\naccount--balance a1: Account => Int.\\nFee.\\nfee--amount f: Fee => Int.\\n~> Deduct-fees @ a: Account, fees: [Fee].\\n\\n---\\n\\naccount--balance' a = account--balance a - (+ over each f1 in fees | fee--amount f1).\\naccount--total' a1 = account--total a1.\\nfee--amount' f = fee--amount f.\\n"
+"module DEDUCT_FEES.\\n\\nAccount.\\naccount--total a1: Account => Int.\\naccount--balance a1: Account => Int.\\nFee.\\nfee--amount f: Fee => Int.\\n~> Deduct-fees @ a: Account, fees: [Fee].\\n\\n---\\n\\naccount--balance' a = account--balance a - (+ over each f2 in fees | fee--amount f2).\\naccount--total' a1 = account--total a1.\\nfee--amount' f = fee--amount f.\\n"
 `;
 
 exports[`functions-mutating-loop.ts > forEachActivate 1`] = `
@@ -891,23 +891,23 @@ exports[`functions-mutating-loop.ts > forEachActivate 1`] = `
 `;
 
 exports[`functions-mutating-loop.ts > forEachSum 1`] = `
-"module FOR_EACH_SUM.\\n\\nAccount.\\naccount--total a1: Account => Int.\\naccount--balance a1: Account => Int.\\nItem.\\nitem--value i: Item => Int.\\nitem--tagged i: Item => Bool.\\n~> For-each-sum @ a: Account, items: [Item].\\n\\n---\\n\\naccount--total' a = account--total a + (+ over each x in items | item--value x).\\naccount--balance' a1 = account--balance a1.\\nitem--value' i = item--value i.\\nitem--tagged' i = item--tagged i.\\n"
+"module FOR_EACH_SUM.\\n\\nAccount.\\naccount--total a1: Account => Int.\\naccount--balance a1: Account => Int.\\nItem.\\nitem--value i: Item => Int.\\nitem--tagged i: Item => Bool.\\n~> For-each-sum @ a: Account, items: [Item].\\n\\n---\\n\\naccount--total' a = account--total a + (+ over each x1 in items | item--value x1).\\naccount--balance' a1 = account--balance a1.\\nitem--value' i = item--value i.\\nitem--tagged' i = item--tagged i.\\n"
 `;
 
 exports[`functions-mutating-loop.ts > mixedUpdates 1`] = `
-"module MIXED_UPDATES.\\n\\nAccount.\\naccount--total a1: Account => Int.\\naccount--balance a1: Account => Int.\\nItem.\\nitem--value i: Item => Int.\\nitem--tagged i: Item => Bool.\\n~> Mixed-updates @ a: Account, items: [Item].\\n\\n---\\n\\nall x in items | item--tagged' x = true.\\naccount--total' a = account--total a + (+ over each x in items | item--value x).\\naccount--balance' a1 = account--balance a1.\\nitem--value' i = item--value i.\\n"
+"module MIXED_UPDATES.\\n\\nAccount.\\naccount--total a1: Account => Int.\\naccount--balance a1: Account => Int.\\nItem.\\nitem--value i: Item => Int.\\nitem--tagged i: Item => Bool.\\n~> Mixed-updates @ a: Account, items: [Item].\\n\\n---\\n\\nall x1 in items | item--tagged' x1 = true.\\naccount--total' a = account--total a + (+ over each x1 in items | item--value x1).\\naccount--balance' a1 = account--balance a1.\\nitem--value' i = item--value i.\\n"
 `;
 
 exports[`functions-mutating-loop.ts > sumAmounts 1`] = `
-"module SUM_AMOUNTS.\\n\\nAccount.\\naccount--total a1: Account => Int.\\naccount--balance a1: Account => Int.\\nItem.\\nitem--value i: Item => Int.\\nitem--tagged i: Item => Bool.\\n~> Sum-amounts @ a: Account, items: [Item].\\n\\n---\\n\\naccount--total' a = account--total a + (+ over each x in items | item--value x).\\naccount--balance' a1 = account--balance a1.\\nitem--value' i = item--value i.\\nitem--tagged' i = item--tagged i.\\n"
+"module SUM_AMOUNTS.\\n\\nAccount.\\naccount--total a1: Account => Int.\\naccount--balance a1: Account => Int.\\nItem.\\nitem--value i: Item => Int.\\nitem--tagged i: Item => Bool.\\n~> Sum-amounts @ a: Account, items: [Item].\\n\\n---\\n\\naccount--total' a = account--total a + (+ over each x1 in items | item--value x1).\\naccount--balance' a1 = account--balance a1.\\nitem--value' i = item--value i.\\nitem--tagged' i = item--tagged i.\\n"
 `;
 
 exports[`functions-mutating-loop.ts > sumIntoAnon 1`] = `
-"module SUM_INTO_ANON.\\n\\nTotalRec.\\ntotal-rec--total r: TotalRec => Int.\\n~> Sum-into-anon @ acc: TotalRec, items: [Int].\\n\\n---\\n\\ntotal-rec--total' acc = total-rec--total acc + (+ over each x in items | x).\\n"
+"module SUM_INTO_ANON.\\n\\nTotalRec.\\ntotal-rec--total r: TotalRec => Int.\\n~> Sum-into-anon @ acc: TotalRec, items: [Int].\\n\\n---\\n\\ntotal-rec--total' acc = total-rec--total acc + (+ over each x1 in items | x1).\\n"
 `;
 
 exports[`functions-mutating-loop.ts > sumPositive 1`] = `
-"module SUM_POSITIVE.\\n\\nAccount.\\naccount--total a1: Account => Int.\\naccount--balance a1: Account => Int.\\nItem.\\nitem--value i: Item => Int.\\nitem--tagged i: Item => Bool.\\n~> Sum-positive @ a: Account, items: [Item].\\n\\n---\\n\\naccount--total' a = account--total a + (+ over each x in items, item--value x > 0 | item--value x).\\naccount--balance' a1 = account--balance a1.\\nitem--value' i = item--value i.\\nitem--tagged' i = item--tagged i.\\n"
+"module SUM_POSITIVE.\\n\\nAccount.\\naccount--total a1: Account => Int.\\naccount--balance a1: Account => Int.\\nItem.\\nitem--value i: Item => Int.\\nitem--tagged i: Item => Bool.\\n~> Sum-positive @ a: Account, items: [Item].\\n\\n---\\n\\naccount--total' a = account--total a + (+ over each x1 in items, item--value x1 > 0 | item--value x1).\\naccount--balance' a1 = account--balance a1.\\nitem--value' i = item--value i.\\nitem--tagged' i = item--tagged i.\\n"
 `;
 
 exports[`functions-mutating-loop.ts > sumPositiveAssert 1`] = `
@@ -915,7 +915,7 @@ exports[`functions-mutating-loop.ts > sumPositiveAssert 1`] = `
 `;
 
 exports[`functions-mutating-loop.ts > sumScaledAssert 1`] = `
-"module SUM_SCALED_ASSERT.\\n\\nAccount.\\naccount--total a1: Account => Int.\\naccount--balance a1: Account => Int.\\nItem.\\nitem--value i: Item => Int.\\nitem--tagged i: Item => Bool.\\n~> Sum-scaled-assert @ a: Account, items: [Item], scale: Int, scale >= 0.\\n\\n---\\n\\naccount--total' a = account--total a + (+ over each x in items | item--value x).\\naccount--balance' a1 = account--balance a1.\\nitem--value' i = item--value i.\\nitem--tagged' i = item--tagged i.\\n"
+"module SUM_SCALED_ASSERT.\\n\\nAccount.\\naccount--total a1: Account => Int.\\naccount--balance a1: Account => Int.\\nItem.\\nitem--value i: Item => Int.\\nitem--tagged i: Item => Bool.\\n~> Sum-scaled-assert @ a: Account, items: [Item], scale: Int, scale >= 0.\\n\\n---\\n\\naccount--total' a = account--total a + (+ over each x1 in items | item--value x1).\\naccount--balance' a1 = account--balance a1.\\nitem--value' i = item--value i.\\nitem--tagged' i = item--tagged i.\\n"
 `;
 
 exports[`functions-mutating.ts > deposit 1`] = `

--- a/tools/ts2pant/tests/ir1-ssa-lower.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-lower.test.mts
@@ -20,13 +20,13 @@ import {
   lowerL1Body,
   lowerScalarL1BodyToSsaResult,
 } from "../src/ir1-lower-body.js";
+import { lowerCollectionSsaToProps } from "../src/ir1-ssa-collections.js";
 import {
   appendFramesForUnmodifiedRules,
   combineIR1SsaBodyLowerResults,
   ir1SsaBodyLowerSuccess,
   ir1SsaBodyLowerUnsupported,
 } from "../src/ir1-ssa-lower.js";
-import { lowerCollectionSsaToProps } from "../src/ir1-ssa-collections.js";
 import {
   lowerForeachShapeASummaries,
   lowerForeachShapeBSummaries,

--- a/tools/ts2pant/tests/ir1-ssa-propresult-lowering.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-propresult-lowering.test.mts
@@ -14,6 +14,10 @@ import {
   ir1Var,
 } from "../src/ir1.js";
 import { lowerCollectionSsaToResult } from "../src/ir1-ssa-collections.js";
+import {
+  appendFramesForUnmodifiedRules,
+  ir1SsaBodyLowerSuccess,
+} from "../src/ir1-ssa-lower.js";
 import { lowerForeachSummary } from "../src/ir1-ssa-loops.js";
 import { lowerScalarSsaToProps } from "../src/ir1-ssa-scalars.js";
 import { getAst, loadAst } from "../src/pant-wasm.js";
@@ -238,27 +242,74 @@ describe("ir1-ssa-propresult-lowering", () => {
     },
   );
 
-  it.skip("frames derive from result modified rules", () => {
-    const result = pendingUnifiedLowerResult({
-      declaredRules: ["Account_balance", "Account_limit", "Account_limit"],
-      modifiedRules: ["Account_balance", "Account_balance"],
-      diagnostics: [],
-    });
+  it("frames derive from result modified rules", () => {
+    const result = appendFramesForUnmodifiedRules(
+      ir1SsaBodyLowerSuccess({
+        modifiedRules: ["Account_balance", "Account_balance"],
+      }),
+      [
+        {
+          kind: "rule",
+          name: "Account_balance",
+          params: [{ name: "account", type: "Account" }],
+          returnType: "Nat",
+        },
+        {
+          kind: "rule",
+          name: "Account_limit",
+          params: [{ name: "account", type: "Account" }],
+          returnType: "Nat",
+        },
+        {
+          kind: "rule",
+          name: "Account_limit",
+          params: [{ name: "account", type: "Account" }],
+          returnType: "Nat",
+        },
+      ],
+    );
+    const ast = getAst();
+    const framedRules = result.propositions
+      .filter((p) => p.kind === "equation")
+      .map((p) => ast.strExpr(p.lhs).replace(/'.*/u, ""));
 
     assert.deepEqual(result.modifiedRules, ["Account_balance"]);
-    assert.deepEqual(result.framedRules, ["Account_limit"]);
+    assert.deepEqual(framedRules, ["Account_limit"]);
     assert.equal(
-      result.framedRules.filter((rule) => rule === "Account_limit").length,
+      framedRules.filter((rule) => rule === "Account_limit").length,
       1,
     );
   });
 
-  it.skip("unsupported diagnostics suppress frame emission", () => {
+  it("unsupported diagnostics suppress frame emission", () => {
     const unsupported = lowerCollectionSsaToResult(
       ir1Assign(ir1Var("x"), ir1LitNat(1)),
       { declaredRules: ["Account_balance", "Account_limit"] },
     );
-    const result = pendingUnifiedLowerResult({
+    const result = appendFramesForUnmodifiedRules(
+      {
+        programs: [unsupported.program],
+        finalProperties: unsupported.finalProperties,
+        propositions: unsupported.propositions,
+        modifiedRules: unsupported.modifiedRules,
+        diagnostics: unsupported.diagnostics,
+      },
+      [
+        {
+          kind: "rule",
+          name: "Account_balance",
+          params: [{ name: "account", type: "Account" }],
+          returnType: "Nat",
+        },
+        {
+          kind: "rule",
+          name: "Account_limit",
+          params: [{ name: "account", type: "Account" }],
+          returnType: "Nat",
+        },
+      ],
+    );
+    const pendingEquivalent = pendingUnifiedLowerResult({
       declaredRules: unsupported.program.declaredRules,
       propositions: unsupported.propositions,
       modifiedRules: unsupported.modifiedRules,
@@ -268,10 +319,10 @@ describe("ir1-ssa-propresult-lowering", () => {
     assert.equal(result.diagnostics.length, 1);
     assert.deepEqual(result.modifiedRules, []);
     assert.deepEqual(result.propositions, []);
-    assert.deepEqual(result.framedRules, []);
+    assert.deepEqual(pendingEquivalent.framedRules, []);
     assert.equal(
       result.diagnostics[0]?.reason,
-      "statement is not supported by collection SSA lowering",
+      "collection SSA assignment target must be a property member",
     );
   });
 });

--- a/workstreams/ts2pant-ir1-ssa.md
+++ b/workstreams/ts2pant-ir1-ssa.md
@@ -19,9 +19,11 @@ directly through `lowerL1Body` in `tools/ts2pant/src/ir1-lower-body.ts`, with
 scalar property mutation routed through `tools/ts2pant/src/ir1-ssa-scalars.ts`
 collection mutation routed through `tools/ts2pant/src/ir1-ssa-collections.ts`,
 and loop-summary mutation routed through `tools/ts2pant/src/ir1-ssa-loops.ts`.
+M5 added the body-level `lowerL1BodyToSsaProps` boundary, so successful
+supported mutating bodies now return final propositions, modified rules, and
+frames from IR1 SSA lowering rather than from `SymbolicState.modifiedProps`.
 `SymbolicState` still exists in `tools/ts2pant/src/translate-body.ts`, but it
-is no longer the backing model for the supported foreach and μ-search summary
-forms after M4.
+is fallback-only for shapes intentionally left to M6 cleanup.
 
 That design is now partially SSA. Scalar property mutation, read-after-write,
 branch joins, and supported early-exit continuation merges are represented by
@@ -30,7 +32,7 @@ IR1 SSA. IR1 still contains `assign`, `while`, `for`, `foreach`, `cond-stmt`,
 `Set.clear()`, now lower through the collection SSA module, while μ-search and
 supported foreach loop summaries lower through the dedicated loop-summary
 helper. General `for` / `while` SSA remains out of scope for this workstream,
-and the remaining `SymbolicState` cleanup is deferred to the M5/M6 transition.
+and the remaining `SymbolicState` cleanup is deferred to M6.
 
 ## Key Challenges
 
@@ -210,8 +212,10 @@ those outputs into the unified `PropResult[]` lowering path.
 
 ### Milestone 5: ir1-ssa-propresult-lowering
 
+**Status**: Landed in patch 5.
+
 **Definition of Done**:
-IR1 SSA has one lowering path to `PropResult[]`:
+IR1 SSA has one lowering path to `PropResult[]` for supported mutating bodies:
 
 - property SSA final versions lower to primed equations
 - Map SSA final versions lower to value and membership override equations
@@ -221,14 +225,16 @@ IR1 SSA has one lowering path to `PropResult[]`:
 - frame conditions derive from IR1's modified-rule set, not from
   `SymbolicState.modifiedProps`
 
-`tools/ts2pant/src/ir1-lower-body.ts` is either rewritten as the IR1 SSA lowerer
-or replaced by a clearly named module. `translate-body.ts` no longer owns
-mutation semantics beyond orchestration and helper utilities.
+`tools/ts2pant/src/ir1-lower-body.ts` now exposes `lowerL1BodyToSsaProps`,
+which appends frames from the unified `modifiedRules` set. `translate-body.ts`
+tries that boundary for supported SSA-backed bodies and falls back only when
+the unified lowerer rejects a shape that M6 still needs to delete or migrate.
 
 **Why this is a safe pause point**:
-The new IR1 SSA architecture is end-to-end for all currently supported syntax.
-The old lowering machinery may still exist as dead code, but the production path
-does not depend on it.
+The new IR1 SSA architecture is end-to-end for the currently supported
+SSA-backed syntax. The old lowering machinery still exists as fallback code for
+deferred shapes, but supported scalar, collection, and loop-summary final
+emission no longer belongs to `translate-body.ts`.
 
 **Unlocks**:
 Code deletion and simplification.
@@ -241,11 +247,13 @@ Code deletion and simplification.
 The obsolete symbolic-state execution machinery is removed or narrowed to
 small pure utilities:
 
-- `SymbolicState` no longer serves as the semantic model for mutating bodies.
+- Remove the fallback paths that still execute mutating bodies through
+  `SymbolicState`.
 - `putWrite`, `addWrittenKey`, `mergeOverrides`, `installMapWrite`,
   `installSetWrite`, `readMapThroughWrites`, and `readSetThroughWrites` are
   deleted, renamed, or moved behind IR1 SSA lowering if still genuinely useful.
-- `translate-body.ts` no longer contains parallel mutation paths.
+- `translate-body.ts` no longer contains parallel mutation paths or final
+  emission fallback code.
 - Comments in `tools/ts2pant/AGENTS.md` and the old imperative-IR workstream
   are updated to mark `SymbolicState` as superseded.
 - Full ts2pant unit and integration suites pass.


### PR DESCRIPTION
## Patch 5: Move supported final emission and frames to IR1 SSA lowering

- Add or expose a high-level `lowerL1BodyToSsaProps` entry point that accepts declarations and returns final propositions plus frames for successful supported SSA-backed bodies.
- Change `translateMutatingBody` so supported SSA-backed bodies use the high-level IR1 lowering entry point instead of walking `state.writes` for final equation emission.
- Derive frames from the unified result's `modifiedRules`; a modified rule must not receive an identity frame.
- Preserve fallback final-emission code only for bodies that the unified SSA lowering does not accept and that are intentionally deferred to M6.
- Enable the Patch 1 frame and unsupported-diagnostic tests.
- Run ts2pant unit and integration suites and update snapshots only for semantically equivalent expected churn.
- Update workstream and agent guidance documentation with the M5 landed status and exact remaining M6 scope.

## Changes
- Add or expose a high-level `lowerL1BodyToSsaProps` entry point that accepts declarations and returns final propositions plus frames for successful supported SSA-backed bodies.
- Change `translateMutatingBody` so supported SSA-backed bodies use the high-level IR1 lowering entry point instead of walking `state.writes` for final equation emission.
- Derive frames from the unified result's `modifiedRules`; a modified rule must not receive an identity frame.
- Preserve fallback final-emission code only for bodies that the unified SSA lowering does not accept and that are intentionally deferred to M6.
- Enable the Patch 1 frame and unsupported-diagnostic tests.
- Run ts2pant unit and integration suites and update snapshots only for semantically equivalent expected churn.
- Update workstream and agent guidance documentation with the M5 landed status and exact remaining M6 scope.

## Files to Modify
- tools/ts2pant/src/translate-body.ts (modify): Delegates supported mutating-body final emission and frame generation to the unified IR1 SSA lowering result; leaves `SymbolicState` final emission only for fallback paths.
- tools/ts2pant/src/ir1-lower-body.ts (modify): Exports a body-level lowering entry point that returns propositions with frames appended for successful SSA-backed bodies.
- tools/ts2pant/tests/ir1-ssa-propresult-lowering.test.mts (modify): Enable frame and unsupported-diagnostic tests.
- tools/ts2pant/tests/integration/collection-ssa-parity.test.mts (modify): Extend parity assertions if needed to cover final frame behavior through the unified lowering path.
- tools/ts2pant/AGENTS.md (modify): Document that M5 landed and `translate-body.ts` no longer owns final emission for supported SSA-backed bodies.
- workstreams/ts2pant-ir1-ssa.md (modify): Mark Milestone 5 landed and list remaining M6 cleanup.

## Gameplan Specification

```
module TS2PANT_IR1_SSA_PROPRESULT_LOWERING.

LowerResult.
Rule.
Location.
Version.
LoopSummary.
PropResult.

successful? r: LowerResult => Bool.
has-diagnostic? r: LowerResult => Bool.
declared? r: LowerResult, rule: Rule => Bool.
modified? r: LowerResult, rule: Rule => Bool.
framed? r: LowerResult, rule: Rule => Bool.
property-location? l: Location => Bool.
collection-location? l: Location => Bool.
final-version? r: LowerResult, l: Location, v: Version => Bool.
lowered-final? r: LowerResult, l: Location => Bool.
rule-of l: Location => Rule.
summary-of? r: LowerResult, s: LoopSummary => Bool.
lowered-summary? r: LowerResult, s: LoopSummary => Bool.
summary-modifies? s: LoopSummary, rule: Rule => Bool.
general-loop-summary? s: LoopSummary => Bool.
emits? r: LowerResult, p: PropResult => Bool.
translate-body-final-emitter? r: LowerResult => Bool.
---
> Every supported final scalar or collection SSA version is lowered.
all r: LowerResult, l: Location, v: Version, successful? r, final-version? r l v, property-location? l | lowered-final? r l.
all r: LowerResult, l: Location, v: Version, successful? r, final-version? r l v, collection-location? l | lowered-final? r l.

> Every supported loop summary is lowered by the same result boundary.
all r: LowerResult, s: LoopSummary, successful? r, summary-of? r s | lowered-summary? r s.

> Final locations and loop summaries drive the modified-rule set used for frames.
all r: LowerResult, l: Location, successful? r, lowered-final? r l | modified? r (rule-of l).
all r: LowerResult, s: LoopSummary, rule: Rule, successful? r, summary-of? r s, summary-modifies? s rule | modified? r rule.

> Successful results frame exactly declared rules that were not modified.
all r: LowerResult, rule: Rule, successful? r, declared? r rule, modified? r rule | ~framed? r rule.
all r: LowerResult, rule: Rule, successful? r, declared? r rule, ~modified? r rule | framed? r rule.

> Unsupported diagnostics suppress frame emission.
all r: LowerResult, has-diagnostic? r | all rule: Rule | ~framed? r rule.

> M5 does not introduce general loop SSA.
all s: LoopSummary | ~general-loop-summary? s.

> Supported SSA-backed final emission is no longer owned by translate-body.
all r: LowerResult, successful? r | ~translate-body-final-emitter? r.

```

## Patch Specification

```
module TS2PANT_IR1_SSA_PROPRESULT_LOWERING_PATCH_5.

LowerResult.
Rule.
PropResult.
Diagnostic.

successful? r: LowerResult => Bool.
modified? r: LowerResult, rule: Rule => Bool.
framed? r: LowerResult, rule: Rule => Bool.
declared? r: LowerResult, rule: Rule => Bool.
has-diagnostic? r: LowerResult => Bool.
emits? r: LowerResult, p: PropResult => Bool.
translate-body-final-emitter? r: LowerResult => Bool.
---
> Successful SSA-backed lowering frames exactly the declared rules it did not modify.
all r: LowerResult, rule: Rule, successful? r, declared? r rule, modified? r rule | ~framed? r rule.
all r: LowerResult, rule: Rule, successful? r, declared? r rule, ~modified? r rule | framed? r rule.

> Diagnostics suppress frame emission.
all r: LowerResult, has-diagnostic? r | all rule: Rule | ~framed? r rule.

> Supported SSA-backed final emission is no longer owned by translate-body.
all r: LowerResult, successful? r | ~translate-body-final-emitter? r.

```


## Implementation Notes

- The TS-body fast path is intentionally conservative: bodies with state-aware Map/Set reads or Shape B fold leaves still defer to the existing fallback when the speculative whole-body SSA build cannot preserve prior-write semantics. Shape A loop summaries and straightforward scalar/collection bodies use the new IR1 result boundary.
- `lowerL1BodyToSsaProps` threads final property values between block children before appending frames. This is what keeps later loop summaries observing earlier SSA-backed property writes without using `SymbolicState` as the transport.
- Collection-only deletes now receive identity frames for the value rule when only membership changes. That is expected churn from deriving frames from `modifiedRules` instead of suppressing frames via `SymbolicState.modifiedProps`.
- I deduped frame emission by rule name in `appendFramesForUnmodifiedRules`; duplicate rule declarations should not produce duplicate identity frames.