### PR TITLE
[ts2pant-ir1-ssa-printer] Patch 1: Add formatIR1Expr — Pantagruel-flavored debug printer for IR1 expressions

### DIFF
--- a/tools/ts2pant/src/ir1-printer.ts
+++ b/tools/ts2pant/src/ir1-printer.ts
@@ -41,7 +41,9 @@ export function formatIR1Expr(expr: IR1Expr): string {
       return `${formatIR1Expr(expr.elem)} in ${formatIR1Expr(expr.receiver)}`;
     default: {
       const _exhaustive: never = expr;
-      throw new Error(`Unhandled IR1 expression kind: ${String(_exhaustive)}`);
+      throw new Error(
+        `Unhandled IR1 expression kind: ${JSON.stringify(_exhaustive)}`,
+      );
     }
   }
 }
@@ -56,7 +58,9 @@ function formatIR1Literal(literal: IR1Literal): string {
       return JSON.stringify(literal.value);
     default: {
       const _exhaustive: never = literal;
-      throw new Error(`Unhandled IR1 literal kind: ${String(_exhaustive)}`);
+      throw new Error(
+        `Unhandled IR1 literal kind: ${JSON.stringify(_exhaustive)}`,
+      );
     }
   }
 }
@@ -71,7 +75,9 @@ function formatUnop(op: IR1Unop, arg: IR1Expr): string {
       return `${unopGlyph(op)}${formatAsTightPrefixArg(arg)}`;
     default: {
       const _exhaustive: never = op;
-      throw new Error(`Unhandled IR1 unary operator: ${String(_exhaustive)}`);
+      throw new Error(
+        `Unhandled IR1 unary operator: ${JSON.stringify(_exhaustive)}`,
+      );
     }
   }
 }
@@ -112,7 +118,9 @@ function binopGlyph(op: IR1Binop): string {
       return "/";
     default: {
       const _exhaustive: never = op;
-      throw new Error(`Unhandled IR1 binary operator: ${String(_exhaustive)}`);
+      throw new Error(
+        `Unhandled IR1 binary operator: ${JSON.stringify(_exhaustive)}`,
+      );
     }
   }
 }
@@ -127,7 +135,9 @@ function unopGlyph(op: IR1Unop): string {
       return "#";
     default: {
       const _exhaustive: never = op;
-      throw new Error(`Unhandled IR1 unary operator: ${String(_exhaustive)}`);
+      throw new Error(
+        `Unhandled IR1 unary operator: ${JSON.stringify(_exhaustive)}`,
+      );
     }
   }
 }

