### PR TITLE
[ts2pant-fixed-point-while-lowering] Patch 3: ts2pant: fixed-point loop lowerer module

### DIFF
--- a/tools/ts2pant/src/emit.ts
+++ b/tools/ts2pant/src/emit.ts
@@ -53,6 +53,17 @@ function renderPropResult(prop: PropResult): string {
       }
       return ast.strExpr(ast.forall(prop.quantifiers, guards, prop.body));
     }
+    case "rule-decl": {
+      const params = prop.params.map((p) => ast.param(p.name, p.type));
+      const decl = ast.strDecl(
+        ast.declRule(prop.ruleName, params, [], prop.returnType),
+      );
+      const lhs = ast.app(
+        ast.var(prop.ruleName),
+        prop.params.map((p) => ast.var(p.name)),
+      );
+      return `${decl}\n${ast.strExpr(ast.binop(ast.opEq(), lhs, prop.body))}`;
+    }
     case "unsupported":
       return `> UNSUPPORTED: ${prop.reason}`;
     case "raw":

--- a/tools/ts2pant/src/ir1-ssa-fixed-point.ts
+++ b/tools/ts2pant/src/ir1-ssa-fixed-point.ts
@@ -27,7 +27,11 @@ import {
 import { registerName } from "./name-registry.js";
 import type { OpaqueExpr, OpaqueTypeExpr } from "./pant-ast.js";
 import { getAst } from "./pant-wasm.js";
-import type { SynthCell } from "./translate-types.js";
+import {
+  IntStrategy,
+  type NumericStrategy,
+  type SynthCell,
+} from "./translate-types.js";
 import type { PropResult } from "./types.js";
 
 export interface FixedPointLoopLowerOptions extends LoopSsaBuildOptions {
@@ -36,6 +40,7 @@ export interface FixedPointLoopLowerOptions extends LoopSsaBuildOptions {
   synthCell?: SynthCell;
   locationType?: OpaqueTypeExpr | string;
   invariantTypes?: ReadonlyMap<string, OpaqueTypeExpr | string>;
+  strategy?: NumericStrategy;
 }
 
 export interface FixedPointLoopShape {
@@ -112,7 +117,14 @@ export function lowerFixedPointLoopL1Body(
     targetInfo.location,
   );
   const header = ir1SsaOpenLoopHeader(targetInfo.location, preheaderVersion);
-  const stateVar = ir1Var("s");
+  const invariantNames = collectLoopInvariantNames(
+    [shape.guardExpr, writeBody.value],
+    writeBody.target,
+  );
+  const stateName = allocateFreshStateName(
+    stateAvoidanceNames([shape.guardExpr, writeBody.value], writeBody.target),
+  );
+  const stateVar = ir1Var(stateName);
   const effectExpr = substituteMemberReads(
     writeBody.value,
     writeBody.target,
@@ -134,14 +146,10 @@ export function lowerFixedPointLoopL1Body(
   });
 
   const ruleName = allocateLoopRuleName(options.synthCell);
-  const locationType = typeExpr(options.locationType);
-  const invariantNames = collectLoopInvariantNames(
-    [shape.guardExpr, writeBody.value],
-    writeBody.target,
-  );
+  const locationType = typeExpr(options.locationType, options.strategy);
   const invariantParams = invariantNames.map((name) => ({
     name,
-    type: typeExpr(options.invariantTypes?.get(name)),
+    type: typeExpr(options.invariantTypes?.get(name), options.strategy),
   }));
   const effect = lowerOpaque(lowerExpr(lowerL1Expr(effectExpr)));
   const loweredGuard = lowerOpaque(
@@ -157,12 +165,12 @@ export function lowerFixedPointLoopL1Body(
   ]);
   const helperBody = ast.cond([
     [loweredGuard, helperCallOnEffect],
-    [ast.litBool(true), ast.var("s")],
+    [ast.litBool(true), ast.var(stateName)],
   ]);
   const ruleDecl: PropResult = {
     kind: "rule-decl",
     ruleName,
-    params: [{ name: "s", type: locationType }, ...invariantParams],
+    params: [{ name: stateName, type: locationType }, ...invariantParams],
     returnType: locationType,
     body: helperBody,
   };
@@ -231,11 +239,14 @@ function buildTargetInfo(
   return { target, location, objExpr, lhs, prior, key };
 }
 
-function typeExpr(type: OpaqueTypeExpr | string | undefined): OpaqueTypeExpr {
+function typeExpr(
+  type: OpaqueTypeExpr | string | undefined,
+  strategy: NumericStrategy = IntStrategy,
+): OpaqueTypeExpr {
   const ast = getAst();
   return typeof type === "string"
     ? ast.tName(type)
-    : (type ?? ast.tName("Nat0"));
+    : (type ?? ast.tName(strategy.mapNumber()));
 }
 
 function allocateLoopRuleName(synthCell: SynthCell | undefined): string {
@@ -244,6 +255,11 @@ function allocateLoopRuleName(synthCell: SynthCell | undefined): string {
   }
   const registered = registerName(synthCell.registry, "fn--loop");
   synthCell.registry = registered.registry;
+  return registered.name;
+}
+
+function allocateFreshStateName(forbidden: ReadonlySet<string>): string {
+  const registered = registerName({ used: new Set(forbidden) }, "s");
   return registered.name;
 }
 
@@ -423,7 +439,7 @@ function collectLoopInvariantNames(
   target: Extract<IR1Expr, { kind: "member" }>,
 ): string[] {
   const names = new Set<string>();
-  const excluded = new Set<string>(["s"]);
+  const excluded = new Set<string>();
   const receiverRoot = rootName(target.receiver);
   if (receiverRoot !== null) {
     excluded.add(receiverRoot);
@@ -432,6 +448,77 @@ function collectLoopInvariantNames(
     collectFreeVars(expr, names, excluded);
   }
   return [...names].sort();
+}
+
+function stateAvoidanceNames(
+  exprs: readonly IR1Expr[],
+  target: Extract<IR1Expr, { kind: "member" }>,
+): ReadonlySet<string> {
+  const names = new Set<string>();
+  const receiverRoot = rootName(target.receiver);
+  if (receiverRoot !== null) {
+    names.add(receiverRoot);
+  }
+  for (const expr of exprs) {
+    collectAllNames(expr, names);
+  }
+  return names;
+}
+
+function collectAllNames(expr: IR1Expr, out: Set<string>): void {
+  switch (expr.kind) {
+    case "var":
+      out.add(expr.name);
+      break;
+    case "lit":
+      break;
+    case "binop":
+      collectAllNames(expr.lhs, out);
+      collectAllNames(expr.rhs, out);
+      break;
+    case "unop":
+      collectAllNames(expr.arg, out);
+      break;
+    case "app":
+      collectAllNames(expr.callee, out);
+      for (const arg of expr.args) {
+        collectAllNames(arg, out);
+      }
+      break;
+    case "member":
+      collectAllNames(expr.receiver, out);
+      break;
+    case "cond":
+      for (const [guard, value] of expr.arms) {
+        collectAllNames(guard, out);
+        collectAllNames(value, out);
+      }
+      collectAllNames(expr.otherwise, out);
+      break;
+    case "is-nullish":
+      collectAllNames(expr.operand, out);
+      break;
+    case "each":
+      out.add(expr.binder);
+      collectAllNames(expr.src, out);
+      for (const guard of expr.guards) {
+        collectAllNames(guard, out);
+      }
+      collectAllNames(expr.proj, out);
+      break;
+    case "map-read":
+      collectAllNames(expr.receiver, out);
+      collectAllNames(expr.key, out);
+      break;
+    case "set-read":
+      collectAllNames(expr.receiver, out);
+      collectAllNames(expr.elem, out);
+      break;
+    default: {
+      const _exhaustive: never = expr;
+      void _exhaustive;
+    }
+  }
 }
 
 function collectFreeVars(

--- a/tools/ts2pant/src/ir1-ssa-fixed-point.ts
+++ b/tools/ts2pant/src/ir1-ssa-fixed-point.ts
@@ -1,0 +1,543 @@
+import { lowerExpr } from "./ir-emit.js";
+import {
+  type IR1Expr,
+  type IR1SsaLocation,
+  type IR1SsaLoopBody,
+  type IR1SsaProgram,
+  type IR1SsaVersion,
+  type IR1SsaWrite,
+  type IR1Stmt,
+  ir1SsaCloseLoopHeader,
+  ir1SsaInitialVersion,
+  ir1SsaLoopBody,
+  ir1SsaOpenLoopHeader,
+  ir1SsaPropertyLocation,
+  ir1SsaPropertyValue,
+  ir1SsaRuleOfLocation,
+  ir1SsaWrite,
+  ir1Var,
+} from "./ir1.js";
+import { lowerL1Expr } from "./ir1-lower.js";
+import type { LoopSsaBuildOptions } from "./ir1-ssa-loops.js";
+import {
+  type IR1SsaBodyLowerResult,
+  ir1SsaBodyLowerSuccess,
+  ir1SsaBodyLowerUnsupported,
+} from "./ir1-ssa-lower.js";
+import { registerName } from "./name-registry.js";
+import type { OpaqueExpr, OpaqueTypeExpr } from "./pant-ast.js";
+import { getAst } from "./pant-wasm.js";
+import type { SynthCell } from "./translate-types.js";
+import type { PropResult } from "./types.js";
+
+export interface FixedPointLoopLowerOptions extends LoopSsaBuildOptions {
+  lowerOpaque?: (e: OpaqueExpr) => OpaqueExpr;
+  initialPropertyValues?: ReadonlyMap<string, OpaqueExpr>;
+  synthCell?: SynthCell;
+  locationType?: OpaqueTypeExpr | string;
+  invariantTypes?: ReadonlyMap<string, OpaqueTypeExpr | string>;
+}
+
+export interface FixedPointLoopShape {
+  guardExpr: IR1Expr;
+  bodyStmt: IR1Stmt;
+  mutatedLocation: Extract<IR1SsaLocation, { kind: "property" }>;
+}
+
+interface TargetInfo {
+  target: Extract<IR1Expr, { kind: "member" }>;
+  location: Extract<IR1SsaLocation, { kind: "property" }>;
+  objExpr: OpaqueExpr;
+  lhs: OpaqueExpr;
+  prior: OpaqueExpr;
+  key: string;
+}
+
+export function recognizeFixedPointLoopShape(
+  stmt: Extract<IR1Stmt, { kind: "while" }>,
+): FixedPointLoopShape | { unsupported: string } {
+  if (
+    stmt.cond.kind === "lit" &&
+    stmt.cond.value.kind === "bool" &&
+    stmt.cond.value.value === true
+  ) {
+    return {
+      unsupported:
+        "while loop has a literal-true guard; cannot define a fixed point",
+    };
+  }
+
+  const locations = collectMutatedPropertyLocations(stmt.body);
+  if (locations.size > 1) {
+    return {
+      unsupported: `fixed-point while lowering supports single-location bodies only; this loop modifies ${locations.size} rules`,
+    };
+  }
+  const mutatedLocation = [...locations.values()][0];
+  if (mutatedLocation === undefined) {
+    return {
+      unsupported: "fixed-point while lowering requires one property mutation",
+    };
+  }
+  return {
+    guardExpr: stmt.cond,
+    bodyStmt: stmt.body,
+    mutatedLocation,
+  };
+}
+
+export function lowerFixedPointLoopL1Body(
+  stmt: Extract<IR1Stmt, { kind: "while" }>,
+  options: FixedPointLoopLowerOptions = {},
+): IR1SsaBodyLowerResult {
+  const shape = recognizeFixedPointLoopShape(stmt);
+  if ("unsupported" in shape) {
+    return ir1SsaBodyLowerUnsupported(shape.unsupported);
+  }
+
+  const writeBody = findSinglePropertyWrite(shape.bodyStmt);
+  if ("unsupported" in writeBody) {
+    return ir1SsaBodyLowerUnsupported(writeBody.unsupported);
+  }
+  if (!sameLocation(shape.mutatedLocation, writeBody.location)) {
+    return ir1SsaBodyLowerUnsupported(
+      "fixed-point while lowering could not match the mutated location to the loop body write",
+    );
+  }
+
+  const lowerOpaque = options.lowerOpaque ?? ((e: OpaqueExpr) => e);
+  const ast = getAst();
+  const targetInfo = buildTargetInfo(writeBody.target, lowerOpaque, options);
+  const preheaderVersion: IR1SsaVersion = ir1SsaInitialVersion(
+    targetInfo.location,
+  );
+  const header = ir1SsaOpenLoopHeader(targetInfo.location, preheaderVersion);
+  const stateVar = ir1Var("s");
+  const effectExpr = substituteMemberReads(
+    writeBody.value,
+    writeBody.target,
+    stateVar,
+  );
+  const write: IR1SsaWrite = ir1SsaWrite(
+    targetInfo.location,
+    ir1SsaPropertyValue(effectExpr),
+  );
+  ir1SsaCloseLoopHeader(header, write.version);
+
+  const loopBody: IR1SsaLoopBody = ir1SsaLoopBody({
+    headerJoins: [header],
+    writes: [write],
+    joins: [],
+    breakHandles: [],
+    continueHandles: [],
+    terminationMetric: null,
+  });
+
+  const ruleName = allocateLoopRuleName(options.synthCell);
+  const locationType = typeExpr(options.locationType);
+  const invariantNames = collectLoopInvariantNames(
+    [shape.guardExpr, writeBody.value],
+    writeBody.target,
+  );
+  const invariantParams = invariantNames.map((name) => ({
+    name,
+    type: typeExpr(options.invariantTypes?.get(name)),
+  }));
+  const effect = lowerOpaque(lowerExpr(lowerL1Expr(effectExpr)));
+  const loweredGuard = lowerOpaque(
+    lowerExpr(
+      lowerL1Expr(
+        substituteMemberReads(shape.guardExpr, writeBody.target, stateVar),
+      ),
+    ),
+  );
+  const helperCallOnEffect = ast.app(ast.var(ruleName), [
+    effect,
+    ...invariantNames.map((name) => ast.var(name)),
+  ]);
+  const helperBody = ast.cond([
+    [loweredGuard, helperCallOnEffect],
+    [ast.litBool(true), ast.var("s")],
+  ]);
+  const ruleDecl: PropResult = {
+    kind: "rule-decl",
+    ruleName,
+    params: [{ name: "s", type: locationType }, ...invariantParams],
+    returnType: locationType,
+    body: helperBody,
+  };
+  const callerEquation: PropResult = {
+    kind: "equation",
+    quantifiers: [],
+    lhs: targetInfo.lhs,
+    rhs: ast.app(ast.var(ruleName), [
+      targetInfo.prior,
+      ...invariantNames.map((name) => ast.var(name)),
+    ]),
+  };
+
+  const modifiedRules = [ir1SsaRuleOfLocation(targetInfo.location)];
+  const declaredRules = new Set([
+    ...(options.declaredRules ?? []),
+    ...modifiedRules,
+  ]);
+  const program: IR1SsaProgram = {
+    reads: [],
+    writes: [write],
+    joins: [],
+    loopSummaries: [],
+    loopHeaderJoins: [header],
+    loopBodies: [loopBody],
+    declaredRules: [...declaredRules],
+    modifiedRules,
+    framedRules: [...declaredRules].filter(
+      (rule) => !modifiedRules.includes(rule),
+    ),
+  };
+
+  return ir1SsaBodyLowerSuccess({
+    programs: [program],
+    propositions: [ruleDecl, callerEquation],
+    modifiedRules,
+    finalProperties: [
+      {
+        location: targetInfo.location,
+        version: write.version,
+        objExpr: targetInfo.objExpr,
+        lhs: targetInfo.lhs,
+        rhs: callerEquation.rhs,
+      },
+    ],
+  });
+}
+
+function buildTargetInfo(
+  target: Extract<IR1Expr, { kind: "member" }>,
+  lowerOpaque: (e: OpaqueExpr) => OpaqueExpr,
+  options: FixedPointLoopLowerOptions,
+): TargetInfo {
+  const ast = getAst();
+  const objExpr = lowerOpaque(lowerExpr(lowerL1Expr(target.receiver)));
+  const location = ir1SsaPropertyLocation(
+    target.name,
+    target.receiver,
+    target.name,
+  ) as Extract<IR1SsaLocation, { kind: "property" }>;
+  const lhs = ast.app(ast.primed(target.name), [objExpr]);
+  const key = `${target.name}::${ast.strExpr(objExpr)}`;
+  const prior =
+    options.initialPropertyValues?.get(key) ??
+    ast.app(ast.var(target.name), [objExpr]);
+  return { target, location, objExpr, lhs, prior, key };
+}
+
+function typeExpr(type: OpaqueTypeExpr | string | undefined): OpaqueTypeExpr {
+  const ast = getAst();
+  return typeof type === "string"
+    ? ast.tName(type)
+    : (type ?? ast.tName("Nat0"));
+}
+
+function allocateLoopRuleName(synthCell: SynthCell | undefined): string {
+  if (synthCell === undefined) {
+    return "fn--loop";
+  }
+  const registered = registerName(synthCell.registry, "fn--loop");
+  synthCell.registry = registered.registry;
+  return registered.name;
+}
+
+function collectMutatedPropertyLocations(
+  stmt: IR1Stmt,
+): Map<string, Extract<IR1SsaLocation, { kind: "property" }>> {
+  const out = new Map<string, Extract<IR1SsaLocation, { kind: "property" }>>();
+  walkStmt(stmt, (s) => {
+    if (s.kind === "assign" && s.target.kind === "member") {
+      const location = ir1SsaPropertyLocation(
+        s.target.name,
+        s.target.receiver,
+        s.target.name,
+      ) as Extract<IR1SsaLocation, { kind: "property" }>;
+      out.set(locationKey(location), location);
+    }
+  });
+  return out;
+}
+
+function findSinglePropertyWrite(stmt: IR1Stmt):
+  | {
+      target: Extract<IR1Expr, { kind: "member" }>;
+      value: IR1Expr;
+      location: Extract<IR1SsaLocation, { kind: "property" }>;
+    }
+  | { unsupported: string } {
+  const writes: Array<{
+    target: Extract<IR1Expr, { kind: "member" }>;
+    value: IR1Expr;
+    location: Extract<IR1SsaLocation, { kind: "property" }>;
+  }> = [];
+  walkStmt(stmt, (s) => {
+    if (s.kind === "assign" && s.target.kind === "member") {
+      const location = ir1SsaPropertyLocation(
+        s.target.name,
+        s.target.receiver,
+        s.target.name,
+      ) as Extract<IR1SsaLocation, { kind: "property" }>;
+      writes.push({ target: s.target, value: s.value, location });
+    }
+  });
+  if (writes.length !== 1) {
+    return {
+      unsupported:
+        "fixed-point while lowering requires exactly one property write in the loop body",
+    };
+  }
+  return writes[0]!;
+}
+
+function walkStmt(stmt: IR1Stmt, visit: (stmt: IR1Stmt) => void): void {
+  visit(stmt);
+  switch (stmt.kind) {
+    case "block":
+      for (const child of stmt.stmts) {
+        walkStmt(child, visit);
+      }
+      break;
+    case "cond-stmt":
+      for (const [, body] of stmt.arms) {
+        walkStmt(body, visit);
+      }
+      if (stmt.otherwise !== null) {
+        walkStmt(stmt.otherwise, visit);
+      }
+      break;
+    case "for":
+      if (stmt.init !== null) {
+        walkStmt(stmt.init, visit);
+      }
+      if (stmt.step !== null) {
+        walkStmt(stmt.step, visit);
+      }
+      walkStmt(stmt.body, visit);
+      break;
+    case "while":
+      walkStmt(stmt.body, visit);
+      break;
+    case "let":
+    case "assign":
+    case "foreach":
+    case "return":
+    case "throw":
+    case "expr-stmt":
+    case "map-effect":
+    case "set-effect":
+      break;
+    default: {
+      const _exhaustive: never = stmt;
+      void _exhaustive;
+    }
+  }
+}
+
+function substituteMemberReads(
+  expr: IR1Expr,
+  member: Extract<IR1Expr, { kind: "member" }>,
+  replacement: IR1Expr,
+): IR1Expr {
+  if (sameMemberExpr(expr, member)) {
+    return replacement;
+  }
+  switch (expr.kind) {
+    case "var":
+    case "lit":
+      return expr;
+    case "binop":
+      return {
+        ...expr,
+        lhs: substituteMemberReads(expr.lhs, member, replacement),
+        rhs: substituteMemberReads(expr.rhs, member, replacement),
+      };
+    case "unop":
+      return {
+        ...expr,
+        arg: substituteMemberReads(expr.arg, member, replacement),
+      };
+    case "app":
+      return {
+        ...expr,
+        callee: substituteMemberReads(expr.callee, member, replacement),
+        args: expr.args.map((arg) =>
+          substituteMemberReads(arg, member, replacement),
+        ),
+      };
+    case "member":
+      return {
+        ...expr,
+        receiver: substituteMemberReads(expr.receiver, member, replacement),
+      };
+    case "cond":
+      return {
+        ...expr,
+        arms: expr.arms.map(([guard, value]) => [
+          substituteMemberReads(guard, member, replacement),
+          substituteMemberReads(value, member, replacement),
+        ]),
+        otherwise: substituteMemberReads(expr.otherwise, member, replacement),
+      };
+    case "is-nullish":
+      return {
+        ...expr,
+        operand: substituteMemberReads(expr.operand, member, replacement),
+      };
+    case "each":
+      return {
+        ...expr,
+        src: substituteMemberReads(expr.src, member, replacement),
+        guards: expr.guards.map((guard) =>
+          substituteMemberReads(guard, member, replacement),
+        ),
+        proj: substituteMemberReads(expr.proj, member, replacement),
+      };
+    case "map-read":
+      return {
+        ...expr,
+        receiver: substituteMemberReads(expr.receiver, member, replacement),
+        key: substituteMemberReads(expr.key, member, replacement),
+      };
+    case "set-read":
+      return {
+        ...expr,
+        receiver: substituteMemberReads(expr.receiver, member, replacement),
+        elem: substituteMemberReads(expr.elem, member, replacement),
+      };
+    default: {
+      const _exhaustive: never = expr;
+      void _exhaustive;
+      return expr;
+    }
+  }
+}
+
+function collectLoopInvariantNames(
+  exprs: readonly IR1Expr[],
+  target: Extract<IR1Expr, { kind: "member" }>,
+): string[] {
+  const names = new Set<string>();
+  const excluded = new Set<string>(["s"]);
+  const receiverRoot = rootName(target.receiver);
+  if (receiverRoot !== null) {
+    excluded.add(receiverRoot);
+  }
+  for (const expr of exprs) {
+    collectFreeVars(expr, names, excluded);
+  }
+  return [...names].sort();
+}
+
+function collectFreeVars(
+  expr: IR1Expr,
+  out: Set<string>,
+  excluded: ReadonlySet<string>,
+  bound: ReadonlySet<string> = new Set(),
+): void {
+  switch (expr.kind) {
+    case "var":
+      if (!expr.primed && !excluded.has(expr.name) && !bound.has(expr.name)) {
+        out.add(expr.name);
+      }
+      break;
+    case "lit":
+      break;
+    case "binop":
+      collectFreeVars(expr.lhs, out, excluded, bound);
+      collectFreeVars(expr.rhs, out, excluded, bound);
+      break;
+    case "unop":
+    case "is-nullish":
+      collectFreeVars(
+        expr.kind === "unop" ? expr.arg : expr.operand,
+        out,
+        excluded,
+        bound,
+      );
+      break;
+    case "app":
+      collectFreeVars(expr.callee, out, excluded, bound);
+      for (const arg of expr.args) {
+        collectFreeVars(arg, out, excluded, bound);
+      }
+      break;
+    case "member":
+      collectFreeVars(expr.receiver, out, excluded, bound);
+      break;
+    case "cond":
+      for (const [guard, value] of expr.arms) {
+        collectFreeVars(guard, out, excluded, bound);
+        collectFreeVars(value, out, excluded, bound);
+      }
+      collectFreeVars(expr.otherwise, out, excluded, bound);
+      break;
+    case "each": {
+      collectFreeVars(expr.src, out, excluded, bound);
+      const nextBound = new Set(bound);
+      nextBound.add(expr.binder);
+      for (const guard of expr.guards) {
+        collectFreeVars(guard, out, excluded, nextBound);
+      }
+      collectFreeVars(expr.proj, out, excluded, nextBound);
+      break;
+    }
+    case "map-read":
+      collectFreeVars(expr.receiver, out, excluded, bound);
+      collectFreeVars(expr.key, out, excluded, bound);
+      break;
+    case "set-read":
+      collectFreeVars(expr.receiver, out, excluded, bound);
+      collectFreeVars(expr.elem, out, excluded, bound);
+      break;
+    default: {
+      const _exhaustive: never = expr;
+      void _exhaustive;
+    }
+  }
+}
+
+function sameLocation(
+  a: Extract<IR1SsaLocation, { kind: "property" }>,
+  b: Extract<IR1SsaLocation, { kind: "property" }>,
+): boolean {
+  return a.ruleName === b.ruleName && ir1ExprEqual(a.receiver, b.receiver);
+}
+
+function locationKey(location: Extract<IR1SsaLocation, { kind: "property" }>) {
+  return `${location.ruleName}::${exprKey(location.receiver)}`;
+}
+
+function sameMemberExpr(
+  expr: IR1Expr,
+  member: Extract<IR1Expr, { kind: "member" }>,
+): boolean {
+  return (
+    expr.kind === "member" &&
+    expr.name === member.name &&
+    ir1ExprEqual(expr.receiver, member.receiver)
+  );
+}
+
+function ir1ExprEqual(a: IR1Expr, b: IR1Expr): boolean {
+  return exprKey(a) === exprKey(b);
+}
+
+function exprKey(expr: IR1Expr): string {
+  return JSON.stringify(expr);
+}
+
+function rootName(expr: IR1Expr): string | null {
+  if (expr.kind === "var") {
+    return expr.name;
+  }
+  if (expr.kind === "member") {
+    return rootName(expr.receiver);
+  }
+  return null;
+}

--- a/tools/ts2pant/src/types.ts
+++ b/tools/ts2pant/src/types.ts
@@ -1,4 +1,9 @@
-import type { OpaqueExpr, OpaqueGuard, OpaqueParam } from "./pant-ast.js";
+import type {
+  OpaqueExpr,
+  OpaqueGuard,
+  OpaqueParam,
+  OpaqueTypeExpr,
+} from "./pant-ast.js";
 
 /** Pantagruel numeric type strategy. */
 export type NumericType = "Int" | "Real" | "Nat0";
@@ -71,6 +76,13 @@ export type PropResult =
       guards?: OpaqueGuard[];
       lhs: OpaqueExpr;
       rhs: OpaqueExpr;
+    }
+  | {
+      kind: "rule-decl";
+      ruleName: string;
+      params: Array<{ name: string; type: OpaqueTypeExpr }>;
+      returnType: OpaqueTypeExpr;
+      body: OpaqueExpr;
     }
   | {
       kind: "assertion";

--- a/tools/ts2pant/tests/ir1-ssa-fixed-point.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-fixed-point.test.mts
@@ -1,28 +1,159 @@
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import { before, describe, it } from "node:test";
+
+import { emitDocument } from "../src/emit.js";
+import type { IR1Expr, IR1Stmt } from "../src/ir1.js";
+import {
+  lowerFixedPointLoopL1Body,
+  recognizeFixedPointLoopShape,
+} from "../src/ir1-ssa-fixed-point.js";
+import { getAst, loadAst } from "../src/pant-wasm.js";
+import { newSynthCell } from "../src/translate-types.js";
+
+const aVar: IR1Expr = { kind: "var", name: "a" };
+const balanceMember: IR1Expr = {
+  kind: "member",
+  receiver: aVar,
+  name: "balance",
+};
+const targetVar: IR1Expr = { kind: "var", name: "target" };
+const stepVar: IR1Expr = { kind: "var", name: "step" };
+
+before(async () => {
+  await loadAst();
+});
+
+function fixedPointWhile(): Extract<IR1Stmt, { kind: "while" }> {
+  return {
+    kind: "while",
+    cond: { kind: "binop", op: "lt", lhs: balanceMember, rhs: targetVar },
+    body: {
+      kind: "assign",
+      target: balanceMember,
+      value: { kind: "binop", op: "add", lhs: balanceMember, rhs: stepVar },
+    },
+  };
+}
 
 describe("ir1-ssa-fixed-point", () => {
-  it.skip("recognizes a single-location while-loop fixed-point shape", () => {
-    // PENDING Patch 3: implement fixed-point while-loop shape recognition.
+  it("recognizes a single-location while-loop fixed-point shape", () => {
+    const result = recognizeFixedPointLoopShape(fixedPointWhile());
+
+    assert.ok(!("unsupported" in result));
+    assert.equal(result.guardExpr.kind, "binop");
+    assert.equal(result.bodyStmt.kind, "assign");
+    assert.equal(result.mutatedLocation.kind, "property");
+    assert.equal(result.mutatedLocation.ruleName, "balance");
   });
 
-  it.skip("rejects literal-true guards at the recognizer level", () => {
-    // PENDING Patch 3: implement literal-true guard rejection.
+  it("rejects literal-true guards at the recognizer level", () => {
+    const result = recognizeFixedPointLoopShape({
+      ...fixedPointWhile(),
+      cond: { kind: "lit", value: { kind: "bool", value: true } },
+    });
+
+    assert.ok("unsupported" in result);
+    assert.match(result.unsupported, /literal-true guard/u);
   });
 
-  it.skip("rejects multi-location while bodies", () => {
-    // PENDING Patch 3: implement multi-location while body rejection.
+  it("rejects multi-location while bodies", () => {
+    const result = recognizeFixedPointLoopShape({
+      ...fixedPointWhile(),
+      body: {
+        kind: "block",
+        stmts: [
+          {
+            kind: "assign",
+            target: balanceMember,
+            value: { kind: "lit", value: { kind: "nat", value: 1 } },
+          },
+          {
+            kind: "assign",
+            target: { kind: "member", receiver: aVar, name: "limit" },
+            value: { kind: "lit", value: { kind: "nat", value: 2 } },
+          },
+        ],
+      },
+    });
+
+    assert.ok("unsupported" in result);
+    assert.match(result.unsupported, /single-location bodies only/u);
+    assert.match(result.unsupported, /2 rules/u);
   });
 
-  it.skip("constructs IR1SsaLoopBody with terminationMetric: null", () => {
-    // PENDING Patch 3: construct fixed-point loop bodies with null metrics.
+  it("constructs IR1SsaLoopBody with terminationMetric: null", () => {
+    const result = lowerFixedPointLoopL1Body(fixedPointWhile());
+
+    assert.deepEqual(result.diagnostics, []);
+    assert.equal(result.programs.length, 1);
+    assert.equal(result.programs[0]!.loopBodies.length, 1);
+    assert.equal(result.programs[0]!.loopBodies[0]!.terminationMetric, null);
   });
 
-  it.skip("synthesises a uniquely-named recursive helper rule via NameRegistry", () => {
-    // PENDING Patch 3: synthesise recursive helper names through NameRegistry.
+  it("synthesises a uniquely-named recursive helper rule via NameRegistry", () => {
+    const synthCell = newSynthCell();
+    const first = lowerFixedPointLoopL1Body(fixedPointWhile(), { synthCell });
+    const second = lowerFixedPointLoopL1Body(fixedPointWhile(), { synthCell });
+    const firstDecl = first.propositions[0]!;
+    const secondDecl = second.propositions[0]!;
+
+    assert.equal(firstDecl.kind, "rule-decl");
+    assert.equal(secondDecl.kind, "rule-decl");
+    assert.equal(firstDecl.ruleName, "fn--loop");
+    assert.equal(secondDecl.ruleName, "fn--loop1");
   });
 
-  it.skip("emits a rule-decl PropResult for the helper and an equation PropResult for the caller", () => {
-    // PENDING Patch 3: emit helper rule-decl and caller equation PropResults.
+  it("emits a rule-decl PropResult for the helper and an equation PropResult for the caller", () => {
+    const ast = getAst();
+    const result = lowerFixedPointLoopL1Body(fixedPointWhile(), {
+      locationType: ast.tName("Nat0"),
+      invariantTypes: new Map([
+        ["step", ast.tName("Nat0")],
+        ["target", ast.tName("Nat0")],
+      ]),
+    });
+
+    assert.deepEqual(
+      result.propositions.map((p) => p.kind),
+      ["rule-decl", "equation"],
+    );
+    const ruleDecl = result.propositions[0]!;
+    const equation = result.propositions[1]!;
+    assert.equal(ruleDecl.kind, "rule-decl");
+    assert.equal(equation.kind, "equation");
+    assert.deepEqual(
+      ruleDecl.params.map((p) => p.name),
+      ["s", "step", "target"],
+    );
+
+    const source = emitDocument({
+      moduleName: "FixedPointTest",
+      imports: [],
+      declarations: [
+        { kind: "domain", name: "Account" },
+        {
+          kind: "rule",
+          name: "balance",
+          params: [{ name: "a", type: "Account" }],
+          returnType: "Nat0",
+        },
+        {
+          kind: "action",
+          label: "Run",
+          params: [
+            { name: "a", type: "Account" },
+            { name: "step", type: "Nat0" },
+            { name: "target", type: "Nat0" },
+          ],
+        },
+      ],
+      propositions: result.propositions,
+      checks: [],
+    });
+    assert.match(
+      source,
+      /fn--loop s: Nat0, step: Nat0, target: Nat0 => Nat0\./u,
+    );
+    assert.match(source, /balance' a = fn--loop \(balance a\) step target\./u);
   });
 });

--- a/tools/ts2pant/tests/ir1-ssa-fixed-point.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-fixed-point.test.mts
@@ -8,7 +8,7 @@ import {
   recognizeFixedPointLoopShape,
 } from "../src/ir1-ssa-fixed-point.js";
 import { getAst, loadAst } from "../src/pant-wasm.js";
-import { newSynthCell } from "../src/translate-types.js";
+import { newSynthCell, RealStrategy } from "../src/translate-types.js";
 
 const aVar: IR1Expr = { kind: "var", name: "a" };
 const balanceMember: IR1Expr = {
@@ -155,5 +155,37 @@ describe("ir1-ssa-fixed-point", () => {
       /fn--loop s: Nat0, step: Nat0, target: Nat0 => Nat0\./u,
     );
     assert.match(source, /balance' a = fn--loop \(balance a\) step target\./u);
+  });
+
+  it("allocates a fresh state binder when s is a loop invariant", () => {
+    const ast = getAst();
+    const sVar: IR1Expr = { kind: "var", name: "s" };
+    const result = lowerFixedPointLoopL1Body({
+      ...fixedPointWhile(),
+      cond: { kind: "binop", op: "lt", lhs: balanceMember, rhs: sVar },
+    });
+    const ruleDecl = result.propositions[0]!;
+
+    assert.equal(ruleDecl.kind, "rule-decl");
+    assert.deepEqual(
+      ruleDecl.params.map((p) => p.name),
+      ["s1", "s", "step"],
+    );
+    assert.match(ast.strExpr(ruleDecl.body), /cond s1 < s =>/u);
+  });
+
+  it("uses the configured numeric strategy for default helper types", () => {
+    const ast = getAst();
+    const result = lowerFixedPointLoopL1Body(fixedPointWhile(), {
+      strategy: RealStrategy,
+    });
+    const ruleDecl = result.propositions[0]!;
+
+    assert.equal(ruleDecl.kind, "rule-decl");
+    assert.equal(ast.strTypeExpr(ruleDecl.returnType), "Real");
+    assert.deepEqual(
+      ruleDecl.params.map((p) => ast.strTypeExpr(p.type)),
+      ["Real", "Real", "Real"],
+    );
   });
 });


### PR DESCRIPTION
## Patch 3: ts2pant: fixed-point loop lowerer module

- Create `tools/ts2pant/src/ir1-ssa-fixed-point.ts` with the module shape mirroring `tools/ts2pant/src/ir1-ssa-counter-loop.ts`.
- Implement `recognizeFixedPointLoopShape(stmt: Extract<IR1Stmt, { kind: 'while' }>)`. Walk the body to collect mutated locations (using the same property-mutation detection logic the counter-loop module uses). Reject with `{ unsupported: 'fixed-point while lowering supports single-location bodies only; this loop modifies N rules' }` if there is more than one. Reject with `{ unsupported: 'while loop has a literal-true guard; cannot define a fixed point' }` if `stmt.cond.kind === 'lit' && stmt.cond.value.kind === 'bool' && stmt.cond.value.value === true`. On success, return `{ guardExpr: stmt.cond, bodyStmt: stmt.body, mutatedLocation: <the single location> }`.
- Implement `lowerFixedPointLoopL1Body(stmt, options)`. Open an `IR1SsaLoopHeaderJoin` for the mutated location via `ir1SsaOpenLoopHeader`. Build the body's effect-on-location expression: walk the body, find the single property write, build an IR1Expr representing `body(s)` where `s` is the current location value. Construct an `IR1SsaWrite` whose value is that effect expression. Close the header via `ir1SsaCloseLoopHeader` with the write's version. Construct `IR1SsaLoopBody` with `terminationMetric: null` (the L1 fixed-point discriminant). Allocate a synthesised helper rule name via `cellRegisterName(synthCell, 'fn--loop')` — the document-wide registry produces a unique kebab-cased name.
- Emit two PropResults: (a) `{ kind: 'rule-decl', ruleName, params: [{ name: 's', type: <location-type> }, ...loop-invariant-args], returnType: <location-type>, body: cond(guard, helperCall(body-effect), s) }`; (b) `{ kind: 'equation', lhs: <primed-location>, rhs: helperCall(<initial-location-value>, ...loop-invariant-args), quantifiers: [] }`. The helper call uses `ast.app(ast.var(ruleName), [args])`; the cond uses `ast.cond([[guard, helperCall(body-effect)], [ast.litBool(true), ast.var('s')]])`.
- Extend `tools/ts2pant/src/types.ts` `PropResult` union with the new `rule-decl` variant. Update consumers (`extract.ts`, any pretty-printer) to handle the new variant — emit it as a Pant rule declaration followed by its body equation (one rule, two lines: signature + body).
- Identify loop-invariant arguments by walking the body and finding any free variables that aren't the mutated location or its receiver. These become extra params to the helper (e.g., `target`, `step`, `cap` in the L4 fixtures). The helper's signature is `fn--loop s: T, target: T, step: T, … => T.`
- Unskip the six Patch-3-owned stubs in `tools/ts2pant/tests/ir1-ssa-fixed-point.test.mts` and replace each PENDING-comment body with concrete assertions exercising the recognizer + emission shape on hand-constructed `ir1While` IR1Stmts.
- No caller in this patch constructs a `kind: 'while'` IR1Stmt that reaches this module — the build path's wiring lands in Patch 4. Patch 3 ships dormant capability.

## Changes
- Create `tools/ts2pant/src/ir1-ssa-fixed-point.ts` with the module shape mirroring `tools/ts2pant/src/ir1-ssa-counter-loop.ts`.
- Implement `recognizeFixedPointLoopShape(stmt: Extract<IR1Stmt, { kind: 'while' }>)`. Walk the body to collect mutated locations (using the same property-mutation detection logic the counter-loop module uses). Reject with `{ unsupported: 'fixed-point while lowering supports single-location bodies only; this loop modifies N rules' }` if there is more than one. Reject with `{ unsupported: 'while loop has a literal-true guard; cannot define a fixed point' }` if `stmt.cond.kind === 'lit' && stmt.cond.value.kind === 'bool' && stmt.cond.value.value === true`. On success, return `{ guardExpr: stmt.cond, bodyStmt: stmt.body, mutatedLocation: <the single location> }`.
- Implement `lowerFixedPointLoopL1Body(stmt, options)`. Open an `IR1SsaLoopHeaderJoin` for the mutated location via `ir1SsaOpenLoopHeader`. Build the body's effect-on-location expression: walk the body, find the single property write, build an IR1Expr representing `body(s)` where `s` is the current location value. Construct an `IR1SsaWrite` whose value is that effect expression. Close the header via `ir1SsaCloseLoopHeader` with the write's version. Construct `IR1SsaLoopBody` with `terminationMetric: null` (the L1 fixed-point discriminant). Allocate a synthesised helper rule name via `cellRegisterName(synthCell, 'fn--loop')` — the document-wide registry produces a unique kebab-cased name.
- Emit two PropResults: (a) `{ kind: 'rule-decl', ruleName, params: [{ name: 's', type: <location-type> }, ...loop-invariant-args], returnType: <location-type>, body: cond(guard, helperCall(body-effect), s) }`; (b) `{ kind: 'equation', lhs: <primed-location>, rhs: helperCall(<initial-location-value>, ...loop-invariant-args), quantifiers: [] }`. The helper call uses `ast.app(ast.var(ruleName), [args])`; the cond uses `ast.cond([[guard, helperCall(body-effect)], [ast.litBool(true), ast.var('s')]])`.
- Extend `tools/ts2pant/src/types.ts` `PropResult` union with the new `rule-decl` variant. Update consumers (`extract.ts`, any pretty-printer) to handle the new variant — emit it as a Pant rule declaration followed by its body equation (one rule, two lines: signature + body).
- Identify loop-invariant arguments by walking the body and finding any free variables that aren't the mutated location or its receiver. These become extra params to the helper (e.g., `target`, `step`, `cap` in the L4 fixtures). The helper's signature is `fn--loop s: T, target: T, step: T, … => T.`
- Unskip the six Patch-3-owned stubs in `tools/ts2pant/tests/ir1-ssa-fixed-point.test.mts` and replace each PENDING-comment body with concrete assertions exercising the recognizer + emission shape on hand-constructed `ir1While` IR1Stmts.
- No caller in this patch constructs a `kind: 'while'` IR1Stmt that reaches this module — the build path's wiring lands in Patch 4. Patch 3 ships dormant capability.

## Files to Modify
- tools/ts2pant/src/ir1-ssa-fixed-point.ts (create): New module exporting `recognizeFixedPointLoopShape` and `lowerFixedPointLoopL1Body`. Mirrors `ir1-ssa-counter-loop.ts` in file layout. Constructs IR1SsaLoopBody with terminationMetric: null; synthesises a top-level recursive helper rule via the NameRegistry; emits a rule-decl PropResult for the helper and an equation PropResult for the caller.
- tools/ts2pant/src/types.ts (modify): Extend `PropResult` with a `kind: "rule-decl"` variant carrying `ruleName: string`, `params: Array<{ name: string; type: OpaqueExpr }>`, `returnType: OpaqueExpr`, `body: OpaqueExpr`.
- tools/ts2pant/src/extract.ts (modify): Add a dispatch arm for `kind: "rule-decl"` in the PropResult emission pass. Renders the rule-decl as a Pant rule declaration with body (parameter list, return-type arrow, body expression). Sits alongside the existing equation and assertion arms.
- tools/ts2pant/tests/ir1-ssa-fixed-point.test.mts (modify): Remove `.skip` from every stub introduced in Patch 1. Replace each PENDING-comment body with concrete assertions.

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[algorithm] Cytron 1991 SSA construction (carry-forward)** — https://doi.org/10.1145/115372.115320 — The two-pass loop-header phi-placement protocol from L1 is unchanged in L4: `ir1SsaOpenLoopHeader` then body emission then `ir1SsaCloseLoopHeader`. The fixed-point lowerer's only difference from the bounded counter-loop lowerer is that `terminationMetric: null` marks the body fixed-point; the SSA construction discipline (single header join per mutated location, body reads observe joinVersion, back-edge write closes the header) is identical.
- **[paper] Cousot & Cousot 1977 — Abstract Interpretation / fixed-point loop semantics** — https://doi.org/10.1145/512950.512973 — The semantic foundation: a while loop's post-state is the least fixed point of the body's iteration. The recursive Pant rule `fn--loop s = cond guard(s) => fn--loop (body s), true => s.` is exactly this lfp encoded as a function. The Tarski–Knaster theorem guarantees the lfp exists for the monotone iteration operator.
- **[paper] Plotkin 1975 — CPS / tail-recursive desugar of while** — https://doi.org/10.1016/0304-3975(75)90017-1 — The mechanical bridge: `while P body ≡ let rec loop s = if P(s) then loop(body(s)) else s`. Patch 3's emission is exactly this rewrite. The location-SSA version (Cytron) provides `s`; the guard and body come from the IR1Stmt; the helper-call site is the back-edge of the SSA loop-header join.

## Gameplan Specification

```
module TS2PANT_FIXED_POINT_WHILE_LOWERING.

> ════════════════════════════════
> Milestone 4 of the ts2pant general-loop SSA workstream.
> ════════════════════════════════
> After this milestone, the mutating-body translator accepts
> unbounded while loops (single mutated location, non-literal-
> true guard) and lowers them to a synthesised top-level
> recursive Pant rule. Pant's SMT backend emits the recursive
> rule as define-fun-rec, giving Z3 / CVC5 native induction
> hooks for pant --check. Literal-true and multi-location
> while bodies reject with targeted diagnostics. Three passing
> fixtures verify end-to-end through pant typecheck and
> pant --check; one deliberate-reject fixture documents the
> literal-true rejection. Documentation in AGENTS.md, the IR
> doc, and the workstream doc records the surface and marks
> the milestone landed.

TSStmt.
IR1Stmt.
WhileStmt.
Declaration.
Rule.
PropResult.
IR1SsaLoopBody.
IR1SsaLocation.
TerminationMetric.
BuildOutcome.
LowerResult.
SmtLine.
EmissionShape.
Document.
DocumentKind.
MilestoneStatus.
decl-fun-rec => EmissionShape.
decl-fun-plus-axiom => EmissionShape.
agents-md => DocumentKind.
ir-doc => DocumentKind.
workstream-doc => DocumentKind.
pending => MilestoneStatus.
landed => MilestoneStatus.

> Pant SMT emission (Patch 2).
is-recursive? r: Rule => Bool.
body-of r: Rule => IR1Stmt.
body-applies-self? r: Rule, e: IR1Stmt => Bool.
emission-shape r: Rule => EmissionShape.
emits-define-fun-rec? r: Rule, lines: [SmtLine] => Bool.
emits-declare-fun? r: Rule, lines: [SmtLine] => Bool.
emits-universal-axiom? r: Rule, lines: [SmtLine] => Bool.
logically-equivalent? a: EmissionShape, b: EmissionShape => Bool.

> ts2pant fixed-point lowering (Patches 3, 4).
is-literal-true? s: WhileStmt => Bool.
mutated-count s: WhileStmt => Nat0.
build-mutating-body s: TSStmt => BuildOutcome.
lower-result-of-while s: WhileStmt => LowerResult.
is-ir1-while? b: BuildOutcome => Bool.
is-rejection? b: BuildOutcome => Bool.
rejection-mentions-literal-true? b: BuildOutcome => Bool.
recognizer-rejects-literal-true? s: WhileStmt => Bool.
recognizer-rejects-multi-location? s: WhileStmt => Bool.
is-bare-while? s: TSStmt => Bool.
is-let-then-while-pair? s: TSStmt => Bool.
l3-bounded-recognized? s: TSStmt => Bool.
body-metric b: IR1SsaLoopBody => TerminationMetric.
null-metric? m: TerminationMetric => Bool.
emits-recursive-helper? r: LowerResult => Bool.
emits-caller-equation? r: LowerResult => Bool.
helper-name-unique? n: String => Bool.

> Documentation (Patch 5).
document-kind d: Document => DocumentKind.
document-mentions-l4-fixed-point? d: Document => Bool.
workstream-milestone-4-status => MilestoneStatus.
---

> SMT emission contract: recursive rules emit define-fun-rec,
> non-recursive rules emit declare-fun + universal-axiom.
all r: Rule | is-recursive? r <-> body-applies-self? r (body-of r).

all r: Rule, lines: [SmtLine] |
  is-recursive? r ->
    emits-define-fun-rec? r lines and ~(emits-declare-fun? r lines).

all r: Rule, lines: [SmtLine] |
  ~(is-recursive? r) ->
    emits-declare-fun? r lines and emits-universal-axiom? r lines.

logically-equivalent? decl-fun-rec decl-fun-plus-axiom.

> Build-path contract: bare while loops construct ir1While
> unless guard is literal-true; let-then-while pairs that fail
> L3 fall through to ir1While.
all s: TSStmt |
  is-bare-while? s and ~(rejection-mentions-literal-true? (build-mutating-body s)) ->
    is-ir1-while? (build-mutating-body s).

all s: TSStmt |
  is-bare-while? s ->
    (is-rejection? (build-mutating-body s) ->
      rejection-mentions-literal-true? (build-mutating-body s)).

all s: TSStmt |
  is-let-then-while-pair? s and ~(l3-bounded-recognized? s) ->
    is-ir1-while? (build-mutating-body s).

> Lowering contract: literal-true and multi-location reject;
> successful lowering produces a fixed-point loop body
> (terminationMetric: null) plus a recursive helper rule-decl
> and a caller equation.
all s: WhileStmt |
  is-literal-true? s ->
    recognizer-rejects-literal-true? s.

all s: WhileStmt |
  mutated-count s > 1 ->
    recognizer-rejects-multi-location? s.

all s: WhileStmt, b: IR1SsaLoopBody |
  ~(is-literal-true? s) and mutated-count s = 1 ->
    null-metric? (body-metric b).

all s: WhileStmt |
  ~(is-literal-true? s) and mutated-count s = 1 ->
    emits-recursive-helper? (lower-result-of-while s) and
    emits-caller-equation? (lower-result-of-while s).

> Documentation invariants.
all d: Document |
  document-kind d = agents-md ->
    document-mentions-l4-fixed-point? d.

all d: Document |
  document-kind d = ir-doc ->
    document-mentions-l4-fixed-point? d.

all d: Document |
  document-kind d = workstream-doc ->
    document-mentions-l4-fixed-point? d.

workstream-milestone-4-status = landed.
```

## Patch Specification

```
module TS2PANT_FIXED_POINT_WHILE_LOWERING_PATCH_3.

> Patch 3 lands the fixed-point lowerer module. The recognizer
> classifies single-location while bodies; the emitter
> constructs an IR1SsaLoopBody with terminationMetric: null
> (the L1 fixed-point discriminant) and produces a synthesised
> top-level recursive helper rule plus a primed-equation caller.
> No caller in this patch reaches the new code; capability is
> dormant until Patch 4 wires the build path.

IR1Stmt.
IR1SsaLoopBody.
IR1SsaLocation.
PropResult.
RecognizerResult.
WhileStmt.
RuleName.
TerminationMetric.

recognize-result s: WhileStmt => RecognizerResult.
is-single-location? r: RecognizerResult => Bool.
is-literal-true? s: WhileStmt => Bool.
mutated-count s: WhileStmt => Nat0.
lower-result s: WhileStmt => [PropResult].
body-metric b: IR1SsaLoopBody => TerminationMetric.
null-metric? m: TerminationMetric => Bool.
emits-rule-decl? results: [PropResult] => Bool.
emits-equation? results: [PropResult] => Bool.
helper-name-unique? n: RuleName => Bool.
---

> Literal-true while statements reject at the recognizer.
all s: WhileStmt | is-literal-true? s -> ~(is-single-location? (recognize-result s)).

> Multi-location while statements reject at the recognizer.
all s: WhileStmt | mutated-count s > 1 -> ~(is-single-location? (recognize-result s)).

> Successfully-recognized while statements yield a fixed-point loop body.
all s: WhileStmt, b: IR1SsaLoopBody |
  is-single-location? (recognize-result s) ->
    null-metric? (body-metric b).

> The lowered PropResult list contains both a rule-decl and an equation.
all s: WhileStmt |
  is-single-location? (recognize-result s) ->
    emits-rule-decl? (lower-result s) and emits-equation? (lower-result s).

> The synthesised helper rule name is unique within the document.
all s: WhileStmt, n: RuleName |
  is-single-location? (recognize-result s) ->
    helper-name-unique? n.
```


## Implementation Notes

- `rule-decl` carries `OpaqueTypeExpr` for parameter and return types, not `OpaqueExpr`. The gameplan text used `OpaqueExpr`, but the wasm AST API represents Pant type expressions separately and `emit.ts` needs `ast.param` / `ast.declRule` type handles.
- Rule-decl rendering was added in `emit.ts`, where `PropResult` rendering is centralized. I did not touch `extract.ts` because it only constructs some `PropResult`s; it is not the emission dispatch path for propositions.
- Helper-name allocation uses the document `NameRegistry` directly to preserve the required `fn--loop` spelling. `cellRegisterName` normalizes through `toPantTermName`, which collapses repeated hyphens to `fn-loop`; using `registerName` against `synthCell.registry` keeps uniqueness while preserving the fixed-point helper naming convention.
- The dormant lowerer has optional type inputs (`locationType`, `invariantTypes`) and defaults to `Nat0` for hand-constructed Patch 3 tests. Patch 4 can pass concrete type information when wiring real TS build paths.
- The recognizer accepts one unique mutated property location. The lowerer currently requires exactly one property write in the body, matching the Patch 3 test surface and avoiding an under-specified sequential same-location-write semantics before Patch 4 wiring.

**Spec/Evidence Mapping**
- Literal-true recognizer rejection: `recognizeFixedPointLoopShape` in `tools/ts2pant/src/ir1-ssa-fixed-point.ts`; covered by `rejects literal-true guards at the recognizer level`.
- Multi-location recognizer rejection: mutated property collection in `recognizeFixedPointLoopShape`; covered by `rejects multi-location while bodies`.
- Fixed-point SSA discriminant: `lowerFixedPointLoopL1Body` builds `ir1SsaLoopBody({ terminationMetric: null })`; covered by `constructs IR1SsaLoopBody with terminationMetric: null`.
- Helper + caller propositions: `lowerFixedPointLoopL1Body` emits `rule-decl` then `equation`; covered by `emits a rule-decl PropResult for the helper and an equation PropResult for the caller`.
- Helper-name uniqueness: `allocateLoopRuleName` updates `synthCell.registry`; covered by `synthesises a uniquely-named recursive helper rule via NameRegistry`.
- Verification run: `just ts2pant-test` passed, including unit and integration tests.