### PR TITLE
[ts2pant-bounded-counter-loop-lowering] Patch 5: Three representative counter-loop fixtures with pant --check coverage

### DIFF
--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -842,6 +842,18 @@ exports[`functions-mutating-const.ts > multiConstMutating 1`] = `
 "module MULTI_CONST_MUTATING.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\n~> Multi-const-mutating @ a: Account, amount: Int, rate: Int.\\n\\n---\\n\\naccount--balance' a = account--balance a - amount * rate.\\n"
 `;
 
+exports[`functions-mutating-counter-loop.ts > setLastIndex 1`] = `
+"module SET_LAST_INDEX.\\n\\nAccount.\\naccount--total a1: Account => Int.\\naccount--last-index a1: Account => Int.\\n~> Set-last-index @ a: Account, n: Int.\\n\\n---\\n\\naccount--last-index' a = (cond 0 < n => n - 1, true => account--last-index a).\\naccount--total' a1 = account--total a1.\\n"
+`;
+
+exports[`functions-mutating-counter-loop.ts > sumFirstN 1`] = `
+"module SUM_FIRST_N.\\n\\nAccount.\\naccount--total a1: Account => Int.\\naccount--last-index a1: Account => Int.\\n~> Sum-first-n @ a: Account, n: Int.\\n\\n---\\n\\naccount--total' a = account--total a + (+ over each i: Nat0, i >= 0, i < n | i).\\naccount--last-index' a1 = account--last-index a1.\\n"
+`;
+
+exports[`functions-mutating-counter-loop.ts > sumIfPositiveFirstN 1`] = `
+"module SUM_IF_POSITIVE_FIRST_N.\\n\\nAccount.\\naccount--total a1: Account => Int.\\naccount--last-index a1: Account => Int.\\n~> Sum-if-positive-first-n @ a: Account, n: Int.\\n\\n---\\n\\naccount--total' a = account--total a + (+ over each i: Nat0, i >= 0, i < n, i > 0 | i).\\naccount--last-index' a1 = account--last-index a1.\\n"
+`;
+
 exports[`functions-mutating-early-exit.ts > chainedEarlyReturns 1`] = `
 "module CHAINED_EARLY_RETURNS.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--owner a1: Account => String.\\n~> Chained-early-returns @ a: Account, g: Bool, h: Bool.\\n\\n---\\n\\naccount--balance' a = (cond ~g => (cond ~h => 1, true => account--balance a), true => account--balance a).\\naccount--owner' a1 = account--owner a1.\\n"
 `;

--- a/tools/ts2pant/tests/fixtures/constructs/functions-mutating-counter-loop.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/functions-mutating-counter-loop.ts
@@ -1,0 +1,39 @@
+interface Account {
+  total: number;
+  lastIndex: number;
+}
+
+/**
+ * Canonical bounded counter fold: the recognizer accepts the literal-zero
+ * `let` init, strict `i < n` guard, and `i++` step, then lowers the mutation to
+ * `account--total' a = account--total a + (+ over each i: Nat0, i >= 0,
+ * i < n | i)`.
+ */
+export function sumFirstN(a: Account, n: number): void {
+  for (let i = 0; i < n; i++) {
+    a.total += i;
+  }
+}
+
+/**
+ * Guarded bounded counter fold: the inner counter-dependent `if` is folded
+ * into the over-each guard list, yielding
+ * `+ over each i: Nat0, i >= 0, i < n, i > 0`.
+ */
+export function sumIfPositiveFirstN(a: Account, n: number): void {
+  for (let i = 0; i < n; i++) {
+    if (i > 0) {
+      a.total += i;
+    }
+  }
+}
+
+/**
+ * Simple counter-only assignment: the body does not read `a.lastIndex`, so the
+ * loop lowers to last-iteration-wins `cond n > 0 => n - 1, true => prior`.
+ */
+export function setLastIndex(a: Account, n: number): void {
+  for (let i = 0; i < n; i++) {
+    a.lastIndex = i;
+  }
+}

--- a/tools/ts2pant/tests/integration/e2e.test.mts
+++ b/tools/ts2pant/tests/integration/e2e.test.mts
@@ -235,4 +235,58 @@ describe("pant --check", () => {
     assert.ok(result.checks.length > 0);
     assert.ok(result.checks.every((c) => c.passed));
   });