--- a/tools/ts2pant/src/ir1-printer.ts
+++ b/tools/ts2pant/src/ir1-printer.ts
@@ -1,0 +1,169 @@
+import type { IR1Binop, IR1Expr, IR1Literal, IR1Unop } from "./ir1.js";
+
+export function formatIR1Expr(expr: IR1Expr): string {
+  switch (expr.kind) {
+    case "var":
+      return `${expr.name}${expr.primed === true ? "'" : ""}`;
+    case "lit":
+      return formatIR1Literal(expr.value);
+    case "binop":
+      return `(${formatIR1Expr(expr.lhs)} ${binopGlyph(expr.op)} ${formatIR1Expr(expr.rhs)})`;
+    case "unop":
+      return formatUnop(expr.op, expr.arg);
+    case "app": {
+      const callee = formatAsAppCallee(expr.callee);
+      const args = expr.args.map(formatAsAppArg);
+      return [callee, ...args].join(" ");
+    }
+    case "member":
+      return `${expr.name} ${formatAsMemberReceiver(expr.receiver)}`;
+    case "cond": {
+      const arms = expr.arms.map(
+        ([guard, value]) =>
+          `${formatIR1Expr(guard)} => ${formatIR1Expr(value)}`,
+      );
+      arms.push(`true => ${formatIR1Expr(expr.otherwise)}`);
+      return `cond ${arms.join(", ")}`;
+    }
+    case "is-nullish":
+      return `nullish? ${formatAsAppArg(expr.operand)}`;
+    case "each": {
+      const guards = expr.guards.map(
+        (guard) => `, when ${formatIR1Expr(guard)}`,
+      );
+      return `each ${expr.binder} in ${formatIR1Expr(expr.src)} | ${formatIR1Expr(expr.proj)}${guards.join("")}`;
+    }
+    case "map-read": {
+      const ruleName = expr.op === "get" ? expr.ruleName : expr.keyPredName;
+      return `${ruleName} ${formatAsAppArg(expr.receiver)} ${formatAsAppArg(expr.key)}`;
+    }
+    case "set-read":
+      return `${formatIR1Expr(expr.elem)} in ${formatIR1Expr(expr.receiver)}`;
+    default: {
+      const _exhaustive: never = expr;
+      throw new Error(`Unhandled IR1 expression kind: ${String(_exhaustive)}`);
+    }
+  }
+}
+
+function formatIR1Literal(literal: IR1Literal): string {
+  switch (literal.kind) {
+    case "nat":
+      return String(literal.value);
+    case "bool":
+      return literal.value ? "true" : "false";
+    case "string":
+      return JSON.stringify(literal.value);
+    default: {
+      const _exhaustive: never = literal;
+      throw new Error(`Unhandled IR1 literal kind: ${String(_exhaustive)}`);
+    }
+  }
+}
+
+function formatUnop(op: IR1Unop, arg: IR1Expr): string {
+  switch (op) {
+    case "not":
+      return `${unopGlyph(op)}${formatAsTightPrefixArg(arg)}`;
+    case "neg":
+      return `(${unopGlyph(op)}${formatIR1Expr(arg)})`;
+    case "card":
+      return `${unopGlyph(op)}${formatAsTightPrefixArg(arg)}`;
+    default: {
+      const _exhaustive: never = op;
+      throw new Error(`Unhandled IR1 unary operator: ${String(_exhaustive)}`);
+    }
+  }
+}
+
+function binopGlyph(op: IR1Binop): string {
+  switch (op) {
+    case "and":
+      return "and";
+    case "or":
+      return "or";
+    case "impl":
+      return "->";
+    case "iff":
+      return "<->";
+    case "eq":
+      return "=";
+    case "neq":
+      return "~=";
+    case "lt":
+      return "<";
+    case "gt":
+      return ">";
+    case "le":
+      return "<=";
+    case "ge":
+      return ">=";
+    case "in":
+      return "in";
+    case "subset":
+      return "subset";
+    case "add":
+      return "+";
+    case "sub":
+      return "-";
+    case "mul":
+      return "*";
+    case "div":
+      return "/";
+    default: {
+      const _exhaustive: never = op;
+      throw new Error(`Unhandled IR1 binary operator: ${String(_exhaustive)}`);
+    }
+  }
+}
+
+function unopGlyph(op: IR1Unop): string {
+  switch (op) {
+    case "not":
+      return "~";
+    case "neg":
+      return "-";
+    case "card":
+      return "#";
+    default: {
+      const _exhaustive: never = op;
+      throw new Error(`Unhandled IR1 unary operator: ${String(_exhaustive)}`);
+    }
+  }
+}
+
+function formatAsAppCallee(expr: IR1Expr): string {
+  return needsCalleeParens(expr)
+    ? `(${formatIR1Expr(expr)})`
+    : formatIR1Expr(expr);
+}
+
+function formatAsAppArg(expr: IR1Expr): string {
+  return needsAppArgParens(expr)
+    ? `(${formatIR1Expr(expr)})`
+    : formatIR1Expr(expr);
+}
+
+function formatAsMemberReceiver(expr: IR1Expr): string {
+  return needsMemberReceiverParens(expr)
+    ? `(${formatIR1Expr(expr)})`
+    : formatIR1Expr(expr);
+}
+
+function formatAsTightPrefixArg(expr: IR1Expr): string {
+  return expr.kind === "binop" || expr.kind === "cond"
+    ? formatIR1Expr(expr)
+    : formatAsAppArg(expr);
+}
+
+function needsCalleeParens(expr: IR1Expr): boolean {
+  return expr.kind === "binop" || expr.kind === "cond";
+}
+
+function needsAppArgParens(expr: IR1Expr): boolean {
+  return expr.kind === "app" || expr.kind === "cond";
+}
+
+function needsMemberReceiverParens(expr: IR1Expr): boolean {
+  return expr.kind === "binop" || expr.kind === "member";
+}

