### PR TITLE
[ts2pant-fixed-point-while-lowering] Patch 2: Pant: emit define-fun-rec for self-referential rule definitions

### DIFF
--- a/lib/ast.ml
+++ b/lib/ast.ml
@@ -446,6 +446,7 @@ type declaration =
       params : param list;
       guards : guard list;
       return_type : type_expr;
+      body : expr option;
       contexts : upper_ident list;
           (** Context footprint: "{Accounts} balance ..." *)
     }
@@ -469,11 +470,15 @@ let pp_declaration fmt = function
   | DeclDomain (Upper n) -> Format.fprintf fmt "DeclDomain (Upper %S)" n
   | DeclAlias (Upper n, t) ->
       Format.fprintf fmt "DeclAlias (Upper %S, %a)" n pp_type_expr t
-  | DeclRule { name = Lower n; params; guards; return_type; contexts } ->
+  | DeclRule { name = Lower n; params; guards; return_type; body; contexts } ->
       Format.fprintf fmt
         "DeclRule {@[name = Lower %S;@ params = %a;@ guards = %a;@ return_type \
-         = %a;@ contexts = [@[%a@]]@]}"
+         = %a;@ body = %a;@ contexts = [@[%a@]]@]}"
         n pp_params params pp_guards guards pp_type_expr return_type
+        (fun fmt -> function
+          | None -> Format.fprintf fmt "None"
+          | Some e -> Format.fprintf fmt "Some (%a)" pp_expr e)
+        body
         (Format.pp_print_list
            ~pp_sep:(fun fmt () -> Format.fprintf fmt ";@ ")
            (fun fmt (Upper u) -> Format.fprintf fmt "Upper %S" u))
@@ -501,13 +506,27 @@ let equal_declaration (d1 : declaration) (d2 : declaration) : bool =
   | DeclAlias (a, t1), DeclAlias (b, t2) ->
       equal_upper_ident a b && equal_type_expr t1 t2
   | ( DeclRule
-        { name = n1; params = p1; guards = g1; return_type = r1; contexts = c1 },
+        {
+          name = n1;
+          params = p1;
+          guards = g1;
+          return_type = r1;
+          body = b1;
+          contexts = c1;
+        },
       DeclRule
-        { name = n2; params = p2; guards = g2; return_type = r2; contexts = c2 }
-    ) ->
+        {
+          name = n2;
+          params = p2;
+          guards = g2;
+          return_type = r2;
+          body = b2;
+          contexts = c2;
+        } ) ->
       equal_lower_ident n1 n2 && equal_params p1 p2
       && List.equal equal_guard g1 g2
       && equal_type_expr r1 r2
+      && Option.equal equal_expr b1 b2
       && List.equal equal_upper_ident c1 c2
   | ( DeclAction { label = l1; params = p1; guards = g1; contexts = c1 },
       DeclAction { label = l2; params = p2; guards = g2; contexts = c2 } ) ->

--- a/lib/check.ml
+++ b/lib/check.ml
@@ -607,7 +607,24 @@ let check_rule_guards ctx (decl : declaration located) =
     Ok ()
   in
   match decl.value with
-  | DeclRule { params; guards; _ } -> check_guards params guards
+  | DeclRule { params; guards; return_type; body; _ } -> (
+      let* () = check_guards params guards in
+      match body with
+      | None -> Ok ()
+      | Some body ->
+          let* param_bindings =
+            map_result (resolve_param_type ctx.env decl.loc) params
+          in
+          let env' = Env.with_vars param_bindings ctx.env in
+          let ctx' = { env = env'; loc = decl.loc } in
+          let* expected =
+            resolve_param_type ctx.env decl.loc
+              { param_name = Lower "_return"; param_type = return_type }
+          in
+          let _, expected_ty = expected in
+          let* actual_ty = infer_type ctx' body in
+          if is_subtype actual_ty expected_ty then Ok ()
+          else Error (TypeMismatch (expected_ty, actual_ty, decl.loc)))
   | DeclAction { params; guards; _ } -> check_guards params guards
   | DeclClosure _ -> Ok () (* Closures have no guards *)
   | DeclDomain _ | DeclAlias _ -> Ok ()

--- a/lib/collect.ml
+++ b/lib/collect.ml
@@ -239,7 +239,8 @@ let collect_chapter_head ~chapter ~doc_contexts env
   (* Pass 3: Add rules/actions and register context footprints *)
   let add_rule env (decl : declaration located) =
     match decl.value with
-    | DeclRule { name = Lower name; params; guards; return_type; contexts } ->
+    | DeclRule
+        { name = Lower name; params; guards; return_type; body; contexts } ->
         let* param_types =
           map_result (fun p -> resolve_type env p.param_type decl.loc) params
         in
@@ -270,7 +271,8 @@ let collect_chapter_head ~chapter ~doc_contexts env
                 check_overload_coherence name params param_types ret_ty decl.loc
                   env
               in
