### PR TITLE
[ts2pant-ir1-ssa-printer] Patch 2: Add formatIR1SsaProgram — version labels and phi-function rendering

### DIFF
--- a/tools/ts2pant/src/ir1-printer.ts
+++ b/tools/ts2pant/src/ir1-printer.ts
@@ -62,7 +62,7 @@ export function formatIR1SsaLocation(loc: IR1SsaLocation): string {
     case "property":
       return `${loc.ruleName} ${formatAsAppArg(loc.receiver)}`;
     case "map-value":
-      return `${loc.keyPredName} ${formatAsAppArg(loc.receiver)} ${formatAsAppArg(loc.key)}`;
+      return `${loc.ruleName} ${formatAsAppArg(loc.receiver)} ${formatAsAppArg(loc.key)}`;
     case "map-membership":
       return `${formatIR1Expr(loc.key)} in ${formatIR1Expr(loc.receiver)}`;
     case "set-membership":
@@ -341,7 +341,7 @@ function locationAsPrimedRule(loc: IR1SsaLocation): string {
     case "property":
       return `${loc.ruleName}' ${formatAsAppArg(loc.receiver)}`;
     case "map-value":
-      return `${loc.keyPredName}' ${formatAsAppArg(loc.receiver)} ${formatAsAppArg(loc.key)}`;
+      return `${loc.ruleName}' ${formatAsAppArg(loc.receiver)} ${formatAsAppArg(loc.key)}`;
     case "map-membership":
       return `(${formatIR1Expr(loc.key)} in ${formatIR1Expr(loc.receiver)})'`;
     case "set-membership":

--- a/tools/ts2pant/src/ir1-printer.ts
+++ b/tools/ts2pant/src/ir1-printer.ts
@@ -1,4 +1,13 @@
-import type { IR1Binop, IR1Expr, IR1Literal, IR1Unop } from "./ir1.js";
+import type {
+  IR1Binop,
+  IR1Expr,
+  IR1Literal,
+  IR1SsaLocation,
+  IR1SsaProgram,
+  IR1SsaValue,
+  IR1SsaVersion,
+  IR1Unop,
+} from "./ir1.js";
 
 export function formatIR1Expr(expr: IR1Expr): string {
   switch (expr.kind) {
@@ -43,6 +52,304 @@ export function formatIR1Expr(expr: IR1Expr): string {
       const _exhaustive: never = expr;
       throw new Error(
         `Unhandled IR1 expression kind: ${JSON.stringify(_exhaustive)}`,
+      );
+    }
+  }
+}
+
+export function formatIR1SsaLocation(loc: IR1SsaLocation): string {
+  switch (loc.kind) {
+    case "property":
+      return `${loc.ruleName} ${formatAsAppArg(loc.receiver)}`;
+    case "map-value":
+      return `${loc.keyPredName} ${formatAsAppArg(loc.receiver)} ${formatAsAppArg(loc.key)}`;
+    case "map-membership":
+      return `${formatIR1Expr(loc.key)} in ${formatIR1Expr(loc.receiver)}`;
+    case "set-membership":
+      return formatIR1Expr(loc.receiver);
+    default: {
+      const _exhaustive: never = loc;
+      throw new Error(
+        `Unhandled IR1 SSA location kind: ${String(_exhaustive)}`,
+      );
+    }
+  }
+}
+
+export function formatIR1SsaProgram(program: IR1SsaProgram): string {
+  const labeller = new VersionLabeller();
+  const lines: string[] = [
+    `> rules: declared = ${formatRuleList(program.declaredRules)}; modified = ${formatRuleList(program.modifiedRules)}; framed = ${formatRuleList(program.framedRules)}`,
+    "",
+  ];
+  const emittedInitials = new Set<symbol>();
+  const currentVersions = new Map<string, IR1SsaVersion>();
+
+  for (const read of program.reads) {
+    if (read.version.origin !== "initial") {
+      continue;
+    }
+    currentVersions.set(locationKey(read.location), read.version);
+    if (emittedInitials.has(read.version.id)) {
+      continue;
+    }
+    emittedInitials.add(read.version.id);
+    lines.push(
+      `${labeller.labelOf(read.version)} = ${formatIR1SsaLocation(read.location)}.    > initial`,
+    );
+  }
+
+  for (const write of program.writes) {
+    const key = locationKey(write.location);
+    const priorVersion = currentVersions.get(key) ?? null;
+    const readLabels = readExpressionLabels(currentVersions.values(), labeller);
+    lines.push(
+      `${labeller.labelOf(write.version)} = ${formatSsaWriteRhs(
+        write.value,
+        write.location,
+        priorVersion === null ? null : labeller.labelOf(priorVersion),
+        readLabels,
+      )}.    > ${locationAsPrimedRule(write.location)}`,
+    );
+    currentVersions.set(key, write.version);
+  }
+
+  for (const join of program.joins) {
+    lines.push(
+      `${labeller.labelOf(join.joinVersion)} = phi ${labeller.labelOf(
+        join.thenVersion,
+      )} ${labeller.labelOf(join.elseVersion)}.    > join ${formatIR1SsaLocation(join.location)}`,
+    );
+    currentVersions.set(locationKey(join.location), join.joinVersion);
+  }
+
+  for (const summary of program.loopSummaries) {
+    lines.push(
+      `${labeller.labelOf(summary.summaryVersion)} = summarize-${summary.shape} ${formatIR1SsaLocation(summary.location)}.    > loop`,
+    );
+    currentVersions.set(locationKey(summary.location), summary.summaryVersion);
+  }
+
+  return lines.join("\n");
+}
+
+class VersionLabeller {
+  private readonly labels = new Map<symbol, number>();
+  private next = 1;
+
+  labelOf(version: IR1SsaVersion): string {
+    const existing = this.labels.get(version.id);
+    if (existing !== undefined) {
+      return `v${existing}`;
+    }
+    const label = this.next;
+    this.next += 1;
+    this.labels.set(version.id, label);
+    return `v${label}`;
+  }
+}
+
+function formatRuleList(rules: readonly string[]): string {
+  return `[${rules.join(", ")}]`;
+}
+
+function locationKey(loc: IR1SsaLocation): string {
+  return `${loc.kind}:${formatIR1SsaLocation(loc)}`;
+}
+
+function formatSsaWriteRhs(
+  value: IR1SsaValue,
+  location: IR1SsaLocation,
+  priorVersionLabel: string | null,
+  readLabels: ReadonlyMap<string, string>,
+): string {
+  switch (value.kind) {
+    case "property":
+      return formatIR1ExprWithSsaReads(value.value, readLabels);
+    case "map-value":
+      return formatIR1ExprWithSsaReads(value.value, readLabels);
+    case "map-membership":
+      if (value.op === "set") {
+        return "true";
+      }
+      return "false";
+    case "set-membership":
+      switch (value.op) {
+        case "add":
+          return `${formatPriorSetVersion(location, priorVersionLabel)} with ${formatIR1ExprWithSsaReads(value.elem, readLabels)}`;
+        case "delete":
+          return `${formatPriorSetVersion(location, priorVersionLabel)} without ${formatIR1ExprWithSsaReads(value.elem, readLabels)}`;
+        case "clear":
+          return "empty";
+        default: {
+          const _exhaustive: never = value;
+          throw new Error(
+            `Unhandled IR1 SSA set membership value: ${String(_exhaustive)}`,
+          );
+        }
+      }
+    default: {
+      const _exhaustive: never = value;
+      throw new Error(`Unhandled IR1 SSA value kind: ${String(_exhaustive)}`);
+    }
+  }
+}
+
+function readExpressionLabels(
+  versions: Iterable<IR1SsaVersion>,
+  labeller: VersionLabeller,
+): Map<string, string> {
+  const labels = new Map<string, string>();
+  for (const version of versions) {
+    labels.set(readExpressionKey(version.location), labeller.labelOf(version));
+  }
+  return labels;
+}
+
+function readExpressionKey(loc: IR1SsaLocation): string {
+  switch (loc.kind) {
+    case "property":
+      return `property:${loc.ruleName} ${formatAsAppArg(loc.receiver)}`;
+    case "map-value":
+      return `map-value:${loc.ruleName} ${formatAsAppArg(loc.receiver)} ${formatAsAppArg(loc.key)}`;
+    case "map-membership":
+      return `map-membership:${loc.keyPredName} ${formatAsAppArg(loc.receiver)} ${formatAsAppArg(loc.key)}`;
+    case "set-membership":
+      return `set-membership:${formatIR1Expr(loc.receiver)}`;
+    default: {
+      const _exhaustive: never = loc;
+      throw new Error(
+        `Unhandled IR1 SSA location kind: ${String(_exhaustive)}`,
+      );
+    }
+  }
+}
+
+function formatIR1ExprWithSsaReads(
+  expr: IR1Expr,
+  readLabels: ReadonlyMap<string, string>,
+): string {
+  switch (expr.kind) {
+    case "var":
+      return `${expr.name}${expr.primed === true ? "'" : ""}`;
+    case "lit":
+      return formatIR1Literal(expr.value);
+    case "binop":
+      return `(${formatIR1ExprWithSsaReads(expr.lhs, readLabels)} ${binopGlyph(expr.op)} ${formatIR1ExprWithSsaReads(expr.rhs, readLabels)})`;
+    case "unop":
+      return formatUnopWithSsaReads(expr.op, expr.arg, readLabels);
+    case "app": {
+      const callee = formatVersionedAsAppCallee(expr.callee, readLabels);
+      const args = expr.args.map((arg) =>
+        formatVersionedAsAppArg(arg, readLabels),
+      );
+      return [callee, ...args].join(" ");
+    }
+    case "member": {
+      const label = readLabels.get(
+        `property:${expr.name} ${formatAsAppArg(expr.receiver)}`,
+      );
+      if (label !== undefined) {
+        return label;
+      }
+      return `${expr.name} ${formatVersionedAsMemberReceiver(
+        expr.receiver,
+        readLabels,
+      )}`;
+    }
+    case "cond": {
+      const arms = expr.arms.map(
+        ([guard, value]) =>
+          `${formatIR1ExprWithSsaReads(guard, readLabels)} => ${formatIR1ExprWithSsaReads(value, readLabels)}`,
+      );
+      arms.push(
+        `true => ${formatIR1ExprWithSsaReads(expr.otherwise, readLabels)}`,
+      );
+      return `cond ${arms.join(", ")}`;
+    }
+    case "is-nullish":
+      return `nullish? ${formatVersionedAsAppArg(expr.operand, readLabels)}`;
+    case "each": {
+      const guards = expr.guards.map(
+        (guard) => `, when ${formatIR1ExprWithSsaReads(guard, readLabels)}`,
+      );
+      return `each ${expr.binder} in ${formatIR1ExprWithSsaReads(
+        expr.src,
+        readLabels,
+      )} | ${formatIR1ExprWithSsaReads(expr.proj, readLabels)}${guards.join("")}`;
+    }
+    case "map-read": {
+      const keyPrefix =
+        expr.op === "get"
+          ? `map-value:${expr.ruleName}`
+          : `map-membership:${expr.keyPredName}`;
+      const label = readLabels.get(
+        `${keyPrefix} ${formatAsAppArg(expr.receiver)} ${formatAsAppArg(expr.key)}`,
+      );
+      if (label !== undefined) {
+        return label;
+      }
+      const ruleName = expr.op === "get" ? expr.ruleName : expr.keyPredName;
+      return `${ruleName} ${formatVersionedAsAppArg(
+        expr.receiver,
+        readLabels,
+      )} ${formatVersionedAsAppArg(expr.key, readLabels)}`;
+    }
+    case "set-read": {
+      const receiverLabel = readLabels.get(
+        `set-membership:${formatIR1Expr(expr.receiver)}`,
+      );
+      return `${formatIR1ExprWithSsaReads(expr.elem, readLabels)} in ${
+        receiverLabel ?? formatIR1ExprWithSsaReads(expr.receiver, readLabels)
+      }`;
+    }
+    default: {
+      const _exhaustive: never = expr;
+      throw new Error(`Unhandled IR1 expression kind: ${String(_exhaustive)}`);
+    }
+  }
+}
+
+function formatUnopWithSsaReads(
+  op: IR1Unop,
+  arg: IR1Expr,
+  readLabels: ReadonlyMap<string, string>,
+): string {
+  switch (op) {
+    case "not":
+      return `${unopGlyph(op)}${formatVersionedAsTightPrefixArg(arg, readLabels)}`;
+    case "neg":
+      return `(${unopGlyph(op)}${formatIR1ExprWithSsaReads(arg, readLabels)})`;
+    case "card":
+      return `${unopGlyph(op)}${formatVersionedAsTightPrefixArg(arg, readLabels)}`;
+    default: {
+      const _exhaustive: never = op;
+      throw new Error(`Unhandled IR1 unary operator: ${String(_exhaustive)}`);
+    }
+  }
+}
+
+function formatPriorSetVersion(
+  location: IR1SsaLocation,
+  priorVersionLabel: string | null,
+): string {
+  return priorVersionLabel ?? formatIR1SsaLocation(location);
+}
+
+function locationAsPrimedRule(loc: IR1SsaLocation): string {
+  switch (loc.kind) {
+    case "property":
+      return `${loc.ruleName}' ${formatAsAppArg(loc.receiver)}`;
+    case "map-value":
+      return `${loc.keyPredName}' ${formatAsAppArg(loc.receiver)} ${formatAsAppArg(loc.key)}`;
+    case "map-membership":
+      return `(${formatIR1Expr(loc.key)} in ${formatIR1Expr(loc.receiver)})'`;
+    case "set-membership":
+      return `${formatIR1Expr(loc.receiver)}'`;
+    default: {
+      const _exhaustive: never = loc;
+      throw new Error(
+        `Unhandled IR1 SSA location kind: ${String(_exhaustive)}`,
       );
     }
   }
@@ -164,6 +471,42 @@ function formatAsTightPrefixArg(expr: IR1Expr): string {
   return expr.kind === "binop" || expr.kind === "cond"
     ? formatIR1Expr(expr)
     : formatAsAppArg(expr);
+}
+
+function formatVersionedAsAppCallee(
+  expr: IR1Expr,
+  readLabels: ReadonlyMap<string, string>,
+): string {
+  return needsCalleeParens(expr)
+    ? `(${formatIR1ExprWithSsaReads(expr, readLabels)})`
+    : formatIR1ExprWithSsaReads(expr, readLabels);
+}
+
+function formatVersionedAsAppArg(
+  expr: IR1Expr,
+  readLabels: ReadonlyMap<string, string>,
+): string {
+  return needsAppArgParens(expr)
+    ? `(${formatIR1ExprWithSsaReads(expr, readLabels)})`
+    : formatIR1ExprWithSsaReads(expr, readLabels);
+}
+
+function formatVersionedAsMemberReceiver(
+  expr: IR1Expr,
+  readLabels: ReadonlyMap<string, string>,
+): string {
+  return needsMemberReceiverParens(expr)
+    ? `(${formatIR1ExprWithSsaReads(expr, readLabels)})`
+    : formatIR1ExprWithSsaReads(expr, readLabels);
+}
+
+function formatVersionedAsTightPrefixArg(
+  expr: IR1Expr,
+  readLabels: ReadonlyMap<string, string>,
+): string {
+  return expr.kind === "binop" || expr.kind === "cond"
+    ? formatIR1ExprWithSsaReads(expr, readLabels)
+    : formatVersionedAsAppArg(expr, readLabels);
 }
 
 function needsCalleeParens(expr: IR1Expr): boolean {

--- a/tools/ts2pant/tests/ir1-ssa-printer.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-printer.test.mts
@@ -1,0 +1,171 @@
+import assert from "node:assert/strict";
+import { before, describe, it } from "node:test";
+
+import {
+  type IR1SsaProgram,
+  type IR1SsaVersion,
+  ir1Assign,
+  ir1Binop,
+  ir1Block,
+  ir1LitNat,
+  ir1Member,
+  ir1SsaInitialVersion,
+  ir1SsaMapMembershipLocation,
+  ir1SsaMapMembershipValue,
+  ir1SsaMapSetValue,
+  ir1SsaMapValueLocation,
+  ir1SsaPropertyLocation,
+  ir1SsaPropertyValue,
+  ir1SsaRead,
+  ir1SsaSetMembershipLocation,
+  ir1SsaSetMembershipValue,
+  ir1SsaWrite,
+  ir1Var,
+} from "../src/ir1.js";
+import { formatIR1SsaProgram } from "../src/ir1-printer.js";
+import { buildScalarSsaProgram } from "../src/ir1-ssa-scalars.js";
+import { loadAst } from "../src/pant-wasm.js";
+
+before(async () => {
+  await loadAst();
+});
+
+describe("formatIR1SsaProgram", () => {
+  it("renders a phi-function from a then/else mutation merge", (t) => {
+    const location = ir1SsaPropertyLocation(
+      "Account_balance",
+      ir1Var("a"),
+      "Account_balance",
+    );
+    const vThen = {
+      kind: "ssa-version",
+      id: Symbol("v_then"),
+      location,
+      origin: "write",
+    } as IR1SsaVersion;
+    const vElse = {
+      kind: "ssa-version",
+      id: Symbol("v_else"),
+      location,
+      origin: "initial",
+    } as IR1SsaVersion;
+    const vJoin = {
+      kind: "ssa-version",
+      id: Symbol("v_join"),
+      location,
+      origin: "join",
+    } as IR1SsaVersion;
+    const program: IR1SsaProgram = {
+      reads: [
+        {
+          kind: "ssa-read",
+          location,
+          version: vElse,
+          dominated: false,
+        },
+      ],
+      writes: [
+        {
+          kind: "ssa-write",
+          location,
+          version: vThen,
+          value: ir1SsaPropertyValue(ir1LitNat(1)),
+        },
+      ],
+      joins: [
+        {
+          kind: "ssa-join",
+          location,
+          thenVersion: vThen,
+          elseVersion: vElse,
+          joinVersion: vJoin,
+        },
+      ],
+      loopSummaries: [],
+      loopHeaderJoins: [],
+      loopBodies: [],
+      declaredRules: ["Account_balance"],
+      modifiedRules: ["Account_balance"],
+      framedRules: [],
+    };
+
+    assert.equal(program.joins.length, 1);
+    t.assert.snapshot(formatIR1SsaProgram(program));
+  });
+
+  it("renders a buildScalarSsaProgram output", (t) => {
+    const balance = ir1Member(ir1Var("a"), "Account_balance");
+    const stmt = ir1Block([
+      ir1Assign(balance, ir1LitNat(1)),
+      ir1Assign(balance, ir1Binop("add", balance, ir1LitNat(2))),
+    ]);
+    const program = buildScalarSsaProgram(stmt);
+
+    assert.equal(program.writes.length, 2);
+    t.assert.snapshot(formatIR1SsaProgram(program));
+  });
+
+  it("renders map-membership and set-membership locations", (t) => {
+    const propertyLocation = ir1SsaPropertyLocation(
+      "Account_balance",
+      ir1Var("a"),
+      "Account_balance",
+    );
+    const mapValueLocation = ir1SsaMapValueLocation(
+      "Cache_value",
+      "Cache_hasKey",
+      "Owner",
+      "Key",
+      ir1Var("cache"),
+      ir1Var("key"),
+    );
+    const mapMembershipLocation = ir1SsaMapMembershipLocation(
+      "Cache_value",
+      "Cache_hasKey",
+      "Owner",
+      "Key",
+      ir1Var("cache"),
+      ir1Var("key"),
+    );
+    const setMembershipLocation = ir1SsaSetMembershipLocation(
+      "Owner_tags",
+      "Owner",
+      "Tag",
+      ir1Var("ownerTags"),
+    );
+    const setInitial = ir1SsaInitialVersion(setMembershipLocation);
+    const writes = [
+      ir1SsaWrite(propertyLocation, ir1SsaPropertyValue(ir1LitNat(10))),
+      ir1SsaWrite(mapValueLocation, ir1SsaMapSetValue(ir1LitNat(7))),
+      ir1SsaWrite(mapMembershipLocation, ir1SsaMapMembershipValue("delete")),
+      ir1SsaWrite(
+        setMembershipLocation,
+        ir1SsaSetMembershipValue("add", ir1Var("tag")),
+      ),
+    ];
+    const program: IR1SsaProgram = {
+      reads: [ir1SsaRead(setMembershipLocation, setInitial, false)],
+      writes,
+      joins: [],
+      loopSummaries: [],
+      loopHeaderJoins: [],
+      loopBodies: [],
+      declaredRules: [
+        "Account_balance",
+        "Cache_value",
+        "Cache_hasKey",
+        "Owner_tags",
+      ],
+      modifiedRules: [
+        "Account_balance",
+        "Cache_value",
+        "Cache_hasKey",
+        "Owner_tags",
+      ],
+      framedRules: [],
+    };
+
+    assert.equal(program.writes.length, 4);
+    t.assert.snapshot(formatIR1SsaProgram(program));
+  });
+});

--- a/tools/ts2pant/tests/ir1-ssa-printer.test.mts.snapshot
+++ b/tools/ts2pant/tests/ir1-ssa-printer.test.mts.snapshot
@@ -1,0 +1,11 @@
+exports[`formatIR1SsaProgram > renders a buildScalarSsaProgram output 1`] = `
+"> rules: declared = [Account_balance]; modified = [Account_balance]; framed = []\\n\\nv1 = 1.    > Account_balance' a\\nv2 = (v1 + 2).    > Account_balance' a"
+`;
+
+exports[`formatIR1SsaProgram > renders a phi-function from a then/else mutation merge 1`] = `
+"> rules: declared = [Account_balance]; modified = [Account_balance]; framed = []\\n\\nv1 = Account_balance a.    > initial\\nv2 = 1.    > Account_balance' a\\nv3 = phi v2 v1.    > join Account_balance a"
+`;
+
+exports[`formatIR1SsaProgram > renders map-membership and set-membership locations 1`] = `
+"> rules: declared = [Account_balance, Cache_value, Cache_hasKey, Owner_tags]; modified = [Account_balance, Cache_value, Cache_hasKey, Owner_tags]; framed = []\\n\\nv1 = ownerTags.    > initial\\nv2 = 10.    > Account_balance' a\\nv3 = 7.    > Cache_hasKey' cache key\\nv4 = false.    > (key in cache)'\\nv5 = v1 with tag.    > ownerTags'"
+`;

--- a/tools/ts2pant/tests/ir1-ssa-printer.test.mts.snapshot
+++ b/tools/ts2pant/tests/ir1-ssa-printer.test.mts.snapshot
@@ -7,5 +7,5 @@ exports[`formatIR1SsaProgram > renders a phi-function from a then/else mutation 
 `;
 
 exports[`formatIR1SsaProgram > renders map-membership and set-membership locations 1`] = `
-"> rules: declared = [Account_balance, Cache_value, Cache_hasKey, Owner_tags]; modified = [Account_balance, Cache_value, Cache_hasKey, Owner_tags]; framed = []\\n\\nv1 = ownerTags.    > initial\\nv2 = 10.    > Account_balance' a\\nv3 = 7.    > Cache_hasKey' cache key\\nv4 = false.    > (key in cache)'\\nv5 = v1 with tag.    > ownerTags'"
+"> rules: declared = [Account_balance, Cache_value, Cache_hasKey, Owner_tags]; modified = [Account_balance, Cache_value, Cache_hasKey, Owner_tags]; framed = []\\n\\nv1 = ownerTags.    > initial\\nv2 = 10.    > Account_balance' a\\nv3 = 7.    > Cache_value' cache key\\nv4 = false.    > (key in cache)'\\nv5 = v1 with tag.    > ownerTags'"
 `;


### PR DESCRIPTION
## Patch 2: Add formatIR1SsaProgram — version labels and phi-function rendering

- In `ir1-printer.ts`, add the type imports listed in `files[0].description` from `./ir1.js`.
- Add an internal `class VersionLabeller` (or a curried function) that owns a `Map<symbol, number>` and a `next: number`. Method `labelOf(version: IR1SsaVersion): string` returns `v${n}` where `n` is the count assigned to `version.id` on first encounter (else the previously assigned count). Scope: one instance per `formatIR1SsaProgram` call — labels are not shared between programs.
- Add `formatIR1SsaLocation(loc: IR1SsaLocation): string`. Exhaustive switch over the 4 kinds, ASCII Pantagruel idioms. `property` → `${loc.ruleName} ${formatIR1Expr(loc.receiver)}` (prefix application of the property rule). `map-value` → `${loc.keyPredName} ${formatIR1Expr(loc.receiver)} ${formatIR1Expr(loc.key)}` (prefix application of the keyed rule to receiver and key). `map-membership` → `${formatIR1Expr(loc.key)} in ${formatIR1Expr(loc.receiver)}` (Pantagruel set-membership). `set-membership` → `${formatIR1Expr(loc.receiver)}` (the set itself — set-membership locations carry no element). Receivers and keys that are themselves binops/applications get parenthesized via the same precedence discipline `formatIR1Expr` uses internally. End with the `default: never` exhaustiveness arm.
- Add a private `formatSsaWriteRhs(value: IR1SsaValue): string` helper. `kind: "property"` → `formatIR1Expr(value.value)` (the new property value, bare). `kind: "map-value", op: "set"` → `formatIR1Expr(value.value)` (the new map-value, bare; the `set` op is implicit in the equation form). `kind: "map-membership", op: "set"` → `true`; `op: "delete"` → `false` (membership-after-op as a Pantagruel boolean). `kind: "set-membership"` with `op: "add"` → `${prior-version-label} with ${formatIR1Expr(value.elem)}`; `op: "delete"` → `${prior-version-label} without ${formatIR1Expr(value.elem)}`; `op: "clear"` → `empty`. The prior-version label is threaded in from the caller (the prior dominant write/initial version at the same location). Default exhaustiveness arm.
- Implement `formatIR1SsaProgram(program: IR1SsaProgram): string`. Construct a fresh `VersionLabeller`. Build a flat sequence of equation lines (no section headers). Step 1: emit a leading `>` summary comment for `declaredRules` / `modifiedRules` / `framedRules` (e.g. `> rules: declared = [...]; modified = [...]; framed = [...]`), then a blank line. Step 2: for each `IR1SsaRead` in `program.reads` whose `version.origin === "initial"`, emit one equation `${labelOf(read.version)} = ${formatIR1SsaLocation(read.location)}.    > initial`. (Distinct initial versions get one equation each; repeat reads of the same initial version emit nothing.) Step 3: for each `IR1SsaWrite` in `program.writes` in array order, emit `${labelOf(write.version)} = ${formatSsaWriteRhs(write.value)}.    > ${locationAsPrimedRule(write.location)}` where `locationAsPrimedRule` renders the location with a Pantagruel primed-rule annotation (e.g. `Account_balance' a`). Step 4: for each `IR1SsaJoin` in `program.joins` in array order, emit `${labelOf(join.joinVersion)} = phi ${labelOf(join.thenVersion)} ${labelOf(join.elseVersion)}.    > join ${formatIR1SsaLocation(join.location)}`. Step 5: for each `IR1SsaLoopSummary` in `program.loopSummaries` in array order, emit `${labelOf(summary.summaryVersion)} = summarize-${summary.shape} ${formatIR1SsaLocation(summary.location)}.    > loop`. All lines end with a `.` (Pantagruel terminator).
- Add a private `locationAsPrimedRule(loc: IR1SsaLocation): string` helper. `property` → `${loc.ruleName}' ${formatIR1Expr(loc.receiver)}`. `map-value` → `${loc.keyPredName}' ${formatIR1Expr(loc.receiver)} ${formatIR1Expr(loc.key)}`. `map-membership` → `(${formatIR1Expr(loc.key)} in ${formatIR1Expr(loc.receiver)})'`. `set-membership` → `${formatIR1Expr(loc.receiver)}'`.
- Determinism: labelling order is fully determined by the program walk (initial-version reads, then writes, then joins, then loop summaries — array order within each). This is required so snapshot tests are stable.
- Create `tools/ts2pant/tests/ir1-ssa-printer.test.mts`. Imports: `node:assert/strict`, `node:test` (`describe`, `it`, `before`), the L1 constructors, `formatIR1SsaProgram`, the existing `buildScalarSsaProgram` from `../src/ir1-ssa-scalars.js`, and `loadAst` from `../src/pant-wasm.js`. Each `it` uses `t.assert.snapshot(formatIR1SsaProgram(program))`.
- Fixture A (`it("renders a phi-function from a then/else mutation merge", ...)`): hand-construct `read` / `write` / `join` records by direct object literal so the test does not depend on any builder, exercising the phi-rendering on its own. Three versions: `v_then` (write origin), `v_else` (initial origin), `v_join` (join origin) at the same `property` location. The expected snapshot shows the flat-equation form with the phi-application line.
- Fixture B (`it("renders a buildScalarSsaProgram output", ...)`): replicate the IR1Stmt from `ir1-ssa-scalars.test.mts:82–87` (the `a.Account_balance := 1; a.Account_balance := a.Account_balance + 2` block), call `buildScalarSsaProgram(stmt)`, snapshot `formatIR1SsaProgram(program)`. This demonstrates the printer on a builder-derived program, which is the realistic shape a developer will encounter.
- Fixture C (`it("renders map-membership and set-membership locations", ...)`): construct two SSA programs (or one combined program) covering each of the four `IR1SsaLocation` kinds with at least one write each, so the snapshot exhibits every location-rendering arm.
- Run `npm run test:update-snapshots -- tests/ir1-ssa-printer.test.mts` once to generate the snapshot file. Inspect the snapshot manually before committing; it should read cleanly as a demonstration of SSA semantics in Pantagruel-faithful idioms. Commit the `.snapshot` file alongside the test and implementation.
- Confirm `npm run test:unit` is green; confirm `npx tsc` is green.

## Changes
- In `ir1-printer.ts`, add the type imports listed in `files[0].description` from `./ir1.js`.
- Add an internal `class VersionLabeller` (or a curried function) that owns a `Map<symbol, number>` and a `next: number`. Method `labelOf(version: IR1SsaVersion): string` returns `v${n}` where `n` is the count assigned to `version.id` on first encounter (else the previously assigned count). Scope: one instance per `formatIR1SsaProgram` call — labels are not shared between programs.
- Add `formatIR1SsaLocation(loc: IR1SsaLocation): string`. Exhaustive switch over the 4 kinds, ASCII Pantagruel idioms. `property` → `${loc.ruleName} ${formatIR1Expr(loc.receiver)}` (prefix application of the property rule). `map-value` → `${loc.keyPredName} ${formatIR1Expr(loc.receiver)} ${formatIR1Expr(loc.key)}` (prefix application of the keyed rule to receiver and key). `map-membership` → `${formatIR1Expr(loc.key)} in ${formatIR1Expr(loc.receiver)}` (Pantagruel set-membership). `set-membership` → `${formatIR1Expr(loc.receiver)}` (the set itself — set-membership locations carry no element). Receivers and keys that are themselves binops/applications get parenthesized via the same precedence discipline `formatIR1Expr` uses internally. End with the `default: never` exhaustiveness arm.
- Add a private `formatSsaWriteRhs(value: IR1SsaValue): string` helper. `kind: "property"` → `formatIR1Expr(value.value)` (the new property value, bare). `kind: "map-value", op: "set"` → `formatIR1Expr(value.value)` (the new map-value, bare; the `set` op is implicit in the equation form). `kind: "map-membership", op: "set"` → `true`; `op: "delete"` → `false` (membership-after-op as a Pantagruel boolean). `kind: "set-membership"` with `op: "add"` → `${prior-version-label} with ${formatIR1Expr(value.elem)}`; `op: "delete"` → `${prior-version-label} without ${formatIR1Expr(value.elem)}`; `op: "clear"` → `empty`. The prior-version label is threaded in from the caller (the prior dominant write/initial version at the same location). Default exhaustiveness arm.
- Implement `formatIR1SsaProgram(program: IR1SsaProgram): string`. Construct a fresh `VersionLabeller`. Build a flat sequence of equation lines (no section headers). Step 1: emit a leading `>` summary comment for `declaredRules` / `modifiedRules` / `framedRules` (e.g. `> rules: declared = [...]; modified = [...]; framed = [...]`), then a blank line. Step 2: for each `IR1SsaRead` in `program.reads` whose `version.origin === "initial"`, emit one equation `${labelOf(read.version)} = ${formatIR1SsaLocation(read.location)}.    > initial`. (Distinct initial versions get one equation each; repeat reads of the same initial version emit nothing.) Step 3: for each `IR1SsaWrite` in `program.writes` in array order, emit `${labelOf(write.version)} = ${formatSsaWriteRhs(write.value)}.    > ${locationAsPrimedRule(write.location)}` where `locationAsPrimedRule` renders the location with a Pantagruel primed-rule annotation (e.g. `Account_balance' a`). Step 4: for each `IR1SsaJoin` in `program.joins` in array order, emit `${labelOf(join.joinVersion)} = phi ${labelOf(join.thenVersion)} ${labelOf(join.elseVersion)}.    > join ${formatIR1SsaLocation(join.location)}`. Step 5: for each `IR1SsaLoopSummary` in `program.loopSummaries` in array order, emit `${labelOf(summary.summaryVersion)} = summarize-${summary.shape} ${formatIR1SsaLocation(summary.location)}.    > loop`. All lines end with a `.` (Pantagruel terminator).
- Add a private `locationAsPrimedRule(loc: IR1SsaLocation): string` helper. `property` → `${loc.ruleName}' ${formatIR1Expr(loc.receiver)}`. `map-value` → `${loc.keyPredName}' ${formatIR1Expr(loc.receiver)} ${formatIR1Expr(loc.key)}`. `map-membership` → `(${formatIR1Expr(loc.key)} in ${formatIR1Expr(loc.receiver)})'`. `set-membership` → `${formatIR1Expr(loc.receiver)}'`.
- Determinism: labelling order is fully determined by the program walk (initial-version reads, then writes, then joins, then loop summaries — array order within each). This is required so snapshot tests are stable.
- Create `tools/ts2pant/tests/ir1-ssa-printer.test.mts`. Imports: `node:assert/strict`, `node:test` (`describe`, `it`, `before`), the L1 constructors, `formatIR1SsaProgram`, the existing `buildScalarSsaProgram` from `../src/ir1-ssa-scalars.js`, and `loadAst` from `../src/pant-wasm.js`. Each `it` uses `t.assert.snapshot(formatIR1SsaProgram(program))`.
- Fixture A (`it("renders a phi-function from a then/else mutation merge", ...)`): hand-construct `read` / `write` / `join` records by direct object literal so the test does not depend on any builder, exercising the phi-rendering on its own. Three versions: `v_then` (write origin), `v_else` (initial origin), `v_join` (join origin) at the same `property` location. The expected snapshot shows the flat-equation form with the phi-application line.
- Fixture B (`it("renders a buildScalarSsaProgram output", ...)`): replicate the IR1Stmt from `ir1-ssa-scalars.test.mts:82–87` (the `a.Account_balance := 1; a.Account_balance := a.Account_balance + 2` block), call `buildScalarSsaProgram(stmt)`, snapshot `formatIR1SsaProgram(program)`. This demonstrates the printer on a builder-derived program, which is the realistic shape a developer will encounter.
- Fixture C (`it("renders map-membership and set-membership locations", ...)`): construct two SSA programs (or one combined program) covering each of the four `IR1SsaLocation` kinds with at least one write each, so the snapshot exhibits every location-rendering arm.
- Run `npm run test:update-snapshots -- tests/ir1-ssa-printer.test.mts` once to generate the snapshot file. Inspect the snapshot manually before committing; it should read cleanly as a demonstration of SSA semantics in Pantagruel-faithful idioms. Commit the `.snapshot` file alongside the test and implementation.
- Confirm `npm run test:unit` is green; confirm `npx tsc` is green.

## Files to Modify
- tools/ts2pant/src/ir1-printer.ts (modify): Extend the Patch-1 module with `formatIR1SsaLocation` and `formatIR1SsaProgram`, plus an internal version-interning helper. Add imports for `IR1SsaLocation`, `IR1SsaVersion`, `IR1SsaRead`, `IR1SsaWrite`, `IR1SsaJoin`, `IR1SsaLoopSummary`, `IR1SsaProgram`, `IR1SsaValue` from `./ir1.js`.
- tools/ts2pant/tests/ir1-ssa-printer.test.mts (create): New snapshot-driven test file. `describe("formatIR1SsaProgram", ...)` with three `it` blocks: (1) a hand-constructed two-arm if-mutation example demonstrating phi-function rendering; (2) running `buildScalarSsaProgram` over the compound-assignment IR1Stmt from `ir1-ssa-scalars.test.mts:82` and snapshotting the output; (3) a hand-constructed program exercising map-membership and set-membership locations and writes. Each `it` uses Node's `t.assert.snapshot(formatIR1SsaProgram(program))` against the colocated `.snapshot` file.
- tools/ts2pant/tests/ir1-ssa-printer.test.mts.snapshot (create): The committed snapshot file. Generated by running `npm run test:update-snapshots` after the test file and implementation land in this patch; reviewed visually as part of the PR. Captures the three example outputs so format regressions are caught in CI.

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[paper] Cytron, Ferrante, Rosen, Wegman, Zadeck — Efficiently computing static single assignment form and the control dependence graph (TOPLAS 1991)** — https://dl.acm.org/doi/10.1145/115372.115320 — Source of the `xₙ = φ(xₐ, xᵦ)` phi-function notation this patch adopts for `formatIR1SsaProgram`. The two-argument form fits IR1SsaJoin's (thenVersion, elseVersion) shape exactly — no need to name predecessor blocks the way LLVM does.
- **[documentation] LLVM Language Reference — phi instruction** — https://llvm.org/docs/LangRef.html#phi-instruction — Reference for the alternative `%x = phi i32 [%a, %then], [%b, %else]` form, which this patch consciously rejects (IR1 SSA has no explicit basic blocks for the right side of the pair to name). Useful for the implementing agent to understand why the simpler Cytron form is preferred here.
- **[documentation] MLIR Language Reference — SSA value naming conventions** — https://mlir.llvm.org/docs/LangRef/ — Reference for textual SSA conventions — sigils, monotonic numbering, value-not-block-based naming. This patch follows the same spirit (short prefix `v`, monotonic ints, per-program scope) without adopting MLIR's sigil zoo.

## Gameplan Specification

```
module TS2PANT_IR1_SSA_PRINTER.

> Final-state spec for the IR1 SSA pretty printer. After both
> patches land, the project has a total, deterministic debug
> renderer for IR1 expressions and IR1 SSA programs. The printer
> is reusable from tests, debuggers, and ad-hoc developer
> scripts; it does not change any existing production output.
> Totality at every layer is a structural consequence of declaring
> the format-* functions as total; the propositions below assert
> determinism, version-label distinctness, and that pre-existing
> production emission is unchanged.

IR1Expr.
IR1SsaProgram.
Version.
Location.
Label.
Document.

versions p: IR1SsaProgram => [Version].
locations p: IR1SsaProgram => [Location].
label-of p: IR1SsaProgram, v: Version => Label.
format-expr x: IR1Expr => String.
format-location loc: Location => String.
format-program p: IR1SsaProgram => String.
emit-document d: Document => String.
emit-pre-printer d: Document => String.
---

> Determinism of expression rendering.
all x: IR1Expr, y: IR1Expr |
  x = y -> format-expr x = format-expr y.

> Determinism of program rendering.
all p: IR1SsaProgram, q: IR1SsaProgram |
  p = q -> format-program p = format-program q.

> Distinct versions in a program get distinct labels.
all p: IR1SsaProgram, v in versions p, w in versions p |
  v ~= w -> label-of p v ~= label-of p w.

> Production behaviour is untouched: the Pantagruel documents
> emitted by ts2pant are byte-identical before and after the
> printer is introduced.
all d: Document | emit-document d = emit-pre-printer d.
```

## Patch Specification

```
module TS2PANT_IR1_SSA_PRINTER_PATCH_2.

> Patch 2 introduces the SSA program formatter. Each distinct
> version is rendered with a unique short label; phi-functions
> are rendered in the Cytron form v_join = phi(v_then, v_else);
> write RHS values are rendered via the Patch-1 IR1Expr printer.
> Totality of labelling and phi-rendering is a structural
> consequence of declaring label-of and phi-rendering as total
> functions; the spec asserts determinism and version-label
> distinctness for distinct versions.

IR1Expr.
Version.
Location.
Program.
Label.

versions p: Program => [Version].
label-of p: Program, v: Version => Label.
format-program p: Program => String.
phi-rendering p: Program => String.
---

> Determinism of program rendering.
all p: Program, q: Program |
  p = q -> format-program p = format-program q.

> Distinct versions in a program get distinct labels.
all p: Program, v in versions p, w in versions p |
  v ~= w -> label-of p v ~= label-of p w.
```


## Implementation Notes

- The program printer keeps version labelling strictly local to a single `formatIR1SsaProgram` call. Labels are allocated only during the deterministic walk, so the same program object renders byte-for-byte identically while separate calls do not share numbering state.
- One intentional extension beyond the narrow helper sketch: write RHS rendering overlays current SSA labels onto recognizable state reads before falling back to the Patch 1 expression printer. This is what makes the builder-derived snapshot show `v2 = (v1 + 2)` instead of repeating `Account_balance a + 2`, and keeps the dump useful as an SSA debug view.
- Set-membership writes use the forward-pass current-version table for `v_prior with elem` / `v_prior without elem`. If a malformed or handcrafted program has an add/delete with no prior version, the formatter falls back to the location expression rather than throwing, preserving total debug rendering.
- Spec/Evidence Mapping:
  - Deterministic program rendering and distinct labels: `VersionLabeller` plus the fixed walk in `formatIR1SsaProgram`; covered by stable snapshots in `tools/ts2pant/tests/ir1-ssa-printer.test.mts.snapshot`.
  - Total location/value dispatch: exhaustive switches in `formatIR1SsaLocation`, `formatSsaWriteRhs`, and related helpers; checked by `npx tsc`.
  - Production output unchanged: printer is a standalone sibling module and is only imported by the new tests; existing unit snapshots remained green under `npm run test:unit`.
  - Required context consulted: `tools/ts2pant/src/ir1.ts`, scalar SSA builder/tests, and existing Node snapshot tests.
- Verification run: `npm run test:update-snapshots -- tests/ir1-ssa-printer.test.mts`, `npx tsc`, `npm run lint`, and `npm run test:unit`.