--- a/tools/ts2pant/tests/ir1-printer.test.mts
+++ b/tools/ts2pant/tests/ir1-printer.test.mts
@@ -1,0 +1,173 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  ir1App,
+  ir1Binop,
+  ir1Cond,
+  ir1Each,
+  ir1IsNullish,
+  ir1LitBool,
+  ir1LitNat,
+  ir1LitString,
+  ir1MapRead,
+  ir1Member,
+  ir1SetRead,
+  ir1Unop,
+  ir1Var,
+} from "../src/ir1.js";
+import { formatIR1Expr } from "../src/ir1-printer.js";
+
+describe("formatIR1Expr", () => {
+  it("formats var expressions", () => {
+    assert.equal(formatIR1Expr(ir1Var("balance")), "balance");
+    assert.equal(formatIR1Expr(ir1Var("balance", true)), "balance'");
+  });
+
+  it("formats lit expressions", () => {
+    assert.equal(formatIR1Expr(ir1LitNat(42)), "42");
+    assert.equal(formatIR1Expr(ir1LitBool(false)), "false");
+    assert.equal(
+      formatIR1Expr(ir1LitString('a "quoted" value')),
+      '"a \\"quoted\\" value"',
+    );
+  });
+
+  it("formats binop expressions", () => {
+    assert.equal(
+      formatIR1Expr(ir1Binop("neq", ir1Var("left"), ir1Var("right"))),
+      "(left ~= right)",
+    );
+    assert.equal(
+      formatIR1Expr(
+        ir1Binop(
+          "and",
+          ir1Binop("le", ir1Var("x"), ir1LitNat(3)),
+          ir1Binop("ge", ir1Var("y"), ir1LitNat(2)),
+        ),
+      ),
+      "((x <= 3) and (y >= 2))",
+    );
+  });
+
+  it("formats unop expressions", () => {
+    assert.equal(formatIR1Expr(ir1Unop("not", ir1Var("ready"))), "~ready");
+    assert.equal(formatIR1Expr(ir1Unop("neg", ir1Var("delta"))), "(-delta)");
+    assert.equal(formatIR1Expr(ir1Unop("card", ir1Var("items"))), "#items");
+    assert.equal(
+      formatIR1Expr(ir1Unop("not", ir1Binop("eq", ir1Var("x"), ir1LitNat(0)))),
+      "~(x = 0)",
+    );
+  });
+
+  it("formats app expressions", () => {
+    assert.equal(
+      formatIR1Expr(
+        ir1App(ir1Var("f"), [
+          ir1Var("x"),
+          ir1Binop("add", ir1Var("y"), ir1LitNat(1)),
+        ]),
+      ),
+      "f x (y + 1)",
+    );
+    assert.equal(
+      formatIR1Expr(ir1App(ir1App(ir1Var("f"), [ir1Var("x")]), [ir1Var("y")])),
+      "f x y",
+    );
+  });
+
+  it("formats member expressions", () => {
+    assert.equal(
+      formatIR1Expr(ir1Member(ir1Var("account"), "Account_balance")),
+      "Account_balance account",
+    );
+    assert.equal(
+      formatIR1Expr(
+        ir1Member(ir1Member(ir1Var("account"), "profile"), "Profile_name"),
+      ),
+      "Profile_name (profile account)",
+    );
+  });
+
+  it("formats cond expressions", () => {
+    assert.equal(
+      formatIR1Expr(
+        ir1Cond(
+          [
+            [ir1Var("g1"), ir1LitNat(1)],
+            [ir1Var("g2"), ir1LitNat(2)],
+          ],
+          ir1LitNat(0),
+        ),
+      ),
+      "cond g1 => 1, g2 => 2, true => 0",
+    );
+  });
+
+  it("formats is-nullish expressions", () => {
+    assert.equal(
+      formatIR1Expr(ir1IsNullish(ir1Member(ir1Var("user"), "User_name"))),
+      "nullish? User_name user",
+    );
+  });
+
+  it("formats each expressions", () => {
+    assert.equal(
+      formatIR1Expr(
+        ir1Each(
+          "n",
+          ir1Var("nums"),
+          [ir1Binop("gt", ir1Var("n"), ir1LitNat(0))],
+          ir1Binop("mul", ir1Var("n"), ir1LitNat(2)),
+        ),
+      ),
+      "each n in nums | (n * 2), when (n > 0)",
+    );
+  });
+
+  it("formats map-read expressions", () => {
+    assert.equal(
+      formatIR1Expr(
+        ir1MapRead(
+          "get",
+          "Score_value",
+          "Score_hasKey",
+          "Scoreboard",
+          "Player",
+          ir1Var("scores"),
+          ir1Var("player"),
+        ),
+      ),
+      "Score_value scores player",
+    );
+    assert.equal(
+      formatIR1Expr(
+        ir1MapRead(
+          "has",
+          "Score_value",
+          "Score_hasKey",
+          "Scoreboard",
+          "Player",
+          ir1Var("scores"),
+          ir1Var("player"),
+        ),
+      ),
+      "Score_hasKey scores player",
+    );
+  });
+
+  it("formats set-read expressions", () => {
+    assert.equal(
+      formatIR1Expr(
+        ir1SetRead(
+          "Group_members",
+          "Group",
+          "User",
+          ir1Var("group"),
+          ir1Var("user"),
+        ),
+      ),
+      "user in group",
+    );
+  });
+});


