### PR TITLE
[ts2pant-bounded-while-lowering] Patch 3: Recognize let-then-while pairs at the mutating-body build pass; ship fixtures

### DIFF
--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -26,6 +26,7 @@ import {
   tryRecognizeFunctorLift,
 } from "./ir1-build.js";
 import {
+  type BuildBodyCtx,
   buildL1AssignStmt,
   buildL1EffectCall,
   buildL1ForEachCall,
@@ -4337,12 +4338,40 @@ function buildSupportedSsaMutatingBody(
   const applyConst = (e: OpaqueExpr): OpaqueExpr =>
     applyOpaqueAliases(applyConstChain(e), supply);
   setCanonicalize(state, applyConst);
-  for (const stmt of body.statements) {
+  for (let i = 0; i < body.statements.length; i++) {
+    const stmt = body.statements[i]!;
     if (isGuardStatement(stmt, checker)) {
       continue;
     }
     if (ts.isReturnStatement(stmt) && !stmt.expression) {
       continue;
+    }
+    if (
+      ts.isVariableStatement(stmt) &&
+      stmt.declarationList.flags & ts.NodeFlags.Let &&
+      stmt.declarationList.declarations.length === 1 &&
+      ts.isIdentifier(stmt.declarationList.declarations[0]!.name) &&
+      stmt.declarationList.declarations[0]!.initializer !== undefined &&
+      i + 1 < body.statements.length &&
+      ts.isWhileStatement(body.statements[i + 1]!)
+    ) {
+      const built = buildL1LetWhileMutation(
+        stmt,
+        body.statements[i + 1]! as ts.WhileStatement,
+        {
+          checker,
+          strategy,
+          paramNames: scopedParamNames,
+          state,
+          supply,
+          applyConst,
+        },
+      );
+      if (built !== null) {
+        stmts.push(built);
+        i += 1;
+        continue;
+      }
     }
     if (ts.isVariableStatement(stmt)) {
       const declList = stmt.declarationList;
@@ -4461,11 +4490,13 @@ function buildSupportedSsaStatement(
       return buildL1AssignStmt(stmt, ctx);
     }
   }
-  if (
-    ts.isForInStatement(stmt) ||
-    ts.isWhileStatement(stmt) ||
-    ts.isDoStatement(stmt)
-  ) {
+  if (ts.isWhileStatement(stmt)) {
+    return {
+      unsupported:
+        "while loop is not a recognized bounded-counter shape; lift to L4 fixed-point lowering when that milestone ships",
+    };
+  }
+  if (ts.isForInStatement(stmt) || ts.isDoStatement(stmt)) {
     return { unsupported: "loop assignment" };
   }
   return {
@@ -4535,6 +4566,136 @@ function buildL1ForCounterMutation(
   }
 
   return ir1For(init.initStmt, cond, step, bodyStmt);
+}
+
+function buildL1LetWhileMutation(
+  letStmt: ts.VariableStatement,
+  whileStmt: ts.WhileStatement,
+  ctx: BuildBodyCtx & { paramNames: Map<string, string> },
+): IR1Stmt | null {
+  const declList = letStmt.declarationList;
+  if (
+    !(declList.flags & ts.NodeFlags.Let) ||
+    declList.declarations.length !== 1
+  ) {
+    return null;
+  }
+
+  const decl = declList.declarations[0]!;
+  if (!ts.isIdentifier(decl.name) || decl.initializer === undefined) {
+    return null;
+  }
+
+  const counterName = decl.name.text;
+  const initExpr = buildL1SubExpr(decl.initializer, ctx);
+  if (isUnsupported(initExpr)) {
+    return null;
+  }
+
+  const cond = buildL1LetWhileCounterCondition(
+    whileStmt.expression,
+    counterName,
+    ctx,
+  );
+  if (cond === null) {
+    return null;
+  }
+
+  if (!ts.isBlock(whileStmt.statement)) {
+    return null;
+  }
+  const bodyStatements = [...whileStmt.statement.statements];
+  const trailingStep = bodyStatements.at(-1);
+  if (
+    trailingStep === undefined ||
+    !ts.isExpressionStatement(trailingStep) ||
+    counterStepHasEffectfulOperand(trailingStep.expression, counterName, ctx)
+  ) {
+    return null;
+  }
+
+  const step = buildL1IncrementStep(trailingStep.expression, counterName, ctx);
+  if (isL1StmtUnsupported(step)) {
+    return null;
+  }
+  if (!isCanonicalUnitCounterStep(step, counterName)) {
+    return null;
+  }
+
+  const bodyWithoutStep = ts.factory.updateBlock(
+    whileStmt.statement,
+    bodyStatements.slice(0, -1),
+  );
+  const bodyStmt = buildSupportedSsaMutatingBody(
+    bodyWithoutStep,
+    ctx.checker,
+    ctx.strategy,
+    ctx.paramNames,
+    ctx.state,
+    ctx.supply,
+  );
+  if (isUnsupported(bodyStmt)) {
+    return null;
+  }
+
+  return ir1For(ir1Let(counterName, initExpr), cond, step, bodyStmt);
+}
+
+function isCanonicalUnitCounterStep(
+  step: IR1Stmt,
+  counterName: string,
+): boolean {
+  return (
+    step.kind === "assign" &&
+    step.target.kind === "var" &&
+    step.target.name === counterName &&
+    step.value.kind === "binop" &&
+    (step.value.op === "add" || step.value.op === "sub") &&
+    step.value.lhs.kind === "var" &&
+    step.value.lhs.name === counterName &&
+    step.value.rhs.kind === "lit" &&
+    step.value.rhs.value.kind === "nat" &&
+    step.value.rhs.value.value === 1
+  );
+}
+
+function buildL1LetWhileCounterCondition(
+  condition: ts.Expression,
+  counterName: string,
+  ctx: BuildBodyCtx,
+): IR1Expr | null {
+  const cond = unwrapExpression(condition);
+  if (
+    !ts.isBinaryExpression(cond) ||
+    (cond.operatorToken.kind !== ts.SyntaxKind.LessThanToken &&
+      cond.operatorToken.kind !== ts.SyntaxKind.LessThanEqualsToken &&
+      cond.operatorToken.kind !== ts.SyntaxKind.GreaterThanToken &&
+      cond.operatorToken.kind !== ts.SyntaxKind.GreaterThanEqualsToken) ||
+    !ts.isIdentifier(cond.left) ||
+    cond.left.text !== counterName
+  ) {
+    return null;
+  }
+  if (
+    expressionReferencesNames(cond.right, new Set([counterName])) ||
+    expressionHasSideEffects(cond.right, ctx.checker)
+  ) {
+    return null;
+  }
+  const bound = buildL1SubExpr(cond.right, { ...ctx, applyConst: (e) => e });
+  if (isUnsupported(bound)) {
+    return null;
+  }
+
+  const op =
+    cond.operatorToken.kind === ts.SyntaxKind.LessThanToken
+      ? "lt"
+      : cond.operatorToken.kind === ts.SyntaxKind.LessThanEqualsToken
+        ? "le"
+        : cond.operatorToken.kind === ts.SyntaxKind.GreaterThanToken
+          ? "gt"
+          : "ge";
+  return ir1Binop(op, ir1Var(counterName), bound);
 }
 
 function buildL1ForCounterInit(

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -766,6 +766,26 @@ exports[`functions-class.ts > Account.getBalance 1`] = `
 "module GET_BALANCE.\\n\\nget-balance a: Account => Int.\\n\\n---\\n\\nget-balance a = account--balance a.\\n"
 `;
 
+exports[`functions-mutating-bounded-while.ts > setLastIndexDescending 1`] = `
+"module SET_LAST_INDEX_DESCENDING.\\n\\nAccount.\\naccount--total a1: Account => Int.\\naccount--last-index a1: Account => Int.\\n~> Set-last-index-descending @ a: Account, n: Int.\\n\\n---\\n\\naccount--last-index' a = (cond n > 0 => 0 + 1, true => account--last-index a).\\naccount--total' a1 = account--total a1.\\n"
+`;
+
+exports[`functions-mutating-bounded-while.ts > setLastIndexWhile 1`] = `
+"module SET_LAST_INDEX_WHILE.\\n\\nAccount.\\naccount--total a1: Account => Int.\\naccount--last-index a1: Account => Int.\\n~> Set-last-index-while @ a: Account, n: Int.\\n\\n---\\n\\naccount--last-index' a = (cond 0 < n => n - 1, true => account--last-index a).\\naccount--total' a1 = account--total a1.\\n"
+`;
+
+exports[`functions-mutating-bounded-while.ts > sumFirstNDescending 1`] = `
+"module SUM_FIRST_N_DESCENDING.\\n\\nAccount.\\naccount--total a1: Account => Int.\\naccount--last-index a1: Account => Int.\\n~> Sum-first-n-descending @ a: Account, n: Int.\\n\\n---\\n\\naccount--total' a = account--total a + (+ over each i: Nat0, i <= n, i > 0 | i).\\naccount--last-index' a1 = account--last-index a1.\\n"
+`;
+
+exports[`functions-mutating-bounded-while.ts > sumFirstNWhile 1`] = `
+"module SUM_FIRST_N_WHILE.\\n\\nAccount.\\naccount--total a1: Account => Int.\\naccount--last-index a1: Account => Int.\\n~> Sum-first-n-while @ a: Account, n: Int.\\n\\n---\\n\\naccount--total' a = account--total a + (+ over each i: Nat0, i >= 0, i < n | i).\\naccount--last-index' a1 = account--last-index a1.\\n"
+`;
+
+exports[`functions-mutating-bounded-while.ts > unboundedWhile 1`] = `
+"module UNBOUNDED_WHILE.\\n\\nAccount.\\naccount--total a1: Account => Int.\\naccount--last-index a1: Account => Int.\\n~> Unbounded-while @ a: Account, n: Int.\\n\\n---\\n\\n> UNSUPPORTED: while loop is not a recognized bounded-counter shape; lift to L4 fixed-point lowering when that milestone ships.\\n"
+`;
+
 exports[`functions-mutating-compound.ts > addAmount 1`] = `
 "module ADD_AMOUNT.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--count a1: Account => Int.\\n~> Add-amount @ a: Account, amount: Int.\\n\\n---\\n\\naccount--balance' a = account--balance a + amount.\\naccount--count' a1 = account--count a1.\\n"
 `;

--- a/tools/ts2pant/tests/fixtures/constructs/functions-mutating-bounded-while.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/functions-mutating-bounded-while.ts
@@ -1,0 +1,47 @@
+interface Account {
+  total: number;
+  lastIndex: number;
+}
+
+/** Ascending bounded while accumulator fold; mirrors sumFirstN. */
+export function sumFirstNWhile(a: Account, n: number): void {
+  let i = 0;
+  while (i < n) {
+    a.total += i;
+    i++;
+  }
+}
+
+/** Ascending bounded while simple assignment; mirrors setLastIndex. */
+export function setLastIndexWhile(a: Account, n: number): void {
+  let i = 0;
+  while (i < n) {
+    a.lastIndex = i;
+    i++;
+  }
+}
+
+/** Descending bounded while accumulator fold. */
+export function sumFirstNDescending(a: Account, n: number): void {
+  let i = n;
+  while (i > 0) {
+    a.total += i;
+    i--;
+  }
+}
+
+/** Descending bounded while simple assignment. */
+export function setLastIndexDescending(a: Account, n: number): void {
+  let i = n;
+  while (i > 0) {
+    a.lastIndex = i;
+    i--;
+  }
+}
+
+/** Deliberate reject: bare while without a preceding counter let. */
+export function unboundedWhile(a: Account, n: number): void {
+  while (a.lastIndex < n) {
+    a.total += 1;
+  }
+}

--- a/tools/ts2pant/tests/integration/e2e.test.mts
+++ b/tools/ts2pant/tests/integration/e2e.test.mts
@@ -289,4 +289,29 @@ describe("pant --check", () => {
     assert.ok(result.checks.length > 0);
     assert.ok(result.checks.every((c) => c.passed));
   });
+
+  for (const fn of [
+    "sumFirstNWhile",
+    "setLastIndexWhile",
+    "sumFirstNDescending",
+    "setLastIndexDescending",
+  ]) {
+    it(`functions-mutating-bounded-while.ts ${fn} is checkable`, {
+      skip: !hasSolver ? "z3 not available" : undefined,
+    }, async () => {
+      const doc = await buildDocument(
+        "constructs/functions-mutating-bounded-while.ts",
+        fn,
+      );
+      const output = await emitAndCheck(doc);
+      const result = runCheck(output, {
+        projectRoot: PROJECT_ROOT,
+        pantBin: getPantBin(),
+      });
+
+      assert.equal(result.passed, true);
+      assert.ok(result.checks.length > 0);
+      assert.ok(result.checks.every((c) => c.passed));
+    });
+  }
 });

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -268,20 +268,100 @@ describe("unsupported patterns", () => {
     assert.equal(props[0]?.kind, "unsupported");
   });
 
-  it.skip("desugars let-then-while ascending counter into ir1For", () => {
-    // PENDING Patch 3: implement let-then-while ascending counter desugar.
+  it("desugars let-then-while ascending counter into ir1For", () => {
+    const source = `
+      interface Account { total: number; lastIndex: number }
+      export function sumFirstNWhile(a: Account, n: number): void {
+        let i = 0;
+        while (i < n) {
+          a.total += i;
+          i++;
+        }
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBodyWithSynth(sourceFile, "sumFirstNWhile");
+
+    assert.equal(props.some((p) => p.kind === "unsupported"), false);
+    const equations = props.filter((p) => p.kind === "equation");
+    assert.ok(equations.length > 0);
+    const ast = getAst();
+    const totalEq = equations.find(
+      (p) => p.kind === "equation" && ast.strExpr(p.lhs) === "account--total' a",
+    );
+    assert.ok(totalEq);
+    assert.equal(
+      ast.strExpr(totalEq.rhs),
+      "account--total a + (+ over each i: Nat0, i >= 0, i < n | i)",
+    );
   });
 
-  it.skip("desugars let-then-while descending counter into ir1For", () => {
-    // PENDING Patch 3: implement let-then-while descending counter desugar.
+  it("desugars let-then-while descending counter into ir1For", () => {
+    const source = `
+      interface Account { total: number; lastIndex: number }
+      export function sumFirstNDescending(a: Account, n: number): void {
+        let i = n;
+        while (i > 0) {
+          a.total += i;
+          i--;
+        }
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBodyWithSynth(sourceFile, "sumFirstNDescending");
+
+    assert.equal(props.some((p) => p.kind === "unsupported"), false);
+    const equations = props.filter((p) => p.kind === "equation");
+    assert.ok(equations.length > 0);
+    const ast = getAst();
+    const totalEq = equations.find(
+      (p) => p.kind === "equation" && ast.strExpr(p.lhs) === "account--total' a",
+    );
+    assert.ok(totalEq);
+    assert.equal(
+      ast.strExpr(totalEq.rhs),
+      "account--total a + (+ over each i: Nat0, i <= n, i > 0 | i)",
+    );
   });
 
-  it.skip("falls through to let-rejection on non-matching let-then-while pair", () => {
-    // PENDING Patch 3: implement non-matching let-then-while fallthrough coverage.
+  it("falls through to let-rejection on non-matching let-then-while pair", () => {
+    const source = `
+      interface Account { total: number }
+      export function badStep(a: Account, n: number): void {
+        let i = 0;
+        while (i < n) {
+          a.total += i;
+          i += 2;
+        }
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBodyWithSynth(sourceFile, "badStep");
+
+    assertUnsupportedReason(
+      props,
+      /local variable declaration \(let\/var or effectful const\)/u,
+      "non-matching let-then-while should fall through to let rejection",
+    );
   });
 
-  it.skip("rejects bare while loop with L4 fixed-point pointer", () => {
-    // PENDING Patch 3: implement bare while L4 fixed-point diagnostic.
+  it("rejects bare while loop with L4 fixed-point pointer", () => {
+    const source = `
+      interface Account { total: number; lastIndex: number }
+      export function bareWhile(a: Account, n: number): void {
+        while (a.lastIndex < n) {
+          a.total += 1;
+        }
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBodyWithSynth(sourceFile, "bareWhile");
+
+    assertUnsupportedReason(
+      props,
+      /while loop is not a recognized bounded-counter shape; lift to L4 fixed-point lowering when that milestone ships/u,
+      "bare while should reject with L4 pointer",
+    );
   });
 
   it("unwraps AsExpression at the body translation entry", () => {


### PR DESCRIPTION
## Patch 3: Recognize let-then-while pairs at the mutating-body build pass; ship fixtures

- In `buildSupportedSsaMutatingBody` (translate-body.ts:4326): convert the `for (const stmt of body.statements)` iteration into an indexed `for (let i = 0; i < body.statements.length; i++)` loop so look-ahead is available. Preserve the existing branches (guard-statement skip, return-without-expression skip, `VariableStatement` const-binding handling, dispatch to `buildSupportedSsaStatement`).
- Add the let-then-while peephole as a new branch before the existing `ts.isVariableStatement(stmt)` arm. Conditions: (a) current stmt is `VariableStatement` with `declarationList.flags & Let`, a single declarator, identifier name, present initializer; (b) next stmt at `i+1` exists and is a `WhileStatement`; (c) classify the trio (let, while.expression, while.statement) via a new helper `buildL1LetWhileMutation(letStmt, whileStmt, ctx)` returning either an `IR1Stmt` (success) or `null` (not a match — fall through to existing branches).
- `buildL1LetWhileMutation` extracts: init from the let declarator's initializer, cond from the while's expression, step from the while-body's trailing statement (must be a recognized increment/decrement form — reuse the existing increment-step builder `buildL1IncrementStep`), body from the while-body with the trailing step removed. Build the let's init as `ir1Let(counterName, initExpr)`. Construct `ir1For(initStmt, cond, step, bodyStmt)` and return it. If any sub-build fails, return `null`.
- When `buildL1LetWhileMutation` returns an `IR1Stmt`, push it to `stmts` and set `i = i + 1` so the inner iteration advances past the while as well. When it returns `null`, fall through unchanged (the let triggers the existing rejection at translate-body.ts:4391).
- Replace the rejection at translate-body.ts:4466 — split the previously-bundled `ForInStatement || WhileStatement || DoStatement` reject into two branches: `WhileStatement` returns `{ unsupported: "while loop is not a recognized bounded-counter shape; lift to L4 fixed-point lowering when that milestone ships" }`; `ForInStatement || DoStatement` keep returning `{ unsupported: "loop assignment" }` as today.
- Create `tools/ts2pant/tests/fixtures/constructs/functions-mutating-bounded-while.ts` with five exported functions: `sumFirstNWhile` (asc accumulator-fold mirror of `sumFirstN`), `setLastIndexWhile` (asc simple-assign mirror of `setLastIndex`), `sumFirstNDescending` (desc accumulator-fold), `setLastIndexDescending` (desc simple-assign), and `unboundedWhile` (deliberate-reject fixture).
- Run `just ts2pant-test-update-snapshots`; manually inspect the resulting `tests/constructs.test.mts.snapshot` diff for the new fixture entries. Verify: (a) asc fixtures emit byte-identical Pant to their `for` counterparts in `functions-mutating-counter-loop.ts`; (b) desc fixtures emit the symmetric over-each / cond forms; (c) `unboundedWhile` emits the `> UNSUPPORTED:` line with the L4-pointer message.
- Run `just ts2pant-test-integration` (which builds `pant` first) to verify each passing fixture passes `pant` typecheck and `pant --check`. The reject fixture should be skipped from `--check` via the existing `> UNSUPPORTED:` short-circuit.
- Unskip the four Patch-3-owned `translate-body.test.mts` stubs and replace their bodies with concrete assertions.
- Do not modify `ir1-ssa-counter-loop.ts` in this patch — Patch 2 already shipped the recognizer extension. Do not modify `ir1-lower-body.ts` — the existing `kind: "for"` dispatch arm handles `ir1For` regardless of which TS shape produced it.

## Changes
- In `buildSupportedSsaMutatingBody` (translate-body.ts:4326): convert the `for (const stmt of body.statements)` iteration into an indexed `for (let i = 0; i < body.statements.length; i++)` loop so look-ahead is available. Preserve the existing branches (guard-statement skip, return-without-expression skip, `VariableStatement` const-binding handling, dispatch to `buildSupportedSsaStatement`).
- Add the let-then-while peephole as a new branch before the existing `ts.isVariableStatement(stmt)` arm. Conditions: (a) current stmt is `VariableStatement` with `declarationList.flags & Let`, a single declarator, identifier name, present initializer; (b) next stmt at `i+1` exists and is a `WhileStatement`; (c) classify the trio (let, while.expression, while.statement) via a new helper `buildL1LetWhileMutation(letStmt, whileStmt, ctx)` returning either an `IR1Stmt` (success) or `null` (not a match — fall through to existing branches).
- `buildL1LetWhileMutation` extracts: init from the let declarator's initializer, cond from the while's expression, step from the while-body's trailing statement (must be a recognized increment/decrement form — reuse the existing increment-step builder `buildL1IncrementStep`), body from the while-body with the trailing step removed. Build the let's init as `ir1Let(counterName, initExpr)`. Construct `ir1For(initStmt, cond, step, bodyStmt)` and return it. If any sub-build fails, return `null`.
- When `buildL1LetWhileMutation` returns an `IR1Stmt`, push it to `stmts` and set `i = i + 1` so the inner iteration advances past the while as well. When it returns `null`, fall through unchanged (the let triggers the existing rejection at translate-body.ts:4391).
- Replace the rejection at translate-body.ts:4466 — split the previously-bundled `ForInStatement || WhileStatement || DoStatement` reject into two branches: `WhileStatement` returns `{ unsupported: "while loop is not a recognized bounded-counter shape; lift to L4 fixed-point lowering when that milestone ships" }`; `ForInStatement || DoStatement` keep returning `{ unsupported: "loop assignment" }` as today.
- Create `tools/ts2pant/tests/fixtures/constructs/functions-mutating-bounded-while.ts` with five exported functions: `sumFirstNWhile` (asc accumulator-fold mirror of `sumFirstN`), `setLastIndexWhile` (asc simple-assign mirror of `setLastIndex`), `sumFirstNDescending` (desc accumulator-fold), `setLastIndexDescending` (desc simple-assign), and `unboundedWhile` (deliberate-reject fixture).
- Run `just ts2pant-test-update-snapshots`; manually inspect the resulting `tests/constructs.test.mts.snapshot` diff for the new fixture entries. Verify: (a) asc fixtures emit byte-identical Pant to their `for` counterparts in `functions-mutating-counter-loop.ts`; (b) desc fixtures emit the symmetric over-each / cond forms; (c) `unboundedWhile` emits the `> UNSUPPORTED:` line with the L4-pointer message.
- Run `just ts2pant-test-integration` (which builds `pant` first) to verify each passing fixture passes `pant` typecheck and `pant --check`. The reject fixture should be skipped from `--check` via the existing `> UNSUPPORTED:` short-circuit.
- Unskip the four Patch-3-owned `translate-body.test.mts` stubs and replace their bodies with concrete assertions.
- Do not modify `ir1-ssa-counter-loop.ts` in this patch — Patch 2 already shipped the recognizer extension. Do not modify `ir1-lower-body.ts` — the existing `kind: "for"` dispatch arm handles `ir1For` regardless of which TS shape produced it.

## Files to Modify
- tools/ts2pant/src/translate-body.ts (modify): Inside `buildSupportedSsaMutatingBody`'s statement-list walk, detect adjacent `VariableStatement` (single `let` declarator binding an identifier to an initializer) + `WhileStatement` pairs. When the pair matches the bounded-counter shape — the while's condition is `counter CMP bound`, the while-body's trailing statement is a `++/--/+=1/-=1/=c+1/=1+c/=c-1` counter step on the same identifier, and the let/while/step are jointly recognizable by L2's (Patch-2 extended) recognizer — build the pair as one `ir1For(initStmt, cond, step, body-without-trailing-step)` and advance the walk past the while. On any classification miss, fall through unchanged so the existing `let` rejection at line 4391 fires for the let, and the existing-or-updated WhileStatement reject (see next change) fires for the while. Replace the catch-all `WhileStatement` rejection at line 4466 with the L4-pointer diagnostic.
- tools/ts2pant/tests/translate-body.test.mts (modify): Remove `.skip` from the Patch-3-owned stubs introduced in Patch 1. Replace each PENDING-comment body with concrete assertions: recognized pairs produce non-rejected propositions whose emitted Pant matches the L2 over-each / cond shapes; unrecognized pairs reject with the existing `let` diagnostic; bare while loops reject with the new L4 pointer.
- tools/ts2pant/tests/fixtures/constructs/functions-mutating-bounded-while.ts (create): Four passing fixtures (asc accumulator-fold, asc simple-assign, desc accumulator-fold, desc simple-assign) using the same `Account` interface as `functions-mutating-counter-loop.ts`. One deliberate-reject fixture: a bare `while (a.lastIndex < n) { a.total += 1 }` that surfaces the L4-pointer rejection.
- tools/ts2pant/tests/constructs.test.mts.snapshot (modify): Snapshot update after the fixture lands. Run `just ts2pant-test-update-snapshots` and commit the snapshot diff. Verify the diff contains only the new fixture's emitted Pant plus the `> UNSUPPORTED:` line for the reject fixture, with no changes to other fixtures' snapshots.

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[pattern] Source-level peephole (look-ahead in statement list)** — Two-statement source-level peephole: the let-then-while pair canonicalises to a for-statement at the build pass. The existing pure-path equivalent at translate-body.ts:1820-1827 demonstrates the idiom (detect pair, route to specialised builder, fall through on miss). Mirror the structure for symmetric handler placement.
- **[paper] IRSC (Vekris, Cosman, Jhala — PLDI 2016)** — https://doi.org/10.1145/2908080.2908110 — Normalising TS surface variation into a small canonical IR — `for` and `let+while` collapse to the same `IR1Stmt.for` form so the L2 SSA lowering reasons about one shape. Carry-forward of the workstream's IR-faithful posture.

## Gameplan Specification

```
module TS2PANT_BOUNDED_WHILE_LOWERING.

> ════════════════════════════════
> Milestone 3 of the ts2pant general-loop SSA workstream.
> ════════════════════════════════
> After this milestone, the mutating-body translator accepts
> bounded counter shapes spelled with either `for` or
> `let; while`, in either ascending or descending direction.
> Lowering reuses L2's quantified-over-each machinery for
> accumulator folds and L2's last-iteration cond for simple
> assignments; the symmetric descending metric is
> `counter - bound`. Unsupported while loops reject with one
> diagnostic naming L4 fixed-point lowering. Documentation in
> AGENTS.md and the workstream doc records the surface and
> marks the milestone landed.

TSStmt.
IR1Stmt.
CounterLoop.
Direction.
Metric.
Expr.
Diagnostic.
BuildOutcome.
Document.
DocumentKind.
MilestoneStatus.
asc => Direction.
desc => Direction.
agents-md => DocumentKind.
workstream-doc => DocumentKind.
pending => MilestoneStatus.
landed => MilestoneStatus.

direction l: CounterLoop => Direction.
init-expr l: CounterLoop => Expr.
bound-expr l: CounterLoop => Expr.
metric-expr l: CounterLoop => Metric.
is-numeric-literal? e: Expr => Bool.
is-loop-invariant? e: Expr, l: CounterLoop => Bool.
lower-bound m: Metric => Expr.
metric-decreasing m: Metric, l: CounterLoop => Bool.
represents-zero? e: Expr => Bool.
recognized-let-while? letStmt: TSStmt, whileStmt: TSStmt => Bool.
let-while-direction letStmt: TSStmt, whileStmt: TSStmt => Direction.
build-pair letStmt: TSStmt, whileStmt: TSStmt => BuildOutcome.
build-mutating-body s: TSStmt => BuildOutcome.
is-ir1-for? b: BuildOutcome => Bool.
is-rejection? b: BuildOutcome => Bool.
rejection-mentions-l4? b: BuildOutcome => Bool.
is-bare-while? s: TSStmt => Bool.
is-bounded-counter-shape? s: TSStmt => Bool.
document-kind d: Document => DocumentKind.
document-mentions-l3-bounded-while? d: Document => Bool.
workstream-milestone-3-status => MilestoneStatus.
---

> Direction-dependent shape constraints (carry-forward from
> Patch 2's spec).
all l: CounterLoop |
  direction l = asc -> is-numeric-literal? (init-expr l).

all l: CounterLoop |
  direction l = desc -> is-numeric-literal? (bound-expr l).

all l: CounterLoop |
  is-loop-invariant? (init-expr l) l.

all l: CounterLoop |
  is-loop-invariant? (bound-expr l) l.

> Termination metric correctness in both directions.
all l: CounterLoop |
  metric-decreasing (metric-expr l) l.

all l: CounterLoop |
  represents-zero? (lower-bound (metric-expr l)).

> Build-pass peephole: recognized let-then-while pairs flow
> into ir1For; bare while loops without a matching let reject
> with the L4-pointer diagnostic.
all letStmt: TSStmt, whileStmt: TSStmt |
  recognized-let-while? letStmt whileStmt ->
    is-ir1-for? (build-pair letStmt whileStmt).

all s: TSStmt |
  is-bare-while? s and ~(is-bounded-counter-shape? s) ->
    is-rejection? (build-mutating-body s) and
    rejection-mentions-l4? (build-mutating-body s).

> The peephole is direction-aware.
some letStmt: TSStmt, whileStmt: TSStmt |
  recognized-let-while? letStmt whileStmt and
  let-while-direction letStmt whileStmt = asc.

some letStmt: TSStmt, whileStmt: TSStmt |
  recognized-let-while? letStmt whileStmt and
  let-while-direction letStmt whileStmt = desc.

> Documentation invariants.
all d: Document |
  document-kind d = agents-md ->
    document-mentions-l3-bounded-while? d.

all d: Document |
  document-kind d = workstream-doc ->
    document-mentions-l3-bounded-while? d.

workstream-milestone-3-status = landed.
```

## Patch Specification

```
module TS2PANT_BOUNDED_WHILE_LOWERING_PATCH_3.

> Patch 3 activates the build-path peephole that desugars
> bounded let-then-while pairs into ir1For. Behavior changes:
> shapes that previously rejected as `let local binding` now
> translate through L2's counter-loop machinery; bare while
> loops without a matching let reject with the L4-pointer
> diagnostic.

TSStmt.
IR1Stmt.
Diagnostic.
BuildOutcome.
Direction.
asc => Direction.
desc => Direction.

recognized-let-while? letStmt: TSStmt, whileStmt: TSStmt => Bool.
let-while-direction letStmt: TSStmt, whileStmt: TSStmt => Direction.
build-mutating-body s: TSStmt => BuildOutcome.
build-pair letStmt: TSStmt, whileStmt: TSStmt => BuildOutcome.
is-ir1-for? b: BuildOutcome => Bool.
is-rejection? b: BuildOutcome => Bool.
rejection-mentions-l4? b: BuildOutcome => Bool.
is-bare-while? s: TSStmt => Bool.
is-bounded-counter-shape? s: TSStmt => Bool.
---

> Recognized let-then-while pairs build as ir1For.
all letStmt: TSStmt, whileStmt: TSStmt |
  recognized-let-while? letStmt whileStmt ->
    is-ir1-for? (build-pair letStmt whileStmt).

> Bare while loops (no matching let) reject with the L4 pointer.
all s: TSStmt |
  is-bare-while? s and ~(is-bounded-counter-shape? s) ->
    is-rejection? (build-mutating-body s) and
    rejection-mentions-l4? (build-mutating-body s).

> The peephole is direction-aware: both asc and desc pairs are
> recognizable.
some letStmt: TSStmt, whileStmt: TSStmt |
  recognized-let-while? letStmt whileStmt and
  let-while-direction letStmt whileStmt = asc.

some letStmt: TSStmt, whileStmt: TSStmt |
  recognized-let-while? letStmt whileStmt and
  let-while-direction letStmt whileStmt = desc.
```


## Implementation Notes

- `buildL1IncrementStep` intentionally canonicalizes non-unit spellings like `i += 2` into an IR assignment so downstream recognizers can produce their own diagnostics. The let-while peephole adds an explicit unit-step guard before consuming the pair; this preserves the required fall-through behavior where non-matching pairs still reject at the original `let` local-binding boundary.
- The helper builds the synthetic loop body by updating the original `while` block with the trailing step removed, then reuses `buildSupportedSsaMutatingBody` for the remaining statements. That keeps const-alias handling, guard skipping, nested `if`, and mutation-state behavior identical to ordinary mutating-body translation.
- I added explicit integration coverage for the four passing bounded-while fixtures in `tests/integration/e2e.test.mts`, because the existing integration suite only had `pant --check` assertions for the older `functions-mutating-counter-loop.ts` fixtures.
- Spec/Evidence Mapping:
  - Recognized let-then-while builds as `ir1For`: implemented in `buildSupportedSsaMutatingBody` plus `buildL1LetWhileMutation`; covered by the two unskipped translate-body tests and the four construct snapshots.
  - Bare while rejects with the L4 pointer: implemented in the split `WhileStatement` branch of `buildSupportedSsaStatement`; covered by the translate-body rejection test and `unboundedWhile` snapshot.
  - Asc/desc direction awareness: condition builder accepts `<`, `<=`, `>`, `>=` and step guard accepts `+1`/`-1`; covered by ascending and descending translate-body tests plus fixture snapshots.
  - End-to-end Pant validation: `just ts2pant-test-update-snapshots`, `just ts2pant-test-integration`, and `npx tsc --noEmit` passed.