### PR TITLE
[ts2pant-bounded-counter-loop-lowering] Patch 2: Pant SMT: bounded numeric over-each enumeration

### DIFF
--- a/lib/smt.ml
+++ b/lib/smt.ml
@@ -674,12 +674,17 @@ and translate_aggregate config env (comb : combiner) params guards body =
         match resolve_numeric_comprehension_binding env params with
         | Error _ -> None
         | Ok (binder_name, binder_ty, bindings) -> (
+            let has_upper_bound =
+              match params with
+              | [ p ] -> Option.is_some (extract_upper_bound p guards)
+              | _ -> false
+            in
             let all_gexpr =
               List.for_all
                 (function GExpr _ -> true | GIn _ | GParam _ -> false)
                 guards
             in
-            if not all_gexpr then None
+            if has_upper_bound || not all_gexpr then None
             else
               match[@warning "-4"] body with
               | EVar (Lower n) when n = binder_name ->
@@ -772,8 +777,47 @@ and translate_aggregate_finite config env inner_config (comb : combiner) params
           | GExpr _ -> [])
         guards
   in
+  (* Infer body type to choose correct SMT sort for identity values *)
+  let body_is_real =
+    match resolve_comprehension_binding env params guards with
+    | Ok (Domain { bindings; _ } | Numeric { bindings; _ }) -> (
+        let env_inner = Env.with_vars bindings env in
+        match
+          Check.infer_type { Check.env = env_inner; loc = dummy_loc } body
+        with
+        | Ok TyReal -> true
+        | Ok
+            ( TyBool | TyNat | TyNat0 | TyInt | TyString | TyNothing
+            | TyDomain _ | TyList _ | TyProduct _ | TySum _ | TyFunc _ )
+        | Error _ ->
+            false)
+    | Error _ -> false
+  in
+  let aggregate_neutral =
+    match comb with
+    | CombAdd -> Some (if body_is_real then "0.0" else "0")
+    | CombMul -> Some (if body_is_real then "1.0" else "1")
+    | CombAnd -> Some "true"
+    | CombOr -> Some "false"
+    | CombMin -> Some "2147483648"
+    | CombMax -> Some "(- 2147483648)"
+  in
+  let guards_for_expand =
+    if not config.inject_guards then guards
+    else
+      match resolve_comprehension_binding env params guards with
+      | Ok (Numeric { bindings; _ }) ->
+          let env_inner = Env.with_vars bindings env in
+          let bound_names = local_bound @ config.quant_bound in
+          let app_guards =
+            collect_body_guards ~bound:bound_names env_inner body
+          in
+          guards @ List.map (fun e -> GExpr e) app_guards
+      | Ok (Domain _) | Error _ -> guards
+  in
   let expanded =
-    expand_comprehension translate_expr inner_config env params guards body
+    expand_comprehension ?numeric_neutral:aggregate_neutral translate_expr
+      inner_config env params guards_for_expand body
   in
   (* Inject declaration guards from guarded rule applications in the body *)
   let expanded =
@@ -781,7 +825,8 @@ and translate_aggregate_finite config env inner_config (comb : combiner) params
     else
       match resolve_comprehension_binding env params guards with
       | Error _ -> expanded
-      | Ok (var_name, dname, _, bindings) ->
+      | Ok (Numeric _) -> expanded
+      | Ok (Domain { name = var_name; domain = dname; bindings; _ }) ->
           let env_inner = Env.with_vars bindings env in
           let bound_names = local_bound @ config.quant_bound in
           let app_guards =
@@ -812,22 +857,10 @@ and translate_aggregate_finite config env inner_config (comb : combiner) params
                 (merged, value_str))
               expanded elems
   in
-  (* Infer body type to choose correct SMT sort for identity values *)
-  let body_is_real =
-    match resolve_comprehension_binding env params guards with
-    | Ok (_, _, _, bindings) -> (
-        let env_inner = Env.with_vars bindings env in
-        match
-          Check.infer_type { Check.env = env_inner; loc = dummy_loc } body
-        with
-        | Ok TyReal -> true
-        | Ok
-            ( TyBool | TyNat | TyNat0 | TyInt | TyString | TyNothing
-            | TyDomain _ | TyList _ | TyProduct _ | TySum _ | TyFunc _ )
-        | Error _ ->
-            false)
-    | Error _ -> false
-  in
+  (* Aggregate identities / numeric neutrals:
+      + -> 0, * -> 1, and -> true, or -> false, min -> large positive
+      sentinel, max -> large negative sentinel. Numeric comprehensions use
+      these as the inactive branch for config-bounded ite enumeration. *)
   let smt_op_and_identity =
     match comb with
     | CombAdd -> Some ("+", if body_is_real then "0.0" else "0")

--- a/lib/smt_expr.ml
+++ b/lib/smt_expr.ml
@@ -11,6 +11,75 @@ open Types
 open Smt_types
 open Smt_preamble
 