### PR DESCRIPTION
## Patch 1: Add formatIR1Expr — Pantagruel-flavored debug printer for IR1 expressions

- Create `tools/ts2pant/src/ir1-printer.ts`. Import only `IR1Expr` (and the `IR1Literal` / `IR1Binop` / `IR1Unop` types if needed for sub-dispatch) from `./ir1.js`. No dependency on `ir.ts`, `pant-ast.ts`, or `pant-wasm.ts` — the printer is L1-only.
- Implement `formatIR1Expr` as a pure exhaustive `switch` on `expr.kind`. Each arm returns a string; the function never throws on a well-typed input. Place an unreachable `default: const _exhaustive: never = expr; throw new Error(...)` arm at the end so adding a new IR1Expr variant in the future produces a compile-time error here.
- Render variables as `expr.name`, with a trailing `'` when `expr.primed === true` (Pantagruel primed-rule idiom).
- Render literals: `nat` → decimal digits; `bool` → `true` / `false`; `string` → JSON-quoted (`JSON.stringify`).
- Render `binop` as `(<lhs> <op-glyph> <rhs>)` with Pantagruel infix glyphs: `add` → `+`, `sub` → `-`, `mul` → `*`, `div` → `/`, `eq` → `=`, `neq` → `~=`, `lt` → `<`, `lte` → `<=`, `gt` → `>`, `gte` → `>=`, `and` → `and`, `or` → `or`, `in` → `in`. Provide a `binopGlyph(op): string` helper covering the IRBinop union exhaustively; throw on unknown. The outer parentheses make precedence explicit when the binop is itself a sub-expression of another binop, application, or member.
- Render `unop` Pantagruel-style: `not` → `~<arg>` (Pantagruel negation glyph), `neg` → `(-<arg>)`. Use a `unopGlyph` helper. No outer parens around `~x` since `~` is a tight prefix in Pantagruel; do wrap when `~` would chain with a binop (e.g. `(~x)` if part of a larger expression).
- Render `app` as Pantagruel prefix application: `<callee> <arg0> <arg1> ...` (space-separated, no parens around the call). Wrap any argument that is itself a binop, app, or cond in parentheses to preserve precedence. The callee is recursively formatted; if it is itself a binop or cond, wrap it too.
- Render `member` as `<name> <receiver>` (Pantagruel prefix function application — `obj.field` in TS is `field obj` in Pantagruel). Wrap the receiver in parens if it is itself a binop or another member chain.
- Render `cond` as `cond <g1> => <e1>, <g2> => <e2>, ..., true => <e_otherwise>` (Pantagruel multi-arm value-position conditional). The trailing arm uses guard `true` as Pantagruel idiom (see `samples/10-cond.pant`).
- Render `is-nullish` as `nullish? <operand>` — the trailing `?` is a Pantagruel-permitted suffix in lowercase rule names, and prefix application style fits the language.
- Render `each` as `each <binder> in <src> | <proj>` plus `, when <g1>, when <g2>, ...` for each guard, matching the L1 comprehension shape (already Pantagruel-like).
- Render `map-read` as Pantagruel prefix application: for `op: "get"`, `<ruleName> <receiver> <key>`; for `op: "has"`, `<keyPredName> <receiver> <key>` so the rule name reflects whether the read is value-bearing or membership-bearing. (`ruleName`, `keyPredName` are translation descriptors carried by the IR1 node.)
- Render `set-read` as `<elem> in <receiver>` (Pantagruel set membership).
- Create `tools/ts2pant/tests/ir1-printer.test.mts`. Import `assert from "node:assert/strict"`, `describe, it` from `"node:test"`, `formatIR1Expr` from `../src/ir1-printer.js`, plus the L1 constructors from `../src/ir1.js`. Add one `it` per IR1Expr kind. Each test constructs a small example and asserts the exact string output.
- Confirm `npm run test:unit -- tests/ir1-printer.test.mts` passes locally before declaring the patch done; confirm `npx tsc` succeeds with no new errors.

