### PR TITLE
[ts2pant-bounded-counter-loop-lowering] Patch 1: Pending Pant SMT tests for bounded numeric over-each

### DIFF
--- a/test/test_smt.ml
+++ b/test/test_smt.ml
@@ -1888,101 +1888,105 @@ let test_card_nat_comprehension_error () =
   check bool "refined diagnostic mentions μ-search or upper bound" true
     raised_with_hint
 
-let skip_pending_bounded_numeric_over_each () =
-  if Sys.getenv_opt "TS2PANT_RUN_PENDING_BOUNDED_NUMERIC_OVER_EACH" = None then
-    Alcotest.skip ()
+module Pending_bounded_numeric_over_each = struct
+  let test_bounded_sum_over_nat0_symbolic_bound () =
+    (* PENDING Patch 2: bounded Nat0 add-over-each with symbolic upper bound. *)
+    let env = Env.empty "" |> Env.add_var "n" Types.TyNat0 in
+    let expr =
+      Ast.make_each
+        [ { param_name = Lower "j"; param_type = TName (Upper "Nat0") } ]
+        [ GExpr (EBinop (OpLt, EVar (Lower "j"), EVar (Lower "n"))) ]
+        (Some CombAdd) (EVar (Lower "j"))
+    in
+    let result = Smt.translate_expr config env expr in
+    check bool "has +" true (contains result "(+")
 
-let test_bounded_sum_over_nat0_symbolic_bound () =
-  (* PENDING Patch 2: bounded Nat0 add-over-each with symbolic upper bound. *)
-  skip_pending_bounded_numeric_over_each ();
-  let env = Env.empty "" |> Env.add_var "n" Types.TyNat0 in
-  let expr =
-    Ast.make_each
-      [ { param_name = Lower "j"; param_type = TName (Upper "Nat0") } ]
-      [ GExpr (EBinop (OpLt, EVar (Lower "j"), EVar (Lower "n"))) ]
-      (Some CombAdd) (EVar (Lower "j"))
-  in
-  let result = Smt.translate_expr config env expr in
-  check bool "has +" true (contains result "(+")
+  let test_bounded_sum_over_nat0_concrete_bound () =
+    (* PENDING Patch 2: bounded Nat0 add-over-each with concrete upper bound. *)
+    let env = Env.empty "" in
+    let expr =
+      Ast.make_each
+        [ { param_name = Lower "j"; param_type = TName (Upper "Nat0") } ]
+        [ GExpr (EBinop (OpLt, EVar (Lower "j"), ELitNat 5)) ]
+        (Some CombAdd) (EVar (Lower "j"))
+    in
+    let result = Smt.translate_expr config env expr in
+    check bool "has +" true (contains result "(+")
 
-let test_bounded_sum_over_nat0_concrete_bound () =
-  (* PENDING Patch 2: bounded Nat0 add-over-each with concrete upper bound. *)
-  skip_pending_bounded_numeric_over_each ();
-  let env = Env.empty "" in
-  let expr =
-    Ast.make_each
-      [ { param_name = Lower "j"; param_type = TName (Upper "Nat0") } ]
-      [ GExpr (EBinop (OpLt, EVar (Lower "j"), ELitNat 5)) ]
-      (Some CombAdd) (EVar (Lower "j"))
-  in
-  let result = Smt.translate_expr config env expr in
-  check bool "has +" true (contains result "(+")
+  let test_bounded_and_over_nat0_bool_body () =
+    (* PENDING Patch 2: bounded Nat0 and-over-each with Bool body. *)
+    let env =
+      Env.empty ""
+      |> Env.add_var "n" Types.TyNat0
+      |> Env.add_rule "p?"
+           (Types.TyFunc ([ Types.TyNat0 ], Some Types.TyBool))
+           Ast.dummy_loc ~chapter:0
+    in
+    let expr =
+      Ast.make_each
+        [ { param_name = Lower "j"; param_type = TName (Upper "Nat0") } ]
+        [ GExpr (EBinop (OpLt, EVar (Lower "j"), EVar (Lower "n"))) ]
+        (Some CombAnd)
+        (EApp (EVar (Lower "p?"), [ EVar (Lower "j") ]))
+    in
+    let result = Smt.translate_expr config env expr in
+    check bool "has and" true (contains result "(and");
+    check bool "has predicate body" true (contains result "(pp")
 