-              Ok (Env.add_rule name proc_ty decl.loc ~chapter env)
+              let body = Option.map (fun body -> (decl.value, body)) body in
+              Ok (Env.add_rule ?body name proc_ty decl.loc ~chapter env)
         in
         let env = Env.add_rule_guards name params guards env in
         (* Add rule to each context's member list *)

--- a/lib/env.ml
+++ b/lib/env.ml
@@ -150,6 +150,7 @@ let arity_of_ty (ty : ty) : int =
 
 let expr_applies_name target e =
   let rec go bound = function[@warning "-4"]
+    | EVar (Lower n) when n = target && not (List.mem n bound) -> true
     | Ast.EApp (Ast.EVar (Ast.Lower n), args)
       when n = target && not (List.mem n bound) ->
         let _ = args in

--- a/lib/env.ml
+++ b/lib/env.ml
@@ -1,6 +1,7 @@
 (** Type environment for Pantagruel *)
 
 open Types
+open Ast
 
 (** What kind of binding is this? *)
 type entry_kind =
@@ -72,6 +73,8 @@ type t = {
           [(name, arity)] don't clobber each other's declaration guards.
           Qualified guard lookup reads directly from this index; flat
           [rule_guards] only promotes single-origin entries. *)
+  rule_bodies : (Ast.declaration * Ast.expr * bool) TermMap.t;
+      (** Optional local rule bodies keyed by (rule name, arity). *)
   action : string option;  (** Action in current chapter (for prime checking) *)
   action_contexts : string list;
       (** Active contexts for current action (for primed-in-context enforcement)
@@ -92,6 +95,7 @@ let empty module_name =
     contexts = StringMap.empty;
     rule_guards = TermMap.empty;
     imported_rule_guards = TermMap.empty;
+    rule_bodies = TermMap.empty;
     action = None;
     action_contexts = [];
     local_vars = [];
@@ -144,12 +148,60 @@ let arity_of_ty (ty : ty) : int =
   | TyFunc (params, _) -> List.length params
   | _ -> 0
 
+let expr_applies_name target e =
+  let rec go bound = function[@warning "-4"]
+    | Ast.EApp (Ast.EVar (Ast.Lower n), args)
+      when n = target && not (List.mem n bound) ->
+        let _ = args in
+        true
+    | EApp (func, args) -> List.exists (go bound) (func :: args)
+    | EBinop (_, e1, e2) -> go bound e1 || go bound e2
+    | EUnop (_, e1) | EProj (e1, _) | EInitially e1 -> go bound e1
+    | ETuple es -> List.exists (go bound) es
+    | EOverride (_, pairs) ->
+        List.exists (fun (k, v) -> go bound k || go bound v) pairs
+    | ECond arms -> List.exists (fun (g, c) -> go bound g || go bound c) arms
+    | EForall (mb, metas) | EExists (mb, metas) ->
+        let params, guards, body = Ast.unbind_quant mb metas in
+        go_quant bound params guards body
+    | EEach (mb, metas, _) ->
+        let params, guards, body = Ast.unbind_quant mb metas in
+        go_quant bound params guards body
+    | EVar _ | EPrimed _ | EDomain _ | EQualified _ | ELitNat _ | ELitReal _
+    | ELitString _ | ELitBool _ ->
+        false
+  and go_quant bound params guards body =
+    let bound =
+      List.map (fun (p : Ast.param) -> Ast.lower_name p.param_name) params
+      @ bound
+    in
+    let bound, guard_hit =
+      List.fold_left
+        (fun (bound, hit) -> function
+          | Ast.GParam p -> (Ast.lower_name p.param_name :: bound, hit)
+          | GIn (Lower n, list_expr) -> (n :: bound, hit || go bound list_expr)
+          | GExpr e -> (bound, hit || go bound e))
+        (bound, false) guards
+    in
+    guard_hit || go bound body
+  in
+  go [] e
+
 (** Add a rule to the term namespace, keyed by [(name, arity)]. *)
-let add_rule name ty loc ~chapter env =
+let add_rule ?body name ty loc ~chapter env =
   let entry =
     { kind = KRule ty; loc; module_origin = None; decl_chapter = chapter }
   in
-  { env with terms = TermMap.add (name, arity_of_ty ty) entry env.terms }
+  let arity = arity_of_ty ty in
+  let rule_bodies =
+    match body with
+    | None -> env.rule_bodies
+    | Some (decl, expr) ->
+        TermMap.add (name, arity)
+          (decl, expr, expr_applies_name name expr)
+          env.rule_bodies
+  in
+  { env with terms = TermMap.add (name, arity) entry env.terms; rule_bodies }
 
 (** Add a closure rule to the term namespace, keyed by [(name, arity)]. *)
 let add_closure name ty target loc ~chapter env =
@@ -240,6 +292,14 @@ let lookup_rule_guards name env =
 (** Lookup rule guards by [(name, arity)]. *)
 let lookup_rule_guards_arity name arity env =
   TermMap.find_opt (name, arity) env.rule_guards
+
+let lookup_rule_body_arity name arity env =
+  TermMap.find_opt (name, arity) env.rule_bodies
+
+let fold_rule_bodies f env acc =
+  TermMap.fold
+    (fun (name, arity) body acc -> f name arity body acc)
+    env.rule_bodies acc
 
 (** Lookup rule guards by module, name, AND arity in the import index. Returns
     exactly the overload's guards exported by [mod_name]. *)
@@ -481,6 +541,7 @@ let add_import env other origin_module =
     terms = flat_of_term_index imported_terms;
     contexts = merged_contexts;
     rule_guards = flat_of_guards_index imported_rule_guards;
+    rule_bodies = TermMap.empty;
   }
 
 (** Lookup a type by module and name in the import index *)
@@ -556,6 +617,13 @@ let visible_in_head chapter_idx env =
     types = filter_string_map env.types;
     terms = filter_term_map env.terms;
     vars = filter_string_map env.vars;
+    rule_bodies =
+      TermMap.filter
+        (fun key _ ->
+          match TermMap.find_opt key env.terms with
+          | Some entry -> entry.decl_chapter <= chapter_idx
+          | None -> false)
+        env.rule_bodies;
   }
 
 (** Filter environment for visibility in a chapter body. Declaration in chapter
@@ -573,4 +641,11 @@ let visible_in_body chapter_idx env =
     types = filter_string_map env.types;
     terms = filter_term_map env.terms;
     vars = filter_string_map env.vars;
+    rule_bodies =
+      TermMap.filter
+        (fun key _ ->
+          match TermMap.find_opt key env.terms with
+          | Some entry -> entry.decl_chapter <= chapter_idx + 1
+          | None -> false)
+        env.rule_bodies;
   }

--- a/lib/env.mli
+++ b/lib/env.mli
@@ -30,7 +30,15 @@ val add_type_entry : string -> entry -> t -> t
 val add_term_entry : string -> entry -> t -> t
 val add_domain : string -> Ast.loc -> chapter:int -> t -> t
 val add_alias : string -> Types.ty -> Ast.loc -> chapter:int -> t -> t
-val add_rule : string -> Types.ty -> Ast.loc -> chapter:int -> t -> t
+
+val add_rule :
+  ?body:Ast.declaration * Ast.expr ->
+  string ->
+  Types.ty ->
+  Ast.loc ->
+  chapter:int ->
+  t ->
+  t
 
 val add_closure :
   string -> Types.ty -> string -> Ast.loc -> chapter:int -> t -> t
@@ -48,6 +56,15 @@ val lookup_rule_guards : string -> t -> (Ast.param list * Ast.guard list) option
 val lookup_rule_guards_arity :
   string -> int -> t -> (Ast.param list * Ast.guard list) option
 (** Arity-aware rule-guard lookup. *)
+
+val lookup_rule_body_arity :
+  string -> int -> t -> (Ast.declaration * Ast.expr * bool) option
+
+val fold_rule_bodies :
+  (string -> int -> Ast.declaration * Ast.expr * bool -> 'a -> 'a) ->
+  t ->
+  'a ->
+  'a
 
 val lookup_qualified_rule_guards_arity :
   string -> string -> int -> t -> (Ast.param list * Ast.guard list) option

--- a/lib/json_output.ml
+++ b/lib/json_output.ml
@@ -247,7 +247,7 @@ let decl_to_json env (decl_loc : declaration located) =
             ("type", type_expr_to_json te);
           ]
         @ match resolved with Some t -> [ ("resolved", t) ] | None -> [])
-  | DeclRule { name; params; guards; return_type; contexts } ->
+  | DeclRule { name; params; guards; return_type; body; contexts } ->
       let name = Ast.lower_name name in
       (* Look up resolved type for the specific overload whose arity matches
          this declaration's param count. *)
@@ -278,6 +278,9 @@ let decl_to_json env (decl_loc : declaration located) =
                );
              ]
            else [])
+        @ (match body with
+          | Some e -> [ ("body", expr_to_json e) ]
+          | None -> [])
         @ match resolved with Some t -> [ ("resolved", t) ] | None -> [])
   | DeclAction { label; params; guards; contexts } ->
       let param_tys =

--- a/lib/markdown_output.ml
+++ b/lib/markdown_output.ml
@@ -284,7 +284,7 @@ let pp_guard procs fmt = function
 let pp_declaration procs fmt = function
   | DeclDomain (Upper name) -> fprintf fmt "`%s`." name
   | DeclAlias (Upper name, te) -> fprintf fmt "`%s` = %a." name pp_type_expr te