## Changes
- Create `tools/ts2pant/src/ir1-printer.ts`. Import only `IR1Expr` (and the `IR1Literal` / `IR1Binop` / `IR1Unop` types if needed for sub-dispatch) from `./ir1.js`. No dependency on `ir.ts`, `pant-ast.ts`, or `pant-wasm.ts` — the printer is L1-only.
- Implement `formatIR1Expr` as a pure exhaustive `switch` on `expr.kind`. Each arm returns a string; the function never throws on a well-typed input. Place an unreachable `default: const _exhaustive: never = expr; throw new Error(...)` arm at the end so adding a new IR1Expr variant in the future produces a compile-time error here.
- Render variables as `expr.name`, with a trailing `'` when `expr.primed === true` (Pantagruel primed-rule idiom).
- Render literals: `nat` → decimal digits; `bool` → `true` / `false`; `string` → JSON-quoted (`JSON.stringify`).
- Render `binop` as `(<lhs> <op-glyph> <rhs>)` with Pantagruel infix glyphs: `add` → `+`, `sub` → `-`, `mul` → `*`, `div` → `/`, `eq` → `=`, `neq` → `~=`, `lt` → `<`, `lte` → `<=`, `gt` → `>`, `gte` → `>=`, `and` → `and`, `or` → `or`, `in` → `in`. Provide a `binopGlyph(op): string` helper covering the IRBinop union exhaustively; throw on unknown. The outer parentheses make precedence explicit when the binop is itself a sub-expression of another binop, application, or member.
- Render `unop` Pantagruel-style: `not` → `~<arg>` (Pantagruel negation glyph), `neg` → `(-<arg>)`. Use a `unopGlyph` helper. No outer parens around `~x` since `~` is a tight prefix in Pantagruel; do wrap when `~` would chain with a binop (e.g. `(~x)` if part of a larger expression).
- Render `app` as Pantagruel prefix application: `<callee> <arg0> <arg1> ...` (space-separated, no parens around the call). Wrap any argument that is itself a binop, app, or cond in parentheses to preserve precedence. The callee is recursively formatted; if it is itself a binop or cond, wrap it too.
- Render `member` as `<name> <receiver>` (Pantagruel prefix function application — `obj.field` in TS is `field obj` in Pantagruel). Wrap the receiver in parens if it is itself a binop or another member chain.
- Render `cond` as `cond <g1> => <e1>, <g2> => <e2>, ..., true => <e_otherwise>` (Pantagruel multi-arm value-position conditional). The trailing arm uses guard `true` as Pantagruel idiom (see `samples/10-cond.pant`).
- Render `is-nullish` as `nullish? <operand>` — the trailing `?` is a Pantagruel-permitted suffix in lowercase rule names, and prefix application style fits the language.
- Render `each` as `each <binder> in <src> | <proj>` plus `, when <g1>, when <g2>, ...` for each guard, matching the L1 comprehension shape (already Pantagruel-like).
- Render `map-read` as Pantagruel prefix application: for `op: "get"`, `<ruleName> <receiver> <key>`; for `op: "has"`, `<keyPredName> <receiver> <key>` so the rule name reflects whether the read is value-bearing or membership-bearing. (`ruleName`, `keyPredName` are translation descriptors carried by the IR1 node.)
- Render `set-read` as `<elem> in <receiver>` (Pantagruel set membership).
- Create `tools/ts2pant/tests/ir1-printer.test.mts`. Import `assert from "node:assert/strict"`, `describe, it` from `"node:test"`, `formatIR1Expr` from `../src/ir1-printer.js`, plus the L1 constructors from `../src/ir1.js`. Add one `it` per IR1Expr kind. Each test constructs a small example and asserts the exact string output.
- Confirm `npm run test:unit -- tests/ir1-printer.test.mts` passes locally before declaring the patch done; confirm `npx tsc` succeeds with no new errors.

