### PR TITLE
[ts2pant-general-loop-contract] Patch 1: Pending contract tests for general-loop SSA vocabulary

### DIFF
--- a/tools/ts2pant/tests/ir1-ssa-loop-contract.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-loop-contract.test.mts
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  ir1LitNat,
+  ir1SsaInitialVersion,
+  ir1SsaPropertyLocation,
+  ir1SsaPropertyValue,
+  ir1SsaWrite,
+  ir1Var,
+} from "../src/ir1.js";
+
+describe("ir1-ssa-loop-contract", () => {
+  it.skip("opens a loop-header join with a placeholder loop-back input", () => {
+    const location = ir1SsaPropertyLocation(
+      "Account_balance",
+      ir1Var("account"),
+      "balance",
+    );
+    const preheaderVersion = ir1SsaInitialVersion(location);
+
+    assert.equal(preheaderVersion.location, location);
+    // PENDING Patch 2: ir1SsaOpenLoopHeader returns an open header
+    // (closed=false, loopBackVersion=null) with a fresh joinVersion whose
+    // origin is loop-header.
+  });
+
+  it.skip(
+    "closes a loop-header join via back-patch and rejects double-close",
+    () => {
+      const location = ir1SsaPropertyLocation(
+        "Account_balance",
+        ir1Var("account"),
+        "balance",
+      );
+      const preheaderVersion = ir1SsaInitialVersion(location);
+      const loopBackVersion = ir1SsaWrite(
+        location,
+        ir1SsaPropertyValue(ir1LitNat(1)),
+      ).version;
+
+      assert.equal(preheaderVersion.location, location);
+      assert.equal(loopBackVersion.location, location);
+      // PENDING Patch 2: ir1SsaCloseLoopHeader back-patches the single
+      // loop-back input, marks the same header object closed, and rejects
+      // double-close attempts.
+    },
+  );
+
+  it.skip(
+    "rejects loop-back versions whose location does not match the header",
+    () => {
+      const headerLocation = ir1SsaPropertyLocation(
+        "Account_balance",
+        ir1Var("account"),
+        "balance",
+      );
+      const otherLocation = ir1SsaPropertyLocation(
+        "Account_limit",
+        ir1Var("account"),
+        "limit",
+      );
+      const mismatchedVersion = ir1SsaInitialVersion(otherLocation);
+
+      assert.notEqual(mismatchedVersion.location, headerLocation);
+      // PENDING Patch 2: ir1SsaCloseLoopHeader rejects loop-back versions
+      // whose version.location is not compatible with the header location.
+    },
+  );
+
+  it.skip("rejects a loop body containing an open header join", () => {
+    const location = ir1SsaPropertyLocation(
+      "Account_balance",
+      ir1Var("account"),
+      "balance",
+    );
+    const write = ir1SsaWrite(location, ir1SsaPropertyValue(ir1LitNat(2)));
+
+    assert.equal(write.version.location, location);
+    // PENDING Patch 2: ir1SsaLoopBody accepts only closed header joins and
+    // rejects any body.headerJoins entry that still has closed=false.
+  });
+
+  it.skip("constructs a termination metric with optional lower bound", () => {
+    const metricExpr = ir1Var("remaining");
+    const lowerBound = ir1LitNat(0);
+
+    assert.equal(metricExpr.kind, "var");
+    assert.equal(lowerBound.kind, "lit");
+    // PENDING Patch 2: ir1SsaTerminationMetric stores the metric expression
+    // and defaults lowerBound to null when callers omit it.
+  });
+
+  it.skip(
+    "snapshots break and continue handle versions with location compatibility",
+    () => {
+      const location = ir1SsaPropertyLocation(
+        "Account_balance",
+        ir1Var("account"),
+        "balance",
+      );
+      const snapshotVersion = ir1SsaWrite(
+        location,
+        ir1SsaPropertyValue(ir1LitNat(3)),
+      ).version;
+
+      assert.equal(snapshotVersion.location, location);
+      // PENDING Patch 2: ir1SsaBreakHandle and ir1SsaContinueHandle snapshot
+      // existing versions and assert each version is compatible with the
+      // handle location.
+    },
+  );
+
+  it.skip(
+    "IR1SsaProgram declares loopHeaderJoins and loopBodies arrays",
+    () => {
+      const location = ir1SsaPropertyLocation(
+        "Account_balance",
+        ir1Var("account"),
+        "balance",
+      );
+      const write = ir1SsaWrite(location, ir1SsaPropertyValue(ir1LitNat(4)));
+
+      assert.equal(write.location, location);
+      // PENDING Patch 2: IR1SsaProgram includes loopHeaderJoins and
+      // loopBodies arrays, and existing initializers default them to [].
+    },
+  );
+});