+
+  it("functions-mutating-counter-loop.ts sumFirstN is checkable", {
+    skip: !hasSolver ? "z3 not available" : undefined,
+  }, async () => {
+    const doc = await buildDocument(
+      "constructs/functions-mutating-counter-loop.ts",
+      "sumFirstN",
+    );
+    const output = await emitAndCheck(doc);
+    const result = runCheck(output, {
+      projectRoot: PROJECT_ROOT,
+      pantBin: getPantBin(),
+    });
+
+    assert.equal(result.passed, true);
+    assert.ok(result.checks.length > 0);
+    assert.ok(result.checks.every((c) => c.passed));
+  });
+
+  it("functions-mutating-counter-loop.ts sumIfPositiveFirstN is checkable", {
+    skip: !hasSolver ? "z3 not available" : undefined,
+  }, async () => {
+    const doc = await buildDocument(
+      "constructs/functions-mutating-counter-loop.ts",
+      "sumIfPositiveFirstN",
+    );
+    const output = await emitAndCheck(doc);
+    const result = runCheck(output, {
+      projectRoot: PROJECT_ROOT,
+      pantBin: getPantBin(),
+    });
+
+    assert.equal(result.passed, true);
+    assert.ok(result.checks.length > 0);
+    assert.ok(result.checks.every((c) => c.passed));
+  });
+
+  it("functions-mutating-counter-loop.ts setLastIndex is checkable", {
+    skip: !hasSolver ? "z3 not available" : undefined,
+  }, async () => {
+    const doc = await buildDocument(
+      "constructs/functions-mutating-counter-loop.ts",
+      "setLastIndex",
+    );
+    const output = await emitAndCheck(doc);
+    const result = runCheck(output, {
+      projectRoot: PROJECT_ROOT,
+      pantBin: getPantBin(),
+    });
+
+    assert.equal(result.passed, true);
+    assert.ok(result.checks.length > 0);
+    assert.ok(result.checks.every((c) => c.passed));
+  });
 });


### PR DESCRIPTION
## Patch 5: Three representative counter-loop fixtures with pant --check coverage

- Author `tools/ts2pant/tests/fixtures/constructs/functions-mutating-counter-loop.ts` with three exported functions: (1) `sumFirstN(a: Account, n: number): void` — plain fold `for (let i = 0; i < n; i++) { a.total += i; }` (exercises CombAdd over-each emission); (2) `sumIfPositiveFirstN(a: Account, n: number): void` — guarded fold `for (let i = 0; i < n; i++) { if (i > 0) { a.total += i; } }` (exercises guard-folding into the over-each gExpr list); (3) `setLastIndex(a: Account, n: number): void` — simple counter-only assign `for (let i = 0; i < n; i++) { a.lastIndex = i; }` (exercises the `cond n > 0 => F(n-1), true => prior` emission path for the simple-assign body class).
- Each fixture has a JSDoc summary referencing the canonical Pant lowering shape and any non-obvious aspects of the recognizer.
- Run the existing snapshot-test scaffolding (`bun run test tools/ts2pant/tests/constructs.test.mts`) and accept the new snapshot entries.
- Add three new `it(...)` cases under the existing `describe("pant --check")` block in `tools/ts2pant/tests/integration/e2e.test.mts`, one per fixture: `buildDocument("functions-mutating-counter-loop.ts", "sumFirstN")`, `... "sumIfPositiveFirstN"`, `... "setLastIndex"`. Each emits, checks, runs `pant --check`, and asserts `result.passed === true` with `result.checks.every((c) => c.passed)`. Reuse the `skip: !hasSolver ? "z3 not available" : undefined` guard.
- Run the integration tests with z3 available locally and confirm all three new cases pass. If any fixture fails `pant --check`, debug the emitted Pant (likely a guard ordering or bound-expression shape issue) and adjust the lowerer in Patch 4's territory — but note that Patch 4 has already merged in dependency-graph terms, so any required fix here should be a forward-only refinement in this Patch 5's diff that does not retroactively touch Patch 4's files unless absolutely necessary. (If the fix DOES require touching Patch 4 files, that's a signal the gameplan should be reworked to merge Patch 4 and Patch 5; flag it in review.)
- Confirm full `bun run test` passes (existing tests unchanged; new fixtures pass snapshot + pant --check; integration suite passes).