+(** A comprehension binding can enumerate a finite domain, or a bounded numeric
+    range. Numeric ranges use [config.bound] for symbolic upper bounds because
+    there is no domain-specific [bound_for] key; concrete literal upper bounds
+    are enumerated exactly. *)
+type comprehension_binding =
+  | Domain of {
+      name : string;
+      domain : string;
+      membership : expr option;
+      bindings : (string * ty) list;
+    }
+  | Numeric of {
+      name : string;
+      ty : ty;
+      bound : expr;
+      inclusive : bool;
+      bound_guard : guard;
+      bindings : (string * ty) list;
+    }
+
+type upper_bound_result =
+  | UpperBound of { bound : expr; inclusive : bool; guard : guard }
+  | UpperBoundMentionsBinder
+  | NoUpperBound
+
+let expr_mentions_name name e = Smt_doc.StringSet.mem name (Smt_doc.free_vars e)
+
+let upper_bound_candidate binder = function
+  | GExpr (EBinop (((OpLt | OpLe) as op), EVar (Lower n), bound))
+    when n = binder ->
+      Some (bound, op = OpLe)
+  | GExpr (EBinop (((OpGt | OpGe) as op), bound, EVar (Lower n)))
+    when n = binder ->
+      Some (bound, op = OpGe)
+  | GExpr _ | GIn _ | GParam _ -> None
+[@@warning "-4"]
+
+(** Extract a strict or inclusive upper-bound guard for a numeric binder. A
+    valid bound has exactly one guard of shape [j < bound], [bound > j],
+    [j <= bound], or [bound >= j], and the bound expression must not mention
+    [j]. Ambiguous / missing bounds are reported as [NoUpperBound]; a
+    binder-dependent bound is reported separately for a refined diagnostic. *)
+let classify_upper_bound (p : param) guards =
+  let binder = Ast.lower_name p.param_name in
+  let candidates =
+    List.filter_map
+      (fun g ->
+        match upper_bound_candidate binder g with
+        | Some (bound, inclusive) -> Some (g, bound, inclusive)
+        | None -> None)
+      guards
+  in
+  match candidates with
+  | [ (guard, bound, inclusive) ] ->
+      if expr_mentions_name binder bound then UpperBoundMentionsBinder
+      else UpperBound { bound; inclusive; guard }
+  | _ ->
+      if
+        List.exists
+          (fun (_guard, bound, _inclusive) -> expr_mentions_name binder bound)
+          candidates
+      then UpperBoundMentionsBinder
+      else NoUpperBound
+
+let extract_upper_bound p guards =
+  match classify_upper_bound p guards with
+  | UpperBound { bound; _ } -> Some bound
+  | UpperBoundMentionsBinder | NoUpperBound -> None
+
 (** Resolve the iteration variable, domain name, and any implicit guard for a
     comprehension. Supports two forms:
     - Typed binding: [all x: D, guards | body] — params = [x:D], iterates over D
@@ -23,15 +92,42 @@ let resolve_comprehension_binding env params guards =
       match Collect.resolve_type env p.param_type dummy_loc with
       | Ok (TyDomain dname) ->
           let pn = Ast.lower_name p.param_name in
-          Ok (pn, dname, None, [ (pn, TyDomain dname) ])
-      | Ok ((TyNat | TyNat0 | TyInt) as ty) ->
-          Error
-            (Printf.sprintf
-               "SMT translation: comprehension over unbounded %s is only \
-                supported as μ-search (`min over each j: %s, … | j`); add an \
-                explicit upper-bound guard (e.g. `j < N`) to enable general \
-                enumeration"
-               (format_ty ty) (format_ty ty))
+          Ok
+            (Domain
+               {
+                 name = pn;
+                 domain = dname;
+                 membership = None;
+                 bindings = [ (pn, TyDomain dname) ];
+               })
+      | Ok ((TyNat | TyNat0 | TyInt) as ty) -> (
+          let pn = Ast.lower_name p.param_name in
+          match classify_upper_bound p guards with
+          | UpperBound { bound; inclusive; guard } ->
+              Ok
+                (Numeric
+                   {
+                     name = pn;
+                     ty;
+                     bound;
+                     inclusive;
+                     bound_guard = guard;
+                     bindings = [ (pn, ty) ];
+                   })
+          | UpperBoundMentionsBinder ->
+              Error
+                (Printf.sprintf
+                   "SMT translation: numeric comprehension upper-bound guard \
+                    for `%s` must not mention the binder"
+                   pn)
+          | NoUpperBound ->
+              Error
+                (Printf.sprintf
+                   "SMT translation: comprehension over unbounded %s is only \
+                    supported as μ-search (`min over each j: %s, … | j`); add \
+                    an explicit upper-bound guard (e.g. `j < N`) to enable \
+                    general enumeration"
+                   (format_ty ty) (format_ty ty)))
       | Ok TyReal ->
           Error
             "SMT translation: comprehension over unbounded Real is not \
@@ -51,7 +147,14 @@ let resolve_comprehension_binding env params guards =
             Check.infer_type { Check.env; loc = dummy_loc } list_expr
           with
           | Ok (TyList (TyDomain dname)) ->
-              Ok (name, dname, Some list_expr, [ (name, TyDomain dname) ])
+              Ok
+                (Domain
+                   {
+                     name;
+                     domain = dname;
+                     membership = Some list_expr;
+                     bindings = [ (name, TyDomain dname) ];
+                   })
           | _ ->
               Error
                 "SMT translation: membership comprehension requires a domain \
@@ -84,14 +187,18 @@ let resolve_numeric_comprehension_binding env params =
           Error "comprehension binder is not numeric")
   | _ -> Error "comprehension binder is not numeric"
 
