### PR TITLE
[ts2pant-bounded-while-lowering] Patch 1: Pending tests for descending counter recognizer and let-then-while desugar

### DIFF
--- a/tools/ts2pant/tests/ir1-ssa-counter-loop.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-counter-loop.test.mts
@@ -196,4 +196,32 @@ describe("ir1-ssa-counter-loop", () => {
       /step must be a canonical \+1 increment/u,
     );
   });
+
+  it.skip("recognizes descending counter loop shape (`>` + `-1` step)", () => {
+    // PENDING Patch 2: implement descending counter-loop recognition.
+  });
+
+  it.skip("attaches counter - bound termination metric for desc loops", () => {
+    // PENDING Patch 2: implement descending counter-loop metrics.
+  });
+
+  it.skip("emits desc over-each accumulator fold equation", () => {
+    // PENDING Patch 2: implement descending accumulator-fold lowering.
+  });
+
+  it.skip("emits desc cond simple-assign equation", () => {
+    // PENDING Patch 2: implement descending simple-assign lowering.
+  });
+
+  it.skip("rejects asc cmp with -1 step as mixed-direction", () => {
+    // PENDING Patch 2: implement mixed-direction counter-loop rejection.
+  });
+
+  it.skip("rejects desc shape with non-literal bound", () => {
+    // PENDING Patch 2: implement descending bound literal validation.
+  });
+
+  it.skip("accepts non-literal init for desc shape", () => {
+    // PENDING Patch 2: implement descending init validation.
+  });
 });

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -268,6 +268,22 @@ describe("unsupported patterns", () => {
     assert.equal(props[0]?.kind, "unsupported");
   });
 