## Changes
- Author `tools/ts2pant/tests/fixtures/constructs/functions-mutating-counter-loop.ts` with three exported functions: (1) `sumFirstN(a: Account, n: number): void` — plain fold `for (let i = 0; i < n; i++) { a.total += i; }` (exercises CombAdd over-each emission); (2) `sumIfPositiveFirstN(a: Account, n: number): void` — guarded fold `for (let i = 0; i < n; i++) { if (i > 0) { a.total += i; } }` (exercises guard-folding into the over-each gExpr list); (3) `setLastIndex(a: Account, n: number): void` — simple counter-only assign `for (let i = 0; i < n; i++) { a.lastIndex = i; }` (exercises the `cond n > 0 => F(n-1), true => prior` emission path for the simple-assign body class).
- Each fixture has a JSDoc summary referencing the canonical Pant lowering shape and any non-obvious aspects of the recognizer.
- Run the existing snapshot-test scaffolding (`bun run test tools/ts2pant/tests/constructs.test.mts`) and accept the new snapshot entries.
- Add three new `it(...)` cases under the existing `describe("pant --check")` block in `tools/ts2pant/tests/integration/e2e.test.mts`, one per fixture: `buildDocument("functions-mutating-counter-loop.ts", "sumFirstN")`, `... "sumIfPositiveFirstN"`, `... "setLastIndex"`. Each emits, checks, runs `pant --check`, and asserts `result.passed === true` with `result.checks.every((c) => c.passed)`. Reuse the `skip: !hasSolver ? "z3 not available" : undefined` guard.
- Run the integration tests with z3 available locally and confirm all three new cases pass. If any fixture fails `pant --check`, debug the emitted Pant (likely a guard ordering or bound-expression shape issue) and adjust the lowerer in Patch 4's territory — but note that Patch 4 has already merged in dependency-graph terms, so any required fix here should be a forward-only refinement in this Patch 5's diff that does not retroactively touch Patch 4's files unless absolutely necessary. (If the fix DOES require touching Patch 4 files, that's a signal the gameplan should be reworked to merge Patch 4 and Patch 5; flag it in review.)
- Confirm full `bun run test` passes (existing tests unchanged; new fixtures pass snapshot + pant --check; integration suite passes).

## Files to Modify
- tools/ts2pant/tests/fixtures/constructs/functions-mutating-counter-loop.ts (create): New fixture file with three TS counter-loop functions covering the surface shapes the open-question dialogue settles on. JSDoc on each cross-references the canonical Pant lowering shape.
- tools/ts2pant/tests/constructs.test.mts.snapshot (modify): Add new snapshot entries for each fixture, mirroring the existing `functions-mutating-loop.ts` snapshot format.
- tools/ts2pant/tests/integration/e2e.test.mts (modify): Add three new `it(...)` cases inside `describe("pant --check", ...)` — one per fixture — that build the document, emit-and-check it, run `pant --check` via `runCheck`, and assert `result.passed === true` with `result.checks.every((c) => c.passed)`.

## Gameplan Specification

```
module TS2PANT_BOUNDED_COUNTER_LOOP_LOWERING.

> ════════════════════════════════════════
> Milestone 2 of the ts2pant general-loop SSA workstream.
> ════════════════════════════════════════
> After this milestone, Pant `pant --check` accepts bounded numeric
> over-each comprehensions with an extractable upper-bound guard,
> ts2pant lowers canonical bounded TS counter loops via the L1 SSA
> vocabulary, three representative fixtures emit Pant that verifies
> end-to-end, and the contract is documented.

Location.
Version.
Expr.
ForStmt.
LoopHeaderJoin.
LoopBody.
TerminationMetric.
Proposition.
Fixture.
PantCheckResult.
NumericTy.
Comb.
Comprehension.
Document.
DocumentKind.
MilestoneStatus.
ClosedStatus.
open => ClosedStatus.
closed => ClosedStatus.
passed => PantCheckResult.
failed => PantCheckResult.
nat0-ty => NumericTy.
nat-ty => NumericTy.
int-ty => NumericTy.
add => Comb.
mul => Comb.
and-c => Comb.
or-c => Comb.
min-c => Comb.
max-c => Comb.
agents-md => DocumentKind.
workstream-doc => DocumentKind.
pending => MilestoneStatus.
landed => MilestoneStatus.

> Pant SMT layer.
binder-ty c: Comprehension => NumericTy.
upper-bound? c: Comprehension => Bool.
upper-bound-mentions-binder? c: Comprehension => Bool.
comb-of c: Comprehension => Comb.
body-is-binder? c: Comprehension => Bool.
rejected? c: Comprehension => Bool.

> ts2pant layer.
stmt-is-canonical-counter? f: ForStmt => Bool.
loop-body-of f: ForStmt => LoopBody.
body-header-joins b: LoopBody => [LoopHeaderJoin].
body-termination-metric b: LoopBody => TerminationMetric.
header-location h: LoopHeaderJoin => Location.
header-status h: LoopHeaderJoin => ClosedStatus.
metric-expr m: TerminationMetric => Expr.
emitted-propositions f: ForStmt => [Proposition].
proposition-references-counter? p: Proposition => Bool.

> Integration layer.
fixture-name f: Fixture => String.
emits-bounded-counter-equation? f: Fixture => Bool.
pant-typecheck-result f: Fixture => PantCheckResult.
pant-check-result f: Fixture => PantCheckResult.
fixture-count => Nat.

> Documentation layer.
document-kind d: Document => DocumentKind.
document-mentions-counter-loop-lowering? d: Document => Bool.
workstream-milestone-2-status => MilestoneStatus.
---

> Pant SMT acceptance.
all c: Comprehension |
  upper-bound? c and
  ~(upper-bound-mentions-binder? c) and
  ~(comb-of c = min-c and ~(upper-bound? c))
    -> ~(rejected? c).

all c: Comprehension |
  comb-of c = min-c and
  body-is-binder? c and
  ~(upper-bound? c)
    -> ~(rejected? c).

all c: Comprehension |
  ~(upper-bound? c) and
  ~(comb-of c = min-c and body-is-binder? c)
    -> rejected? c.

all c: Comprehension |
  upper-bound? c and upper-bound-mentions-binder? c
    -> rejected? c.

> ts2pant counter-loop SSA invariants.
all f: ForStmt |
  stmt-is-canonical-counter? f ->
    (all h in body-header-joins (loop-body-of f) |
       header-status h = closed).

all f: ForStmt |
  stmt-is-canonical-counter? f ->
    (all p in emitted-propositions f | proposition-references-counter? p).

> Fixture corpus.
all f: Fixture | emits-bounded-counter-equation? f.

all f: Fixture |
  pant-typecheck-result f = passed and
  pant-check-result f = passed.

fixture-count = 3.

> Documentation.
all d: Document |
  document-kind d = agents-md ->
    document-mentions-counter-loop-lowering? d.

all d: Document |
  document-kind d = workstream-doc ->
    document-mentions-counter-loop-lowering? d.

workstream-milestone-2-status = landed.
```