-  | DeclRule { name; params; guards; return_type; contexts } ->
+  | DeclRule { name; params; guards; return_type; body; contexts } ->
       if contexts <> [] then
         fprintf fmt "{%a} "
           (pp_print_list ~pp_sep:pp_params_sep (fun fmt (Upper c) ->
@@ -297,7 +297,9 @@ let pp_declaration procs fmt = function
         fprintf fmt ", %a"
           (pp_print_list ~pp_sep:pp_params_sep (pp_guard procs))
           guards;
-      fprintf fmt " ⇒ %a." pp_type_expr return_type
+      fprintf fmt " ⇒ %a" pp_type_expr return_type;
+      Option.iter (fun body -> fprintf fmt " = %a" (pp_expr procs) body) body;
+      fprintf fmt "."
   | DeclAction { label; params; guards; contexts } ->
       (match contexts with
       | [] -> fprintf fmt "↝ "

--- a/lib/parser.mly
+++ b/lib/parser.mly
@@ -120,6 +120,18 @@ declaration:
         params;
         guards;
         return_type = ret;
+        body = None;
+        contexts = List.map (fun c -> Upper c) ctxs;
+      }) }
+  | LBRACE ctxs=separated_nonempty_list(COMMA, UPPER_IDENT) RBRACE
+    name=LOWER_IDENT pg=rule_params_guards DARROW ret=type_expr EQ body=expr DOT
+    { let (params, guards) = pg in
+      located_with_doc $startpos $endpos (DeclRule {
+        name = Lower name;
+        params;
+        guards;
+        return_type = ret;
+        body = Some body;
         contexts = List.map (fun c -> Upper c) ctxs;
       }) }
   | name=LOWER_IDENT pg=rule_params_guards DARROW ret=type_expr DOT
@@ -129,6 +141,17 @@ declaration:
         params;
         guards;
         return_type = ret;
+        body = None;
+        contexts = [];
+      }) }
+  | name=LOWER_IDENT pg=rule_params_guards DARROW ret=type_expr EQ body=expr DOT
+    { let (params, guards) = pg in
+      located_with_doc $startpos $endpos (DeclRule {
+        name = Lower name;
+        params;
+        guards;
+        return_type = ret;
+        body = Some body;
         contexts = [];
       }) }
   | name=LOWER_IDENT pg=rule_params_guards DARROW ret=type_expr EQ CLOSURE target=LOWER_IDENT DOT

--- a/lib/pretty.ml
+++ b/lib/pretty.ml
@@ -273,7 +273,8 @@ let pp_guard fmt = function
 let pp_declaration fmt = function
   | DeclDomain (Upper name) -> fprintf fmt "%s." name
   | DeclAlias (Upper name, te) -> fprintf fmt "%s = %a." name pp_type_expr te