## Files to Modify
- tools/ts2pant/src/ir1-printer.ts (create): New module exporting `formatIR1Expr(expr: IR1Expr): string`. Exhaustive `switch (expr.kind)` over all 11 variants (`var`, `lit`, `binop`, `unop`, `app`, `member`, `cond`, `is-nullish`, `each`, `map-read`, `set-read`) with a `default: throw` arm and a `never`-typed exhaustiveness check. Binop/unop sub-expressions are parenthesized to make precedence explicit; literal booleans render as `true` / `false`; literal naturals render as decimal; variables render as `name` (with trailing `'` for `primed: true`). Conditionals render as `if g1 -> e1; g2 -> e2; otherwise -> e0`. `each` renders as `each n in src | proj` (with `, guard` for each guard). `map-read`/`set-read` render as `get(receiver, key)` / `has(receiver, key)` / `elem in receiver` so a reader can distinguish state-aware reads from pure ones.
- tools/ts2pant/tests/ir1-printer.test.mts (create): New test file. `describe("formatIR1Expr", ...)` with one `it` per IR1Expr variant. Each `it` constructs the variant via the existing `ir1Var`, `ir1LitNat`, `ir1Binop`, etc. constructors from `ir1.js` and asserts the formatted output via `assert.equal`. No snapshots — expressions are short enough to assert inline, and inline assertions read better in a PR diff.

## Gameplan Specification

```
module TS2PANT_IR1_SSA_PRINTER.

> Final-state spec for the IR1 SSA pretty printer. After both
> patches land, the project has a total, deterministic debug
> renderer for IR1 expressions and IR1 SSA programs. The printer
> is reusable from tests, debuggers, and ad-hoc developer
> scripts; it does not change any existing production output.
> Totality at every layer is a structural consequence of declaring
> the format-* functions as total; the propositions below assert
> determinism, version-label distinctness, and that pre-existing
> production emission is unchanged.

IR1Expr.
IR1SsaProgram.
Version.
Location.
Label.
Document.

versions p: IR1SsaProgram => [Version].
locations p: IR1SsaProgram => [Location].
label-of p: IR1SsaProgram, v: Version => Label.
format-expr x: IR1Expr => String.
format-location loc: Location => String.
format-program p: IR1SsaProgram => String.
emit-document d: Document => String.
emit-pre-printer d: Document => String.
---

> Determinism of expression rendering.
all x: IR1Expr, y: IR1Expr |
  x = y -> format-expr x = format-expr y.

> Determinism of program rendering.
all p: IR1SsaProgram, q: IR1SsaProgram |
  p = q -> format-program p = format-program q.

> Distinct versions in a program get distinct labels.
all p: IR1SsaProgram, v in versions p, w in versions p |
  v ~= w -> label-of p v ~= label-of p w.

> Production behaviour is untouched: the Pantagruel documents
> emitted by ts2pant are byte-identical before and after the
> printer is introduced.
all d: Document | emit-document d = emit-pre-printer d.
```

