### PR TITLE
[ts2pant-fixed-point-while-lowering] Patch 1: Pending tests for L4 fixed-point lowering and define-fun-rec emission

### DIFF
--- a/test/test_smt.ml
+++ b/test/test_smt.ml
@@ -196,6 +196,18 @@ let test_function_declarations () =
   check bool "has balance_prime decl" true
     (contains decls "(declare-fun balance_prime (Account) Int)")
 
+let test_is_rule_recursive_detects_self_reference () =
+  (* PENDING Patch 2: implement Smt.is_rule_recursive for self-referential rule bodies. *)
+  () [@tags "pending"]
+
+let test_recursive_rule_emits_define_fun_rec () =
+  (* PENDING Patch 2: emit define-fun-rec and suppress declare-fun for recursive rules. *)
+  () [@tags "pending"]
+
+let test_non_recursive_rule_emits_existing_shape () =
+  (* PENDING Patch 2: preserve declare-fun plus universal-axiom emission for non-recursive rules. *)
+  () [@tags "pending"]
+
 let test_nullary_rule () =
   let env =
     Env.empty ""
@@ -1297,6 +1309,14 @@ let integration_tests =
   [
     test_case "domain preamble" `Quick test_preamble_domains_simple;
     test_case "function declarations" `Quick test_function_declarations;
+    test_case "is_rule_recursive detects self-referential rule body" `Quick
+      test_is_rule_recursive_detects_self_reference;
+    test_case
+      "recursive rule emits define-fun-rec form with body and skips \
+       declare-fun line"
+      `Quick test_recursive_rule_emits_define_fun_rec;
+    test_case "non-recursive rule emits declare-fun + universal-axiom unchanged"
+      `Quick test_non_recursive_rule_emits_existing_shape;
     test_case "nullary rule" `Quick test_nullary_rule;
     test_case "classify chapters" `Quick test_classify_chapters;
     test_case "generate queries" `Quick test_generate_queries;

--- a/tools/ts2pant/tests/ir1-ssa-fixed-point.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-fixed-point.test.mts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+describe("ir1-ssa-fixed-point", () => {
+  it.skip("recognizes a single-location while-loop fixed-point shape", () => {
+    // PENDING Patch 3: implement fixed-point while-loop shape recognition.
+  });
+
+  it.skip("rejects literal-true guards at the recognizer level", () => {
+    // PENDING Patch 3: implement literal-true guard rejection.
+  });
+
+  it.skip("rejects multi-location while bodies", () => {
+    // PENDING Patch 3: implement multi-location while body rejection.
+  });
+
+  it.skip("constructs IR1SsaLoopBody with terminationMetric: null", () => {
+    // PENDING Patch 3: construct fixed-point loop bodies with null metrics.
+  });
+
+  it.skip("synthesises a uniquely-named recursive helper rule via NameRegistry", () => {
+    // PENDING Patch 3: synthesise recursive helper names through NameRegistry.
+  });
+
+  it.skip("emits a rule-decl PropResult for the helper and an equation PropResult for the caller", () => {
+    // PENDING Patch 3: emit helper rule-decl and caller equation PropResults.
+  });
+});

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -2478,3 +2478,17 @@ describe("Set mutation (Stage A: interface-field .add / .delete / .clear)", () =
     }
   });
 });
+
+describe("fixed-point while lowering", () => {
+  it.skip("desugars let-then-while pair that fails L3 bounded recognition to ir1While", () => {
+    // PENDING Patch 4: route failed L3 let-while recognition into ir1While.
+  });
+
+  it.skip("builds ir1While for a bare while loop with non-literal guard", () => {
+    // PENDING Patch 4: build ir1While for supported bare while statements.
+  });
+
+  it.skip("rejects while (true) with no-observable-termination diagnostic", () => {
+    // PENDING Patch 4: reject literal-true while guards in the build pass.
+  });
+});


