### PR TITLE
[ts2pant-ir1-ssa-printer] Patch 3: Fix branch-local read versions, join-referenced initials, and wasm-bundle freshness

### DIFF
--- a/justfile
+++ b/justfile
@@ -80,18 +80,25 @@ ts2pant-typecheck:
     cd tools/ts2pant && npx tsc --noEmit
 
 # Run ts2pant unit tests (no pant binary needed)
-ts2pant-test-unit:
+#
+# Depends on `ts2pant-build-wasm` so a stale bundle can't survive a
+# `wasm/pant_wasm.ml` edit. The wasm-side rename/parse path is exercised
+# by tests via the embedded checker — if the source is updated but the
+# consumer bundle isn't rebuilt, tests run against last-build behaviour
+# and surface as confusing test failures. Dune is incremental, so a
+# no-op rebuild is cheap.
+ts2pant-test-unit: ts2pant-build-wasm
     cd tools/ts2pant && npm run test:unit
 
-# Run ts2pant integration tests (e2e + dogfood); builds pant first
-ts2pant-test-integration: build-pant
+# Run ts2pant integration tests (e2e + dogfood); builds pant + wasm first
+ts2pant-test-integration: build-pant ts2pant-build-wasm
     cd tools/ts2pant && npm run test:integration
 
 # Run all ts2pant tests (unit then integration)
 ts2pant-test: ts2pant-test-unit ts2pant-test-integration
 
-# Update snapshot expectations for ts2pant tests; rebuilds pant first
-ts2pant-test-update-snapshots: build-pant
+# Update snapshot expectations for ts2pant tests; rebuilds pant + wasm first
+ts2pant-test-update-snapshots: build-pant ts2pant-build-wasm
     cd tools/ts2pant && npm run test:update-snapshots
 
 # Run what the pre-commit hook runs for ts2pant

