### PR TITLE
[ts2pant-bounded-counter-loop-lowering] Patch 3: Pending ts2pant tests for bounded counter loop SSA

### DIFF
--- a/tools/ts2pant/tests/ir1-ssa-counter-loop.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-counter-loop.test.mts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  ir1LitNat,
+  ir1SsaLoopBody,
+  ir1SsaTerminationMetric,
+  ir1Var,
+} from "../src/ir1.js";
+
+const pendingLoopBodySetup = ir1SsaLoopBody({
+  terminationMetric: ir1SsaTerminationMetric(ir1Var("remaining"), ir1LitNat(0)),
+});
+void pendingLoopBodySetup;
+
+describe("ir1-ssa-counter-loop", () => {
+  it.skip("builds a loop-header join per mutated location", () => {
+    // PENDING Patch 4: lowerCounterLoopL1Body opens one ir1SsaOpenLoopHeader per mutated location and back-patches each with the body's terminal write version.
+    assert.fail("PENDING Patch 4: loop-header joins per mutated location");
+  });
+
+  it.skip("attaches a termination metric to the loop body", () => {
+    // PENDING Patch 4: IR1SsaLoopBody.terminationMetric is non-null and references the counter and bound expressions.
+    assert.fail("PENDING Patch 4: termination metric");
+  });
+
+  it.skip(
+    "emits an over-each equation for an accumulator-fold body",
+    () => {
+      // PENDING Patch 4: propositions contain exactly one equation-kind PropResult per mutated location, with the counter as the over-each binder and the bound as a guard.
+      assert.fail("PENDING Patch 4: accumulator-fold over-each equation");
+    },
+  );
+
+  it.skip(
+    "emits a cond equation for a simple counter-only assign body",
+    () => {
+      // PENDING Patch 4: propositions contain a cond BOUND > 0 => F(BOUND - 1), true => prior equation rather than an over-each.
+      assert.fail("PENDING Patch 4: simple-assign cond equation");
+    },
+  );
+
+  it.skip("rejects non-literal init", () => {
+    // PENDING Patch 4: canonical counter loops require a literal-zero let binding in the for initializer.
+    assert.fail("PENDING Patch 4: reject non-literal init");
+  });
+
+  it.skip("rejects non-canonical step", () => {
+    // PENDING Patch 4: canonical counter loops require counter++ / ++counter / counter += 1 / counter = counter + 1.
+    assert.fail("PENDING Patch 4: reject non-canonical step");
+  });
+
+  it.skip("rejects body with accumulator self-recurrence", () => {
+    // PENDING Patch 4: bodies that read their own loop-header join version are rejected for L4 fixed-point handling.
+    assert.fail("PENDING Patch 4: reject accumulator self-recurrence");
+  });
+
+  it.skip("rejects body with effectful step expression", () => {
+    // PENDING Patch 4: counter-loop recognition rejects steps whose expression has non-counter side effects.
+    assert.fail("PENDING Patch 4: reject effectful step expression");
+  });
+});


### PR DESCRIPTION
## Patch 3: Pending ts2pant tests for bounded counter loop SSA

