### PR TITLE
[ts2pant-ir1-ssa-ripout] Patch 2: Promote remaining supported shapes into SSA

### DIFF
--- a/tools/ts2pant/src/ir1-build-body.ts
+++ b/tools/ts2pant/src/ir1-build-body.ts
@@ -690,7 +690,7 @@ function classifyForeachStmt(
  * type), and those are preserved because they live inside the inner
  * `PropertyAccessExpression`'s `expression` field, untouched here.
  */
-function buildL1SubExpr(
+export function buildL1SubExpr(
   node: ts.Expression,
   ctx: BuildBodyCtx,
 ): BuildResult<IR1Expr> {

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -4581,6 +4581,12 @@ function buildSupportedSsaMutatingBody(
         [...exit.continuationPrefix, ...bodyStmts.slice(index + 1)],
         true,
       );
+      const prefix =
+        stmts.length === 0
+          ? null
+          : stmts.length === 1
+            ? stmts[0]!
+            : ir1Block(stmts as [IR1Stmt, ...IR1Stmt[]]);
       const continuationBody = buildSupportedSsaMutatingBody(
         continuation,
         checker,
@@ -4591,17 +4597,14 @@ function buildSupportedSsaMutatingBody(
         applyConstChain,
       );
       if (isUnsupported(continuationBody)) {
+        if (continuationBody.unsupported === "empty mutating body") {
+          return prefix ?? { unsupported: "empty mutating body" };
+        }
         return continuationBody;
       }
       const continuationGuard = exit.earlyExitWhenTrue
         ? ir1Unop("not", guard)
         : guard;
-      const prefix =
-        stmts.length === 0
-          ? null
-          : stmts.length === 1
-            ? stmts[0]!
-            : ir1Block(stmts as [IR1Stmt, ...IR1Stmt[]]);
       const gated = ir1CondStmt([[continuationGuard, continuationBody]], null);
       if (prefix === null) {
         return gated;

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -2,7 +2,7 @@ import type { SourceFile } from "ts-morph";
 import ts from "typescript";
 import { buildIR, isBuildUnsupported } from "./ir-build.js";
 import { lowerExpr } from "./ir-emit.js";
-import { type IR1Expr, type IR1Stmt, ir1Block } from "./ir1.js";
+import { type IR1Stmt, ir1Block } from "./ir1.js";
 import {
   buildL1Conditional,
   buildL1LetWhile,
@@ -4509,6 +4509,7 @@ function translateMutatingBody(
     ssaState,
     ssaSupply,
   );
+
   if (!isUnsupported(ssaBody) && !containsDeferredSsaFastPathShape(ssaBody)) {
     const lowered = lowerL1BodyToSsaProps(ssaBody, declarations, {
       applyConst: (e) => applyOpaqueAliases(e, ssaSupply),
@@ -4579,96 +4580,8 @@ function translateMutatingBody(
 }
 
 function containsDeferredSsaFastPathShape(stmt: IR1Stmt): boolean {
-  switch (stmt.kind) {
-    case "foreach":
-      return stmt.foldLeaves.length > 0 || containsStateAwareRead(stmt.source);
-    case "assign":
-      return (
-        containsStateAwareRead(stmt.target) ||
-        containsStateAwareRead(stmt.value)
-      );
-    case "map-effect":
-      return (
-        containsStateAwareRead(stmt.objExpr) ||
-        containsStateAwareRead(stmt.keyExpr) ||
-        (stmt.valueExpr !== null && containsStateAwareRead(stmt.valueExpr))
-      );
-    case "set-effect":
-      return (
-        containsStateAwareRead(stmt.objExpr) ||
-        (stmt.elemExpr !== null && containsStateAwareRead(stmt.elemExpr))
-      );
-    case "cond-stmt":
-      return (
-        stmt.arms.some(
-          ([guard, body]) =>
-            containsStateAwareRead(guard) ||
-            containsDeferredSsaFastPathShape(body),
-        ) ||
-        (stmt.otherwise !== null &&
-          containsDeferredSsaFastPathShape(stmt.otherwise))
-      );
-    case "block":
-      return stmt.stmts.some(containsDeferredSsaFastPathShape);
-    case "let":
-      return containsStateAwareRead(stmt.value);
-    case "return":
-    case "throw":
-    case "expr-stmt":
-      return stmt.expr !== null && containsStateAwareRead(stmt.expr);
-    case "while":
-    case "for":
-      return true;
-    default: {
-      const _exhaustive: never = stmt;
-      void _exhaustive;
-      return true;
-    }
-  }
-}
-
-function containsStateAwareRead(expr: IR1Expr): boolean {
-  switch (expr.kind) {
-    case "map-read":
-    case "set-read":
-      return true;
-    case "var":
-    case "lit":
-      return false;
-    case "member":
-      return containsStateAwareRead(expr.receiver);
-    case "binop":
-      return (
-        containsStateAwareRead(expr.lhs) || containsStateAwareRead(expr.rhs)
-      );
-    case "unop":
-      return containsStateAwareRead(expr.arg);
-    case "app":
-      return (
-        containsStateAwareRead(expr.callee) ||
-        expr.args.some(containsStateAwareRead)
-      );
-    case "cond":
-      return (
-        expr.arms.some(
-          ([guard, value]) =>
-            containsStateAwareRead(guard) || containsStateAwareRead(value),
-        ) || containsStateAwareRead(expr.otherwise)
-      );
-    case "is-nullish":
-      return containsStateAwareRead(expr.operand);
-    case "each":
-      return (
-        containsStateAwareRead(expr.src) ||
-        expr.guards.some(containsStateAwareRead) ||
-        containsStateAwareRead(expr.proj)
-      );
-    default: {
-      const _exhaustive: never = expr;
-      void _exhaustive;
-      return true;
-    }
-  }
+  void stmt;
+  return false;
 }
 
 function buildSupportedSsaMutatingBody(
@@ -4680,8 +4593,11 @@ function buildSupportedSsaMutatingBody(
   supply: UniqueSupply,
 ): IR1Stmt | { unsupported: string } {
   const stmts: IR1Stmt[] = [];
+  const scopedParamNames = new Map(paramNames);
+  let applyConstChain: (e: OpaqueExpr) => OpaqueExpr = (e) => e;
   const applyConst = (e: OpaqueExpr): OpaqueExpr =>
-    applyOpaqueAliases(e, supply);
+    applyOpaqueAliases(applyConstChain(e), supply);
+  setCanonicalize(state, applyConst);
   for (const stmt of body.statements) {
     if (isGuardStatement(stmt, checker)) {
       continue;
@@ -4689,10 +4605,58 @@ function buildSupportedSsaMutatingBody(
     if (ts.isReturnStatement(stmt) && !stmt.expression) {
       continue;
     }
+    if (ts.isVariableStatement(stmt)) {
+      const declList = stmt.declarationList;
+      if (declList.flags & ts.NodeFlags.Const) {
+        const bindings: ConstBinding[] = [];
+        let allPure = true;
+        for (const decl of declList.declarations) {
+          if (
+            !ts.isIdentifier(decl.name) ||
+            !decl.initializer ||
+            expressionHasSideEffects(decl.initializer, checker)
+          ) {
+            allPure = false;
+            break;
+          }
+          bindings.push({
+            kind: "const",
+            tsName: decl.name.text,
+            initializer: decl.initializer,
+          });
+        }
+        if (allPure) {
+          const inlined = inlineConstBindings(
+            bindings,
+            checker,
+            strategy,
+            scopedParamNames,
+            supply,
+            state,
+          );
+          if ("error" in inlined) {
+            return { unsupported: inlined.error };
+          }
+          for (const binding of inlined.translatedBindings) {
+            registerOpaqueAlias(supply, binding.hygienicName, binding.initExpr);
+          }
+          for (const [key, value] of inlined.scopedParams) {
+            scopedParamNames.set(key, value);
+          }
+          const prevChain = applyConstChain;
+          applyConstChain = (e) => prevChain(inlined.applyTo(e));
+          setCanonicalize(state, applyConst);
+          continue;
+        }
+      }
+      return {
+        unsupported: "local variable declaration (let/var or effectful const)",
+      };
+    }
     const built = buildSupportedSsaStatement(stmt, {
       checker,
       strategy,
-      paramNames,
+      paramNames: scopedParamNames,
       state,
       supply,
       applyConst,

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -4668,7 +4668,7 @@ function buildSupportedSsaMutatingBody(
       applyConst,
     });
     if (isUnsupported(built)) {
-      if (built.unsupported === "empty mutating body" && stmts.length > 0) {
+      if (built.unsupported === "empty mutating body") {
         continue;
       }
       return built;

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -2,7 +2,7 @@ import type { SourceFile } from "ts-morph";
 import ts from "typescript";
 import { buildIR, isBuildUnsupported } from "./ir-build.js";
 import { lowerExpr } from "./ir-emit.js";
-import { type IR1Stmt, ir1Block } from "./ir1.js";
+import { type IR1Stmt, ir1Block, ir1CondStmt, ir1Unop } from "./ir1.js";
 import {
   buildL1Conditional,
   buildL1LetWhile,
@@ -21,6 +21,7 @@ import {
   buildL1ForEachCall,
   buildL1ForOfMutation,
   buildL1IfMutation,
+  buildL1SubExpr,
   isUnsupported,
 } from "./ir1-build-body.js";
 import { lowerL1MuSearch, type MuSearchLowerCtx } from "./ir1-lower.js";
@@ -4497,8 +4498,6 @@ function translateMutatingBody(
     return [];
   }
 
-  const ast = getAst();
-  const propositions: PropResult[] = [];
   const ssaState = makeSymbolicState();
   const ssaSupply = makeUniqueSupply(synthCell);
   const ssaBody = buildSupportedSsaMutatingBody(
@@ -4510,73 +4509,28 @@ function translateMutatingBody(
     ssaSupply,
   );
 
-  if (!isUnsupported(ssaBody) && !containsDeferredSsaFastPathShape(ssaBody)) {
-    const lowered = lowerL1BodyToSsaProps(ssaBody, declarations, {
-      applyConst: (e) => applyOpaqueAliases(e, ssaSupply),
-    });
-    if (lowered.diagnostics.length === 0) {
-      return lowered.propositions;
+  if (isUnsupported(ssaBody)) {
+    if (ssaBody.unsupported === "empty mutating body") {
+      return [];
     }
+    return [{ kind: "unsupported", reason: ssaBody.unsupported }];
   }
 
-  const state = makeSymbolicState();
-  const supply = makeUniqueSupply(synthCell);
-  const ok = symbolicExecute(
-    node.body,
-    checker,
-    strategy,
-    paramNames,
-    state,
-    propositions,
-    (e) => e,
-    supply,
-  );
-
-  // Only emit state equations + frames when the whole body was translatable;
-  // partial emission would be unsound (frames would mask unhandled writes).
-  if (!ok) {
-    return propositions;
+  if (containsDeferredSsaFastPathShape(ssaBody)) {
+    return [
+      {
+        kind: "unsupported",
+        reason: "statement is not supported by unified SSA body lowering",
+      },
+    ];
   }
 
-  // Quantifier binders allocated through the document-wide name registry
-  // (inside synthCell) so they don't collide with the function's own
-  // params or with type-derived accessor rule binders — unlike the
-  // internal `freshHygienicBinder` which emits `$N` names that don't
-  // round-trip through the Pantagruel parser.
-  const allocBinder = (hint: string): string =>
-    allocComprehensionBinder(supply, hint);
-  for (const [, entry] of state.writes) {
-    switch (entry.kind) {
-      case "property":
-        propositions.push({
-          kind: "equation",
-          quantifiers: [] as OpaqueParam[],
-          lhs: ast.app(ast.primed(entry.prop), [entry.objExpr]),
-          rhs: entry.value,
-        });
-        state.modifiedProps = addModifiedProp(state.modifiedProps, entry.prop);
-        break;
-      case "map":
-        emitMapEquations(entry, propositions, allocBinder, state);
-        break;
-      case "set":
-        emitSetMembershipEquation(entry, propositions, allocBinder, state);
-        break;
-      default: {
-        // Exhaustiveness guard: `entry.kind` is discriminated across
-        // property / map / set. If a new kind is added without updating
-        // this switch, the `_exhaustive: never` assignment will fail to
-        // compile — TS's standard exhaustive-switch pattern.
-        const _exhaustive: never = entry;
-        void _exhaustive;
-      }
-    }
-  }
-
-  const frames = generateFrameConditions(state.modifiedProps, declarations);
-  propositions.push(...frames);
-
-  return propositions;
+  const lowered = lowerL1BodyToSsaProps(ssaBody, declarations, {
+    applyConst: (e) => applyOpaqueAliases(e, ssaSupply),
+  });
+  return lowered.diagnostics.length === 0
+    ? lowered.propositions
+    : lowered.diagnostics;
 }
 
 function containsDeferredSsaFastPathShape(stmt: IR1Stmt): boolean {
@@ -4591,19 +4545,68 @@ function buildSupportedSsaMutatingBody(
   paramNames: Map<string, string>,
   state: SymbolicState,
   supply: UniqueSupply,
+  outerApplyConstChain: (e: OpaqueExpr) => OpaqueExpr = (e) => e,
 ): IR1Stmt | { unsupported: string } {
   const stmts: IR1Stmt[] = [];
   const scopedParamNames = new Map(paramNames);
-  let applyConstChain: (e: OpaqueExpr) => OpaqueExpr = (e) => e;
+  let applyConstChain = outerApplyConstChain;
   const applyConst = (e: OpaqueExpr): OpaqueExpr =>
     applyOpaqueAliases(applyConstChain(e), supply);
   setCanonicalize(state, applyConst);
-  for (const stmt of body.statements) {
+  const bodyStmts = Array.from(body.statements);
+  for (const [index, stmt] of bodyStmts.entries()) {
     if (isGuardStatement(stmt, checker)) {
       continue;
     }
     if (ts.isReturnStatement(stmt) && !stmt.expression) {
       continue;
+    }
+    const exit = detectEarlyExit(stmt);
+    if (exit !== null) {
+      if (expressionHasSideEffects(exit.condition, checker)) {
+        return { unsupported: "impure if-condition in mutating body" };
+      }
+      const guard = buildL1SubExpr(exit.condition, {
+        checker,
+        strategy,
+        paramNames: scopedParamNames,
+        state,
+        supply,
+        applyConst,
+      });
+      if (isUnsupported(guard)) {
+        return guard;
+      }
+      const continuation = ts.factory.createBlock(
+        [...exit.continuationPrefix, ...bodyStmts.slice(index + 1)],
+        true,
+      );
+      const continuationBody = buildSupportedSsaMutatingBody(
+        continuation,
+        checker,
+        strategy,
+        scopedParamNames,
+        state,
+        supply,
+        applyConstChain,
+      );
+      if (isUnsupported(continuationBody)) {
+        return continuationBody;
+      }
+      const continuationGuard = exit.earlyExitWhenTrue
+        ? ir1Unop("not", guard)
+        : guard;
+      const prefix =
+        stmts.length === 0
+          ? null
+          : stmts.length === 1
+            ? stmts[0]!
+            : ir1Block(stmts as [IR1Stmt, ...IR1Stmt[]]);
+      const gated = ir1CondStmt([[continuationGuard, continuationBody]], null);
+      if (prefix === null) {
+        return gated;
+      }
+      return ir1Block([prefix, gated]);
     }
     if (ts.isVariableStatement(stmt)) {
       const declList = stmt.declarationList;

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -4668,6 +4668,9 @@ function buildSupportedSsaMutatingBody(
       applyConst,
     });
     if (isUnsupported(built)) {
+      if (built.unsupported === "empty mutating body" && stmts.length > 0) {
+        continue;
+      }
       return built;
     }
     stmts.push(built);

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -375,11 +375,11 @@ exports[`expressions-map-mutation-field.ts > cachePutNonNull 1`] = `
 `;
 
 exports[`expressions-map-mutation.ts > bump 1`] = `
-"module BUMP.\\n\\nStringToIntMap.\\nstring-to-int-map-key m: StringToIntMap, k1: String => Bool.\\nstring-to-int-map m: StringToIntMap, k1: String, string-to-int-map-key m k1 => Int.\\n~> Bump @ counts: StringToIntMap, k: String.\\n\\n---\\n\\nall m1: StringToIntMap, k2: String | string-to-int-map' m1 k2 = string-to-int-map[(counts, k) |-> string-to-int-map counts k + 1] m1 k2.\\nall m2: StringToIntMap, k3: String | string-to-int-map-key' m2 k3 = string-to-int-map-key[(counts, k) |-> true] m2 k3.\\n"
+"module BUMP.\\n\\nStringToIntMap.\\nstring-to-int-map-key m: StringToIntMap, k1: String => Bool.\\nstring-to-int-map m: StringToIntMap, k1: String, string-to-int-map-key m k1 => Int.\\n~> Bump @ counts: StringToIntMap, k: String.\\n\\n---\\n\\nall m: StringToIntMap, k1: String | string-to-int-map' m k1 = string-to-int-map[(counts, k) |-> string-to-int-map counts k + 1] m k1.\\nall m: StringToIntMap, k1: String | string-to-int-map-key' m k1 = string-to-int-map-key[(counts, k) |-> true] m k1.\\n"
 `;
 
 exports[`expressions-map-mutation.ts > deleteThenCopy 1`] = `
-"module DELETE_THEN_COPY.\\n\\nStringToIntMap.\\nstring-to-int-map-key m1: StringToIntMap, k: String => Bool.\\nstring-to-int-map m1: StringToIntMap, k: String, string-to-int-map-key m1 k => Int.\\n~> Delete-then-copy @ m: StringToIntMap, k-a: String, k-b: String, v: Int.\\n\\n---\\n\\nall m2: StringToIntMap, k1: String | string-to-int-map' m2 k1 = string-to-int-map[(m, k-b) |-> string-to-int-map m k-a] m2 k1.\\nall m3: StringToIntMap, k2: String | string-to-int-map-key' m3 k2 = string-to-int-map-key[(m, k-a) |-> false, (m, k-b) |-> true] m3 k2.\\n"
+"module DELETE_THEN_COPY.\\n\\nStringToIntMap.\\nstring-to-int-map-key m1: StringToIntMap, k: String => Bool.\\nstring-to-int-map m1: StringToIntMap, k: String, string-to-int-map-key m1 k => Int.\\n~> Delete-then-copy @ m: StringToIntMap, k-a: String, k-b: String, v: Int.\\n\\n---\\n\\nall m1: StringToIntMap, k1: String | string-to-int-map' m1 k1 = string-to-int-map[(m, k-a) |-> v, (m, k-b) |-> string-to-int-map m k-a] m1 k1.\\nall m1: StringToIntMap, k1: String | string-to-int-map-key' m1 k1 = string-to-int-map-key[(m, k-a) |-> false, (m, k-b) |-> true] m1 k1.\\n"
 `;
 
 exports[`expressions-map-mutation.ts > put 1`] = `
@@ -387,7 +387,7 @@ exports[`expressions-map-mutation.ts > put 1`] = `
 `;
 
 exports[`expressions-map-mutation.ts > putIfAbsent 1`] = `
-"module PUT_IF_ABSENT.\\n\\nStringToIntMap.\\nstring-to-int-map-key m1: StringToIntMap, k1: String => Bool.\\nstring-to-int-map m1: StringToIntMap, k1: String, string-to-int-map-key m1 k1 => Int.\\n~> Put-if-absent @ m: StringToIntMap, k: String, v: Int.\\n\\n---\\n\\nall m2: StringToIntMap, k2: String | string-to-int-map' m2 k2 = string-to-int-map[(m, k) |-> cond ~(string-to-int-map-key m k) => v, true => string-to-int-map m k] m2 k2.\\nall m3: StringToIntMap, k3: String | string-to-int-map-key' m3 k3 = string-to-int-map-key[(m, k) |-> cond ~(string-to-int-map-key m k) => true, true => string-to-int-map-key m k] m3 k3.\\n"
+"module PUT_IF_ABSENT.\\n\\nStringToIntMap.\\nstring-to-int-map-key m1: StringToIntMap, k1: String => Bool.\\nstring-to-int-map m1: StringToIntMap, k1: String, string-to-int-map-key m1 k1 => Int.\\n~> Put-if-absent @ m: StringToIntMap, k: String, v: Int.\\n\\n---\\n\\nall m1: StringToIntMap, k1: String | string-to-int-map' m1 k1 = string-to-int-map[(m, k) |-> cond ~(string-to-int-map-key m k) => v, true => string-to-int-map m k] m1 k1.\\nall m1: StringToIntMap, k1: String | string-to-int-map-key' m1 k1 = string-to-int-map-key[(m, k) |-> cond ~(string-to-int-map-key m k) => true, true => string-to-int-map-key m k] m1 k1.\\n"
 `;
 
 exports[`expressions-map-mutation.ts > putPair 1`] = `
@@ -399,7 +399,7 @@ exports[`expressions-map-mutation.ts > remove 1`] = `
 `;
 
 exports[`expressions-map-mutation.ts > setAndCopy 1`] = `
-"module SET_AND_COPY.\\n\\nStringToIntMap.\\nstring-to-int-map-key m1: StringToIntMap, k: String => Bool.\\nstring-to-int-map m1: StringToIntMap, k: String, string-to-int-map-key m1 k => Int.\\n~> Set-and-copy @ m: StringToIntMap, k-src: String, k-dst: String, v: Int.\\n\\n---\\n\\nall m2: StringToIntMap, k1: String | string-to-int-map' m2 k1 = string-to-int-map[(m, k-src) |-> v, (m, k-dst) |-> string-to-int-map[(m, k-src) |-> v] m k-src] m2 k1.\\nall m3: StringToIntMap, k2: String | string-to-int-map-key' m3 k2 = string-to-int-map-key[(m, k-src) |-> true, (m, k-dst) |-> true] m3 k2.\\n"
+"module SET_AND_COPY.\\n\\nStringToIntMap.\\nstring-to-int-map-key m1: StringToIntMap, k: String => Bool.\\nstring-to-int-map m1: StringToIntMap, k: String, string-to-int-map-key m1 k => Int.\\n~> Set-and-copy @ m: StringToIntMap, k-src: String, k-dst: String, v: Int.\\n\\n---\\n\\nall m1: StringToIntMap, k1: String | string-to-int-map' m1 k1 = string-to-int-map[(m, k-src) |-> v, (m, k-dst) |-> v] m1 k1.\\nall m1: StringToIntMap, k1: String | string-to-int-map-key' m1 k1 = string-to-int-map-key[(m, k-src) |-> true, (m, k-dst) |-> true] m1 k1.\\n"
 `;
 
 exports[`expressions-map-mutation.ts > setThenDelete 1`] = `
@@ -679,15 +679,15 @@ exports[`expressions-set.ts > contains 1`] = `
 `;
 
 exports[`expressions-state-aware-reads.ts > bumpInBranch 1`] = `
-"module BUMP_IN_BRANCH.\\n\\nStringToIntMap.\\nstring-to-int-map-key m1: StringToIntMap, k1: String => Bool.\\nstring-to-int-map m1: StringToIntMap, k1: String, string-to-int-map-key m1 k1 => Int.\\n~> Bump-in-branch @ m: StringToIntMap, k: String, v: Int, gate: Bool.\\n\\n---\\n\\nall m2: StringToIntMap, k2: String | string-to-int-map' m2 k2 = string-to-int-map[(m, k) |-> cond gate => string-to-int-map[(m, k) |-> v] m k + 1, true => string-to-int-map m k] m2 k2.\\nall m3: StringToIntMap, k3: String | string-to-int-map-key' m3 k3 = string-to-int-map-key[(m, k) |-> cond gate => true, true => string-to-int-map-key m k] m3 k3.\\n"
+"module BUMP_IN_BRANCH.\\n\\nStringToIntMap.\\nstring-to-int-map-key m1: StringToIntMap, k1: String => Bool.\\nstring-to-int-map m1: StringToIntMap, k1: String, string-to-int-map-key m1 k1 => Int.\\n~> Bump-in-branch @ m: StringToIntMap, k: String, v: Int, gate: Bool.\\n\\n---\\n\\nall m1: StringToIntMap, k1: String | string-to-int-map' m1 k1 = string-to-int-map[(m, k) |-> cond gate => v + 1, true => string-to-int-map m k] m1 k1.\\nall m1: StringToIntMap, k1: String | string-to-int-map-key' m1 k1 = string-to-int-map-key[(m, k) |-> cond gate => true, true => string-to-int-map-key m k] m1 k1.\\n"
 `;
 
 exports[`expressions-state-aware-reads.ts > entrySetThenCheck 1`] = `
-"module ENTRY_SET_THEN_CHECK.\\n\\nCache.\\ncache--entries-key c1: Cache, k1: String => Bool.\\ncache--entries c1: Cache, k1: String, cache--entries-key c1 k1 => Int.\\ncache--hits c1: Cache => Int.\\n~> Entry-set-then-check @ c: Cache, k: String, v: Int, gate: Bool.\\n\\n---\\n\\nall m: Cache, k2: String | cache--entries' m k2 = cache--entries[(c, k) |-> cond gate => v, true => cache--entries c k] m k2.\\nall m1: Cache, k3: String | cache--entries-key' m1 k3 = cache--entries-key[(c, k) |-> cond gate => true, true => cache--entries-key c k] m1 k3.\\ncache--hits' c = (cond gate => (cond cache--entries-key[(c, k) |-> true] c k => cache--hits c + 1, true => cache--hits c), true => cache--hits c).\\n"
+"module ENTRY_SET_THEN_CHECK.\\n\\nCache.\\ncache--entries-key c1: Cache, k1: String => Bool.\\ncache--entries c1: Cache, k1: String, cache--entries-key c1 k1 => Int.\\ncache--hits c1: Cache => Int.\\n~> Entry-set-then-check @ c: Cache, k: String, v: Int, gate: Bool.\\n\\n---\\n\\nall m: Cache, k1: String | cache--entries' m k1 = cache--entries[(c, k) |-> cond gate => v, true => cache--entries c k] m k1.\\nall m: Cache, k1: String | cache--entries-key' m k1 = cache--entries-key[(c, k) |-> cond gate => true, true => cache--entries-key c k] m k1.\\ncache--hits' c = (cond gate => (cond true => cache--hits c + 1, true => cache--hits c), true => cache--hits c).\\n"
 `;
 
 exports[`expressions-state-aware-reads.ts > setIfThenBump 1`] = `
-"module SET_IF_THEN_BUMP.\\n\\nStringToIntMap.\\nstring-to-int-map-key m1: StringToIntMap, k1: String => Bool.\\nstring-to-int-map m1: StringToIntMap, k1: String, string-to-int-map-key m1 k1 => Int.\\n~> Set-if-then-bump @ m: StringToIntMap, k: String, v: Int, gate: Bool.\\n\\n---\\n\\nall m2: StringToIntMap, k2: String | string-to-int-map' m2 k2 = string-to-int-map[(m, k) |-> cond gate => (cond string-to-int-map-key[(m, k) |-> true] m k => string-to-int-map[(m, k) |-> v] m k + 1, true => v), true => string-to-int-map m k] m2 k2.\\nall m3: StringToIntMap, k3: String | string-to-int-map-key' m3 k3 = string-to-int-map-key[(m, k) |-> cond gate => (cond string-to-int-map-key[(m, k) |-> true] m k => true, true => true), true => string-to-int-map-key m k] m3 k3.\\n"
+"module SET_IF_THEN_BUMP.\\n\\nStringToIntMap.\\nstring-to-int-map-key m1: StringToIntMap, k1: String => Bool.\\nstring-to-int-map m1: StringToIntMap, k1: String, string-to-int-map-key m1 k1 => Int.\\n~> Set-if-then-bump @ m: StringToIntMap, k: String, v: Int, gate: Bool.\\n\\n---\\n\\nall m1: StringToIntMap, k1: String | string-to-int-map' m1 k1 = string-to-int-map[(m, k) |-> cond gate => (cond true => v + 1, true => v), true => string-to-int-map m k] m1 k1.\\nall m1: StringToIntMap, k1: String | string-to-int-map-key' m1 k1 = string-to-int-map-key[(m, k) |-> cond gate => (cond true => true, true => true), true => string-to-int-map-key m k] m1 k1.\\n"
 `;
 
 exports[`expressions-state-aware-reads.ts > tagThenCheck 1`] = `
@@ -883,7 +883,7 @@ exports[`functions-mutating-loop.ts > activateAll 1`] = `
 `;
 
 exports[`functions-mutating-loop.ts > deductFees 1`] = `
-"module DEDUCT_FEES.\\n\\nAccount.\\naccount--total a1: Account => Int.\\naccount--balance a1: Account => Int.\\nFee.\\nfee--amount f: Fee => Int.\\n~> Deduct-fees @ a: Account, fees: [Fee].\\n\\n---\\n\\naccount--balance' a = account--balance a - (+ over each f2 in fees | fee--amount f2).\\naccount--total' a1 = account--total a1.\\nfee--amount' f = fee--amount f.\\n"
+"module DEDUCT_FEES.\\n\\nAccount.\\naccount--total a1: Account => Int.\\naccount--balance a1: Account => Int.\\nFee.\\nfee--amount f: Fee => Int.\\n~> Deduct-fees @ a: Account, fees: [Fee].\\n\\n---\\n\\naccount--balance' a = account--balance a - (+ over each f1 in fees | fee--amount f1).\\naccount--total' a1 = account--total a1.\\nfee--amount' f = fee--amount f.\\n"
 `;
 
 exports[`functions-mutating-loop.ts > forEachActivate 1`] = `
@@ -891,23 +891,23 @@ exports[`functions-mutating-loop.ts > forEachActivate 1`] = `
 `;
 
 exports[`functions-mutating-loop.ts > forEachSum 1`] = `
-"module FOR_EACH_SUM.\\n\\nAccount.\\naccount--total a1: Account => Int.\\naccount--balance a1: Account => Int.\\nItem.\\nitem--value i: Item => Int.\\nitem--tagged i: Item => Bool.\\n~> For-each-sum @ a: Account, items: [Item].\\n\\n---\\n\\naccount--total' a = account--total a + (+ over each x1 in items | item--value x1).\\naccount--balance' a1 = account--balance a1.\\nitem--value' i = item--value i.\\nitem--tagged' i = item--tagged i.\\n"
+"module FOR_EACH_SUM.\\n\\nAccount.\\naccount--total a1: Account => Int.\\naccount--balance a1: Account => Int.\\nItem.\\nitem--value i: Item => Int.\\nitem--tagged i: Item => Bool.\\n~> For-each-sum @ a: Account, items: [Item].\\n\\n---\\n\\naccount--total' a = account--total a + (+ over each x in items | item--value x).\\naccount--balance' a1 = account--balance a1.\\nitem--value' i = item--value i.\\nitem--tagged' i = item--tagged i.\\n"
 `;
 
 exports[`functions-mutating-loop.ts > mixedUpdates 1`] = `
-"module MIXED_UPDATES.\\n\\nAccount.\\naccount--total a1: Account => Int.\\naccount--balance a1: Account => Int.\\nItem.\\nitem--value i: Item => Int.\\nitem--tagged i: Item => Bool.\\n~> Mixed-updates @ a: Account, items: [Item].\\n\\n---\\n\\nall x1 in items | item--tagged' x1 = true.\\naccount--total' a = account--total a + (+ over each x1 in items | item--value x1).\\naccount--balance' a1 = account--balance a1.\\nitem--value' i = item--value i.\\n"
+"module MIXED_UPDATES.\\n\\nAccount.\\naccount--total a1: Account => Int.\\naccount--balance a1: Account => Int.\\nItem.\\nitem--value i: Item => Int.\\nitem--tagged i: Item => Bool.\\n~> Mixed-updates @ a: Account, items: [Item].\\n\\n---\\n\\nall x in items | item--tagged' x = true.\\naccount--total' a = account--total a + (+ over each x in items | item--value x).\\naccount--balance' a1 = account--balance a1.\\nitem--value' i = item--value i.\\n"
 `;
 
 exports[`functions-mutating-loop.ts > sumAmounts 1`] = `
-"module SUM_AMOUNTS.\\n\\nAccount.\\naccount--total a1: Account => Int.\\naccount--balance a1: Account => Int.\\nItem.\\nitem--value i: Item => Int.\\nitem--tagged i: Item => Bool.\\n~> Sum-amounts @ a: Account, items: [Item].\\n\\n---\\n\\naccount--total' a = account--total a + (+ over each x1 in items | item--value x1).\\naccount--balance' a1 = account--balance a1.\\nitem--value' i = item--value i.\\nitem--tagged' i = item--tagged i.\\n"
+"module SUM_AMOUNTS.\\n\\nAccount.\\naccount--total a1: Account => Int.\\naccount--balance a1: Account => Int.\\nItem.\\nitem--value i: Item => Int.\\nitem--tagged i: Item => Bool.\\n~> Sum-amounts @ a: Account, items: [Item].\\n\\n---\\n\\naccount--total' a = account--total a + (+ over each x in items | item--value x).\\naccount--balance' a1 = account--balance a1.\\nitem--value' i = item--value i.\\nitem--tagged' i = item--tagged i.\\n"
 `;
 
 exports[`functions-mutating-loop.ts > sumIntoAnon 1`] = `
-"module SUM_INTO_ANON.\\n\\nTotalRec.\\ntotal-rec--total r: TotalRec => Int.\\n~> Sum-into-anon @ acc: TotalRec, items: [Int].\\n\\n---\\n\\ntotal-rec--total' acc = total-rec--total acc + (+ over each x1 in items | x1).\\n"
+"module SUM_INTO_ANON.\\n\\nTotalRec.\\ntotal-rec--total r: TotalRec => Int.\\n~> Sum-into-anon @ acc: TotalRec, items: [Int].\\n\\n---\\n\\ntotal-rec--total' acc = total-rec--total acc + (+ over each x in items | x).\\n"
 `;
 
 exports[`functions-mutating-loop.ts > sumPositive 1`] = `
-"module SUM_POSITIVE.\\n\\nAccount.\\naccount--total a1: Account => Int.\\naccount--balance a1: Account => Int.\\nItem.\\nitem--value i: Item => Int.\\nitem--tagged i: Item => Bool.\\n~> Sum-positive @ a: Account, items: [Item].\\n\\n---\\n\\naccount--total' a = account--total a + (+ over each x1 in items, item--value x1 > 0 | item--value x1).\\naccount--balance' a1 = account--balance a1.\\nitem--value' i = item--value i.\\nitem--tagged' i = item--tagged i.\\n"
+"module SUM_POSITIVE.\\n\\nAccount.\\naccount--total a1: Account => Int.\\naccount--balance a1: Account => Int.\\nItem.\\nitem--value i: Item => Int.\\nitem--tagged i: Item => Bool.\\n~> Sum-positive @ a: Account, items: [Item].\\n\\n---\\n\\naccount--total' a = account--total a + (+ over each x in items, item--value x > 0 | item--value x).\\naccount--balance' a1 = account--balance a1.\\nitem--value' i = item--value i.\\nitem--tagged' i = item--tagged i.\\n"
 `;
 
 exports[`functions-mutating-loop.ts > sumPositiveAssert 1`] = `
@@ -915,7 +915,7 @@ exports[`functions-mutating-loop.ts > sumPositiveAssert 1`] = `
 `;
 
 exports[`functions-mutating-loop.ts > sumScaledAssert 1`] = `
-"module SUM_SCALED_ASSERT.\\n\\nAccount.\\naccount--total a1: Account => Int.\\naccount--balance a1: Account => Int.\\nItem.\\nitem--value i: Item => Int.\\nitem--tagged i: Item => Bool.\\n~> Sum-scaled-assert @ a: Account, items: [Item], scale: Int, scale >= 0.\\n\\n---\\n\\naccount--total' a = account--total a + (+ over each x1 in items | item--value x1).\\naccount--balance' a1 = account--balance a1.\\nitem--value' i = item--value i.\\nitem--tagged' i = item--tagged i.\\n"
+"module SUM_SCALED_ASSERT.\\n\\nAccount.\\naccount--total a1: Account => Int.\\naccount--balance a1: Account => Int.\\nItem.\\nitem--value i: Item => Int.\\nitem--tagged i: Item => Bool.\\n~> Sum-scaled-assert @ a: Account, items: [Item], scale: Int, scale >= 0.\\n\\n---\\n\\naccount--total' a = account--total a + (+ over each x in items | item--value x).\\naccount--balance' a1 = account--balance a1.\\nitem--value' i = item--value i.\\nitem--tagged' i = item--tagged i.\\n"
 `;
 
 exports[`functions-mutating.ts > deposit 1`] = `

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -843,23 +843,23 @@ exports[`functions-mutating-const.ts > multiConstMutating 1`] = `
 `;
 
 exports[`functions-mutating-early-exit.ts > chainedEarlyReturns 1`] = `
-"module CHAINED_EARLY_RETURNS.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--owner a1: Account => String.\\n~> Chained-early-returns @ a: Account, g: Bool, h: Bool.\\n\\n---\\n\\naccount--balance' a = (cond g => account--balance a, true => (cond h => account--balance a, true => 1)).\\naccount--owner' a1 = account--owner a1.\\n"
+"module CHAINED_EARLY_RETURNS.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--owner a1: Account => String.\\n~> Chained-early-returns @ a: Account, g: Bool, h: Bool.\\n\\n---\\n\\naccount--balance' a = (cond ~g => (cond ~h => 1, true => account--balance a), true => account--balance a).\\naccount--owner' a1 = account--owner a1.\\n"
 `;
 
 exports[`functions-mutating-early-exit.ts > earlyReturnMulti 1`] = `
-"module EARLY_RETURN_MULTI.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--owner a1: Account => String.\\n~> Early-return-multi @ a: Account, g: Bool, v: Int, who: String.\\n\\n---\\n\\naccount--balance' a = (cond g => account--balance a, true => v).\\naccount--owner' a = (cond g => account--owner a, true => who).\\n"
+"module EARLY_RETURN_MULTI.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--owner a1: Account => String.\\n~> Early-return-multi @ a: Account, g: Bool, v: Int, who: String.\\n\\n---\\n\\naccount--balance' a = (cond ~g => v, true => account--balance a).\\naccount--owner' a = (cond ~g => who, true => account--owner a).\\n"
 `;
 
 exports[`functions-mutating-early-exit.ts > earlyReturnNoBraces 1`] = `
-"module EARLY_RETURN_NO_BRACES.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--owner a1: Account => String.\\n~> Early-return-no-braces @ a: Account, g: Bool.\\n\\n---\\n\\naccount--balance' a = (cond g => account--balance a, true => 0).\\naccount--owner' a1 = account--owner a1.\\n"
+"module EARLY_RETURN_NO_BRACES.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--owner a1: Account => String.\\n~> Early-return-no-braces @ a: Account, g: Bool.\\n\\n---\\n\\naccount--balance' a = (cond ~g => 0, true => account--balance a).\\naccount--owner' a1 = account--owner a1.\\n"
 `;
 
 exports[`functions-mutating-early-exit.ts > earlyReturnSimple 1`] = `
-"module EARLY_RETURN_SIMPLE.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--owner a1: Account => String.\\n~> Early-return-simple @ a: Account, g: Bool.\\n\\n---\\n\\naccount--balance' a = (cond g => account--balance a, true => 1).\\naccount--owner' a1 = account--owner a1.\\n"
+"module EARLY_RETURN_SIMPLE.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--owner a1: Account => String.\\n~> Early-return-simple @ a: Account, g: Bool.\\n\\n---\\n\\naccount--balance' a = (cond ~g => 1, true => account--balance a).\\naccount--owner' a1 = account--owner a1.\\n"
 `;
 
 exports[`functions-mutating-early-exit.ts > earlyReturnThenCond 1`] = `
-"module EARLY_RETURN_THEN_COND.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--owner a1: Account => String.\\n~> Early-return-then-cond @ a: Account, g: Bool, h: Bool.\\n\\n---\\n\\naccount--balance' a = (cond g => account--balance a, true => (cond h => 1, true => 2)).\\naccount--owner' a1 = account--owner a1.\\n"
+"module EARLY_RETURN_THEN_COND.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--owner a1: Account => String.\\n~> Early-return-then-cond @ a: Account, g: Bool, h: Bool.\\n\\n---\\n\\naccount--balance' a = (cond ~g => (cond h => 1, true => 2), true => account--balance a).\\naccount--owner' a1 = account--owner a1.\\n"
 `;
 
 exports[`functions-mutating-early-exit.ts > elseBranchReturn 1`] = `
@@ -871,7 +871,7 @@ exports[`functions-mutating-early-exit.ts > elseReturnThenMore 1`] = `
 `;
 
 exports[`functions-mutating-early-exit.ts > writeThenEarlyReturn 1`] = `
-"module WRITE_THEN_EARLY_RETURN.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--owner a1: Account => String.\\n~> Write-then-early-return @ a: Account, g: Bool.\\n\\n---\\n\\naccount--balance' a = (cond g => 10, true => 10 + 5).\\naccount--owner' a1 = account--owner a1.\\n"
+"module WRITE_THEN_EARLY_RETURN.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--owner a1: Account => String.\\n~> Write-then-early-return @ a: Account, g: Bool.\\n\\n---\\n\\naccount--balance' a = (cond ~g => 10 + 5, true => 10).\\naccount--owner' a1 = account--owner a1.\\n"
 `;
 
 exports[`functions-mutating-loop.ts > activateActive 1`] = `
@@ -1055,7 +1055,7 @@ exports[`unsupported.ts > impureGuardAssign 1`] = `
 `;
 
 exports[`unsupported.ts > loopAssign 1`] = `
-"module LOOP_ASSIGN.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--owner a1: Account => String.\\n~> Loop-assign @ a: Account.\\n\\n---\\n\\n> UNSUPPORTED: loop assignment.\\n"
+"module LOOP_ASSIGN.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--owner a1: Account => String.\\n~> Loop-assign @ a: Account.\\n\\n---\\n\\n> UNSUPPORTED: statement is not supported by unified SSA body lowering: ForStatement.\\n"
 `;
 
 exports[`unsupported.ts > multiParamCallback 1`] = `

--- a/tools/ts2pant/tests/ir1-ssa-ripout.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-ripout.test.mts
@@ -80,7 +80,7 @@ function exportedSymbolNames(sourceText: string): Set<string> {
 }
 
 describe("ir1-ssa-ripout", () => {
-  it.skip(
+  it(
     "lowers fallback-era supported mutating fixtures through SSA",
     async () => {
       const fixtures = [
@@ -107,7 +107,7 @@ describe("ir1-ssa-ripout", () => {
     },
   );
 
-  it.skip(
+  it(
     "const aliases and state-aware reads survive without symbolic fallback",
     async () => {
       const fixtures = [

--- a/tools/ts2pant/tests/ir1-ssa-ripout.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-ripout.test.mts
@@ -133,7 +133,7 @@ describe("ir1-ssa-ripout", () => {
     },
   );
 
-  it.skip("unsupported SSA build failure emits no frames", () => {
+  it("unsupported SSA build failure emits no frames", () => {
     const props = translateMutatingSource(
       `
         interface Account {
@@ -163,7 +163,7 @@ describe("ir1-ssa-ripout", () => {
     );
   });
 
-  it.skip("translate-body has no symbolicExecute fallback", () => {
+  it("translate-body has no symbolicExecute fallback", () => {
     const sourceText = readFileSync(resolve(SRC_DIR, "translate-body.ts"), "utf8");
     const translateMutatingBodySource =
       extractTranslateMutatingBodySource(sourceText);

--- a/tools/ts2pant/tests/ir1-ssa-scalars.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-scalars.test.mts
@@ -292,7 +292,7 @@ describe("ir1-ssa-scalars", () => {
 
     assert.match(
       output,
-      /account--balance' a = \(cond g => account--balance a, true => \(cond h => account--balance a, true => 1\)\)\./u,
+      /account--balance' a = \(cond ~g => \(cond ~h => 1, true => account--balance a\), true => account--balance a\)\./u,
     );
   });
 
@@ -316,7 +316,7 @@ describe("ir1-ssa-scalars", () => {
 
     assert.match(
       output,
-      /account--balance' a = \(cond g => 10, true => 10 \+ 5\)\./u,
+      /account--balance' a = \(cond ~g => 10 \+ 5, true => 10\)\./u,
     );
   });
 });

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -981,6 +981,30 @@ describe("conditional mutations (symbolic last-write)", () => {
     assert.equal(ast.strExpr(eq.rhs), "1");
   });
 
+  it("nested tail early-exit block preserves prior writes", () => {
+    const source = `
+      interface Account { balance: number; }
+      function writeThenNestedTailGuard(a: Account, g: boolean): void {
+        a.balance = 1;
+        { if (g) { return; } }
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "writeThenNestedTailGuard",
+      strategy: IntStrategy,
+    });
+
+    const equations = props.filter((p) => p.kind === "equation");
+    assert.equal(equations.length, 1);
+    const eq = equations[0]!;
+    if (eq.kind !== "equation") return;
+    const ast = getAst();
+    assert.equal(ast.strExpr(eq.lhs), "account--balance' a");
+    assert.equal(ast.strExpr(eq.rhs), "1");
+  });
+
   it("sequential composition: later conditional reads earlier unconditional write", () => {
     const source = `
       interface Account { balance: number; }

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -936,8 +936,8 @@ describe("conditional mutations (symbolic last-write)", () => {
     if (eq.kind !== "equation") return;
     const ast = getAst();
     assert.equal(ast.strExpr(eq.lhs), "account--balance' a");
-    // Early return path keeps pre-state identity; fall-through path writes 1.
-    assert.equal(ast.strExpr(eq.rhs), "cond g => account--balance a, true => 1");
+    // Fall-through path writes 1; early return path keeps pre-state identity.
+    assert.equal(ast.strExpr(eq.rhs), "cond ~g => 1, true => account--balance a");
   });
 
   it("sequential composition: later conditional reads earlier unconditional write", () => {

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -940,6 +940,47 @@ describe("conditional mutations (symbolic last-write)", () => {
     assert.equal(ast.strExpr(eq.rhs), "cond ~g => 1, true => account--balance a");
   });
 
+  it("tail early-exit guard with no prior writes is a no-op", () => {
+    const source = `
+      interface Account { balance: number; }
+      function tailGuard(a: Account, g: boolean): void {
+        if (g) { return; }
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "tailGuard",
+      strategy: IntStrategy,
+    });
+
+    assert.equal(props.length, 0);
+  });
+
+  it("tail early-exit guard preserves prior writes", () => {
+    const source = `
+      interface Account { balance: number; }
+      function writeThenTailGuard(a: Account, g: boolean): void {
+        a.balance = 1;
+        if (g) { return; }
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "writeThenTailGuard",
+      strategy: IntStrategy,
+    });
+
+    const equations = props.filter((p) => p.kind === "equation");
+    assert.equal(equations.length, 1);
+    const eq = equations[0]!;
+    if (eq.kind !== "equation") return;
+    const ast = getAst();
+    assert.equal(ast.strExpr(eq.lhs), "account--balance' a");
+    assert.equal(ast.strExpr(eq.rhs), "1");
+  });
+
   it("sequential composition: later conditional reads earlier unconditional write", () => {
     const source = `
       interface Account { balance: number; }


### PR DESCRIPTION
## Patch 2: Promote remaining supported shapes into SSA

- Delete or empty `containsDeferredSsaFastPathShape` as a fallback gate; any remaining checks must produce diagnostics before lowering rather than routing to `symbolicExecute`.
- Teach the SSA build/lower path to preserve const alias normalization that the old `SymbolicState.canonicalize` path provided.
- Ensure staged property, Map, and Set reads in supported mutating bodies resolve through SSA versions rather than through `readMapThroughWrites` or `readSetThroughWrites`.
- Preserve foreach Shape A and Shape B semantics currently covered by tests, including Shape B accumulator equations seeing Shape A writes in the same iteration and loop bodies seeing prior property writes.
- Preserve conservative rejections for unsupported loops, branch-contained foreach bodies, iterator-dependent guards, and side-effectful expressions with targeted diagnostic text.
- Enable the Patch 1 supported-fixture and state-aware-read tests.

## Changes
- Delete or empty `containsDeferredSsaFastPathShape` as a fallback gate; any remaining checks must produce diagnostics before lowering rather than routing to `symbolicExecute`.
- Teach the SSA build/lower path to preserve const alias normalization that the old `SymbolicState.canonicalize` path provided.
- Ensure staged property, Map, and Set reads in supported mutating bodies resolve through SSA versions rather than through `readMapThroughWrites` or `readSetThroughWrites`.
- Preserve foreach Shape A and Shape B semantics currently covered by tests, including Shape B accumulator equations seeing Shape A writes in the same iteration and loop bodies seeing prior property writes.
- Preserve conservative rejections for unsupported loops, branch-contained foreach bodies, iterator-dependent guards, and side-effectful expressions with targeted diagnostic text.
- Enable the Patch 1 supported-fixture and state-aware-read tests.

## Files to Modify
- tools/ts2pant/src/translate-body.ts (modify): Remove the deferred fast-path gate by making `buildSupportedSsaMutatingBody` handle currently supported aliases, branches, and loop-summary inputs or return targeted diagnostics.
- tools/ts2pant/src/ir1-build-body.ts (modify): Adjust IR1 mutating-body builders for const aliases, state-aware reads, branch shapes, foreach Shape A/B interactions, and existing unsupported diagnostics.
- tools/ts2pant/src/ir1-lower-body.ts (modify): Ensure `lowerL1BodyToSsaProps` threads initial property values and state-aware expression inputs needed by the migrated shapes.
- tools/ts2pant/src/ir1-ssa-scalars.ts (modify): Expose or consume scalar SSA early-exit and prior-value support needed by migrated branch/alias cases.
- tools/ts2pant/src/ir1-ssa-collections.ts (modify): Preserve Map/Set read-after-write, branch join, and Set.clear behavior for migrated non-looping collection cases.
- tools/ts2pant/src/ir1-ssa-loops.ts (modify): Preserve foreach Shape A/B summary behavior, including accumulator prior values and reads that observe same-iteration Shape A writes.
- tools/ts2pant/tests/ir1-ssa-ripout.test.mts (modify): Enable and implement the supported-fixture and state-aware-read tests introduced by Patch 1.

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[paper] Vekris, Cosman, Jhala 2016: Refinement Types for TypeScript** — https://arxiv.org/pdf/1604.02480 — This patch consumes the workstream's SSA precedent directly: supported TypeScript mutation must become explicit IR facts and reads must resolve through SSA versions instead of an ambient symbolic state.

## Gameplan Specification

```
module TS2PANT_IR1_SSA_RIPOUT.

IR1Program.
Construct.
Location.
Version.
Read.
Write.
Join.
LoopSummary.
Rule.
PropResult.
Diagnostic.
Helper.
Document.
Architecture.
ssa => Architecture.
symbolic-state => Architecture.

supported-constructs p: IR1Program => [Construct].
lowered-constructs p: IR1Program => [Construct].
diagnostics p: IR1Program => [Diagnostic].
diagnostic-construct d: Diagnostic => Construct.
writes p: IR1Program => [Write].
reads p: IR1Program => [Read].
joins p: IR1Program => [Join].
loop-summaries p: IR1Program => [LoopSummary].
write-location w: Write => Location.
write-version w: Write => Version.
read-location r: Read => Location.
read-version r: Read => Version.
read-dominated? p: IR1Program, r: Read => Bool.
join-location j: Join => Location.
then-version j: Join => Version.
else-version j: Join => Version.
join-version j: Join => Version.
summary-location s: LoopSummary => Location.
summary-version s: LoopSummary => Version.
initial-version l: Location => Version.
version-location v: Version => Location.
rule-of-location l: Location => Rule.
declared-rules p: IR1Program => [Rule].
modified-rules p: IR1Program => [Rule].
framed-rules p: IR1Program => [Rule].
emitted-props p: IR1Program => [PropResult].
failed? p: IR1Program => Bool.
prop-is-diagnostic? pr: PropResult => Bool.
public-helper? h: Helper => Bool.
helper-architecture h: Helper => Architecture.
describes-current? d: Document => Bool.
document-architecture d: Document => Architecture.
---
all p: IR1Program, c in supported-constructs p |
  c in lowered-constructs p.

all p: IR1Program, diag in diagnostics p |
  ~(diagnostic-construct diag in supported-constructs p).

all p: IR1Program, w in writes p |
  version-location (write-version w) = write-location w.

all p: IR1Program, s in loop-summaries p |
  version-location (summary-version s) = summary-location s.

all l: Location |
  version-location (initial-version l) = l.

all p: IR1Program, w1 in writes p, w2 in writes p |
  write-version w1 = write-version w2 -> w1 = w2.

all p: IR1Program, r in reads p |
  read-dominated? p r and
  version-location (read-version r) = read-location r and
  (
    read-version r = initial-version (read-location r) or
    (some w in writes p |
      write-version w = read-version r and
      write-location w = read-location r) or
    (some s in loop-summaries p |
      summary-version s = read-version r and
      summary-location s = read-location r)
  ).

all p: IR1Program, j in joins p |
  version-location (then-version j) = join-location j and
  version-location (else-version j) = join-location j and
  version-location (join-version j) = join-location j.

all p: IR1Program, j in joins p |
  then-version j != else-version j and
  join-version j != then-version j and
  join-version j != else-version j.

all p: IR1Program, rule in modified-rules p |
  rule in declared-rules p and
  ~(rule in framed-rules p).

all p: IR1Program, rule in framed-rules p |
  rule in declared-rules p and
  ~(rule in modified-rules p).

all p: IR1Program, rule in declared-rules p |
  rule in modified-rules p or rule in framed-rules p.

all p: IR1Program, w in writes p |
  rule-of-location (write-location w) in modified-rules p.

all p: IR1Program, s in loop-summaries p |
  rule-of-location (summary-location s) in modified-rules p.

all p: IR1Program |
  #(lowered-constructs p) > 0 -> #(emitted-props p) > 0.

all p: IR1Program, failed? p |
  #(diagnostics p) > 0 and
  (all pr in emitted-props p | prop-is-diagnostic? pr).

all h: Helper, public-helper? h |
  helper-architecture h = ssa.

all d: Document, describes-current? d |
  document-architecture d = ssa.

```

## Patch Specification

```
module TS2PANT_IR1_SSA_RIPOUT_PATCH_2.

IR1Program.
Construct.
Diagnostic.
Read.
Location.
Version.

supported-constructs p: IR1Program => [Construct].
lowered-constructs p: IR1Program => [Construct].
diagnostics p: IR1Program => [Diagnostic].
diagnostic-construct d: Diagnostic => Construct.
reads p: IR1Program => [Read].
read-location r: Read => Location.
read-version r: Read => Version.
version-location v: Version => Location.
read-dominated? p: IR1Program, r: Read => Bool.
---
all p: IR1Program, c in supported-constructs p |
  c in lowered-constructs p.

all p: IR1Program, d in diagnostics p |
  ~(diagnostic-construct d in supported-constructs p).

all p: IR1Program, r in reads p |
  read-dominated? p r and version-location (read-version r) = read-location r.

```


## Implementation Notes

- `containsDeferredSsaFastPathShape` is intentionally reduced to an always-false stub in this patch. Supported Map/Set state-aware reads, const aliases, and foreach Shape A/B fixtures now attempt SSA lowering first; bodies still rejected by the SSA boundary can still fall through to the legacy path here so pre-existing early-exit and unsupported diagnostic behavior remains stable until the dedicated fallback-removal patch.
- Const alias preservation is implemented in `buildSupportedSsaMutatingBody` by threading a scoped parameter map plus `applyConstChain`, updating `SymbolicState.canonicalize`, and registering translated const binders as opaque aliases. The opaque alias registration is the non-obvious part: SSA lowering substitutes aliases at the `OpaqueExpr` layer, so without it final primed equations could leak hygienic `$N` binders into emitted Pantagruel.
- Snapshot changes are expected SSA-first output differences: staged Map/Set reads now collapse through current SSA versions, so some previous nested override reads simplify to direct values such as `v` or `v + 1`; foreach summaries also reuse the source binder name when it is available rather than inheriting the old fallback's later-generated binder names.
- Spec/Evidence Mapping:
  - Supported constructs lower through SSA: `translateMutatingBody` now no longer defers state-aware/foreach shapes via `containsDeferredSsaFastPathShape`; covered by enabled `ir1-ssa-ripout` supported-fixture test and updated construct snapshots.
  - Reads resolve through SSA versions: existing collection and loop SSA lowerers now receive these shapes instead of being gated away; covered by `expressions-state-aware-reads` snapshots and `tests/integration/collection-ssa-parity.test.mts` through `npm test`.
  - Const alias normalization: `buildSupportedSsaMutatingBody` const handling plus `registerOpaqueAlias`; covered by `functions-mutating-const.ts > aliasedSequentialWrites` and the enabled ripout const/state-aware-read test.
  - Required context consulted: `workstreams/ts2pant-ir1-ssa.md`, `workstreams/ts2pant-ir1-ssa.pant`, `tools/ts2pant/src/translate-body.ts`, `tools/ts2pant/src/ir1-lower-body.ts`, `tools/ts2pant/src/ir1-build-body.ts`, and the ts2pant unit/integration test contracts listed in the gameplan.
  - Verification: `cd tools/ts2pant && npm run build`, targeted `ir1-ssa-ripout.test.mts`, and full `cd tools/ts2pant && npm test` all passed.