### PR TITLE
[ts2pant-bounded-while-lowering] Patch 4: Document L3 lowering surface; mark milestone landed

### DIFF
--- a/tools/ts2pant/AGENTS.md
+++ b/tools/ts2pant/AGENTS.md
@@ -961,6 +961,88 @@ expressions, conditions other than `COUNTER < BOUND_EXPR` or
 `COUNTER <= BOUND_EXPR`, and bounds that mention the counter. Recurrences are
 explicitly deferred to L4 fixed-point lowering.
 
+### Bounded while loop lowering (L3)
+
+The bounded while milestone reuses the L2 counter-loop SSA and lowering path
+for counter loops spelled as adjacent `let` plus `while` statements. The
+mutating-body builder recognizes the pair and desugars it to an `ir1For`, so
+`src/ir1-ssa-counter-loop.ts` remains the single lowering source for bounded
+counter loops regardless of source spelling.
+
+Accepted ascending forms are the structural twin of L2:
+
+```ts
+let i = 0;
+while (i < n) {
+  body;
+  i++;
+}
+```
+
+The `<=` condition variant is accepted as well. The initializer must be a
+numeric literal, the bound expression must be loop-invariant with respect to
+the counter, and the trailing body step must canonicalize to `COUNTER =
+COUNTER + 1`.
+
+L3 also accepts the symmetric descending forms:
+
+```ts
+let i = n;
+while (i > 0) {
+  body;
+  i--;
+}
+```
+
+The `>=` condition variant is accepted as well. For descending loops, the
+bound expression must be a numeric literal, the init expression must be
+loop-invariant with respect to the counter, and the trailing body step must
+canonicalize to `COUNTER = COUNTER - 1`. The emitted termination metric is
+`COUNTER - BOUND_EXPR` with lower bound `0`; this is the descending mirror of
+L2's ascending `BOUND_EXPR - COUNTER` metric.
+
+Descending accumulator folds lower to one Pant equation per mutated property
+with the counter range encoded as over-each guards:
+
+```pant
+acc--p' obj = acc--p obj OUTER_OP
+  (COMB over each i: Nat0, i <= INIT, i > BOUND | F(i))
+```
+
+For `>=`, the final guard uses `i >= BOUND`. Optional TS body guards become
+additional over-each guards, as in L2. Descending simple assignments lower to
+last-iteration-wins `cond` equations. For the strict `>` form, the selected
+last counter value is `BOUND + 1`:
+
+```pant
+p' obj = cond INIT > BOUND => F(BOUND + 1), true => p obj
+```
+
+For `>=`, the selected last counter value is `BOUND`. Ascending simple
+assignments keep the L2 last-iteration convention with the comparison and
+endpoint determined by `<` versus `<=`.
+
+The let-then-while peephole lives in `buildSupportedSsaMutatingBody`, where
+the statement-list iterator can look ahead and consume two adjacent
+statements. It matches a side-effect-free counter `let`, a following
+`while`, and a trailing counter step in the while body. The builder removes
+that trailing step from the body and emits `ir1For(initStmt, cond, step,
+bodyWithoutTrailingStep)`. These shapes fall through unchanged and continue
+to reject through the ordinary statement path: `let` with an effectful
+initializer, `let` without a matching following `while`, `while` without a
+preceding matched `let`, and `while` whose body does not end in a recognized
+counter step.
+
+Unsupported `while` loops reject with one diagnostic:
+
+```text
+while loop is not a recognized bounded-counter shape; lift to L4 fixed-point lowering when that milestone ships
+```
+
+This message replaces the previous generic `loop assignment` diagnostic for
+`WhileStatement` specifically. `ForInStatement` and `DoStatement` still reject
+with the older generic loop-assignment message.
+
 ### Mutating-body output (no L2 IR)
 
 The mutating path emits `PropResult[]` directly:

