### PR TITLE
[ts2pant-ir1-ssa-invariants] Patch 3: Assert dominating-read invariant across the corpus

### DIFF
--- a/tools/ts2pant/tests/ir1-ssa-invariants.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-invariants.test.mts
@@ -292,6 +292,24 @@ function representativePrograms(): RepresentativeProgram[] {
         ),
     },
     {
+      name: "expressions-state-aware-reads.ts > entrySetThenCheck",
+      kind: "map",
+      build: () =>
+        buildFixtureBodyLowerResult(
+          "expressions-state-aware-reads.ts",
+          "entrySetThenCheck",
+        ),
+    },
+    {
+      name: "expressions-state-aware-reads.ts > tagThenCheck",
+      kind: "set",
+      build: () =>
+        buildFixtureBodyLowerResult(
+          "expressions-state-aware-reads.ts",
+          "tagThenCheck",
+        ),
+    },
+    {
       name: "expressions-state-aware-reads.ts > bumpInBranch",
       kind: "branch",
       build: async () =>
@@ -316,6 +334,27 @@ function representativePrograms(): RepresentativeProgram[] {
             ),
           ),
         ),
+    },
+    {
+      name: "scalar branch join continuation read",
+      kind: "branch",
+      build: async () => {
+        const balance = ir1Member(ir1Var("account"), "Account_balance");
+        return buildScalarResult(
+          ir1Block([
+            ir1CondStmt(
+              [
+                [
+                  ir1Var("g"),
+                  ir1Assign(balance, ir1LitNat(1)),
+                ],
+              ],
+              ir1Assign(balance, ir1LitNat(2)),
+            ),
+            ir1Assign(balance, ir1Binop("add", balance, ir1LitNat(1))),
+          ]),
+        );
+      },
     },
     {
       name: "functions-mutating-loop.ts > forEachActivate",
@@ -357,6 +396,13 @@ function walkSsaProgram(program: IR1SsaProgram, visit: SsaProgramVisitor): void 
 
 function locationSignature(location: IR1SsaLocation): string {
   return JSON.stringify(location);
+}
+
+function readSignature(read: IR1SsaRead): string {
+  return [
+    `${read.location.kind} read at ${locationSignature(read.location)}`,
+    `using ${read.version.origin} version ${String(read.version.id)}`,
+  ].join(" ");
 }
 
 before(async () => {
@@ -543,10 +589,72 @@ describe("ir1-ssa-invariants", () => {
     },
   );
 
-  it.skip(
+  it(
     "every read resolves to a dominating version, initial version, or explicit loop summary at its own location",
-    () => {
-      // PENDING Patch 3: every read resolves to a dominating version, initial version, or explicit loop summary at its own location
+    async () => {
+      for (const representative of representativePrograms()) {
+        const result = await representative.build();
+        assert.equal(
+          result.diagnostics.length,
+          0,
+          `${representative.name} should lower without diagnostics`,
+        );
+        assert.ok(
+          result.programs.length > 0,
+          `${representative.name} should emit at least one SSA program`,
+        );
+
+        for (const [programIndex, program] of result.programs.entries()) {
+          walkSsaProgram(program, {
+            onRead(read, readIndex) {
+              const readDetail = [
+                `${representative.name} [program ${programIndex}]`,
+                `read #${readIndex}: ${readSignature(read)}`,
+              ].join(" ");
+              assert.equal(
+                locationSignature(read.version.location),
+                locationSignature(read.location),
+                `${readDetail} should keep its version at the read location`,
+              );
+              assert.equal(
+                read.dominated,
+                true,
+                `${readDetail} should be marked as dominated`,
+              );
+
+              const location = locationSignature(read.location);
+              const initial = ir1SsaInitialVersion(read.location);
+              const resolvesToInitial =
+                read.version.origin === initial.origin &&
+                locationSignature(read.version.location) ===
+                  locationSignature(initial.location);
+              const resolvesToWrite = program.writes.some(
+                (write) =>
+                  write.version === read.version &&
+                  locationSignature(write.location) === location,
+              );
+              const resolvesToJoin = program.joins.some(
+                (join) =>
+                  join.joinVersion === read.version &&
+                  locationSignature(join.location) === location,
+              );
+              const resolvesToLoopSummary = program.loopSummaries.some(
+                (summary) =>
+                  summary.summaryVersion === read.version &&
+                  locationSignature(summary.location) === location,
+              );
+
+              assert.ok(
+                resolvesToInitial ||
+                  resolvesToWrite ||
+                  resolvesToJoin ||
+                  resolvesToLoopSummary,
+                `${readDetail} did not resolve to an initial, write, join, or loop-summary version at its own location`,
+              );
+            },
+          });
+        }
+      }
     },
   );
 


### PR DESCRIPTION
## Patch 3: Assert dominating-read invariant across the corpus

- Remove the PENDING marker on `ir1-ssa-invariants > every read resolves to a dominating version at its own location`.
- For every program returned by the corpus walker, traverse `program.reads`; for each read assert `read.version.location` matches `read.location`, and that the read's version is one of: the initial version for its location (computed via `ir1SsaInitialVersion(read.location)` and compared by `version.origin === "initial"` and location equality), a version recorded in `program.writes[i].version` at the same location, a version recorded in `program.joins[i].joinVersion` at the same location, or a version recorded in `program.loopSummaries[i].summaryVersion` at the same location.
- Cover the full corpus: scalar read-after-write (`expressions-state-aware-reads.ts > bumpInBranch`), Map staged read (`expressions-state-aware-reads.ts > entrySetThenCheck`), Set staged read (`expressions-state-aware-reads.ts > tagThenCheck`), branch-join continuation reads, and loop-summary-resolved reads from `functions-mutating-loop.ts`.
- Fail the test with a specific message naming the program and the offending read when no dominating version is found, so a future regression points at the exact construct.

## Changes
- Remove the PENDING marker on `ir1-ssa-invariants > every read resolves to a dominating version at its own location`.
- For every program returned by the corpus walker, traverse `program.reads`; for each read assert `read.version.location` matches `read.location`, and that the read's version is one of: the initial version for its location (computed via `ir1SsaInitialVersion(read.location)` and compared by `version.origin === "initial"` and location equality), a version recorded in `program.writes[i].version` at the same location, a version recorded in `program.joins[i].joinVersion` at the same location, or a version recorded in `program.loopSummaries[i].summaryVersion` at the same location.
- Cover the full corpus: scalar read-after-write (`expressions-state-aware-reads.ts > bumpInBranch`), Map staged read (`expressions-state-aware-reads.ts > entrySetThenCheck`), Set staged read (`expressions-state-aware-reads.ts > tagThenCheck`), branch-join continuation reads, and loop-summary-resolved reads from `functions-mutating-loop.ts`.
- Fail the test with a specific message naming the program and the offending read when no dominating version is found, so a future regression points at the exact construct.

## Files to Modify
- tools/ts2pant/tests/ir1-ssa-invariants.test.mts (modify): Unskip and implement the dominating-read invariant: every IR1SsaRead resolves to an initial, write, join, or loop-summary version at its own location.

## Gameplan Specification

```
module TS2PANT_IR1_SSA_INVARIANTS.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> After Milestone 7, the IR1 SSA architecture is guarded by
> runtime tests that target the abstraction directly. The
> invariants below are the ones the workstream's Pantagruel
> spec (`workstreams/ts2pant-ir1-ssa.pant`) defines, now
> mechanically witnessed by `ir1-ssa-invariants.test.mts`.

IR1Program.
Construct.
ConstructKind.
Location.
Version.
Read.
Write.
Join.
LoopSummary.
Rule.
PropResult.
Diagnostic.
Document.
MilestoneStatus.
scalar => ConstructKind.
map => ConstructKind.
set-kind => ConstructKind.
branch => ConstructKind.
foreach-shape-a => ConstructKind.
foreach-shape-b => ConstructKind.
mu-search => ConstructKind.
pending => MilestoneStatus.
landed => MilestoneStatus.

writes p: IR1Program => [Write].
reads p: IR1Program => [Read].
joins p: IR1Program => [Join].
loop-summaries p: IR1Program => [LoopSummary].
write-location w: Write => Location.
write-version w: Write => Version.
read-location r: Read => Location.
read-version r: Read => Version.
join-location j: Join => Location.
then-version j: Join => Version.
else-version j: Join => Version.
join-version j: Join => Version.
summary-location s: LoopSummary => Location.
summary-version s: LoopSummary => Version.
version-location v: Version => Location.
initial-version l: Location => Version.
rule-of-location l: Location => Rule.
declared-rules p: IR1Program => [Rule].
modified-rules p: IR1Program => [Rule].
framed-rules p: IR1Program => [Rule].
diagnostics p: IR1Program => [Diagnostic].
emitted-props p: IR1Program => [PropResult].
prop-is-diagnostic? pr: PropResult => Bool.
failed? p: IR1Program => Bool.
diagnostic-construct d: Diagnostic => Construct.
construct-kind c: Construct => ConstructKind.
representative-corpus => [Construct].
m7-status d: Document => MilestoneStatus.
m7-references-suite? d: Document => Bool.
---

> ── Fresh versions and location agreement ────────────────
all p: IR1Program, w in writes p |
  version-location (write-version w) = write-location w.

all p: IR1Program, s in loop-summaries p |
  version-location (summary-version s) = summary-location s.

all l: Location |
  version-location (initial-version l) = l.

all p: IR1Program, w1 in writes p, w2 in writes p |
  write-version w1 = write-version w2 -> w1 = w2.

> ── Joins are constrained to a single location ───────────
all p: IR1Program, j in joins p |
  version-location (then-version j) = join-location j and
  version-location (else-version j) = join-location j and
  version-location (join-version j) = join-location j.

all p: IR1Program, j in joins p |
  then-version j != else-version j and
  join-version j != then-version j and
  join-version j != else-version j.

> ── Reads resolve to a dominating version ────────────────
all p: IR1Program, r in reads p |
  version-location (read-version r) = read-location r and
  (
    read-version r = initial-version (read-location r) or
    (some w in writes p |
      write-version w = read-version r and
      write-location w = read-location r) or
    (some j in joins p |
      join-version j = read-version r and
      join-location j = read-location r) or
    (some s in loop-summaries p |
      summary-version s = read-version r and
      summary-location s = read-location r)
  ).

> ── Rule partitioning and frame suppression ──────────────
all p: IR1Program, rule in modified-rules p |
  rule in declared-rules p and
  ~(rule in framed-rules p).

all p: IR1Program, rule in framed-rules p |
  rule in declared-rules p and
  ~(rule in modified-rules p).

all p: IR1Program, rule in declared-rules p |
  rule in modified-rules p or rule in framed-rules p.

all p: IR1Program, w in writes p |
  rule-of-location (write-location w) in modified-rules p.

all p: IR1Program, s in loop-summaries p |
  rule-of-location (summary-location s) in modified-rules p.

> ── Unsupported failure mode ─────────────────────────────
all p: IR1Program, failed? p |
  #(diagnostics p) = 1 and
  (all pr in emitted-props p | prop-is-diagnostic? pr).

all p: IR1Program, diag in diagnostics p |
  ~(diagnostic-construct diag in representative-corpus).

> ── Corpus coverage ──────────────────────────────────────
all k: ConstructKind |
  (some c in representative-corpus | construct-kind c = k).

> ── Documentation pointer ────────────────────────────────
all doc: Document |
  m7-status doc = landed and m7-references-suite? doc.

```

## Patch Specification

```
module TS2PANT_IR1_SSA_INVARIANTS_PATCH_3.

> Patch 3 asserts the dominating-read invariant on every program
> the corpus walker builds. Every read resolves to an initial,
> write, join, or loop-summary version at its location.

IR1Program.
Location.
Version.
Read.
Write.
Join.
LoopSummary.

reads p: IR1Program => [Read].
writes p: IR1Program => [Write].
joins p: IR1Program => [Join].
loop-summaries p: IR1Program => [LoopSummary].
read-location r: Read => Location.
read-version r: Read => Version.
write-location w: Write => Location.
write-version w: Write => Version.
join-location j: Join => Location.
join-version j: Join => Version.
summary-location s: LoopSummary => Location.
summary-version s: LoopSummary => Version.
version-location v: Version => Location.
initial-version l: Location => Version.
---
> Every read resolves to an initial, write, join, or
> loop-summary version at its own location.
all p: IR1Program, r in reads p |
  version-location (read-version r) = read-location r and
  (
    read-version r = initial-version (read-location r) or
    (some w in writes p |
      write-version w = read-version r and
      write-location w = read-location r) or
    (some j in joins p |
      join-version j = read-version r and
      join-location j = read-location r) or
    (some s in loop-summaries p |
      summary-version s = read-version r and
      summary-location s = read-location r)
  ).

```


## Implementation Notes

- The corpus walker now includes the state-aware Map/Set fixture functions directly (`entrySetThenCheck`, `tagThenCheck`) plus an explicit scalar post-branch read case. The post-branch case is synthetic but still goes through `lowerScalarSsaToProps`; it exists because the existing fixture corpus did not give the invariant test a simple, isolated read from a `joinVersion`.
- Initial-version matching intentionally follows the patch spec rather than object identity: it checks `origin === "initial"` and location equality. `ir1SsaInitialVersion(location)` creates a fresh symbol each call, so identity comparison would incorrectly reject valid initial reads.
- Read provenance for writes, joins, and loop summaries is checked by version object identity plus same-location equality. This mirrors how production SSA threads versions through `program.writes`, `program.joins`, and `program.loopSummaries`, while still producing a location-specific diagnostic if a future builder wires a version across locations.
- Failure messages include representative program name, program index, read index, location signature, and version origin so regressions point at the exact offending read rather than only the invariant class.

Spec/Evidence Mapping:
- Dominating-read clause: implemented in `tools/ts2pant/tests/ir1-ssa-invariants.test.mts` under `every read resolves to a dominating version...`, using `walkSsaProgram(program, { onRead })`.
- Required production paths consulted/used: fixture bodies flow through `lowerL1BodyToSsaProps`; direct scalar/collection cases flow through `lowerScalarSsaToProps` and `lowerCollectionSsaToResult` via the existing suite helpers.
- Verification: focused `npx tsx --test --test-timeout=300000 tests/ir1-ssa-invariants.test.mts` passed, and `just ts2pant-typecheck` passed. Full `npm run test:unit` still reports unrelated existing early-return snapshot/parity failures and `unsupported.ts > loopAssign`; the new invariants suite passed in that run.