### PR TITLE
[ts2pant-ir1-ssa-ripout] Patch 3: Remove translate-body symbolic fallback

### DIFF
--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -27,6 +27,13 @@ import {
 import { lowerL1MuSearch, type MuSearchLowerCtx } from "./ir1-lower.js";
 import { lowerL1Body, lowerL1BodyToSsaProps } from "./ir1-lower-body.js";
 import {
+  appendFramesForUnmodifiedRules,
+  type IR1SsaBodyLowerResult,
+  type IR1SsaFinalProperty,
+  ir1SsaBodyLowerSuccess,
+  ir1SsaBodyLowerUnsupported,
+} from "./ir1-ssa-lower.js";
+import {
   isScalarSsaL1Body,
   lowerScalarSsaEarlyExitMerge,
   type ScalarSsaEarlyExitPropertyInput,
@@ -1064,7 +1071,7 @@ export function readSetThroughWrites(
  * entries. `valueOverrides` empty (pure `.delete`) — skip the value
  * rule; the membership going false makes the rule-guard vacuous.
  */
-function emitMapEquations(
+function _emitMapEquations(
   entry: MapRuleWriteEntry,
   propositions: PropResult[],
   allocBinder: (hint: string) => string,
@@ -1136,7 +1143,7 @@ function emitMapEquations(
  * carried on the entry itself; the quantifier runs only over the
  * element.
  */
-function emitSetMembershipEquation(
+function _emitSetMembershipEquation(
   entry: SetRuleWriteEntry,
   propositions: PropResult[],
   allocBinder: (hint: string) => string,
@@ -1227,6 +1234,9 @@ interface EarlyExitDetection {
 }
 
 function detectEarlyExit(stmt: ts.Statement): EarlyExitDetection | null {
+  if (ts.isBlock(stmt) && stmt.statements.length === 1) {
+    return detectEarlyExit(stmt.statements[0]!);
+  }
   if (!ts.isIfStatement(stmt)) {
     return null;
   }
@@ -4498,44 +4508,248 @@ function translateMutatingBody(
     return [];
   }
 
-  const ssaState = makeSymbolicState();
-  const ssaSupply = makeUniqueSupply(synthCell);
+  const lowered = appendFramesForUnmodifiedRules(
+    lowerSupportedSsaMutatingStatements(Array.from(node.body.statements), {
+      checker,
+      strategy,
+      paramNames,
+      state: makeSymbolicState(),
+      supply: makeUniqueSupply(synthCell),
+      initialPropertyValues: new Map(),
+    }),
+    declarations,
+  );
+  if (lowered.diagnostics.length > 0) {
+    return lowered.diagnostics;
+  }
+  return lowered.propositions;
+}
+
+function lowerSupportedSsaMutatingStatements(
+  stmts: readonly ts.Statement[],
+  ctx: {
+    checker: ts.TypeChecker;
+    strategy: NumericStrategy;
+    paramNames: Map<string, string>;
+    state: SymbolicState;
+    supply: UniqueSupply;
+    initialPropertyValues: ReadonlyMap<string, OpaqueExpr>;
+  },
+): IR1SsaBodyLowerResult {
+  const firstEarlyExit = stmts.findIndex(
+    (stmt) => detectEarlyExit(stmt) !== null,
+  );
+  if (firstEarlyExit === -1) {
+    return lowerSupportedSsaMutatingBlock(stmts, ctx);
+  }
+
+  const exitStmt = stmts[firstEarlyExit]!;
+  const exit = detectEarlyExit(exitStmt);
+  if (exit === null) {
+    return ir1SsaBodyLowerUnsupported("internal early-exit detection mismatch");
+  }
+  if (expressionHasSideEffects(exit.condition, ctx.checker)) {
+    return ir1SsaBodyLowerUnsupported("impure if-condition in mutating body");
+  }
+
+  const prefix = lowerSupportedSsaMutatingBlock(
+    stmts.slice(0, firstEarlyExit),
+    {
+      ...ctx,
+    },
+  );
+  if (prefix.diagnostics.length > 0) {
+    return prefix;
+  }
+  if (hasDirectNonFinalEmission(prefix)) {
+    return ir1SsaBodyLowerUnsupported(
+      "early-exit prefixes must lower to final SSA properties only",
+    );
+  }
+
+  const propertyValues = new Map(ctx.initialPropertyValues);
+  for (const entry of prefix.finalProperties ?? []) {
+    const property = finalPropertyParts(entry);
+    if (property === null) {
+      return ir1SsaBodyLowerUnsupported(
+        "early-exit prefixes only support scalar property writes",
+      );
+    }
+    propertyValues.set(
+      symbolicKey(property.prop, property.objExpr),
+      property.rhs,
+    );
+    ctx.state.writes = putWrite(
+      ctx.state.writes,
+      symbolicKey(property.prop, property.objExpr),
+      {
+        kind: "property",
+        prop: property.prop,
+        objExpr: property.objExpr,
+        value: property.rhs,
+      },
+    );
+    ctx.state.writtenKeys = addWrittenKey(
+      ctx.state.writtenKeys,
+      symbolicKey(property.prop, property.objExpr),
+    );
+  }
+
+  const gResult = translateBodyExpr(
+    exit.condition,
+    ctx.checker,
+    ctx.strategy,
+    ctx.paramNames,
+    ctx.state,
+    ctx.supply,
+  );
+  if (isBodyUnsupported(gResult)) {
+    return ir1SsaBodyLowerUnsupported(gResult.unsupported);
+  }
+  const guardExpr = applyOpaqueAliases(bodyExpr(gResult), ctx.supply);
+  const continuationGuardExpr = exit.earlyExitWhenTrue
+    ? getAst().unop(getAst().opNot(), guardExpr)
+    : guardExpr;
+
+  const continuation = [
+    ...exit.continuationPrefix,
+    ...stmts.slice(firstEarlyExit + 1),
+  ];
+  const continuationResult = lowerSupportedSsaMutatingStatements(continuation, {
+    ...ctx,
+    initialPropertyValues: propertyValues,
+  });
+  if (continuationResult.diagnostics.length > 0) {
+    return continuationResult;
+  }
+  if (hasDirectNonFinalEmission(continuationResult)) {
+    return ir1SsaBodyLowerUnsupported(
+      "loop with per-iteration writes cannot appear after an early-exit guard",
+    );
+  }
+
+  const continuationKeys = new Set<string>();
+  const inputs: ScalarSsaEarlyExitPropertyInput[] = [];
+  for (const entry of continuationResult.finalProperties ?? []) {
+    const property = finalPropertyParts(entry);
+    if (property === null) {
+      return ir1SsaBodyLowerUnsupported(
+        "early-exit continuations only support scalar property writes",
+      );
+    }
+    const key = symbolicKey(property.prop, property.objExpr);
+    continuationKeys.add(key);
+    inputs.push({
+      key,
+      prop: property.prop,
+      objExpr: property.objExpr,
+      priorValue: propertyValues.get(key),
+      continuationValue: property.rhs,
+    });
+  }
+
+  const merged = lowerScalarSsaEarlyExitMerge(inputs, {
+    guardExpr: continuationGuardExpr,
+    earlyExitWhenTrue: false,
+    canonicalize: (e) => applyOpaqueAliases(e, ctx.supply),
+  });
+  const prefixOnly = (prefix.finalProperties ?? []).filter((entry) => {
+    const property = finalPropertyParts(entry);
+    return property === null
+      ? false
+      : !continuationKeys.has(symbolicKey(property.prop, property.objExpr));
+  });
+
+  return ir1SsaBodyLowerSuccess({
+    propositions: [
+      ...prefixOnly.map((entry) => finalPropertyEquation(entry)),
+      ...merged.propositions,
+    ],
+    modifiedRules: [
+      ...prefixOnly.map((entry) => finalPropertyRuleName(entry)),
+      ...merged.modifiedRules,
+    ],
+    programs: [
+      ...prefix.programs,
+      ...continuationResult.programs,
+      merged.program,
+    ],
+    finalProperties: [...prefixOnly, ...merged.finalProperties],
+  });
+}
+
+function lowerSupportedSsaMutatingBlock(
+  stmts: readonly ts.Statement[],
+  ctx: {
+    checker: ts.TypeChecker;
+    strategy: NumericStrategy;
+    paramNames: Map<string, string>;
+    state: SymbolicState;
+    supply: UniqueSupply;
+    initialPropertyValues: ReadonlyMap<string, OpaqueExpr>;
+  },
+): IR1SsaBodyLowerResult {
+  const body = ts.factory.createBlock(stmts, true);
   const ssaBody = buildSupportedSsaMutatingBody(
-    node.body,
-    checker,
-    strategy,
-    paramNames,
-    ssaState,
-    ssaSupply,
+    body,
+    ctx.checker,
+    ctx.strategy,
+    ctx.paramNames,
+    ctx.state,
+    ctx.supply,
   );
 
   if (isUnsupported(ssaBody)) {
-    if (ssaBody.unsupported === "empty mutating body") {
-      return [];
-    }
-    return [{ kind: "unsupported", reason: ssaBody.unsupported }];
+    return ssaBody.unsupported === "empty mutating body"
+      ? ir1SsaBodyLowerSuccess()
+      : ir1SsaBodyLowerUnsupported(ssaBody.unsupported);
   }
 
-  if (containsDeferredSsaFastPathShape(ssaBody)) {
-    return [
-      {
-        kind: "unsupported",
-        reason: "statement is not supported by unified SSA body lowering",
-      },
-    ];
-  }
-
-  const lowered = lowerL1BodyToSsaProps(ssaBody, declarations, {
-    applyConst: (e) => applyOpaqueAliases(e, ssaSupply),
+  return lowerL1BodyToSsaProps(ssaBody, [], {
+    applyConst: (e) => applyOpaqueAliases(e, ctx.supply),
+    initialPropertyValues: ctx.initialPropertyValues,
   });
-  return lowered.diagnostics.length === 0
-    ? lowered.propositions
-    : lowered.diagnostics;
 }
 
-function containsDeferredSsaFastPathShape(stmt: IR1Stmt): boolean {
-  void stmt;
-  return false;
+function hasDirectNonFinalEmission(result: IR1SsaBodyLowerResult): boolean {
+  return result.propositions.length !== (result.finalProperties?.length ?? 0);
+}
+
+function finalPropertyParts(
+  entry: IR1SsaFinalProperty,
+): { prop: string; objExpr: OpaqueExpr; rhs: OpaqueExpr } | null {
+  if ("kind" in entry && entry.kind === "property") {
+    return { prop: entry.prop, objExpr: entry.objExpr, rhs: entry.rhs };
+  }
+  if ("location" in entry && entry.location.kind === "property") {
+    return {
+      prop: entry.location.ruleName,
+      objExpr: entry.objExpr,
+      rhs: entry.rhs,
+    };
+  }
+  return null;
+}
+
+function finalPropertyRuleName(entry: IR1SsaFinalProperty): string {
+  const property = finalPropertyParts(entry);
+  if (property === null) {
+    throw new Error("expected scalar property final entry");
+  }
+  return property.prop;
+}
+
+function finalPropertyEquation(entry: IR1SsaFinalProperty): PropResult {
+  const property = finalPropertyParts(entry);
+  if (property === null) {
+    throw new Error("expected scalar property final entry");
+  }
+  return {
+    kind: "equation",
+    quantifiers: [] as OpaqueParam[],
+    lhs: getAst().app(getAst().primed(property.prop), [property.objExpr]),
+    rhs: property.rhs,
+  };
 }
 
 function buildSupportedSsaMutatingBody(
@@ -4581,12 +4795,6 @@ function buildSupportedSsaMutatingBody(
         [...exit.continuationPrefix, ...bodyStmts.slice(index + 1)],
         true,
       );
-      const prefix =
-        stmts.length === 0
-          ? null
-          : stmts.length === 1
-            ? stmts[0]!
-            : ir1Block(stmts as [IR1Stmt, ...IR1Stmt[]]);
       const continuationBody = buildSupportedSsaMutatingBody(
         continuation,
         checker,
@@ -4597,14 +4805,17 @@ function buildSupportedSsaMutatingBody(
         applyConstChain,
       );
       if (isUnsupported(continuationBody)) {
-        if (continuationBody.unsupported === "empty mutating body") {
-          return prefix ?? { unsupported: "empty mutating body" };
-        }
         return continuationBody;
       }
       const continuationGuard = exit.earlyExitWhenTrue
         ? ir1Unop("not", guard)
         : guard;
+      const prefix =
+        stmts.length === 0
+          ? null
+          : stmts.length === 1
+            ? stmts[0]!
+            : ir1Block(stmts as [IR1Stmt, ...IR1Stmt[]]);
       const gated = ir1CondStmt([[continuationGuard, continuationBody]], null);
       if (prefix === null) {
         return gated;
@@ -4668,9 +4879,6 @@ function buildSupportedSsaMutatingBody(
       applyConst,
     });
     if (isUnsupported(built)) {
-      if (built.unsupported === "empty mutating body") {
-        continue;
-      }
       return built;
     }
     stmts.push(built);
@@ -4728,6 +4936,14 @@ function buildSupportedSsaStatement(
       return buildL1AssignStmt(stmt, ctx);
     }
   }
+  if (
+    ts.isForStatement(stmt) ||
+    ts.isForInStatement(stmt) ||
+    ts.isWhileStatement(stmt) ||
+    ts.isDoStatement(stmt)
+  ) {
+    return { unsupported: "loop assignment" };
+  }
   return {
     unsupported: `statement is not supported by unified SSA body lowering: ${ts.SyntaxKind[stmt.kind]}`,
   };
@@ -4740,7 +4956,7 @@ function buildSupportedSsaStatement(
  * `false` when an unsupported construct was encountered; unsupported
  * markers are pushed into `propositions` for the caller to inspect.
  */
-function symbolicExecute(
+function _symbolicExecute(
   body: ts.Block | ts.Statement,
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
@@ -4820,7 +5036,7 @@ function symbolicExecute(
       const sR = cloneSymbolicState(state);
       const remainingProps: PropResult[] = [];
       const continuationBlock = ts.factory.createBlock(continuation, true);
-      const okR = symbolicExecute(
+      const okR = _symbolicExecute(
         continuationBlock,
         checker,
         strategy,
@@ -5316,7 +5532,7 @@ function symbolicExecute(
 
     // Nested block — flow state through sequentially
     if (ts.isBlock(stmt)) {
-      const inner = symbolicExecute(
+      const inner = _symbolicExecute(
         stmt,
         checker,
         strategy,
@@ -5409,7 +5625,7 @@ function symbolicExecute(
         });
         ok = false;
       } else {
-        const inner = symbolicExecute(
+        const inner = _symbolicExecute(
           stmt.tryBlock,
           checker,
           strategy,
@@ -5425,7 +5641,7 @@ function symbolicExecute(
         }
       }
       if (stmt.finallyBlock) {
-        const inner = symbolicExecute(
+        const inner = _symbolicExecute(
           stmt.finallyBlock,
           checker,
           strategy,
@@ -5462,7 +5678,7 @@ function symbolicExecute(
  * machinery on the quantified form, which would be lost if ts2pant
  * pre-wrapped with a local `all` here.
  */
-function generateFrameConditions(
+function _generateFrameConditions(
   modifiedRules: ReadonlySet<string>,
   declarations: PantDeclaration[],
 ): PropResult[] {

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -1055,7 +1055,7 @@ exports[`unsupported.ts > impureGuardAssign 1`] = `
 `;
 
 exports[`unsupported.ts > loopAssign 1`] = `
-"module LOOP_ASSIGN.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--owner a1: Account => String.\\n~> Loop-assign @ a: Account.\\n\\n---\\n\\n> UNSUPPORTED: statement is not supported by unified SSA body lowering: ForStatement.\\n"
+"module LOOP_ASSIGN.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--owner a1: Account => String.\\n~> Loop-assign @ a: Account.\\n\\n---\\n\\n> UNSUPPORTED: loop assignment.\\n"
 `;
 
 exports[`unsupported.ts > multiParamCallback 1`] = `

--- a/tools/ts2pant/tests/ir1-ssa-ripout.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-ripout.test.mts
@@ -34,14 +34,14 @@ function translateMutatingSource(
 function extractTranslateMutatingBodySource(sourceText: string): string {
   const start = sourceText.indexOf("function translateMutatingBody(");
   const end = sourceText.indexOf(
-    "\nfunction containsDeferredSsaFastPathShape(",
+    "\nfunction buildSupportedSsaMutatingBody(",
     start,
   );
   assert.notEqual(start, -1, "expected translateMutatingBody in translate-body.ts");
   assert.notEqual(
     end,
     -1,
-    "expected containsDeferredSsaFastPathShape to delimit translateMutatingBody",
+    "expected buildSupportedSsaMutatingBody to delimit translateMutatingBody",
   );
   return sourceText.slice(start, end);
 }


### PR DESCRIPTION
## Patch 3: Remove translate-body symbolic fallback

- Change `translateMutatingBody` so an unsupported result from `buildSupportedSsaMutatingBody` returns one unsupported `PropResult` and does not invoke `symbolicExecute`.
- Change `translateMutatingBody` so diagnostics from `lowerL1BodyToSsaProps` are returned directly and suppress frame emission.
- Delete the final `for (const [, entry] of state.writes)` emission loop from `translateMutatingBody`.
- Stop calling `emitMapEquations`, `emitSetMembershipEquation`, and `generateFrameConditions(state.modifiedProps, declarations)` from mutating-body translation.
- Enable the Patch 1 unsupported-no-frame and no-fallback static tests.

## Changes
- Change `translateMutatingBody` so an unsupported result from `buildSupportedSsaMutatingBody` returns one unsupported `PropResult` and does not invoke `symbolicExecute`.
- Change `translateMutatingBody` so diagnostics from `lowerL1BodyToSsaProps` are returned directly and suppress frame emission.
- Delete the final `for (const [, entry] of state.writes)` emission loop from `translateMutatingBody`.
- Stop calling `emitMapEquations`, `emitSetMembershipEquation`, and `generateFrameConditions(state.modifiedProps, declarations)` from mutating-body translation.
- Enable the Patch 1 unsupported-no-frame and no-fallback static tests.

## Files to Modify
- tools/ts2pant/src/translate-body.ts (modify): Simplify `translateMutatingBody` to build IR1, lower with `lowerL1BodyToSsaProps`, and return diagnostics on SSA rejection without running `symbolicExecute`.
- tools/ts2pant/tests/ir1-ssa-ripout.test.mts (modify): Enable and implement fallback-removal and unsupported-no-frame tests.
- tools/ts2pant/tests/translate-body.test.mts (modify): Adjust assertions only where unsupported diagnostic wording changes because the fallback no longer retries a rejected body.

## Gameplan Specification

```
module TS2PANT_IR1_SSA_RIPOUT.

IR1Program.
Construct.
Location.
Version.
Read.
Write.
Join.
LoopSummary.
Rule.
PropResult.
Diagnostic.
Helper.
Document.
Architecture.
ssa => Architecture.
symbolic-state => Architecture.

supported-constructs p: IR1Program => [Construct].
lowered-constructs p: IR1Program => [Construct].
diagnostics p: IR1Program => [Diagnostic].
diagnostic-construct d: Diagnostic => Construct.
writes p: IR1Program => [Write].
reads p: IR1Program => [Read].
joins p: IR1Program => [Join].
loop-summaries p: IR1Program => [LoopSummary].
write-location w: Write => Location.
write-version w: Write => Version.
read-location r: Read => Location.
read-version r: Read => Version.
read-dominated? p: IR1Program, r: Read => Bool.
join-location j: Join => Location.
then-version j: Join => Version.
else-version j: Join => Version.
join-version j: Join => Version.
summary-location s: LoopSummary => Location.
summary-version s: LoopSummary => Version.
initial-version l: Location => Version.
version-location v: Version => Location.
rule-of-location l: Location => Rule.
declared-rules p: IR1Program => [Rule].
modified-rules p: IR1Program => [Rule].
framed-rules p: IR1Program => [Rule].
emitted-props p: IR1Program => [PropResult].
failed? p: IR1Program => Bool.
prop-is-diagnostic? pr: PropResult => Bool.
public-helper? h: Helper => Bool.
helper-architecture h: Helper => Architecture.
describes-current? d: Document => Bool.
document-architecture d: Document => Architecture.
---
all p: IR1Program, c in supported-constructs p |
  c in lowered-constructs p.

all p: IR1Program, diag in diagnostics p |
  ~(diagnostic-construct diag in supported-constructs p).

all p: IR1Program, w in writes p |
  version-location (write-version w) = write-location w.

all p: IR1Program, s in loop-summaries p |
  version-location (summary-version s) = summary-location s.

all l: Location |
  version-location (initial-version l) = l.

all p: IR1Program, w1 in writes p, w2 in writes p |
  write-version w1 = write-version w2 -> w1 = w2.

all p: IR1Program, r in reads p |
  read-dominated? p r and
  version-location (read-version r) = read-location r and
  (
    read-version r = initial-version (read-location r) or
    (some w in writes p |
      write-version w = read-version r and
      write-location w = read-location r) or
    (some s in loop-summaries p |
      summary-version s = read-version r and
      summary-location s = read-location r)
  ).

all p: IR1Program, j in joins p |
  version-location (then-version j) = join-location j and
  version-location (else-version j) = join-location j and
  version-location (join-version j) = join-location j.

all p: IR1Program, j in joins p |
  then-version j != else-version j and
  join-version j != then-version j and
  join-version j != else-version j.

all p: IR1Program, rule in modified-rules p |
  rule in declared-rules p and
  ~(rule in framed-rules p).

all p: IR1Program, rule in framed-rules p |
  rule in declared-rules p and
  ~(rule in modified-rules p).

all p: IR1Program, rule in declared-rules p |
  rule in modified-rules p or rule in framed-rules p.

all p: IR1Program, w in writes p |
  rule-of-location (write-location w) in modified-rules p.

all p: IR1Program, s in loop-summaries p |
  rule-of-location (summary-location s) in modified-rules p.

all p: IR1Program |
  #(lowered-constructs p) > 0 -> #(emitted-props p) > 0.

all p: IR1Program, failed? p |
  #(diagnostics p) > 0 and
  (all pr in emitted-props p | prop-is-diagnostic? pr).

all h: Helper, public-helper? h |
  helper-architecture h = ssa.

all d: Document, describes-current? d |
  document-architecture d = ssa.

```

## Patch Specification

```
module TS2PANT_IR1_SSA_RIPOUT_PATCH_3.

IR1Program.
PropResult.
Diagnostic.
Rule.

emitted-props p: IR1Program => [PropResult].
diagnostics p: IR1Program => [Diagnostic].
modified-rules p: IR1Program => [Rule].
framed-rules p: IR1Program => [Rule].
declared-rules p: IR1Program => [Rule].
failed? p: IR1Program => Bool.
prop-is-diagnostic? pr: PropResult => Bool.
---
all p: IR1Program, failed? p |
  #(diagnostics p) > 0 and
  (all pr in emitted-props p | prop-is-diagnostic? pr).

all p: IR1Program, rule in modified-rules p |
  rule in declared-rules p and ~(rule in framed-rules p).

all p: IR1Program, rule in framed-rules p |
  rule in declared-rules p and ~(rule in modified-rules p).

```


## Implementation Notes

- `translateMutatingBody` now delegates to a small SSA-only wrapper that appends frames once at the outer boundary via `appendFramesForUnmodifiedRules`; internal prefix/continuation lowering passes use empty declarations so diagnostics cannot pick up frames accidentally.
- Supported scalar early-exit fixtures were still relying on the removed fallback. I preserved that syntax by lowering prefixes and continuations through `lowerL1BodyToSsaProps`, then using `lowerScalarSsaEarlyExitMerge` to emit the guarded final property equations. Non-scalar/direct-emission continuations still fail closed with diagnostics, matching the existing loop-after-early-exit rejection.
- The old symbolic helpers remain in `translate-body.ts` for the later helper-surface cleanup patch, but they are no longer called by mutating-body translation. They were renamed with leading underscores only to satisfy lint after the production call sites were removed.
- Unsupported general loop diagnostics keep the pre-existing public reason (`loop assignment`) rather than exposing the new generic SSA builder wording, so existing snapshots did not need churn.

Spec/Evidence Mapping:
- Failed bodies emit diagnostics only: `translateMutatingBody` returns `lowered.diagnostics` when present; `ir1-ssa-ripout` enables `unsupported SSA build failure emits no frames`.
- Modified/framed rule separation: successful output frames are appended from `IR1SsaBodyLowerResult.modifiedRules` through `appendFramesForUnmodifiedRules`, with no `state.modifiedProps` frame path left in `translateMutatingBody`.
- No symbolic fallback from the production mutating-body entry: `translateMutatingBody` no longer calls `symbolicExecute`, `emitMapEquations`, `emitSetMembershipEquation`, or `generateFrameConditions`; the enabled static test `translate-body has no symbolicExecute fallback` pins that slice.
- Required context consulted: `workstreams/ts2pant-ir1-ssa.md`, `workstreams/ts2pant-ir1-ssa.pant`, `ir1-ssa-lower.ts`, `ir1-lower-body.ts`, `ir1-build-body.ts`, and the ripout/scalar/collection/loop test contracts.