### PR TITLE
[ts2pant-ir1-ssa-invariants] Patch 2: Assert fresh-version and join-location-compatibility invariants

### DIFF
--- a/tools/ts2pant/tests/ir1-ssa-invariants.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-invariants.test.mts
@@ -18,21 +18,41 @@ import {
   adaptLoopSummaryLowerResult,
 } from "../src/ir1-lower-body.js";
 import { lowerL1BodyToSsaProps } from "../src/ir1-lower-body.js";
-import type { IR1SsaBodyLowerResult } from "../src/ir1-ssa-lower.js";
+import {
+  scalarSsaBodyLowerResult,
+  collectionSsaBodyLowerResult,
+  type IR1SsaBodyLowerResult,
+} from "../src/ir1-ssa-lower.js";
 import {
   type IR1SsaJoin,
+  type IR1SsaLocation,
   type IR1SsaLoopSummary,
   type IR1SsaProgram,
   type IR1SsaRead,
   type IR1SsaWrite,
   type IR1Stmt,
+  ir1Assign,
   ir1Binop,
   ir1Block,
+  ir1CondStmt,
+  ir1LitNat,
+  ir1MapRead,
+  ir1MapSet,
+  ir1Member,
+  ir1SsaInitialVersion,
+  ir1SsaJoin,
+  ir1SsaMapMembershipLocation,
+  ir1SsaMapValueLocation,
   ir1SsaPropertyLocation,
+  ir1SsaSetMembershipLocation,
+  ir1SetAddOrDelete,
+  ir1SetClear,
   ir1Var,
 } from "../src/ir1.js";
 import { lowerExpr } from "../src/ir-emit.js";
 import { lowerL1Expr } from "../src/ir1-lower.js";
+import { lowerCollectionSsaToResult } from "../src/ir1-ssa-collections.js";
+import { lowerScalarSsaToProps } from "../src/ir1-ssa-scalars.js";
 import {
   lowerForeachShapeASummaries,
   lowerForeachShapeBSummaries,
@@ -203,6 +223,14 @@ async function buildMuSearchFixtureResult(): Promise<IR1SsaBodyLowerResult> {
   );
 }
 