## Patch Specification

```
module TS2PANT_BOUNDED_COUNTER_LOOP_LOWERING_PATCH_5.

> Patch 5 lands three representative bounded counter loop fixtures
> and confirms each emits Pant that passes `pant --check`.

Fixture.
PantCheckResult.
passed => PantCheckResult.
failed => PantCheckResult.

fixture-name f: Fixture => String.
emits-bounded-counter-equation? f: Fixture => Bool.
pant-typecheck-result f: Fixture => PantCheckResult.
pant-check-result f: Fixture => PantCheckResult.
fixture-count => Nat.
---

> Every landed fixture emits at least one bounded counter equation.
all f: Fixture | emits-bounded-counter-equation? f.

> Every landed fixture passes both pant typecheck and pant --check.
all f: Fixture |
  pant-typecheck-result f = passed and
  pant-check-result f = passed.

> Three fixtures land in this milestone.
fixture-count = 3.
```


## Implementation Notes

- The fixture work exposed that this worktree still routed bounded numeric `over each` aggregates through the old unbounded numeric rejection. I included a forward SMT refinement in `lib/smt.ml`: numeric aggregates with an extractable `binder < bound` / `binder <= bound` guard now enumerate `0..config.bound-1` for symbolic bounds, skip the upper-bound guard for concrete literal bounds, and preserve remaining guards as identity-gated aggregate elements.
- The new integration tests resolve the fixture as `constructs/functions-mutating-counter-loop.ts` because `e2e.test.mts` resolves fixture names from `tests/fixtures`, while the required fixture lives under `tests/fixtures/constructs`.
- The emitted fold snapshots include the explicit init guard `i >= 0` before `i < n`. That is intentional: the counter loop lowerer carries the literal-zero initializer as a comprehension guard, and the SMT upper-bound extractor scans the full guard list rather than relying on the upper bound being first.

Spec/Evidence Mapping:
- `fixture-count = 3` and all fixtures emit bounded counter equations: `tools/ts2pant/tests/fixtures/constructs/functions-mutating-counter-loop.ts` plus the three new entries in `tools/ts2pant/tests/constructs.test.mts.snapshot`; proven by `npx tsx --test --test-timeout=300000 tests/constructs.test.mts`.
- `pant-typecheck-result = passed` and `pant-check-result = passed`: the three new `pant --check` cases in `tools/ts2pant/tests/integration/e2e.test.mts`; proven by `npx tsx --test --test-timeout=300000 tests/integration/e2e.test.mts` with z3 available.
- Full regression evidence: `bun run test` from `tools/ts2pant` passed, and `dune test` passed after the SMT change.