-  | DeclRule { name = Lower name; params; guards; return_type; contexts } ->
+  | DeclRule { name = Lower name; params; guards; return_type; body; contexts }
+    ->
       if contexts <> [] then
         fprintf fmt "{%a} "
           (pp_print_list ~pp_sep:pp_sep_comma (fun fmt c ->
@@ -284,7 +285,9 @@ let pp_declaration fmt = function
         fprintf fmt " %a" (pp_print_list ~pp_sep:pp_sep_comma pp_param) params;
       if guards <> [] then
         fprintf fmt ", %a" (pp_print_list ~pp_sep:pp_sep_comma pp_guard) guards;
-      fprintf fmt " => %a." pp_type_expr return_type
+      fprintf fmt " => %a" pp_type_expr return_type;
+      Option.iter (fun body -> fprintf fmt " = %a" pp_expr body) body;
+      fprintf fmt "."
   | DeclAction { label; params; guards; contexts } ->
       (match contexts with
       | [] -> fprintf fmt "~> "

--- a/lib/smt.ml
+++ b/lib/smt.ml
@@ -1172,6 +1172,130 @@ let translate_proposition config env (e : expr) =
             in
             Printf.sprintf "(=> %s %s)" guard_conj smt_expr)
 
+let is_rule_recursive (decl : Ast.declaration) : bool =
+  match decl with
+  | DeclRule { name = Lower name; body = Some body; _ } ->
+      Smt_expr.expr_applies_name name body
+  | DeclRule { body = None; _ }
+  | DeclDomain _ | DeclAlias _ | DeclAction _ | DeclClosure _ ->
+      false
+
+let emit_rule_recursive config (env : Env.t) (decl : Ast.declaration) : string =
+  match decl with
+  | DeclRule { name = Lower name; params; return_type; body = Some body; _ } ->
+      let args =
+        List.map
+          (fun (p : Ast.param) ->
+            let sort =
+              match Collect.resolve_type env p.param_type dummy_loc with
+              | Ok ty -> sort_of_ty ty
+              | Error _ ->
+                  failwith
+                    (Printf.sprintf
+                       "SMT translation: cannot resolve type for parameter `%s`"
+                       (Ast.lower_name p.param_name))
+            in
+            Printf.sprintf "(%s %s)"
+              (sanitize_ident (Ast.lower_name p.param_name))
+              sort)
+          params
+      in
+      let ret =
+        match Collect.resolve_type env return_type dummy_loc with
+        | Ok ty -> sort_of_ty ty
+        | Error _ ->
+            failwith
+              (Printf.sprintf
+                 "SMT translation: cannot resolve return type for recursive \
+                  rule `%s`"
+                 name)
+      in
+      let bindings =
+        List.filter_map
+          (fun (p : Ast.param) ->
+            match Collect.resolve_type env p.param_type dummy_loc with
+            | Ok ty -> Some (Ast.lower_name p.param_name, ty)
+            | Error _ -> None)
+          params
+      in
+      let env_body = Env.with_vars bindings env in
+      let body_smt = translate_expr config env_body body in
+      Printf.sprintf "(define-fun-rec %s (%s) %s %s)"
+        (smt_rule_name env name (List.length params))
+        (String.concat " " args) ret body_smt
+  | DeclRule { body = None; _ }
+  | DeclDomain _ | DeclAlias _ | DeclAction _ | DeclClosure _ ->
+      invalid_arg "emit_rule_recursive: expected a rule declaration with a body"
+
+let emit_rule_axiom config env (decl : Ast.declaration) body : string =
+  match decl with
+  | DeclRule { name = Lower name; params; _ } -> (
+      let args =
+        List.map
+          (fun (p : Ast.param) ->
+            let sort =
+              match Collect.resolve_type env p.param_type dummy_loc with
+              | Ok ty -> sort_of_ty ty
+              | Error _ -> "Int"
+            in
+            Printf.sprintf "(%s %s)"
+              (sanitize_ident (Ast.lower_name p.param_name))
+              sort)
+          params
+      in
+      let arg_names =
+        List.map
+          (fun (p : Ast.param) -> sanitize_ident (Ast.lower_name p.param_name))
+          params
+      in
+      let bindings =
+        List.filter_map
+          (fun (p : Ast.param) ->
+            match Collect.resolve_type env p.param_type dummy_loc with
+            | Ok ty -> Some (Ast.lower_name p.param_name, ty)
+            | Error _ -> None)
+          params
+      in
+      let env_body = Env.with_vars bindings env in
+      let lhs =
+        match arg_names with
+        | [] -> smt_rule_name env name 0
+        | _ ->
+            Printf.sprintf "(%s %s)"
+              (smt_rule_name env name (List.length params))
+              (String.concat " " arg_names)
+      in
+      let eq =
+        Printf.sprintf "(= %s %s)" lhs (translate_expr config env_body body)
+      in
+      match args with
+      | [] -> Printf.sprintf "(assert %s)" eq
+      | _ ->
+          Printf.sprintf "(assert (forall (%s) %s))" (String.concat " " args) eq
+      )
+  | DeclDomain _ | DeclAlias _ | DeclAction _ | DeclClosure _ ->
+      invalid_arg "emit_rule_axiom: expected a rule declaration"
+
+let emit_rule_definitions config env =
+  Env.fold_rule_bodies
+    (fun _name _arity (decl, body, recursive) acc ->
+      let line =
+        if recursive then emit_rule_recursive config env decl
+        else emit_rule_axiom config env decl body
+      in
+      line :: acc)
+    env []
+  |> List.rev |> String.concat "\n"
+
+let generate_preamble_with_rule_bodies ?(constrain_primed = true)
+    ?(include_type_constraints = true) config env =
+  let base =
+    generate_preamble ~constrain_primed ~include_type_constraints config env
+  in
+  let defs = emit_rule_definitions config env in
+  if defs = "" then base
+  else base ^ "\n; --- Rule definitions ---\n" ^ defs ^ "\n"
+
 (** Translate a list of propositions into a conjunction *)
 let conjoin_propositions config env props =
   match props with
@@ -1367,7 +1491,8 @@ let generate_contradiction_query config env action =
     (Printf.sprintf "; Contradiction check: %s\n" action.a_label);
   Buffer.add_string buf "(set-option :produce-unsat-cores true)\n";
   Buffer.add_string buf
-    (generate_preamble ~include_type_constraints:false config env);
+    (generate_preamble_with_rule_bodies ~include_type_constraints:false config
+       env);
   Buffer.add_string buf "\n; --- Action parameters ---\n";
   Buffer.add_string buf (declare_action_params env action.a_params);
   declare_domain_membership config buf action.a_params env;
@@ -1427,7 +1552,8 @@ let generate_invariant_query config env ~all_invariants ~index
   Buffer.add_string buf
     (Printf.sprintf "; Invariant preservation: %s / %s\n" action.a_label
        inv_text);
-  Buffer.add_string buf (generate_preamble ~constrain_primed:false config env);
+  Buffer.add_string buf
+    (generate_preamble_with_rule_bodies ~constrain_primed:false config env);
   Buffer.add_string buf "\n; --- Action parameters ---\n";
   Buffer.add_string buf (declare_action_params env action.a_params);
   Buffer.add_string buf (declare_param_constraints env action.a_params);
@@ -1477,7 +1603,8 @@ let generate_precondition_query config env invariant_props action =
     (Printf.sprintf "; Precondition satisfiability: %s\n" action.a_label);
   Buffer.add_string buf "(set-option :produce-unsat-cores true)\n";
   Buffer.add_string buf
-    (generate_preamble ~include_type_constraints:false config env);
+    (generate_preamble_with_rule_bodies ~include_type_constraints:false config
+       env);
   Buffer.add_string buf "\n; --- Action parameters ---\n";
   Buffer.add_string buf (declare_action_params env action.a_params);
   declare_domain_membership config buf action.a_params env;
@@ -1555,8 +1682,8 @@ let generate_invariant_consistency_query config env invariant_props =
   Buffer.add_string buf "; Invariant consistency check\n";
   Buffer.add_string buf "(set-option :produce-unsat-cores true)\n";
   Buffer.add_string buf
-    (generate_preamble ~constrain_primed:false ~include_type_constraints:false
-       config env);
+    (generate_preamble_with_rule_bodies ~constrain_primed:false
+       ~include_type_constraints:false config env);
   Buffer.add_string buf "\n; --- Type constraints ---\n";
   let type_exprs =
     collect_type_constraint_exprs ~constrain_primed:false config env
@@ -1593,8 +1720,8 @@ let generate_init_consistency_query config env init_props =
   Buffer.add_string buf "; Initial state consistency check\n";
   Buffer.add_string buf "(set-option :produce-unsat-cores true)\n";
   Buffer.add_string buf
-    (generate_preamble ~constrain_primed:false ~include_type_constraints:false
-       config env);
+    (generate_preamble_with_rule_bodies ~constrain_primed:false
+       ~include_type_constraints:false config env);
   Buffer.add_string buf "\n; --- Type constraints ---\n";
   let type_exprs =
     collect_type_constraint_exprs ~constrain_primed:false config env
@@ -1631,7 +1758,8 @@ let generate_init_invariant_query config env init_props ~index
   let inv_text = Pretty.str_expr inv.value in
   Buffer.add_string buf
     (Printf.sprintf "; Initial state satisfies invariant: %s\n" inv_text);
-  Buffer.add_string buf (generate_preamble ~constrain_primed:false config env);
+  Buffer.add_string buf
+    (generate_preamble_with_rule_bodies ~constrain_primed:false config env);
   Buffer.add_string buf
     (declare_type_constraints ~constrain_primed:false config env);
   (* Assert init props *)
@@ -2204,7 +2332,8 @@ let generate_exhaustiveness_query config env ~all_invariants:_ ~index cond =
   let buf = Buffer.create 1024 in
   Buffer.add_string buf
     (Printf.sprintf "; Cond exhaustiveness check: %s\n" cond.cond_text);
-  Buffer.add_string buf (generate_preamble ~constrain_primed:false config env);
+  Buffer.add_string buf
+    (generate_preamble_with_rule_bodies ~constrain_primed:false config env);
   Buffer.add_string buf
     (declare_type_constraints ~constrain_primed:false config env);
   (* Build the disjunction of all arms *)
@@ -2247,7 +2376,8 @@ let generate_invariant_entailment_query config env invariant_props ~index
   let goal_text = Pretty.str_expr goal.value in
   Buffer.add_string buf
     (Printf.sprintf "; Entailment check (invariant): %s\n" goal_text);
-  Buffer.add_string buf (generate_preamble ~constrain_primed:false config env);
+  Buffer.add_string buf
+    (generate_preamble_with_rule_bodies ~constrain_primed:false config env);
   (* Assert all invariants as assumptions *)
   if invariant_props <> [] then begin
     Buffer.add_string buf "\n; --- Invariants (assumptions) ---\n";
@@ -2281,7 +2411,8 @@ let generate_action_entailment_query config env ~all_invariants ~index
   Buffer.add_string buf
     (Printf.sprintf "; Entailment check (action %s): %s\n" action.a_label
        goal_text);
-  Buffer.add_string buf (generate_preamble ~constrain_primed:false config env);
+  Buffer.add_string buf
+    (generate_preamble_with_rule_bodies ~constrain_primed:false config env);
   Buffer.add_string buf "\n; --- Action parameters ---\n";
   Buffer.add_string buf (declare_action_params env action.a_params);
   Buffer.add_string buf (declare_param_constraints env action.a_params);

--- a/lib/smt_expr.ml
+++ b/lib/smt_expr.ml
@@ -38,6 +38,71 @@ type upper_bound_result =
 
 let expr_mentions_name name e = Smt_doc.StringSet.mem name (Smt_doc.free_vars e)
 
+(** Binder-aware fold over expression nodes. Quantifier binders are unbound via
+    the AST/Bindlib helper before folding their guards and body. *)
+let fold_expr (f : 'a -> expr -> 'a) (acc : 'a) (e : expr) : 'a =
+  let rec go acc e =
+    let acc = f acc e in
+    match e with
+    | EApp (func, args) -> List.fold_left go (go acc func) args
+    | EBinop (_, e1, e2) -> go (go acc e1) e2
+    | EUnop (_, e1) | EProj (e1, _) | EInitially e1 -> go acc e1
+    | ETuple es -> List.fold_left go acc es
+    | EOverride (_, pairs) ->
+        List.fold_left (fun acc (k, v) -> go (go acc k) v) acc pairs
+    | ECond arms -> List.fold_left (fun acc (g, c) -> go (go acc g) c) acc arms
+    | EForall (mb, metas) | EExists (mb, metas) ->
+        let _, guards, body = Ast.unbind_quant mb metas in
+        go_guards (go acc body) guards
+    | EEach (mb, metas, _) ->
+        let _, guards, body = Ast.unbind_quant mb metas in
+        go_guards (go acc body) guards
+    | EVar _ | EPrimed _ | EDomain _ | EQualified _ | ELitNat _ | ELitReal _
+    | ELitString _ | ELitBool _ ->
+        acc
+  and go_guards acc guards =
+    List.fold_left
+      (fun acc -> function GExpr e | GIn (_, e) -> go acc e | GParam _ -> acc)
+      acc guards
+  in
+  go acc e
+
+let expr_applies_name name e =
+  let rec go bound = function[@warning "-4"]
+    | EApp (EVar (Lower n), _) when n = name && not (List.mem n bound) -> true
+    | EApp (func, args) -> List.exists (go bound) (func :: args)
+    | EBinop (_, e1, e2) -> go bound e1 || go bound e2
+    | EUnop (_, e1) | EProj (e1, _) | EInitially e1 -> go bound e1
+    | ETuple es -> List.exists (go bound) es
+    | EOverride (_, pairs) ->
+        List.exists (fun (k, v) -> go bound k || go bound v) pairs
+    | ECond arms -> List.exists (fun (g, c) -> go bound g || go bound c) arms
+    | EForall (mb, metas) | EExists (mb, metas) ->
+        let params, guards, body = Ast.unbind_quant mb metas in
+        go_quant bound params guards body
+    | EEach (mb, metas, _) ->
+        let params, guards, body = Ast.unbind_quant mb metas in
+        go_quant bound params guards body
+    | EVar _ | EPrimed _ | EDomain _ | EQualified _ | ELitNat _ | ELitReal _
+    | ELitString _ | ELitBool _ ->
+        false
+  and go_quant bound params guards body =
+    let bound =
+      List.map (fun (p : Ast.param) -> Ast.lower_name p.param_name) params
+      @ bound
+    in
+    let bound, guard_hit =
+      List.fold_left
+        (fun (bound, hit) -> function
+          | GParam p -> (Ast.lower_name p.param_name :: bound, hit)
+          | GIn (Lower n, list_expr) -> (n :: bound, hit || go bound list_expr)
+          | GExpr e -> (bound, hit || go bound e))
+        (bound, false) guards
+    in
+    guard_hit || go bound body
+  in
+  go [] e
+
 let upper_bound_candidate binder = function
   | GExpr (EBinop (((OpLt | OpLe) as op), EVar (Lower n), bound))
     when n = binder ->

--- a/lib/smt_expr.ml
+++ b/lib/smt_expr.ml
@@ -69,6 +69,7 @@ let fold_expr (f : 'a -> expr -> 'a) (acc : 'a) (e : expr) : 'a =
 
 let expr_applies_name name e =
   let rec go bound = function[@warning "-4"]
+    | EVar (Lower n) when n = name && not (List.mem n bound) -> true
     | EApp (EVar (Lower n), _) when n = name && not (List.mem n bound) -> true
     | EApp (func, args) -> List.exists (go bound) (func :: args)
     | EBinop (_, e1, e2) -> go bound e1 || go bound e2

--- a/lib/smt_preamble.ml
+++ b/lib/smt_preamble.ml
@@ -169,6 +169,23 @@ let declare_functions env =
              (sort_of_ty ret))
     | None -> ()
   in
+  let emit_primed_rule sname ty =
+    match decompose_func_ty ty with
+    | Some ([], ret) ->
+        Buffer.add_string buf
+          (Printf.sprintf "(declare-const %s_prime %s)\n" sname (sort_of_ty ret))
+    | Some (params, ret) ->
+        let param_sorts = String.concat " " (List.map sort_of_ty params) in
+        Buffer.add_string buf
+          (Printf.sprintf "(declare-fun %s_prime (%s) %s)\n" sname param_sorts
+             (sort_of_ty ret))
+    | None -> ()
+  in
+  let rule_is_recursive name arity =
+    match Env.lookup_rule_body_arity name arity env with
+    | Some (_, _, recursive) -> recursive
+    | None -> false
+  in
   Env.iter_terms
     (fun name entry ->
       match entry.Env.kind with
@@ -178,7 +195,13 @@ let declare_functions env =
             | Some (params, _) -> List.length params
             | None -> 0
           in
-          emit_rule (smt_rule_name env name arity) ty
+          let sname = smt_rule_name env name arity in
+          if
+            match entry.Env.kind with
+            | Env.KRule _ -> rule_is_recursive name arity
+            | Env.KClosure _ | Env.KDomain | Env.KAlias _ | Env.KVar _ -> false
+          then emit_primed_rule sname ty
+          else emit_rule sname ty
       | Env.KDomain | Env.KAlias _ | Env.KVar _ -> ())
     env;
   (* Emit declarations for qualified-only imports. When a (name, arity) is in

--- a/test/test_normalize.ml
+++ b/test/test_normalize.ml
@@ -20,6 +20,7 @@ let test_decl_name () =
             params = [];
             guards = [];
             return_type = TName (Upper "Bool");
+            body = None;
             contexts = [];
           }));
   check string "action" "Do thing"
@@ -52,6 +53,7 @@ let test_is_type_decl () =
             params = [];
             guards = [];
             return_type = TName (Upper "Bool");
+            body = None;
             contexts = [];
           }));
   check bool "action" false
