### PR TITLE
[ts2pant-ir1-ssa-invariants] Patch 1: Add pending M7 invariants suite with corpus walker

### DIFF
--- a/tools/ts2pant/tests/ir1-ssa-invariants.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-invariants.test.mts
@@ -1,0 +1,323 @@
+import assert from "node:assert/strict";
+import { resolve } from "node:path";
+import { before, describe, it } from "node:test";
+
+import ts from "typescript";
+
+import { createSourceFile, getChecker } from "../src/extract.js";
+import {
+  buildL1AssignStmt,
+  buildL1EffectCall,
+  buildL1ForEachCall,
+  buildL1ForOfMutation,
+  buildL1IfMutation,
+  type BuildBodyCtx,
+  isUnsupported,
+} from "../src/ir1-build-body.js";
+import {
+  adaptLoopSummaryLowerResult,
+} from "../src/ir1-lower-body.js";
+import { lowerL1BodyToSsaProps } from "../src/ir1-lower-body.js";
+import type { IR1SsaBodyLowerResult } from "../src/ir1-ssa-lower.js";
+import {
+  type IR1SsaJoin,
+  type IR1SsaLoopSummary,
+  type IR1SsaProgram,
+  type IR1SsaRead,
+  type IR1SsaWrite,
+  type IR1Stmt,
+  ir1Binop,
+  ir1Block,
+  ir1SsaPropertyLocation,
+  ir1Var,
+} from "../src/ir1.js";
+import { lowerExpr } from "../src/ir-emit.js";
+import { lowerL1Expr } from "../src/ir1-lower.js";
+import {
+  lowerForeachShapeASummaries,
+  lowerForeachShapeBSummaries,
+  lowerMuSearchSummary,
+} from "../src/ir1-ssa-loops.js";
+import { getAst, loadAst } from "../src/pant-wasm.js";
+import { IntStrategy } from "../src/translate-types.js";
+import { buildDocumentFromSourceFile } from "./helpers.mts";
+
+const CONSTRUCTS_DIR = resolve(import.meta.dirname, "fixtures/constructs");
+
+type RepresentativeProgramKind =
+  | "scalar"
+  | "map"
+  | "set"
+  | "branch"
+  | "foreach-shape-a"
+  | "foreach-shape-b"
+  | "mu-search";
+
+interface RepresentativeProgram {
+  name: string;
+  kind: RepresentativeProgramKind;
+  build: () => Promise<IR1SsaBodyLowerResult>;
+}
+
+interface SsaProgramVisitor {
+  onWrite?: (write: IR1SsaWrite, index: number) => void;
+  onRead?: (read: IR1SsaRead, index: number) => void;
+  onJoin?: (join: IR1SsaJoin, index: number) => void;
+  onSummary?: (summary: IR1SsaLoopSummary, index: number) => void;
+}
+
+function loadFixture(fileName: string) {
+  return createSourceFile(resolve(CONSTRUCTS_DIR, fileName));
+}
+
+async function buildFixtureBodyLowerResult(
+  fileName: string,
+  functionName: string,
+): Promise<IR1SsaBodyLowerResult> {
+  const sourceFile = loadFixture(fileName);
+  const stmt = buildFixtureSupportedSsaBody(sourceFile, functionName);
+  const doc = await buildDocumentFromSourceFile(sourceFile, functionName);
+  return lowerL1BodyToSsaProps(stmt, doc.declarations, {
+    applyConst: (expr) => expr,
+  });
+}
+
+function buildFixtureSupportedSsaBody(
+  sourceFile: ReturnType<typeof createSourceFile>,
+  functionName: string,
+): IR1Stmt {
+  const fn = sourceFile.getFunctionOrThrow(functionName);
+  const body = fn.getBodyOrThrow().compilerNode;
+  assert.ok(ts.isBlock(body), `${functionName} should have a block body`);
+
+  const checker = getChecker(sourceFile);
+  const paramNames = new Map(
+    fn.getParameters().map((param) => [param.getName(), param.getName()]),
+  );
+  const ctx: BuildBodyCtx = {
+    checker,
+    strategy: IntStrategy,
+    paramNames,
+    state: {
+      writes: new Map(),
+      writtenKeys: new Set(),
+      modifiedProps: new Set(),
+      canonicalize: (expr) => expr,
+    },
+    supply: { n: 0 } as BuildBodyCtx["supply"],
+    applyConst: (expr) => expr,
+  };
+
+  const stmts: IR1Stmt[] = [];
+  for (const stmt of body.statements) {
+    if (ts.isReturnStatement(stmt) && stmt.expression === undefined) {
+      continue;
+    }
+    if (ts.isVariableStatement(stmt)) {
+      assert.fail(
+        `${functionName} uses local declarations that Patch 1's fixture bridge does not mirror yet`,
+      );
+    }
+    const built = buildSupportedFixtureStatement(stmt, ctx);
+    if (isUnsupported(built)) {
+      assert.fail(`${functionName}: ${built.unsupported}`);
+    }
+    stmts.push(built);
+  }
+
+  assert.ok(stmts.length > 0, `${functionName} should produce an SSA body`);
+  return stmts.length === 1 ? stmts[0]! : ir1Block([stmts[0]!, ...stmts.slice(1)]);
+}
+
+function buildSupportedFixtureStatement(
+  stmt: ts.Statement,
+  ctx: BuildBodyCtx,
+): IR1Stmt | { unsupported: string } {
+  if (ts.isBlock(stmt)) {
+    const children: IR1Stmt[] = [];
+    for (const child of stmt.statements) {
+      if (ts.isReturnStatement(child) && child.expression === undefined) {
+        continue;
+      }
+      const built = buildSupportedFixtureStatement(child, ctx);
+      if (isUnsupported(built)) {
+        return built;
+      }
+      children.push(built);
+    }
+    if (children.length === 0) {
+      return { unsupported: "empty mutating body" };
+    }
+    return children.length === 1
+      ? children[0]!
+      : ir1Block([children[0]!, ...children.slice(1)]);
+  }
+  if (ts.isIfStatement(stmt)) {
+    return buildL1IfMutation(stmt, ctx);
+  }
+  if (ts.isForOfStatement(stmt)) {
+    return buildL1ForOfMutation(stmt, ctx);
+  }
+  if (ts.isExpressionStatement(stmt)) {
+    const expr = ts.skipPartiallyEmittedExpressions(stmt.expression);
+    if (
+      ts.isCallExpression(expr) &&
+      ts.isPropertyAccessExpression(expr.expression) &&
+      expr.expression.name.text === "forEach"
+    ) {
+      return buildL1ForEachCall(expr, ctx);
+    }
+    if (ts.isCallExpression(expr)) {
+      return buildL1EffectCall(expr, ctx);
+    }
+    if (ts.isBinaryExpression(expr)) {
+      return buildL1AssignStmt(stmt, ctx);
+    }
+  }
+  return {
+    unsupported: "statement is not supported by Patch 1's fixture bridge",
+  };
+}
+
+async function buildMuSearchFixtureResult(): Promise<IR1SsaBodyLowerResult> {
+  const sourceFile = loadFixture("expressions-while-mu-search.ts");
+  await buildDocumentFromSourceFile(sourceFile, "firstUnusedSuffix");
+  return adaptLoopSummaryLowerResult(
+    lowerMuSearchSummary({
+      location: ir1SsaPropertyLocation(
+        "Name_firstUnusedSuffix",
+        ir1Var("name"),
+        "firstUnusedSuffix",
+      ),
+      counterType: "Int",
+      counterPantName: "i",
+      binder: "j1",
+      initExpr: getAst().litNat(1),
+      predicateExpr: lowerExpr(
+        lowerL1Expr(ir1Binop("in", ir1Var("j1"), ir1Var("used"))),
+      ),
+    }),
+  );
+}
+
+function representativePrograms(): RepresentativeProgram[] {
+  return [
+    {
+      name: "functions-mutating.ts > deposit",
+      kind: "scalar",
+      build: () => buildFixtureBodyLowerResult("functions-mutating.ts", "deposit"),
+    },
+    {
+      name: "expressions-map-mutation.ts > setAndCopy",
+      kind: "map",
+      build: () =>
+        buildFixtureBodyLowerResult("expressions-map-mutation.ts", "setAndCopy"),
+    },
+    {
+      name: "expressions-set-mutation-field.ts > tagClearAndAdd",
+      kind: "set",
+      build: () =>
+        buildFixtureBodyLowerResult(
+          "expressions-set-mutation-field.ts",
+          "tagClearAndAdd",
+        ),
+    },
+    {
+      name: "expressions-state-aware-reads.ts > bumpInBranch",
+      kind: "branch",
+      build: () =>
+        buildFixtureBodyLowerResult(
+          "expressions-state-aware-reads.ts",
+          "bumpInBranch",
+        ),
+    },
+    {
+      name: "functions-mutating-loop.ts > forEachActivate",
+      kind: "foreach-shape-a",
+      build: () =>
+        buildFixtureBodyLowerResult(
+          "functions-mutating-loop.ts",
+          "forEachActivate",
+        ),
+    },
+    {
+      name: "functions-mutating-loop.ts > forEachSum",
+      kind: "foreach-shape-b",
+      build: () =>
+        buildFixtureBodyLowerResult("functions-mutating-loop.ts", "forEachSum"),
+    },
+    {
+      name: "expressions-while-mu-search.ts > firstUnusedSuffix",
+      kind: "mu-search",
+      build: () => buildMuSearchFixtureResult(),
+    },
+  ];
+}
+
+function walkSsaProgram(program: IR1SsaProgram, visit: SsaProgramVisitor): void {
+  for (const [index, write] of program.writes.entries()) {
+    visit.onWrite?.(write, index);
+  }
+  for (const [index, read] of program.reads.entries()) {
+    visit.onRead?.(read, index);
+  }
+  for (const [index, join] of program.joins.entries()) {
+    visit.onJoin?.(join, index);
+  }
+  for (const [index, summary] of program.loopSummaries.entries()) {
+    visit.onSummary?.(summary, index);
+  }
+}
+
+before(async () => {
+  await loadAst();
+});
+
+describe("ir1-ssa-invariants", () => {
+  void representativePrograms;
+  void walkSsaProgram;
+  void lowerForeachShapeASummaries;
+  void lowerForeachShapeBSummaries;
+
+  it.skip(
+    "each write, join, and summary produces a fresh SSA version at its location",
+    () => {
+      // PENDING Patch 2: each write/join/summary produces a fresh SSA version at its location
+    },
+  );
+
+  it.skip(
+    "ir1SsaJoin rejects mismatched-location inputs across all four location kinds",
+    () => {
+      // PENDING Patch 2: ir1SsaJoin rejects mismatched-location inputs across all four location kinds
+    },
+  );
+
+  it.skip(
+    "every read resolves to a dominating version, initial version, or explicit loop summary at its own location",
+    () => {
+      // PENDING Patch 3: every read resolves to a dominating version, initial version, or explicit loop summary at its own location
+    },
+  );
+
+  it.skip(
+    "every modified rule suppresses frame generation exactly once and every framed rule is unmodified",
+    () => {
+      // PENDING Patch 4: every modified rule suppresses frame generation exactly once and every framed rule is unmodified
+    },
+  );
+
+  it.skip(
+    "unsupported loops and branch shapes return targeted diagnostics with no equations or frames",
+    () => {
+      // PENDING Patch 5: unsupported loops and branch shapes return targeted diagnostics with no equations or frames
+    },
+  );
+
+  it.skip(
+    "the table-driven corpus satisfies all SSA invariants for scalar, Map, Set, branch, foreach Shape A, foreach Shape B, and μ-search programs",
+    () => {
+      // PENDING Patch 5: the table-driven corpus satisfies all SSA invariants for scalar, Map, Set, branch, foreach Shape A, foreach Shape B, and μ-search programs
+    },
+  );
+});