--- a/workstreams/ts2pant-general-loop-ssa.md
+++ b/workstreams/ts2pant-general-loop-ssa.md
@@ -178,6 +178,11 @@ L2's quantification path.
 
 ### Milestone 3: bounded-while-lowering
 
+**Status**: Landed in `ts2pant-bounded-while-lowering`. See
+`tools/ts2pant/AGENTS.md` section `### Bounded while loop lowering (L3)` for
+the accepted ascending and descending counter-desugar surface, peephole, and
+rejection contract.
+
 **Definition of Done**:
 The mutating-body build path emits IR1 SSA for bounded `while` loops — those
 whose guard expression admits ranking-function extraction. Lowering reuses
@@ -389,7 +394,7 @@ machinery to be feature-complete before they touch it.
 
 | Question | Notes | Resolve By |
 |----------|-------|------------|
-| L2/L3 merge | Whether bounded counter and bounded while are distinct enough to be separate milestones, or whether L2's gameplan reveals they should be one. | After L2 |
+| L2/L3 merge | Resolved: keep separate. The recognizer surface is structurally different between `for` and `let`-then-`while` shapes; the statement-list peephole is the only new build-pass machinery and does not merge cleanly with `buildL1ForCounterMutation`. See `tools/ts2pant/AGENTS.md` section `### Bounded while loop lowering (L3)`. | Resolved in L3 |
 
 Other design questions are scoped to specific milestones and resolved during
 their respective `write-gameplan` invocations. See each milestone's


### PR DESCRIPTION
## Patch 4: Document L3 lowering surface; mark milestone landed