@@ -82,6 +84,7 @@ let test_is_action () =
             params = [];
             guards = [];
             return_type = TName (Upper "Bool");
+            body = None;
             contexts = [];
           }))
 

--- a/test/test_pretty.ml
+++ b/test/test_pretty.ml
@@ -181,6 +181,7 @@ let test_decl_rule () =
               [ { param_name = Lower "x"; param_type = TName (Upper "Nat") } ];
             guards = [];
             return_type = TName (Upper "Bool");
+            body = None;
             contexts = [];
           }))
 
@@ -194,6 +195,7 @@ let test_decl_rule_with_guards () =
               [ { param_name = Lower "x"; param_type = TName (Upper "Nat") } ];
             guards = [ GExpr (EBinop (OpGt, EVar (Lower "x"), ELitNat 0)) ];
             return_type = TName (Upper "Bool");
+            body = None;
             contexts = [];
           }))
 
@@ -207,6 +209,7 @@ let test_decl_rule_with_context () =
               [ { param_name = Lower "x"; param_type = TName (Upper "Nat") } ];
             guards = [];
             return_type = TName (Upper "Bool");
+            body = None;
             contexts = [ Upper "Ctx" ];
           }))
 

--- a/test/test_smt.ml
+++ b/test/test_smt.ml
@@ -210,6 +210,16 @@ let test_is_rule_recursive_detects_self_reference () =
         (Smt.is_rule_recursive decl.value)
   | [] -> fail "expected rule declaration"
 