+  it.skip("desugars let-then-while ascending counter into ir1For", () => {
+    // PENDING Patch 3: implement let-then-while ascending counter desugar.
+  });
+
+  it.skip("desugars let-then-while descending counter into ir1For", () => {
+    // PENDING Patch 3: implement let-then-while descending counter desugar.
+  });
+
+  it.skip("falls through to let-rejection on non-matching let-then-while pair", () => {
+    // PENDING Patch 3: implement non-matching let-then-while fallthrough coverage.
+  });
+
+  it.skip("rejects bare while loop with L4 fixed-point pointer", () => {
+    // PENDING Patch 3: implement bare while L4 fixed-point diagnostic.
+  });
+
   it("unwraps AsExpression at the body translation entry", () => {
     // The fixture-side `asNumber(x: number)` snapshots `as-number x =
     // x.` whether `unwrapExpression` strips the `as number` cast or


### PR DESCRIPTION
## Patch 1: Pending tests for descending counter recognizer and let-then-while desugar

- In `tools/ts2pant/tests/ir1-ssa-counter-loop.test.mts`, add skipped stubs: `it.skip("recognizes descending counter loop shape (`>` + `-1` step)", ...)`, `it.skip("attaches counter - bound termination metric for desc loops", ...)`, `it.skip("emits desc over-each accumulator fold equation", ...)`, `it.skip("emits desc cond simple-assign equation", ...)`, `it.skip("rejects asc cmp with -1 step as mixed-direction", ...)`, `it.skip("rejects desc shape with non-literal bound", ...)`, `it.skip("accepts non-literal init for desc shape", ...)`.
- In `tools/ts2pant/tests/translate-body.test.mts`, add skipped stubs: `it.skip("desugars let-then-while ascending counter into ir1For", ...)`, `it.skip("desugars let-then-while descending counter into ir1For", ...)`, `it.skip("falls through to let-rejection on non-matching let-then-while pair", ...)`, `it.skip("rejects bare while loop with L4 fixed-point pointer", ...)`.
- Each stub body contains only the PENDING comment naming the implementing patch — no constructor calls or assertions that reference Patch-2 or Patch-3 symbols (those symbols / shapes don't exist yet).
- Do not modify any non-test file in this patch.

## Changes
- In `tools/ts2pant/tests/ir1-ssa-counter-loop.test.mts`, add skipped stubs: `it.skip("recognizes descending counter loop shape (`>` + `-1` step)", ...)`, `it.skip("attaches counter - bound termination metric for desc loops", ...)`, `it.skip("emits desc over-each accumulator fold equation", ...)`, `it.skip("emits desc cond simple-assign equation", ...)`, `it.skip("rejects asc cmp with -1 step as mixed-direction", ...)`, `it.skip("rejects desc shape with non-literal bound", ...)`, `it.skip("accepts non-literal init for desc shape", ...)`.
- In `tools/ts2pant/tests/translate-body.test.mts`, add skipped stubs: `it.skip("desugars let-then-while ascending counter into ir1For", ...)`, `it.skip("desugars let-then-while descending counter into ir1For", ...)`, `it.skip("falls through to let-rejection on non-matching let-then-while pair", ...)`, `it.skip("rejects bare while loop with L4 fixed-point pointer", ...)`.
- Each stub body contains only the PENDING comment naming the implementing patch — no constructor calls or assertions that reference Patch-2 or Patch-3 symbols (those symbols / shapes don't exist yet).
- Do not modify any non-test file in this patch.

## Files to Modify
- tools/ts2pant/tests/ir1-ssa-counter-loop.test.mts (modify): Add `it.skip` stubs for descending recognizer shapes, descending termination metric, descending accumulator-fold and simple-assign output, and rejection of mixed-direction shapes. Each stub carries a `// PENDING Patch 2:` comment naming the implementing patch.
- tools/ts2pant/tests/translate-body.test.mts (modify): Add `it.skip` stubs for the let-then-while desugar at the mutating-body build pass: recognized-pair routes through `lowerCounterLoopL1Body`; unrecognized-pair falls through to the existing `let` rejection; bare `WhileStatement` rejects with the new L4 diagnostic. Each stub carries a `// PENDING Patch 3:` comment.

## Gameplan Specification

```
module TS2PANT_BOUNDED_WHILE_LOWERING.

> ════════════════════════════════
> Milestone 3 of the ts2pant general-loop SSA workstream.
> ════════════════════════════════
> After this milestone, the mutating-body translator accepts
> bounded counter shapes spelled with either `for` or
> `let; while`, in either ascending or descending direction.
> Lowering reuses L2's quantified-over-each machinery for
> accumulator folds and L2's last-iteration cond for simple
> assignments; the symmetric descending metric is
> `counter - bound`. Unsupported while loops reject with one
> diagnostic naming L4 fixed-point lowering. Documentation in
> AGENTS.md and the workstream doc records the surface and
> marks the milestone landed.

TSStmt.
IR1Stmt.
CounterLoop.
Direction.
Metric.
Expr.
Diagnostic.
BuildOutcome.
Document.
DocumentKind.
MilestoneStatus.
asc => Direction.
desc => Direction.
agents-md => DocumentKind.
workstream-doc => DocumentKind.
pending => MilestoneStatus.
landed => MilestoneStatus.

direction l: CounterLoop => Direction.
init-expr l: CounterLoop => Expr.
bound-expr l: CounterLoop => Expr.
metric-expr l: CounterLoop => Metric.
is-numeric-literal? e: Expr => Bool.
is-loop-invariant? e: Expr, l: CounterLoop => Bool.
lower-bound m: Metric => Expr.
metric-decreasing m: Metric, l: CounterLoop => Bool.
represents-zero? e: Expr => Bool.
recognized-let-while? letStmt: TSStmt, whileStmt: TSStmt => Bool.
let-while-direction letStmt: TSStmt, whileStmt: TSStmt => Direction.
build-pair letStmt: TSStmt, whileStmt: TSStmt => BuildOutcome.
build-mutating-body s: TSStmt => BuildOutcome.
is-ir1-for? b: BuildOutcome => Bool.
is-rejection? b: BuildOutcome => Bool.
rejection-mentions-l4? b: BuildOutcome => Bool.
is-bare-while? s: TSStmt => Bool.
is-bounded-counter-shape? s: TSStmt => Bool.
document-kind d: Document => DocumentKind.
document-mentions-l3-bounded-while? d: Document => Bool.
workstream-milestone-3-status => MilestoneStatus.
---

> Direction-dependent shape constraints (carry-forward from
> Patch 2's spec).
all l: CounterLoop |
  direction l = asc -> is-numeric-literal? (init-expr l).

all l: CounterLoop |
  direction l = desc -> is-numeric-literal? (bound-expr l).

all l: CounterLoop |
  is-loop-invariant? (init-expr l) l.

all l: CounterLoop |
  is-loop-invariant? (bound-expr l) l.

> Termination metric correctness in both directions.
all l: CounterLoop |
  metric-decreasing (metric-expr l) l.

all l: CounterLoop |
  represents-zero? (lower-bound (metric-expr l)).

> Build-pass peephole: recognized let-then-while pairs flow
> into ir1For; bare while loops without a matching let reject
> with the L4-pointer diagnostic.
all letStmt: TSStmt, whileStmt: TSStmt |
  recognized-let-while? letStmt whileStmt ->
    is-ir1-for? (build-pair letStmt whileStmt).

all s: TSStmt |
  is-bare-while? s and ~(is-bounded-counter-shape? s) ->
    is-rejection? (build-mutating-body s) and
    rejection-mentions-l4? (build-mutating-body s).

> The peephole is direction-aware.
some letStmt: TSStmt, whileStmt: TSStmt |
  recognized-let-while? letStmt whileStmt and
  let-while-direction letStmt whileStmt = asc.

some letStmt: TSStmt, whileStmt: TSStmt |
  recognized-let-while? letStmt whileStmt and
  let-while-direction letStmt whileStmt = desc.

> Documentation invariants.
all d: Document |
  document-kind d = agents-md ->
    document-mentions-l3-bounded-while? d.

all d: Document |
  document-kind d = workstream-doc ->
    document-mentions-l3-bounded-while? d.

workstream-milestone-3-status = landed.
```

## Patch Specification

```
module TS2PANT_BOUNDED_WHILE_LOWERING_PATCH_1.

> Patch 1 lands the test scaffolding for L3. Stubs are skipped;
> Patches 2 and 3 unskip them in-place with concrete
> assertions. No runtime invariants change.

TestStub.
PendingFor.
patch-2 => PendingFor.
patch-3 => PendingFor.

stub-pending-for s: TestStub => PendingFor.
---
true.
```


## Implementation Notes

- No implementation trade-offs beyond placement: I put the skipped stubs in the existing related `describe` blocks so Patch 2/3 can unskip them in place without moving test structure.
- The stubs intentionally contain only `// PENDING Patch N:` comments and no fixture builders, IR constructors, or diagnostic assertions, preserving the patch's role as scaffolding only.
- Spec/Evidence Mapping: Patch 1's "stubs are skipped; no runtime invariants change" clause maps to `it.skip` additions in `tools/ts2pant/tests/ir1-ssa-counter-loop.test.mts` and `tools/ts2pant/tests/translate-body.test.mts`; required context consulted was the L3 workstream plus the existing L2 counter-loop implementation/tests/fixture; verification passed via the two focused `npm test -- --test-reporter=spec ...` invocations, which also ran the package unit suite.