--- a/tools/ts2pant/src/ir1-printer.ts
+++ b/tools/ts2pant/src/ir1-printer.ts
@@ -4,6 +4,7 @@ import type {
   IR1Literal,
   IR1SsaLocation,
   IR1SsaProgram,
+  IR1SsaRead,
   IR1SsaValue,
   IR1SsaVersion,
   IR1Unop,
@@ -85,24 +86,71 @@ export function formatIR1SsaProgram(program: IR1SsaProgram): string {
   const emittedInitials = new Set<symbol>();
   const currentVersions = new Map<string, IR1SsaVersion>();
 
-  for (const read of program.reads) {
-    if (read.version.origin !== "initial") {
-      continue;
+  // Emit `> initial` lines for every initial version referenced
+  // anywhere in the program. Reads aren't the only source — a
+  // cond-stmt that touches a location in one arm but not the other
+  // produces a join whose untouched-side `elseVersion` (or
+  // `thenVersion`) is the initial, with no corresponding read entry.
+  // Loop header joins carry an initial as `preheaderVersion`. Walking
+  // reads + joins + loop-header joins covers every site an initial can
+  // surface from.
+  const emitInitial = (version: IR1SsaVersion) => {
+    if (version.origin !== "initial") {
+      return;
     }
-    currentVersions.set(locationKey(read.location), read.version);
-    if (emittedInitials.has(read.version.id)) {
-      continue;
+    if (emittedInitials.has(version.id)) {
+      return;
     }
-    emittedInitials.add(read.version.id);
+    emittedInitials.add(version.id);
     lines.push(
-      `${labeller.labelOf(read.version)} = ${formatIR1SsaLocation(read.location)}.    > initial`,
+      `${labeller.labelOf(version)} = ${formatIR1SsaLocation(version.location)}.    > initial`,
     );
+  };
+  for (const read of program.reads) {
+    if (read.version.origin === "initial") {
+      currentVersions.set(locationKey(read.location), read.version);
+    }
+    emitInitial(read.version);
+  }
+  for (const join of program.joins) {
+    emitInitial(join.thenVersion);
+    emitInitial(join.elseVersion);
+  }
+  for (const headerJoin of program.loopHeaderJoins) {
+    emitInitial(headerJoin.preheaderVersion);
   }
 
+  // For scalar property writes, derive per-write `readLabels` by
+  // consuming entries from `program.reads` in the same order
+  // `scalarSsaReadExpr` pushed them at build time — one read per
+  // `member` subtree of the value expression. This preserves
+  // branch-local read versions across cond-stmt boundaries: both
+  // branches read from the pre-cond state, not from each other's
+  // writes, even though the flat `program.writes` array interleaves
+  // them as `[...thenWrites, ...elseWrites]`.
+  //
+  // Collection writes (map/set effects) keep the snapshot-of-
+  // `currentVersions` shape: scalar SSA never emits them, and the
+  // collection SSA build doesn't push Member-derived reads, so the
+  // cursor approach has nothing to consume for those values.
+  let readCursor = 0;
   for (const write of program.writes) {
     const key = locationKey(write.location);
     const priorVersion = currentVersions.get(key) ?? null;
-    const readLabels = readExpressionLabels(currentVersions.values(), labeller);
+    let readLabels: ReadonlyMap<string, string>;
+    if (write.value.kind === "property") {
+      const built = new Map<string, string>();
+      readCursor = consumeScalarReadsForExpr(
+        write.value.value,
+        program.reads,
+        readCursor,
+        built,
+        labeller,
+      );
+      readLabels = built;
+    } else {
+      readLabels = readExpressionLabels(currentVersions.values(), labeller);
+    }
     lines.push(
       `${labeller.labelOf(write.version)} = ${formatSsaWriteRhs(
         write.value,
@@ -204,6 +252,157 @@ function readExpressionLabels(
     labels.set(readExpressionKey(version.location), labeller.labelOf(version));
   }
   return labels;
+}
+
+/**
+ * Walk a scalar SSA property-write's value expression in the same order
+ * `scalarSsaReadExpr` pushed reads at build time (one read per `member`
+ * subtree, traversed left-to-right), populating `readLabels` from the
+ * corresponding entries in `program.reads`. Returns the new cursor.
+ *
+ * The build emits all then-branch reads + writes followed by all
+ * else-branch reads + writes for a cond-stmt, so walking writes in
+ * lockstep with reads pairs each write with the reads its RHS consulted
+ * — including across branches where a flat `currentVersions` snapshot
+ * would over-write the pre-cond state.
+ */
+function consumeScalarReadsForExpr(
+  expr: IR1Expr,
+  reads: readonly IR1SsaRead[],
+  cursor: number,
+  readLabels: Map<string, string>,
+  labeller: VersionLabeller,
+): number {
+  switch (expr.kind) {
+    case "member": {
+      const read = reads[cursor];
+      if (read !== undefined && read.location.kind === "property") {
+        readLabels.set(
+          readExpressionKey(read.location),
+          labeller.labelOf(read.version),
+        );
+      }
+      return consumeScalarReadsForExpr(
+        expr.receiver,
+        reads,
+        cursor + 1,
+        readLabels,
+        labeller,
+      );
+    }
+    case "binop":
+      cursor = consumeScalarReadsForExpr(
+        expr.lhs,
+        reads,
+        cursor,
+        readLabels,
+        labeller,
+      );
+      return consumeScalarReadsForExpr(
+        expr.rhs,
+        reads,
+        cursor,
+        readLabels,
+        labeller,
+      );
+    case "unop":
+      return consumeScalarReadsForExpr(
+        expr.arg,
+        reads,
+        cursor,
+        readLabels,
+        labeller,
+      );
+    case "app":
+      cursor = consumeScalarReadsForExpr(
+        expr.callee,
+        reads,
+        cursor,
+        readLabels,
+        labeller,
+      );
+      for (const arg of expr.args) {
+        cursor = consumeScalarReadsForExpr(
+          arg,
+          reads,
+          cursor,
+          readLabels,
+          labeller,
+        );
+      }
+      return cursor;
+    case "cond":
+      for (const [g, v] of expr.arms) {
+        cursor = consumeScalarReadsForExpr(
+          g,
+          reads,
+          cursor,
+          readLabels,
+          labeller,
+        );
+        cursor = consumeScalarReadsForExpr(
+          v,
+          reads,
+          cursor,
+          readLabels,
+          labeller,
+        );
+      }
+      return consumeScalarReadsForExpr(
+        expr.otherwise,
+        reads,
+        cursor,
+        readLabels,
+        labeller,
+      );
+    case "is-nullish":
+      return consumeScalarReadsForExpr(
+        expr.operand,
+        reads,
+        cursor,
+        readLabels,
+        labeller,
+      );
+    case "each":
+      cursor = consumeScalarReadsForExpr(
+        expr.src,
+        reads,
+        cursor,
+        readLabels,
+        labeller,
+      );
+      for (const guard of expr.guards) {
+        cursor = consumeScalarReadsForExpr(
+          guard,
+          reads,
+          cursor,
+          readLabels,
+          labeller,
+        );
+      }
+      return consumeScalarReadsForExpr(
+        expr.proj,
+        reads,
+        cursor,
+        readLabels,
+        labeller,
+      );
+    case "var":
+    case "lit":
+      return cursor;
+    case "map-read":
+    case "set-read":
+      // Scalar SSA programs never put these forms in a property write's
+      // value expression (`scalarSsaReadExpr` throws on them). Defensive
+      // no-op — keep the cursor steady so a malformed input doesn't
+      // mis-attribute a downstream read.
+      return cursor;
+    default: {
+      const _exhaustive: never = expr;
+      void _exhaustive;
+      return cursor;
+    }
+  }
 }
 
 function readExpressionKey(loc: IR1SsaLocation): string {

--- a/tools/ts2pant/tests/ir1-ssa-printer.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-printer.test.mts
@@ -7,6 +7,7 @@ import {
   ir1Assign,
   ir1Binop,
   ir1Block,
+  ir1CondStmt,
   ir1LitNat,
   ir1Member,
   ir1SsaInitialVersion,
@@ -167,5 +168,86 @@ describe("formatIR1SsaProgram", () => {
 
     assert.equal(program.writes.length, 4);
     t.assert.snapshot(formatIR1SsaProgram(program));
+  });
+
+  // Regression: an if/else mutation merge where both arms read and write
+  // the same property. The printer used to label the else-branch's RHS
+  // read against the then-branch's write version (a flat
+  // `currentVersions` snapshot leaked across the branch boundary). The
+  // fix walks `program.reads` in lockstep with `program.writes`, so
+  // each branch's RHS read resolves to the pre-cond initial. The
+  // observable contract: the else-write's RHS labels v1 (the initial),
+  // not v2 (the then-write).
+  it("renders else-branch RHS reads against the pre-cond initial", (t) => {
+    const balance = ir1Member(ir1Var("a"), "Account_balance");
+    const stmt = ir1CondStmt(
+      [
+        [
+          ir1Binop("gt", ir1Var("amount"), ir1LitNat(0)),
+          ir1Assign(balance, ir1Binop("add", balance, ir1Var("amount"))),
+        ],
+      ],
+      ir1Assign(balance, ir1Binop("sub", balance, ir1LitNat(1))),
+    );
+    const program = buildScalarSsaProgram(stmt);
+    const output = formatIR1SsaProgram(program);
+    assert.equal(program.writes.length, 2);
+    assert.equal(program.joins.length, 1);
+    // Then-write reads the initial.
+    assert.match(output, /v2 = \(v1 \+ amount\)\./u);
+    // Else-write also reads the initial — v1, not v2.
+    assert.match(output, /v3 = \(v1 - 1\)\./u);
+    // Phi joins the two candidate post-states.
+    assert.match(output, /v4 = phi v2 v3\./u);
+    t.assert.snapshot(output);
+  });
+
+  // Regression: a cond-stmt that touches a location whose RHS has no
+  // read (e.g., `a.status = 1`) — the falsy arm's contribution to the
+  // join is the location's initial version, but no `program.reads`
+  // entry references it (the body never read `a.status`). The printer
+  // used to label the initial at first reference inside the phi line,
+  // producing an undeclared `v_N = ... > initial` reference. The fix
+  // walks joins + loop-header joins for additional initial sources.
+  it("emits initial lines for join-referenced initials without reads", (t) => {
+    const status = ir1Member(ir1Var("a"), "Account_status");
+    const stmt = ir1CondStmt(
+      [[ir1Binop("gt", ir1Var("amount"), ir1LitNat(0)),
+        ir1Assign(status, ir1LitNat(1))]],
+      null,
+    );
+    const program = buildScalarSsaProgram(stmt);
+    const output = formatIR1SsaProgram(program);
+    // The initial must be emitted before it's referenced in the phi.
+    const lines = output.split("\n");
+    const initialIdx = lines.findIndex((l) =>
+      /^v\d+ = Account_status a\.\s+> initial$/u.test(l),
+    );
+    const phiIdx = lines.findIndex((l) => /^v\d+ = phi /u.test(l));
+    assert.notEqual(initialIdx, -1, "initial line was not emitted");
+    assert.notEqual(phiIdx, -1, "phi line was not emitted");
+    assert.ok(
+      initialIdx < phiIdx,
+      `initial line (${initialIdx}) must precede phi line (${phiIdx})`,
+    );
+    // Every v-label referenced on the RHS of any line must be defined
+    // on the LHS of a preceding line.
+    const defined = new Set<string>();
+    for (const line of lines) {
+      const lhsMatch = line.match(/^(v\d+) = /u);
+      const rhsMatches = line.match(/(?<![A-Za-z_])v\d+/gu) ?? [];
+      if (lhsMatch) {
+        const lhs = lhsMatch[1]!;
+        for (const ref of rhsMatches) {
+          if (ref === lhs) continue;
+          assert.ok(
+            defined.has(ref),
+            `${ref} referenced before definition in line: ${line}`,
+          );
+        }
+        defined.add(lhs);
+      }
+    }
+    t.assert.snapshot(output);
   });
 });

--- a/tools/ts2pant/tests/ir1-ssa-printer.test.mts.snapshot
+++ b/tools/ts2pant/tests/ir1-ssa-printer.test.mts.snapshot
@@ -1,9 +1,17 @@
+exports[`formatIR1SsaProgram > emits initial lines for join-referenced initials without reads 1`] = `
+"> rules: declared = [Account_status]; modified = [Account_status]; framed = []\\n\\nv1 = Account_status a.    > initial\\nv2 = 1.    > Account_status' a\\nv3 = phi v2 v1.    > join Account_status a"
+`;
+
 exports[`formatIR1SsaProgram > renders a buildScalarSsaProgram output 1`] = `
 "> rules: declared = [Account_balance]; modified = [Account_balance]; framed = []\\n\\nv1 = 1.    > Account_balance' a\\nv2 = (v1 + 2).    > Account_balance' a"
 `;
 
 exports[`formatIR1SsaProgram > renders a phi-function from a then/else mutation merge 1`] = `
 "> rules: declared = [Account_balance]; modified = [Account_balance]; framed = []\\n\\nv1 = Account_balance a.    > initial\\nv2 = 1.    > Account_balance' a\\nv3 = phi v2 v1.    > join Account_balance a"
+`;
+
+exports[`formatIR1SsaProgram > renders else-branch RHS reads against the pre-cond initial 1`] = `
+"> rules: declared = [Account_balance]; modified = [Account_balance]; framed = []\\n\\nv1 = Account_balance a.    > initial\\nv2 = (v1 + amount).    > Account_balance' a\\nv3 = (v1 - 1).    > Account_balance' a\\nv4 = phi v2 v3.    > join Account_balance a"
 `;
 
 exports[`formatIR1SsaProgram > renders map-membership and set-membership locations 1`] = `


### PR DESCRIPTION
## Summary

Two SSA printer bugs and one build-graph gap that masked them.

**Printer fix #1 — branch-local read versions.** `formatIR1SsaProgram` used a flat `currentVersions` snapshot to label reads in each write's RHS. For a cond-stmt where both arms read+write the same location, the snapshot already pointed at the then-arm's write by the time the else-arm rendered, so the else-write's RHS mis-labelled the then-write's version instead of the pre-cond initial. The branches in the SSA program are semantically independent — the misrender contradicted what `lowerScalarSsaToProps` actually emits.

Fix: walk `program.reads` in lockstep with `program.writes`, attributing reads via the same traversal order `scalarSsaReadExpr` uses at build time (one read per `member` subtree). Each branch's reads sit contiguously before its writes in the flat arrays, so the cursor stays aligned across cond-stmt boundaries. Collection writes (map/set effects) keep the snapshot path — scalar SSA never emits them, and collection SSA doesn't push Member-derived reads.

**Printer fix #2 — initials reachable only through joins.** When a cond touches a location with no read (e.g., `a.status = 1`), the falsy arm's join contribution is the initial — but no `program.reads` entry carries it, so the printer referenced an undeclared `v_N`. Extend the initials loop to also walk `program.joins.thenVersion` / `elseVersion` and `program.loopHeaderJoins.preheaderVersion`.

**Build-graph fix — justfile recipe dependencies.** `just ts2pant-test*` didn't declare `ts2pant-build-wasm` as a dep, so editing `wasm/pant_wasm.ml` left the consumer bundle in `tools/ts2pant/src/wasm/` stale. That bit this PR: the `EDomain → EVar` rename for module-const annotation references (e.g., `UNSUPPORTED_UNKNOWN → unsupported-unknown`) lives in OCaml source but wasn't in the cached bundle, so two dogfood tests failed locally even though CI passed cleanly. Adding the dep ensures local pre-commit and CI both rebuild before testing; dune is incremental, so a no-op rebuild is cheap.

## Concrete improvement

Before (Example 3 from the SSA tour — incorrect):

    v1 = Account_balance a.    > initial
    v2 = (v1 + amount).        > Account_balance' a
    v3 = (v2 - 1).             > Account_balance' a    ← wrong, v2 leaked from then-branch
    v4 = phi v2 v3.            > join Account_balance a

After:

    v1 = Account_balance a.    > initial
    v2 = (v1 + amount).        > Account_balance' a
    v3 = (v1 - 1).             > Account_balance' a    ← correct, both branches read v1
    v4 = phi v2 v3.            > join Account_balance a

## Tests

Two new tests in `tests/ir1-ssa-printer.test.mts`, each backed by a snapshot:
- `renders else-branch RHS reads against the pre-cond initial` — drives the per-branch read-cursor logic through `buildScalarSsaProgram` and asserts both arms label the initial, not each other's writes.
- `emits initial lines for join-referenced initials without reads` — exercises the if-only-with-literal-RHS case and asserts (a) the `> initial` line is emitted, (b) it precedes the phi that references it, (c) a general invariant: every `v_N` on any RHS has a preceding LHS definition.

All 5 SSA-printer tests pass. Full pre-commit (lint + typecheck + 880 unit + 41 integration) passes locally.

## Test plan

- [x] `just ts2pant-precommit` — green
- [ ] CI: ts2pant job (build pant → build wasm → typecheck → lint → test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)