+let test_is_rule_recursive_detects_nullary_self_reference () =
+  let _env, doc =
+    parse_and_collect "module Test.\nloop => Bool = loop.\n---\nloop.\n"
+  in
+  match (List.hd doc.chapters).head with
+  | decl :: _ ->
+      check bool "nullary recursive rule detected" true
+        (Smt.is_rule_recursive decl.value)
+  | [] -> fail "expected nullary rule declaration"
+
 let test_recursive_rule_emits_define_fun_rec () =
   let env, _doc =
     parse_and_collect
@@ -225,7 +235,9 @@ let test_recursive_rule_emits_define_fun_rec () =
   check bool "skips current declare-fun" false
     (contains smt "(declare-fun loop (Int) Int)");
   check bool "keeps primed declare-fun" true
-    (contains smt "(declare-fun loop_prime (Int) Int)")
+    (contains smt "(declare-fun loop_prime (Int) Int)");
+  check bool "no legacy forall axiom for recursive rule" false
+    (contains smt "(assert (forall ((x Int)) (= (loop x)")
 
 let test_non_recursive_rule_emits_existing_shape () =
   let env, doc =
@@ -1348,6 +1360,8 @@ let integration_tests =
     test_case "function declarations" `Quick test_function_declarations;
     test_case "is_rule_recursive detects self-referential rule body" `Quick
       test_is_rule_recursive_detects_self_reference;
