### PR TITLE
[ts2pant-ir1-ssa-ripout] Patch 1: Add pending M6 ripout contract tests

### DIFF
--- a/tools/ts2pant/tests/ir1-ssa-ripout.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-ripout.test.mts
@@ -1,0 +1,216 @@
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, it } from "node:test";
+
+import { createSourceFileFromSource } from "../src/extract.js";
+import { translateBody } from "../src/translate-body.js";
+import { IntStrategy } from "../src/translate-types.js";
+import type { PropResult } from "../src/types.js";
+import { buildDocument, emitAndCheck } from "./helpers.mts";
+
+const CONSTRUCTS_DIR = resolve(import.meta.dirname, "fixtures/constructs");
+const SRC_DIR = resolve(import.meta.dirname, "../src");
+
+async function emitFixture(fileName: string, functionName: string): Promise<string> {
+  const doc = await buildDocument(
+    resolve(CONSTRUCTS_DIR, fileName),
+    functionName,
+  );
+  return emitAndCheck(doc);
+}
+
+function translateMutatingSource(
+  source: string,
+  functionName: string,
+): readonly PropResult[] {
+  return translateBody({
+    sourceFile: createSourceFileFromSource(source),
+    functionName,
+    strategy: IntStrategy,
+  });
+}
+
+function extractTranslateMutatingBodySource(sourceText: string): string {
+  const start = sourceText.indexOf("function translateMutatingBody(");
+  const end = sourceText.indexOf(
+    "\nfunction containsDeferredSsaFastPathShape(",
+    start,
+  );
+  assert.notEqual(start, -1, "expected translateMutatingBody in translate-body.ts");
+  assert.notEqual(
+    end,
+    -1,
+    "expected containsDeferredSsaFastPathShape to delimit translateMutatingBody",
+  );
+  return sourceText.slice(start, end);
+}
+
+function exportedSymbolNames(sourceText: string): Set<string> {
+  const names = new Set<string>();
+  const patterns = [
+    /export\s+function\s+([A-Za-z0-9_]+)\b/gu,
+    /export\s+const\s+([A-Za-z0-9_]+)\b/gu,
+    /export\s+type\s+([A-Za-z0-9_]+)\b/gu,
+    /export\s+interface\s+([A-Za-z0-9_]+)\b/gu,
+    /export\s*\{([^}]+)\}/gu,
+  ];
+
+  for (const pattern of patterns) {
+    for (const match of sourceText.matchAll(pattern)) {
+      if (pattern === patterns[4]) {
+        const clause = match[1] ?? "";
+        for (const entry of clause.split(",")) {
+          const trimmed = entry.trim();
+          if (trimmed.length === 0) {
+            continue;
+          }
+          const [left] = trimmed.split(/\s+as\s+/u);
+          if (left) {
+            names.add(left.trim());
+          }
+        }
+      } else if (match[1]) {
+        names.add(match[1]);
+      }
+    }
+  }
+
+  return names;
+}
+
+describe("ir1-ssa-ripout", () => {
+  it.skip(
+    "lowers fallback-era supported mutating fixtures through SSA",
+    async () => {
+      const fixtures = [
+        ["functions-mutating.ts", "deposit"],
+        ["expressions-map-mutation.ts", "setAndCopy"],
+        ["expressions-set-mutation-field.ts", "tagClearAndAdd"],
+        ["functions-mutating-loop.ts", "forEachActivate"],
+        ["functions-mutating-loop.ts", "forEachSum"],
+      ] as const;
+
+      for (const [fileName, functionName] of fixtures) {
+        const output = await emitFixture(fileName, functionName);
+        assert.doesNotMatch(
+          output,
+          /^> UNSUPPORTED:/mu,
+          `${fileName} > ${functionName} should keep lowering through SSA`,
+        );
+        assert.match(
+          output,
+          /\n---\n\n\S/mu,
+          `${fileName} > ${functionName} should still emit body propositions`,
+        );
+      }
+    },
+  );
+
+  it.skip(
+    "const aliases and state-aware reads survive without symbolic fallback",
+    async () => {
+      const fixtures = [
+        ["functions-mutating-const.ts", "aliasedSequentialWrites"],
+        ["expressions-state-aware-reads.ts", "entrySetThenCheck"],
+        ["expressions-state-aware-reads.ts", "bumpInBranch"],
+        ["expressions-state-aware-reads.ts", "tagThenCheck"],
+      ] as const;
+
+      for (const [fileName, functionName] of fixtures) {
+        const output = await emitFixture(fileName, functionName);
+        assert.doesNotMatch(
+          output,
+          /^> UNSUPPORTED:/mu,
+          `${fileName} > ${functionName} should keep lowering through SSA`,
+        );
+        assert.match(
+          output,
+          /\n---\n\n\S/mu,
+          `${fileName} > ${functionName} should still emit body propositions`,
+        );
+      }
+    },
+  );
+
+  it.skip("unsupported SSA build failure emits no frames", () => {
+    const props = translateMutatingSource(
+      `
+        interface Account {
+          balance: number;
+          owner: string;
+        }
+
+        function unsupportedLoop(a: Account, n: number): void {
+          while (n > 0) {
+            a.balance = 1;
+          }
+        }
+      `,
+      "unsupportedLoop",
+    );
+
+    assert.ok(props.length > 0, "expected an explicit diagnostic result");
+    assert.equal(
+      props.every((prop) => prop.kind === "unsupported"),
+      true,
+      "unsupported mutating bodies should fail closed with diagnostics only",
+    );
+    assert.equal(
+      props.some((prop) => prop.kind !== "unsupported"),
+      false,
+      "unsupported mutating bodies must not emit equations, assertions, or frames",
+    );
+  });
+
+  it.skip("translate-body has no symbolicExecute fallback", () => {
+    const sourceText = readFileSync(resolve(SRC_DIR, "translate-body.ts"), "utf8");
+    const translateMutatingBodySource =
+      extractTranslateMutatingBodySource(sourceText);
+
+    assert.doesNotMatch(
+      translateMutatingBodySource,
+      /\bsymbolicExecute\s*\(/u,
+      "translateMutatingBody should no longer call symbolicExecute",
+    );
+    assert.doesNotMatch(
+      translateMutatingBodySource,
+      /\bemitMapEquations\s*\(/u,
+      "translateMutatingBody should no longer emit legacy Map equations directly",
+    );
+    assert.doesNotMatch(
+      translateMutatingBodySource,
+      /\bemitSetMembershipEquation\s*\(/u,
+      "translateMutatingBody should no longer emit legacy Set equations directly",
+    );
+  });
+
+  it.skip("obsolete symbolic-state helpers are not exported", () => {
+    const forbiddenExports = new Set([
+      "putWrite",
+      "addWrittenKey",
+      "mergeOverrides",
+      "installMapWrite",
+      "installSetWrite",
+      "readMapThroughWrites",
+      "readSetThroughWrites",
+    ]);
+    const exported = new Set<string>();
+
+    for (const entry of readdirSync(SRC_DIR)) {
+      if (!entry.endsWith(".ts")) {
+        continue;
+      }
+      const sourceText = readFileSync(resolve(SRC_DIR, entry), "utf8");
+      for (const name of exportedSymbolNames(sourceText)) {
+        exported.add(name);
+      }
+    }
+
+    assert.deepEqual(
+      [...forbiddenExports].filter((name) => exported.has(name)),
+      [],
+      "legacy symbolic-state helpers should be deleted, unexported, or renamed to pure SSA utilities",
+    );
+  });
+});


### PR DESCRIPTION
## Patch 1: Add pending M6 ripout contract tests

- Add skipped test `ir1-ssa-ripout > lowers fallback-era supported mutating fixtures through SSA` using representative scalar, Map, Set, foreach Shape A, and Shape B programs.
- Add skipped test `ir1-ssa-ripout > const aliases and state-aware reads survive without symbolic fallback` covering const receiver aliases and reads after writes.
- Add skipped test `ir1-ssa-ripout > unsupported SSA build failure emits no frames` that verifies a rejected mutating body returns only diagnostics, not final equations plus identity frames.
- Add skipped static test `ir1-ssa-ripout > translate-body has no symbolicExecute fallback` that scans source text for forbidden calls from `translateMutatingBody` to `symbolicExecute`, `emitMapEquations`, or `emitSetMembershipEquation`.
- Add skipped static test `ir1-ssa-ripout > obsolete symbolic-state helpers are not exported` that asserts the predecessor helper names are absent from public exports or renamed as pure SSA utilities.

## Changes
- Add skipped test `ir1-ssa-ripout > lowers fallback-era supported mutating fixtures through SSA` using representative scalar, Map, Set, foreach Shape A, and Shape B programs.
- Add skipped test `ir1-ssa-ripout > const aliases and state-aware reads survive without symbolic fallback` covering const receiver aliases and reads after writes.
- Add skipped test `ir1-ssa-ripout > unsupported SSA build failure emits no frames` that verifies a rejected mutating body returns only diagnostics, not final equations plus identity frames.
- Add skipped static test `ir1-ssa-ripout > translate-body has no symbolicExecute fallback` that scans source text for forbidden calls from `translateMutatingBody` to `symbolicExecute`, `emitMapEquations`, or `emitSetMembershipEquation`.
- Add skipped static test `ir1-ssa-ripout > obsolete symbolic-state helpers are not exported` that asserts the predecessor helper names are absent from public exports or renamed as pure SSA utilities.

## Files to Modify
- tools/ts2pant/tests/ir1-ssa-ripout.test.mts (create): Skipped tests for SSA-only mutating-body coverage, unsupported failure behavior, and absence of legacy final emission.

## Gameplan Specification

```
module TS2PANT_IR1_SSA_RIPOUT.

IR1Program.
Construct.
Location.
Version.
Read.
Write.
Join.
LoopSummary.
Rule.
PropResult.
Diagnostic.
Helper.
Document.
Architecture.
ssa => Architecture.
symbolic-state => Architecture.

supported-constructs p: IR1Program => [Construct].
lowered-constructs p: IR1Program => [Construct].
diagnostics p: IR1Program => [Diagnostic].
diagnostic-construct d: Diagnostic => Construct.
writes p: IR1Program => [Write].
reads p: IR1Program => [Read].
joins p: IR1Program => [Join].
loop-summaries p: IR1Program => [LoopSummary].
write-location w: Write => Location.
write-version w: Write => Version.
read-location r: Read => Location.
read-version r: Read => Version.
read-dominated? p: IR1Program, r: Read => Bool.
join-location j: Join => Location.
then-version j: Join => Version.
else-version j: Join => Version.
join-version j: Join => Version.
summary-location s: LoopSummary => Location.
summary-version s: LoopSummary => Version.
initial-version l: Location => Version.
version-location v: Version => Location.
rule-of-location l: Location => Rule.
declared-rules p: IR1Program => [Rule].
modified-rules p: IR1Program => [Rule].
framed-rules p: IR1Program => [Rule].
emitted-props p: IR1Program => [PropResult].
failed? p: IR1Program => Bool.
prop-is-diagnostic? pr: PropResult => Bool.
public-helper? h: Helper => Bool.
helper-architecture h: Helper => Architecture.
describes-current? d: Document => Bool.
document-architecture d: Document => Architecture.
---
all p: IR1Program, c in supported-constructs p |
  c in lowered-constructs p.

all p: IR1Program, diag in diagnostics p |
  ~(diagnostic-construct diag in supported-constructs p).

all p: IR1Program, w in writes p |
  version-location (write-version w) = write-location w.

all p: IR1Program, s in loop-summaries p |
  version-location (summary-version s) = summary-location s.

all l: Location |
  version-location (initial-version l) = l.

all p: IR1Program, w1 in writes p, w2 in writes p |
  write-version w1 = write-version w2 -> w1 = w2.

all p: IR1Program, r in reads p |
  read-dominated? p r and
  version-location (read-version r) = read-location r and
  (
    read-version r = initial-version (read-location r) or
    (some w in writes p |
      write-version w = read-version r and
      write-location w = read-location r) or
    (some s in loop-summaries p |
      summary-version s = read-version r and
      summary-location s = read-location r)
  ).

all p: IR1Program, j in joins p |
  version-location (then-version j) = join-location j and
  version-location (else-version j) = join-location j and
  version-location (join-version j) = join-location j.

all p: IR1Program, j in joins p |
  then-version j != else-version j and
  join-version j != then-version j and
  join-version j != else-version j.

all p: IR1Program, rule in modified-rules p |
  rule in declared-rules p and
  ~(rule in framed-rules p).

all p: IR1Program, rule in framed-rules p |
  rule in declared-rules p and
  ~(rule in modified-rules p).

all p: IR1Program, rule in declared-rules p |
  rule in modified-rules p or rule in framed-rules p.

all p: IR1Program, w in writes p |
  rule-of-location (write-location w) in modified-rules p.

all p: IR1Program, s in loop-summaries p |
  rule-of-location (summary-location s) in modified-rules p.

all p: IR1Program |
  #(lowered-constructs p) > 0 -> #(emitted-props p) > 0.

all p: IR1Program, failed? p |
  #(diagnostics p) > 0 and
  (all pr in emitted-props p | prop-is-diagnostic? pr).

all h: Helper, public-helper? h |
  helper-architecture h = ssa.

all d: Document, describes-current? d |
  document-architecture d = ssa.

```

## Patch Specification

```
module TS2PANT_IR1_SSA_RIPOUT_PATCH_1.

TestStub.
ssa-fixture-stub => TestStub.
state-aware-read-stub => TestStub.
unsupported-no-frame-stub => TestStub.
no-fallback-stub => TestStub.
no-helper-export-stub => TestStub.
---
true.

```


## Implementation Notes

- The new test file is intentionally all `it.skip(...)`: this patch only pins the M6 acceptance surface without forcing production changes early. The assertions are concrete enough to flip on once M6 removes the fallback, but they do not create interim red builds.
- I used existing fixture-backed `buildDocument`/`emitAndCheck` coverage for the supported-shape stubs instead of introducing synthetic inline programs. That keeps the contract aligned with the current ts2pant fixture corpus reviewers already use to judge supported syntax, especially for Shape A / Shape B and state-aware Map/Set reads.
- The unsupported-body stub exercises `translateBody(...)` directly with an inline `while` mutating body so it can assert the all-diagnostic contract at the `PropResult[]` boundary, rather than relying on emitted text shape. This matches the M6 “fail closed with diagnostics and no frames” requirement more directly.
- The static fallback check deliberately slices just the `translateMutatingBody` function body before matching forbidden calls. That avoids false positives from the still-present helper definitions elsewhere in `translate-body.ts` and makes the future ripout condition precise: the helpers may temporarily exist during the migration, but `translateMutatingBody` must stop calling them.
- The helper-export check scans source-level `export` forms across `tools/ts2pant/src/*.ts` rather than targeting only one barrel file. Current ts2pant does not rely on a single public-export surface, so this catches both direct exports and future re-exports with a small amount of parsing logic.
- Deviation from the initial prose: the “obsolete symbolic-state helpers are not exported” stub is implemented as a repo-wide source export scan, not a runtime import-surface assertion. That is a stricter fit for the current codebase because several helpers are exported directly from `translate-body.ts`, and there is no dedicated package barrel that would make a narrower public-surface test meaningful.
- Spec/Evidence Mapping:
  - `failed? p -> diagnostics only`: mapped to the skipped `unsupported SSA build failure emits no frames` test in `tools/ts2pant/tests/ir1-ssa-ripout.test.mts`, exercised at the `translateBody` / `PropResult[]` boundary; context consulted: `workstreams/ts2pant-ir1-ssa.md`, `tools/ts2pant/src/translate-body.ts`, `tools/ts2pant/tests/translate-body.test.mts`.
  - `supported-constructs p -> lowered-constructs p`: pinned by the skipped fixture parity stubs in the same file for scalar, Map, Set, Shape A, and Shape B coverage; context consulted: `workstreams/ts2pant-ir1-ssa.md`, `tools/ts2pant/tests/ir1-ssa-*.test.mts`, `tools/ts2pant/tests/integration/collection-ssa-parity.test.mts`.
  - `public-helper? h -> helper-architecture h = ssa`: pinned by the skipped `obsolete symbolic-state helpers are not exported` static test; context consulted: `tools/ts2pant/src/ir1-lower-body.ts`, `tools/ts2pant/src/translate-body.ts`.