## Patch Specification

```
module TS2PANT_IR1_SSA_PRINTER_PATCH_1.

> Patch 1 introduces a total IR1 expression formatter. The contract
> is purely functional: every IR1Expr form has a defined string
> rendering, and the same input always produces the same output.
> Totality is a structural consequence of declaring format-ir1-expr
> as a total function from IR1Expr to String; the spec also asserts
> determinism (input equality implies output equality).

IR1Expr.
IR1ExprKind.
expr-var => IR1ExprKind.
expr-lit => IR1ExprKind.
expr-binop => IR1ExprKind.
expr-unop => IR1ExprKind.
expr-app => IR1ExprKind.
expr-member => IR1ExprKind.
expr-cond => IR1ExprKind.
expr-is-nullish => IR1ExprKind.
expr-each => IR1ExprKind.
expr-map-read => IR1ExprKind.
expr-set-read => IR1ExprKind.

kind-of x: IR1Expr => IR1ExprKind.
format-ir1-expr x: IR1Expr => String.
---

> Determinism of expression rendering.
all x: IR1Expr, y: IR1Expr |
  x = y -> format-ir1-expr x = format-ir1-expr y.
```


## Implementation Notes

- The actual `IR1Binop`/`IR1Unop` unions differ slightly from the gameplan prose: the source uses `le`/`ge` rather than `lte`/`gte`, and `IR1Unop` also includes `card`. The printer covers the real unions exhaustively, rendering `le`/`ge` as `<=`/`>=` and `card` as Pantagruel cardinality `#x`.
- Parenthesization avoids redundant double-wrapping where the recursive formatter already emits explicit parentheses, notably binop arguments in applications. This keeps outputs like `f x (y + 1)` rather than `f x ((y + 1))` while preserving precedence.
- `map-read`/`set-read` stay purely L1-debug formatting; no production emit path imports this module, so the “production behaviour untouched” clause is satisfied by isolation rather than by branching inside existing emit/lower code.

Spec/Evidence Mapping:
- Total expression dispatch: [tools/ts2pant/src/ir1-printer.ts](/Users/zax/worktrees/ts2pant-ir1-ssa-printer/patch-1/tools/ts2pant/src/ir1-printer.ts) switches over all 11 `IR1Expr.kind` variants with `never` exhaustiveness checks. Verified by `npx tsc`.
- Deterministic formatting: `formatIR1Expr` is pure and only derives strings from the input object. Covered by one inline assertion test per expression variant in [tools/ts2pant/tests/ir1-printer.test.mts](/Users/zax/worktrees/ts2pant-ir1-ssa-printer/patch-1/tools/ts2pant/tests/ir1-printer.test.mts).
- Required context consulted: `tools/ts2pant/src/ir1.ts` for the authoritative IR1 unions and constructors, `tools/ts2pant/tests/ir1-ssa-*.test.mts` for test style, and `tools/ts2pant/src/emit.ts`/WASM strExpr precedents for Pantagruel formatting conventions.
- Checks run: `npm run test:unit -- tests/ir1-printer.test.mts`, `npx tsx --test --test-timeout=300000 tests/ir1-printer.test.mts`, `npx tsc`, and `npx biome check src/ir1-printer.ts tests/ir1-printer.test.mts`.