- Mirror the shape of `tools/ts2pant/tests/ir1-ssa-loop-contract.test.mts` (which lands in this same workstream's L1). Use `describe` from `node:test` and `node:assert/strict` for assertions.
- Add `it.skip("builds a loop-header join per mutated location", () => { /* PENDING Patch 4: lowerCounterLoopL1Body opens one ir1SsaOpenLoopHeader per mutated location and back-patches each with the body's terminal write version */ });`
- Add `it.skip("attaches a termination metric to the loop body", ...)` — verifies `IR1SsaLoopBody.terminationMetric` is non-null and references the counter and bound expressions.
- Add `it.skip("emits an over-each equation for an accumulator-fold body", ...)` — verifies the propositions array contains exactly one `equation`-kind PropResult per mutated location, with the counter as the over-each binder and the bound as a guard.
- Add `it.skip("emits a cond equation for a simple counter-only assign body", ...)` — verifies the propositions array contains a `(cond BOUND > 0 => F(BOUND - 1), true => prior)` equation rather than an over-each.
- Add `it.skip("rejects non-literal init", ...)`, `it.skip("rejects non-canonical step", ...)`, `it.skip("rejects body with accumulator self-recurrence", ...)`, `it.skip("rejects body with effectful step expression", ...)`.
- Each stub carries a `// PENDING Patch 4: <invariant>` comment.
- File compiles (does not reference any not-yet-existing symbol) and `bun run test` reports the stubs as skipped.

## Changes
- Mirror the shape of `tools/ts2pant/tests/ir1-ssa-loop-contract.test.mts` (which lands in this same workstream's L1). Use `describe` from `node:test` and `node:assert/strict` for assertions.
- Add `it.skip("builds a loop-header join per mutated location", () => { /* PENDING Patch 4: lowerCounterLoopL1Body opens one ir1SsaOpenLoopHeader per mutated location and back-patches each with the body's terminal write version */ });`
- Add `it.skip("attaches a termination metric to the loop body", ...)` — verifies `IR1SsaLoopBody.terminationMetric` is non-null and references the counter and bound expressions.
- Add `it.skip("emits an over-each equation for an accumulator-fold body", ...)` — verifies the propositions array contains exactly one `equation`-kind PropResult per mutated location, with the counter as the over-each binder and the bound as a guard.
- Add `it.skip("emits a cond equation for a simple counter-only assign body", ...)` — verifies the propositions array contains a `(cond BOUND > 0 => F(BOUND - 1), true => prior)` equation rather than an over-each.
- Add `it.skip("rejects non-literal init", ...)`, `it.skip("rejects non-canonical step", ...)`, `it.skip("rejects body with accumulator self-recurrence", ...)`, `it.skip("rejects body with effectful step expression", ...)`.
- Each stub carries a `// PENDING Patch 4: <invariant>` comment.
- File compiles (does not reference any not-yet-existing symbol) and `bun run test` reports the stubs as skipped.

## Files to Modify
- tools/ts2pant/tests/ir1-ssa-counter-loop.test.mts (create): New contract test file `describe("ir1-ssa-counter-loop", ...)` with `it.skip` stubs for the bounded counter loop SSA invariants. Imports existing IR1 SSA symbols for setup; does NOT import `lowerCounterLoopL1Body` (it doesn't exist yet).

## Gameplan Specification

```
module TS2PANT_BOUNDED_COUNTER_LOOP_LOWERING.

> ════════════════════════════════════════
> Milestone 2 of the ts2pant general-loop SSA workstream.
> ════════════════════════════════════════
> After this milestone, Pant `pant --check` accepts bounded numeric
> over-each comprehensions with an extractable upper-bound guard,
> ts2pant lowers canonical bounded TS counter loops via the L1 SSA
> vocabulary, three representative fixtures emit Pant that verifies
> end-to-end, and the contract is documented.

Location.
Version.
Expr.
ForStmt.
LoopHeaderJoin.
LoopBody.
TerminationMetric.
Proposition.
Fixture.
PantCheckResult.
NumericTy.
Comb.
Comprehension.
Document.
DocumentKind.
MilestoneStatus.
ClosedStatus.
open => ClosedStatus.
closed => ClosedStatus.
passed => PantCheckResult.
failed => PantCheckResult.
nat0-ty => NumericTy.
nat-ty => NumericTy.
int-ty => NumericTy.
add => Comb.
mul => Comb.
and-c => Comb.
or-c => Comb.
min-c => Comb.
max-c => Comb.
agents-md => DocumentKind.
workstream-doc => DocumentKind.
pending => MilestoneStatus.
landed => MilestoneStatus.

> Pant SMT layer.
binder-ty c: Comprehension => NumericTy.
upper-bound? c: Comprehension => Bool.
upper-bound-mentions-binder? c: Comprehension => Bool.
comb-of c: Comprehension => Comb.
body-is-binder? c: Comprehension => Bool.
rejected? c: Comprehension => Bool.

> ts2pant layer.
stmt-is-canonical-counter? f: ForStmt => Bool.
loop-body-of f: ForStmt => LoopBody.
body-header-joins b: LoopBody => [LoopHeaderJoin].
body-termination-metric b: LoopBody => TerminationMetric.
header-location h: LoopHeaderJoin => Location.
header-status h: LoopHeaderJoin => ClosedStatus.
metric-expr m: TerminationMetric => Expr.
emitted-propositions f: ForStmt => [Proposition].
proposition-references-counter? p: Proposition => Bool.

> Integration layer.
fixture-name f: Fixture => String.
emits-bounded-counter-equation? f: Fixture => Bool.
pant-typecheck-result f: Fixture => PantCheckResult.
pant-check-result f: Fixture => PantCheckResult.
fixture-count => Nat.

> Documentation layer.
document-kind d: Document => DocumentKind.
document-mentions-counter-loop-lowering? d: Document => Bool.
workstream-milestone-2-status => MilestoneStatus.
---

> Pant SMT acceptance.
all c: Comprehension |
  upper-bound? c and
  ~(upper-bound-mentions-binder? c) and
  ~(comb-of c = min-c and ~(upper-bound? c))
    -> ~(rejected? c).

all c: Comprehension |
  comb-of c = min-c and
  body-is-binder? c and
  ~(upper-bound? c)
    -> ~(rejected? c).

all c: Comprehension |
  ~(upper-bound? c) and
  ~(comb-of c = min-c and body-is-binder? c)
    -> rejected? c.

all c: Comprehension |
  upper-bound? c and upper-bound-mentions-binder? c
    -> rejected? c.

> ts2pant counter-loop SSA invariants.
all f: ForStmt |
  stmt-is-canonical-counter? f ->
    (all h in body-header-joins (loop-body-of f) |
       header-status h = closed).

all f: ForStmt |
  stmt-is-canonical-counter? f ->
    (all p in emitted-propositions f | proposition-references-counter? p).

> Fixture corpus.
all f: Fixture | emits-bounded-counter-equation? f.

all f: Fixture |
  pant-typecheck-result f = passed and
  pant-check-result f = passed.

fixture-count = 3.

> Documentation.
all d: Document |
  document-kind d = agents-md ->
    document-mentions-counter-loop-lowering? d.

all d: Document |
  document-kind d = workstream-doc ->
    document-mentions-counter-loop-lowering? d.

workstream-milestone-2-status = landed.
```

## Patch Specification

```
module TS2PANT_BOUNDED_COUNTER_LOOP_LOWERING_PATCH_3.

> Patch 3 introduces ts2pant SSA contract test stubs naming Patch 4.
> No runtime invariant changes.

TestStub.
InvariantFamily.
header-join-per-location => InvariantFamily.
termination-metric => InvariantFamily.
accumulator-fold-emission => InvariantFamily.
simple-assign-emission => InvariantFamily.
rejects-non-literal-init => InvariantFamily.
rejects-non-canonical-step => InvariantFamily.
rejects-self-recurrence => InvariantFamily.
rejects-effectful-step => InvariantFamily.

stub-for f: InvariantFamily => TestStub.
---
true.
```


## Implementation Notes

- Kept the new counter-loop suite intentionally non-binding: the skipped tests import only stable IR1 SSA constructors and do not reference the future `lowerCounterLoopL1Body` symbol, so Patch 3 can compile independently while naming the Patch 4 contract.
- Added `assert.fail(...)` inside each skipped body. This has no runtime effect while skipped, but makes accidental unskipping before implementation fail loudly with the specific pending invariant.
- The only setup code constructs a minimal `IR1SsaLoopBody` with an `IR1SsaTerminationMetric` from existing L1 SSA vocabulary; this satisfies the PR's setup-import requirement without asserting any behavior that belongs to Patch 4.
- Spec/Evidence Mapping: `stub-for` coverage maps to the eight `it.skip` cases in `tools/ts2pant/tests/ir1-ssa-counter-loop.test.mts`; required context consulted was `workstreams/ts2pant-general-loop-ssa.md`, `tools/ts2pant/src/ir1.ts`, and `tools/ts2pant/tests/ir1-ssa-loop-contract.test.mts`; verified with `bun run test` from `tools/ts2pant` (`fail 0`, unit skipped count includes these stubs).