+    test_case "is_rule_recursive detects nullary self-referential rule body"
+      `Quick test_is_rule_recursive_detects_nullary_self_reference;
     test_case
       "recursive rule emits define-fun-rec form with body and skips \
        declare-fun line"

--- a/test/test_smt.ml
+++ b/test/test_smt.ml
@@ -197,16 +197,53 @@ let test_function_declarations () =
     (contains decls "(declare-fun balance_prime (Account) Int)")
 
 let test_is_rule_recursive_detects_self_reference () =
-  (* PENDING Patch 2: implement Smt.is_rule_recursive for self-referential rule bodies. *)
-  () [@tags "pending"]
+  let _env, doc =
+    parse_and_collect
+      "module Test.\n\
+       loop x: Int => Int = cond x > 0 => loop (x - 1), true => x.\n\
+       ---\n\
+       loop 0 = 0.\n"
+  in
+  match (List.hd doc.chapters).head with
+  | decl :: _ ->
+      check bool "recursive rule detected" true
+        (Smt.is_rule_recursive decl.value)
+  | [] -> fail "expected rule declaration"
 
 let test_recursive_rule_emits_define_fun_rec () =
-  (* PENDING Patch 2: emit define-fun-rec and suppress declare-fun for recursive rules. *)
-  () [@tags "pending"]
+  let env, _doc =
+    parse_and_collect
+      "module Test.\n\
+       loop x: Int => Int = cond x > 0 => loop (x - 1), true => x.\n\
+       ---\n\
+       loop 0 = 0.\n"
+  in
+  let smt = Smt.generate_preamble_with_rule_bodies config env in
+  check bool "has define-fun-rec" true
+    (contains smt "(define-fun-rec loop ((x Int)) Int");
+  check bool "has recursive call in body" true (contains smt "(loop (- x 1))");
+  check bool "skips current declare-fun" false
+    (contains smt "(declare-fun loop (Int) Int)");
+  check bool "keeps primed declare-fun" true
+    (contains smt "(declare-fun loop_prime (Int) Int)")
 
 let test_non_recursive_rule_emits_existing_shape () =
-  (* PENDING Patch 2: preserve declare-fun plus universal-axiom emission for non-recursive rules. *)
-  () [@tags "pending"]
+  let env, doc =
+    parse_and_collect
+      "module Test.\nnext x: Int => Int = x + 1.\n---\nnext 0 = 1.\n"
+  in
+  (match (List.hd doc.chapters).head with
+  | decl :: _ ->
+      check bool "non-recursive rule not detected" false
+        (Smt.is_rule_recursive decl.value)
+  | [] -> fail "expected rule declaration");
+  let smt = Smt.generate_preamble_with_rule_bodies config env in
+  check bool "has declare-fun" true
+    (contains smt "(declare-fun next (Int) Int)");
+  check bool "has universal axiom" true
+    (contains smt "(assert (forall ((x Int)) (= (next x) (+ x 1))))");
+  check bool "does not use define-fun-rec" false
+    (contains smt "(define-fun-rec next")
 
 let test_nullary_rule () =
   let env =

--- a/test/test_util.ml
+++ b/test/test_util.ml
@@ -320,6 +320,7 @@ let gen_chapter (world : gen_world) : Ast.chapter QCheck2.Gen.t =
                  params;
                  guards = [];
                  return_type = ret;
+                 body = None;
                  contexts = [];
                }))
         world.rules

--- a/wasm/pant_wasm.ml
+++ b/wasm/pant_wasm.ml
@@ -462,6 +462,7 @@ let () =
              params = js_array_to_list params;
              guards = js_array_to_list guards;
              return_type = returnType;
+             body = None;
              contexts = [];
            }
 


### PR DESCRIPTION
## Patch 2: Pant: emit define-fun-rec for self-referential rule definitions

- In `lib/smt.ml`, add `is_rule_recursive (decl : Ast.declaration) : bool`. Walk the body expression via the existing AST traversal (mutually recursive with `translate_expr` style). A rule's name comes from `decl.d_head` (Lower identifier); a recursive reference is an `EApp` whose head is `EVar (Lower decl_name)`. Use `Smt_expr.fold_expr` (or the equivalent existing walker) — do NOT hand-roll a new traversal; reuse Bindlib-backed primitives so binders are scope-correct.
- In `lib/smt.ml`, add `emit_rule_recursive (env : Env.t) (decl : Ast.declaration) : string`. Returns one SMT line: `(define-fun-rec NAME ((p1 S1) (p2 S2) …) RET-SORT BODY-EXPR)`. Parameter sorts come from `decl.d_params` via the existing `Smt_types.sort_of_type`; return sort comes from `decl.d_return_type`; body expression comes from `decl.d_body` via `translate_expr config env`. No surrounding `(assert ...)` or `(forall ...)` — `define-fun-rec` implicitly quantifies over the formal params.
- In `lib/smt_preamble.ml:165`, where the existing `(declare-fun %s (%s) %s)\n` line is emitted per rule, branch on `Smt.is_rule_recursive` (passing the rule's declaration). When recursive: skip the `(declare-fun ...)` line entirely (define-fun-rec emitted later from the body-emission pass subsumes it). When non-recursive: keep the existing behavior unchanged. The primed-rule `(declare-fun NAME_prime …)` line stays — primed rules represent next-state and are never recursive themselves (they reference but do not call the primed rule).
- Verify the body-emission pass that currently produces `(assert (forall ((args …)) (= (NAME args) BODY)))` for each rule body becomes `(define-fun-rec NAME (ARGS) RET BODY)` via `emit_rule_recursive` for recursive rules. The body translation logic (translate_expr) is unchanged — only the wrapping changes.
- Run `dune test` to surface any snapshot test failures. For each failure, inspect the diff: if the change is the expected `declare-fun + forall` → `define-fun-rec` rewrite, regenerate the snapshot. If any other change appears, halt and debug — that's a regression.
- Unskip the three Patch-2-owned `test/test_smt.ml` stubs. Replace each PENDING comment with concrete assertions matching the existing test patterns in `test_smt.ml`.
- Do NOT modify any ts2pant file in this patch. Patch 2 is Pant-side only.

## Changes
- In `lib/smt.ml`, add `is_rule_recursive (decl : Ast.declaration) : bool`. Walk the body expression via the existing AST traversal (mutually recursive with `translate_expr` style). A rule's name comes from `decl.d_head` (Lower identifier); a recursive reference is an `EApp` whose head is `EVar (Lower decl_name)`. Use `Smt_expr.fold_expr` (or the equivalent existing walker) — do NOT hand-roll a new traversal; reuse Bindlib-backed primitives so binders are scope-correct.
- In `lib/smt.ml`, add `emit_rule_recursive (env : Env.t) (decl : Ast.declaration) : string`. Returns one SMT line: `(define-fun-rec NAME ((p1 S1) (p2 S2) …) RET-SORT BODY-EXPR)`. Parameter sorts come from `decl.d_params` via the existing `Smt_types.sort_of_type`; return sort comes from `decl.d_return_type`; body expression comes from `decl.d_body` via `translate_expr config env`. No surrounding `(assert ...)` or `(forall ...)` — `define-fun-rec` implicitly quantifies over the formal params.
- In `lib/smt_preamble.ml:165`, where the existing `(declare-fun %s (%s) %s)\n` line is emitted per rule, branch on `Smt.is_rule_recursive` (passing the rule's declaration). When recursive: skip the `(declare-fun ...)` line entirely (define-fun-rec emitted later from the body-emission pass subsumes it). When non-recursive: keep the existing behavior unchanged. The primed-rule `(declare-fun NAME_prime …)` line stays — primed rules represent next-state and are never recursive themselves (they reference but do not call the primed rule).
- Verify the body-emission pass that currently produces `(assert (forall ((args …)) (= (NAME args) BODY)))` for each rule body becomes `(define-fun-rec NAME (ARGS) RET BODY)` via `emit_rule_recursive` for recursive rules. The body translation logic (translate_expr) is unchanged — only the wrapping changes.
- Run `dune test` to surface any snapshot test failures. For each failure, inspect the diff: if the change is the expected `declare-fun + forall` → `define-fun-rec` rewrite, regenerate the snapshot. If any other change appears, halt and debug — that's a regression.
- Unskip the three Patch-2-owned `test/test_smt.ml` stubs. Replace each PENDING comment with concrete assertions matching the existing test patterns in `test_smt.ml`.
- Do NOT modify any ts2pant file in this patch. Patch 2 is Pant-side only.

## Files to Modify
- lib/smt.ml (modify): Add `is_rule_recursive : Ast.declaration -> bool` that walks a rule's body expression and returns true when the body contains an application whose head matches the rule's own name. Add a sibling emitter for the recursive case that produces `(define-fun-rec NAME ((p1 S1) (p2 S2) …) RET-SORT BODY)`. Dispatch the existing rule-emission path on `is_rule_recursive`.
- lib/smt_preamble.ml (modify): Update the rule-declaration emission at line 165 to suppress the `(declare-fun NAME …)` line when `Smt.is_rule_recursive` returns true on the rule. The `(define-fun-rec …)` line emitted by smt.ml replaces it.
- test/test_smt.ml (modify): Remove `[@tags "pending"]` from the Patch-2-owned stubs in Patch 1. Replace each PENDING-comment body with concrete assertions: build a small `Ast.declaration` for a self-referential rule, call `Smt.is_rule_recursive`, assert true; check emitted SMT text contains `define-fun-rec` and does not contain `declare-fun NAME`. Build a non-recursive rule, assert false + the unchanged shape.
- test/snapshots/ (modify): Regenerate any SMT-text snapshots affected by the new emission. Fixtures whose rules are recursive (e.g., `samples/07-pantagruel.pant` exercising `infer e env = ... (infer ...)`) will see their SMT text change to the new `define-fun-rec` shape. Confirm `dune test` passes after regeneration.

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[rfc-spec] SMT-LIB 2.6 — define-fun-rec** — https://smt-lib.org/papers/smt-lib-reference-v2.6-r2021-05-12.pdf — Section on recursive function definitions specifies the `(define-fun-rec NAME ((p1 S1) … (pn Sn)) RET BODY)` syntactic form Patch 2 emits. Argument sorts match the rule's parameter types; return sort matches the rule's return type; body is the rule's RHS expression. The standard also defines `(define-funs-rec ...)` for mutual recursion — out of scope for L4 (single-loop functions only) but worth knowing about for L5/L6.
- **[paper] Vazou et al. POPL 2018 — Refinement Reflection** — https://doi.org/10.1145/3158141 — Closest peer system for what Patch 2 enables: making recursive function bodies SMT-visible via `define-fun-rec` and definitional axioms. The paper's PLE / proof-by-logical-evaluation discussion informs the SMT-performance expectations — Z3's built-in induction tactic handles many shapes automatically but bounded unfolding remains a useful fallback (relevant to per-fixture timeout policy in Patch 4).

## Gameplan Specification

```
module TS2PANT_FIXED_POINT_WHILE_LOWERING.

> ════════════════════════════════
> Milestone 4 of the ts2pant general-loop SSA workstream.
> ════════════════════════════════
> After this milestone, the mutating-body translator accepts
> unbounded while loops (single mutated location, non-literal-
> true guard) and lowers them to a synthesised top-level
> recursive Pant rule. Pant's SMT backend emits the recursive
> rule as define-fun-rec, giving Z3 / CVC5 native induction
> hooks for pant --check. Literal-true and multi-location
> while bodies reject with targeted diagnostics. Three passing
> fixtures verify end-to-end through pant typecheck and
> pant --check; one deliberate-reject fixture documents the
> literal-true rejection. Documentation in AGENTS.md, the IR
> doc, and the workstream doc records the surface and marks
> the milestone landed.

TSStmt.
IR1Stmt.
WhileStmt.
Declaration.
Rule.
PropResult.
IR1SsaLoopBody.
IR1SsaLocation.
TerminationMetric.
BuildOutcome.
LowerResult.
SmtLine.
EmissionShape.
Document.
DocumentKind.
MilestoneStatus.
decl-fun-rec => EmissionShape.
decl-fun-plus-axiom => EmissionShape.
agents-md => DocumentKind.
ir-doc => DocumentKind.
workstream-doc => DocumentKind.
pending => MilestoneStatus.
landed => MilestoneStatus.