### PR DESCRIPTION
## Patch 1: Pending contract tests for general-loop SSA vocabulary

- Create `tools/ts2pant/tests/ir1-ssa-loop-contract.test.mts` modeled on `tools/ts2pant/tests/ir1-ssa-contract.test.mts`'s shape (describe block, direct constructor calls, `node:assert/strict` for assertions).
- Import existing IR1 symbols from `../src/ir1.js` that the stub file legitimately uses for setup (`ir1Var`, `ir1LitNat`, `ir1SsaPropertyLocation`, `ir1SsaInitialVersion`, `ir1SsaWrite`, `ir1SsaPropertyValue`). Do NOT import the new vocabulary symbols — they don't exist yet.
- Add `it.skip("opens a loop-header join with a placeholder loop-back input", () => { /* PENDING Patch 2: ir1SsaOpenLoopHeader returns open header (closed=false, loopBackVersion=null) with fresh joinVersion whose origin is loop-header */ });` and equivalent skipped stubs for: closing the header (single back-patch, double-close rejection, location-mismatch rejection); building a loop body that rejects open header joins; termination metric construction (null lowerBound default); break/continue handle construction with location-compatibility assertions; IR1SsaProgram now declares loopHeaderJoins and loopBodies arrays.
- Ensure the file compiles and `bun run test` (or equivalent) reports the stubs as skipped rather than failing.
- Do not modify any other file in this patch.

## Changes
- Create `tools/ts2pant/tests/ir1-ssa-loop-contract.test.mts` modeled on `tools/ts2pant/tests/ir1-ssa-contract.test.mts`'s shape (describe block, direct constructor calls, `node:assert/strict` for assertions).
- Import existing IR1 symbols from `../src/ir1.js` that the stub file legitimately uses for setup (`ir1Var`, `ir1LitNat`, `ir1SsaPropertyLocation`, `ir1SsaInitialVersion`, `ir1SsaWrite`, `ir1SsaPropertyValue`). Do NOT import the new vocabulary symbols — they don't exist yet.
- Add `it.skip("opens a loop-header join with a placeholder loop-back input", () => { /* PENDING Patch 2: ir1SsaOpenLoopHeader returns open header (closed=false, loopBackVersion=null) with fresh joinVersion whose origin is loop-header */ });` and equivalent skipped stubs for: closing the header (single back-patch, double-close rejection, location-mismatch rejection); building a loop body that rejects open header joins; termination metric construction (null lowerBound default); break/continue handle construction with location-compatibility assertions; IR1SsaProgram now declares loopHeaderJoins and loopBodies arrays.
- Ensure the file compiles and `bun run test` (or equivalent) reports the stubs as skipped rather than failing.
- Do not modify any other file in this patch.

## Files to Modify
- tools/ts2pant/tests/ir1-ssa-loop-contract.test.mts (create): New contract test file with `describe("ir1-ssa-loop-contract", ...)` and `it.skip` stubs for each invariant family. Imports only existing IR1 SSA symbols. Each stub carries a `// PENDING Patch 2: <invariant>` comment naming the implementing patch.

## Gameplan Specification

