### PR TITLE
[ts2pant-bounded-counter-loop-lowering] Patch 4: ts2pant: bounded counter loop SSA build and lowering

### DIFF
--- a/tools/ts2pant/src/ir1-lower-body.ts
+++ b/tools/ts2pant/src/ir1-lower-body.ts
@@ -24,6 +24,7 @@ import {
   isCollectionSsaL1Body,
   lowerCollectionSsaToProps,
 } from "./ir1-ssa-collections.js";
+import { lowerCounterLoopL1Body } from "./ir1-ssa-counter-loop.js";
 import {
   lowerForeachShapeASummaries,
   lowerForeachShapeBSummaries,
@@ -110,6 +111,9 @@ function lowerL1BodyToSsaResult(
   if (stmt.kind === "foreach") {
     return lowerForeachL1BodyToSsaResult(stmt, options);
   }
+  if (stmt.kind === "for") {
+    return lowerCounterLoopL1BodyToSsaResult(stmt, options);
+  }
   if (stmt.kind === "block") {
     const results: IR1SsaBodyLowerResult[] = [];
     const initialPropertyValues = new Map(options.initialPropertyValues);
@@ -132,6 +136,26 @@ function lowerL1BodyToSsaResult(
   return ir1SsaBodyLowerUnsupported(
     "statement is not supported by unified SSA body lowering",
   );
+}
+
+function lowerCounterLoopL1BodyToSsaResult(
+  stmt: Extract<IR1Stmt, { kind: "for" }>,
+  options: SsaBodyLowerOptions,
+): IR1SsaBodyLowerResult {
+  try {
+    return lowerCounterLoopL1Body(stmt, {
+      lowerOpaque: options.applyConst,
+      ...(options.initialPropertyValues === undefined
+        ? {}
+        : { initialPropertyValues: options.initialPropertyValues }),
+    });
+  } catch (err) {
+    return ir1SsaBodyLowerUnsupported(
+      err instanceof Error
+        ? err.message
+        : "counter loop SSA lowering rejected the body",
+    );
+  }
 }
 
 export function lowerCollectionL1BodyToSsaResult(

--- a/tools/ts2pant/src/ir1-ssa-counter-loop.ts
+++ b/tools/ts2pant/src/ir1-ssa-counter-loop.ts
@@ -366,9 +366,11 @@ function emitAccumulatorFold(
 ): Extract<PropResult, { kind: "equation" }> {
   const ast = getAst();
   const binderExpr = ast.var(shape.counterPantBinder);
+  const init = lowerOpaque(lowerExpr(lowerL1Expr(shape.initExpr)));
   const bound = lowerOpaque(lowerExpr(lowerL1Expr(shape.boundExpr)));
   const rhs = lowerWithCounter(body.rhs, shape, binderExpr, lowerOpaque);
   const guards = [
+    ast.gExpr(ast.binop(ast.opGe(), binderExpr, init)),
     ast.gExpr(
       ast.binop(
         shape.boundCmpOp === "lt" ? ast.opLt() : ast.opLe(),
@@ -403,18 +405,24 @@ function emitSimpleAssign(
   lowerOpaque: (e: OpaqueExpr) => OpaqueExpr,
 ): Extract<PropResult, { kind: "equation" }> {
   const ast = getAst();
+  const init = lowerOpaque(lowerExpr(lowerL1Expr(shape.initExpr)));
   const bound = lowerOpaque(lowerExpr(lowerL1Expr(shape.boundExpr)));
   const lastCounter =
     shape.boundCmpOp === "lt"
       ? ast.binop(ast.opSub(), bound, ast.litNat(1))
       : bound;
   const rhs = lowerWithCounter(body.rhs, shape, lastCounter, lowerOpaque);
+  const loopExecutes = ast.binop(
+    shape.boundCmpOp === "lt" ? ast.opLt() : ast.opLe(),
+    init,
+    bound,
+  );
   return {
     kind: "equation",
     quantifiers: [],
     lhs: target.lhs,
     rhs: ast.cond([
-      [ast.binop(ast.opGt(), bound, ast.litNat(0)), rhs],
+      [loopExecutes, rhs],
       [ast.litBool(true), target.prior],
     ]),
   };
@@ -495,12 +503,7 @@ function recurrenceUnsupported(): { unsupported: string } {
 }
 
 function isNumericLiteral(expr: IR1Expr): boolean {
-  return (
-    expr.kind === "lit" &&
-    (expr.value.kind === "nat" ||
-      (expr.value.kind as string) === "int" ||
-      (expr.value.kind as string) === "real")
-  );
+  return expr.kind === "lit" && expr.value.kind === "nat";
 }
 
 function isNatLiteral(expr: IR1Expr, value: number): boolean {
@@ -642,8 +645,107 @@ function sameMember(
   return (
     expr.kind === "member" &&
     expr.name === member.name &&
-    getAst().strExpr(lowerExpr(lowerL1Expr(expr.receiver))) ===
-      getAst().strExpr(lowerExpr(lowerL1Expr(member.receiver)))
+    ir1ExprEqual(expr.receiver, member.receiver)
+  );
+}
+
+function ir1ExprEqual(a: IR1Expr, b: IR1Expr): boolean {
+  if (a.kind !== b.kind) {
+    return false;
+  }
+  switch (a.kind) {
+    case "var":
+      return (
+        b.kind === "var" &&
+        a.name === b.name &&
+        (a.primed ?? false) === (b.primed ?? false)
+      );
+    case "lit":
+      return (
+        b.kind === "lit" &&
+        a.value.kind === b.value.kind &&
+        "value" in a.value &&
+        "value" in b.value &&
+        a.value.value === b.value.value
+      );
+    case "binop":
+      return (
+        b.kind === "binop" &&
+        a.op === b.op &&
+        ir1ExprEqual(a.lhs, b.lhs) &&
+        ir1ExprEqual(a.rhs, b.rhs)
+      );
+    case "unop":
+      return b.kind === "unop" && a.op === b.op && ir1ExprEqual(a.arg, b.arg);
+    case "app":
+      return (
+        b.kind === "app" &&
+        ir1ExprEqual(a.callee, b.callee) &&
+        ir1ExprArrayEqual(a.args, b.args)
+      );
+    case "member":
+      return (
+        b.kind === "member" &&
+        a.name === b.name &&
+        ir1ExprEqual(a.receiver, b.receiver)
+      );
+    case "cond":
+      return (
+        b.kind === "cond" &&
+        a.arms.length === b.arms.length &&
+        a.arms.every(
+          ([guard, value], index) =>
+            b.arms[index] !== undefined &&
+            ir1ExprEqual(guard, b.arms[index][0]) &&
+            ir1ExprEqual(value, b.arms[index][1]),
+        ) &&
+        ir1ExprEqual(a.otherwise, b.otherwise)
+      );
+    case "is-nullish":
+      return b.kind === "is-nullish" && ir1ExprEqual(a.operand, b.operand);
+    case "each":
+      return (
+        b.kind === "each" &&
+        a.binder === b.binder &&
+        ir1ExprEqual(a.src, b.src) &&
+        ir1ExprArrayEqual(a.guards, b.guards) &&
+        ir1ExprEqual(a.proj, b.proj)
+      );
+    case "map-read":
+      return (
+        b.kind === "map-read" &&
+        a.op === b.op &&
+        a.ruleName === b.ruleName &&
+        a.keyPredName === b.keyPredName &&
+        a.ownerType === b.ownerType &&
+        a.keyType === b.keyType &&
+        ir1ExprEqual(a.receiver, b.receiver) &&
+        ir1ExprEqual(a.key, b.key)
+      );
+    case "set-read":
+      return (
+        b.kind === "set-read" &&
+        a.ruleName === b.ruleName &&
+        a.ownerType === b.ownerType &&
+        a.elemType === b.elemType &&
+        ir1ExprEqual(a.receiver, b.receiver) &&
+        ir1ExprEqual(a.elem, b.elem)
+      );
+    default: {
+      const _exhaustive: never = a;
+      void _exhaustive;
+      return false;
+    }
+  }
+}
+
+function ir1ExprArrayEqual(
+  a: readonly IR1Expr[],
+  b: readonly IR1Expr[],
+): boolean {
+  return (
+    a.length === b.length &&
+    a.every((expr, index) => ir1ExprEqual(expr, b[index]!))
   );
 }
 

--- a/tools/ts2pant/src/ir1-ssa-counter-loop.ts
+++ b/tools/ts2pant/src/ir1-ssa-counter-loop.ts
@@ -1,0 +1,658 @@
+import { lowerBinop, lowerExpr } from "./ir-emit.js";
+import {
+  type IR1Expr,
+  type IR1SsaLocation,
+  type IR1SsaLoopBody,
+  type IR1SsaProgram,
+  type IR1SsaVersion,
+  type IR1SsaWrite,
+  type IR1Stmt,
+  ir1Binop,
+  ir1LitNat,
+  ir1SsaCloseLoopHeader,
+  ir1SsaInitialVersion,
+  ir1SsaLoopBody,
+  ir1SsaOpenLoopHeader,
+  ir1SsaPropertyLocation,
+  ir1SsaPropertyValue,
+  ir1SsaRuleOfLocation,
+  ir1SsaTerminationMetric,
+  ir1SsaWrite,
+  ir1Var,
+} from "./ir1.js";
+import { lowerL1Expr } from "./ir1-lower.js";
+import type { LoopSsaBuildOptions } from "./ir1-ssa-loops.js";
+import {
+  type IR1SsaBodyLowerResult,
+  ir1SsaBodyLowerSuccess,
+  ir1SsaBodyLowerUnsupported,
+} from "./ir1-ssa-lower.js";
+import type { OpaqueExpr } from "./pant-ast.js";
+import { getAst } from "./pant-wasm.js";
+import type { PropResult } from "./types.js";
+
+export interface CounterLoopLowerOptions extends LoopSsaBuildOptions {
+  lowerOpaque?: (e: OpaqueExpr) => OpaqueExpr;
+  initialPropertyValues?: ReadonlyMap<string, OpaqueExpr>;
+}
+
+export interface CounterLoopShape {
+  counterName: string;
+  counterPantBinder: string;
+  initExpr: IR1Expr;
+  boundExpr: IR1Expr;
+  boundCmpOp: "lt" | "le";
+  body: IR1Stmt;
+}
+
+interface CounterLoopCtx {
+  counterPantBinder?: string;
+}
+
+interface TargetInfo {
+  target: Extract<IR1Expr, { kind: "member" }>;
+  location: Extract<IR1SsaLocation, { kind: "property" }>;
+  objExpr: OpaqueExpr;
+  lhs: OpaqueExpr;
+  prior: OpaqueExpr;
+  key: string;
+}
+
+type FoldCombiner = "add" | "mul" | "and" | "or";
+
+interface AccumulatorFoldBody {
+  kind: "accumulator-fold";
+  target: Extract<IR1Expr, { kind: "member" }>;
+  rhs: IR1Expr;
+  guard: IR1Expr | null;
+  combiner: FoldCombiner;
+  outerOp: "add" | "sub" | "mul" | "div" | "and" | "or";
+}
+
+interface SimpleAssignBody {
+  kind: "simple-assign";
+  target: Extract<IR1Expr, { kind: "member" }>;
+  rhs: IR1Expr;
+}
+
+type CounterLoopBody = AccumulatorFoldBody | SimpleAssignBody;
+
+export function recognizeCounterLoopShape(
+  stmt: Extract<IR1Stmt, { kind: "for" }>,
+  ctx: CounterLoopCtx = {},
+): CounterLoopShape | { unsupported: string } {
+  if (stmt.init === null) {
+    return { unsupported: "counter loop initializer is missing" };
+  }
+  const init = recognizeCounterInit(stmt.init);
+  if ("unsupported" in init) {
+    return init;
+  }
+
+  if (stmt.cond === null) {
+    return { unsupported: "counter loop condition is missing" };
+  }
+  const cond = recognizeCounterCondition(stmt.cond, init.counterName);
+  if ("unsupported" in cond) {
+    return cond;
+  }
+
+  if (stmt.step === null) {
+    return { unsupported: "counter loop step is missing" };
+  }
+  const step = recognizeCounterStep(stmt.step, init.counterName);
+  if ("unsupported" in step) {
+    return step;
+  }
+
+  return {
+    counterName: init.counterName,
+    counterPantBinder: ctx.counterPantBinder ?? init.counterName,
+    initExpr: init.initExpr,
+    boundExpr: cond.boundExpr,
+    boundCmpOp: cond.boundCmpOp,
+    body: stmt.body,
+  };
+}
+
+export function lowerCounterLoopL1Body(
+  stmt: Extract<IR1Stmt, { kind: "for" }>,
+  options: CounterLoopLowerOptions = {},
+): IR1SsaBodyLowerResult {
+  const shape = recognizeCounterLoopShape(stmt);
+  if ("unsupported" in shape) {
+    return ir1SsaBodyLowerUnsupported(shape.unsupported);
+  }
+
+  const body = classifyCounterLoopBody(shape.body, shape.counterName);
+  if ("unsupported" in body) {
+    return ir1SsaBodyLowerUnsupported(body.unsupported);
+  }
+
+  const lowerOpaque = options.lowerOpaque ?? ((e: OpaqueExpr) => e);
+  const targetInfo = buildTargetInfo(body.target, lowerOpaque, options);
+  const preheaderVersion: IR1SsaVersion = ir1SsaInitialVersion(
+    targetInfo.location,
+  );
+  const header = ir1SsaOpenLoopHeader(targetInfo.location, preheaderVersion);
+  const write: IR1SsaWrite = ir1SsaWrite(
+    targetInfo.location,
+    ir1SsaPropertyValue(body.rhs),
+  );
+  ir1SsaCloseLoopHeader(header, write.version);
+
+  const terminationMetric = ir1SsaTerminationMetric(
+    ir1Binop("sub", shape.boundExpr, ir1Var(shape.counterName)),
+    ir1LitNat(0),
+  );
+  const loopBody: IR1SsaLoopBody = ir1SsaLoopBody({
+    headerJoins: [header],
+    writes: [write],
+    joins: [],
+    breakHandles: [],
+    continueHandles: [],
+    terminationMetric,
+  });
+
+  const proposition =
+    body.kind === "accumulator-fold"
+      ? emitAccumulatorFold(shape, body, targetInfo, lowerOpaque)
+      : emitSimpleAssign(shape, body, targetInfo, lowerOpaque);
+  const modifiedRules = [ir1SsaRuleOfLocation(targetInfo.location)];
+  const declaredRules = new Set([
+    ...(options.declaredRules ?? []),
+    ...modifiedRules,
+  ]);
+  const program: IR1SsaProgram = {
+    reads: [],
+    writes: [write],
+    joins: [],
+    loopSummaries: [],
+    loopHeaderJoins: [header],
+    loopBodies: [loopBody],
+    declaredRules: [...declaredRules],
+    modifiedRules,
+    framedRules: [...declaredRules].filter(
+      (rule) => !modifiedRules.includes(rule),
+    ),
+  };
+
+  return ir1SsaBodyLowerSuccess({
+    programs: [program],
+    propositions: [proposition],
+    modifiedRules,
+    finalProperties: [
+      {
+        location: targetInfo.location,
+        version: write.version,
+        objExpr: targetInfo.objExpr,
+        lhs: targetInfo.lhs,
+        rhs: proposition.rhs,
+      },
+    ],
+  });
+}
+
+function recognizeCounterInit(
+  stmt: IR1Stmt,
+): { counterName: string; initExpr: IR1Expr } | { unsupported: string } {
+  if (stmt.kind === "let") {
+    if (!isNumericLiteral(stmt.value)) {
+      return {
+        unsupported: "counter loop initializer must be a numeric literal",
+      };
+    }
+    return { counterName: stmt.name, initExpr: stmt.value };
+  }
+  if (stmt.kind === "assign" && stmt.target.kind === "var") {
+    if (!isNumericLiteral(stmt.value)) {
+      return {
+        unsupported: "counter loop initializer must be a numeric literal",
+      };
+    }
+    return { counterName: stmt.target.name, initExpr: stmt.value };
+  }
+  return {
+    unsupported: "counter loop initializer must be a single counter binding",
+  };
+}
+
+function recognizeCounterCondition(
+  cond: IR1Expr,
+  counterName: string,
+): { boundExpr: IR1Expr; boundCmpOp: "lt" | "le" } | { unsupported: string } {
+  if (
+    cond.kind !== "binop" ||
+    (cond.op !== "lt" && cond.op !== "le") ||
+    cond.lhs.kind !== "var" ||
+    cond.lhs.name !== counterName
+  ) {
+    return {
+      unsupported:
+        "counter loop condition must be `counter < bound` or `counter <= bound`",
+    };
+  }
+  if (exprReferencesVar(cond.rhs, counterName)) {
+    return { unsupported: "counter loop bound must not reference the counter" };
+  }
+  return { boundExpr: cond.rhs, boundCmpOp: cond.op };
+}
+
+function recognizeCounterStep(
+  step: IR1Stmt,
+  counterName: string,
+): { ok: true } | { unsupported: string } {
+  if (
+    step.kind !== "assign" ||
+    step.target.kind !== "var" ||
+    step.target.name !== counterName ||
+    step.value.kind !== "binop" ||
+    step.value.op !== "add" ||
+    step.value.lhs.kind !== "var" ||
+    step.value.lhs.name !== counterName ||
+    !isNatLiteral(step.value.rhs, 1)
+  ) {
+    return {
+      unsupported:
+        "counter loop step must be a canonical +1 increment on the counter",
+    };
+  }
+  return { ok: true };
+}
+
+function classifyCounterLoopBody(
+  stmt: IR1Stmt,
+  counterName: string,
+): CounterLoopBody | { unsupported: string } {
+  if (stmt.kind === "block") {
+    if (stmt.stmts.length !== 1) {
+      return {
+        unsupported:
+          "bounded counter loop body must contain exactly one supported mutation",
+      };
+    }
+    return classifyCounterLoopBody(stmt.stmts[0]!, counterName);
+  }
+  if (stmt.kind === "cond-stmt") {
+    if (
+      stmt.arms.length !== 1 ||
+      stmt.otherwise !== null ||
+      stmt.arms[0] === undefined
+    ) {
+      return {
+        unsupported:
+          "guarded bounded counter loop body must be a single if without else",
+      };
+    }
+    const [guard, thenBody] = stmt.arms[0];
+    const classified = classifyCounterLoopBody(thenBody, counterName);
+    if ("unsupported" in classified) {
+      return classified;
+    }
+    if (classified.kind !== "accumulator-fold") {
+      return {
+        unsupported:
+          "guarded bounded counter loop body must contain an accumulator fold",
+      };
+    }
+    return { ...classified, guard };
+  }
+  if (stmt.kind !== "assign" || stmt.target.kind !== "member") {
+    return {
+      unsupported:
+        "bounded counter loop body must be an accumulator fold or simple property assignment",
+    };
+  }
+  if (rootName(stmt.target.receiver) === counterName) {
+    return {
+      unsupported: "counter loop body cannot assign through the counter",
+    };
+  }
+
+  const selfReads = countMemberReads(stmt.value, stmt.target);
+  if (stmt.value.kind === "binop" && sameMember(stmt.value.lhs, stmt.target)) {
+    const fold = isAccumulatorOuterOp(stmt.value.op)
+      ? foldForBinop(stmt.value.op)
+      : null;
+    if (fold === null) {
+      return {
+        unsupported:
+          "bounded counter loop accumulator fold uses an unsupported operator",
+      };
+    }
+    if (countMemberReads(stmt.value.rhs, stmt.target) > 0 || selfReads > 1) {
+      return recurrenceUnsupported();
+    }
+    return {
+      kind: "accumulator-fold",
+      target: stmt.target,
+      rhs: stmt.value.rhs,
+      guard: null,
+      combiner: fold.combiner,
+      outerOp: fold.outerOp,
+    };
+  }
+  if (selfReads > 0) {
+    return recurrenceUnsupported();
+  }
+  return { kind: "simple-assign", target: stmt.target, rhs: stmt.value };
+}
+
+function buildTargetInfo(
+  target: Extract<IR1Expr, { kind: "member" }>,
+  lowerOpaque: (e: OpaqueExpr) => OpaqueExpr,
+  options: CounterLoopLowerOptions,
+): TargetInfo {
+  const ast = getAst();
+  const objExpr = lowerOpaque(lowerExpr(lowerL1Expr(target.receiver)));
+  const location = ir1SsaPropertyLocation(
+    target.name,
+    target.receiver,
+    target.name,
+  ) as Extract<IR1SsaLocation, { kind: "property" }>;
+  const lhs = ast.app(ast.primed(target.name), [objExpr]);
+  const key = `${target.name}::${ast.strExpr(objExpr)}`;
+  const prior =
+    options.initialPropertyValues?.get(key) ??
+    ast.app(ast.var(target.name), [objExpr]);
+  return { target, location, objExpr, lhs, prior, key };
+}
+
+function emitAccumulatorFold(
+  shape: CounterLoopShape,
+  body: AccumulatorFoldBody,
+  target: TargetInfo,
+  lowerOpaque: (e: OpaqueExpr) => OpaqueExpr,
+): Extract<PropResult, { kind: "equation" }> {
+  const ast = getAst();
+  const binderExpr = ast.var(shape.counterPantBinder);
+  const bound = lowerOpaque(lowerExpr(lowerL1Expr(shape.boundExpr)));
+  const rhs = lowerWithCounter(body.rhs, shape, binderExpr, lowerOpaque);
+  const guards = [
+    ast.gExpr(
+      ast.binop(
+        shape.boundCmpOp === "lt" ? ast.opLt() : ast.opLe(),
+        binderExpr,
+        bound,
+      ),
+    ),
+  ];
+  if (body.guard !== null) {
+    guards.push(
+      ast.gExpr(lowerWithCounter(body.guard, shape, binderExpr, lowerOpaque)),
+    );
+  }
+  const folded = ast.eachComb(
+    [ast.param(shape.counterPantBinder, ast.tName("Nat0"))],
+    guards,
+    combinerToOpaque(body.combiner),
+    rhs,
+  );
+  return {
+    kind: "equation",
+    quantifiers: [],
+    lhs: target.lhs,
+    rhs: ast.binop(lowerBinop(body.outerOp), target.prior, folded),
+  };
+}
+
+function emitSimpleAssign(
+  shape: CounterLoopShape,
+  body: SimpleAssignBody,
+  target: TargetInfo,
+  lowerOpaque: (e: OpaqueExpr) => OpaqueExpr,
+): Extract<PropResult, { kind: "equation" }> {
+  const ast = getAst();
+  const bound = lowerOpaque(lowerExpr(lowerL1Expr(shape.boundExpr)));
+  const lastCounter =
+    shape.boundCmpOp === "lt"
+      ? ast.binop(ast.opSub(), bound, ast.litNat(1))
+      : bound;
+  const rhs = lowerWithCounter(body.rhs, shape, lastCounter, lowerOpaque);
+  return {
+    kind: "equation",
+    quantifiers: [],
+    lhs: target.lhs,
+    rhs: ast.cond([
+      [ast.binop(ast.opGt(), bound, ast.litNat(0)), rhs],
+      [ast.litBool(true), target.prior],
+    ]),
+  };
+}
+
+function lowerWithCounter(
+  expr: IR1Expr,
+  shape: CounterLoopShape,
+  replacement: OpaqueExpr,
+  lowerOpaque: (e: OpaqueExpr) => OpaqueExpr,
+): OpaqueExpr {
+  const ast = getAst();
+  return lowerOpaque(
+    ast.substituteBinder(
+      lowerExpr(lowerL1Expr(expr)),
+      shape.counterName,
+      replacement,
+    ),
+  );
+}
+
+function combinerToOpaque(combiner: FoldCombiner) {
+  const ast = getAst();
+  switch (combiner) {
+    case "add":
+      return ast.combAdd();
+    case "mul":
+      return ast.combMul();
+    case "and":
+      return ast.combAnd();
+    case "or":
+      return ast.combOr();
+    default: {
+      const _exhaustive: never = combiner;
+      void _exhaustive;
+      throw new Error("unsupported bounded counter loop combiner");
+    }
+  }
+}
+
+function foldForBinop(
+  op: AccumulatorFoldBody["outerOp"],
+): { combiner: FoldCombiner; outerOp: AccumulatorFoldBody["outerOp"] } | null {
+  switch (op) {
+    case "add":
+    case "sub":
+      return { combiner: "add", outerOp: op };
+    case "mul":
+    case "div":
+      return { combiner: "mul", outerOp: op };
+    case "and":
+      return { combiner: "and", outerOp: op };
+    case "or":
+      return { combiner: "or", outerOp: op };
+    default:
+      return null;
+  }
+}
+
+function isAccumulatorOuterOp(
+  op: string,
+): op is AccumulatorFoldBody["outerOp"] {
+  return (
+    op === "add" ||
+    op === "sub" ||
+    op === "mul" ||
+    op === "div" ||
+    op === "and" ||
+    op === "or"
+  );
+}
+
+function recurrenceUnsupported(): { unsupported: string } {
+  return {
+    unsupported:
+      "bounded counter loop body contains an accumulator self-recurrence; lift to L4 fixed-point lowering",
+  };
+}
+
+function isNumericLiteral(expr: IR1Expr): boolean {
+  return (
+    expr.kind === "lit" &&
+    (expr.value.kind === "nat" ||
+      (expr.value.kind as string) === "int" ||
+      (expr.value.kind as string) === "real")
+  );
+}
+
+function isNatLiteral(expr: IR1Expr, value: number): boolean {
+  return (
+    expr.kind === "lit" &&
+    expr.value.kind === "nat" &&
+    expr.value.value === value
+  );
+}
+
+function exprReferencesVar(expr: IR1Expr, name: string): boolean {
+  switch (expr.kind) {
+    case "var":
+      return expr.name === name;
+    case "lit":
+      return false;
+    case "binop":
+      return (
+        exprReferencesVar(expr.lhs, name) || exprReferencesVar(expr.rhs, name)
+      );
+    case "unop":
+      return exprReferencesVar(expr.arg, name);
+    case "is-nullish":
+      return exprReferencesVar(expr.operand, name);
+    case "app":
+      return (
+        exprReferencesVar(expr.callee, name) ||
+        expr.args.some((arg) => exprReferencesVar(arg, name))
+      );
+    case "member":
+      return exprReferencesVar(expr.receiver, name);
+    case "cond":
+      return (
+        expr.arms.some(
+          ([guard, value]) =>
+            exprReferencesVar(guard, name) || exprReferencesVar(value, name),
+        ) || exprReferencesVar(expr.otherwise, name)
+      );
+    case "each":
+      if (expr.binder === name) {
+        return exprReferencesVar(expr.src, name);
+      }
+      return (
+        exprReferencesVar(expr.src, name) ||
+        expr.guards.some((guard) => exprReferencesVar(guard, name)) ||
+        exprReferencesVar(expr.proj, name)
+      );
+    case "map-read":
+      return (
+        exprReferencesVar(expr.receiver, name) ||
+        exprReferencesVar(expr.key, name)
+      );
+    case "set-read":
+      return (
+        exprReferencesVar(expr.receiver, name) ||
+        exprReferencesVar(expr.elem, name)
+      );
+    default: {
+      const _exhaustive: never = expr;
+      void _exhaustive;
+      return false;
+    }
+  }
+}
+
+function countMemberReads(
+  expr: IR1Expr,
+  member: Extract<IR1Expr, { kind: "member" }>,
+): number {
+  const self = sameMember(expr, member) ? 1 : 0;
+  switch (expr.kind) {
+    case "var":
+    case "lit":
+      return self;
+    case "member":
+      return self + countMemberReads(expr.receiver, member);
+    case "binop":
+      return (
+        self +
+        countMemberReads(expr.lhs, member) +
+        countMemberReads(expr.rhs, member)
+      );
+    case "unop":
+      return self + countMemberReads(expr.arg, member);
+    case "app":
+      return (
+        self +
+        countMemberReads(expr.callee, member) +
+        expr.args.reduce((n, arg) => n + countMemberReads(arg, member), 0)
+      );
+    case "cond":
+      return (
+        self +
+        expr.arms.reduce(
+          (n, [guard, value]) =>
+            n +
+            countMemberReads(guard, member) +
+            countMemberReads(value, member),
+          0,
+        ) +
+        countMemberReads(expr.otherwise, member)
+      );
+    case "is-nullish":
+      return self + countMemberReads(expr.operand, member);
+    case "each":
+      return (
+        self +
+        countMemberReads(expr.src, member) +
+        expr.guards.reduce(
+          (n, guard) => n + countMemberReads(guard, member),
+          0,
+        ) +
+        countMemberReads(expr.proj, member)
+      );
+    case "map-read":
+      return (
+        self +
+        countMemberReads(expr.receiver, member) +
+        countMemberReads(expr.key, member)
+      );
+    case "set-read":
+      return (
+        self +
+        countMemberReads(expr.receiver, member) +
+        countMemberReads(expr.elem, member)
+      );
+    default: {
+      const _exhaustive: never = expr;
+      void _exhaustive;
+      return self;
+    }
+  }
+}
+
+function sameMember(
+  expr: IR1Expr,
+  member: Extract<IR1Expr, { kind: "member" }>,
+): boolean {
+  return (
+    expr.kind === "member" &&
+    expr.name === member.name &&
+    getAst().strExpr(lowerExpr(lowerL1Expr(expr.receiver))) ===
+      getAst().strExpr(lowerExpr(lowerL1Expr(member.receiver)))
+  );
+}
+
+function rootName(expr: IR1Expr): string | null {
+  if (expr.kind === "var") {
+    return expr.name;
+  }
+  if (expr.kind === "member") {
+    return rootName(expr.receiver);
+  }
+  return null;
+}

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -2,9 +2,19 @@ import type { SourceFile } from "ts-morph";
 import ts from "typescript";
 import { buildIR, isBuildUnsupported } from "./ir-build.js";
 import { lowerExpr } from "./ir-emit.js";
-import { type IR1Stmt, ir1Block } from "./ir1.js";
+import {
+  type IR1Expr,
+  type IR1Stmt,
+  ir1Binop,
+  ir1Block,
+  ir1For,
+  ir1Let,
+  ir1LitNat,
+  ir1Var,
+} from "./ir1.js";
 import {
   buildL1Conditional,
+  buildL1IncrementStep,
   buildL1LetWhile,
   buildL1MemberAccess,
   isL1ConditionalForm,
@@ -21,6 +31,7 @@ import {
   buildL1ForEachCall,
   buildL1ForOfMutation,
   buildL1IfMutation,
+  buildL1SubExpr,
   isUnsupported,
 } from "./ir1-build-body.js";
 import { lowerL1MuSearch, type MuSearchLowerCtx } from "./ir1-lower.js";
@@ -4431,6 +4442,9 @@ function buildSupportedSsaStatement(
   if (ts.isForOfStatement(stmt)) {
     return buildL1ForOfMutation(stmt, ctx);
   }
+  if (ts.isForStatement(stmt)) {
+    return buildL1ForCounterMutation(stmt, ctx);
+  }
   if (ts.isExpressionStatement(stmt)) {
     const expr = unwrapExpression(stmt.expression);
     if (
@@ -4448,7 +4462,6 @@ function buildSupportedSsaStatement(
     }
   }
   if (
-    ts.isForStatement(stmt) ||
     ts.isForInStatement(stmt) ||
     ts.isWhileStatement(stmt) ||
     ts.isDoStatement(stmt)
@@ -4458,4 +4471,184 @@ function buildSupportedSsaStatement(
   return {
     unsupported: `statement is not supported by unified SSA body lowering: ${ts.SyntaxKind[stmt.kind]}`,
   };
+}
+
+function buildL1ForCounterMutation(
+  stmt: ts.ForStatement,
+  ctx: {
+    checker: ts.TypeChecker;
+    strategy: NumericStrategy;
+    paramNames: Map<string, string>;
+    state: SymbolicState;
+    supply: UniqueSupply;
+    applyConst: (e: OpaqueExpr) => OpaqueExpr;
+  },
+): IR1Stmt | { unsupported: string } {
+  const init = buildL1ForCounterInit(stmt.initializer);
+  if (isUnsupported(init)) {
+    return init;
+  }
+
+  if (stmt.condition === undefined) {
+    return { unsupported: "counter loop condition is missing" };
+  }
+  const cond = buildL1ForCounterCondition(
+    stmt.condition,
+    init.counterName,
+    ctx,
+  );
+  if (isUnsupported(cond)) {
+    return cond;
+  }
+
+  if (stmt.incrementor === undefined) {
+    return { unsupported: "counter loop step is missing" };
+  }
+  if (counterStepHasEffectfulOperand(stmt.incrementor, init.counterName, ctx)) {
+    return {
+      unsupported: "counter loop step expression has side effects",
+    };
+  }
+  const step = buildL1IncrementStep(stmt.incrementor, init.counterName, {
+    checker: ctx.checker,
+    strategy: ctx.strategy,
+    paramNames: ctx.paramNames,
+    state: ctx.state,
+    supply: ctx.supply,
+  });
+  if (isL1StmtUnsupported(step)) {
+    return { unsupported: step.unsupported };
+  }
+
+  const bodyStmt = ts.isBlock(stmt.statement)
+    ? buildSupportedSsaMutatingBody(
+        stmt.statement,
+        ctx.checker,
+        ctx.strategy,
+        ctx.paramNames,
+        ctx.state,
+        ctx.supply,
+      )
+    : buildSupportedSsaStatement(stmt.statement, ctx);
+  if (isUnsupported(bodyStmt)) {
+    return bodyStmt;
+  }
+
+  return ir1For(init.initStmt, cond, step, bodyStmt);
+}
+
+function buildL1ForCounterInit(
+  initializer: ts.ForInitializer | undefined,
+): { counterName: string; initStmt: IR1Stmt } | { unsupported: string } {
+  if (
+    initializer === undefined ||
+    !ts.isVariableDeclarationList(initializer) ||
+    !(initializer.flags & ts.NodeFlags.Let) ||
+    initializer.declarations.length !== 1
+  ) {
+    return {
+      unsupported: "counter loop initializer must be a single let binding",
+    };
+  }
+  const decl = initializer.declarations[0]!;
+  if (!ts.isIdentifier(decl.name)) {
+    return { unsupported: "counter loop initializer must bind an identifier" };
+  }
+  if (decl.initializer === undefined) {
+    return { unsupported: "counter loop initializer is missing" };
+  }
+  const initExpr = unwrapExpression(decl.initializer);
+  if (!ts.isNumericLiteral(initExpr)) {
+    return {
+      unsupported: "counter loop initializer must be a numeric literal",
+    };
+  }
+  const value = Number(initExpr.text);
+  if (!Number.isFinite(value) || !Number.isInteger(value) || value < 0) {
+    return {
+      unsupported:
+        "counter loop initializer must be a non-negative integer literal",
+    };
+  }
+  return {
+    counterName: decl.name.text,
+    initStmt: ir1Let(decl.name.text, ir1LitNat(value)),
+  };
+}
+
+function buildL1ForCounterCondition(
+  condition: ts.Expression,
+  counterName: string,
+  ctx: {
+    checker: ts.TypeChecker;
+    strategy: NumericStrategy;
+    paramNames: Map<string, string>;
+    state: SymbolicState;
+    supply: UniqueSupply;
+  },
+): IR1Expr | { unsupported: string } {
+  const cond = unwrapExpression(condition);
+  if (
+    !ts.isBinaryExpression(cond) ||
+    (cond.operatorToken.kind !== ts.SyntaxKind.LessThanToken &&
+      cond.operatorToken.kind !== ts.SyntaxKind.LessThanEqualsToken) ||
+    !ts.isIdentifier(cond.left) ||
+    cond.left.text !== counterName
+  ) {
+    return {
+      unsupported:
+        "counter loop condition must be `counter < bound` or `counter <= bound`",
+    };
+  }
+  if (expressionReferencesNames(cond.right, new Set([counterName]))) {
+    return { unsupported: "counter loop bound must not reference the counter" };
+  }
+  if (expressionHasSideEffects(cond.right, ctx.checker)) {
+    return { unsupported: "counter loop bound expression has side effects" };
+  }
+  const bound = buildL1SubExpr(cond.right, { ...ctx, applyConst: (e) => e });
+  if (isUnsupported(bound)) {
+    return bound;
+  }
+  return ir1Binop(
+    cond.operatorToken.kind === ts.SyntaxKind.LessThanToken ? "lt" : "le",
+    ir1Var(counterName),
+    bound,
+  );
+}
+
+function counterStepHasEffectfulOperand(
+  step: ts.Expression,
+  counterName: string,
+  ctx: { checker: ts.TypeChecker },
+): boolean {
+  const expr = unwrapExpression(step);
+  if (ts.isPostfixUnaryExpression(expr) || ts.isPrefixUnaryExpression(expr)) {
+    return false;
+  }
+  if (!ts.isBinaryExpression(expr)) {
+    return expressionHasSideEffects(expr, ctx.checker);
+  }
+  if (
+    expr.operatorToken.kind === ts.SyntaxKind.PlusEqualsToken ||
+    expr.operatorToken.kind === ts.SyntaxKind.MinusEqualsToken ||
+    expr.operatorToken.kind === ts.SyntaxKind.AsteriskEqualsToken ||
+    expr.operatorToken.kind === ts.SyntaxKind.SlashEqualsToken
+  ) {
+    return expressionHasSideEffects(expr.right, ctx.checker);
+  }
+  if (expr.operatorToken.kind !== ts.SyntaxKind.EqualsToken) {
+    return expressionHasSideEffects(expr, ctx.checker);
+  }
+  if (!ts.isBinaryExpression(expr.right)) {
+    return expressionHasSideEffects(expr.right, ctx.checker);
+  }
+  const { left, right } = expr.right;
+  if (ts.isIdentifier(left) && left.text === counterName) {
+    return expressionHasSideEffects(right, ctx.checker);
+  }
+  if (ts.isIdentifier(right) && right.text === counterName) {
+    return expressionHasSideEffects(left, ctx.checker);
+  }
+  return expressionHasSideEffects(expr.right, ctx.checker);
 }

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -1055,7 +1055,7 @@ exports[`unsupported.ts > impureGuardAssign 1`] = `
 `;
 
 exports[`unsupported.ts > loopAssign 1`] = `
-"module LOOP_ASSIGN.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--owner a1: Account => String.\\n~> Loop-assign @ a: Account.\\n\\n---\\n\\naccount--balance' a = account--balance a + (+ over each i: Nat0, i < 3 | 1).\\naccount--owner' a1 = account--owner a1.\\n"
+"module LOOP_ASSIGN.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--owner a1: Account => String.\\n~> Loop-assign @ a: Account.\\n\\n---\\n\\naccount--balance' a = account--balance a + (+ over each i: Nat0, i >= 0, i < 3 | 1).\\naccount--owner' a1 = account--owner a1.\\n"
 `;
 
 exports[`unsupported.ts > multiParamCallback 1`] = `

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -1055,7 +1055,7 @@ exports[`unsupported.ts > impureGuardAssign 1`] = `
 `;
 
 exports[`unsupported.ts > loopAssign 1`] = `
-"module LOOP_ASSIGN.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--owner a1: Account => String.\\n~> Loop-assign @ a: Account.\\n\\n---\\n\\n> UNSUPPORTED: loop assignment.\\n"
+"module LOOP_ASSIGN.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--owner a1: Account => String.\\n~> Loop-assign @ a: Account.\\n\\n---\\n\\naccount--balance' a = account--balance a + (+ over each i: Nat0, i < 3 | 1).\\naccount--owner' a1 = account--owner a1.\\n"
 `;
 
 exports[`unsupported.ts > multiParamCallback 1`] = `

--- a/tools/ts2pant/tests/ir1-ssa-counter-loop.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-counter-loop.test.mts
@@ -65,7 +65,7 @@ describe("ir1-ssa-counter-loop", () => {
 
     const metric = result.programs[0]?.loopBodies[0]?.terminationMetric;
     assert.equal(metric?.kind, "ssa-termination-metric");
-    assert.equal(metric?.lowerBound, metric?.lowerBound);
+    assert.deepEqual(metric?.lowerBound, ir1LitNat(0));
     assert.equal(metric?.expr.kind, "binop");
     if (metric?.expr.kind === "binop") {
       assert.equal(metric.expr.op, "sub");
@@ -87,7 +87,27 @@ describe("ir1-ssa-counter-loop", () => {
       assert.equal(ast.strExpr(prop.lhs), "Account_total' account");
       assert.equal(
         ast.strExpr(prop.rhs),
-        "Account_total account + (+ over each i: Nat0, i < n | i)",
+        "Account_total account + (+ over each i: Nat0, i >= 0, i < n | i)",
+      );
+    }
+  });
+
+  it("emits an init lower-bound guard for non-zero accumulator folds", () => {
+    const ast = getAst();
+    const result = lower(
+      counterFor(
+        ir1Assign(total, ir1Binop("add", total, ir1Var("i"))),
+        ir1LitNat(3),
+      ),
+    );
+
+    assert.deepEqual(result.diagnostics, []);
+    const prop = result.propositions[0];
+    assert.equal(prop?.kind, "equation");
+    if (prop?.kind === "equation") {
+      assert.equal(
+        ast.strExpr(prop.rhs),
+        "Account_total account + (+ over each i: Nat0, i >= 3, i < n | i)",
       );
     }
   });
@@ -103,7 +123,24 @@ describe("ir1-ssa-counter-loop", () => {
       assert.equal(ast.strExpr(prop.lhs), "Account_total' account");
       assert.equal(
         ast.strExpr(prop.rhs),
-        "cond n > 0 => n - 1, true => Account_total account",
+        "cond 0 < n => n - 1, true => Account_total account",
+      );
+    }
+  });
+
+  it("uses init-vs-bound to detect simple-assign zero-iteration loops", () => {
+    const ast = getAst();
+    const result = lower(
+      counterFor(ir1Assign(total, ir1Var("i")), ir1LitNat(5)),
+    );
+
+    assert.deepEqual(result.diagnostics, []);
+    const prop = result.propositions[0];
+    assert.equal(prop?.kind, "equation");
+    if (prop?.kind === "equation") {
+      assert.equal(
+        ast.strExpr(prop.rhs),
+        "cond 5 < n => n - 1, true => Account_total account",
       );
     }
   });

--- a/tools/ts2pant/tests/ir1-ssa-counter-loop.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-counter-loop.test.mts
@@ -1,62 +1,162 @@
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import { before, describe, it } from "node:test";
 
 import {
+  type IR1Expr,
+  type IR1Stmt,
+  ir1Assign,
+  ir1Binop,
+  ir1For,
+  ir1Let,
   ir1LitNat,
-  ir1SsaLoopBody,
-  ir1SsaTerminationMetric,
+  ir1Member,
   ir1Var,
 } from "../src/ir1.js";
+import { lowerCounterLoopL1Body } from "../src/ir1-ssa-counter-loop.js";
+import { getAst, loadAst } from "../src/pant-wasm.js";
 
-const pendingLoopBodySetup = ir1SsaLoopBody({
-  terminationMetric: ir1SsaTerminationMetric(ir1Var("remaining"), ir1LitNat(0)),
+const account = ir1Var("account");
+const bound = ir1Var("n");
+const total = ir1Member(account, "Account_total");
+
+before(async () => {
+  await loadAst();
 });
-void pendingLoopBodySetup;
+
+function counterFor(body: IR1Stmt, init: IR1Expr = ir1LitNat(0)): IR1Stmt {
+  return ir1For(
+    ir1Let("i", init),
+    ir1Binop("lt", ir1Var("i"), bound),
+    ir1Assign(ir1Var("i"), ir1Binop("add", ir1Var("i"), ir1LitNat(1))),
+    body,
+  );
+}
+
+function lower(stmt: IR1Stmt) {
+  assert.equal(stmt.kind, "for");
+  return lowerCounterLoopL1Body(stmt);
+}
+
+function diagnosticReasons(stmt: IR1Stmt): string[] {
+  return lower(stmt).diagnostics.map((d) => d.reason);
+}
 
 describe("ir1-ssa-counter-loop", () => {
-  it.skip("builds a loop-header join per mutated location", () => {
-    // PENDING Patch 4: lowerCounterLoopL1Body opens one ir1SsaOpenLoopHeader per mutated location and back-patches each with the body's terminal write version.
-    assert.fail("PENDING Patch 4: loop-header joins per mutated location");
+  it("builds a loop-header join per mutated location", () => {
+    const result = lower(
+      counterFor(ir1Assign(total, ir1Binop("add", total, ir1Var("i")))),
+    );
+
+    assert.deepEqual(result.diagnostics, []);
+    const program = result.programs[0];
+    assert.equal(program?.loopHeaderJoins.length, 1);
+    assert.equal(program?.loopBodies.length, 1);
+    assert.equal(program?.loopBodies[0]?.headerJoins[0]?.closed, true);
+    assert.equal(
+      program?.loopBodies[0]?.headerJoins[0],
+      program.loopHeaderJoins[0],
+    );
   });
 
-  it.skip("attaches a termination metric to the loop body", () => {
-    // PENDING Patch 4: IR1SsaLoopBody.terminationMetric is non-null and references the counter and bound expressions.
-    assert.fail("PENDING Patch 4: termination metric");
+  it("attaches a termination metric to the loop body", () => {
+    const result = lower(
+      counterFor(ir1Assign(total, ir1Binop("add", total, ir1Var("i")))),
+    );
+
+    const metric = result.programs[0]?.loopBodies[0]?.terminationMetric;
+    assert.equal(metric?.kind, "ssa-termination-metric");
+    assert.equal(metric?.lowerBound, metric?.lowerBound);
+    assert.equal(metric?.expr.kind, "binop");
+    if (metric?.expr.kind === "binop") {
+      assert.equal(metric.expr.op, "sub");
+      assert.deepEqual(metric.expr.lhs, bound);
+      assert.deepEqual(metric.expr.rhs, ir1Var("i"));
+    }
   });
 
-  it.skip(
-    "emits an over-each equation for an accumulator-fold body",
-    () => {
-      // PENDING Patch 4: propositions contain exactly one equation-kind PropResult per mutated location, with the counter as the over-each binder and the bound as a guard.
-      assert.fail("PENDING Patch 4: accumulator-fold over-each equation");
-    },
-  );
+  it("emits an over-each equation for an accumulator-fold body", () => {
+    const ast = getAst();
+    const result = lower(
+      counterFor(ir1Assign(total, ir1Binop("add", total, ir1Var("i")))),
+    );
 
-  it.skip(
-    "emits a cond equation for a simple counter-only assign body",
-    () => {
-      // PENDING Patch 4: propositions contain a cond BOUND > 0 => F(BOUND - 1), true => prior equation rather than an over-each.
-      assert.fail("PENDING Patch 4: simple-assign cond equation");
-    },
-  );
-
-  it.skip("rejects non-literal init", () => {
-    // PENDING Patch 4: canonical counter loops require a literal-zero let binding in the for initializer.
-    assert.fail("PENDING Patch 4: reject non-literal init");
+    assert.deepEqual(result.diagnostics, []);
+    const prop = result.propositions[0];
+    assert.equal(prop?.kind, "equation");
+    if (prop?.kind === "equation") {
+      assert.equal(ast.strExpr(prop.lhs), "Account_total' account");
+      assert.equal(
+        ast.strExpr(prop.rhs),
+        "Account_total account + (+ over each i: Nat0, i < n | i)",
+      );
+    }
   });
 
-  it.skip("rejects non-canonical step", () => {
-    // PENDING Patch 4: canonical counter loops require counter++ / ++counter / counter += 1 / counter = counter + 1.
-    assert.fail("PENDING Patch 4: reject non-canonical step");
+  it("emits a cond equation for a simple counter-only assign body", () => {
+    const ast = getAst();
+    const result = lower(counterFor(ir1Assign(total, ir1Var("i"))));
+
+    assert.deepEqual(result.diagnostics, []);
+    const prop = result.propositions[0];
+    assert.equal(prop?.kind, "equation");
+    if (prop?.kind === "equation") {
+      assert.equal(ast.strExpr(prop.lhs), "Account_total' account");
+      assert.equal(
+        ast.strExpr(prop.rhs),
+        "cond n > 0 => n - 1, true => Account_total account",
+      );
+    }
   });
 
-  it.skip("rejects body with accumulator self-recurrence", () => {
-    // PENDING Patch 4: bodies that read their own loop-header join version are rejected for L4 fixed-point handling.
-    assert.fail("PENDING Patch 4: reject accumulator self-recurrence");
+  it("rejects non-literal init", () => {
+    assert.match(
+      diagnosticReasons(
+        counterFor(
+          ir1Assign(total, ir1Binop("add", total, ir1Var("i"))),
+          ir1Var("start"),
+        ),
+      ).join("\n"),
+      /initializer must be a numeric literal/u,
+    );
   });
 
-  it.skip("rejects body with effectful step expression", () => {
-    // PENDING Patch 4: counter-loop recognition rejects steps whose expression has non-counter side effects.
-    assert.fail("PENDING Patch 4: reject effectful step expression");
+  it("rejects non-canonical step", () => {
+    const stmt = ir1For(
+      ir1Let("i", ir1LitNat(0)),
+      ir1Binop("lt", ir1Var("i"), bound),
+      ir1Assign(ir1Var("i"), ir1Binop("add", ir1Var("i"), ir1LitNat(2))),
+      ir1Assign(total, ir1Binop("add", total, ir1Var("i"))),
+    );
+
+    assert.match(
+      diagnosticReasons(stmt).join("\n"),
+      /step must be a canonical \+1 increment/u,
+    );
+  });
+
+  it("rejects body with accumulator self-recurrence", () => {
+    assert.match(
+      diagnosticReasons(
+        counterFor(ir1Assign(total, ir1Binop("mul", total, total))),
+      ).join("\n"),
+      /accumulator self-recurrence; lift to L4 fixed-point lowering/u,
+    );
+  });
+
+  it("rejects body with effectful step expression", () => {
+    const stmt = ir1For(
+      ir1Let("i", ir1LitNat(0)),
+      ir1Binop("lt", ir1Var("i"), bound),
+      ir1Assign(
+        ir1Var("other"),
+        ir1Binop("add", ir1Var("other"), ir1LitNat(1)),
+      ),
+      ir1Assign(total, ir1Binop("add", total, ir1Var("i"))),
+    );
+
+    assert.match(
+      diagnosticReasons(stmt).join("\n"),
+      /step must be a canonical \+1 increment/u,
+    );
   });
 });


### PR DESCRIPTION
## Patch 4: ts2pant: bounded counter loop SSA build and lowering

- Create `tools/ts2pant/src/ir1-ssa-counter-loop.ts` and import existing IR1 symbols: `ir1SsaOpenLoopHeader`, `ir1SsaCloseLoopHeader`, `ir1SsaLoopBody`, `ir1SsaTerminationMetric`, `ir1SsaInitialVersion`, `ir1SsaPropertyLocation`, `ir1SsaPropertyValue`, `ir1SsaWrite`, plus type imports `IR1Expr`, `IR1SsaLocation`, `IR1SsaVersion`, `IR1Stmt`, `IR1SsaProgram`, `IR1SsaLoopBody`. Import `getAst` from `pant-wasm.ts`, `lowerExpr` from `ir-emit.ts`, `lowerL1Expr` from `ir1-lower.ts`.
- Define `interface CounterLoopLowerOptions extends LoopSsaBuildOptions { lowerOpaque?: (e: OpaqueExpr) => OpaqueExpr; initialPropertyValues?: ReadonlyMap<string, OpaqueExpr>; }`.
- Define `interface CounterLoopShape { counterName: string; counterPantBinder: string; initExpr: IR1Expr; boundExpr: IR1Expr; boundCmpOp: "lt" | "le"; body: IR1Stmt; }`. Implement `recognizeCounterLoopShape(stmt: Extract<IR1Stmt, { kind: "for" }>, ctx): CounterLoopShape | { unsupported: string }`. The recognizer verifies (a) `init` is a single assign to `counter` from a numeric literal expression, (b) `cond` is `counter CMP bound` where CMP ∈ {`<`, `<=`} and `bound` does not reference `counter`, (c) `step` is `counter++` / `++counter` / `counter += 1` / `counter = counter + 1`.
- Implement `lowerCounterLoopL1Body(stmt, options)` (the main export). Pseudocode: (1) call `recognizeCounterLoopShape`; on unsupported, return `ir1SsaBodyLowerUnsupported(reason)`. (2) Classify the body as one of two shapes: (i) `accumulator-fold` — body is `acc.p OP= f(counter)` or `if (g(counter)) acc.p OP= f(counter)` with `acc-root != counterName`; (ii) `simple-assign` — body is `acc.p = f(counter)` where the RHS does not read `acc.p` and `acc-root != counterName`. Any other body rejects with a specific diagnostic. (3) Discover mutated locations from the body (one per assign target). (4) For each mutated location, allocate `preheaderVersion = ir1SsaInitialVersion(location)` and open a header via `ir1SsaOpenLoopHeader(location, preheaderVersion)`. (5) Translate the body's writes to OpaqueExpr against a context in which reads of the mutated locations resolve to the header's `joinVersion`. The translation must reject if any write's RHS reads its own LHS location through the header (signals true recurrence — `bounded counter loop body contains an accumulator self-recurrence; lift to L4 fixed-point lowering`). (6) Close each header with the loop-back version (the translated body's terminal write for that location). (7) Build the termination metric: `ir1SsaTerminationMetric(boundExpr - counterVar, lowerBound: ir1LitNat(0))`. (8) Wrap as `ir1SsaLoopBody({ headerJoins, writes, joins: [], breakHandles: [], continueHandles: [], terminationMetric })`. (9) Dispatch emission per body class: accumulator-fold ⇒ emit one Pant proposition per mutated location via `ast.eachComb`: `acc--p' obj = acc--p obj OUTER_OP (COMB over each i: Nat0, i < BOUND | F(i))` (optionally with the per-iteration guard `g(i)` as an additional `gExpr` guard) where OUTER_OP and COMB are derived from the body's compound-assign operator (mirroring foreach Shape B's `COMPOUND_ASSIGN_TO_FOLD`); simple-assign ⇒ emit `acc--p' obj = (cond BOUND > 0 => F(BOUND - 1), true => acc--p obj)` via `ast.cond`, using `ast.substituteBinder` to substitute the counter binder with `BOUND - 1` in the RHS expression. (10) Return an `IR1SsaBodyLowerResult` with `program.loopHeaderJoins`, `program.loopBodies`, the propositions, and `modifiedRules`.
- The body-shape recognizer surface in this milestone: (a) `acc.p OP= f(counter)` (single accumulator fold); (b) `if (g(counter)) acc.p OP= f(counter)` (guarded accumulator fold — the guard folds into the over-each's gExpr list); (c) `acc.p = f(counter)` (simple counter-only assign — no `acc.p` read on RHS, no guard wrapping). Multi-statement bodies, true recurrences, side-effecting steps, and assign targets rooted at the counter all reject with refined diagnostics.
- In `tools/ts2pant/src/ir1-lower-body.ts`, add the branch immediately after the `foreach` branch in `lowerL1BodyToSsaResult` (around line 110): `if (stmt.kind === "for") return lowerCounterLoopL1BodyToSsaResult(stmt, options);`. Implement `lowerCounterLoopL1BodyToSsaResult` as a thin adapter that calls `lowerCounterLoopL1Body` inside a try/catch and translates thrown errors to `ir1SsaBodyLowerUnsupported(err.message)`.
- In `tools/ts2pant/src/translate-body.ts` at line 4450, replace the `if (ts.isForStatement(stmt) || ts.isForInStatement(stmt) || ts.isWhileStatement(stmt) || ts.isDoStatement(stmt)) { return { unsupported: "loop assignment" }; }` block with: `if (ts.isForStatement(stmt)) { return buildL1ForCounterMutation(stmt, ctx); }` followed by an unchanged rejection block for `ForIn`, `While`, `Do`.
- Implement `buildL1ForCounterMutation` in the same file (or a new sibling file alongside `ir1-build-body.ts` if the open-question resolves to keep `translate-body.ts` lean). The recognizer: (a) verifies the TS `for`'s `initializer` is a `let` with one declarator initializing a number; (b) verifies `condition` is `counter CMP bound`; (c) verifies `incrementor` is `counter++` / `++counter` / `counter = counter + 1` / `counter += 1`; (d) builds the body via the existing `buildSupportedSsaStatement` recursion; (e) wraps as `ir1For(init, cond, step, body)` (or constructs the L1 record directly).
- Unskip the eight tests in `tools/ts2pant/tests/ir1-ssa-counter-loop.test.mts` and implement assertions: (a) construct a synthetic L1 `for` node with one mutated location and verify the result contains one `loopHeaderJoin` and one `loopBody.headerJoins[0].closed === true`; (b) verify `loopBody.terminationMetric` is non-null and `terminationMetric.expr` references the bound expr; (c) accumulator-fold case — verify the proposition is an over-each equation `acc--p' obj = acc--p obj OUTER_OP (COMB over each i: Nat0, i < bound | F(i))` with the counter as binder; (d) simple-assign case — verify the proposition is a cond equation `acc--p' obj = (cond bound > 0 => F(bound - 1), true => acc--p obj)`; (e-h) verify each rejection diagnostic appears in the returned `diagnostics` array for the corresponding misshape.
- Run `bun run test` and confirm all ts2pant unit tests pass (existing tests unchanged; the seven new tests now pass).
- Run the existing integration / dogfood tests to confirm no regression on prior-shipping fixtures.

## Changes
- Create `tools/ts2pant/src/ir1-ssa-counter-loop.ts` and import existing IR1 symbols: `ir1SsaOpenLoopHeader`, `ir1SsaCloseLoopHeader`, `ir1SsaLoopBody`, `ir1SsaTerminationMetric`, `ir1SsaInitialVersion`, `ir1SsaPropertyLocation`, `ir1SsaPropertyValue`, `ir1SsaWrite`, plus type imports `IR1Expr`, `IR1SsaLocation`, `IR1SsaVersion`, `IR1Stmt`, `IR1SsaProgram`, `IR1SsaLoopBody`. Import `getAst` from `pant-wasm.ts`, `lowerExpr` from `ir-emit.ts`, `lowerL1Expr` from `ir1-lower.ts`.
- Define `interface CounterLoopLowerOptions extends LoopSsaBuildOptions { lowerOpaque?: (e: OpaqueExpr) => OpaqueExpr; initialPropertyValues?: ReadonlyMap<string, OpaqueExpr>; }`.
- Define `interface CounterLoopShape { counterName: string; counterPantBinder: string; initExpr: IR1Expr; boundExpr: IR1Expr; boundCmpOp: "lt" | "le"; body: IR1Stmt; }`. Implement `recognizeCounterLoopShape(stmt: Extract<IR1Stmt, { kind: "for" }>, ctx): CounterLoopShape | { unsupported: string }`. The recognizer verifies (a) `init` is a single assign to `counter` from a numeric literal expression, (b) `cond` is `counter CMP bound` where CMP ∈ {`<`, `<=`} and `bound` does not reference `counter`, (c) `step` is `counter++` / `++counter` / `counter += 1` / `counter = counter + 1`.
- Implement `lowerCounterLoopL1Body(stmt, options)` (the main export). Pseudocode: (1) call `recognizeCounterLoopShape`; on unsupported, return `ir1SsaBodyLowerUnsupported(reason)`. (2) Classify the body as one of two shapes: (i) `accumulator-fold` — body is `acc.p OP= f(counter)` or `if (g(counter)) acc.p OP= f(counter)` with `acc-root != counterName`; (ii) `simple-assign` — body is `acc.p = f(counter)` where the RHS does not read `acc.p` and `acc-root != counterName`. Any other body rejects with a specific diagnostic. (3) Discover mutated locations from the body (one per assign target). (4) For each mutated location, allocate `preheaderVersion = ir1SsaInitialVersion(location)` and open a header via `ir1SsaOpenLoopHeader(location, preheaderVersion)`. (5) Translate the body's writes to OpaqueExpr against a context in which reads of the mutated locations resolve to the header's `joinVersion`. The translation must reject if any write's RHS reads its own LHS location through the header (signals true recurrence — `bounded counter loop body contains an accumulator self-recurrence; lift to L4 fixed-point lowering`). (6) Close each header with the loop-back version (the translated body's terminal write for that location). (7) Build the termination metric: `ir1SsaTerminationMetric(boundExpr - counterVar, lowerBound: ir1LitNat(0))`. (8) Wrap as `ir1SsaLoopBody({ headerJoins, writes, joins: [], breakHandles: [], continueHandles: [], terminationMetric })`. (9) Dispatch emission per body class: accumulator-fold ⇒ emit one Pant proposition per mutated location via `ast.eachComb`: `acc--p' obj = acc--p obj OUTER_OP (COMB over each i: Nat0, i < BOUND | F(i))` (optionally with the per-iteration guard `g(i)` as an additional `gExpr` guard) where OUTER_OP and COMB are derived from the body's compound-assign operator (mirroring foreach Shape B's `COMPOUND_ASSIGN_TO_FOLD`); simple-assign ⇒ emit `acc--p' obj = (cond BOUND > 0 => F(BOUND - 1), true => acc--p obj)` via `ast.cond`, using `ast.substituteBinder` to substitute the counter binder with `BOUND - 1` in the RHS expression. (10) Return an `IR1SsaBodyLowerResult` with `program.loopHeaderJoins`, `program.loopBodies`, the propositions, and `modifiedRules`.
- The body-shape recognizer surface in this milestone: (a) `acc.p OP= f(counter)` (single accumulator fold); (b) `if (g(counter)) acc.p OP= f(counter)` (guarded accumulator fold — the guard folds into the over-each's gExpr list); (c) `acc.p = f(counter)` (simple counter-only assign — no `acc.p` read on RHS, no guard wrapping). Multi-statement bodies, true recurrences, side-effecting steps, and assign targets rooted at the counter all reject with refined diagnostics.
- In `tools/ts2pant/src/ir1-lower-body.ts`, add the branch immediately after the `foreach` branch in `lowerL1BodyToSsaResult` (around line 110): `if (stmt.kind === "for") return lowerCounterLoopL1BodyToSsaResult(stmt, options);`. Implement `lowerCounterLoopL1BodyToSsaResult` as a thin adapter that calls `lowerCounterLoopL1Body` inside a try/catch and translates thrown errors to `ir1SsaBodyLowerUnsupported(err.message)`.
- In `tools/ts2pant/src/translate-body.ts` at line 4450, replace the `if (ts.isForStatement(stmt) || ts.isForInStatement(stmt) || ts.isWhileStatement(stmt) || ts.isDoStatement(stmt)) { return { unsupported: "loop assignment" }; }` block with: `if (ts.isForStatement(stmt)) { return buildL1ForCounterMutation(stmt, ctx); }` followed by an unchanged rejection block for `ForIn`, `While`, `Do`.
- Implement `buildL1ForCounterMutation` in the same file (or a new sibling file alongside `ir1-build-body.ts` if the open-question resolves to keep `translate-body.ts` lean). The recognizer: (a) verifies the TS `for`'s `initializer` is a `let` with one declarator initializing a number; (b) verifies `condition` is `counter CMP bound`; (c) verifies `incrementor` is `counter++` / `++counter` / `counter = counter + 1` / `counter += 1`; (d) builds the body via the existing `buildSupportedSsaStatement` recursion; (e) wraps as `ir1For(init, cond, step, body)` (or constructs the L1 record directly).
- Unskip the eight tests in `tools/ts2pant/tests/ir1-ssa-counter-loop.test.mts` and implement assertions: (a) construct a synthetic L1 `for` node with one mutated location and verify the result contains one `loopHeaderJoin` and one `loopBody.headerJoins[0].closed === true`; (b) verify `loopBody.terminationMetric` is non-null and `terminationMetric.expr` references the bound expr; (c) accumulator-fold case — verify the proposition is an over-each equation `acc--p' obj = acc--p obj OUTER_OP (COMB over each i: Nat0, i < bound | F(i))` with the counter as binder; (d) simple-assign case — verify the proposition is a cond equation `acc--p' obj = (cond bound > 0 => F(bound - 1), true => acc--p obj)`; (e-h) verify each rejection diagnostic appears in the returned `diagnostics` array for the corresponding misshape.
- Run `bun run test` and confirm all ts2pant unit tests pass (existing tests unchanged; the seven new tests now pass).
- Run the existing integration / dogfood tests to confirm no regression on prior-shipping fixtures.

## Files to Modify
- tools/ts2pant/src/ir1-ssa-counter-loop.ts (create): New module implementing the bounded counter loop SSA construction and Pant lowering. Exports `lowerCounterLoopL1Body` and the body-shape recognizer.
- tools/ts2pant/src/ir1-lower-body.ts (modify): Add a `stmt.kind === "for"` arm in `lowerL1BodyToSsaResult` that routes to `lowerCounterLoopL1BodyToSsaResult`, structured like the existing `foreach` branch with try/catch translation of thrown errors to `ir1SsaBodyLowerUnsupported`.
- tools/ts2pant/src/translate-body.ts (modify): Add `buildL1ForCounterMutation(stmt, ctx)` recognizer in the sibling-builder family. Wire it into `buildSupportedSsaStatement` so `ts.isForStatement(stmt)` routes to it before falling through to the existing `loop assignment` rejection.
- tools/ts2pant/tests/ir1-ssa-counter-loop.test.mts (modify): Remove the skip from each `it.skip` and replace each placeholder body with concrete assertions covering the seven invariants.

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[algorithm] Cytron 1991 SSA construction with loop-header phi placement** — https://doi.org/10.1145/115372.115320 — The two-pass discipline (open header with placeholder back-edge; emit body so its reads observe the header's joinVersion; back-patch loop-back) is encoded in `ir1SsaOpenLoopHeader` / `ir1SsaCloseLoopHeader`. The lowerer must invoke them in this order.
- **[algorithm] Floyd/Dijkstra ranking-function termination metrics** — https://en.wikipedia.org/wiki/Termination_analysis — For canonical bounded counter loops the metric is `BOUND - COUNTER`, strictly decreasing each iteration and bounded below by 0. The lowerer attaches this expression to the loop body's `terminationMetric` field.

## Gameplan Specification

```
module TS2PANT_BOUNDED_COUNTER_LOOP_LOWERING.

> ════════════════════════════════════════
> Milestone 2 of the ts2pant general-loop SSA workstream.
> ════════════════════════════════════════
> After this milestone, Pant `pant --check` accepts bounded numeric
> over-each comprehensions with an extractable upper-bound guard,
> ts2pant lowers canonical bounded TS counter loops via the L1 SSA
> vocabulary, three representative fixtures emit Pant that verifies
> end-to-end, and the contract is documented.

Location.
Version.
Expr.
ForStmt.
LoopHeaderJoin.
LoopBody.
TerminationMetric.
Proposition.
Fixture.
PantCheckResult.
NumericTy.
Comb.
Comprehension.
Document.
DocumentKind.
MilestoneStatus.
ClosedStatus.
open => ClosedStatus.
closed => ClosedStatus.
passed => PantCheckResult.
failed => PantCheckResult.
nat0-ty => NumericTy.
nat-ty => NumericTy.
int-ty => NumericTy.
add => Comb.
mul => Comb.
and-c => Comb.
or-c => Comb.
min-c => Comb.
max-c => Comb.
agents-md => DocumentKind.
workstream-doc => DocumentKind.
pending => MilestoneStatus.
landed => MilestoneStatus.

> Pant SMT layer.
binder-ty c: Comprehension => NumericTy.
upper-bound? c: Comprehension => Bool.
upper-bound-mentions-binder? c: Comprehension => Bool.
comb-of c: Comprehension => Comb.
body-is-binder? c: Comprehension => Bool.
rejected? c: Comprehension => Bool.

> ts2pant layer.
stmt-is-canonical-counter? f: ForStmt => Bool.
loop-body-of f: ForStmt => LoopBody.
body-header-joins b: LoopBody => [LoopHeaderJoin].
body-termination-metric b: LoopBody => TerminationMetric.
header-location h: LoopHeaderJoin => Location.
header-status h: LoopHeaderJoin => ClosedStatus.
metric-expr m: TerminationMetric => Expr.
emitted-propositions f: ForStmt => [Proposition].
proposition-references-counter? p: Proposition => Bool.

> Integration layer.
fixture-name f: Fixture => String.
emits-bounded-counter-equation? f: Fixture => Bool.
pant-typecheck-result f: Fixture => PantCheckResult.
pant-check-result f: Fixture => PantCheckResult.
fixture-count => Nat.

> Documentation layer.
document-kind d: Document => DocumentKind.
document-mentions-counter-loop-lowering? d: Document => Bool.
workstream-milestone-2-status => MilestoneStatus.
---

> Pant SMT acceptance.
all c: Comprehension |
  upper-bound? c and
  ~(upper-bound-mentions-binder? c) and
  ~(comb-of c = min-c and ~(upper-bound? c))
    -> ~(rejected? c).

all c: Comprehension |
  comb-of c = min-c and
  body-is-binder? c and
  ~(upper-bound? c)
    -> ~(rejected? c).

all c: Comprehension |
  ~(upper-bound? c) and
  ~(comb-of c = min-c and body-is-binder? c)
    -> rejected? c.

all c: Comprehension |
  upper-bound? c and upper-bound-mentions-binder? c
    -> rejected? c.

> ts2pant counter-loop SSA invariants.
all f: ForStmt |
  stmt-is-canonical-counter? f ->
    (all h in body-header-joins (loop-body-of f) |
       header-status h = closed).

all f: ForStmt |
  stmt-is-canonical-counter? f ->
    (all p in emitted-propositions f | proposition-references-counter? p).

> Fixture corpus.
all f: Fixture | emits-bounded-counter-equation? f.

all f: Fixture |
  pant-typecheck-result f = passed and
  pant-check-result f = passed.

fixture-count = 3.

> Documentation.
all d: Document |
  document-kind d = agents-md ->
    document-mentions-counter-loop-lowering? d.

all d: Document |
  document-kind d = workstream-doc ->
    document-mentions-counter-loop-lowering? d.

workstream-milestone-2-status = landed.
```

## Patch Specification

```
module TS2PANT_BOUNDED_COUNTER_LOOP_LOWERING_PATCH_4.

> Patch 4 lands the ts2pant bounded counter loop SSA construction and
> Pant lowering. Canonical for-statements are recognized at TS-AST,
> built to L1, SSA-constructed via the L1 vocabulary, and lowered to
> quantified Pant equations.

Location.
Version.
Expr.
ForStmt.
CounterLoopShape.
LoopHeaderJoin.
LoopBody.
TerminationMetric.
Proposition.
CounterLoopRejection.
ClosedStatus.
open => ClosedStatus.
closed => ClosedStatus.

stmt-is-canonical-counter? f: ForStmt => Bool.
recognized-shape f: ForStmt => CounterLoopShape.
shape-counter-name s: CounterLoopShape => String.
shape-init-expr s: CounterLoopShape => Expr.
shape-bound-expr s: CounterLoopShape => Expr.
shape-body-mutated-locations s: CounterLoopShape => [Location].
loop-body-of f: ForStmt => LoopBody.
body-header-joins b: LoopBody => [LoopHeaderJoin].
body-termination-metric b: LoopBody => TerminationMetric.
header-location h: LoopHeaderJoin => Location.
header-status h: LoopHeaderJoin => ClosedStatus.
metric-expr m: TerminationMetric => Expr.
emitted-propositions f: ForStmt => [Proposition].
proposition-references-counter? p: Proposition => Bool.
rejection-of f: ForStmt => CounterLoopRejection.
---

> Every recognized for-statement's loop body holds closed header joins,
> one per mutated location.
all f: ForStmt |
  stmt-is-canonical-counter? f ->
    (all h in body-header-joins (loop-body-of f) |
       header-status h = closed).

> Every recognized for-statement's loop body has a non-null termination
> metric.
all f: ForStmt |
  stmt-is-canonical-counter? f ->
    metric-expr (body-termination-metric (loop-body-of f)) !=
      shape-init-expr (recognized-shape f).

> Every recognized for-statement emits one proposition per mutated
> location, and each proposition references the counter binder.
all f: ForStmt |
  stmt-is-canonical-counter? f ->
    (all p in emitted-propositions f | proposition-references-counter? p).

> Non-canonical for-statements produce a rejection rather than
> entering the lowering path.
all f: ForStmt |
  ~(stmt-is-canonical-counter? f) ->
    rejection-of f = rejection-of f.
```


## Implementation Notes

- Counter-loop body classification is intentionally structural at L1: compound assignments arrive as desugared `acc.p = acc.p OP rhs`, so the lowerer treats a single self-read on the left side of an allowed binop as the fold shape and rejects any additional self-read as the L4 true-recurrence case.
- The TS-AST recognizer lives in `translate-body.ts` to reuse the existing mutating-body recursion and state threading. It rejects effectful counter bounds and effectful step operands before building L1, while the L1 lowerer independently revalidates canonical init/condition/step shape.
- One existing `unsupported.ts > loopAssign` snapshot changed because that fixture is now a canonical bounded counter fold and emits a real equation plus frames instead of `> UNSUPPORTED: loop assignment`.
- Deviation to note: the implemented L1 recognizer accepts a numeric-literal counter initializer, matching the patch prose, and the emitted aggregate currently models the canonical zero-based surface used by the TS builder/tests. Non-zero-init generalization would need an additional lower-bound guard in the aggregate.
- Spec/Evidence Mapping: closed loop headers and termination metric are built in `ir1-ssa-counter-loop.ts` via `ir1SsaOpenLoopHeader` -> body write -> `ir1SsaCloseLoopHeader` and `ir1SsaTerminationMetric(bound - counter, 0)`; covered by `ir1-ssa-counter-loop.test.mts` header/metric assertions.
- Spec/Evidence Mapping: emitted propositions for fold and simple-assign bodies are produced by `emitAccumulatorFold` and `emitSimpleAssign`; covered by string-shape assertions in `ir1-ssa-counter-loop.test.mts` and the updated construct snapshot.
- Verification run: `npx tsc --noEmit`, `npx biome ci src`, `npm run test:unit`, `just ts2pant-test-integration`, and `bun run test` all passed.