### PR TITLE
[ts2pant-bounded-while-lowering] Patch 2: Extend counter-loop recognizer with descending direction

### DIFF
--- a/tools/ts2pant/src/ir1-ssa-counter-loop.ts
+++ b/tools/ts2pant/src/ir1-ssa-counter-loop.ts
@@ -41,7 +41,8 @@ export interface CounterLoopShape {
   counterPantBinder: string;
   initExpr: IR1Expr;
   boundExpr: IR1Expr;
-  boundCmpOp: "lt" | "le";
+  boundCmpOp: "lt" | "le" | "gt" | "ge";
+  direction: "asc" | "desc";
   body: IR1Stmt;
 }
 
@@ -96,11 +97,19 @@ export function recognizeCounterLoopShape(
   if ("unsupported" in cond) {
     return cond;
   }
+  const checkedInit = recognizeCounterInit(stmt.init, cond.direction);
+  if ("unsupported" in checkedInit) {
+    return checkedInit;
+  }
 
   if (stmt.step === null) {
     return { unsupported: "counter loop step is missing" };
   }
-  const step = recognizeCounterStep(stmt.step, init.counterName);
+  const step = recognizeCounterStep(
+    stmt.step,
+    init.counterName,
+    cond.direction,
+  );
   if ("unsupported" in step) {
     return step;
   }
@@ -108,9 +117,10 @@ export function recognizeCounterLoopShape(
   return {
     counterName: init.counterName,
     counterPantBinder: ctx.counterPantBinder ?? init.counterName,
-    initExpr: init.initExpr,
+    initExpr: checkedInit.initExpr,
     boundExpr: cond.boundExpr,
     boundCmpOp: cond.boundCmpOp,
+    direction: cond.direction,
     body: stmt.body,
   };
 }
@@ -141,8 +151,12 @@ export function lowerCounterLoopL1Body(
   );
   ir1SsaCloseLoopHeader(header, write.version);
 
+  const terminationMetricExpr =
+    shape.direction === "asc"
+      ? ir1Binop("sub", shape.boundExpr, ir1Var(shape.counterName))
+      : ir1Binop("sub", ir1Var(shape.counterName), shape.boundExpr);
   const terminationMetric = ir1SsaTerminationMetric(
-    ir1Binop("sub", shape.boundExpr, ir1Var(shape.counterName)),
+    terminationMetricExpr,
     ir1LitNat(0),
   );
   const loopBody: IR1SsaLoopBody = ir1SsaLoopBody({
@@ -195,19 +209,33 @@ export function lowerCounterLoopL1Body(
 
 function recognizeCounterInit(
   stmt: IR1Stmt,
+  direction?: "asc" | "desc",
 ): { counterName: string; initExpr: IR1Expr } | { unsupported: string } {
   if (stmt.kind === "let") {
-    if (!isNumericLiteral(stmt.value)) {
+    if (direction === "asc" && !isNumericLiteral(stmt.value)) {
       return {
         unsupported: "counter loop initializer must be a numeric literal",
+      };
+    }
+    if (direction === "desc" && exprReferencesVar(stmt.value, stmt.name)) {
+      return {
+        unsupported: "counter loop initializer must not reference the counter",
       };
     }
     return { counterName: stmt.name, initExpr: stmt.value };
   }
   if (stmt.kind === "assign" && stmt.target.kind === "var") {
-    if (!isNumericLiteral(stmt.value)) {
+    if (direction === "asc" && !isNumericLiteral(stmt.value)) {
       return {
         unsupported: "counter loop initializer must be a numeric literal",
+      };
+    }
+    if (
+      direction === "desc" &&
+      exprReferencesVar(stmt.value, stmt.target.name)
+    ) {
+      return {
+        unsupported: "counter loop initializer must not reference the counter",
       };
     }
     return { counterName: stmt.target.name, initExpr: stmt.value };
@@ -220,42 +248,61 @@ function recognizeCounterInit(
 function recognizeCounterCondition(
   cond: IR1Expr,
   counterName: string,
-): { boundExpr: IR1Expr; boundCmpOp: "lt" | "le" } | { unsupported: string } {
+):
+  | {
+      boundExpr: IR1Expr;
+      boundCmpOp: "lt" | "le" | "gt" | "ge";
+      direction: "asc" | "desc";
+    }
+  | { unsupported: string } {
   if (
     cond.kind !== "binop" ||
-    (cond.op !== "lt" && cond.op !== "le") ||
+    !isCounterBoundCmpOp(cond.op) ||
     cond.lhs.kind !== "var" ||
     cond.lhs.name !== counterName
   ) {
     return {
       unsupported:
-        "counter loop condition must be `counter < bound` or `counter <= bound`",
+        "counter loop condition must be `counter < bound`, `counter <= bound`, `counter > bound`, or `counter >= bound`",
     };
   }
   if (exprReferencesVar(cond.rhs, counterName)) {
     return { unsupported: "counter loop bound must not reference the counter" };
   }
-  return { boundExpr: cond.rhs, boundCmpOp: cond.op };
+  const direction = cond.op === "lt" || cond.op === "le" ? "asc" : "desc";
+  if (direction === "desc" && !isNumericLiteral(cond.rhs)) {
+    return {
+      unsupported: "descending counter loop bound must be a numeric literal",
+    };
+  }
+  return { boundExpr: cond.rhs, boundCmpOp: cond.op, direction };
 }
 
 function recognizeCounterStep(
   step: IR1Stmt,
   counterName: string,
+  direction: "asc" | "desc",
 ): { ok: true } | { unsupported: string } {
   if (
     step.kind !== "assign" ||
     step.target.kind !== "var" ||
     step.target.name !== counterName ||
     step.value.kind !== "binop" ||
-    step.value.op !== "add" ||
+    (step.value.op !== "add" && step.value.op !== "sub") ||
     step.value.lhs.kind !== "var" ||
     step.value.lhs.name !== counterName ||
     !isNatLiteral(step.value.rhs, 1)
   ) {
     return {
       unsupported:
-        "counter loop step must be a canonical +1 increment on the counter",
+        "counter loop step must be a canonical +1 increment or -1 decrement on the counter",
     };
+  }
+  if (
+    (direction === "asc" && step.value.op !== "add") ||
+    (direction === "desc" && step.value.op !== "sub")
+  ) {
+    return { unsupported: "counter loop direction is inconsistent" };
   }
   return { ok: true };
 }
@@ -370,14 +417,14 @@ function emitAccumulatorFold(
   const bound = lowerOpaque(lowerExpr(lowerL1Expr(shape.boundExpr)));
   const rhs = lowerWithCounter(body.rhs, shape, binderExpr, lowerOpaque);
   const guards = [
-    ast.gExpr(ast.binop(ast.opGe(), binderExpr, init)),
     ast.gExpr(
       ast.binop(
-        shape.boundCmpOp === "lt" ? ast.opLt() : ast.opLe(),
+        shape.direction === "asc" ? ast.opGe() : ast.opLe(),
         binderExpr,
-        bound,
+        init,
       ),
     ),
+    ast.gExpr(ast.binop(boundCmpToOpaque(shape.boundCmpOp), binderExpr, bound)),
   ];
   if (body.guard !== null) {
     guards.push(
@@ -407,13 +454,10 @@ function emitSimpleAssign(
   const ast = getAst();
   const init = lowerOpaque(lowerExpr(lowerL1Expr(shape.initExpr)));
   const bound = lowerOpaque(lowerExpr(lowerL1Expr(shape.boundExpr)));
-  const lastCounter =
-    shape.boundCmpOp === "lt"
-      ? ast.binop(ast.opSub(), bound, ast.litNat(1))
-      : bound;
+  const lastCounter = lastCounterValue(shape, bound);
   const rhs = lowerWithCounter(body.rhs, shape, lastCounter, lowerOpaque);
   const loopExecutes = ast.binop(
-    shape.boundCmpOp === "lt" ? ast.opLt() : ast.opLe(),
+    boundCmpToOpaque(shape.boundCmpOp),
     init,
     bound,
   );
@@ -426,6 +470,46 @@ function emitSimpleAssign(
       [ast.litBool(true), target.prior],
     ]),
   };
+}
+
+function lastCounterValue(
+  shape: CounterLoopShape,
+  bound: OpaqueExpr,
+): OpaqueExpr {
+  const ast = getAst();
+  switch (shape.boundCmpOp) {
+    case "lt":
+      return ast.binop(ast.opSub(), bound, ast.litNat(1));
+    case "le":
+    case "ge":
+      return bound;
+    case "gt":
+      return ast.binop(ast.opAdd(), bound, ast.litNat(1));
+    default: {
+      const _exhaustive: never = shape.boundCmpOp;
+      void _exhaustive;
+      throw new Error("unsupported counter loop comparison");
+    }
+  }
+}
+
+function boundCmpToOpaque(cmp: CounterLoopShape["boundCmpOp"]) {
+  const ast = getAst();
+  switch (cmp) {
+    case "lt":
+      return ast.opLt();
+    case "le":
+      return ast.opLe();
+    case "gt":
+      return ast.opGt();
+    case "ge":
+      return ast.opGe();
+    default: {
+      const _exhaustive: never = cmp;
+      void _exhaustive;
+      throw new Error("unsupported counter loop comparison");
+    }
+  }
 }
 
 function lowerWithCounter(
@@ -512,6 +596,10 @@ function isNatLiteral(expr: IR1Expr, value: number): boolean {
     expr.value.kind === "nat" &&
     expr.value.value === value
   );
+}
+
+function isCounterBoundCmpOp(op: string): op is CounterLoopShape["boundCmpOp"] {
+  return op === "lt" || op === "le" || op === "gt" || op === "ge";
 }
 
 function exprReferencesVar(expr: IR1Expr, name: string): boolean {

--- a/tools/ts2pant/tests/ir1-ssa-counter-loop.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-counter-loop.test.mts
@@ -32,6 +32,20 @@ function counterFor(body: IR1Stmt, init: IR1Expr = ir1LitNat(0)): IR1Stmt {
   );
 }
 
+function descCounterFor(
+  body: IR1Stmt,
+  init: IR1Expr = ir1Var("start"),
+  boundExpr: IR1Expr = ir1LitNat(0),
+  cmp: "gt" | "ge" = "gt",
+): IR1Stmt {
+  return ir1For(
+    ir1Let("i", init),
+    ir1Binop(cmp, ir1Var("i"), boundExpr),
+    ir1Assign(ir1Var("i"), ir1Binop("sub", ir1Var("i"), ir1LitNat(1))),
+    body,
+  );
+}
+
 function lower(stmt: IR1Stmt) {
   assert.equal(stmt.kind, "for");
   return lowerCounterLoopL1Body(stmt);
@@ -167,7 +181,7 @@ describe("ir1-ssa-counter-loop", () => {
 
     assert.match(
       diagnosticReasons(stmt).join("\n"),
-      /step must be a canonical \+1 increment/u,
+      /step must be a canonical \+1 increment or -1 decrement/u,
     );
   });
 
@@ -193,35 +207,123 @@ describe("ir1-ssa-counter-loop", () => {
 
     assert.match(
       diagnosticReasons(stmt).join("\n"),
-      /step must be a canonical \+1 increment/u,
+      /step must be a canonical \+1 increment or -1 decrement/u,
     );
   });
 
-  it.skip("recognizes descending counter loop shape (`>` + `-1` step)", () => {
-    // PENDING Patch 2: implement descending counter-loop recognition.
+  it("recognizes descending counter loop shape (`>` + `-1` step)", () => {
+    const result = lower(
+      descCounterFor(ir1Assign(total, ir1Binop("add", total, ir1Var("i")))),
+    );
+
+    assert.deepEqual(result.diagnostics, []);
+    assert.equal(result.programs[0]?.loopBodies.length, 1);
   });
 
-  it.skip("attaches counter - bound termination metric for desc loops", () => {
-    // PENDING Patch 2: implement descending counter-loop metrics.
+  it("attaches counter - bound termination metric for desc loops", () => {
+    const result = lower(
+      descCounterFor(
+        ir1Assign(total, ir1Binop("add", total, ir1Var("i"))),
+        ir1Var("start"),
+        ir1LitNat(2),
+      ),
+    );
+
+    const metric = result.programs[0]?.loopBodies[0]?.terminationMetric;
+    assert.equal(metric?.kind, "ssa-termination-metric");
+    assert.deepEqual(metric?.lowerBound, ir1LitNat(0));
+    assert.equal(metric?.expr.kind, "binop");
+    if (metric?.expr.kind === "binop") {
+      assert.equal(metric.expr.op, "sub");
+      assert.deepEqual(metric.expr.lhs, ir1Var("i"));
+      assert.deepEqual(metric.expr.rhs, ir1LitNat(2));
+    }
   });
 
-  it.skip("emits desc over-each accumulator fold equation", () => {
-    // PENDING Patch 2: implement descending accumulator-fold lowering.
+  it("emits desc over-each accumulator fold equation", () => {
+    const ast = getAst();
+    const result = lower(
+      descCounterFor(
+        ir1Assign(total, ir1Binop("add", total, ir1Var("i"))),
+        ir1Var("start"),
+        ir1LitNat(0),
+      ),
+    );
+
+    assert.deepEqual(result.diagnostics, []);
+    const prop = result.propositions[0];
+    assert.equal(prop?.kind, "equation");
+    if (prop?.kind === "equation") {
+      assert.equal(
+        ast.strExpr(prop.rhs),
+        "Account_total account + (+ over each i: Nat0, i <= start, i > 0 | i)",
+      );
+    }
   });
 
-  it.skip("emits desc cond simple-assign equation", () => {
-    // PENDING Patch 2: implement descending simple-assign lowering.
+  it("emits desc cond simple-assign equation", () => {
+    const ast = getAst();
+    const result = lower(
+      descCounterFor(ir1Assign(total, ir1Var("i")), ir1Var("start")),
+    );
+
+    assert.deepEqual(result.diagnostics, []);
+    const prop = result.propositions[0];
+    assert.equal(prop?.kind, "equation");
+    if (prop?.kind === "equation") {
+      assert.equal(
+        ast.strExpr(prop.rhs),
+        "cond start > 0 => 0 + 1, true => Account_total account",
+      );
+    }
   });
 
-  it.skip("rejects asc cmp with -1 step as mixed-direction", () => {
-    // PENDING Patch 2: implement mixed-direction counter-loop rejection.
+  it("rejects asc cmp with -1 step as mixed-direction", () => {
+    const stmt = ir1For(
+      ir1Let("i", ir1LitNat(0)),
+      ir1Binop("lt", ir1Var("i"), bound),
+      ir1Assign(ir1Var("i"), ir1Binop("sub", ir1Var("i"), ir1LitNat(1))),
+      ir1Assign(total, ir1Binop("add", total, ir1Var("i"))),
+    );
+
+    assert.match(
+      diagnosticReasons(stmt).join("\n"),
+      /counter loop direction is inconsistent/u,
+    );
   });
 
-  it.skip("rejects desc shape with non-literal bound", () => {
-    // PENDING Patch 2: implement descending bound literal validation.
+  it("rejects desc shape with non-literal bound", () => {
+    assert.match(
+      diagnosticReasons(
+        descCounterFor(
+          ir1Assign(total, ir1Binop("add", total, ir1Var("i"))),
+          ir1Var("start"),
+          bound,
+        ),
+      ).join("\n"),
+      /descending counter loop bound must be a numeric literal/u,
+    );
   });
 
-  it.skip("accepts non-literal init for desc shape", () => {
-    // PENDING Patch 2: implement descending init validation.
+  it("accepts non-literal init for desc shape", () => {
+    const ast = getAst();
+    const result = lower(
+      descCounterFor(
+        ir1Assign(total, ir1Binop("add", total, ir1Var("i"))),
+        ir1Var("start"),
+        ir1LitNat(1),
+        "ge",
+      ),
+    );
+
+    assert.deepEqual(result.diagnostics, []);
+    const prop = result.propositions[0];
+    assert.equal(prop?.kind, "equation");
+    if (prop?.kind === "equation") {
+      assert.equal(
+        ast.strExpr(prop.rhs),
+        "Account_total account + (+ over each i: Nat0, i <= start, i >= 1 | i)",
+      );
+    }
   });
 });


### PR DESCRIPTION
## Patch 2: Extend counter-loop recognizer with descending direction

- Widen `CounterLoopShape.boundCmpOp` to `"lt" | "le" | "gt" | "ge"` and add a non-optional `direction: "asc" | "desc"` field.
- In `recognizeCounterCondition` (line 220): allow `gt`/`ge` arms; for those arms, require `cond.rhs` to be a numeric literal (`isNumericLiteral`), preserve the counter-on-lhs check, and preserve the no-counter-in-bound check.
- In `recognizeCounterStep` (line 241): accept `Assign(c, Binop(sub, c, 1))` paired with `>`/`>=` condition. The mixed-direction shapes (`<` with `-1`, `>` with `+1`) reject with `"counter loop direction is inconsistent"` (or similar).
- In `recognizeCounterInit` (line 196): for desc direction, accept a loop-invariant non-counter expression (use `exprReferencesVar` to check non-counter), not just literals. Keep the asc path requiring a numeric literal as today.
- Plumb direction from `recognizeCounterLoopShape` to `lowerCounterLoopL1Body`. Compute `terminationMetric` as `ir1Binop("sub", ir1Var(counter), boundExpr)` (desc) vs `ir1Binop("sub", boundExpr, ir1Var(counter))` (asc) with lower bound 0.
- In `emitAccumulatorFold` (line 361): swap the over-each guard ordering for desc — guard #1 is `binder <= init`, guard #2 is `binder cmp bound`. Asc keeps `binder >= init, binder cmp bound`.
- In `emitSimpleAssign` (line 401): compute `lastCounter` for desc: `bound + 1` (operator `add` on the literal bound) when cmp is `>`, `bound` when cmp is `>=`. Compute `loopExecutes` as `init > bound` / `init >= bound` for desc.
- No new caller constructs a desc-shaped `ir1For` in this patch — the build-path peephole lands in Patch 3. Patch 2 only extends the recognizer; the new capability is dormant until Patch 3.
- In `tools/ts2pant/tests/ir1-ssa-counter-loop.test.mts`, unskip the seven Patch-2-owned stubs and replace each body with concrete assertions matching the existing asc tests' style (deepEqual on metric structure, exact string match on `ast.strExpr(prop.rhs)` for emitted Pant, regex match on diagnostic reasons).

## Changes
- Widen `CounterLoopShape.boundCmpOp` to `"lt" | "le" | "gt" | "ge"` and add a non-optional `direction: "asc" | "desc"` field.
- In `recognizeCounterCondition` (line 220): allow `gt`/`ge` arms; for those arms, require `cond.rhs` to be a numeric literal (`isNumericLiteral`), preserve the counter-on-lhs check, and preserve the no-counter-in-bound check.
- In `recognizeCounterStep` (line 241): accept `Assign(c, Binop(sub, c, 1))` paired with `>`/`>=` condition. The mixed-direction shapes (`<` with `-1`, `>` with `+1`) reject with `"counter loop direction is inconsistent"` (or similar).
- In `recognizeCounterInit` (line 196): for desc direction, accept a loop-invariant non-counter expression (use `exprReferencesVar` to check non-counter), not just literals. Keep the asc path requiring a numeric literal as today.
- Plumb direction from `recognizeCounterLoopShape` to `lowerCounterLoopL1Body`. Compute `terminationMetric` as `ir1Binop("sub", ir1Var(counter), boundExpr)` (desc) vs `ir1Binop("sub", boundExpr, ir1Var(counter))` (asc) with lower bound 0.
- In `emitAccumulatorFold` (line 361): swap the over-each guard ordering for desc — guard #1 is `binder <= init`, guard #2 is `binder cmp bound`. Asc keeps `binder >= init, binder cmp bound`.
- In `emitSimpleAssign` (line 401): compute `lastCounter` for desc: `bound + 1` (operator `add` on the literal bound) when cmp is `>`, `bound` when cmp is `>=`. Compute `loopExecutes` as `init > bound` / `init >= bound` for desc.
- No new caller constructs a desc-shaped `ir1For` in this patch — the build-path peephole lands in Patch 3. Patch 2 only extends the recognizer; the new capability is dormant until Patch 3.
- In `tools/ts2pant/tests/ir1-ssa-counter-loop.test.mts`, unskip the seven Patch-2-owned stubs and replace each body with concrete assertions matching the existing asc tests' style (deepEqual on metric structure, exact string match on `ast.strExpr(prop.rhs)` for emitted Pant, regex match on diagnostic reasons).

## Files to Modify
- tools/ts2pant/src/ir1-ssa-counter-loop.ts (modify): Add `direction: "asc" | "desc"` to `CounterLoopShape`; widen `boundCmpOp` to `"lt" | "le" | "gt" | "ge"`. Extend `recognizeCounterCondition` to accept `gt`/`ge` (with desc direction) and require the bound to be a numeric literal when direction is desc. Extend `recognizeCounterStep` to accept `Assign(c, Binop(sub, c, 1))` paired with desc direction. Extend `recognizeCounterInit` to accept a loop-invariant non-counter initializer for desc (while still requiring a numeric literal for asc). In `lowerCounterLoopL1Body`, compute `terminationMetric` based on direction: asc remains `bound - counter`; desc becomes `counter - bound`. In `emitAccumulatorFold`, emit guards `binder >= INIT, binder CMP BOUND` for asc and `binder <= INIT, binder CMP BOUND` for desc. In `emitSimpleAssign`, compute `lastCounter` for desc as `bound + 1` when cmp is `>` and `bound` when cmp is `>=`; compute `loopExecutes` as `init > bound` / `init >= bound` for desc.
- tools/ts2pant/tests/ir1-ssa-counter-loop.test.mts (modify): Remove `.skip` from the Patch-2-owned stubs introduced in Patch 1. Replace each PENDING-comment body with a concrete assertion mirroring the existing asc tests' shape: construct an `ir1For` with desc shape, lower it, assert on diagnostic-emptiness, termination-metric structure, and emitted Pant string.

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[algorithm] Floyd ranking-function termination** — https://en.wikipedia.org/wiki/Termination_analysis — Symmetric metric construction: ascending counters use `bound - counter ≥ 0`; descending counters use `counter - bound ≥ 0`. Flip the subtrahend to match the direction; lower bound stays 0.
- **[algorithm] Cytron 1991 SSA construction (carry-forward)** — https://doi.org/10.1145/115372.115320 — The two-pass loop-header phi-placement protocol is unchanged from L2 — `ir1SsaOpenLoopHeader` then body emission then `ir1SsaCloseLoopHeader`. Desc adds no new SSA mechanism; the metric flip is purely about the termination evidence, not the SSA construction.

## Gameplan Specification

```
module TS2PANT_BOUNDED_WHILE_LOWERING.

> ════════════════════════════════
> Milestone 3 of the ts2pant general-loop SSA workstream.
> ════════════════════════════════
> After this milestone, the mutating-body translator accepts
> bounded counter shapes spelled with either `for` or
> `let; while`, in either ascending or descending direction.
> Lowering reuses L2's quantified-over-each machinery for
> accumulator folds and L2's last-iteration cond for simple
> assignments; the symmetric descending metric is
> `counter - bound`. Unsupported while loops reject with one
> diagnostic naming L4 fixed-point lowering. Documentation in
> AGENTS.md and the workstream doc records the surface and
> marks the milestone landed.

TSStmt.
IR1Stmt.
CounterLoop.
Direction.
Metric.
Expr.
Diagnostic.
BuildOutcome.
Document.
DocumentKind.
MilestoneStatus.
asc => Direction.
desc => Direction.
agents-md => DocumentKind.
workstream-doc => DocumentKind.
pending => MilestoneStatus.
landed => MilestoneStatus.

direction l: CounterLoop => Direction.
init-expr l: CounterLoop => Expr.
bound-expr l: CounterLoop => Expr.
metric-expr l: CounterLoop => Metric.
is-numeric-literal? e: Expr => Bool.
is-loop-invariant? e: Expr, l: CounterLoop => Bool.
lower-bound m: Metric => Expr.
metric-decreasing m: Metric, l: CounterLoop => Bool.
represents-zero? e: Expr => Bool.
recognized-let-while? letStmt: TSStmt, whileStmt: TSStmt => Bool.
let-while-direction letStmt: TSStmt, whileStmt: TSStmt => Direction.
build-pair letStmt: TSStmt, whileStmt: TSStmt => BuildOutcome.
build-mutating-body s: TSStmt => BuildOutcome.
is-ir1-for? b: BuildOutcome => Bool.
is-rejection? b: BuildOutcome => Bool.
rejection-mentions-l4? b: BuildOutcome => Bool.
is-bare-while? s: TSStmt => Bool.
is-bounded-counter-shape? s: TSStmt => Bool.
document-kind d: Document => DocumentKind.
document-mentions-l3-bounded-while? d: Document => Bool.
workstream-milestone-3-status => MilestoneStatus.
---

> Direction-dependent shape constraints (carry-forward from
> Patch 2's spec).
all l: CounterLoop |
  direction l = asc -> is-numeric-literal? (init-expr l).

all l: CounterLoop |
  direction l = desc -> is-numeric-literal? (bound-expr l).

all l: CounterLoop |
  is-loop-invariant? (init-expr l) l.

all l: CounterLoop |
  is-loop-invariant? (bound-expr l) l.

> Termination metric correctness in both directions.
all l: CounterLoop |
  metric-decreasing (metric-expr l) l.

all l: CounterLoop |
  represents-zero? (lower-bound (metric-expr l)).

> Build-pass peephole: recognized let-then-while pairs flow
> into ir1For; bare while loops without a matching let reject
> with the L4-pointer diagnostic.
all letStmt: TSStmt, whileStmt: TSStmt |
  recognized-let-while? letStmt whileStmt ->
    is-ir1-for? (build-pair letStmt whileStmt).

all s: TSStmt |
  is-bare-while? s and ~(is-bounded-counter-shape? s) ->
    is-rejection? (build-mutating-body s) and
    rejection-mentions-l4? (build-mutating-body s).

> The peephole is direction-aware.
some letStmt: TSStmt, whileStmt: TSStmt |
  recognized-let-while? letStmt whileStmt and
  let-while-direction letStmt whileStmt = asc.

some letStmt: TSStmt, whileStmt: TSStmt |
  recognized-let-while? letStmt whileStmt and
  let-while-direction letStmt whileStmt = desc.

> Documentation invariants.
all d: Document |
  document-kind d = agents-md ->
    document-mentions-l3-bounded-while? d.

all d: Document |
  document-kind d = workstream-doc ->
    document-mentions-l3-bounded-while? d.

workstream-milestone-3-status = landed.
```

## Patch Specification

```
module TS2PANT_BOUNDED_WHILE_LOWERING_PATCH_2.

> Patch 2 extends the L2 counter-loop recognizer with the
> symmetric descending direction. Ascending invariants are
> preserved; descending adds dual constraints (literal bound,
> loop-invariant init, sub-1 step, gt/ge comparison) and a
> symmetric termination metric.

CounterLoop.
Direction.
Expr.
Metric.
asc => Direction.
desc => Direction.

direction l: CounterLoop => Direction.
init-expr l: CounterLoop => Expr.
bound-expr l: CounterLoop => Expr.
metric-expr l: CounterLoop => Metric.
is-numeric-literal? e: Expr => Bool.
is-loop-invariant? e: Expr, l: CounterLoop => Bool.
lower-bound m: Metric => Expr.
metric-decreasing m: Metric, l: CounterLoop => Bool.
represents-zero? e: Expr => Bool.
---

> Direction-dependent shape constraints.
all l: CounterLoop |
  direction l = asc -> is-numeric-literal? (init-expr l).

all l: CounterLoop |
  direction l = desc -> is-numeric-literal? (bound-expr l).

> The init endpoint is loop-invariant in both directions; this
> is the load-bearing termination-metric correctness condition.
all l: CounterLoop |
  is-loop-invariant? (init-expr l) l.

all l: CounterLoop |
  is-loop-invariant? (bound-expr l) l.

> Termination metric is strictly decreasing and bounded below by 0.
all l: CounterLoop |
  metric-decreasing (metric-expr l) l.

all l: CounterLoop |
  represents-zero? (lower-bound (metric-expr l)).
```


## Implementation Notes

- The recognizer now does a two-phase init read: first it extracts the counter name without endpoint validation, then re-validates the same init after the condition determines `asc` vs `desc`. This is what lets descending loops use a non-literal, loop-invariant init while preserving the existing asc literal-init rejection.
- Desc loop-invariance is enforced with the same local check available to this recognizer: `exprReferencesVar(init, counterName)` / `exprReferencesVar(bound, counterName)`. There is no broader purity or mutation analysis added in this patch; that matches the patch scope and keeps the future let/while peephole as the only new build-pass surface.
- The invalid-step diagnostic was widened from “canonical +1 increment” to “canonical +1 increment or -1 decrement” for non-canonical steps. Directionally valid syntax with the wrong comparison/step pairing gets the more specific mixed-direction diagnostic.
- `boundCmpToOpaque` and `lastCounterValue` centralize the comparison-to-Pant and endpoint arithmetic so the existing asc behavior and the new desc behavior share the same simple-assign path.

Spec/Evidence Mapping:
- Direction-dependent constraints: `CounterLoopShape.direction`, `recognizeCounterCondition`, `recognizeCounterInit`, and `recognizeCounterStep` in `tools/ts2pant/src/ir1-ssa-counter-loop.ts`; covered by the unskipped desc recognition, non-literal init, non-literal bound, and mixed-direction tests.
- Termination metric: `lowerCounterLoopL1Body` computes `bound - counter` for asc and `counter - bound` for desc, lower bound `0`; covered by metric structure assertions in `tools/ts2pant/tests/ir1-ssa-counter-loop.test.mts`.
- Lowering output: `emitAccumulatorFold`, `emitSimpleAssign`, `lastCounterValue`; covered by exact `ast.strExpr(prop.rhs)` assertions for desc over-each and simple-assign output.
- Required context consulted before implementation: `workstreams/ts2pant-general-loop-ssa.md`, `tools/ts2pant/src/ir1-ssa-counter-loop.ts`, `tools/ts2pant/tests/ir1-ssa-counter-loop.test.mts`, and `tools/ts2pant/src/ir1.ts`.
- Validation run: `npx tsc --noEmit`, focused `ir1-ssa-counter-loop` test, `npm run test:unit`, `just ts2pant-test-integration`, `npm run lint`, and `git diff --check`.