-let test_bounded_and_over_nat0_bool_body () =
-  (* PENDING Patch 2: bounded Nat0 and-over-each with Bool body. *)
-  skip_pending_bounded_numeric_over_each ();
-  let env =
-    Env.empty ""
-    |> Env.add_var "n" Types.TyNat0
-    |> Env.add_rule "p?"
-         (Types.TyFunc ([ Types.TyNat0 ], Some Types.TyBool))
-         Ast.dummy_loc ~chapter:0
-  in
-  let expr =
-    Ast.make_each
-      [ { param_name = Lower "j"; param_type = TName (Upper "Nat0") } ]
-      [ GExpr (EBinop (OpLt, EVar (Lower "j"), EVar (Lower "n"))) ]
-      (Some CombAnd)
-      (EApp (EVar (Lower "p?"), [ EVar (Lower "j") ]))
-  in
-  let result = Smt.translate_expr config env expr in
-  check bool "has and" true (contains result "(and");
-  check bool "has predicate body" true (contains result "(pp")
+  let test_bounded_over_each_rejects_no_bound () =
+    (* PENDING Patch 2: bounded numeric over-each keeps the no-bound rejection. *)
+    let env = Env.empty "" in
+    let expr =
+      Ast.make_each
+        [ { param_name = Lower "j"; param_type = TName (Upper "Nat0") } ]
+        [] (Some CombAdd) (EVar (Lower "j"))
+    in
+    let raised_with_hint =
+      try
+        let _ = Smt.translate_expr config env expr in
+        false
+      with Failure msg ->
+        contains msg "unbounded Nat0" && contains msg "upper-bound guard"
+    in
+    check bool "unbounded numeric comprehension is rejected" true
+      raised_with_hint
 
-let test_bounded_over_each_rejects_no_bound () =
-  (* PENDING Patch 2: bounded numeric over-each keeps the no-bound rejection. *)
-  skip_pending_bounded_numeric_over_each ();
-  let env = Env.empty "" in
-  let expr =
-    Ast.make_each
-      [ { param_name = Lower "j"; param_type = TName (Upper "Nat0") } ]
-      [] (Some CombAdd) (EVar (Lower "j"))
-  in
-  let raised_with_hint =
-    try
-      let _ = Smt.translate_expr config env expr in
-      false
-    with Failure msg ->
-      contains msg "unbounded Nat0" && contains msg "upper-bound guard"
-  in
-  check bool "unbounded numeric comprehension is rejected" true raised_with_hint
+  let test_bounded_over_each_rejects_binder_in_bound () =
+    (* PENDING Patch 2: upper-bound guard must not mention the numeric binder. *)
+    let env = Env.empty "" in
+    let expr =
+      Ast.make_each
+        [ { param_name = Lower "j"; param_type = TName (Upper "Nat0") } ]
+        [
+          GExpr
+            (EBinop
+               ( OpLt,
+                 EVar (Lower "j"),
+                 EBinop (OpAdd, EVar (Lower "j"), ELitNat 1) ));
+        ]
+        (Some CombAdd) (EVar (Lower "j"))
+    in
+    let raised_with_refined_hint =
+      try
+        let _ = Smt.translate_expr config env expr in
+        false
+      with Failure msg ->
+        contains msg "upper-bound" && contains msg "binder"
+        && not (contains msg "unbounded Nat0")
+    in
+    check bool "binder-mentioning upper bound is rejected" true
+      raised_with_refined_hint
+end
 