> Pant SMT emission (Patch 2).
is-recursive? r: Rule => Bool.
body-of r: Rule => IR1Stmt.
body-applies-self? r: Rule, e: IR1Stmt => Bool.
emission-shape r: Rule => EmissionShape.
emits-define-fun-rec? r: Rule, lines: [SmtLine] => Bool.
emits-declare-fun? r: Rule, lines: [SmtLine] => Bool.
emits-universal-axiom? r: Rule, lines: [SmtLine] => Bool.
logically-equivalent? a: EmissionShape, b: EmissionShape => Bool.

> ts2pant fixed-point lowering (Patches 3, 4).
is-literal-true? s: WhileStmt => Bool.
mutated-count s: WhileStmt => Nat0.
build-mutating-body s: TSStmt => BuildOutcome.
lower-result-of-while s: WhileStmt => LowerResult.
is-ir1-while? b: BuildOutcome => Bool.
is-rejection? b: BuildOutcome => Bool.
rejection-mentions-literal-true? b: BuildOutcome => Bool.
recognizer-rejects-literal-true? s: WhileStmt => Bool.
recognizer-rejects-multi-location? s: WhileStmt => Bool.
is-bare-while? s: TSStmt => Bool.
is-let-then-while-pair? s: TSStmt => Bool.
l3-bounded-recognized? s: TSStmt => Bool.
body-metric b: IR1SsaLoopBody => TerminationMetric.
null-metric? m: TerminationMetric => Bool.
emits-recursive-helper? r: LowerResult => Bool.
emits-caller-equation? r: LowerResult => Bool.
helper-name-unique? n: String => Bool.

> Documentation (Patch 5).
document-kind d: Document => DocumentKind.
document-mentions-l4-fixed-point? d: Document => Bool.
workstream-milestone-4-status => MilestoneStatus.
---

> SMT emission contract: recursive rules emit define-fun-rec,
> non-recursive rules emit declare-fun + universal-axiom.
all r: Rule | is-recursive? r <-> body-applies-self? r (body-of r).

all r: Rule, lines: [SmtLine] |
  is-recursive? r ->
    emits-define-fun-rec? r lines and ~(emits-declare-fun? r lines).

all r: Rule, lines: [SmtLine] |
  ~(is-recursive? r) ->
    emits-declare-fun? r lines and emits-universal-axiom? r lines.

logically-equivalent? decl-fun-rec decl-fun-plus-axiom.

> Build-path contract: bare while loops construct ir1While
> unless guard is literal-true; let-then-while pairs that fail
> L3 fall through to ir1While.
all s: TSStmt |
  is-bare-while? s and ~(rejection-mentions-literal-true? (build-mutating-body s)) ->
    is-ir1-while? (build-mutating-body s).

all s: TSStmt |
  is-bare-while? s ->
    (is-rejection? (build-mutating-body s) ->
      rejection-mentions-literal-true? (build-mutating-body s)).

all s: TSStmt |
  is-let-then-while-pair? s and ~(l3-bounded-recognized? s) ->
    is-ir1-while? (build-mutating-body s).

> Lowering contract: literal-true and multi-location reject;
> successful lowering produces a fixed-point loop body
> (terminationMetric: null) plus a recursive helper rule-decl
> and a caller equation.
all s: WhileStmt |
  is-literal-true? s ->
    recognizer-rejects-literal-true? s.

all s: WhileStmt |
  mutated-count s > 1 ->
    recognizer-rejects-multi-location? s.

all s: WhileStmt, b: IR1SsaLoopBody |
  ~(is-literal-true? s) and mutated-count s = 1 ->
    null-metric? (body-metric b).

all s: WhileStmt |
  ~(is-literal-true? s) and mutated-count s = 1 ->
    emits-recursive-helper? (lower-result-of-while s) and
    emits-caller-equation? (lower-result-of-while s).

> Documentation invariants.
all d: Document |
  document-kind d = agents-md ->
    document-mentions-l4-fixed-point? d.

all d: Document |
  document-kind d = ir-doc ->
    document-mentions-l4-fixed-point? d.

all d: Document |
  document-kind d = workstream-doc ->
    document-mentions-l4-fixed-point? d.

workstream-milestone-4-status = landed.
```

## Patch Specification

```
module TS2PANT_FIXED_POINT_WHILE_LOWERING_PATCH_2.

> Patch 2 extends Pant's SMT backend to detect self-referential
> rule definitions and emit them as SMT-LIB define-fun-rec
> instead of declare-fun + universal axiom. The two encodings
> are logically equivalent (both define the recursive function
> by its equation); define-fun-rec gives Z3 / CVC5 native
> induction hooks the universal axiom does not.

Declaration.
Rule.
Expr.
SmtLine.
EmissionShape.
decl-fun-rec => EmissionShape.
decl-fun-plus-axiom => EmissionShape.

is-recursive? r: Rule => Bool.
emission-shape r: Rule => EmissionShape.
body-of r: Rule => Expr.
body-applies-self? r: Rule, e: Expr => Bool.
emits-define-fun-rec? r: Rule, lines: [SmtLine] => Bool.
emits-declare-fun? r: Rule, lines: [SmtLine] => Bool.
emits-universal-axiom? r: Rule, lines: [SmtLine] => Bool.
logically-equivalent? a: EmissionShape, b: EmissionShape => Bool.
---

> A rule is recursive iff its body applies its own name.
all r: Rule | is-recursive? r <-> body-applies-self? r (body-of r).

> Recursive rules emit define-fun-rec and skip declare-fun.
all r: Rule, lines: [SmtLine] |
  is-recursive? r ->
    emits-define-fun-rec? r lines and ~(emits-declare-fun? r lines).

> Non-recursive rules emit declare-fun + universal axiom unchanged.
all r: Rule, lines: [SmtLine] |
  ~(is-recursive? r) ->
    emits-declare-fun? r lines and emits-universal-axiom? r lines.

> The two emission shapes are logically equivalent.
logically-equivalent? decl-fun-rec decl-fun-plus-axiom.
```


## Implementation Notes

- The existing AST had rule signatures only; there was no declaration-level rule body for `is_rule_recursive` to inspect. This patch adds optional rule bodies to `DeclRule` and parser support for `rule ... => T = expr.`, while leaving existing signature-only rules unchanged.
- Recursive detection is computed when collecting rule bodies into `Env` so `smt_preamble.ml` can suppress only the current-state declaration without depending on `smt.ml`/`smt_expr.ml` and creating a module cycle. `Smt.is_rule_recursive` remains available for direct callers/tests.
- `NAME_prime` declarations are intentionally still emitted for recursive rules. The new branch skips only the base `NAME` declaration because `define-fun-rec` owns that symbol; next-state symbols remain ordinary uninterpreted functions.
- Non-recursive rule bodies use the previous universal axiom shape. Existing samples did not contain declaration-level rule bodies, so no snapshot regeneration was needed.
- `Spec/Evidence Mapping`: recursive iff self-application is implemented by binder-aware expression scans in `lib/smt_expr.ml` and `lib/env.ml`; recursive `define-fun-rec` emission is in `lib/smt.ml` plus declaration suppression in `lib/smt_preamble.ml`; non-recursive fallback is `emit_rule_axiom` in `lib/smt.ml`. Evidence: the three Patch-2 `test/test_smt.ml` stubs are now concrete tests, and `dune fmt` plus `dune test` pass.