### PR TITLE
[ts2pant-ir1-ssa-invariants] Patch 5: Assert unsupported diagnostics and table-driven corpus coverage

### DIFF
--- a/tools/ts2pant/tests/ir1-ssa-invariants.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-invariants.test.mts
@@ -1010,6 +1010,7 @@ describe("ir1-ssa-invariants", () => {
               ir1Var("ys"),
               ir1Assign(ir1Member(ir1Var("$1"), "active"), ir1LitBool(true)),
             );
+            // Deliberately bypass the foreach-body type to verify malformed nested loops fail closed.
             const outer = ir1Foreach(
               "$0",
               ir1Var("xs"),

--- a/tools/ts2pant/tests/ir1-ssa-invariants.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-invariants.test.mts
@@ -35,6 +35,9 @@ import {
   ir1Binop,
   ir1Block,
   ir1CondStmt,
+  ir1For,
+  ir1Foreach,
+  ir1LitBool,
   ir1LitNat,
   ir1MapRead,
   ir1MapSet,
@@ -49,6 +52,7 @@ import {
   ir1SetAddOrDelete,
   ir1SetClear,
   ir1Var,
+  ir1While,
 } from "../src/ir1.js";
 import { lowerExpr } from "../src/ir-emit.js";
 import { lowerL1Expr } from "../src/ir1-lower.js";
@@ -531,6 +535,289 @@ function frameRuleNames(result: IR1SsaBodyLowerResult): string[] {
     });
 }
 
+function assertSupportedRepresentativeResult(
+  representativeName: string,
+  result: IR1SsaBodyLowerResult,
+): void {
+  assert.equal(
+    result.diagnostics.length,
+    0,
+    `${representativeName} should lower without diagnostics`,
+  );
+  assert.ok(
+    result.programs.length > 0,
+    `${representativeName} should emit at least one SSA program`,
+  );
+}
+
+function assertFreshVersionsAndJoinLocations(
+  representativeName: string,
+  result: IR1SsaBodyLowerResult,
+): void {
+  assertSupportedRepresentativeResult(representativeName, result);
+
+  for (const [programIndex, program] of result.programs.entries()) {
+    const seenVersionIds = new Map<string, symbol[]>();
+
+    const trackFreshVersion = (
+      occurrence:
+        | { version: IR1SsaWrite["version"]; location: IR1SsaWrite["location"] }
+        | { version: IR1SsaJoin["joinVersion"]; location: IR1SsaJoin["location"] }
+        | {
+            version: IR1SsaLoopSummary["summaryVersion"];
+            location: IR1SsaLoopSummary["location"];
+          },
+      detail: string,
+    ): void => {
+      assert.equal(
+        locationSignature(occurrence.version.location),
+        locationSignature(occurrence.location),
+        `${representativeName} [program ${programIndex}] ${detail} should keep its version at the same location`,
+      );
+      const signature = locationSignature(occurrence.location);
+      const priorIds = seenVersionIds.get(signature) ?? [
+        ir1SsaInitialVersion(occurrence.location).id,
+      ];
+      for (const priorId of priorIds) {
+        assert.notEqual(
+          occurrence.version.id,
+          priorId,
+          `${representativeName} [program ${programIndex}] ${detail} should allocate a fresh SSA version`,
+        );
+      }
+      seenVersionIds.set(signature, [...priorIds, occurrence.version.id]);
+    };
+
+    walkSsaProgram(program, {
+      onWrite(write, index) {
+        trackFreshVersion(
+          { version: write.version, location: write.location },
+          `write #${index}`,
+        );
+      },
+      onJoin(join, index) {
+        assert.equal(
+          locationSignature(join.thenVersion.location),
+          locationSignature(join.location),
+          `${representativeName} [program ${programIndex}] join #${index} then-version should stay at the join location`,
+        );
+        assert.equal(
+          locationSignature(join.elseVersion.location),
+          locationSignature(join.location),
+          `${representativeName} [program ${programIndex}] join #${index} else-version should stay at the join location`,
+        );
+        assert.notEqual(
+          join.thenVersion.id,
+          join.elseVersion.id,
+          `${representativeName} [program ${programIndex}] join #${index} should merge distinct incoming versions`,
+        );
+        trackFreshVersion(
+          { version: join.joinVersion, location: join.location },
+          `join #${index}`,
+        );
+        assert.notEqual(
+          join.joinVersion.id,
+          join.thenVersion.id,
+          `${representativeName} [program ${programIndex}] join #${index} should allocate a fresh result version`,
+        );
+        assert.notEqual(
+          join.joinVersion.id,
+          join.elseVersion.id,
+          `${representativeName} [program ${programIndex}] join #${index} should allocate a fresh result version`,
+        );
+      },
+      onSummary(summary, index) {
+        trackFreshVersion(
+          {
+            version: summary.summaryVersion,
+            location: summary.location,
+          },
+          `loop summary #${index} (${summary.shape})`,
+        );
+      },
+    });
+  }
+}
+
+function assertDominatingReads(
+  representativeName: string,
+  result: IR1SsaBodyLowerResult,
+): void {
+  assertSupportedRepresentativeResult(representativeName, result);
+
+  for (const [programIndex, program] of result.programs.entries()) {
+    walkSsaProgram(program, {
+      onRead(read, readIndex) {
+        const readDetail = [
+          `${representativeName} [program ${programIndex}]`,
+          `read #${readIndex}: ${readSignature(read)}`,
+        ].join(" ");
+        assert.equal(
+          locationSignature(read.version.location),
+          locationSignature(read.location),
+          `${readDetail} should keep its version at the read location`,
+        );
+        assert.equal(
+          read.dominated,
+          true,
+          `${readDetail} should be marked as dominated`,
+        );
+
+        const location = locationSignature(read.location);
+        const initial = ir1SsaInitialVersion(read.location);
+        const resolvesToInitial =
+          read.version.origin === initial.origin &&
+          locationSignature(read.version.location) ===
+            locationSignature(initial.location);
+        const resolvesToWrite = program.writes.some(
+          (write) =>
+            write.version === read.version &&
+            locationSignature(write.location) === location,
+        );
+        const resolvesToJoin = program.joins.some(
+          (join) =>
+            join.joinVersion === read.version &&
+            locationSignature(join.location) === location,
+        );
+        const resolvesToLoopSummary = program.loopSummaries.some(
+          (summary) =>
+            summary.summaryVersion === read.version &&
+            locationSignature(summary.location) === location,
+        );
+
+        assert.ok(
+          resolvesToInitial ||
+            resolvesToWrite ||
+            resolvesToJoin ||
+            resolvesToLoopSummary,
+          `${readDetail} did not resolve to an initial, write, join, or loop-summary version at its own location`,
+        );
+      },
+    });
+  }
+}
+
+function assertFrameSuppression(
+  detail: string,
+  result: IR1SsaBodyLowerResult,
+  declaredRules: readonly string[],
+): void {
+  assert.equal(
+    result.diagnostics.length,
+    0,
+    `${detail} should lower without diagnostics`,
+  );
+
+  const modifiedRules = result.modifiedRules;
+  assert.equal(
+    new Set(modifiedRules).size,
+    modifiedRules.length,
+    `${detail} should list each modified rule at most once`,
+  );
+
+  const declaredRuleSet = new Set(declaredRules);
+  const modifiedRuleSet = new Set(modifiedRules);
+  const expectedFramedRules = declaredRules.filter(
+    (rule) => !modifiedRuleSet.has(rule),
+  );
+  const actualFramedRules = frameRuleNames(result);
+  const actualFramedRuleSet = new Set(actualFramedRules);
+
+  assert.deepEqual(
+    actualFramedRules,
+    expectedFramedRules,
+    `${detail} should append exactly one identity frame for each declared but unmodified rule`,
+  );
+  assert.equal(
+    actualFramedRuleSet.size,
+    actualFramedRules.length,
+    `${detail} should append each frame at most once`,
+  );
+
+  for (const rule of modifiedRuleSet) {
+    assert.ok(
+      declaredRuleSet.has(rule),
+      `${detail} should only mark declared rules as modified`,
+    );
+    assert.ok(
+      !actualFramedRuleSet.has(rule),
+      `${detail} should not frame a modified rule`,
+    );
+  }
+
+  for (const rule of expectedFramedRules) {
+    assert.ok(
+      declaredRuleSet.has(rule),
+      `${detail} should only frame declared rules`,
+    );
+    assert.ok(
+      !modifiedRuleSet.has(rule),
+      `${detail} should keep framed rules disjoint from modified rules`,
+    );
+  }
+
+  for (const [programIndex, program] of result.programs.entries()) {
+    const programDetail = `${detail} [program ${programIndex}]`;
+    const programModifiedRules = new Set(program.modifiedRules);
+    const programRuleSources = new Set([
+      ...program.writes.map((write) => ir1SsaRuleOfLocation(write.location)),
+      ...program.loopSummaries.map((summary) =>
+        ir1SsaRuleOfLocation(summary.location)
+      ),
+    ]);
+
+    for (const modifiedRule of program.modifiedRules) {
+      assert.ok(
+        programRuleSources.has(modifiedRule),
+        `${programDetail} should only mark rules modified when a write or loop summary produced them`,
+      );
+    }
+
+    for (const [writeIndex, write] of program.writes.entries()) {
+      const rule = ir1SsaRuleOfLocation(write.location);
+      assert.ok(
+        programModifiedRules.has(rule),
+        `${programDetail} write #${writeIndex} should mark ${rule} as modified`,
+      );
+    }
+
+    for (const [summaryIndex, summary] of program.loopSummaries.entries()) {
+      const rule = ir1SsaRuleOfLocation(summary.location);
+      assert.ok(
+        programModifiedRules.has(rule),
+        `${programDetail} loop summary #${summaryIndex} should mark ${rule} as modified`,
+      );
+    }
+  }
+}
+
+function assertUnsupportedDiagnosticShape(
+  detail: string,
+  result: IR1SsaBodyLowerResult,
+  reason: RegExp,
+): void {
+  assert.equal(
+    result.diagnostics.length,
+    1,
+    `${detail} should emit exactly one unsupported diagnostic`,
+  );
+  assert.match(
+    result.diagnostics[0]!.reason,
+    reason,
+    `${detail} should emit the targeted unsupported reason family`,
+  );
+  assert.equal(
+    result.propositions.filter((prop) => prop.kind === "equation").length,
+    0,
+    `${detail} should emit no equations after rejection`,
+  );
+  assert.deepEqual(
+    frameRuleNames(result),
+    [],
+    `${detail} should emit no frames after rejection`,
+  );
+}
+
 before(async () => {
   await loadAst();
 });
@@ -546,99 +833,7 @@ describe("ir1-ssa-invariants", () => {
     async () => {
       for (const representative of representativePrograms()) {
         const result = await representative.build();
-        assert.equal(
-          result.diagnostics.length,
-          0,
-          `${representative.name} should lower without diagnostics`,
-        );
-        assert.ok(
-          result.programs.length > 0,
-          `${representative.name} should emit at least one SSA program`,
-        );
-
-        for (const [programIndex, program] of result.programs.entries()) {
-          const seenVersionIds = new Map<string, symbol[]>();
-
-          const trackFreshVersion = (
-            occurrence:
-              | { kind: "write"; version: IR1SsaWrite["version"]; location: IR1SsaWrite["location"] }
-              | { kind: "join"; version: IR1SsaJoin["joinVersion"]; location: IR1SsaJoin["location"] }
-              | {
-                  kind: "loop-summary";
-                  version: IR1SsaLoopSummary["summaryVersion"];
-                  location: IR1SsaLoopSummary["location"];
-                },
-            detail: string,
-          ): void => {
-            assert.equal(
-              locationSignature(occurrence.version.location),
-              locationSignature(occurrence.location),
-              `${representative.name} [program ${programIndex}] ${detail} should keep its version at the same location`,
-            );
-            const signature = locationSignature(occurrence.location);
-            const priorIds = seenVersionIds.get(signature) ?? [
-              ir1SsaInitialVersion(occurrence.location).id,
-            ];
-            for (const priorId of priorIds) {
-              assert.notEqual(
-                occurrence.version.id,
-                priorId,
-                `${representative.name} [program ${programIndex}] ${detail} should allocate a fresh SSA version`,
-              );
-            }
-            seenVersionIds.set(signature, [...priorIds, occurrence.version.id]);
-          };
-
-          walkSsaProgram(program, {
-            onWrite(write, index) {
-              trackFreshVersion(
-                { kind: "write", version: write.version, location: write.location },
-                `write #${index}`,
-              );
-            },
-            onJoin(join, index) {
-              assert.equal(
-                locationSignature(join.thenVersion.location),
-                locationSignature(join.location),
-                `${representative.name} [program ${programIndex}] join #${index} then-version should stay at the join location`,
-              );
-              assert.equal(
-                locationSignature(join.elseVersion.location),
-                locationSignature(join.location),
-                `${representative.name} [program ${programIndex}] join #${index} else-version should stay at the join location`,
-              );
-              assert.notEqual(
-                join.thenVersion.id,
-                join.elseVersion.id,
-                `${representative.name} [program ${programIndex}] join #${index} should merge distinct incoming versions`,
-              );
-              trackFreshVersion(
-                { kind: "join", version: join.joinVersion, location: join.location },
-                `join #${index}`,
-              );
-              assert.notEqual(
-                join.joinVersion.id,
-                join.thenVersion.id,
-                `${representative.name} [program ${programIndex}] join #${index} should allocate a fresh result version`,
-              );
-              assert.notEqual(
-                join.joinVersion.id,
-                join.elseVersion.id,
-                `${representative.name} [program ${programIndex}] join #${index} should allocate a fresh result version`,
-              );
-            },
-            onSummary(summary, index) {
-              trackFreshVersion(
-                {
-                  kind: "loop-summary",
-                  version: summary.summaryVersion,
-                  location: summary.location,
-                },
-                `loop summary #${index} (${summary.shape})`,
-              );
-            },
-          });
-        }
+        assertFreshVersionsAndJoinLocations(representative.name, result);
       }
     },
   );
@@ -720,66 +915,7 @@ describe("ir1-ssa-invariants", () => {
     async () => {
       for (const representative of representativePrograms()) {
         const result = await representative.build();
-        assert.equal(
-          result.diagnostics.length,
-          0,
-          `${representative.name} should lower without diagnostics`,
-        );
-        assert.ok(
-          result.programs.length > 0,
-          `${representative.name} should emit at least one SSA program`,
-        );
-
-        for (const [programIndex, program] of result.programs.entries()) {
-          walkSsaProgram(program, {
-            onRead(read, readIndex) {
-              const readDetail = [
-                `${representative.name} [program ${programIndex}]`,
-                `read #${readIndex}: ${readSignature(read)}`,
-              ].join(" ");
-              assert.equal(
-                locationSignature(read.version.location),
-                locationSignature(read.location),
-                `${readDetail} should keep its version at the read location`,
-              );
-              assert.equal(
-                read.dominated,
-                true,
-                `${readDetail} should be marked as dominated`,
-              );
-
-              const location = locationSignature(read.location);
-              const initial = ir1SsaInitialVersion(read.location);
-              const resolvesToInitial =
-                read.version.origin === initial.origin &&
-                locationSignature(read.version.location) ===
-                  locationSignature(initial.location);
-              const resolvesToWrite = program.writes.some(
-                (write) =>
-                  write.version === read.version &&
-                  locationSignature(write.location) === location,
-              );
-              const resolvesToJoin = program.joins.some(
-                (join) =>
-                  join.joinVersion === read.version &&
-                  locationSignature(join.location) === location,
-              );
-              const resolvesToLoopSummary = program.loopSummaries.some(
-                (summary) =>
-                  summary.summaryVersion === read.version &&
-                  locationSignature(summary.location) === location,
-              );
-
-              assert.ok(
-                resolvesToInitial ||
-                  resolvesToWrite ||
-                  resolvesToJoin ||
-                  resolvesToLoopSummary,
-                `${readDetail} did not resolve to an initial, write, join, or loop-summary version at its own location`,
-              );
-            },
-          });
-        }
+        assertDominatingReads(representative.name, result);
       }
     },
   );
@@ -789,110 +925,146 @@ describe("ir1-ssa-invariants", () => {
     async () => {
       for (const representative of bodyLoweredRepresentativePrograms()) {
         const { result, declaredRules } = await representative.build();
-        const detail = representative.name;
-
-        assert.equal(
-          result.diagnostics.length,
-          0,
-          `${detail} should lower without diagnostics`,
-        );
-
-        const modifiedRules = result.modifiedRules;
-        assert.equal(
-          new Set(modifiedRules).size,
-          modifiedRules.length,
-          `${detail} should list each modified rule at most once`,
-        );
-
-        const declaredRuleSet = new Set(declaredRules);
-        const modifiedRuleSet = new Set(modifiedRules);
-        const expectedFramedRules = declaredRules.filter(
-          (rule) => !modifiedRuleSet.has(rule),
-        );
-        const actualFramedRules = frameRuleNames(result);
-        const actualFramedRuleSet = new Set(actualFramedRules);
-
-        assert.deepEqual(
-          actualFramedRules,
-          expectedFramedRules,
-          `${detail} should append exactly one identity frame for each declared but unmodified rule`,
-        );
-        assert.equal(
-          actualFramedRuleSet.size,
-          actualFramedRules.length,
-          `${detail} should append each frame at most once`,
-        );
-
-        for (const rule of modifiedRuleSet) {
-          assert.ok(
-            declaredRuleSet.has(rule),
-            `${detail} should only mark declared rules as modified`,
-          );
-          assert.ok(
-            !actualFramedRuleSet.has(rule),
-            `${detail} should not frame a modified rule`,
-          );
-        }
-
-        for (const rule of expectedFramedRules) {
-          assert.ok(
-            declaredRuleSet.has(rule),
-            `${detail} should only frame declared rules`,
-          );
-          assert.ok(
-            !modifiedRuleSet.has(rule),
-            `${detail} should keep framed rules disjoint from modified rules`,
-          );
-        }
-
-        for (const [programIndex, program] of result.programs.entries()) {
-          const programDetail = `${detail} [program ${programIndex}]`;
-          const programModifiedRules = new Set(program.modifiedRules);
-          const programRuleSources = new Set([
-            ...program.writes.map((write) => ir1SsaRuleOfLocation(write.location)),
-            ...program.loopSummaries.map((summary) =>
-              ir1SsaRuleOfLocation(summary.location)
-            ),
-          ]);
-
-          for (const modifiedRule of program.modifiedRules) {
-            assert.ok(
-              programRuleSources.has(modifiedRule),
-              `${programDetail} should only mark rules modified when a write or loop summary produced them`,
-            );
-          }
-
-          for (const [writeIndex, write] of program.writes.entries()) {
-            const rule = ir1SsaRuleOfLocation(write.location);
-            assert.ok(
-              programModifiedRules.has(rule),
-              `${programDetail} write #${writeIndex} should mark ${rule} as modified`,
-            );
-          }
-
-          for (const [summaryIndex, summary] of program.loopSummaries.entries()) {
-            const rule = ir1SsaRuleOfLocation(summary.location);
-            assert.ok(
-              programModifiedRules.has(rule),
-              `${programDetail} loop summary #${summaryIndex} should mark ${rule} as modified`,
-            );
-          }
-        }
+        assertFrameSuppression(representative.name, result, declaredRules);
       }
     },
   );
 
-  it.skip(
+  it(
     "unsupported loops and branch shapes return targeted diagnostics with no equations or frames",
-    () => {
-      // PENDING Patch 5: unsupported loops and branch shapes return targeted diagnostics with no equations or frames
+    async () => {
+      const mutatingSourceFile = loadFixture("functions-mutating.ts");
+      const mutatingDoc = await buildDocumentFromSourceFile(
+        mutatingSourceFile,
+        "deposit",
+      );
+      const loopDeclarations = mutatingDoc.declarations;
+      const balance = ir1Member(ir1Var("account"), "Account_balance");
+
+      const unsupportedCases: Array<{
+        name: string;
+        build: () => IR1SsaBodyLowerResult;
+        reason: RegExp;
+      }> = [
+        {
+          name: "while loop on property",
+          build: () =>
+            scalarSsaBodyLowerResult(
+              lowerScalarSsaToProps(
+                ir1While(ir1LitBool(true), ir1Assign(balance, ir1LitNat(1))),
+              ),
+            ),
+          reason: /scalar SSA lowering/u,
+        },
+        {
+          name: "for loop on property",
+          build: () =>
+            scalarSsaBodyLowerResult(
+              lowerScalarSsaToProps(
+                ir1For(
+                  null,
+                  ir1LitBool(true),
+                  null,
+                  ir1Assign(balance, ir1LitNat(1)),
+                ),
+              ),
+            ),
+          reason: /scalar SSA lowering/u,
+        },
+        {
+          name: "multi-arm scalar cond-stmt",
+          build: () =>
+            scalarSsaBodyLowerResult(
+              lowerScalarSsaToProps(
+                ir1CondStmt(
+                  [
+                    [ir1Var("g1"), ir1Assign(balance, ir1LitNat(1))],
+                    [ir1Var("g2"), ir1Assign(balance, ir1LitNat(2))],
+                  ],
+                  ir1Assign(balance, ir1LitNat(3)),
+                ),
+              ),
+            ),
+          reason: /scalar SSA lowering/u,
+        },
+        {
+          name: "foreach Shape A assignment to non-property target",
+          build: () =>
+            lowerL1BodyToSsaProps(
+              ir1Foreach(
+                "$0",
+                ir1Var("xs"),
+                ir1Assign(ir1Var("acc"), ir1LitBool(true)),
+              ),
+              loopDeclarations,
+              { applyConst: (expr) => expr },
+            ),
+            reason:
+              /foreach Shape A summary assignment target must be a property/u,
+        },
+        {
+          name: "nested proposition-emitting loop body",
+          build: () => {
+            const inner = ir1Foreach(
+              "$1",
+              ir1Var("ys"),
+              ir1Assign(ir1Member(ir1Var("$1"), "active"), ir1LitBool(true)),
+            );
+            const outer = ir1Foreach(
+              "$0",
+              ir1Var("xs"),
+              inner as unknown as Parameters<typeof ir1Foreach>[2],
+            );
+            return lowerL1BodyToSsaProps(outer, loopDeclarations, {
+              applyConst: (expr) => expr,
+            });
+          },
+          reason: /nested proposition-emitting loop body/u,
+        },
+      ];
+
+      for (const unsupportedCase of unsupportedCases) {
+        assertUnsupportedDiagnosticShape(
+          unsupportedCase.name,
+          unsupportedCase.build(),
+          unsupportedCase.reason,
+        );
+      }
     },
   );
 
-  it.skip(
+  it(
     "the table-driven corpus satisfies all SSA invariants for scalar, Map, Set, branch, foreach Shape A, foreach Shape B, and μ-search programs",
-    () => {
-      // PENDING Patch 5: the table-driven corpus satisfies all SSA invariants for scalar, Map, Set, branch, foreach Shape A, foreach Shape B, and μ-search programs
+    async () => {
+      const representatives = representativePrograms();
+      const presentKinds = new Set(representatives.map((r) => r.kind));
+
+      for (const kind of [
+        "scalar",
+        "map",
+        "set",
+        "branch",
+        "foreach-shape-a",
+        "foreach-shape-b",
+        "mu-search",
+      ] satisfies RepresentativeProgramKind[]) {
+        assert.ok(
+          presentKinds.has(kind),
+          `representativePrograms() should cover ${kind}`,
+        );
+      }
+
+      for (const representative of representatives) {
+        const result = await representative.build();
+        assertSupportedRepresentativeResult(representative.name, result);
+        assertFreshVersionsAndJoinLocations(representative.name, result);
+        assertDominatingReads(representative.name, result);
+      }
+
+      for (const representative of bodyLoweredRepresentativePrograms()) {
+        const { result, declaredRules } = await representative.build();
+        assertFrameSuppression(representative.name, result, declaredRules);
+      }
     },
   );
 });


### PR DESCRIPTION
## Patch 5: Assert unsupported diagnostics and table-driven corpus coverage

- Remove the PENDING markers on `ir1-ssa-invariants > unsupported loops and branch shapes return targeted diagnostics with no equations or frames` and `ir1-ssa-invariants > the table-driven corpus satisfies all SSA invariants`.
- For each canonical unsupported shape — a `while` loop on a property, a `for` loop on a property, a multi-arm `cond-stmt` over scalars, a foreach Shape A whose body assigns to a non-property target, and a nested proposition-emitting loop body — build the IR1 statement directly via constructors (`ir1While`, `ir1For`, `ir1CondStmt`, `ir1Foreach`, etc.), pass through `lowerL1BodyToSsaProps`, and assert: `result.diagnostics.length === 1`, the diagnostic's reason matches the expected family (e.g. `/while/`, `/multi-armed cond-stmt/`, `/foreach Shape A summary assignment target must be a property/`, `/nested proposition-emitting loop body/`), and `result.propositions` contains no `kind: "equation"` and no frame entries.
- Implement the corpus-wide test using `representativePrograms()`: for each entry, build the program, assert that `result.diagnostics` is empty for the supported entries, then re-run the Patch 2/3/4 invariant assertions on the resulting program(s). Drive coverage over scalar, Map, Set, branch, foreach Shape A, foreach Shape B, and μ-search kinds; assert that the corpus contains at least one entry of each kind via a `present` check on the kinds set so a future removal of a kind from the corpus is caught explicitly.
- Wire each unsupported-shape assertion to a specific failing message naming the construct so a regression that emits frames after a rejected SSA build is easy to attribute.

## Changes
- Remove the PENDING markers on `ir1-ssa-invariants > unsupported loops and branch shapes return targeted diagnostics with no equations or frames` and `ir1-ssa-invariants > the table-driven corpus satisfies all SSA invariants`.
- For each canonical unsupported shape — a `while` loop on a property, a `for` loop on a property, a multi-arm `cond-stmt` over scalars, a foreach Shape A whose body assigns to a non-property target, and a nested proposition-emitting loop body — build the IR1 statement directly via constructors (`ir1While`, `ir1For`, `ir1CondStmt`, `ir1Foreach`, etc.), pass through `lowerL1BodyToSsaProps`, and assert: `result.diagnostics.length === 1`, the diagnostic's reason matches the expected family (e.g. `/while/`, `/multi-armed cond-stmt/`, `/foreach Shape A summary assignment target must be a property/`, `/nested proposition-emitting loop body/`), and `result.propositions` contains no `kind: "equation"` and no frame entries.
- Implement the corpus-wide test using `representativePrograms()`: for each entry, build the program, assert that `result.diagnostics` is empty for the supported entries, then re-run the Patch 2/3/4 invariant assertions on the resulting program(s). Drive coverage over scalar, Map, Set, branch, foreach Shape A, foreach Shape B, and μ-search kinds; assert that the corpus contains at least one entry of each kind via a `present` check on the kinds set so a future removal of a kind from the corpus is caught explicitly.
- Wire each unsupported-shape assertion to a specific failing message naming the construct so a regression that emits frames after a rejected SSA build is easy to attribute.

## Files to Modify
- tools/ts2pant/tests/ir1-ssa-invariants.test.mts (modify): Unskip and implement the unsupported-construct rejection invariants and the corpus-wide table-driven test.

## Gameplan Specification

```
module TS2PANT_IR1_SSA_INVARIANTS.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> After Milestone 7, the IR1 SSA architecture is guarded by
> runtime tests that target the abstraction directly. The
> invariants below are the ones the workstream's Pantagruel
> spec (`workstreams/ts2pant-ir1-ssa.pant`) defines, now
> mechanically witnessed by `ir1-ssa-invariants.test.mts`.

IR1Program.
Construct.
ConstructKind.
Location.
Version.
Read.
Write.
Join.
LoopSummary.
Rule.
PropResult.
Diagnostic.
Document.
MilestoneStatus.
scalar => ConstructKind.
map => ConstructKind.
set-kind => ConstructKind.
branch => ConstructKind.
foreach-shape-a => ConstructKind.
foreach-shape-b => ConstructKind.
mu-search => ConstructKind.
pending => MilestoneStatus.
landed => MilestoneStatus.

writes p: IR1Program => [Write].
reads p: IR1Program => [Read].
joins p: IR1Program => [Join].
loop-summaries p: IR1Program => [LoopSummary].
write-location w: Write => Location.
write-version w: Write => Version.
read-location r: Read => Location.
read-version r: Read => Version.
join-location j: Join => Location.
then-version j: Join => Version.
else-version j: Join => Version.
join-version j: Join => Version.
summary-location s: LoopSummary => Location.
summary-version s: LoopSummary => Version.
version-location v: Version => Location.
initial-version l: Location => Version.
rule-of-location l: Location => Rule.
declared-rules p: IR1Program => [Rule].
modified-rules p: IR1Program => [Rule].
framed-rules p: IR1Program => [Rule].
diagnostics p: IR1Program => [Diagnostic].
emitted-props p: IR1Program => [PropResult].
prop-is-diagnostic? pr: PropResult => Bool.
failed? p: IR1Program => Bool.
diagnostic-construct d: Diagnostic => Construct.
construct-kind c: Construct => ConstructKind.
representative-corpus => [Construct].
m7-status d: Document => MilestoneStatus.
m7-references-suite? d: Document => Bool.
---

> ── Fresh versions and location agreement ────────────────
all p: IR1Program, w in writes p |
  version-location (write-version w) = write-location w.

all p: IR1Program, s in loop-summaries p |
  version-location (summary-version s) = summary-location s.

all l: Location |
  version-location (initial-version l) = l.

all p: IR1Program, w1 in writes p, w2 in writes p |
  write-version w1 = write-version w2 -> w1 = w2.

> ── Joins are constrained to a single location ───────────
all p: IR1Program, j in joins p |
  version-location (then-version j) = join-location j and
  version-location (else-version j) = join-location j and
  version-location (join-version j) = join-location j.

all p: IR1Program, j in joins p |
  then-version j != else-version j and
  join-version j != then-version j and
  join-version j != else-version j.

> ── Reads resolve to a dominating version ────────────────
all p: IR1Program, r in reads p |
  version-location (read-version r) = read-location r and
  (
    read-version r = initial-version (read-location r) or
    (some w in writes p |
      write-version w = read-version r and
      write-location w = read-location r) or
    (some j in joins p |
      join-version j = read-version r and
      join-location j = read-location r) or
    (some s in loop-summaries p |
      summary-version s = read-version r and
      summary-location s = read-location r)
  ).

> ── Rule partitioning and frame suppression ──────────────
all p: IR1Program, rule in modified-rules p |
  rule in declared-rules p and
  ~(rule in framed-rules p).

all p: IR1Program, rule in framed-rules p |
  rule in declared-rules p and
  ~(rule in modified-rules p).

all p: IR1Program, rule in declared-rules p |
  rule in modified-rules p or rule in framed-rules p.

all p: IR1Program, w in writes p |
  rule-of-location (write-location w) in modified-rules p.

all p: IR1Program, s in loop-summaries p |
  rule-of-location (summary-location s) in modified-rules p.

> ── Unsupported failure mode ─────────────────────────────
all p: IR1Program, failed? p |
  #(diagnostics p) = 1 and
  (all pr in emitted-props p | prop-is-diagnostic? pr).

all p: IR1Program, diag in diagnostics p |
  ~(diagnostic-construct diag in representative-corpus).

> ── Corpus coverage ──────────────────────────────────────
all k: ConstructKind |
  (some c in representative-corpus | construct-kind c = k).

> ── Documentation pointer ────────────────────────────────
all doc: Document |
  m7-status doc = landed and m7-references-suite? doc.

```

## Patch Specification

```
module TS2PANT_IR1_SSA_INVARIANTS_PATCH_5.

> Patch 5 asserts that unsupported loops and unsupported branch
> shapes return a single targeted diagnostic with no equations
> or frames, and that the supported corpus covers every
> construct kind the workstream lists.

IR1Program.
Construct.
Diagnostic.
PropResult.
ConstructKind.
scalar => ConstructKind.
map => ConstructKind.
set-kind => ConstructKind.
branch => ConstructKind.
foreach-shape-a => ConstructKind.
foreach-shape-b => ConstructKind.
mu-search => ConstructKind.

failed? p: IR1Program => Bool.
diagnostics p: IR1Program => [Diagnostic].
emitted-props p: IR1Program => [PropResult].
prop-is-diagnostic? pr: PropResult => Bool.
diagnostic-construct d: Diagnostic => Construct.
construct-kind c: Construct => ConstructKind.
corpus-kinds c: Construct => [ConstructKind].
representative-corpus => [Construct].
---
> An unsupported program emits exactly one diagnostic and no
> non-diagnostic propositions (no equations, no frames).
all p: IR1Program, failed? p |
  #(diagnostics p) = 1 and
  (all pr in emitted-props p | prop-is-diagnostic? pr).

> The representative corpus covers every construct kind.
all k: ConstructKind |
  (some c in representative-corpus | construct-kind c = k).

```


## Implementation Notes

- I extracted the Patch 2/3/4 assertions into local helper functions inside `ir1-ssa-invariants.test.mts` and reused them from the new corpus-wide test. That keeps the invariant definitions identical between the original focused tests and the new table-driven pass instead of re-encoding slightly different checks.
- The only material deviation from the patch prose is the unsupported scalar `while` / `for` / multi-arm `cond-stmt` cases: those assertions go through `scalarSsaBodyLowerResult(lowerScalarSsaToProps(...))`, not `lowerL1BodyToSsaProps(...)`. The body-level boundary normalizes these shapes to the generic unified-SSA rejection message, while the scalar SSA entrypoint is the actual production boundary that rejects the canonical scalar shapes. The tests still name each construct explicitly in the assertion message, but they match the real emitted diagnostic family (`/scalar SSA lowering/`) rather than a shape-specific substring that production does not currently expose there.
- I did not extend the frame-suppression corpus check to the standalone mu-search helper result. `buildMuSearchFixtureResult()` is built via `adaptLoopSummaryLowerResult(lowerMuSearchSummary(...))`, which never passes through `appendFramesForUnmodifiedRules`; asserting frames there would be checking a boundary this helper does not exercise.
- The unsupported-shape checks assert both `result.propositions.filter(kind === "equation") === 0` and `frameRuleNames(result) === []`. The second assertion is redundant when there are no equations, but keeping both makes the failure mode obvious if a future refactor starts appending identity frames after a rejection.
- Spec/Evidence Mapping:
  - Unsupported failure mode (`#diagnostics = 1` and no non-diagnostic props`) -> `assertUnsupportedDiagnosticShape(...)` in `tools/ts2pant/tests/ir1-ssa-invariants.test.mts`; consulted `tools/ts2pant/src/ir1-lower-body.ts`, `ir1-ssa-scalars.ts`, and `ir1-ssa-loops.ts`; proved by `npx tsx --test --test-timeout=300000 tests/ir1-ssa-invariants.test.mts`.
  - Representative-corpus kind coverage -> `presentKinds` set check in the new corpus test; consulted the fixture corpus listed in the patch context plus `representativePrograms()` in the same test file; proved by the same targeted test run.
  - “Re-run prior invariants on supported corpus entries” acceptance criterion -> the new corpus test calls the extracted freshness/join, dominating-read, and frame-suppression helpers instead of adding a second hand-written copy; proved by the same targeted test run.