```
module TS2PANT_GENERAL_LOOP_CONTRACT.

> ════════════════════════════════════════
> Milestone 1 of the ts2pant general-loop SSA workstream.
> ════════════════════════════════════════
> After this milestone, ir1.ts exports the IR1 SSA vocabulary
> for general for/while loops: loop-header joins with the
> Cytron-style two-pass open/close protocol, loop body regions
> aggregating writes/joins/handles/metric, termination metrics
> discriminating bounded vs fixed-point loops, and
> break/continue continuation handles. Production builders
> and lowerers are unchanged; the surface is dormant.

Location.
Version.
Expr.
LoopHeaderJoin.
LoopBody.
TerminationMetric.
BreakHandle.
ContinueHandle.
IR1Program.
ClosedStatus.
Document.
DocumentKind.
MilestoneStatus.
open => ClosedStatus.
closed => ClosedStatus.
agents-md => DocumentKind.
workstream-doc => DocumentKind.
pending => MilestoneStatus.
landed => MilestoneStatus.

header-location h: LoopHeaderJoin => Location.
preheader-version h: LoopHeaderJoin => Version.
loop-back-version h: LoopHeaderJoin => Version.
header-join-version h: LoopHeaderJoin => Version.
header-status h: LoopHeaderJoin => ClosedStatus.
body-header-joins b: LoopBody => [LoopHeaderJoin].
body-writes b: LoopBody => [Version].
body-break-handles b: LoopBody => [BreakHandle].
body-continue-handles b: LoopBody => [ContinueHandle].
body-has-metric? b: LoopBody => Bool.
metric-expr m: TerminationMetric => Expr.
break-location bh: BreakHandle => Location.
break-version bh: BreakHandle => Version.
continue-location ch: ContinueHandle => Location.
continue-version ch: ContinueHandle => Version.
version-location v: Version => Location.
program-loop-header-joins p: IR1Program => [LoopHeaderJoin].
program-loop-bodies p: IR1Program => [LoopBody].
document-kind d: Document => DocumentKind.
document-mentions-loop-contract? d: Document => Bool.
workstream-milestone-1-status => MilestoneStatus.
---

> Loop-header structural invariants.
all h: LoopHeaderJoin |
  version-location (preheader-version h) = header-location h and
  version-location (header-join-version h) = header-location h.

all h: LoopHeaderJoin |
  header-status h = closed ->
    version-location (loop-back-version h) = header-location h.

> The join version is distinct from the merged inputs.
all h: LoopHeaderJoin |
  header-join-version h != preheader-version h.

all h: LoopHeaderJoin |
  header-status h = closed ->
    header-join-version h != loop-back-version h.

> Loop body invariants.
all b: LoopBody, h in body-header-joins b |
  header-status h = closed.

all b: LoopBody, bh in body-break-handles b |
  version-location (break-version bh) = break-location bh.

all b: LoopBody, ch in body-continue-handles b |
  version-location (continue-version ch) = continue-location ch.

> Program-level aggregator carries the new arrays.
all p: IR1Program, b in program-loop-bodies p, h in body-header-joins b |
  header-status h = closed.

> Documentation invariants.
all d: Document |
  document-kind d = agents-md ->
    document-mentions-loop-contract? d.

all d: Document |
  document-kind d = workstream-doc ->
    document-mentions-loop-contract? d.

workstream-milestone-1-status = landed.
```

## Patch Specification

```
module TS2PANT_GENERAL_LOOP_CONTRACT_PATCH_1.

> Patch 1 introduces the test scaffolding for the general-loop
> SSA vocabulary. No invariants are asserted at runtime yet; the
> contribution is the named stubs consumed by Patch 2.

TestStub.
InvariantFamily.
loop-header-open => InvariantFamily.
loop-header-close => InvariantFamily.
loop-header-location => InvariantFamily.
loop-body-open-header-rejection => InvariantFamily.
termination-metric-shape => InvariantFamily.
break-continue-handle-shape => InvariantFamily.
program-extension => InvariantFamily.

stub-for f: InvariantFamily => TestStub.
---
true.
```


## Implementation Notes

- The general-loop workstream document named in the task was not present in this checkout, so I used the PR/gameplan text plus `tools/ts2pant/src/ir1.ts`, `tools/ts2pant/tests/ir1-ssa-contract.test.mts`, and the `tools/ts2pant/AGENTS.md` SSA contract section as the implementation references.
- The new test callbacks include small setup expressions using only existing IR1 constructors. They are intentionally skipped, but still type-load today and give Patch 2 concrete locations to replace setup-only assertions with the new vocabulary assertions.
- No production code, exports, or existing tests were changed. The patch adds only `tools/ts2pant/tests/ir1-ssa-loop-contract.test.mts`.

Spec/Evidence Mapping:
- `stub-for loop-header-open`, `loop-header-close`, and `loop-header-location`: covered by the three loop-header `it.skip` stubs in `ir1-ssa-loop-contract.test.mts`; `npm run test:unit` reports them skipped.
- `stub-for loop-body-open-header-rejection`, `termination-metric-shape`, `break-continue-handle-shape`, and `program-extension`: covered by the remaining four named `it.skip` stubs in the same file; `npm run test:unit` reports them skipped.
- Acceptance check: `npm run test:unit` passed with the new suite discovered and seven skipped stubs; `npm run test:integration` also passed.