### PR DESCRIPTION
## Patch 1: Pending tests for L4 fixed-point lowering and define-fun-rec emission

- Create `tools/ts2pant/tests/ir1-ssa-fixed-point.test.mts` modeled on `tests/ir1-ssa-counter-loop.test.mts`'s shape (describe block, direct constructor calls, `node:assert/strict`).
- Add skipped stubs: `it.skip("recognizes a single-location while-loop fixed-point shape", ...)`, `it.skip("rejects literal-true guards at the recognizer level", ...)`, `it.skip("rejects multi-location while bodies", ...)`, `it.skip("constructs IR1SsaLoopBody with terminationMetric: null", ...)`, `it.skip("synthesises a uniquely-named recursive helper rule via NameRegistry", ...)`, `it.skip("emits a rule-decl PropResult for the helper and an equation PropResult for the caller", ...)`.
- In `tools/ts2pant/tests/translate-body.test.mts`, add skipped stubs: `it.skip("desugars let-then-while pair that fails L3 bounded recognition to ir1While", ...)`, `it.skip("builds ir1While for a bare while loop with non-literal guard", ...)`, `it.skip("rejects while (true) with no-observable-termination diagnostic", ...)`.
- In `test/test_smt.ml`, add pending OCaml tests: that `Smt.is_rule_recursive` returns true on a declaration whose body's RHS applies the rule's own name; that the recursive emitter produces a `(define-fun-rec ...)` string with the rule's params/return-sort/body and that the corresponding `(declare-fun ...)` line is suppressed; that non-recursive rules continue to emit the existing shape.
- Each stub body contains only the PENDING comment naming the implementing patch — no constructor calls or assertions that reference Patch-2/3/4 symbols (those symbols / shapes don't exist yet).
- Do not modify any non-test file in this patch.

## Changes
- Create `tools/ts2pant/tests/ir1-ssa-fixed-point.test.mts` modeled on `tests/ir1-ssa-counter-loop.test.mts`'s shape (describe block, direct constructor calls, `node:assert/strict`).
- Add skipped stubs: `it.skip("recognizes a single-location while-loop fixed-point shape", ...)`, `it.skip("rejects literal-true guards at the recognizer level", ...)`, `it.skip("rejects multi-location while bodies", ...)`, `it.skip("constructs IR1SsaLoopBody with terminationMetric: null", ...)`, `it.skip("synthesises a uniquely-named recursive helper rule via NameRegistry", ...)`, `it.skip("emits a rule-decl PropResult for the helper and an equation PropResult for the caller", ...)`.
- In `tools/ts2pant/tests/translate-body.test.mts`, add skipped stubs: `it.skip("desugars let-then-while pair that fails L3 bounded recognition to ir1While", ...)`, `it.skip("builds ir1While for a bare while loop with non-literal guard", ...)`, `it.skip("rejects while (true) with no-observable-termination diagnostic", ...)`.
- In `test/test_smt.ml`, add pending OCaml tests: that `Smt.is_rule_recursive` returns true on a declaration whose body's RHS applies the rule's own name; that the recursive emitter produces a `(define-fun-rec ...)` string with the rule's params/return-sort/body and that the corresponding `(declare-fun ...)` line is suppressed; that non-recursive rules continue to emit the existing shape.
- Each stub body contains only the PENDING comment naming the implementing patch — no constructor calls or assertions that reference Patch-2/3/4 symbols (those symbols / shapes don't exist yet).
- Do not modify any non-test file in this patch.

## Files to Modify
- tools/ts2pant/tests/ir1-ssa-fixed-point.test.mts (create): New unit test file with `it.skip` stubs for the fixed-point lowerer's behaviors. Each stub carries a `// PENDING Patch <N>:` comment naming the implementing patch.
- tools/ts2pant/tests/translate-body.test.mts (modify): Add `it.skip` stubs for the build path's fixed-point routes: let-then-while fall-through builds `ir1While`; bare while builds `ir1While`; literal-true while rejects.
- test/test_smt.ml (modify): Add pending OCaml unit tests (tagged `[@tags "pending"]`) for `Smt.is_rule_recursive` and the recursive-rule emission shape.

## Gameplan Specification

```
module TS2PANT_FIXED_POINT_WHILE_LOWERING.

> ════════════════════════════════
> Milestone 4 of the ts2pant general-loop SSA workstream.
> ════════════════════════════════
> After this milestone, the mutating-body translator accepts
> unbounded while loops (single mutated location, non-literal-
> true guard) and lowers them to a synthesised top-level
> recursive Pant rule. Pant's SMT backend emits the recursive
> rule as define-fun-rec, giving Z3 / CVC5 native induction
> hooks for pant --check. Literal-true and multi-location
> while bodies reject with targeted diagnostics. Three passing
> fixtures verify end-to-end through pant typecheck and
> pant --check; one deliberate-reject fixture documents the
> literal-true rejection. Documentation in AGENTS.md, the IR
> doc, and the workstream doc records the surface and marks
> the milestone landed.

TSStmt.
IR1Stmt.
WhileStmt.
Declaration.
Rule.
PropResult.
IR1SsaLoopBody.
IR1SsaLocation.
TerminationMetric.
BuildOutcome.
LowerResult.
SmtLine.
EmissionShape.
Document.
DocumentKind.
MilestoneStatus.
decl-fun-rec => EmissionShape.
decl-fun-plus-axiom => EmissionShape.
agents-md => DocumentKind.
ir-doc => DocumentKind.
workstream-doc => DocumentKind.
pending => MilestoneStatus.
landed => MilestoneStatus.

> Pant SMT emission (Patch 2).
is-recursive? r: Rule => Bool.
body-of r: Rule => IR1Stmt.
body-applies-self? r: Rule, e: IR1Stmt => Bool.
emission-shape r: Rule => EmissionShape.
emits-define-fun-rec? r: Rule, lines: [SmtLine] => Bool.
emits-declare-fun? r: Rule, lines: [SmtLine] => Bool.
emits-universal-axiom? r: Rule, lines: [SmtLine] => Bool.
logically-equivalent? a: EmissionShape, b: EmissionShape => Bool.

> ts2pant fixed-point lowering (Patches 3, 4).
is-literal-true? s: WhileStmt => Bool.
mutated-count s: WhileStmt => Nat0.
build-mutating-body s: TSStmt => BuildOutcome.
lower-result-of-while s: WhileStmt => LowerResult.
is-ir1-while? b: BuildOutcome => Bool.
is-rejection? b: BuildOutcome => Bool.
rejection-mentions-literal-true? b: BuildOutcome => Bool.
recognizer-rejects-literal-true? s: WhileStmt => Bool.
recognizer-rejects-multi-location? s: WhileStmt => Bool.
is-bare-while? s: TSStmt => Bool.
is-let-then-while-pair? s: TSStmt => Bool.
l3-bounded-recognized? s: TSStmt => Bool.
body-metric b: IR1SsaLoopBody => TerminationMetric.
null-metric? m: TerminationMetric => Bool.
emits-recursive-helper? r: LowerResult => Bool.
emits-caller-equation? r: LowerResult => Bool.
helper-name-unique? n: String => Bool.

> Documentation (Patch 5).
document-kind d: Document => DocumentKind.
document-mentions-l4-fixed-point? d: Document => Bool.
workstream-milestone-4-status => MilestoneStatus.
---

> SMT emission contract: recursive rules emit define-fun-rec,
> non-recursive rules emit declare-fun + universal-axiom.
all r: Rule | is-recursive? r <-> body-applies-self? r (body-of r).

all r: Rule, lines: [SmtLine] |
  is-recursive? r ->
    emits-define-fun-rec? r lines and ~(emits-declare-fun? r lines).

all r: Rule, lines: [SmtLine] |
  ~(is-recursive? r) ->
    emits-declare-fun? r lines and emits-universal-axiom? r lines.

logically-equivalent? decl-fun-rec decl-fun-plus-axiom.

> Build-path contract: bare while loops construct ir1While
> unless guard is literal-true; let-then-while pairs that fail
> L3 fall through to ir1While.
all s: TSStmt |
  is-bare-while? s and ~(rejection-mentions-literal-true? (build-mutating-body s)) ->
    is-ir1-while? (build-mutating-body s).

all s: TSStmt |
  is-bare-while? s ->
    (is-rejection? (build-mutating-body s) ->
      rejection-mentions-literal-true? (build-mutating-body s)).

all s: TSStmt |
  is-let-then-while-pair? s and ~(l3-bounded-recognized? s) ->
    is-ir1-while? (build-mutating-body s).

> Lowering contract: literal-true and multi-location reject;
> successful lowering produces a fixed-point loop body
> (terminationMetric: null) plus a recursive helper rule-decl
> and a caller equation.
all s: WhileStmt |
  is-literal-true? s ->
    recognizer-rejects-literal-true? s.

all s: WhileStmt |
  mutated-count s > 1 ->
    recognizer-rejects-multi-location? s.

all s: WhileStmt, b: IR1SsaLoopBody |
  ~(is-literal-true? s) and mutated-count s = 1 ->
    null-metric? (body-metric b).

all s: WhileStmt |
  ~(is-literal-true? s) and mutated-count s = 1 ->
    emits-recursive-helper? (lower-result-of-while s) and
    emits-caller-equation? (lower-result-of-while s).

> Documentation invariants.
all d: Document |
  document-kind d = agents-md ->
    document-mentions-l4-fixed-point? d.

all d: Document |
  document-kind d = ir-doc ->
    document-mentions-l4-fixed-point? d.

all d: Document |
  document-kind d = workstream-doc ->
    document-mentions-l4-fixed-point? d.

workstream-milestone-4-status = landed.
```

## Patch Specification

```
module TS2PANT_FIXED_POINT_WHILE_LOWERING_PATCH_1.

> Patch 1 lands the test scaffolding for L4. Stubs are skipped;
> Patches 2 / 3 / 4 unskip them in-place with concrete
> assertions. No runtime invariants change.

TestStub.
PendingFor.
patch-2 => PendingFor.
patch-3 => PendingFor.
patch-4 => PendingFor.

stub-pending-for s: TestStub => PendingFor.
---
true.
```


## Implementation Notes

- The OCaml SMT placeholders deliberately avoid referencing future Patch 2 symbols and attach `[@tags "pending"]` to the inert unit expression, so the strict warning-as-error dune settings still compile cleanly.
- The new fixed-point TS test imports `node:assert/strict` to match the counter-loop test shape, but the skipped bodies contain only PENDING comments as required; concrete constructor calls are deferred to Patch 3.
- Spec/Evidence Mapping:
  - Patch-only scaffolding / no runtime invariant change: touched only `test/test_smt.ml` and `tools/ts2pant/tests/*.test.mts`; no production files changed.
  - Patch 2 pending SMT coverage: `test/test_smt.ml` registers three pending integration tests for recursion detection and recursive/non-recursive emission shapes.
  - Patch 3/4 pending ts2pant coverage: `ir1-ssa-fixed-point.test.mts` and `translate-body.test.mts` add the requested skipped stubs.
  - Required context consulted: `workstreams/ts2pant-general-loop-ssa.md`.
  - Verification run: `just test-ocaml`, `npm run test:unit`, `npx tsx --test tests/ir1-ssa-fixed-point.test.mts`, and `git diff --check`.
- Note: `just ts2pant-test-unit` was attempted first, but its prerequisite WASM rebuild slept inside `dune build wasm/` with no worker child/output for several minutes. I terminated that wrapper and ran the ts2pant unit tests directly against the existing built WASM bundle; they passed.