--- a/tools/ts2pant/tests/ir1-ssa-invariants.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-invariants.test.mts
@@ -39,6 +39,7 @@ import {
   lowerMuSearchSummary,
 } from "../src/ir1-ssa-loops.js";
 import { getAst, loadAst } from "../src/pant-wasm.js";
+import { freshHygienicBinder, type UniqueSupply } from "../src/translate-body.js";
 import { IntStrategy } from "../src/translate-types.js";
 import { buildDocumentFromSourceFile } from "./helpers.mts";
 
@@ -182,6 +183,8 @@ function buildSupportedFixtureStatement(
 async function buildMuSearchFixtureResult(): Promise<IR1SsaBodyLowerResult> {
   const sourceFile = loadFixture("expressions-while-mu-search.ts");
   await buildDocumentFromSourceFile(sourceFile, "firstUnusedSuffix");
+  const supply: UniqueSupply = { n: 0 };
+  const binder = freshHygienicBinder(supply);
   return adaptLoopSummaryLowerResult(
     lowerMuSearchSummary({
       location: ir1SsaPropertyLocation(
@@ -191,10 +194,10 @@ async function buildMuSearchFixtureResult(): Promise<IR1SsaBodyLowerResult> {
       ),
       counterType: "Int",
       counterPantName: "i",
-      binder: "j1",
+      binder,
       initExpr: getAst().litNat(1),
       predicateExpr: lowerExpr(
-        lowerL1Expr(ir1Binop("in", ir1Var("j1"), ir1Var("used"))),
+        lowerL1Expr(ir1Binop("in", ir1Var(binder), ir1Var("used"))),
       ),
     }),
   );


### PR DESCRIPTION
## Patch 1: Add pending M7 invariants suite with corpus walker

- Create `tools/ts2pant/tests/ir1-ssa-invariants.test.mts` following the boot pattern from `ir1-ssa-scalars.test.mts` and `ir1-ssa-collections.test.mts` — import `before`/`describe`/`it` from `node:test`, call `await loadAst()` in `before`, and import `createSourceFile` plus the production lowering helpers.
- Add a `representativePrograms()` helper that returns an array of `{ name, kind, build }` entries where `kind` ranges over `"scalar" | "map" | "set" | "branch" | "foreach-shape-a" | "foreach-shape-b" | "mu-search"` and `build()` produces an `IR1SsaBodyLowerResult` by routing the appropriate fixture file and function through `lowerL1BodyToSsaProps` (with declarations stubbed via the existing `buildDocumentFromSourceFile` helper or a comparable harness).
- Add a `walkSsaProgram(program: IR1SsaProgram, visit: { onWrite, onRead, onJoin, onSummary })` helper that visits every node in declaration order and is used by all subsequent patches.
- Add a skipped `it` per invariant family with a PENDING comment naming the implementing patch: `PENDING Patch 2: each write/join/summary produces a fresh SSA version at its location`, `PENDING Patch 2: ir1SsaJoin rejects mismatched-location inputs across all four location kinds`, `PENDING Patch 3: every read resolves to a dominating version, initial version, or explicit loop summary at its own location`, `PENDING Patch 4: every modified rule suppresses frame generation exactly once and every framed rule is unmodified`, `PENDING Patch 5: unsupported loops and branch shapes return a targeted diagnostic with no equations or frames`, `PENDING Patch 5: the table-driven corpus satisfies all SSA invariants for scalar, Map, Set, branch, foreach Shape A, foreach Shape B, and μ-search programs`.
- Ensure `bun run test` (or the project's `just ts2pant-test-unit` equivalent) reports the new file's stubs as skipped rather than failing.

## Changes
- Create `tools/ts2pant/tests/ir1-ssa-invariants.test.mts` following the boot pattern from `ir1-ssa-scalars.test.mts` and `ir1-ssa-collections.test.mts` — import `before`/`describe`/`it` from `node:test`, call `await loadAst()` in `before`, and import `createSourceFile` plus the production lowering helpers.
- Add a `representativePrograms()` helper that returns an array of `{ name, kind, build }` entries where `kind` ranges over `"scalar" | "map" | "set" | "branch" | "foreach-shape-a" | "foreach-shape-b" | "mu-search"` and `build()` produces an `IR1SsaBodyLowerResult` by routing the appropriate fixture file and function through `lowerL1BodyToSsaProps` (with declarations stubbed via the existing `buildDocumentFromSourceFile` helper or a comparable harness).
- Add a `walkSsaProgram(program: IR1SsaProgram, visit: { onWrite, onRead, onJoin, onSummary })` helper that visits every node in declaration order and is used by all subsequent patches.
- Add a skipped `it` per invariant family with a PENDING comment naming the implementing patch: `PENDING Patch 2: each write/join/summary produces a fresh SSA version at its location`, `PENDING Patch 2: ir1SsaJoin rejects mismatched-location inputs across all four location kinds`, `PENDING Patch 3: every read resolves to a dominating version, initial version, or explicit loop summary at its own location`, `PENDING Patch 4: every modified rule suppresses frame generation exactly once and every framed rule is unmodified`, `PENDING Patch 5: unsupported loops and branch shapes return a targeted diagnostic with no equations or frames`, `PENDING Patch 5: the table-driven corpus satisfies all SSA invariants for scalar, Map, Set, branch, foreach Shape A, foreach Shape B, and μ-search programs`.
- Ensure `bun run test` (or the project's `just ts2pant-test-unit` equivalent) reports the new file's stubs as skipped rather than failing.

## Files to Modify
- tools/ts2pant/tests/ir1-ssa-invariants.test.mts (create): New test file containing the corpus walker, the SSA program traversal helper, and one skipped `it` per M7 invariant family — all marked PENDING with the patch number that will implement them.

## Gameplan Specification

```
module TS2PANT_IR1_SSA_INVARIANTS.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> After Milestone 7, the IR1 SSA architecture is guarded by
> runtime tests that target the abstraction directly. The
> invariants below are the ones the workstream's Pantagruel
> spec (`workstreams/ts2pant-ir1-ssa.pant`) defines, now
> mechanically witnessed by `ir1-ssa-invariants.test.mts`.

IR1Program.
Construct.
ConstructKind.
Location.
Version.
Read.
Write.
Join.
LoopSummary.
Rule.
PropResult.
Diagnostic.
Document.
MilestoneStatus.
scalar => ConstructKind.
map => ConstructKind.
set-kind => ConstructKind.
branch => ConstructKind.
foreach-shape-a => ConstructKind.
foreach-shape-b => ConstructKind.
mu-search => ConstructKind.
pending => MilestoneStatus.
landed => MilestoneStatus.

writes p: IR1Program => [Write].
reads p: IR1Program => [Read].
joins p: IR1Program => [Join].
loop-summaries p: IR1Program => [LoopSummary].
write-location w: Write => Location.
write-version w: Write => Version.
read-location r: Read => Location.
read-version r: Read => Version.
join-location j: Join => Location.
then-version j: Join => Version.
else-version j: Join => Version.
join-version j: Join => Version.
summary-location s: LoopSummary => Location.
summary-version s: LoopSummary => Version.
version-location v: Version => Location.
initial-version l: Location => Version.
rule-of-location l: Location => Rule.
declared-rules p: IR1Program => [Rule].
modified-rules p: IR1Program => [Rule].
framed-rules p: IR1Program => [Rule].
diagnostics p: IR1Program => [Diagnostic].
emitted-props p: IR1Program => [PropResult].
prop-is-diagnostic? pr: PropResult => Bool.
failed? p: IR1Program => Bool.
diagnostic-construct d: Diagnostic => Construct.
construct-kind c: Construct => ConstructKind.
representative-corpus => [Construct].
m7-status d: Document => MilestoneStatus.
m7-references-suite? d: Document => Bool.
---

> ── Fresh versions and location agreement ────────────────
all p: IR1Program, w in writes p |
  version-location (write-version w) = write-location w.

all p: IR1Program, s in loop-summaries p |
  version-location (summary-version s) = summary-location s.

all l: Location |
  version-location (initial-version l) = l.

all p: IR1Program, w1 in writes p, w2 in writes p |
  write-version w1 = write-version w2 -> w1 = w2.

> ── Joins are constrained to a single location ───────────
all p: IR1Program, j in joins p |
  version-location (then-version j) = join-location j and
  version-location (else-version j) = join-location j and
  version-location (join-version j) = join-location j.

all p: IR1Program, j in joins p |
  then-version j != else-version j and
  join-version j != then-version j and
  join-version j != else-version j.

> ── Reads resolve to a dominating version ────────────────
all p: IR1Program, r in reads p |
  version-location (read-version r) = read-location r and
  (
    read-version r = initial-version (read-location r) or
    (some w in writes p |
      write-version w = read-version r and
      write-location w = read-location r) or
    (some j in joins p |
      join-version j = read-version r and
      join-location j = read-location r) or
    (some s in loop-summaries p |
      summary-version s = read-version r and
      summary-location s = read-location r)
  ).

> ── Rule partitioning and frame suppression ──────────────
all p: IR1Program, rule in modified-rules p |
  rule in declared-rules p and
  ~(rule in framed-rules p).

all p: IR1Program, rule in framed-rules p |
  rule in declared-rules p and
  ~(rule in modified-rules p).

all p: IR1Program, rule in declared-rules p |
  rule in modified-rules p or rule in framed-rules p.

all p: IR1Program, w in writes p |
  rule-of-location (write-location w) in modified-rules p.

all p: IR1Program, s in loop-summaries p |
  rule-of-location (summary-location s) in modified-rules p.

> ── Unsupported failure mode ─────────────────────────────
all p: IR1Program, failed? p |
  #(diagnostics p) = 1 and
  (all pr in emitted-props p | prop-is-diagnostic? pr).

all p: IR1Program, diag in diagnostics p |
  ~(diagnostic-construct diag in representative-corpus).

> ── Corpus coverage ──────────────────────────────────────
all k: ConstructKind |
  (some c in representative-corpus | construct-kind c = k).

> ── Documentation pointer ────────────────────────────────
all doc: Document |
  m7-status doc = landed and m7-references-suite? doc.

```

## Patch Specification

```
module TS2PANT_IR1_SSA_INVARIANTS_PATCH_1.

> Patch 1 introduces the stub file and the corpus walker. No
> invariants are yet asserted at runtime; the contribution is
> the test scaffolding consumed by Patches 2 through 5.

TestStub.
InvariantFamily.
fresh-version => InvariantFamily.
join-location => InvariantFamily.
read-dominance => InvariantFamily.
frame-partition => InvariantFamily.
unsupported-diagnostic => InvariantFamily.
corpus-coverage => InvariantFamily.

stub-for f: InvariantFamily => TestStub.
---
true.

```


## Implementation Notes

- `buildSupportedSsaMutatingBody` is not exported from production code, so the new test file uses a small local fixture-to-`IR1Stmt` bridge built from the exported `ir1-build-body` helpers (`buildL1AssignStmt`, `buildL1IfMutation`, `buildL1ForOfMutation`, `buildL1ForEachCall`, `buildL1EffectCall`). That keeps Patch 1 INFRA-only: the corpus still routes through production lowering (`lowerL1BodyToSsaProps`) without widening the runtime API just for tests.
- The representative corpus builder intentionally fails fast on local declarations / unsupported statement shapes instead of silently inventing extra harness behavior. That keeps later invariant patches anchored to production-supported mutating-body forms rather than a parallel test-only recognizer.
- The `mu-search` corpus entry is routed through the production loop-summary helper (`lowerMuSearchSummary`) rather than the mutating-body bridge, because the canonical μ-search path is expression-level in production and does not flow through `lowerL1BodyToSsaProps`.
- `representativePrograms()` and `walkSsaProgram(...)` are introduced in Patch 1 but not consumed yet; the file keeps them live with `void` references so the scaffold lands intact without forcing placeholder assertions before Patches 2-5.

- Spec/Evidence Mapping:
  - Patch 1 stub-file guarantee: satisfied by [tools/ts2pant/tests/ir1-ssa-invariants.test.mts](/Users/zax/worktrees/ts2pant-ir1-ssa-invariants/patch-1/tools/ts2pant/tests/ir1-ssa-invariants.test.mts), which contains the corpus helper, walker, and six skipped invariant-family tests; context consulted: `workstreams/ts2pant-ir1-ssa.pant`, `workstreams/ts2pant-ir1-ssa.md`, existing SSA tests, `ir1.ts`, `ir1-lower-body.ts`.
  - “Reports stubs as skipped rather than failing”: proved by `npx tsx --test --test-timeout=300000 tests/ir1-ssa-invariants.test.mts`, which loads the suite and reports 6 skipped tests / 0 failures after installing the missing local Node + wasm prerequisites.