### PR TITLE
[ts2pant-ir1-ssa-invariants] Patch 4: Assert frame-suppression-once invariant on lowered bodies

### DIFF
--- a/tools/ts2pant/tests/ir1-ssa-invariants.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-invariants.test.mts
@@ -44,6 +44,7 @@ import {
   ir1SsaMapMembershipLocation,
   ir1SsaMapValueLocation,
   ir1SsaPropertyLocation,
+  ir1SsaRuleOfLocation,
   ir1SsaSetMembershipLocation,
   ir1SetAddOrDelete,
   ir1SetClear,
@@ -78,6 +79,14 @@ interface RepresentativeProgram {
   name: string;
   kind: RepresentativeProgramKind;
   build: () => Promise<IR1SsaBodyLowerResult>;
+}
+
+interface BodyLoweredRepresentativeProgram {
+  name: string;
+  build: () => Promise<{
+    result: IR1SsaBodyLowerResult;
+    declaredRules: string[];
+  }>;
 }
 
 interface SsaProgramVisitor {
@@ -379,6 +388,107 @@ function representativePrograms(): RepresentativeProgram[] {
   ];
 }
 
+function bodyLoweredRepresentativePrograms(): BodyLoweredRepresentativeProgram[] {
+  return [
+    {
+      name: "functions-mutating.ts > deposit",
+      build: async () => {
+        const sourceFile = loadFixture("functions-mutating.ts");
+        const doc = await buildDocumentFromSourceFile(sourceFile, "deposit");
+        return {
+          result: await buildFixtureBodyLowerResult("functions-mutating.ts", "deposit"),
+          declaredRules: doc.declarations
+            .filter((decl) => decl.kind === "rule")
+            .map((decl) => decl.name),
+        };
+      },
+    },
+    {
+      name: "expressions-state-aware-reads.ts > entrySetThenCheck",
+      build: async () => {
+        const sourceFile = loadFixture("expressions-state-aware-reads.ts");
+        const doc = await buildDocumentFromSourceFile(
+          sourceFile,
+          "entrySetThenCheck",
+        );
+        return {
+          result: await buildFixtureBodyLowerResult(
+            "expressions-state-aware-reads.ts",
+            "entrySetThenCheck",
+          ),
+          declaredRules: doc.declarations
+            .filter((decl) => decl.kind === "rule")
+            .map((decl) => decl.name),
+        };
+      },
+    },
+    {
+      name: "expressions-state-aware-reads.ts > tagThenCheck",
+      build: async () => {
+        const sourceFile = loadFixture("expressions-state-aware-reads.ts");
+        const doc = await buildDocumentFromSourceFile(sourceFile, "tagThenCheck");
+        return {
+          result: await buildFixtureBodyLowerResult(
+            "expressions-state-aware-reads.ts",
+            "tagThenCheck",
+          ),
+          declaredRules: doc.declarations
+            .filter((decl) => decl.kind === "rule")
+            .map((decl) => decl.name),
+        };
+      },
+    },
+    {
+      name: "functions-mutating-conditional.ts > asymmetric",
+      build: async () => {
+        const sourceFile = loadFixture("functions-mutating-conditional.ts");
+        const doc = await buildDocumentFromSourceFile(sourceFile, "asymmetric");
+        return {
+          result: await buildFixtureBodyLowerResult(
+            "functions-mutating-conditional.ts",
+            "asymmetric",
+          ),
+          declaredRules: doc.declarations
+            .filter((decl) => decl.kind === "rule")
+            .map((decl) => decl.name),
+        };
+      },
+    },
+    {
+      name: "functions-mutating-loop.ts > forEachActivate",
+      build: async () => {
+        const sourceFile = loadFixture("functions-mutating-loop.ts");
+        const doc = await buildDocumentFromSourceFile(sourceFile, "forEachActivate");
+        return {
+          result: await buildFixtureBodyLowerResult(
+            "functions-mutating-loop.ts",
+            "forEachActivate",
+          ),
+          declaredRules: doc.declarations
+            .filter((decl) => decl.kind === "rule")
+            .map((decl) => decl.name),
+        };
+      },
+    },
+    {
+      name: "functions-mutating-loop.ts > forEachSum",
+      build: async () => {
+        const sourceFile = loadFixture("functions-mutating-loop.ts");
+        const doc = await buildDocumentFromSourceFile(sourceFile, "forEachSum");
+        return {
+          result: await buildFixtureBodyLowerResult(
+            "functions-mutating-loop.ts",
+            "forEachSum",
+          ),
+          declaredRules: doc.declarations
+            .filter((decl) => decl.kind === "rule")
+            .map((decl) => decl.name),
+        };
+      },
+    },
+  ];
+}
+
 function walkSsaProgram(program: IR1SsaProgram, visit: SsaProgramVisitor): void {
   for (const [index, write] of program.writes.entries()) {
     visit.onWrite?.(write, index);
@@ -403,6 +513,22 @@ function readSignature(read: IR1SsaRead): string {
     `${read.location.kind} read at ${locationSignature(read.location)}`,
     `using ${read.version.origin} version ${String(read.version.id)}`,
   ].join(" ");
+}
+
+function frameRuleNames(result: IR1SsaBodyLowerResult): string[] {
+  const ast = getAst();
+  return result.propositions
+    .filter((prop) => prop.kind === "equation")
+    .flatMap((prop) => {
+      const lhs = ast.strExpr(prop.lhs);
+      const rhs = ast.strExpr(prop.rhs);
+      const match = /^([^'\s]+)'(?:\s|$)/u.exec(lhs);
+      if (match === null) {
+        return [];
+      }
+      const rule = match[1]!;
+      return rhs === lhs.replace("'", "") ? [rule] : [];
+    });
 }
 
 before(async () => {
@@ -658,10 +784,101 @@ describe("ir1-ssa-invariants", () => {
     },
   );
 
-  it.skip(
+  it(
     "every modified rule suppresses frame generation exactly once and every framed rule is unmodified",
-    () => {
-      // PENDING Patch 4: every modified rule suppresses frame generation exactly once and every framed rule is unmodified
+    async () => {
+      for (const representative of bodyLoweredRepresentativePrograms()) {
+        const { result, declaredRules } = await representative.build();
+        const detail = representative.name;
+
+        assert.equal(
+          result.diagnostics.length,
+          0,
+          `${detail} should lower without diagnostics`,
+        );
+
+        const modifiedRules = result.modifiedRules;
+        assert.equal(
+          new Set(modifiedRules).size,
+          modifiedRules.length,
+          `${detail} should list each modified rule at most once`,
+        );
+
+        const declaredRuleSet = new Set(declaredRules);
+        const modifiedRuleSet = new Set(modifiedRules);
+        const expectedFramedRules = declaredRules.filter(
+          (rule) => !modifiedRuleSet.has(rule),
+        );
+        const actualFramedRules = frameRuleNames(result);
+        const actualFramedRuleSet = new Set(actualFramedRules);
+
+        assert.deepEqual(
+          actualFramedRules,
+          expectedFramedRules,
+          `${detail} should append exactly one identity frame for each declared but unmodified rule`,
+        );
+        assert.equal(
+          actualFramedRuleSet.size,
+          actualFramedRules.length,
+          `${detail} should append each frame at most once`,
+        );
+
+        for (const rule of modifiedRuleSet) {
+          assert.ok(
+            declaredRuleSet.has(rule),
+            `${detail} should only mark declared rules as modified`,
+          );
+          assert.ok(
+            !actualFramedRuleSet.has(rule),
+            `${detail} should not frame a modified rule`,
+          );
+        }
+
+        for (const rule of expectedFramedRules) {
+          assert.ok(
+            declaredRuleSet.has(rule),
+            `${detail} should only frame declared rules`,
+          );
+          assert.ok(
+            !modifiedRuleSet.has(rule),
+            `${detail} should keep framed rules disjoint from modified rules`,
+          );
+        }
+
+        for (const [programIndex, program] of result.programs.entries()) {
+          const programDetail = `${detail} [program ${programIndex}]`;
+          const programModifiedRules = new Set(program.modifiedRules);
+          const programRuleSources = new Set([
+            ...program.writes.map((write) => ir1SsaRuleOfLocation(write.location)),
+            ...program.loopSummaries.map((summary) =>
+              ir1SsaRuleOfLocation(summary.location)
+            ),
+          ]);
+
+          for (const modifiedRule of program.modifiedRules) {
+            assert.ok(
+              programRuleSources.has(modifiedRule),
+              `${programDetail} should only mark rules modified when a write or loop summary produced them`,
+            );
+          }
+
+          for (const [writeIndex, write] of program.writes.entries()) {
+            const rule = ir1SsaRuleOfLocation(write.location);
+            assert.ok(
+              programModifiedRules.has(rule),
+              `${programDetail} write #${writeIndex} should mark ${rule} as modified`,
+            );
+          }
+
+          for (const [summaryIndex, summary] of program.loopSummaries.entries()) {
+            const rule = ir1SsaRuleOfLocation(summary.location);
+            assert.ok(
+              programModifiedRules.has(rule),
+              `${programDetail} loop summary #${summaryIndex} should mark ${rule} as modified`,
+            );
+          }
+        }
+      }
     },
   );
 


### PR DESCRIPTION
## Patch 4: Assert frame-suppression-once invariant on lowered bodies

- Remove the PENDING marker on `ir1-ssa-invariants > every modified rule suppresses frame generation exactly once`.
- For each successful program in the corpus (where `result.diagnostics.length === 0`), assert: every rule in `result.modifiedRules` is unique within the array (no duplicates), the resulting frames in `result.propositions` have an LHS rule name that is exactly the set of `declaredRules \ modifiedRules`, every frame appears at most once, and the modified-rules array intersected with the framed rules of `appendFramesForUnmodifiedRules` is empty.
- Also assert that for every `IR1SsaWrite` in `program.writes` and every `IR1SsaLoopSummary` in `program.loopSummaries`, `ir1SsaRuleOfLocation(write.location)` and `ir1SsaRuleOfLocation(summary.location)` appear in `program.modifiedRules` — the workstream spec's `write -> modified-rules` and `summary -> modified-rules` invariants.
- Use a small per-corpus assertion message so a regression points at the program whose frames went wrong.

## Changes
- Remove the PENDING marker on `ir1-ssa-invariants > every modified rule suppresses frame generation exactly once`.
- For each successful program in the corpus (where `result.diagnostics.length === 0`), assert: every rule in `result.modifiedRules` is unique within the array (no duplicates), the resulting frames in `result.propositions` have an LHS rule name that is exactly the set of `declaredRules \ modifiedRules`, every frame appears at most once, and the modified-rules array intersected with the framed rules of `appendFramesForUnmodifiedRules` is empty.
- Also assert that for every `IR1SsaWrite` in `program.writes` and every `IR1SsaLoopSummary` in `program.loopSummaries`, `ir1SsaRuleOfLocation(write.location)` and `ir1SsaRuleOfLocation(summary.location)` appear in `program.modifiedRules` — the workstream spec's `write -> modified-rules` and `summary -> modified-rules` invariants.
- Use a small per-corpus assertion message so a regression points at the program whose frames went wrong.

## Files to Modify
- tools/ts2pant/tests/ir1-ssa-invariants.test.mts (modify): Unskip and implement the modified/framed rule partition invariant against `lowerL1BodyToSsaProps` outputs.

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[paper] Borgida, Mylopoulos & Reiter 1995 — And Nothing Else Changes: The Frame Problem in Procedure Specifications** — https://www.researchgate.net/publication/221555223_And_Nothing_Else_Changes_The_Frame_Problem_in_Procedure_Specifications — Borgida et al. articulate the frame discipline this patch validates: a rule is either modified (its primed form gets an equation) or framed (its primed form equals its unprimed form), never both. Patch 4 enforces that bookkeeping on `IR1SsaProgram.modifiedRules` and `IR1SsaProgram.framedRules`.

## Gameplan Specification

```
module TS2PANT_IR1_SSA_INVARIANTS.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> After Milestone 7, the IR1 SSA architecture is guarded by
> runtime tests that target the abstraction directly. The
> invariants below are the ones the workstream's Pantagruel
> spec (`workstreams/ts2pant-ir1-ssa.pant`) defines, now
> mechanically witnessed by `ir1-ssa-invariants.test.mts`.

IR1Program.
Construct.
ConstructKind.
Location.
Version.
Read.
Write.
Join.
LoopSummary.
Rule.
PropResult.
Diagnostic.
Document.
MilestoneStatus.
scalar => ConstructKind.
map => ConstructKind.
set-kind => ConstructKind.
branch => ConstructKind.
foreach-shape-a => ConstructKind.
foreach-shape-b => ConstructKind.
mu-search => ConstructKind.
pending => MilestoneStatus.
landed => MilestoneStatus.

writes p: IR1Program => [Write].
reads p: IR1Program => [Read].
joins p: IR1Program => [Join].
loop-summaries p: IR1Program => [LoopSummary].
write-location w: Write => Location.
write-version w: Write => Version.
read-location r: Read => Location.
read-version r: Read => Version.
join-location j: Join => Location.
then-version j: Join => Version.
else-version j: Join => Version.
join-version j: Join => Version.
summary-location s: LoopSummary => Location.
summary-version s: LoopSummary => Version.
version-location v: Version => Location.
initial-version l: Location => Version.
rule-of-location l: Location => Rule.
declared-rules p: IR1Program => [Rule].
modified-rules p: IR1Program => [Rule].
framed-rules p: IR1Program => [Rule].
diagnostics p: IR1Program => [Diagnostic].
emitted-props p: IR1Program => [PropResult].
prop-is-diagnostic? pr: PropResult => Bool.
failed? p: IR1Program => Bool.
diagnostic-construct d: Diagnostic => Construct.
construct-kind c: Construct => ConstructKind.
representative-corpus => [Construct].
m7-status d: Document => MilestoneStatus.
m7-references-suite? d: Document => Bool.
---

> ── Fresh versions and location agreement ────────────────
all p: IR1Program, w in writes p |
  version-location (write-version w) = write-location w.

all p: IR1Program, s in loop-summaries p |
  version-location (summary-version s) = summary-location s.

all l: Location |
  version-location (initial-version l) = l.

all p: IR1Program, w1 in writes p, w2 in writes p |
  write-version w1 = write-version w2 -> w1 = w2.

> ── Joins are constrained to a single location ───────────
all p: IR1Program, j in joins p |
  version-location (then-version j) = join-location j and
  version-location (else-version j) = join-location j and
  version-location (join-version j) = join-location j.

all p: IR1Program, j in joins p |
  then-version j != else-version j and
  join-version j != then-version j and
  join-version j != else-version j.

> ── Reads resolve to a dominating version ────────────────
all p: IR1Program, r in reads p |
  version-location (read-version r) = read-location r and
  (
    read-version r = initial-version (read-location r) or
    (some w in writes p |
      write-version w = read-version r and
      write-location w = read-location r) or
    (some j in joins p |
      join-version j = read-version r and
      join-location j = read-location r) or
    (some s in loop-summaries p |
      summary-version s = read-version r and
      summary-location s = read-location r)
  ).

> ── Rule partitioning and frame suppression ──────────────
all p: IR1Program, rule in modified-rules p |
  rule in declared-rules p and
  ~(rule in framed-rules p).

all p: IR1Program, rule in framed-rules p |
  rule in declared-rules p and
  ~(rule in modified-rules p).

all p: IR1Program, rule in declared-rules p |
  rule in modified-rules p or rule in framed-rules p.

all p: IR1Program, w in writes p |
  rule-of-location (write-location w) in modified-rules p.

all p: IR1Program, s in loop-summaries p |
  rule-of-location (summary-location s) in modified-rules p.

> ── Unsupported failure mode ─────────────────────────────
all p: IR1Program, failed? p |
  #(diagnostics p) = 1 and
  (all pr in emitted-props p | prop-is-diagnostic? pr).

all p: IR1Program, diag in diagnostics p |
  ~(diagnostic-construct diag in representative-corpus).

> ── Corpus coverage ──────────────────────────────────────
all k: ConstructKind |
  (some c in representative-corpus | construct-kind c = k).

> ── Documentation pointer ────────────────────────────────
all doc: Document |
  m7-status doc = landed and m7-references-suite? doc.

```

## Patch Specification

```
module TS2PANT_IR1_SSA_INVARIANTS_PATCH_4.

> Patch 4 asserts the modified/framed rule partition invariant
> after `lowerL1BodyToSsaProps` appends frames.

IR1Program.
Location.
Write.
LoopSummary.
Rule.

writes p: IR1Program => [Write].
loop-summaries p: IR1Program => [LoopSummary].
write-location w: Write => Location.
summary-location s: LoopSummary => Location.
rule-of-location l: Location => Rule.
declared-rules p: IR1Program => [Rule].
modified-rules p: IR1Program => [Rule].
framed-rules p: IR1Program => [Rule].
---
> No rule is both modified and framed.
all p: IR1Program, rule in modified-rules p |
  rule in declared-rules p and
  ~(rule in framed-rules p).

all p: IR1Program, rule in framed-rules p |
  rule in declared-rules p and
  ~(rule in modified-rules p).

> Every declared rule lands in exactly one bucket.
all p: IR1Program, rule in declared-rules p |
  rule in modified-rules p or rule in framed-rules p.

> Every write or summary marks its rule as modified.
all p: IR1Program, w in writes p |
  rule-of-location (write-location w) in modified-rules p.

all p: IR1Program, s in loop-summaries p |
  rule-of-location (summary-location s) in modified-rules p.

```


## Implementation Notes

- The body-lowered corpus for this patch is intentionally narrower than the full invariants corpus: it only exercises `lowerL1BodyToSsaProps` cases where frame appending is the boundary under test. I added one branch-shaped fixture (`functions-mutating-conditional.ts > asymmetric`) so the partition assertions cover a multi-rule branch body, not just straight-line scalar/collection/loop examples.
- Frame detection is structural rather than helper-coupled. The test derives framed rules by scanning appended `equation` propositions for identity shapes `rule' ... = rule ...` via `getAst().strExpr(...)`, instead of reaching into `appendFramesForUnmodifiedRules` internals. That keeps the invariant check anchored at the observable lowering result.
- I did not keep a stronger result-level assertion that every entry in `result.modifiedRules` must be sourced by a write or loop summary somewhere in `result.programs`. On the rebased production path, `lowerL1BodyToSsaProps` can legitimately carry modified-rule bookkeeping that is broader than the concrete per-program write/summary sets, while the patch spec only requires the forward direction (`write`/`summary` => modified). The implemented checks therefore stay at the spec boundary: declared-vs-framed partition on the body result, plus per-program write/summary membership in `program.modifiedRules`.
- Spec/Evidence Mapping:
  - Patch spec: modified/framed disjointness and declared-rule partition. Code path: `bodyLoweredRepresentativePrograms()` + `frameRuleNames()` + the unskipped `every modified rule suppresses frame generation exactly once...` test in `tools/ts2pant/tests/ir1-ssa-invariants.test.mts`. Context consulted: `workstreams/ts2pant-ir1-ssa.pant`, `tools/ts2pant/src/ir1-lower-body.ts`, `tools/ts2pant/src/ir1-ssa-lower.ts`. Evidence: `npx tsx --test --test-timeout=300000 tests/ir1-ssa-invariants.test.mts`.
  - Patch spec: every write or summary marks its rule as modified. Code path: per-program assertions over `program.writes`, `program.loopSummaries`, and `ir1SsaRuleOfLocation(...)` in the same test block. Context consulted: `tools/ts2pant/src/ir1.ts` for SSA program shape and rule-of-location mapping. Evidence: same targeted invariants suite.