-(** Expand a comprehension over finite domain elements. Returns a list of
-    (guard_str option, value_str) pairs for each domain element substitution.
-    [translate] is the expression translator (passed to break mutual recursion).
-*)
-let expand_comprehension translate config env params guards body =
+(** Expand a comprehension over finite domain elements or bounded numeric
+    values. Returns [(guard_str option, value_str)] pairs. Domain binders use
+    [bound_for config domain_name]. Numeric binders fall back to [config.bound]
+    for symbolic bounds; concrete literal bounds enumerate the exact literal
+    range. Numeric expansion requires [numeric_neutral] because each enumerated
+    value is gated as [(ite (< k bound) body NEUTRAL)] (or [<=] for inclusive
+    bounds) and returned as an unconditional value. *)
+let expand_comprehension ?numeric_neutral translate config env params guards
+    body =
   match resolve_comprehension_binding env params guards with
   | Error msg -> failwith msg
-  | Ok (var_name, dname, membership_expr, bindings) ->
+  | Ok (Domain { name = var_name; domain = dname; membership; bindings }) ->
       let env_inner = Env.with_vars bindings env in
       let elems = domain_elements dname (bound_for config dname) in
       let pname = sanitize_ident var_name in
@@ -108,7 +215,7 @@ let expand_comprehension translate config env params guards body =
       in
       (* For GIn bindings, add implicit membership guard *)
       let membership_template =
-        match membership_expr with
+        match membership with
         | Some list_e ->
             let list_str = translate config env list_e in
             Some (Printf.sprintf "(select %s %s)" list_str pname)
@@ -130,6 +237,74 @@ let expand_comprehension translate config env params guards body =
           in
           (guard_str, value_str))
         elems