- In `tools/ts2pant/AGENTS.md`, document the descending counter loop surface following the L2 subsection's structure: surface form (`let i = N; while (i > 0) { body; i-- }` and `>=` variant), recognizer constraints (literal bound, loop-invariant init, canonical `-1` step), accumulator-fold output (`(comb over each i: Nat0, i <= INIT, i > BOUND | F(i))`), simple-assign output (`cond INIT > BOUND => BOUND + 1, true => prior`), rejection text.
- Document the let-then-while build-path peephole: where it lives (`buildSupportedSsaMutatingBody`), how the pair is matched (look-ahead on statement list, trailing step removed from body), what shapes fall through unchanged (let with effectful initializer, let without matching while, while without preceding let, while whose body's trailing statement is not a counter step).
- Document the unbounded-while rejection: `"while loop is not a recognized bounded-counter shape; lift to L4 fixed-point lowering when that milestone ships"`. Note that this single message replaces the prior generic `"loop assignment"` for WhileStatement specifically; `ForInStatement` and `DoStatement` still reject with the older message.
- In `workstreams/ts2pant-general-loop-ssa.md`, add the landed-status line under Milestone 3. Update the `Open Questions` table to mark the `L2/L3 merge` row resolved (keep separate; rationale: structural difference between for and let-then-while shapes; the peephole is the only new build-pass machinery and doesn't merge cleanly with `buildL1ForCounterMutation`). Cross-reference the AGENTS.md subsection.
- Do not modify any source or test file in this patch.

## Changes
- In `tools/ts2pant/AGENTS.md`, document the descending counter loop surface following the L2 subsection's structure: surface form (`let i = N; while (i > 0) { body; i-- }` and `>=` variant), recognizer constraints (literal bound, loop-invariant init, canonical `-1` step), accumulator-fold output (`(comb over each i: Nat0, i <= INIT, i > BOUND | F(i))`), simple-assign output (`cond INIT > BOUND => BOUND + 1, true => prior`), rejection text.
- Document the let-then-while build-path peephole: where it lives (`buildSupportedSsaMutatingBody`), how the pair is matched (look-ahead on statement list, trailing step removed from body), what shapes fall through unchanged (let with effectful initializer, let without matching while, while without preceding let, while whose body's trailing statement is not a counter step).
- Document the unbounded-while rejection: `"while loop is not a recognized bounded-counter shape; lift to L4 fixed-point lowering when that milestone ships"`. Note that this single message replaces the prior generic `"loop assignment"` for WhileStatement specifically; `ForInStatement` and `DoStatement` still reject with the older message.
- In `workstreams/ts2pant-general-loop-ssa.md`, add the landed-status line under Milestone 3. Update the `Open Questions` table to mark the `L2/L3 merge` row resolved (keep separate; rationale: structural difference between for and let-then-while shapes; the peephole is the only new build-pass machinery and doesn't merge cleanly with `buildL1ForCounterMutation`). Cross-reference the AGENTS.md subsection.
- Do not modify any source or test file in this patch.

## Files to Modify
- tools/ts2pant/AGENTS.md (modify): Extend the existing `### Bounded counter loop lowering (L2)` subsection — either retitle to `### Bounded counter and bounded-while loop lowering (L2, L3)` or add a sibling `### Bounded while loop lowering (L3)` immediately after it (implementer picks the cleaner shape). Document: the descending counter shape (`>`/`>=` + `-1` step + literal bound + loop-invariant init); the let-then-while build-path peephole; the symmetric descending metric `counter - bound`; the desc over-each guard ordering; the desc simple-assign last-iteration cond; the single rejection message for unsupported while shapes naming L4.
- workstreams/ts2pant-general-loop-ssa.md (modify): Add `**Status**: Landed in `ts2pant-bounded-while-lowering`.` immediately under `### Milestone 3: bounded-while-lowering`. Update the workstream's `Open Questions` table to mark `L2/L3 merge` as resolved (kept separate, with rationale from this gameplan's `explicitOpinions`). Cross-reference the AGENTS.md subsection.

## Gameplan Specification

```
module TS2PANT_BOUNDED_WHILE_LOWERING.

> ════════════════════════════════
> Milestone 3 of the ts2pant general-loop SSA workstream.
> ════════════════════════════════
> After this milestone, the mutating-body translator accepts
> bounded counter shapes spelled with either `for` or
> `let; while`, in either ascending or descending direction.
> Lowering reuses L2's quantified-over-each machinery for
> accumulator folds and L2's last-iteration cond for simple
> assignments; the symmetric descending metric is
> `counter - bound`. Unsupported while loops reject with one
> diagnostic naming L4 fixed-point lowering. Documentation in
> AGENTS.md and the workstream doc records the surface and
> marks the milestone landed.

TSStmt.
IR1Stmt.
CounterLoop.
Direction.
Metric.
Expr.
Diagnostic.
BuildOutcome.
Document.
DocumentKind.
MilestoneStatus.
asc => Direction.
desc => Direction.
agents-md => DocumentKind.
workstream-doc => DocumentKind.
pending => MilestoneStatus.
landed => MilestoneStatus.

direction l: CounterLoop => Direction.
init-expr l: CounterLoop => Expr.
bound-expr l: CounterLoop => Expr.
metric-expr l: CounterLoop => Metric.
is-numeric-literal? e: Expr => Bool.
is-loop-invariant? e: Expr, l: CounterLoop => Bool.
lower-bound m: Metric => Expr.
metric-decreasing m: Metric, l: CounterLoop => Bool.
represents-zero? e: Expr => Bool.
recognized-let-while? letStmt: TSStmt, whileStmt: TSStmt => Bool.
let-while-direction letStmt: TSStmt, whileStmt: TSStmt => Direction.
build-pair letStmt: TSStmt, whileStmt: TSStmt => BuildOutcome.
build-mutating-body s: TSStmt => BuildOutcome.
is-ir1-for? b: BuildOutcome => Bool.
is-rejection? b: BuildOutcome => Bool.
rejection-mentions-l4? b: BuildOutcome => Bool.
is-bare-while? s: TSStmt => Bool.
is-bounded-counter-shape? s: TSStmt => Bool.
document-kind d: Document => DocumentKind.
document-mentions-l3-bounded-while? d: Document => Bool.
workstream-milestone-3-status => MilestoneStatus.
---

> Direction-dependent shape constraints (carry-forward from
> Patch 2's spec).
all l: CounterLoop |
  direction l = asc -> is-numeric-literal? (init-expr l).

all l: CounterLoop |
  direction l = desc -> is-numeric-literal? (bound-expr l).

all l: CounterLoop |
  is-loop-invariant? (init-expr l) l.

all l: CounterLoop |
  is-loop-invariant? (bound-expr l) l.

> Termination metric correctness in both directions.
all l: CounterLoop |
  metric-decreasing (metric-expr l) l.

all l: CounterLoop |
  represents-zero? (lower-bound (metric-expr l)).

> Build-pass peephole: recognized let-then-while pairs flow
> into ir1For; bare while loops without a matching let reject
> with the L4-pointer diagnostic.
all letStmt: TSStmt, whileStmt: TSStmt |
  recognized-let-while? letStmt whileStmt ->
    is-ir1-for? (build-pair letStmt whileStmt).

all s: TSStmt |
  is-bare-while? s and ~(is-bounded-counter-shape? s) ->
    is-rejection? (build-mutating-body s) and
    rejection-mentions-l4? (build-mutating-body s).

> The peephole is direction-aware.
some letStmt: TSStmt, whileStmt: TSStmt |
  recognized-let-while? letStmt whileStmt and
  let-while-direction letStmt whileStmt = asc.

some letStmt: TSStmt, whileStmt: TSStmt |
  recognized-let-while? letStmt whileStmt and
  let-while-direction letStmt whileStmt = desc.

> Documentation invariants.
all d: Document |
  document-kind d = agents-md ->
    document-mentions-l3-bounded-while? d.

all d: Document |
  document-kind d = workstream-doc ->
    document-mentions-l3-bounded-while? d.

workstream-milestone-3-status = landed.
```

## Patch Specification

```
module TS2PANT_BOUNDED_WHILE_LOWERING_PATCH_4.

> Patch 4 lands documentation. AGENTS.md gains the L3
> bounded-while subsection or extends the L2 one;
> the workstream marks Milestone 3 as landed. No runtime
> invariants change.

Document.
DocumentKind.
MilestoneStatus.
agents-md => DocumentKind.
workstream-doc => DocumentKind.
pending => MilestoneStatus.
landed => MilestoneStatus.

document-kind d: Document => DocumentKind.
document-mentions-l3-bounded-while? d: Document => Bool.
workstream-milestone-3-status => MilestoneStatus.
---

all d: Document |
  document-kind d = agents-md ->
    document-mentions-l3-bounded-while? d.

all d: Document |
  document-kind d = workstream-doc ->
    document-mentions-l3-bounded-while? d.

workstream-milestone-3-status = landed.
```


## Implementation Notes

- Added a sibling `### Bounded while loop lowering (L3)` section instead of retitling or broadening the existing L2 section. This keeps the L2 `for` contract stable while giving reviewers a narrow anchor for the new `let`-then-`while` peephole and rejection behavior.
- No source or test files were touched. The only verification run was `git diff --check`, which is appropriate for this documentation-only patch.
- Spec/Evidence Mapping: `document-mentions-l3-bounded-while? agents-md` is satisfied by `tools/ts2pant/AGENTS.md` documenting accepted ascending/descending shapes, metric/output forms, peephole fallthroughs, and the L4 rejection diagnostic; `document-mentions-l3-bounded-while? workstream-doc` and `workstream-milestone-3-status = landed` are satisfied by `workstreams/ts2pant-general-loop-ssa.md` marking Milestone 3 landed and resolving the L2/L3 merge question. Required context consulted: the existing L2 AGENTS subsection and the Milestone 3/Open Questions sections in the workstream doc.