-let test_bounded_over_each_rejects_binder_in_bound () =
-  (* PENDING Patch 2: upper-bound guard must not mention the numeric binder. *)
-  skip_pending_bounded_numeric_over_each ();
-  let env = Env.empty "" in
-  let expr =
-    Ast.make_each
-      [ { param_name = Lower "j"; param_type = TName (Upper "Nat0") } ]
-      [
-        GExpr
-          (EBinop
-             ( OpLt,
-               EVar (Lower "j"),
-               EBinop (OpAdd, EVar (Lower "j"), ELitNat 1) ));
-      ]
-      (Some CombAdd) (EVar (Lower "j"))
-  in
-  let raised_with_refined_hint =
-    try
-      let _ = Smt.translate_expr config env expr in
-      false
-    with Failure msg ->
-      contains msg "upper-bound" && contains msg "binder"
-      && not (contains msg "unbounded Nat0")
-  in
-  check bool "binder-mentioning upper bound is rejected" true
-    raised_with_refined_hint
+let _pending_bounded_numeric_over_each_stubs =
+  let module P = Pending_bounded_numeric_over_each in
+  [
+    P.test_bounded_sum_over_nat0_symbolic_bound;
+    P.test_bounded_sum_over_nat0_concrete_bound;
+    P.test_bounded_and_over_nat0_bool_body;
+    P.test_bounded_over_each_rejects_no_bound;
+    P.test_bounded_over_each_rejects_binder_in_bound;
+  ]
 
 let comprehension_tests =
   [
@@ -2013,16 +2017,6 @@ let comprehension_tests =
     test_case "μ-search max rejected" `Quick test_mu_search_max_rejected;
     test_case "card nat comprehension error" `Quick
       test_card_nat_comprehension_error;
-    test_case "bounded sum over Nat0 symbolic bound" `Quick
-      test_bounded_sum_over_nat0_symbolic_bound;
-    test_case "bounded sum over Nat0 concrete bound" `Quick
-      test_bounded_sum_over_nat0_concrete_bound;
-    test_case "bounded and over Nat0 bool body" `Quick
-      test_bounded_and_over_nat0_bool_body;
-    test_case "bounded over-each rejects no bound" `Quick
-      test_bounded_over_each_rejects_no_bound;
-    test_case "bounded over-each rejects binder in bound" `Quick
-      test_bounded_over_each_rejects_binder_in_bound;
   ]
 
 (* --- Closure tests --- *)

--- a/test/test_smt.ml
+++ b/test/test_smt.ml
@@ -1888,6 +1888,102 @@ let test_card_nat_comprehension_error () =
   check bool "refined diagnostic mentions μ-search or upper bound" true
     raised_with_hint
 
+let skip_pending_bounded_numeric_over_each () =
+  if Sys.getenv_opt "TS2PANT_RUN_PENDING_BOUNDED_NUMERIC_OVER_EACH" = None then
+    Alcotest.skip ()
+
+let test_bounded_sum_over_nat0_symbolic_bound () =
+  (* PENDING Patch 2: bounded Nat0 add-over-each with symbolic upper bound. *)
+  skip_pending_bounded_numeric_over_each ();
+  let env = Env.empty "" |> Env.add_var "n" Types.TyNat0 in
+  let expr =
+    Ast.make_each
+      [ { param_name = Lower "j"; param_type = TName (Upper "Nat0") } ]
+      [ GExpr (EBinop (OpLt, EVar (Lower "j"), EVar (Lower "n"))) ]
+      (Some CombAdd) (EVar (Lower "j"))
+  in
+  let result = Smt.translate_expr config env expr in
+  check bool "has +" true (contains result "(+")
+
+let test_bounded_sum_over_nat0_concrete_bound () =
+  (* PENDING Patch 2: bounded Nat0 add-over-each with concrete upper bound. *)
+  skip_pending_bounded_numeric_over_each ();
+  let env = Env.empty "" in
+  let expr =
+    Ast.make_each
+      [ { param_name = Lower "j"; param_type = TName (Upper "Nat0") } ]
+      [ GExpr (EBinop (OpLt, EVar (Lower "j"), ELitNat 5)) ]
+      (Some CombAdd) (EVar (Lower "j"))
+  in
+  let result = Smt.translate_expr config env expr in
+  check bool "has +" true (contains result "(+")
+
+let test_bounded_and_over_nat0_bool_body () =
+  (* PENDING Patch 2: bounded Nat0 and-over-each with Bool body. *)
+  skip_pending_bounded_numeric_over_each ();
+  let env =
+    Env.empty ""
+    |> Env.add_var "n" Types.TyNat0
+    |> Env.add_rule "p?"
+         (Types.TyFunc ([ Types.TyNat0 ], Some Types.TyBool))
+         Ast.dummy_loc ~chapter:0
+  in
+  let expr =
+    Ast.make_each
+      [ { param_name = Lower "j"; param_type = TName (Upper "Nat0") } ]
+      [ GExpr (EBinop (OpLt, EVar (Lower "j"), EVar (Lower "n"))) ]
+      (Some CombAnd)
+      (EApp (EVar (Lower "p?"), [ EVar (Lower "j") ]))
+  in
+  let result = Smt.translate_expr config env expr in
+  check bool "has and" true (contains result "(and");
+  check bool "has predicate body" true (contains result "(pp")
+
+let test_bounded_over_each_rejects_no_bound () =
+  (* PENDING Patch 2: bounded numeric over-each keeps the no-bound rejection. *)
+  skip_pending_bounded_numeric_over_each ();
+  let env = Env.empty "" in
+  let expr =
+    Ast.make_each
+      [ { param_name = Lower "j"; param_type = TName (Upper "Nat0") } ]
+      [] (Some CombAdd) (EVar (Lower "j"))
+  in
+  let raised_with_hint =
+    try
+      let _ = Smt.translate_expr config env expr in
+      false
+    with Failure msg ->
+      contains msg "unbounded Nat0" && contains msg "upper-bound guard"
+  in
+  check bool "unbounded numeric comprehension is rejected" true raised_with_hint
+
+let test_bounded_over_each_rejects_binder_in_bound () =
+  (* PENDING Patch 2: upper-bound guard must not mention the numeric binder. *)
+  skip_pending_bounded_numeric_over_each ();
+  let env = Env.empty "" in
+  let expr =
+    Ast.make_each
+      [ { param_name = Lower "j"; param_type = TName (Upper "Nat0") } ]
+      [
+        GExpr
+          (EBinop
+             ( OpLt,
+               EVar (Lower "j"),
+               EBinop (OpAdd, EVar (Lower "j"), ELitNat 1) ));
+      ]
+      (Some CombAdd) (EVar (Lower "j"))
+  in
+  let raised_with_refined_hint =
+    try
+      let _ = Smt.translate_expr config env expr in
+      false
+    with Failure msg ->
+      contains msg "upper-bound" && contains msg "binder"
+      && not (contains msg "unbounded Nat0")
+  in
+  check bool "binder-mentioning upper bound is rejected" true
+    raised_with_refined_hint
+
 let comprehension_tests =
   [
     test_case "in each comprehension" `Quick test_in_each_comprehension;
@@ -1917,6 +2013,16 @@ let comprehension_tests =
     test_case "μ-search max rejected" `Quick test_mu_search_max_rejected;
     test_case "card nat comprehension error" `Quick
       test_card_nat_comprehension_error;
+    test_case "bounded sum over Nat0 symbolic bound" `Quick
+      test_bounded_sum_over_nat0_symbolic_bound;
+    test_case "bounded sum over Nat0 concrete bound" `Quick
+      test_bounded_sum_over_nat0_concrete_bound;
+    test_case "bounded and over Nat0 bool body" `Quick
+      test_bounded_and_over_nat0_bool_body;
+    test_case "bounded over-each rejects no bound" `Quick
+      test_bounded_over_each_rejects_no_bound;
+    test_case "bounded over-each rejects binder in bound" `Quick
+      test_bounded_over_each_rejects_binder_in_bound;
   ]
 
 (* --- Closure tests --- *)


### PR DESCRIPTION
## Patch 1: Pending Pant SMT tests for bounded numeric over-each

- Inspect `test/test_smt.ml` to confirm the project's preferred skip pattern (whether `Alcotest.skip ()`, a leading `assert false |> ignore`, or a custom helper) and use the same idiom.
- Add `test_bounded_sum_over_nat0_symbolic_bound`: builds an `EEach` over `j: Nat0` with guard `j < n` (where `n` is a free `Nat0` parameter declared in the env), CombAdd, body `j`. Asserts the SMT translation succeeds and the result is a well-formed `(+ ...)` expression. Body is currently `Alcotest.skip ()` / equivalent.
- Add `test_bounded_sum_over_nat0_concrete_bound`: same but with guard `j < 5`. Currently skipped.
- Add `test_bounded_and_over_nat0_bool_body`: comb=And, body is a Bool-typed application `p? j`. Currently skipped.
- Add `test_bounded_over_each_rejects_no_bound`: comb=Add over `j: Nat0`, no guards. Asserts the existing unbounded-Nat0 diagnostic still fires. Currently skipped.
- Add `test_bounded_over_each_rejects_binder_in_bound`: comb=Add over `j: Nat0`, guard `j < j + 1`. Asserts a refined diagnostic distinct from the no-bound case. Currently skipped.
- Register all five tests in the `comprehension_tests` list.
- Run `dune build @runtest` and confirm the new tests are reported as skipped, not failed.

## Changes
- Inspect `test/test_smt.ml` to confirm the project's preferred skip pattern (whether `Alcotest.skip ()`, a leading `assert false |> ignore`, or a custom helper) and use the same idiom.
- Add `test_bounded_sum_over_nat0_symbolic_bound`: builds an `EEach` over `j: Nat0` with guard `j < n` (where `n` is a free `Nat0` parameter declared in the env), CombAdd, body `j`. Asserts the SMT translation succeeds and the result is a well-formed `(+ ...)` expression. Body is currently `Alcotest.skip ()` / equivalent.
- Add `test_bounded_sum_over_nat0_concrete_bound`: same but with guard `j < 5`. Currently skipped.
- Add `test_bounded_and_over_nat0_bool_body`: comb=And, body is a Bool-typed application `p? j`. Currently skipped.
- Add `test_bounded_over_each_rejects_no_bound`: comb=Add over `j: Nat0`, no guards. Asserts the existing unbounded-Nat0 diagnostic still fires. Currently skipped.
- Add `test_bounded_over_each_rejects_binder_in_bound`: comb=Add over `j: Nat0`, guard `j < j + 1`. Asserts a refined diagnostic distinct from the no-bound case. Currently skipped.
- Register all five tests in the `comprehension_tests` list.
- Run `dune build @runtest` and confirm the new tests are reported as skipped, not failed.

## Files to Modify
- test/test_smt.ml (modify): Add five new pending unit tests for bounded numeric over-each comprehensions: symbolic upper bound (`i < n`), concrete upper bound (`i < 5`), Bool combs (and/or), missing upper bound rejection, binder-mentioning bound rejection. Each test uses the existing `Alcotest.test_case` shape with a `Quick` speed marker and is wired into the `comprehension_tests` list, but the test body is wrapped in a `Alcotest.skip ()` (or equivalent project pattern) with a `(* PENDING Patch 2: <description> *)` comment.

## Gameplan Specification

```
module TS2PANT_BOUNDED_COUNTER_LOOP_LOWERING.

> ════════════════════════════════════════
> Milestone 2 of the ts2pant general-loop SSA workstream.
> ════════════════════════════════════════
> After this milestone, Pant `pant --check` accepts bounded numeric
> over-each comprehensions with an extractable upper-bound guard,
> ts2pant lowers canonical bounded TS counter loops via the L1 SSA
> vocabulary, three representative fixtures emit Pant that verifies
> end-to-end, and the contract is documented.

Location.
Version.
Expr.
ForStmt.
LoopHeaderJoin.
LoopBody.
TerminationMetric.
Proposition.
Fixture.
PantCheckResult.
NumericTy.
Comb.
Comprehension.
Document.
DocumentKind.
MilestoneStatus.
ClosedStatus.
open => ClosedStatus.
closed => ClosedStatus.
passed => PantCheckResult.
failed => PantCheckResult.
nat0-ty => NumericTy.
nat-ty => NumericTy.
int-ty => NumericTy.
add => Comb.
mul => Comb.
and-c => Comb.
or-c => Comb.
min-c => Comb.
max-c => Comb.
agents-md => DocumentKind.
workstream-doc => DocumentKind.
pending => MilestoneStatus.
landed => MilestoneStatus.

> Pant SMT layer.
binder-ty c: Comprehension => NumericTy.
upper-bound? c: Comprehension => Bool.
upper-bound-mentions-binder? c: Comprehension => Bool.
comb-of c: Comprehension => Comb.
body-is-binder? c: Comprehension => Bool.
rejected? c: Comprehension => Bool.

> ts2pant layer.
stmt-is-canonical-counter? f: ForStmt => Bool.
loop-body-of f: ForStmt => LoopBody.
body-header-joins b: LoopBody => [LoopHeaderJoin].
body-termination-metric b: LoopBody => TerminationMetric.
header-location h: LoopHeaderJoin => Location.
header-status h: LoopHeaderJoin => ClosedStatus.
metric-expr m: TerminationMetric => Expr.
emitted-propositions f: ForStmt => [Proposition].
proposition-references-counter? p: Proposition => Bool.

> Integration layer.
fixture-name f: Fixture => String.
emits-bounded-counter-equation? f: Fixture => Bool.
pant-typecheck-result f: Fixture => PantCheckResult.
pant-check-result f: Fixture => PantCheckResult.
fixture-count => Nat.

> Documentation layer.
document-kind d: Document => DocumentKind.
document-mentions-counter-loop-lowering? d: Document => Bool.
workstream-milestone-2-status => MilestoneStatus.
---

> Pant SMT acceptance.
all c: Comprehension |
  upper-bound? c and
  ~(upper-bound-mentions-binder? c) and
  ~(comb-of c = min-c and ~(upper-bound? c))
    -> ~(rejected? c).

all c: Comprehension |
  comb-of c = min-c and
  body-is-binder? c and
  ~(upper-bound? c)
    -> ~(rejected? c).

all c: Comprehension |
  ~(upper-bound? c) and
  ~(comb-of c = min-c and body-is-binder? c)
    -> rejected? c.

all c: Comprehension |
  upper-bound? c and upper-bound-mentions-binder? c
    -> rejected? c.

> ts2pant counter-loop SSA invariants.
all f: ForStmt |
  stmt-is-canonical-counter? f ->
    (all h in body-header-joins (loop-body-of f) |
       header-status h = closed).

all f: ForStmt |
  stmt-is-canonical-counter? f ->
    (all p in emitted-propositions f | proposition-references-counter? p).

> Fixture corpus.
all f: Fixture | emits-bounded-counter-equation? f.

all f: Fixture |
  pant-typecheck-result f = passed and
  pant-check-result f = passed.

fixture-count = 3.

> Documentation.
all d: Document |
  document-kind d = agents-md ->
    document-mentions-counter-loop-lowering? d.

all d: Document |
  document-kind d = workstream-doc ->
    document-mentions-counter-loop-lowering? d.

workstream-milestone-2-status = landed.
```

## Patch Specification

```
module TS2PANT_BOUNDED_COUNTER_LOOP_LOWERING_PATCH_1.

> Patch 1 lands skipped SMT unit-test stubs naming Patch 2. No runtime
> invariant changes.

TestStub.
InvariantFamily.
bounded-numeric-symbolic => InvariantFamily.
bounded-numeric-concrete => InvariantFamily.
bounded-numeric-bool-body => InvariantFamily.
bounded-numeric-rejects-no-bound => InvariantFamily.
bounded-numeric-rejects-binder-in-bound => InvariantFamily.

stub-for f: InvariantFamily => TestStub.
---
true.
```


## Implementation Notes

- After review, the pending bounded numeric over-each cases are no longer registered with Alcotest and no runtime skip gate remains. They live in `Pending_bounded_numeric_over_each` and are referenced from an underscore-prefixed list so the bodies still compile without executing.
- This intentionally deviates from the original skipped-test wording to satisfy the repo guideline that committed tests should not be skipped. Patch 2 can promote these functions into `comprehension_tests` when the SMT implementation exists.
- Spec/Evidence Mapping: the five `stub-for` invariant families map to the five pending `test_bounded_*` functions in `test/test_smt.ml`; the required SMT context was checked in `lib/smt_expr.ml`, `lib/smt.ml`, and `lib/smt_types.ml`; `dune build @runtest` passes with no skipped bounded numeric tests in the registered suite.