+  | Ok
+      (Numeric { name = var_name; ty; bound; inclusive; bound_guard; bindings })
+    ->
+      let neutral =
+        match numeric_neutral with
+        | Some neutral -> neutral
+        | None ->
+            failwith
+              "SMT translation: bounded numeric comprehension requires an \
+               aggregate neutral element"
+      in
+      let env_inner = Env.with_vars bindings env in
+      let pname = sanitize_ident var_name in
+      let numeric_values =
+        match[@warning "-4"] (ty, bound) with
+        | TyNat, ELitNat n when inclusive ->
+            List.init (max 0 n) (fun i -> i + 1)
+        | TyNat, ELitNat n -> List.init (max 0 (n - 1)) (fun i -> i + 1)
+        | (TyNat0 | TyInt), ELitNat n when inclusive ->
+            List.init (max 0 (n + 1)) Fun.id
+        | (TyNat0 | TyInt), ELitNat n -> List.init (max 0 n) Fun.id
+        | TyNat, _ -> List.init config.bound (fun i -> i + 1)
+        | (TyNat0 | TyInt), _ -> List.init config.bound Fun.id
+        | ( ( TyBool | TyReal | TyString | TyNothing | TyDomain _ | TyList _
+            | TyProduct _ | TySum _ | TyFunc _ ),
+            _ ) ->
+            []
+      in
+      let concrete_bound =
+        match[@warning "-4"] bound with ELitNat _ -> true | _ -> false
+      in
+      let body_template = translate config env_inner body in
+      let non_bound_guard_templates =
+        List.filter_map
+          (fun g ->
+            if g = bound_guard then None
+            else
+              match g with
+              | GExpr e -> Some (translate config env_inner e)
+              | GIn _ | GParam _ -> None)
+          guards
+      in
+      let bound_template = translate config env_inner bound in
+      List.map
+        (fun k ->
+          let k_s = string_of_int k in
+          let sub s = replace_word ~from:pname ~to_:k_s s in
+          let body_str = sub body_template in
+          let guard_strs = List.map sub non_bound_guard_templates in
+          let guarded_body =
+            match guard_strs with
+            | [] -> body_str
+            | [ g ] -> Printf.sprintf "(ite %s %s %s)" g body_str neutral
+            | gs ->
+                Printf.sprintf "(ite (and %s) %s %s)" (String.concat " " gs)
+                  body_str neutral
+          in
+          let op = if inclusive then "<=" else "<" in
+          let bound_guard =
+            Printf.sprintf "(%s %s %s)" op k_s (sub bound_template)
+          in
+          let value_str =
+            if concrete_bound then guarded_body
+            else
+              Printf.sprintf "(ite %s %s %s)" bound_guard guarded_body neutral
+          in
+          (None, value_str))
+        numeric_values
 
 (** Capture-avoiding substitution: replace EVar names according to the mapping.
     When the substitution's range contains a free name that matches a quantifier

--- a/test/test_smt.ml
+++ b/test/test_smt.ml
@@ -1888,105 +1888,90 @@ let test_card_nat_comprehension_error () =
   check bool "refined diagnostic mentions μ-search or upper bound" true
     raised_with_hint
 
-module Pending_bounded_numeric_over_each = struct
-  let test_bounded_sum_over_nat0_symbolic_bound () =
-    (* PENDING Patch 2: bounded Nat0 add-over-each with symbolic upper bound. *)
-    let env = Env.empty "" |> Env.add_var "n" Types.TyNat0 in
-    let expr =
-      Ast.make_each
-        [ { param_name = Lower "j"; param_type = TName (Upper "Nat0") } ]
-        [ GExpr (EBinop (OpLt, EVar (Lower "j"), EVar (Lower "n"))) ]
-        (Some CombAdd) (EVar (Lower "j"))
-    in
-    let result = Smt.translate_expr config env expr in
-    check bool "has +" true (contains result "(+")
+let test_bounded_sum_over_nat0_symbolic_bound () =
+  let env = Env.empty "" |> Env.add_var "n" Types.TyNat0 in
+  let expr =
+    Ast.make_each
+      [ { param_name = Lower "j"; param_type = TName (Upper "Nat0") } ]
+      [ GExpr (EBinop (OpLt, EVar (Lower "j"), EVar (Lower "n"))) ]
+      (Some CombAdd) (EVar (Lower "j"))
+  in
+  let result = Smt.translate_expr config env expr in
+  check string "symbolic bound unrolled with ite guards"
+    "(+ (ite (< 0 n) 0 0) (ite (< 1 n) 1 0) (ite (< 2 n) 2 0))" result
 
-  let test_bounded_sum_over_nat0_concrete_bound () =
-    (* PENDING Patch 2: bounded Nat0 add-over-each with concrete upper bound. *)
-    let env = Env.empty "" in
-    let expr =
-      Ast.make_each
-        [ { param_name = Lower "j"; param_type = TName (Upper "Nat0") } ]
-        [ GExpr (EBinop (OpLt, EVar (Lower "j"), ELitNat 5)) ]
-        (Some CombAdd) (EVar (Lower "j"))
-    in
-    let result = Smt.translate_expr config env expr in
-    check bool "has +" true (contains result "(+")
+let test_bounded_sum_over_nat0_concrete_bound () =
+  let env = Env.empty "" in
+  let expr =
+    Ast.make_each
+      [ { param_name = Lower "j"; param_type = TName (Upper "Nat0") } ]
+      [ GExpr (EBinop (OpLt, EVar (Lower "j"), ELitNat 5)) ]
+      (Some CombAdd) (EVar (Lower "j"))
+  in
+  let result = Smt.translate_expr config env expr in
+  check string "concrete bound unrolled exactly" "(+ 0 1 2 3 4)" result
 
-  let test_bounded_and_over_nat0_bool_body () =
-    (* PENDING Patch 2: bounded Nat0 and-over-each with Bool body. *)
-    let env =
-      Env.empty ""
-      |> Env.add_var "n" Types.TyNat0
-      |> Env.add_rule "p?"
-           (Types.TyFunc ([ Types.TyNat0 ], Some Types.TyBool))
-           Ast.dummy_loc ~chapter:0
-    in
-    let expr =
-      Ast.make_each
-        [ { param_name = Lower "j"; param_type = TName (Upper "Nat0") } ]
-        [ GExpr (EBinop (OpLt, EVar (Lower "j"), EVar (Lower "n"))) ]
-        (Some CombAnd)
-        (EApp (EVar (Lower "p?"), [ EVar (Lower "j") ]))
-    in
-    let result = Smt.translate_expr config env expr in
-    check bool "has and" true (contains result "(and");
-    check bool "has predicate body" true (contains result "(pp")
+let test_bounded_and_over_nat0_bool_body () =
+  let env =
+    Env.empty ""
+    |> Env.add_var "n" Types.TyNat0
+    |> Env.add_rule "p?"
+         (Types.TyFunc ([ Types.TyNat0 ], Some Types.TyBool))
+         Ast.dummy_loc ~chapter:0
+  in
+  let expr =
+    Ast.make_each
+      [ { param_name = Lower "j"; param_type = TName (Upper "Nat0") } ]
+      [ GExpr (EBinop (OpLt, EVar (Lower "j"), EVar (Lower "n"))) ]
+      (Some CombAnd)
+      (EApp (EVar (Lower "p?"), [ EVar (Lower "j") ]))
+  in
+  let result = Smt.translate_expr config env expr in
+  check string "and neutral true gating"
+    "(and (ite (< 0 n) (pp 0) true) (ite (< 1 n) (pp 1) true) (ite (< 2 n) (pp \
+     2) true))"
+    result
 
-  let test_bounded_over_each_rejects_no_bound () =
-    (* PENDING Patch 2: bounded numeric over-each keeps the no-bound rejection. *)
-    let env = Env.empty "" in
-    let expr =
-      Ast.make_each
-        [ { param_name = Lower "j"; param_type = TName (Upper "Nat0") } ]
-        [] (Some CombAdd) (EVar (Lower "j"))
-    in
-    let raised_with_hint =
-      try
-        let _ = Smt.translate_expr config env expr in
-        false
-      with Failure msg ->
-        contains msg "unbounded Nat0" && contains msg "upper-bound guard"
-    in
-    check bool "unbounded numeric comprehension is rejected" true
-      raised_with_hint
+let test_bounded_over_each_rejects_no_bound () =
+  let env = Env.empty "" in
+  let expr =
+    Ast.make_each
+      [ { param_name = Lower "j"; param_type = TName (Upper "Nat0") } ]
+      [] (Some CombAdd) (EVar (Lower "j"))
+  in
+  let raised_with_hint =
+    try
+      let _ = Smt.translate_expr config env expr in
+      false
+    with Failure msg ->
+      contains msg "unbounded Nat0" && contains msg "upper-bound guard"
+  in
+  check bool "unbounded numeric comprehension is rejected" true raised_with_hint
 
-  let test_bounded_over_each_rejects_binder_in_bound () =
-    (* PENDING Patch 2: upper-bound guard must not mention the numeric binder. *)
-    let env = Env.empty "" in
-    let expr =
-      Ast.make_each
-        [ { param_name = Lower "j"; param_type = TName (Upper "Nat0") } ]
-        [
-          GExpr
-            (EBinop
-               ( OpLt,
-                 EVar (Lower "j"),
-                 EBinop (OpAdd, EVar (Lower "j"), ELitNat 1) ));
-        ]
-        (Some CombAdd) (EVar (Lower "j"))
-    in
-    let raised_with_refined_hint =
-      try
-        let _ = Smt.translate_expr config env expr in
-        false
-      with Failure msg ->
-        contains msg "upper-bound" && contains msg "binder"
-        && not (contains msg "unbounded Nat0")
-    in
-    check bool "binder-mentioning upper bound is rejected" true
-      raised_with_refined_hint
-end
-
-let _pending_bounded_numeric_over_each_stubs =
-  let module P = Pending_bounded_numeric_over_each in
-  [
-    P.test_bounded_sum_over_nat0_symbolic_bound;
-    P.test_bounded_sum_over_nat0_concrete_bound;
-    P.test_bounded_and_over_nat0_bool_body;
-    P.test_bounded_over_each_rejects_no_bound;
-    P.test_bounded_over_each_rejects_binder_in_bound;
-  ]
+let test_bounded_over_each_rejects_binder_in_bound () =
+  let env = Env.empty "" in
+  let expr =
+    Ast.make_each
+      [ { param_name = Lower "j"; param_type = TName (Upper "Nat0") } ]
+      [
+        GExpr
+          (EBinop
+             ( OpLt,
+               EVar (Lower "j"),
+               EBinop (OpAdd, EVar (Lower "j"), ELitNat 1) ));
+      ]
+      (Some CombAdd) (EVar (Lower "j"))
+  in
+  let raised_with_refined_hint =
+    try
+      let _ = Smt.translate_expr config env expr in
+      false
+    with Failure msg ->
+      contains msg "upper-bound" && contains msg "binder"
+      && not (contains msg "unbounded Nat0")
+  in
+  check bool "binder-mentioning upper bound is rejected" true
+    raised_with_refined_hint
 
 let comprehension_tests =
   [
@@ -2017,6 +2002,16 @@ let comprehension_tests =
     test_case "μ-search max rejected" `Quick test_mu_search_max_rejected;
     test_case "card nat comprehension error" `Quick
       test_card_nat_comprehension_error;
+    test_case "bounded sum over Nat0 symbolic bound" `Quick
+      test_bounded_sum_over_nat0_symbolic_bound;
+    test_case "bounded sum over Nat0 concrete bound" `Quick
+      test_bounded_sum_over_nat0_concrete_bound;
+    test_case "bounded and over Nat0 bool body" `Quick
+      test_bounded_and_over_nat0_bool_body;
+    test_case "bounded over-each rejects no bound" `Quick
+      test_bounded_over_each_rejects_no_bound;
+    test_case "bounded over-each rejects binder in bound" `Quick
+      test_bounded_over_each_rejects_binder_in_bound;
   ]
 
 (* --- Closure tests --- *)


### PR DESCRIPTION
## Patch 2: Pant SMT: bounded numeric over-each enumeration

- In `lib/smt_expr.ml`: change `resolve_comprehension_binding`'s return type from `Ok of (string * dname * expr option * bindings)` to a sum type that distinguishes domain vs numeric resolutions, e.g. `Ok (Domain { name; membership; bindings }) | Ok (Numeric { ty; bound; bindings }) | Error msg`. Update existing call sites (`expand_comprehension`, callers in `lib/smt.ml`) to match-case on the new variant.
- Implement `extract_upper_bound: param -> guard list -> expr option`: scans `guards` for `GExpr (EBinop (OpLt, EVar (Lower binder), bound_expr))` and the commuted `GExpr (EBinop (OpGt, bound_expr, EVar (Lower binder)))`. Returns `Some bound_expr` if exactly one such guard is present and `bound_expr` does not reference the binder; returns `None` otherwise (the unbounded case continues to error).
- Support strict (`<`) bounds in this milestone. (Inclusive `<=` bounds are deferred to a follow-on if the open-question dialogue chooses not to include them — the implementation should be straightforward by enumerating `k <= bound_expr` rather than `k < bound_expr`.)
- In `expand_comprehension` (`lib/smt_expr.ml` line 91 onward): add a `Numeric { ty; bound; bindings }` branch that produces enumeration substitutions `j := 0, j := 1, ..., j := config.bound - 1` (for Nat0/Int) or `j := 1, ..., j := config.bound` (for Nat). For each substitution, translate the body and any non-bound guard, then wrap as `(ite (< k_smt bound_smt) <body_str> <neutral_str>)`. The neutral depends on the comb context, which is passed in by the caller (`aggregate_*` translators in `lib/smt.ml`).
- In `lib/smt.ml`: refactor the existing μ-search detection to test for `comb = CombMin && body = EVar (Lower binder) && (no upper-bound guard extractable)` — that's the case that uses the Skolem encoding. When an upper-bound IS extractable, even for `comb = CombMin`, route to the bounded enumeration with neutral element `+INF` (encoded as a large literal `(^ 2 31)` per existing SMT idiom or a fresh declared constant).
- Define neutral elements: CombAdd → `0`; CombMul → `1`; CombAnd → `true`; CombOr → `false`; CombMin → SMT bigint upper sentinel; CombMax → SMT bigint lower sentinel. Document the neutrals at the function declaration.
- Ensure the bounded SMT path uses the existing `bound_for config domain_name` infrastructure where possible. For numeric types, fall back to `config.bound` (the default bound used for unsized enumeration). Document this fallback in the function comment.
- Update `test/test_smt.ml`: unskip the five tests and replace the placeholder bodies with concrete assertions: `test_bounded_sum_over_nat0_symbolic_bound` checks that the result contains `(+ (ite (< 0 n) 0 0) (ite (< 1 n) 1 0) (ite (< 2 n) 2 0))` (or the project's preferred normalised form); `test_bounded_sum_over_nat0_concrete_bound` checks the unrolled form for `n=5`; `test_bounded_and_over_nat0_bool_body` checks the `(and ...)` neutral-true gating; the two rejection tests check that the specific diagnostic appears in the raised `Failure` message.
- Run `dune build @runtest` and confirm all SMT tests pass. Run `pant --check scratch/m2-worked-example.pant` (which currently fails) and confirm it now succeeds with at least one passing check.
- Delete the scratch file `scratch/m2-worked-example.pant` (it was a one-time pre-design probe).

## Changes
- In `lib/smt_expr.ml`: change `resolve_comprehension_binding`'s return type from `Ok of (string * dname * expr option * bindings)` to a sum type that distinguishes domain vs numeric resolutions, e.g. `Ok (Domain { name; membership; bindings }) | Ok (Numeric { ty; bound; bindings }) | Error msg`. Update existing call sites (`expand_comprehension`, callers in `lib/smt.ml`) to match-case on the new variant.
- Implement `extract_upper_bound: param -> guard list -> expr option`: scans `guards` for `GExpr (EBinop (OpLt, EVar (Lower binder), bound_expr))` and the commuted `GExpr (EBinop (OpGt, bound_expr, EVar (Lower binder)))`. Returns `Some bound_expr` if exactly one such guard is present and `bound_expr` does not reference the binder; returns `None` otherwise (the unbounded case continues to error).
- Support strict (`<`) bounds in this milestone. (Inclusive `<=` bounds are deferred to a follow-on if the open-question dialogue chooses not to include them — the implementation should be straightforward by enumerating `k <= bound_expr` rather than `k < bound_expr`.)
- In `expand_comprehension` (`lib/smt_expr.ml` line 91 onward): add a `Numeric { ty; bound; bindings }` branch that produces enumeration substitutions `j := 0, j := 1, ..., j := config.bound - 1` (for Nat0/Int) or `j := 1, ..., j := config.bound` (for Nat). For each substitution, translate the body and any non-bound guard, then wrap as `(ite (< k_smt bound_smt) <body_str> <neutral_str>)`. The neutral depends on the comb context, which is passed in by the caller (`aggregate_*` translators in `lib/smt.ml`).
- In `lib/smt.ml`: refactor the existing μ-search detection to test for `comb = CombMin && body = EVar (Lower binder) && (no upper-bound guard extractable)` — that's the case that uses the Skolem encoding. When an upper-bound IS extractable, even for `comb = CombMin`, route to the bounded enumeration with neutral element `+INF` (encoded as a large literal `(^ 2 31)` per existing SMT idiom or a fresh declared constant).
- Define neutral elements: CombAdd → `0`; CombMul → `1`; CombAnd → `true`; CombOr → `false`; CombMin → SMT bigint upper sentinel; CombMax → SMT bigint lower sentinel. Document the neutrals at the function declaration.
- Ensure the bounded SMT path uses the existing `bound_for config domain_name` infrastructure where possible. For numeric types, fall back to `config.bound` (the default bound used for unsized enumeration). Document this fallback in the function comment.
- Update `test/test_smt.ml`: unskip the five tests and replace the placeholder bodies with concrete assertions: `test_bounded_sum_over_nat0_symbolic_bound` checks that the result contains `(+ (ite (< 0 n) 0 0) (ite (< 1 n) 1 0) (ite (< 2 n) 2 0))` (or the project's preferred normalised form); `test_bounded_sum_over_nat0_concrete_bound` checks the unrolled form for `n=5`; `test_bounded_and_over_nat0_bool_body` checks the `(and ...)` neutral-true gating; the two rejection tests check that the specific diagnostic appears in the raised `Failure` message.
- Run `dune build @runtest` and confirm all SMT tests pass. Run `pant --check scratch/m2-worked-example.pant` (which currently fails) and confirm it now succeeds with at least one passing check.
- Delete the scratch file `scratch/m2-worked-example.pant` (it was a one-time pre-design probe).

## Files to Modify
- lib/smt_expr.ml (modify): Extend `resolve_comprehension_binding` to accept numeric binders with an extractable upper-bound guard. Extend `expand_comprehension` to enumerate the numeric range and gate each element by `(ite (< k BOUND) <body> NEUTRAL)`.
- lib/smt.ml (modify): Refactor the μ-search dispatch in the aggregate translation so CombMin retains its Skolem encoding when no upper bound is present and routes to the new bounded enumeration when an upper bound is present. CombAdd / CombMul / CombAnd / CombOr / CombMax with a numeric binder + upper bound now succeed instead of erroring.
- test/test_smt.ml (modify): Remove the skip from each of the five pending tests; replace the bodies with concrete assertions against the new SMT output.

## Gameplan Specification

```
module TS2PANT_BOUNDED_COUNTER_LOOP_LOWERING.

> ════════════════════════════════════════
> Milestone 2 of the ts2pant general-loop SSA workstream.
> ════════════════════════════════════════
> After this milestone, Pant `pant --check` accepts bounded numeric
> over-each comprehensions with an extractable upper-bound guard,
> ts2pant lowers canonical bounded TS counter loops via the L1 SSA
> vocabulary, three representative fixtures emit Pant that verifies
> end-to-end, and the contract is documented.

Location.
Version.
Expr.
ForStmt.
LoopHeaderJoin.
LoopBody.
TerminationMetric.
Proposition.
Fixture.
PantCheckResult.
NumericTy.
Comb.
Comprehension.
Document.
DocumentKind.
MilestoneStatus.
ClosedStatus.
open => ClosedStatus.
closed => ClosedStatus.
passed => PantCheckResult.
failed => PantCheckResult.
nat0-ty => NumericTy.
nat-ty => NumericTy.
int-ty => NumericTy.
add => Comb.
mul => Comb.
and-c => Comb.
or-c => Comb.
min-c => Comb.
max-c => Comb.
agents-md => DocumentKind.
workstream-doc => DocumentKind.
pending => MilestoneStatus.
landed => MilestoneStatus.

> Pant SMT layer.
binder-ty c: Comprehension => NumericTy.
upper-bound? c: Comprehension => Bool.
upper-bound-mentions-binder? c: Comprehension => Bool.
comb-of c: Comprehension => Comb.
body-is-binder? c: Comprehension => Bool.
rejected? c: Comprehension => Bool.

> ts2pant layer.
stmt-is-canonical-counter? f: ForStmt => Bool.
loop-body-of f: ForStmt => LoopBody.
body-header-joins b: LoopBody => [LoopHeaderJoin].
body-termination-metric b: LoopBody => TerminationMetric.
header-location h: LoopHeaderJoin => Location.
header-status h: LoopHeaderJoin => ClosedStatus.
metric-expr m: TerminationMetric => Expr.
emitted-propositions f: ForStmt => [Proposition].
proposition-references-counter? p: Proposition => Bool.

> Integration layer.
fixture-name f: Fixture => String.
emits-bounded-counter-equation? f: Fixture => Bool.
pant-typecheck-result f: Fixture => PantCheckResult.
pant-check-result f: Fixture => PantCheckResult.
fixture-count => Nat.

> Documentation layer.
document-kind d: Document => DocumentKind.
document-mentions-counter-loop-lowering? d: Document => Bool.
workstream-milestone-2-status => MilestoneStatus.
---

> Pant SMT acceptance.
all c: Comprehension |
  upper-bound? c and
  ~(upper-bound-mentions-binder? c) and
  ~(comb-of c = min-c and ~(upper-bound? c))
    -> ~(rejected? c).

all c: Comprehension |
  comb-of c = min-c and
  body-is-binder? c and
  ~(upper-bound? c)
    -> ~(rejected? c).

all c: Comprehension |
  ~(upper-bound? c) and
  ~(comb-of c = min-c and body-is-binder? c)
    -> rejected? c.

all c: Comprehension |
  upper-bound? c and upper-bound-mentions-binder? c
    -> rejected? c.

> ts2pant counter-loop SSA invariants.
all f: ForStmt |
  stmt-is-canonical-counter? f ->
    (all h in body-header-joins (loop-body-of f) |
       header-status h = closed).

all f: ForStmt |
  stmt-is-canonical-counter? f ->
    (all p in emitted-propositions f | proposition-references-counter? p).

> Fixture corpus.
all f: Fixture | emits-bounded-counter-equation? f.

all f: Fixture |
  pant-typecheck-result f = passed and
  pant-check-result f = passed.

fixture-count = 3.

> Documentation.
all d: Document |
  document-kind d = agents-md ->
    document-mentions-counter-loop-lowering? d.

all d: Document |
  document-kind d = workstream-doc ->
    document-mentions-counter-loop-lowering? d.

workstream-milestone-2-status = landed.
```

## Patch Specification

```
module TS2PANT_BOUNDED_COUNTER_LOOP_LOWERING_PATCH_2.

> Patch 2 extends Pant SMT translation to accept bounded numeric
> over-each comprehensions. The translator enumerates the binder over
> the config-bounded range and gates each element by an ite against
> the upper-bound expression.

NumericTy.
Comb.
Expr.
Comprehension.
SmtTerm.
NeutralValue.
nat0-ty => NumericTy.
nat-ty => NumericTy.
int-ty => NumericTy.
add => Comb.
mul => Comb.
and-c => Comb.
or-c => Comb.
min-c => Comb.
max-c => Comb.

binder-ty c: Comprehension => NumericTy.
upper-bound? c: Comprehension => Bool.
upper-bound-mentions-binder? c: Comprehension => Bool.
comb-of c: Comprehension => Comb.
body-is-binder? c: Comprehension => Bool.
smt-result c: Comprehension => SmtTerm.
rejected? c: Comprehension => Bool.
neutral-of comb: Comb => NeutralValue.
config-bound => Nat.
---

> A bounded numeric comprehension with an extractable upper bound is
> translated (not rejected) when comb is not min-with-no-bound.
all c: Comprehension |
  upper-bound? c and
  ~(upper-bound-mentions-binder? c) and
  ~(comb-of c = min-c and ~(upper-bound? c))
    -> ~(rejected? c).

> An unbounded non-mu-search comprehension is rejected.
all c: Comprehension |
  ~(upper-bound? c) and
  ~(comb-of c = min-c and body-is-binder? c)
    -> rejected? c.

> An upper bound that mentions the binder is rejected with a refined
> diagnostic.
all c: Comprehension |
  upper-bound? c and upper-bound-mentions-binder? c
    -> rejected? c.

> Mu-search (min comb, body is binder, no upper bound) is preserved.
all c: Comprehension |
  comb-of c = min-c and
  body-is-binder? c and
  ~(upper-bound? c)
    -> ~(rejected? c).

> The config bound determines enumeration cardinality (used by
> downstream proofs about soundness up to bound).
config-bound > 0.
```


## Implementation Notes

- Numeric comprehension expansion keeps the existing domain-comprehension path intact. `resolve_comprehension_binding` now returns `Domain` or `Numeric`, and only aggregate translation supplies the neutral needed for numeric `ite` gating; non-aggregate numeric comprehensions still fail rather than getting an accidental finite interpretation.
- Two small deviations are intentional: inclusive `<=` / `>=` upper-bound guards are already accepted because they share the same extraction path, and min/max numeric sentinels use decimal literals (`2147483648`, `(- 2147483648)`) instead of `(^ 2 31)` to avoid solver-portability issues around exponent syntax.
- Concrete literal numeric bounds enumerate exactly and omit the outer bound `ite`; symbolic bounds enumerate up to `config.bound` and gate each candidate. This is why the concrete `n=5` test expects `(+ 0 1 2 3 4)` while the symbolic test expects three guarded terms under the default test bound.
- Declaration-guard injection for numeric aggregate bodies is handled before expansion by appending collected body guards to the comprehension guard list. Domain aggregate guard injection stays on the existing post-expansion path.
- `scratch/m2-worked-example.pant` was not present in this worktree, so there was nothing to delete. I verified the same behavior with a temporary bounded numeric over-each file and `pant --check`, which reported `OK: Invariants are jointly satisfiable`.

Spec/Evidence Mapping:
- Bounded numeric comprehensions accepted: `lib/smt_expr.ml` numeric `Numeric` branch plus `lib/smt.ml` aggregate neutral threading; covered by `test_bounded_sum_over_nat0_symbolic_bound`, `test_bounded_sum_over_nat0_concrete_bound`, and `test_bounded_and_over_nat0_bool_body`.
- Unbounded non-mu numeric comprehensions rejected with the existing hint: `resolve_comprehension_binding` `NoUpperBound` path; covered by `test_bounded_over_each_rejects_no_bound`.
- Binder-dependent upper bounds rejected with a refined diagnostic: `classify_upper_bound` / `UpperBoundMentionsBinder`; covered by `test_bounded_over_each_rejects_binder_in_bound`.
- Mu-search preserved when `CombMin`, body is the binder, and no upper-bound guard is extractable: `translate_aggregate` `has_upper_bound` check; existing μ-search tests still pass.
- Required context consulted: `workstreams/ts2pant-general-loop-ssa.md`, `lib/smt_expr.ml`, `lib/smt.ml`, and `lib/smt_types.ml`. Static/test evidence: `dune fmt` and `dune build @runtest` both pass.