+function buildCollectionResult(stmt: IR1Stmt): IR1SsaBodyLowerResult {
+  return collectionSsaBodyLowerResult(lowerCollectionSsaToResult(stmt));
+}
+
+function buildScalarResult(stmt: IR1Stmt): IR1SsaBodyLowerResult {
+  return scalarSsaBodyLowerResult(lowerScalarSsaToProps(stmt));
+}
+
 function representativePrograms(): RepresentativeProgram[] {
   return [
     {
@@ -213,25 +241,80 @@ function representativePrograms(): RepresentativeProgram[] {
     {
       name: "expressions-map-mutation.ts > setAndCopy",
       kind: "map",
-      build: () =>
-        buildFixtureBodyLowerResult("expressions-map-mutation.ts", "setAndCopy"),
+      build: async () =>
+        buildCollectionResult(
+          ir1Block([
+            ir1MapSet(
+              "stringToIntMap",
+              "stringToIntMapKey",
+              "MapStringInt",
+              "String",
+              ir1Var("m"),
+              ir1Var("kSrc"),
+              ir1Var("v"),
+            ),
+            ir1MapSet(
+              "stringToIntMap",
+              "stringToIntMapKey",
+              "MapStringInt",
+              "String",
+              ir1Var("m"),
+              ir1Var("kDst"),
+              ir1MapRead(
+                "get",
+                "stringToIntMap",
+                "stringToIntMapKey",
+                "MapStringInt",
+                "String",
+                ir1Var("m"),
+                ir1Var("kSrc"),
+              ),
+            ),
+          ]),
+        ),
     },
     {
       name: "expressions-set-mutation-field.ts > tagClearAndAdd",
       kind: "set",
-      build: () =>
-        buildFixtureBodyLowerResult(
-          "expressions-set-mutation-field.ts",
-          "tagClearAndAdd",
+      build: async () =>
+        buildCollectionResult(
+          ir1Block([
+            ir1SetClear("Tagged_tags", "Tagged", "String", ir1Var("c")),
+            ir1SetAddOrDelete(
+              "add",
+              "Tagged_tags",
+              "Tagged",
+              "String",
+              ir1Var("c"),
+              ir1Var("x"),
+            ),
+          ]),
         ),
     },
     {
       name: "expressions-state-aware-reads.ts > bumpInBranch",
       kind: "branch",
-      build: () =>
-        buildFixtureBodyLowerResult(
-          "expressions-state-aware-reads.ts",
-          "bumpInBranch",
+      build: async () =>
+        buildScalarResult(
+          ir1CondStmt(
+            [
+              [
+                ir1Var("g"),
+                ir1Assign(
+                  ir1Member(ir1Var("account"), "Account_balance"),
+                  ir1Binop(
+                    "add",
+                    ir1Member(ir1Var("account"), "Account_balance"),
+                    ir1LitNat(1),
+                  ),
+                ),
+              ],
+            ],
+            ir1Assign(
+              ir1Member(ir1Var("account"), "Account_balance"),
+              ir1LitNat(2),
+            ),
+          ),
         ),
     },
     {
@@ -272,6 +355,10 @@ function walkSsaProgram(program: IR1SsaProgram, visit: SsaProgramVisitor): void 
   }
 }
 
+function locationSignature(location: IR1SsaLocation): string {
+  return JSON.stringify(location);
+}
+
 before(async () => {
   await loadAst();
 });
@@ -282,17 +369,177 @@ describe("ir1-ssa-invariants", () => {
   void lowerForeachShapeASummaries;
   void lowerForeachShapeBSummaries;
 
-  it.skip(
+  it(
     "each write, join, and summary produces a fresh SSA version at its location",
-    () => {
-      // PENDING Patch 2: each write/join/summary produces a fresh SSA version at its location
+    async () => {
+      for (const representative of representativePrograms()) {
+        const result = await representative.build();
+        assert.equal(
+          result.diagnostics.length,
+          0,
+          `${representative.name} should lower without diagnostics`,
+        );
+        assert.ok(
+          result.programs.length > 0,
+          `${representative.name} should emit at least one SSA program`,
+        );
+
+        for (const [programIndex, program] of result.programs.entries()) {
+          const seenVersionIds = new Map<string, symbol[]>();
+
+          const trackFreshVersion = (
+            occurrence:
+              | { kind: "write"; version: IR1SsaWrite["version"]; location: IR1SsaWrite["location"] }
+              | { kind: "join"; version: IR1SsaJoin["joinVersion"]; location: IR1SsaJoin["location"] }
+              | {
+                  kind: "loop-summary";
+                  version: IR1SsaLoopSummary["summaryVersion"];
+                  location: IR1SsaLoopSummary["location"];
+                },
+            detail: string,
+          ): void => {
+            assert.equal(
+              locationSignature(occurrence.version.location),
+              locationSignature(occurrence.location),
+              `${representative.name} [program ${programIndex}] ${detail} should keep its version at the same location`,
+            );
+            const signature = locationSignature(occurrence.location);
+            const priorIds = seenVersionIds.get(signature) ?? [
+              ir1SsaInitialVersion(occurrence.location).id,
+            ];
+            for (const priorId of priorIds) {
+              assert.notEqual(
+                occurrence.version.id,
+                priorId,
+                `${representative.name} [program ${programIndex}] ${detail} should allocate a fresh SSA version`,
+              );
+            }
+            seenVersionIds.set(signature, [...priorIds, occurrence.version.id]);
+          };
+
+          walkSsaProgram(program, {
+            onWrite(write, index) {
+              trackFreshVersion(
+                { kind: "write", version: write.version, location: write.location },
+                `write #${index}`,
+              );
+            },
+            onJoin(join, index) {
+              assert.equal(
+                locationSignature(join.thenVersion.location),
+                locationSignature(join.location),
+                `${representative.name} [program ${programIndex}] join #${index} then-version should stay at the join location`,
+              );
+              assert.equal(
+                locationSignature(join.elseVersion.location),
+                locationSignature(join.location),
+                `${representative.name} [program ${programIndex}] join #${index} else-version should stay at the join location`,
+              );
+              assert.notEqual(
+                join.thenVersion.id,
+                join.elseVersion.id,
+                `${representative.name} [program ${programIndex}] join #${index} should merge distinct incoming versions`,
+              );
+              trackFreshVersion(
+                { kind: "join", version: join.joinVersion, location: join.location },
+                `join #${index}`,
+              );
+              assert.notEqual(
+                join.joinVersion.id,
+                join.thenVersion.id,
+                `${representative.name} [program ${programIndex}] join #${index} should allocate a fresh result version`,
+              );
+              assert.notEqual(
+                join.joinVersion.id,
+                join.elseVersion.id,
+                `${representative.name} [program ${programIndex}] join #${index} should allocate a fresh result version`,
+              );
+            },
+            onSummary(summary, index) {
+              trackFreshVersion(
+                {
+                  kind: "loop-summary",
+                  version: summary.summaryVersion,
+                  location: summary.location,
+                },
+                `loop summary #${index} (${summary.shape})`,
+              );
+            },
+          });
+        }
+      }
     },
   );
 
-  it.skip(
+  it(
     "ir1SsaJoin rejects mismatched-location inputs across all four location kinds",
     () => {
-      // PENDING Patch 2: ir1SsaJoin rejects mismatched-location inputs across all four location kinds
+      const propertyBalance = ir1SsaPropertyLocation(
+        "Account_balance",
+        ir1Var("account"),
+        "balance",
+      );
+      const propertyLimit = ir1SsaPropertyLocation(
+        "Account_limit",
+        ir1Var("account"),
+        "limit",
+      );
+      const mapValue = ir1SsaMapValueLocation(
+        "Account_score",
+        "Account_hasScore",
+        "Account",
+        "User",
+        ir1Var("account"),
+        ir1Var("user"),
+      );
+      const mapMembership = ir1SsaMapMembershipLocation(
+        "Account_score",
+        "Account_hasScore",
+        "Account",
+        "User",
+        ir1Var("account"),
+        ir1Var("user"),
+      );
+      const setMembership = ir1SsaSetMembershipLocation(
+        "Account_tags",
+        "Account",
+        "Tag",
+        ir1Var("account"),
+      );
+      const otherSetMembership = ir1SsaSetMembershipLocation(
+        "Account_tags",
+        "Account",
+        "Tag",
+        ir1Var("otherAccount"),
+      );
+
+      const mismatchedPairs: ReadonlyArray<
+        readonly [name: string, expected: IR1SsaLocation, actual: IR1SsaLocation]
+      > = [
+        ["property vs property", propertyLimit, propertyBalance],
+        ["property vs map-value", propertyBalance, mapValue],
+        ["property vs set-membership", propertyBalance, setMembership],
+        ["map-value vs map-membership", mapValue, mapMembership],
+        [
+          "set-membership vs set-membership receiver mismatch",
+          setMembership,
+          otherSetMembership,
+        ],
+      ];
+
+      for (const [name, expected, actual] of mismatchedPairs) {
+        const initial = ir1SsaInitialVersion(actual);
+        assert.throws(
+          () => ir1SsaJoin(expected, initial, initial),
+          /location mismatch/u,
+          `${name} should reject incompatible locations`,
+        );
+      }
+
+      const version = ir1SsaInitialVersion(propertyBalance);
+      const degenerate = ir1SsaJoin(propertyBalance, version, version);
+      assert.equal(degenerate, version);
+      assert.notEqual(degenerate.kind, "ssa-join");
     },
   );
 


### PR DESCRIPTION
## Patch 2: Assert fresh-version and join-location-compatibility invariants

- Remove the PENDING marker on `ir1-ssa-invariants > each write, join, and summary produces a fresh SSA version at its location` and implement it: build representative scalar, Map, Set, and loop-summary programs via the corpus walker; collect every version that appears as `initial-version`, `write.version`, `join.joinVersion`, `join.thenVersion`, `join.elseVersion`, or `summary.summaryVersion`; assert that every two distinct write/join/summary occurrences in the same program have non-equal `version.id` values; assert that each such version's `location` matches the corresponding write/join/summary `location`.
- Remove the PENDING marker on `ir1-ssa-invariants > ir1SsaJoin rejects mismatched-location inputs across all four location kinds` and implement it: for each pair of distinct `IR1SsaLocation` kinds (property↔property with different rule names, property↔map-value, property↔set-membership, map-value↔map-membership, set-membership↔set-membership with different receivers), build an initial version on one location and assert that `ir1SsaJoin(otherLocation, leftVersion, rightVersion)` throws an error matching `/location mismatch/u`.
- Add a complementary positive assertion: `ir1SsaJoin(location, v, v)` returns `v` directly (degenerate join short-circuit) and never constructs a join node, matching the existing contract test invariant.

## Changes
- Remove the PENDING marker on `ir1-ssa-invariants > each write, join, and summary produces a fresh SSA version at its location` and implement it: build representative scalar, Map, Set, and loop-summary programs via the corpus walker; collect every version that appears as `initial-version`, `write.version`, `join.joinVersion`, `join.thenVersion`, `join.elseVersion`, or `summary.summaryVersion`; assert that every two distinct write/join/summary occurrences in the same program have non-equal `version.id` values; assert that each such version's `location` matches the corresponding write/join/summary `location`.
- Remove the PENDING marker on `ir1-ssa-invariants > ir1SsaJoin rejects mismatched-location inputs across all four location kinds` and implement it: for each pair of distinct `IR1SsaLocation` kinds (property↔property with different rule names, property↔map-value, property↔set-membership, map-value↔map-membership, set-membership↔set-membership with different receivers), build an initial version on one location and assert that `ir1SsaJoin(otherLocation, leftVersion, rightVersion)` throws an error matching `/location mismatch/u`.
- Add a complementary positive assertion: `ir1SsaJoin(location, v, v)` returns `v` directly (degenerate join short-circuit) and never constructs a join node, matching the existing contract test invariant.

## Files to Modify
- tools/ts2pant/tests/ir1-ssa-invariants.test.mts (modify): Unskip and implement the two constructor-and-program-level invariants for write/join/summary version identity and join-location compatibility.

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[paper] Cytron et al. 1991 — Efficiently Computing Static Single Assignment Form** — https://doi.org/10.1145/115372.115320 — Cytron et al. define the SSA discipline this patch validates: every assignment defines a fresh name, and phi nodes are constrained to a single program location. Patch 2's assertions are the runtime witnesses of those properties on `IR1SsaWrite` and `IR1SsaJoin`.

## Gameplan Specification

```
module TS2PANT_IR1_SSA_INVARIANTS.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> After Milestone 7, the IR1 SSA architecture is guarded by
> runtime tests that target the abstraction directly. The
> invariants below are the ones the workstream's Pantagruel
> spec (`workstreams/ts2pant-ir1-ssa.pant`) defines, now
> mechanically witnessed by `ir1-ssa-invariants.test.mts`.

IR1Program.
Construct.
ConstructKind.
Location.
Version.
Read.
Write.
Join.
LoopSummary.
Rule.
PropResult.
Diagnostic.
Document.
MilestoneStatus.
scalar => ConstructKind.
map => ConstructKind.
set-kind => ConstructKind.
branch => ConstructKind.
foreach-shape-a => ConstructKind.
foreach-shape-b => ConstructKind.
mu-search => ConstructKind.
pending => MilestoneStatus.
landed => MilestoneStatus.

writes p: IR1Program => [Write].
reads p: IR1Program => [Read].
joins p: IR1Program => [Join].
loop-summaries p: IR1Program => [LoopSummary].
write-location w: Write => Location.
write-version w: Write => Version.
read-location r: Read => Location.
read-version r: Read => Version.
join-location j: Join => Location.
then-version j: Join => Version.
else-version j: Join => Version.
join-version j: Join => Version.
summary-location s: LoopSummary => Location.
summary-version s: LoopSummary => Version.
version-location v: Version => Location.
initial-version l: Location => Version.
rule-of-location l: Location => Rule.
declared-rules p: IR1Program => [Rule].
modified-rules p: IR1Program => [Rule].
framed-rules p: IR1Program => [Rule].
diagnostics p: IR1Program => [Diagnostic].
emitted-props p: IR1Program => [PropResult].
prop-is-diagnostic? pr: PropResult => Bool.
failed? p: IR1Program => Bool.
diagnostic-construct d: Diagnostic => Construct.
construct-kind c: Construct => ConstructKind.
representative-corpus => [Construct].
m7-status d: Document => MilestoneStatus.
m7-references-suite? d: Document => Bool.
---

> ── Fresh versions and location agreement ────────────────
all p: IR1Program, w in writes p |
  version-location (write-version w) = write-location w.

all p: IR1Program, s in loop-summaries p |
  version-location (summary-version s) = summary-location s.

all l: Location |
  version-location (initial-version l) = l.

all p: IR1Program, w1 in writes p, w2 in writes p |
  write-version w1 = write-version w2 -> w1 = w2.

> ── Joins are constrained to a single location ───────────
all p: IR1Program, j in joins p |
  version-location (then-version j) = join-location j and
  version-location (else-version j) = join-location j and
  version-location (join-version j) = join-location j.

all p: IR1Program, j in joins p |
  then-version j != else-version j and
  join-version j != then-version j and
  join-version j != else-version j.

> ── Reads resolve to a dominating version ────────────────
all p: IR1Program, r in reads p |
  version-location (read-version r) = read-location r and
  (
    read-version r = initial-version (read-location r) or
    (some w in writes p |
      write-version w = read-version r and
      write-location w = read-location r) or
    (some j in joins p |
      join-version j = read-version r and
      join-location j = read-location r) or
    (some s in loop-summaries p |
      summary-version s = read-version r and
      summary-location s = read-location r)
  ).

> ── Rule partitioning and frame suppression ──────────────
all p: IR1Program, rule in modified-rules p |
  rule in declared-rules p and
  ~(rule in framed-rules p).

all p: IR1Program, rule in framed-rules p |
  rule in declared-rules p and
  ~(rule in modified-rules p).

all p: IR1Program, rule in declared-rules p |
  rule in modified-rules p or rule in framed-rules p.

all p: IR1Program, w in writes p |
  rule-of-location (write-location w) in modified-rules p.

all p: IR1Program, s in loop-summaries p |
  rule-of-location (summary-location s) in modified-rules p.

> ── Unsupported failure mode ─────────────────────────────
all p: IR1Program, failed? p |
  #(diagnostics p) = 1 and
  (all pr in emitted-props p | prop-is-diagnostic? pr).

all p: IR1Program, diag in diagnostics p |
  ~(diagnostic-construct diag in representative-corpus).

> ── Corpus coverage ──────────────────────────────────────
all k: ConstructKind |
  (some c in representative-corpus | construct-kind c = k).

> ── Documentation pointer ────────────────────────────────
all doc: Document |
  m7-status doc = landed and m7-references-suite? doc.

```

## Patch Specification

```
module TS2PANT_IR1_SSA_INVARIANTS_PATCH_2.

> Patch 2 asserts the fresh-version and join-location-compatibility
> invariants. Versions are opaque identities; joins are phi-like
> nodes constrained to a single location.

IR1Program.
Location.
Version.
Write.
Join.
LoopSummary.

writes p: IR1Program => [Write].
joins p: IR1Program => [Join].
loop-summaries p: IR1Program => [LoopSummary].
write-location w: Write => Location.
write-version w: Write => Version.
join-location j: Join => Location.
then-version j: Join => Version.
else-version j: Join => Version.
join-version j: Join => Version.
summary-location s: LoopSummary => Location.
summary-version s: LoopSummary => Version.
version-location v: Version => Location.
initial-version l: Location => Version.
---
> Write versions, summary versions, and initial versions belong
> to their locations.
all p: IR1Program, w in writes p |
  version-location (write-version w) = write-location w.

all p: IR1Program, s in loop-summaries p |
  version-location (summary-version s) = summary-location s.

all l: Location |
  version-location (initial-version l) = l.

> Every write inside one IR1 program has a fresh version.
all p: IR1Program, w1 in writes p, w2 in writes p |
  write-version w1 = write-version w2 -> w1 = w2.

> Join versions belong to the join location and are distinct from
> their incoming versions.
all p: IR1Program, j in joins p |
  version-location (then-version j) = join-location j and
  version-location (else-version j) = join-location j and
  version-location (join-version j) = join-location j.

all p: IR1Program, j in joins p |
  then-version j != else-version j and
  join-version j != then-version j and
  join-version j != else-version j.

```


## Implementation Notes

- The freshness test ended up using a mixed representative corpus builder rather than one uniform fixture bridge. Scalar `deposit`, both foreach cases, and `mu-search` still come through the Patch 1 corpus walker; the Map, Set, and branch representatives are built through the production SSA lowerers directly because the generic fixture bridge currently rejects `Map<String, Int>` body shapes with the existing synthesized-domain-name limitation. This keeps the assertions on production helpers (`lowerCollectionSsaToResult`, `lowerScalarSsaToProps`, `lowerL1BodyToSsaProps`) without expanding Patch 2 into fixture-bridge repair.

- Location checks in the new invariants suite use structural equality (`JSON.stringify(location)`) rather than object identity. That is intentional: the constructor contract is location compatibility, and some lowering paths rebuild equivalent location records instead of reusing the same object reference. Using `assert.equal` on the objects produced a false failure on a valid branch join.

- The “fresh version” assertion seeds each location bucket with an `ir1SsaInitialVersion(location).id` before checking writes/joins/summaries. That makes the runtime test cover the stronger acceptance criterion from the patch text: every emitted write/join/summary version must differ not just from sibling write/join/summary versions, but also from the initial version for that location.

- `ir1SsaJoin` mismatch coverage is table-driven over the exact incompatible pairs called out in the patch, plus a positive degenerate-join assertion in the same test block. Grouping those cases made it easier to verify the negative and positive constructor boundary behavior together without duplicating location setup.

- `just ts2pant-precommit` is still red on this branch, but the failures are outside this patch’s write set and concern existing early-return / unsupported snapshot expectations. The Patch 2 evidence point is the focused `tests/ir1-ssa-invariants.test.mts` run, which passes after the new assertions land.

- Spec/Evidence Mapping:
  Fresh version + location clauses (`version-location(write|summary|initial)` and write-version uniqueness): implemented in `ir1-ssa-invariants.test.mts` by the `trackFreshVersion` walk over representative programs; informed by `workstreams/ts2pant-ir1-ssa.pant` and `tools/ts2pant/src/ir1.ts`; proven by `npx tsx --test --test-timeout=300000 tests/ir1-ssa-invariants.test.mts`.
  Join location + distinctness clauses: implemented in the same suite by per-join assertions over `thenVersion`, `elseVersion`, and `joinVersion`, plus constructor-level mismatch/degenerate checks around `ir1SsaJoin`; informed by `tools/ts2pant/src/ir1.ts` and the existing contract test precedent; proven by the same focused test run.