### PR TITLE
[ts2pant-fixed-point-while-lowering] Patch 4: ts2pant: wire build path + lower path; ship fixtures + integration tests

### DIFF
--- a/tools/ts2pant/src/emit.ts
+++ b/tools/ts2pant/src/emit.ts
@@ -135,7 +135,8 @@ function renderDeclaration(decl: PantDocument["declarations"][number]): string {
     }
     case "action": {
       if (decl.params.length === 0) {
-        return `~> ${decl.label}.`;
+        const guard = decl.guard ? ` @ ${getAst().strExpr(decl.guard)}` : "";
+        return `~> ${decl.label}${guard}.`;
       }
       const params = decl.params.map((p) => `${p.name}: ${p.type}`).join(", ");
       const guard = decl.guard ? `, ${getAst().strExpr(decl.guard)}` : "";

--- a/tools/ts2pant/src/emit.ts
+++ b/tools/ts2pant/src/emit.ts
@@ -33,6 +33,7 @@ export interface CheckOptions {
    * `dune exec pant --` from {@link projectRoot}.
    */
   pantBin?: string;
+  timeoutMs?: number;
 }
 
 function renderPropResult(prop: PropResult): string {
@@ -54,15 +55,10 @@ function renderPropResult(prop: PropResult): string {
       return ast.strExpr(ast.forall(prop.quantifiers, guards, prop.body));
     }
     case "rule-decl": {
-      const params = prop.params.map((p) => ast.param(p.name, p.type));
-      const decl = ast.strDecl(
-        ast.declRule(prop.ruleName, params, [], prop.returnType),
-      );
-      const lhs = ast.app(
-        ast.var(prop.ruleName),
-        prop.params.map((p) => ast.var(p.name)),
-      );
-      return `${decl}\n${ast.strExpr(ast.binop(ast.opEq(), lhs, prop.body))}`;
+      const params = prop.params
+        .map((p) => `${p.name}: ${ast.strTypeExpr(p.type)}`)
+        .join(", ");
+      return `${prop.ruleName} ${params} => ${ast.strTypeExpr(prop.returnType)} = ${ast.strExpr(prop.body)}`;
     }
     case "unsupported":
       return `> UNSUPPORTED: ${prop.reason}`;
@@ -80,61 +76,35 @@ function renderPropResult(prop: PropResult): string {
  */
 export function emitDocument(doc: PantDocument): string {
   const lines: string[] = [];
+  const ruleDeclProps = doc.propositions.filter((p) => p.kind === "rule-decl");
+  const bodyProps = doc.propositions.filter((p) => p.kind !== "rule-decl");
+  const actionDecls = doc.declarations.filter((d) => d.kind === "action");
+  const nonActionDecls = doc.declarations.filter((d) => d.kind !== "action");
   lines.push(`module ${doc.moduleName}.`);
   for (const imp of doc.imports) {
     lines.push(`import ${imp.name}.`);
   }
   lines.push("");
 
-  for (const decl of doc.declarations) {
-    switch (decl.kind) {
-      case "domain":
-        lines.push(`${decl.name}.`);
-        break;
-      case "alias":
-        lines.push(`${decl.name} = ${decl.type}.`);
-        break;
-      case "rule": {
-        const params = decl.params
-          .map((p) => `${p.name}: ${p.type}`)
-          .join(", ");
-        const guard = decl.guard ? `, ${getAst().strExpr(decl.guard)}` : "";
-        lines.push(`${decl.name} ${params}${guard} => ${decl.returnType}.`);
-        break;
-      }
-      case "action": {
-        if (decl.params.length === 0) {
-          lines.push(`~> ${decl.label}.`);
-        } else {
-          const params = decl.params
-            .map((p) => `${p.name}: ${p.type}`)
-            .join(", ");
-          const guard = decl.guard ? `, ${getAst().strExpr(decl.guard)}` : "";
-          lines.push(`~> ${decl.label} @ ${params}${guard}.`);
-        }
-        break;
-      }
-      case "unsupported":
-        lines.push(`> UNSUPPORTED: ${decl.reason}`);
-        break;
-      default: {
-        const _exhaustive: never = decl;
-        throw new Error(
-          `Unhandled declaration kind: ${JSON.stringify(_exhaustive)}`,
-        );
-      }
-    }
+  for (const decl of nonActionDecls) {
+    lines.push(renderDeclaration(decl));
+  }
+  for (const prop of ruleDeclProps) {
+    lines.push(`${renderPropResult(prop)}.`);
+  }
+  for (const decl of actionDecls) {
+    lines.push(renderDeclaration(decl));
   }
 
   lines.push("");
   lines.push("---");
   lines.push("");
 
-  if (doc.propositions.length === 0) {
+  if (bodyProps.length === 0) {
     // Keep chapter body non-empty (required when a check block is present).
     lines.push("true.");
   } else {
-    for (const prop of doc.propositions) {
+    for (const prop of bodyProps) {
       lines.push(`${renderPropResult(prop)}.`);
     }
   }
@@ -152,6 +122,36 @@ export function emitDocument(doc: PantDocument): string {
   return lines.join("\n");
 }
 
+function renderDeclaration(decl: PantDocument["declarations"][number]): string {
+  switch (decl.kind) {
+    case "domain":
+      return `${decl.name}.`;
+    case "alias":
+      return `${decl.name} = ${decl.type}.`;
+    case "rule": {
+      const params = decl.params.map((p) => `${p.name}: ${p.type}`).join(", ");
+      const guard = decl.guard ? `, ${getAst().strExpr(decl.guard)}` : "";
+      return `${decl.name} ${params}${guard} => ${decl.returnType}.`;
+    }
+    case "action": {
+      if (decl.params.length === 0) {
+        return `~> ${decl.label}.`;
+      }
+      const params = decl.params.map((p) => `${p.name}: ${p.type}`).join(", ");
+      const guard = decl.guard ? `, ${getAst().strExpr(decl.guard)}` : "";
+      return `~> ${decl.label} @ ${params}${guard}.`;
+    }
+    case "unsupported":
+      return `> UNSUPPORTED: ${decl.reason}`;
+    default: {
+      const _exhaustive: never = decl;
+      throw new Error(
+        `Unhandled declaration kind: ${JSON.stringify(_exhaustive)}`,
+      );
+    }
+  }
+}
+
 /**
  * Write a .pant source string to a temp file, invoke `pant --check`,
  * and parse the output.
@@ -167,12 +167,12 @@ export function runCheck(pantSource: string, opts?: CheckOptions): CheckResult {
     const output = opts?.pantBin
       ? execFileSync(opts.pantBin, ["--check", filePath], {
           encoding: "utf-8",
-          timeout: 60_000,
+          timeout: opts.timeoutMs ?? 60_000,
           cwd,
         })
       : execSync(`dune exec pant -- --check "${filePath}"`, {
           encoding: "utf-8",
-          timeout: 60_000,
+          timeout: opts?.timeoutMs ?? 60_000,
           cwd,
         });
 

--- a/tools/ts2pant/src/ir1-build-body.ts
+++ b/tools/ts2pant/src/ir1-build-body.ts
@@ -516,6 +516,37 @@ function classifyForeachStmt(
 ): BuildResult<ForeachStmtClass> {
   if (
     ts.isExpressionStatement(stmt) &&
+    isUnaryPropertyIncrement(unwrapExpression(stmt.expression))
+  ) {
+    const expr = unwrapExpression(stmt.expression) as
+      | ts.PrefixUnaryExpression
+      | ts.PostfixUnaryExpression;
+    const unary = unaryPropertyIncrementParts(expr);
+    if (isUnsupported(unary)) {
+      return unary;
+    }
+    const rootName = getRootIdentifier(unary.target.expression);
+    if (rootName !== iterName) {
+      return {
+        unsupported:
+          "loop accumulator write must use a compound assignment (+=, -=, *=, /=)",
+      };
+    }
+    const built = buildL1AssignStmt(stmt, subCtx);
+    if (isUnsupported(built)) {
+      return built;
+    }
+    if (parentGuard !== null) {
+      return {
+        unsupported:
+          "Shape A iterator write under an if-guard is not supported in foreach",
+      };
+    }
+    return { kind: "shapeA", built: built as IR1ForeachBody };
+  }
+
+  if (
+    ts.isExpressionStatement(stmt) &&
     ts.isBinaryExpression(unwrapExpression(stmt.expression))
   ) {
     const bin = unwrapExpression(stmt.expression) as ts.BinaryExpression;
@@ -827,6 +858,13 @@ function simulateShapeA(
     return true;
   }
   const expr = unwrapExpression(stmt.expression);
+  if (isUnaryPropertyIncrement(expr)) {
+    const unary = unaryPropertyIncrementParts(expr);
+    if (isUnsupported(unary)) {
+      return unary;
+    }
+    return simulateShapeAPropertyWrite(unary.target, unary.rhs, subCtx);
+  }
   if (!ts.isBinaryExpression(expr)) {
     return true;
   }
@@ -838,8 +876,20 @@ function simulateShapeA(
   if (!ts.isPropertyAccessExpression(expr.left)) {
     return true;
   }
-  const rawProp = expr.left.name.text;
-  const receiverType = subCtx.checker.getTypeAtLocation(expr.left.expression);
+  const rhsNode =
+    compoundOp !== undefined
+      ? ts.factory.createBinaryExpression(expr.left, compoundOp, expr.right)
+      : expr.right;
+  return simulateShapeAPropertyWrite(expr.left, rhsNode, subCtx);
+}
+
+function simulateShapeAPropertyWrite(
+  target: ts.PropertyAccessExpression,
+  rhsNode: ts.Expression,
+  subCtx: BuildBodyCtx,
+): BuildResult<true> {
+  const rawProp = target.name.text;
+  const receiverType = subCtx.checker.getTypeAtLocation(target.expression);
   const prop = qualifyFieldAccess(
     receiverType,
     rawProp,
@@ -856,7 +906,7 @@ function simulateShapeA(
   // `buildL1AssignStmt`.
   const objR = rejectEffect(
     translateBodyExpr(
-      expr.left.expression,
+      target.expression,
       subCtx.checker,
       subCtx.strategy,
       subCtx.paramNames,
@@ -867,10 +917,6 @@ function simulateShapeA(
   if (isBodyUnsupported(objR)) {
     return { unsupported: objR.unsupported };
   }
-  const rhsNode =
-    compoundOp !== undefined
-      ? ts.factory.createBinaryExpression(expr.left, compoundOp, expr.right)
-      : expr.right;
   const valR = rejectEffect(
     translateBodyExpr(
       rhsNode,
@@ -1159,6 +1205,13 @@ export function buildL1AssignStmt(
   // way as `obj.p = 1;`, mirroring the canonicalization the
   // `classifyForeachStmt` outer dispatch already does.
   const expr = unwrapExpression(stmt.expression);
+  if (ts.isPrefixUnaryExpression(expr) || ts.isPostfixUnaryExpression(expr)) {
+    const unary = unaryPropertyIncrementParts(expr);
+    if (isUnsupported(unary)) {
+      return unary;
+    }
+    return buildL1PropertyAssignment(unary.target, unary.rhs, ctx);
+  }
   if (!ts.isBinaryExpression(expr)) {
     return { unsupported: "branch statement must be an assignment" };
   }
@@ -1170,6 +1223,57 @@ export function buildL1AssignStmt(
   if (!ts.isPropertyAccessExpression(expr.left)) {
     return { unsupported: "assign target must be a property access" };
   }
+  const rhsNode =
+    compoundOp !== undefined
+      ? ts.factory.createBinaryExpression(expr.left, compoundOp, expr.right)
+      : expr.right;
+  return buildL1PropertyAssignment(expr.left, rhsNode, ctx);
+}
+
+function isUnaryPropertyIncrement(
+  expr: ts.Expression,
+): expr is ts.PrefixUnaryExpression | ts.PostfixUnaryExpression {
+  return (
+    (ts.isPrefixUnaryExpression(expr) || ts.isPostfixUnaryExpression(expr)) &&
+    (expr.operator === ts.SyntaxKind.PlusPlusToken ||
+      expr.operator === ts.SyntaxKind.MinusMinusToken) &&
+    ts.isPropertyAccessExpression(expr.operand)
+  );
+}
+
+function unaryPropertyIncrementParts(
+  expr: ts.PrefixUnaryExpression | ts.PostfixUnaryExpression,
+): BuildResult<{
+  target: ts.PropertyAccessExpression;
+  rhs: ts.BinaryExpression;
+}> {
+  const op = expr.operator;
+  if (
+    op !== ts.SyntaxKind.PlusPlusToken &&
+    op !== ts.SyntaxKind.MinusMinusToken
+  ) {
+    return { unsupported: "unsupported assignment operator" };
+  }
+  if (!ts.isPropertyAccessExpression(expr.operand)) {
+    return { unsupported: "assign target must be a property access" };
+  }
+  return {
+    target: expr.operand,
+    rhs: ts.factory.createBinaryExpression(
+      expr.operand,
+      op === ts.SyntaxKind.PlusPlusToken
+        ? ts.SyntaxKind.PlusToken
+        : ts.SyntaxKind.MinusToken,
+      ts.factory.createNumericLiteral(1),
+    ),
+  };
+}
+
+function buildL1PropertyAssignment(
+  target: ts.PropertyAccessExpression,
+  rhsNode: ts.Expression,
+  ctx: BuildBodyCtx,
+): BuildResult<IR1Stmt> {
   // Inside a foreach (`ctx.iterRefs` set), Shape A means *uniform
   // iterator writes* — the assign target must be rooted at one of
   // the iterator binders. `for (const x of xs) { if (g) acc.total =
@@ -1177,7 +1281,7 @@ export function buildL1AssignStmt(
   // check in `ensureForeachBodyShape`; we catch it here at the TS-AST
   // level where the root identifier is still visible.
   if (ctx.iterRefs) {
-    const rootName = getRootIdentifier(expr.left.expression);
+    const rootName = getRootIdentifier(target.expression);
     if (rootName === null || !ctx.iterRefs.has(rootName)) {
       return {
         unsupported:
@@ -1185,8 +1289,8 @@ export function buildL1AssignStmt(
       };
     }
   }
-  const rawProp = expr.left.name.text;
-  const receiverType = ctx.checker.getTypeAtLocation(expr.left.expression);
+  const rawProp = target.name.text;
+  const receiverType = ctx.checker.getTypeAtLocation(target.expression);
   const prop = qualifyFieldAccess(
     receiverType,
     rawProp,
@@ -1197,19 +1301,11 @@ export function buildL1AssignStmt(
   if (prop === null) {
     return { unsupported: ambiguousFieldMsg(rawProp) };
   }
-  const objR = buildL1SubExpr(expr.left.expression, ctx);
+  const objR = buildL1SubExpr(target.expression, ctx);
   if (isUnsupported(objR)) {
     return objR;
   }
   const obj = objR;
-  // For compound `a.p OP= v`, desugar the rhs to `a.p OP v`. The new
-  // `a.p` read goes through translateBodyExpr, which consults the
-  // symbolic state and returns the prior-write value or the pre-state
-  // identity.
-  const rhsNode =
-    compoundOp !== undefined
-      ? ts.factory.createBinaryExpression(expr.left, compoundOp, expr.right)
-      : expr.right;
   const val = buildL1SubExpr(rhsNode, ctx);
   if (isUnsupported(val)) {
     return val;

--- a/tools/ts2pant/src/ir1-lower-body.ts
+++ b/tools/ts2pant/src/ir1-lower-body.ts
@@ -89,6 +89,7 @@ export interface SsaBodyLowerOptions extends LowerBodyCtx {
   initialPropertyValues?: ReadonlyMap<string, OpaqueExpr>;
   synthCell?: SynthCell;
   strategy?: NumericStrategy;
+  declarations?: readonly PantDeclaration[];
 }
 
 export function lowerL1BodyToSsaProps(
@@ -96,8 +97,12 @@ export function lowerL1BodyToSsaProps(
   declarations: readonly PantDeclaration[],
   options: SsaBodyLowerOptions,
 ): IR1SsaBodyLowerResult {
+  const lowerDeclarations = options.declarations ?? declarations;
   return appendFramesForUnmodifiedRules(
-    lowerL1BodyToSsaResult(stmt, options),
+    lowerL1BodyToSsaResult(stmt, {
+      ...options,
+      declarations: lowerDeclarations,
+    }),
     declarations,
   );
 }
@@ -169,6 +174,9 @@ function lowerFixedPointL1BodyToSsaResult(
         ? {}
         : { synthCell: options.synthCell }),
       ...(options.strategy === undefined ? {} : { strategy: options.strategy }),
+      ...(options.declarations === undefined
+        ? {}
+        : { declarations: options.declarations }),
     });
   } catch (err) {
     return ir1SsaBodyLowerUnsupported(

--- a/tools/ts2pant/src/ir1-lower-body.ts
+++ b/tools/ts2pant/src/ir1-lower-body.ts
@@ -25,6 +25,7 @@ import {
   lowerCollectionSsaToProps,
 } from "./ir1-ssa-collections.js";
 import { lowerCounterLoopL1Body } from "./ir1-ssa-counter-loop.js";
+import { lowerFixedPointLoopL1Body } from "./ir1-ssa-fixed-point.js";
 import {
   lowerForeachShapeASummaries,
   lowerForeachShapeBSummaries,
@@ -42,6 +43,7 @@ import {
 import { isScalarSsaL1Body, lowerScalarSsaToProps } from "./ir1-ssa-scalars.js";
 import type { OpaqueExpr } from "./pant-ast.js";
 import { symbolicKey } from "./translate-body.js";
+import type { NumericStrategy, SynthCell } from "./translate-types.js";
 import type { PantDeclaration } from "./types.js";
 
 export interface LowerBodyCtx {
@@ -85,6 +87,8 @@ export interface ScalarSsaBodyLowerOptions extends LowerBodyCtx {
 
 export interface SsaBodyLowerOptions extends LowerBodyCtx {
   initialPropertyValues?: ReadonlyMap<string, OpaqueExpr>;
+  synthCell?: SynthCell;
+  strategy?: NumericStrategy;
 }
 
 export function lowerL1BodyToSsaProps(
@@ -111,8 +115,19 @@ function lowerL1BodyToSsaResult(
   if (stmt.kind === "foreach") {
     return lowerForeachL1BodyToSsaResult(stmt, options);
   }
+  if (stmt.kind === "while") {
+    return lowerFixedPointL1BodyToSsaResult(stmt, options);
+  }
   if (stmt.kind === "for") {
     return lowerCounterLoopL1BodyToSsaResult(stmt, options);
+  }
+  if (
+    stmt.kind === "block" &&
+    stmt.stmts.length > 0 &&
+    stmt.stmts.at(-1)?.kind === "while" &&
+    stmt.stmts.slice(0, -1).every((child) => child.kind === "let")
+  ) {
+    return lowerFixedPointL1BodyToSsaResult(stmt, options);
   }
   if (stmt.kind === "block") {
     const results: IR1SsaBodyLowerResult[] = [];
@@ -136,6 +151,32 @@ function lowerL1BodyToSsaResult(
   return ir1SsaBodyLowerUnsupported(
     "statement is not supported by unified SSA body lowering",
   );
+}
+
+function lowerFixedPointL1BodyToSsaResult(
+  stmt:
+    | Extract<IR1Stmt, { kind: "while" }>
+    | Extract<IR1Stmt, { kind: "block" }>,
+  options: SsaBodyLowerOptions,
+): IR1SsaBodyLowerResult {
+  try {
+    return lowerFixedPointLoopL1Body(stmt, {
+      lowerOpaque: options.applyConst,
+      ...(options.initialPropertyValues === undefined
+        ? {}
+        : { initialPropertyValues: options.initialPropertyValues }),
+      ...(options.synthCell === undefined
+        ? {}
+        : { synthCell: options.synthCell }),
+      ...(options.strategy === undefined ? {} : { strategy: options.strategy }),
+    });
+  } catch (err) {
+    return ir1SsaBodyLowerUnsupported(
+      err instanceof Error
+        ? err.message
+        : "fixed-point while SSA lowering rejected the body",
+    );
+  }
 }
 
 function lowerCounterLoopL1BodyToSsaResult(

--- a/tools/ts2pant/src/ir1-ssa-fixed-point.ts
+++ b/tools/ts2pant/src/ir1-ssa-fixed-point.ts
@@ -46,6 +46,7 @@ export interface FixedPointLoopLowerOptions extends LoopSsaBuildOptions {
 export interface FixedPointLoopShape {
   guardExpr: IR1Expr;
   bodyStmt: IR1Stmt;
+  localLets: ReadonlyMap<string, IR1Expr>;
   mutatedLocation: Extract<IR1SsaLocation, { kind: "property" }>;
 }
 
@@ -59,8 +60,33 @@ interface TargetInfo {
 }
 
 export function recognizeFixedPointLoopShape(
-  stmt: Extract<IR1Stmt, { kind: "while" }>,
+  stmt:
+    | Extract<IR1Stmt, { kind: "while" }>
+    | Extract<IR1Stmt, { kind: "block" }>,
 ): FixedPointLoopShape | { unsupported: string } {
+  if (stmt.kind === "block") {
+    const children = stmt.stmts;
+    const last = children.at(-1);
+    if (last?.kind !== "while") {
+      return { unsupported: "fixed-point block must end in a while loop" };
+    }
+    const localLets = new Map<string, IR1Expr>();
+    for (const child of children.slice(0, -1)) {
+      if (child.kind !== "let") {
+        return {
+          unsupported:
+            "fixed-point while prelude must contain let bindings only",
+        };
+      }
+      localLets.set(child.name, child.value);
+    }
+    const recognized = recognizeFixedPointLoopShape(last);
+    if ("unsupported" in recognized) {
+      return recognized;
+    }
+    return { ...recognized, localLets };
+  }
+
   if (
     stmt.cond.kind === "lit" &&
     stmt.cond.value.kind === "bool" &&
@@ -87,12 +113,15 @@ export function recognizeFixedPointLoopShape(
   return {
     guardExpr: stmt.cond,
     bodyStmt: stmt.body,
+    localLets: new Map(),
     mutatedLocation,
   };
 }
 
 export function lowerFixedPointLoopL1Body(
-  stmt: Extract<IR1Stmt, { kind: "while" }>,
+  stmt:
+    | Extract<IR1Stmt, { kind: "while" }>
+    | Extract<IR1Stmt, { kind: "block" }>,
   options: FixedPointLoopLowerOptions = {},
 ): IR1SsaBodyLowerResult {
   const shape = recognizeFixedPointLoopShape(stmt);
@@ -109,6 +138,21 @@ export function lowerFixedPointLoopL1Body(
       "fixed-point while lowering could not match the mutated location to the loop body write",
     );
   }
+  const guardExpr = substituteLocalLets(shape.guardExpr, shape.localLets);
+  const valueExpr = substituteLocalLets(writeBody.value, shape.localLets);
+  if (
+    containsNonTargetMemberRead(guardExpr, writeBody.target) ||
+    containsNonTargetMemberRead(valueExpr, writeBody.target)
+  ) {
+    return ir1SsaBodyLowerUnsupported(
+      "fixed-point while lowering supports guards and updates over the mutated property only",
+    );
+  }
+  if (!containsTargetMemberRead(guardExpr, writeBody.target)) {
+    return ir1SsaBodyLowerUnsupported(
+      "fixed-point while guard must depend on the mutated property",
+    );
+  }
 
   const lowerOpaque = options.lowerOpaque ?? ((e: OpaqueExpr) => e);
   const ast = getAst();
@@ -118,15 +162,15 @@ export function lowerFixedPointLoopL1Body(
   );
   const header = ir1SsaOpenLoopHeader(targetInfo.location, preheaderVersion);
   const invariantNames = collectLoopInvariantNames(
-    [shape.guardExpr, writeBody.value],
+    [guardExpr, valueExpr],
     writeBody.target,
   );
   const stateName = allocateFreshStateName(
-    stateAvoidanceNames([shape.guardExpr, writeBody.value], writeBody.target),
+    stateAvoidanceNames([guardExpr, valueExpr], writeBody.target),
   );
   const stateVar = ir1Var(stateName);
   const effectExpr = substituteMemberReads(
-    writeBody.value,
+    valueExpr,
     writeBody.target,
     stateVar,
   );
@@ -154,9 +198,7 @@ export function lowerFixedPointLoopL1Body(
   const effect = lowerOpaque(lowerExpr(lowerL1Expr(effectExpr)));
   const loweredGuard = lowerOpaque(
     lowerExpr(
-      lowerL1Expr(
-        substituteMemberReads(shape.guardExpr, writeBody.target, stateVar),
-      ),
+      lowerL1Expr(substituteMemberReads(guardExpr, writeBody.target, stateVar)),
     ),
   );
   const helperCallOnEffect = ast.app(ast.var(ruleName), [
@@ -351,6 +393,296 @@ function walkStmt(stmt: IR1Stmt, visit: (stmt: IR1Stmt) => void): void {
     default: {
       const _exhaustive: never = stmt;
       void _exhaustive;
+    }
+  }
+}
+
+function substituteLocalLets(
+  expr: IR1Expr,
+  localLets: ReadonlyMap<string, IR1Expr>,
+  bound: ReadonlySet<string> = new Set(),
+  resolving: ReadonlySet<string> = new Set(),
+): IR1Expr {
+  if (localLets.size === 0) {
+    return expr;
+  }
+  if (
+    expr.kind === "var" &&
+    !expr.primed &&
+    !bound.has(expr.name) &&
+    localLets.has(expr.name) &&
+    !resolving.has(expr.name)
+  ) {
+    return substituteLocalLets(
+      localLets.get(expr.name)!,
+      localLets,
+      bound,
+      new Set([...resolving, expr.name]),
+    );
+  }
+  switch (expr.kind) {
+    case "var":
+    case "lit":
+      return expr;
+    case "binop":
+      return {
+        ...expr,
+        lhs: substituteLocalLets(expr.lhs, localLets, bound, resolving),
+        rhs: substituteLocalLets(expr.rhs, localLets, bound, resolving),
+      };
+    case "unop":
+      return {
+        ...expr,
+        arg: substituteLocalLets(expr.arg, localLets, bound, resolving),
+      };
+    case "app":
+      return {
+        ...expr,
+        callee: substituteLocalLets(expr.callee, localLets, bound, resolving),
+        args: expr.args.map((arg) =>
+          substituteLocalLets(arg, localLets, bound, resolving),
+        ),
+      };
+    case "member":
+      return {
+        ...expr,
+        receiver: substituteLocalLets(
+          expr.receiver,
+          localLets,
+          bound,
+          resolving,
+        ),
+      };
+    case "cond":
+      return {
+        ...expr,
+        arms: expr.arms.map(([guard, value]) => [
+          substituteLocalLets(guard, localLets, bound, resolving),
+          substituteLocalLets(value, localLets, bound, resolving),
+        ]),
+        otherwise: substituteLocalLets(
+          expr.otherwise,
+          localLets,
+          bound,
+          resolving,
+        ),
+      };
+    case "is-nullish":
+      return {
+        ...expr,
+        operand: substituteLocalLets(expr.operand, localLets, bound, resolving),
+      };
+    case "each": {
+      const localFreeVars = localLetValueFreeVars(localLets);
+      const binder =
+        localFreeVars.has(expr.binder) &&
+        (expr.guards.length > 0 || expr.proj !== undefined)
+          ? freshIr1Name(expr.binder, [
+              expr,
+              ...localLets.values(),
+              ...[...bound].map((name) => ir1Var(name)),
+            ])
+          : expr.binder;
+      const guards =
+        binder === expr.binder
+          ? expr.guards
+          : expr.guards.map((guard) =>
+              renameBoundVarRefs(guard, expr.binder, binder),
+            );
+      const proj =
+        binder === expr.binder
+          ? expr.proj
+          : renameBoundVarRefs(expr.proj, expr.binder, binder);
+      const nextBound = new Set(bound);
+      nextBound.add(binder);
+      return {
+        ...expr,
+        binder,
+        src: substituteLocalLets(expr.src, localLets, bound, resolving),
+        guards: guards.map((guard) =>
+          substituteLocalLets(guard, localLets, nextBound, resolving),
+        ),
+        proj: substituteLocalLets(proj, localLets, nextBound, resolving),
+      };
+    }
+    case "map-read":
+      return {
+        ...expr,
+        receiver: substituteLocalLets(
+          expr.receiver,
+          localLets,
+          bound,
+          resolving,
+        ),
+        key: substituteLocalLets(expr.key, localLets, bound, resolving),
+      };
+    case "set-read":
+      return {
+        ...expr,
+        receiver: substituteLocalLets(
+          expr.receiver,
+          localLets,
+          bound,
+          resolving,
+        ),
+        elem: substituteLocalLets(expr.elem, localLets, bound, resolving),
+      };
+    default: {
+      const _exhaustive: never = expr;
+      void _exhaustive;
+      return expr;
+    }
+  }
+}
+
+function localLetValueFreeVars(
+  localLets: ReadonlyMap<string, IR1Expr>,
+): ReadonlySet<string> {
+  const out = new Set<string>();
+  for (const value of localLets.values()) {
+    collectIr1FreeVars(value, out);
+  }
+  return out;
+}
+
+function collectIr1FreeVars(
+  expr: IR1Expr,
+  out: Set<string>,
+  bound: ReadonlySet<string> = new Set(),
+): void {
+  switch (expr.kind) {
+    case "var":
+      if (!expr.primed && !bound.has(expr.name)) {
+        out.add(expr.name);
+      }
+      break;
+    case "lit":
+      break;
+    case "binop":
+      collectIr1FreeVars(expr.lhs, out, bound);
+      collectIr1FreeVars(expr.rhs, out, bound);
+      break;
+    case "unop":
+      collectIr1FreeVars(expr.arg, out, bound);
+      break;
+    case "app":
+      collectIr1FreeVars(expr.callee, out, bound);
+      for (const arg of expr.args) {
+        collectIr1FreeVars(arg, out, bound);
+      }
+      break;
+    case "member":
+      collectIr1FreeVars(expr.receiver, out, bound);
+      break;
+    case "cond":
+      for (const [guard, value] of expr.arms) {
+        collectIr1FreeVars(guard, out, bound);
+        collectIr1FreeVars(value, out, bound);
+      }
+      collectIr1FreeVars(expr.otherwise, out, bound);
+      break;
+    case "is-nullish":
+      collectIr1FreeVars(expr.operand, out, bound);
+      break;
+    case "each": {
+      collectIr1FreeVars(expr.src, out, bound);
+      const nextBound = new Set(bound);
+      nextBound.add(expr.binder);
+      for (const guard of expr.guards) {
+        collectIr1FreeVars(guard, out, nextBound);
+      }
+      collectIr1FreeVars(expr.proj, out, nextBound);
+      break;
+    }
+    case "map-read":
+      collectIr1FreeVars(expr.receiver, out, bound);
+      collectIr1FreeVars(expr.key, out, bound);
+      break;
+    case "set-read":
+      collectIr1FreeVars(expr.receiver, out, bound);
+      collectIr1FreeVars(expr.elem, out, bound);
+      break;
+    default: {
+      const _exhaustive: never = expr;
+      void _exhaustive;
+    }
+  }
+}
+
+function freshIr1Name(base: string, exprs: Iterable<IR1Expr>): string {
+  const used = new Set<string>();
+  for (const expr of exprs) {
+    collectAllNames(expr, used);
+  }
+  let candidate = `${base}1`;
+  for (let i = 2; used.has(candidate); i++) {
+    candidate = `${base}${i}`;
+  }
+  return candidate;
+}
+
+function renameBoundVarRefs(expr: IR1Expr, from: string, to: string): IR1Expr {
+  switch (expr.kind) {
+    case "var":
+      return !expr.primed && expr.name === from ? { ...expr, name: to } : expr;
+    case "lit":
+      return expr;
+    case "binop":
+      return {
+        ...expr,
+        lhs: renameBoundVarRefs(expr.lhs, from, to),
+        rhs: renameBoundVarRefs(expr.rhs, from, to),
+      };
+    case "unop":
+      return { ...expr, arg: renameBoundVarRefs(expr.arg, from, to) };
+    case "app":
+      return {
+        ...expr,
+        callee: renameBoundVarRefs(expr.callee, from, to),
+        args: expr.args.map((arg) => renameBoundVarRefs(arg, from, to)),
+      };
+    case "member":
+      return { ...expr, receiver: renameBoundVarRefs(expr.receiver, from, to) };
+    case "cond":
+      return {
+        ...expr,
+        arms: expr.arms.map(([guard, value]) => [
+          renameBoundVarRefs(guard, from, to),
+          renameBoundVarRefs(value, from, to),
+        ]),
+        otherwise: renameBoundVarRefs(expr.otherwise, from, to),
+      };
+    case "is-nullish":
+      return { ...expr, operand: renameBoundVarRefs(expr.operand, from, to) };
+    case "each":
+      if (expr.binder === from) {
+        return {
+          ...expr,
+          src: renameBoundVarRefs(expr.src, from, to),
+        };
+      }
+      return {
+        ...expr,
+        src: renameBoundVarRefs(expr.src, from, to),
+        guards: expr.guards.map((guard) => renameBoundVarRefs(guard, from, to)),
+        proj: renameBoundVarRefs(expr.proj, from, to),
+      };
+    case "map-read":
+      return {
+        ...expr,
+        receiver: renameBoundVarRefs(expr.receiver, from, to),
+        key: renameBoundVarRefs(expr.key, from, to),
+      };
+    case "set-read":
+      return {
+        ...expr,
+        receiver: renameBoundVarRefs(expr.receiver, from, to),
+        elem: renameBoundVarRefs(expr.elem, from, to),
+      };
+    default: {
+      const _exhaustive: never = expr;
+      void _exhaustive;
+      return expr;
     }
   }
 }
@@ -609,6 +941,86 @@ function sameMemberExpr(
     expr.name === member.name &&
     ir1ExprEqual(expr.receiver, member.receiver)
   );
+}
+
+function containsNonTargetMemberRead(
+  expr: IR1Expr,
+  target: Extract<IR1Expr, { kind: "member" }>,
+): boolean {
+  let found = false;
+  walkExpr(expr, (node) => {
+    if (node.kind === "member" && !sameMemberExpr(node, target)) {
+      found = true;
+    }
+  });
+  return found;
+}
+
+function containsTargetMemberRead(
+  expr: IR1Expr,
+  target: Extract<IR1Expr, { kind: "member" }>,
+): boolean {
+  let found = false;
+  walkExpr(expr, (node) => {
+    if (sameMemberExpr(node, target)) {
+      found = true;
+    }
+  });
+  return found;
+}
+
+function walkExpr(expr: IR1Expr, visit: (expr: IR1Expr) => void): void {
+  visit(expr);
+  switch (expr.kind) {
+    case "var":
+    case "lit":
+      break;
+    case "binop":
+      walkExpr(expr.lhs, visit);
+      walkExpr(expr.rhs, visit);
+      break;
+    case "unop":
+      walkExpr(expr.arg, visit);
+      break;
+    case "app":
+      walkExpr(expr.callee, visit);
+      for (const arg of expr.args) {
+        walkExpr(arg, visit);
+      }
+      break;
+    case "member":
+      walkExpr(expr.receiver, visit);
+      break;
+    case "cond":
+      for (const [guard, value] of expr.arms) {
+        walkExpr(guard, visit);
+        walkExpr(value, visit);
+      }
+      walkExpr(expr.otherwise, visit);
+      break;
+    case "is-nullish":
+      walkExpr(expr.operand, visit);
+      break;
+    case "each":
+      walkExpr(expr.src, visit);
+      for (const guard of expr.guards) {
+        walkExpr(guard, visit);
+      }
+      walkExpr(expr.proj, visit);
+      break;
+    case "map-read":
+      walkExpr(expr.receiver, visit);
+      walkExpr(expr.key, visit);
+      break;
+    case "set-read":
+      walkExpr(expr.receiver, visit);
+      walkExpr(expr.elem, visit);
+      break;
+    default: {
+      const _exhaustive: never = expr;
+      void _exhaustive;
+    }
+  }
 }
 
 function ir1ExprEqual(a: IR1Expr, b: IR1Expr): boolean {

--- a/tools/ts2pant/src/ir1-ssa-fixed-point.ts
+++ b/tools/ts2pant/src/ir1-ssa-fixed-point.ts
@@ -735,8 +735,9 @@ function substituteMemberReads(
   expr: IR1Expr,
   member: Extract<IR1Expr, { kind: "member" }>,
   replacement: IR1Expr,
+  bound: ReadonlySet<string> = new Set(),
 ): IR1Expr {
-  if (sameMemberExpr(expr, member)) {
+  if (sameUnshadowedMemberExpr(expr, member, bound)) {
     return replacement;
   }
   switch (expr.kind) {
@@ -746,61 +747,89 @@ function substituteMemberReads(
     case "binop":
       return {
         ...expr,
-        lhs: substituteMemberReads(expr.lhs, member, replacement),
-        rhs: substituteMemberReads(expr.rhs, member, replacement),
+        lhs: substituteMemberReads(expr.lhs, member, replacement, bound),
+        rhs: substituteMemberReads(expr.rhs, member, replacement, bound),
       };
     case "unop":
       return {
         ...expr,
-        arg: substituteMemberReads(expr.arg, member, replacement),
+        arg: substituteMemberReads(expr.arg, member, replacement, bound),
       };
     case "app":
       return {
         ...expr,
-        callee: substituteMemberReads(expr.callee, member, replacement),
+        callee: substituteMemberReads(expr.callee, member, replacement, bound),
         args: expr.args.map((arg) =>
-          substituteMemberReads(arg, member, replacement),
+          substituteMemberReads(arg, member, replacement, bound),
         ),
       };
     case "member":
       return {
         ...expr,
-        receiver: substituteMemberReads(expr.receiver, member, replacement),
+        receiver: substituteMemberReads(
+          expr.receiver,
+          member,
+          replacement,
+          bound,
+        ),
       };
     case "cond":
       return {
         ...expr,
         arms: expr.arms.map(([guard, value]) => [
-          substituteMemberReads(guard, member, replacement),
-          substituteMemberReads(value, member, replacement),
+          substituteMemberReads(guard, member, replacement, bound),
+          substituteMemberReads(value, member, replacement, bound),
         ]),
-        otherwise: substituteMemberReads(expr.otherwise, member, replacement),
+        otherwise: substituteMemberReads(
+          expr.otherwise,
+          member,
+          replacement,
+          bound,
+        ),
       };
     case "is-nullish":
       return {
         ...expr,
-        operand: substituteMemberReads(expr.operand, member, replacement),
+        operand: substituteMemberReads(
+          expr.operand,
+          member,
+          replacement,
+          bound,
+        ),
       };
-    case "each":
+    case "each": {
+      const nextBound = new Set(bound);
+      nextBound.add(expr.binder);
       return {
         ...expr,
-        src: substituteMemberReads(expr.src, member, replacement),
+        src: substituteMemberReads(expr.src, member, replacement, bound),
         guards: expr.guards.map((guard) =>
-          substituteMemberReads(guard, member, replacement),
+          substituteMemberReads(guard, member, replacement, nextBound),
         ),
-        proj: substituteMemberReads(expr.proj, member, replacement),
+        proj: substituteMemberReads(expr.proj, member, replacement, nextBound),
       };
+    }
     case "map-read":
       return {
         ...expr,
-        receiver: substituteMemberReads(expr.receiver, member, replacement),
-        key: substituteMemberReads(expr.key, member, replacement),
+        receiver: substituteMemberReads(
+          expr.receiver,
+          member,
+          replacement,
+          bound,
+        ),
+        key: substituteMemberReads(expr.key, member, replacement, bound),
       };
     case "set-read":
       return {
         ...expr,
-        receiver: substituteMemberReads(expr.receiver, member, replacement),
-        elem: substituteMemberReads(expr.elem, member, replacement),
+        receiver: substituteMemberReads(
+          expr.receiver,
+          member,
+          replacement,
+          bound,
+        ),
+        elem: substituteMemberReads(expr.elem, member, replacement, bound),
       };
     default: {
       const _exhaustive: never = expr;
@@ -992,8 +1021,11 @@ function containsNonTargetMemberRead(
   target: Extract<IR1Expr, { kind: "member" }>,
 ): boolean {
   let found = false;
-  walkExpr(expr, (node) => {
-    if (node.kind === "member" && !sameMemberExpr(node, target)) {
+  walkExpr(expr, (node, bound) => {
+    if (
+      node.kind === "member" &&
+      !sameUnshadowedMemberExpr(node, target, bound)
+    ) {
       found = true;
     }
   });
@@ -1005,66 +1037,93 @@ function containsTargetMemberRead(
   target: Extract<IR1Expr, { kind: "member" }>,
 ): boolean {
   let found = false;
-  walkExpr(expr, (node) => {
-    if (sameMemberExpr(node, target)) {
+  walkExpr(expr, (node, bound) => {
+    if (sameUnshadowedMemberExpr(node, target, bound)) {
       found = true;
     }
   });
   return found;
 }
 
-function walkExpr(expr: IR1Expr, visit: (expr: IR1Expr) => void): void {
-  visit(expr);
+function walkExpr(
+  expr: IR1Expr,
+  visit: (expr: IR1Expr, bound: ReadonlySet<string>) => void,
+  bound: ReadonlySet<string> = new Set(),
+): void {
+  visit(expr, bound);
   switch (expr.kind) {
     case "var":
     case "lit":
       break;
     case "binop":
-      walkExpr(expr.lhs, visit);
-      walkExpr(expr.rhs, visit);
+      walkExpr(expr.lhs, visit, bound);
+      walkExpr(expr.rhs, visit, bound);
       break;
     case "unop":
-      walkExpr(expr.arg, visit);
+      walkExpr(expr.arg, visit, bound);
       break;
     case "app":
-      walkExpr(expr.callee, visit);
+      walkExpr(expr.callee, visit, bound);
       for (const arg of expr.args) {
-        walkExpr(arg, visit);
+        walkExpr(arg, visit, bound);
       }
       break;
     case "member":
-      walkExpr(expr.receiver, visit);
+      walkExpr(expr.receiver, visit, bound);
       break;
     case "cond":
       for (const [guard, value] of expr.arms) {
-        walkExpr(guard, visit);
-        walkExpr(value, visit);
+        walkExpr(guard, visit, bound);
+        walkExpr(value, visit, bound);
       }
-      walkExpr(expr.otherwise, visit);
+      walkExpr(expr.otherwise, visit, bound);
       break;
     case "is-nullish":
-      walkExpr(expr.operand, visit);
+      walkExpr(expr.operand, visit, bound);
       break;
-    case "each":
-      walkExpr(expr.src, visit);
+    case "each": {
+      walkExpr(expr.src, visit, bound);
+      const nextBound = new Set(bound);
+      nextBound.add(expr.binder);
       for (const guard of expr.guards) {
-        walkExpr(guard, visit);
+        walkExpr(guard, visit, nextBound);
       }
-      walkExpr(expr.proj, visit);
+      walkExpr(expr.proj, visit, nextBound);
       break;
+    }
     case "map-read":
-      walkExpr(expr.receiver, visit);
-      walkExpr(expr.key, visit);
+      walkExpr(expr.receiver, visit, bound);
+      walkExpr(expr.key, visit, bound);
       break;
     case "set-read":
-      walkExpr(expr.receiver, visit);
-      walkExpr(expr.elem, visit);
+      walkExpr(expr.receiver, visit, bound);
+      walkExpr(expr.elem, visit, bound);
       break;
     default: {
       const _exhaustive: never = expr;
       void _exhaustive;
     }
   }
+}
+
+function sameUnshadowedMemberExpr(
+  expr: IR1Expr,
+  member: Extract<IR1Expr, { kind: "member" }>,
+  bound: ReadonlySet<string>,
+): boolean {
+  return (
+    expr.kind === "member" &&
+    !memberReceiverRootIsBound(expr, bound) &&
+    sameMemberExpr(expr, member)
+  );
+}
+
+function memberReceiverRootIsBound(
+  expr: Extract<IR1Expr, { kind: "member" }>,
+  bound: ReadonlySet<string>,
+): boolean {
+  const root = rootName(expr.receiver);
+  return root !== null && bound.has(root);
 }
 
 function ir1ExprEqual(a: IR1Expr, b: IR1Expr): boolean {

--- a/tools/ts2pant/src/ir1-ssa-fixed-point.ts
+++ b/tools/ts2pant/src/ir1-ssa-fixed-point.ts
@@ -32,7 +32,7 @@ import {
   type NumericStrategy,
   type SynthCell,
 } from "./translate-types.js";
-import type { PropResult } from "./types.js";
+import type { PantDeclaration, PropResult } from "./types.js";
 
 export interface FixedPointLoopLowerOptions extends LoopSsaBuildOptions {
   lowerOpaque?: (e: OpaqueExpr) => OpaqueExpr;
@@ -40,6 +40,7 @@ export interface FixedPointLoopLowerOptions extends LoopSsaBuildOptions {
   synthCell?: SynthCell;
   locationType?: OpaqueTypeExpr | string;
   invariantTypes?: ReadonlyMap<string, OpaqueTypeExpr | string>;
+  declarations?: readonly PantDeclaration[];
   strategy?: NumericStrategy;
 }
 
@@ -190,10 +191,21 @@ export function lowerFixedPointLoopL1Body(
   });
 
   const ruleName = allocateLoopRuleName(options.synthCell);
-  const locationType = typeExpr(options.locationType, options.strategy);
+  const inferredInvariantTypes = inferInvariantTypes(
+    invariantNames,
+    options.declarations,
+  );
+  const locationType = typeExpr(
+    options.locationType ??
+      inferLocationType(targetInfo.location.ruleName, options.declarations),
+    options.strategy,
+  );
   const invariantParams = invariantNames.map((name) => ({
     name,
-    type: typeExpr(options.invariantTypes?.get(name), options.strategy),
+    type: typeExpr(
+      options.invariantTypes?.get(name) ?? inferredInvariantTypes.get(name),
+      options.strategy,
+    ),
   }));
   const effect = lowerOpaque(lowerExpr(lowerL1Expr(effectExpr)));
   const loweredGuard = lowerOpaque(
@@ -289,6 +301,38 @@ function typeExpr(
   return typeof type === "string"
     ? ast.tName(type)
     : (type ?? ast.tName(strategy.mapNumber()));
+}
+
+function inferLocationType(
+  ruleName: string,
+  declarations: readonly PantDeclaration[] | undefined,
+): string | undefined {
+  return declarations?.find(
+    (decl): decl is Extract<PantDeclaration, { kind: "rule" }> =>
+      decl.kind === "rule" && decl.name === ruleName,
+  )?.returnType;
+}
+
+function inferInvariantTypes(
+  names: readonly string[],
+  declarations: readonly PantDeclaration[] | undefined,
+): ReadonlyMap<string, string> {
+  const wanted = new Set(names);
+  const out = new Map<string, string>();
+  if (wanted.size === 0 || declarations === undefined) {
+    return out;
+  }
+  for (const decl of declarations) {
+    if (decl.kind !== "action") {
+      continue;
+    }
+    for (const param of decl.params) {
+      if (wanted.has(param.name) && !out.has(param.name)) {
+        out.set(param.name, param.type);
+      }
+    }
+  }
+  return out;
 }
 
 function allocateLoopRuleName(synthCell: SynthCell | undefined): string {

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -4653,6 +4653,10 @@ function buildL1LetWhileFixedPointMutation(
     return null;
   }
 
+  if (!ts.isBlock(whileStmt.statement)) {
+    return null;
+  }
+
   const initExpr = buildL1SubExpr(decl.initializer, ctx);
   if (isUnsupported(initExpr)) {
     return initExpr;
@@ -4667,9 +4671,6 @@ function buildL1LetWhileFixedPointMutation(
   const cond = buildL1SubExpr(whileStmt.expression, ctx);
   if (isUnsupported(cond)) {
     return cond;
-  }
-  if (!ts.isBlock(whileStmt.statement)) {
-    return null;
   }
   const bodyStmt = buildSupportedSsaMutatingBody(
     whileStmt.statement,

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -4095,6 +4095,7 @@ function translateMutatingBody(
       supply: makeUniqueSupply(synthCell),
       initialPropertyValues: new Map(),
       helperNameBase: functionName,
+      declarations,
     }),
     declarations,
   );
@@ -4114,6 +4115,7 @@ function lowerSupportedSsaMutatingStatements(
     supply: UniqueSupply;
     initialPropertyValues: ReadonlyMap<string, OpaqueExpr>;
     helperNameBase: string;
+    declarations: readonly PantDeclaration[];
   },
 ): IR1SsaBodyLowerResult {
   const firstEarlyExit = stmts.findIndex(
@@ -4266,6 +4268,7 @@ function lowerSupportedSsaMutatingBlock(
     supply: UniqueSupply;
     initialPropertyValues: ReadonlyMap<string, OpaqueExpr>;
     helperNameBase: string;
+    declarations: readonly PantDeclaration[];
   },
 ): IR1SsaBodyLowerResult {
   const body = ts.factory.createBlock(stmts, true);
@@ -4288,6 +4291,7 @@ function lowerSupportedSsaMutatingBlock(
     applyConst: (e) => applyOpaqueAliases(e, ctx.supply),
     initialPropertyValues: ctx.initialPropertyValues,
     strategy: ctx.strategy,
+    declarations: ctx.declarations,
     ...(ctx.supply.synthCell === undefined
       ? {}
       : { synthCell: ctx.supply.synthCell }),

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -11,6 +11,7 @@ import {
   ir1Let,
   ir1LitNat,
   ir1Var,
+  ir1While,
 } from "./ir1.js";
 import {
   buildL1Conditional,
@@ -1154,6 +1155,7 @@ export function translateBody(opts: TranslateBodyOptions): PropResult[] {
   } else {
     return translateMutatingBody(
       node,
+      baseName,
       checker,
       strategy,
       paramNames,
@@ -4073,6 +4075,7 @@ function extractArrowBody(
 
 function translateMutatingBody(
   node: ts.FunctionDeclaration | ts.MethodDeclaration,
+  functionName: string,
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
   paramNames: Map<string, string>,
@@ -4091,6 +4094,7 @@ function translateMutatingBody(
       state: makeSymbolicState(),
       supply: makeUniqueSupply(synthCell),
       initialPropertyValues: new Map(),
+      helperNameBase: functionName,
     }),
     declarations,
   );
@@ -4109,6 +4113,7 @@ function lowerSupportedSsaMutatingStatements(
     state: SymbolicState;
     supply: UniqueSupply;
     initialPropertyValues: ReadonlyMap<string, OpaqueExpr>;
+    helperNameBase: string;
   },
 ): IR1SsaBodyLowerResult {
   const firstEarlyExit = stmts.findIndex(
@@ -4190,6 +4195,7 @@ function lowerSupportedSsaMutatingStatements(
   const continuationResult = lowerSupportedSsaMutatingStatements(continuation, {
     ...ctx,
     initialPropertyValues: propertyValues,
+    helperNameBase: ctx.helperNameBase,
   });
   if (continuationResult.diagnostics.length > 0) {
     return continuationResult;
@@ -4259,6 +4265,7 @@ function lowerSupportedSsaMutatingBlock(
     state: SymbolicState;
     supply: UniqueSupply;
     initialPropertyValues: ReadonlyMap<string, OpaqueExpr>;
+    helperNameBase: string;
   },
 ): IR1SsaBodyLowerResult {
   const body = ts.factory.createBlock(stmts, true);
@@ -4280,6 +4287,10 @@ function lowerSupportedSsaMutatingBlock(
   return lowerL1BodyToSsaProps(ssaBody, [], {
     applyConst: (e) => applyOpaqueAliases(e, ctx.supply),
     initialPropertyValues: ctx.initialPropertyValues,
+    strategy: ctx.strategy,
+    ...(ctx.supply.synthCell === undefined
+      ? {}
+      : { synthCell: ctx.supply.synthCell }),
   });
 }
 
@@ -4369,6 +4380,26 @@ function buildSupportedSsaMutatingBody(
       );
       if (built !== null) {
         stmts.push(built);
+        i += 1;
+        continue;
+      }
+      const fixedPointBuilt = buildL1LetWhileFixedPointMutation(
+        stmt,
+        body.statements[i + 1]! as ts.WhileStatement,
+        {
+          checker,
+          strategy,
+          paramNames: scopedParamNames,
+          state,
+          supply,
+          applyConst,
+        },
+      );
+      if (isUnsupported(fixedPointBuilt)) {
+        return fixedPointBuilt;
+      }
+      if (fixedPointBuilt !== null) {
+        stmts.push(fixedPointBuilt);
         i += 1;
         continue;
       }
@@ -4486,15 +4517,16 @@ function buildSupportedSsaStatement(
     if (ts.isCallExpression(expr)) {
       return buildL1EffectCall(expr, ctx);
     }
-    if (ts.isBinaryExpression(expr)) {
+    if (
+      ts.isBinaryExpression(expr) ||
+      ts.isPrefixUnaryExpression(expr) ||
+      ts.isPostfixUnaryExpression(expr)
+    ) {
       return buildL1AssignStmt(stmt, ctx);
     }
   }
   if (ts.isWhileStatement(stmt)) {
-    return {
-      unsupported:
-        "while loop is not a recognized bounded-counter shape; lift to L4 fixed-point lowering when that milestone ships",
-    };
+    return buildL1BareWhileMutation(stmt, ctx);
   }
   if (ts.isForInStatement(stmt) || ts.isDoStatement(stmt)) {
     return { unsupported: "loop assignment" };
@@ -4502,6 +4534,37 @@ function buildSupportedSsaStatement(
   return {
     unsupported: `statement is not supported by unified SSA body lowering: ${ts.SyntaxKind[stmt.kind]}`,
   };
+}
+
+function buildL1BareWhileMutation(
+  stmt: ts.WhileStatement,
+  ctx: BuildBodyCtx & { paramNames: Map<string, string> },
+): IR1Stmt | { unsupported: string } {
+  const expr = unwrapExpression(stmt.expression);
+  if (expr.kind === ts.SyntaxKind.TrueKeyword) {
+    return {
+      unsupported:
+        "while loop has no observable termination condition (literal-true guard); rewrite with a guard that depends on mutated state",
+    };
+  }
+  const cond = buildL1SubExpr(stmt.expression, ctx);
+  if (isUnsupported(cond)) {
+    return cond;
+  }
+  const bodyStmt = ts.isBlock(stmt.statement)
+    ? buildSupportedSsaMutatingBody(
+        stmt.statement,
+        ctx.checker,
+        ctx.strategy,
+        ctx.paramNames,
+        ctx.state,
+        ctx.supply,
+      )
+    : buildSupportedSsaStatement(stmt.statement, ctx);
+  if (isUnsupported(bodyStmt)) {
+    return bodyStmt;
+  }
+  return ir1While(cond, bodyStmt);
 }
 
 function buildL1ForCounterMutation(
@@ -4566,6 +4629,56 @@ function buildL1ForCounterMutation(
   }
 
   return ir1For(init.initStmt, cond, step, bodyStmt);
+}
+
+function buildL1LetWhileFixedPointMutation(
+  letStmt: ts.VariableStatement,
+  whileStmt: ts.WhileStatement,
+  ctx: BuildBodyCtx & { paramNames: Map<string, string> },
+): IR1Stmt | { unsupported: string } | null {
+  const declList = letStmt.declarationList;
+  if (
+    !(declList.flags & ts.NodeFlags.Let) ||
+    declList.declarations.length !== 1
+  ) {
+    return null;
+  }
+
+  const decl = declList.declarations[0]!;
+  if (!ts.isIdentifier(decl.name) || decl.initializer === undefined) {
+    return null;
+  }
+
+  const initExpr = buildL1SubExpr(decl.initializer, ctx);
+  if (isUnsupported(initExpr)) {
+    return initExpr;
+  }
+  const expr = unwrapExpression(whileStmt.expression);
+  if (expr.kind === ts.SyntaxKind.TrueKeyword) {
+    return {
+      unsupported:
+        "while loop has no observable termination condition (literal-true guard); rewrite with a guard that depends on mutated state",
+    };
+  }
+  const cond = buildL1SubExpr(whileStmt.expression, ctx);
+  if (isUnsupported(cond)) {
+    return cond;
+  }
+  if (!ts.isBlock(whileStmt.statement)) {
+    return null;
+  }
+  const bodyStmt = buildSupportedSsaMutatingBody(
+    whileStmt.statement,
+    ctx.checker,
+    ctx.strategy,
+    ctx.paramNames,
+    ctx.state,
+    ctx.supply,
+  );
+  if (isUnsupported(bodyStmt)) {
+    return bodyStmt;
+  }
+  return ir1Block([ir1Let(decl.name.text, initExpr), ir1While(cond, bodyStmt)]);
 }
 
 function buildL1LetWhileMutation(

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -783,7 +783,7 @@ exports[`functions-mutating-bounded-while.ts > sumFirstNWhile 1`] = `
 `;
 
 exports[`functions-mutating-bounded-while.ts > unboundedWhile 1`] = `
-"module UNBOUNDED_WHILE.\\n\\nAccount.\\naccount--total a1: Account => Int.\\naccount--last-index a1: Account => Int.\\n~> Unbounded-while @ a: Account, n: Int.\\n\\n---\\n\\n> UNSUPPORTED: while loop is not a recognized bounded-counter shape; lift to L4 fixed-point lowering when that milestone ships.\\n"
+"module UNBOUNDED_WHILE.\\n\\nAccount.\\naccount--total a1: Account => Int.\\naccount--last-index a1: Account => Int.\\n~> Unbounded-while @ a: Account, n: Int.\\n\\n---\\n\\n> UNSUPPORTED: fixed-point while lowering supports guards and updates over the mutated property only.\\n"
 `;
 
 exports[`functions-mutating-compound.ts > addAmount 1`] = `
@@ -904,6 +904,22 @@ exports[`functions-mutating-early-exit.ts > elseReturnThenMore 1`] = `
 
 exports[`functions-mutating-early-exit.ts > writeThenEarlyReturn 1`] = `
 "module WRITE_THEN_EARLY_RETURN.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--owner a1: Account => String.\\n~> Write-then-early-return @ a: Account, g: Bool.\\n\\n---\\n\\naccount--balance' a = (cond ~g => 10 + 5, true => 10).\\naccount--owner' a1 = account--owner a1.\\n"
+`;
+
+exports[`functions-mutating-fixed-point-while.ts > adjustBalanceTo 1`] = `
+"module ADJUST_BALANCE_TO.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--size a1: Account => Int.\\naccount--tick-count a1: Account => Int.\\nfn--loop s: Int, step: Int, target: Int => Int = cond s < target => fn--loop (s + step) step target, true => s.\\n~> Adjust-balance-to @ a: Account, target: Int, step: Int.\\n\\n---\\n\\naccount--balance' a = fn--loop (account--balance a) step target.\\naccount--size' a1 = account--size a1.\\naccount--tick-count' a1 = account--tick-count a1.\\n"
+`;
+
+exports[`functions-mutating-fixed-point-while.ts > drainTo 1`] = `
+"module DRAIN_TO.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--size a1: Account => Int.\\naccount--tick-count a1: Account => Int.\\nfn--loop s: Int, floor: Int => Int = cond s > floor => fn--loop (s - 1) floor, true => s.\\n~> Drain-to @ a: Account, floor: Int.\\n\\n---\\n\\naccount--balance' a = fn--loop (account--balance a) floor.\\naccount--size' a1 = account--size a1.\\naccount--tick-count' a1 = account--tick-count a1.\\n"
+`;
+
+exports[`functions-mutating-fixed-point-while.ts > fillUpTo 1`] = `
+"module FILL_UP_TO.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--size a1: Account => Int.\\naccount--tick-count a1: Account => Int.\\nfn--loop s: Int, cap: Int => Int = cond s < cap => fn--loop (s + 1) cap, true => s.\\n~> Fill-up-to @ a: Account, cap: Int.\\n\\n---\\n\\naccount--size' a = fn--loop (account--size a) cap.\\naccount--balance' a1 = account--balance a1.\\naccount--tick-count' a1 = account--tick-count a1.\\n"
+`;
+
+exports[`functions-mutating-fixed-point-while.ts > spin 1`] = `
+"module SPIN.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--size a1: Account => Int.\\naccount--tick-count a1: Account => Int.\\n~> Spin @ a: Account.\\n\\n---\\n\\n> UNSUPPORTED: while loop has no observable termination condition (literal-true guard); rewrite with a guard that depends on mutated state.\\n"
 `;
 
 exports[`functions-mutating-loop.ts > activateActive 1`] = `

--- a/tools/ts2pant/tests/emit.test.mts
+++ b/tools/ts2pant/tests/emit.test.mts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import { before, describe, it } from "node:test";
 import { emitDocument } from "../src/emit.js";
+import { getAst, loadAst } from "../src/pant-wasm.js";
 import type { PantDocument } from "../src/types.js";
 
 function emptyDoc(overrides: Partial<PantDocument> = {}): PantDocument {
@@ -13,6 +14,10 @@ function emptyDoc(overrides: Partial<PantDocument> = {}): PantDocument {
     ...overrides,
   };
 }
+
+before(async () => {
+  await loadAst();
+});
 
 describe("emit", () => {
   it("document with no imports is byte-stable vs. pre-patch snapshot", () => {
@@ -33,5 +38,22 @@ describe("emit", () => {
     assert.equal(lines[1], "import JS_MATH.");
     assert.equal(lines[2], "import FOO_AMBIENT.");
     assert.equal(lines[3], "");
+  });
+
+  it("preserves guards on zero-parameter action declarations", () => {
+    const out = emitDocument(
+      emptyDoc({
+        declarations: [
+          {
+            kind: "action",
+            label: "Tick",
+            params: [],
+            guard: getAst().var("ready"),
+          },
+        ],
+      }),
+    );
+
+    assert.match(out, /~> Tick @ ready\./u);
   });
 });

--- a/tools/ts2pant/tests/fixtures/constructs/functions-mutating-fixed-point-while.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/functions-mutating-fixed-point-while.ts
@@ -1,0 +1,33 @@
+interface Account {
+  balance: number;
+  size: number;
+  tickCount: number;
+}
+
+export function adjustBalanceTo(
+  a: Account,
+  target: number,
+  step: number,
+): void {
+  while (a.balance < target) {
+    a.balance += step;
+  }
+}
+
+export function fillUpTo(a: Account, cap: number): void {
+  while (a.size < cap) {
+    a.size++;
+  }
+}
+
+export function drainTo(a: Account, floor: number): void {
+  while (a.balance > floor) {
+    a.balance -= 1;
+  }
+}
+
+export function spin(a: Account): void {
+  while (true) {
+    a.tickCount++;
+  }
+}

--- a/tools/ts2pant/tests/helpers.mts
+++ b/tools/ts2pant/tests/helpers.mts
@@ -1,7 +1,11 @@
 import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
-import { emitDocument } from "../src/emit.js";
+import {
+  emitDocument,
+  runCheck as runCheckWithOptions,
+  type CheckOptions,
+} from "../src/emit.js";
 import { createSourceFile, type SourceFile } from "../src/extract.js";
 import { assertWasmTypeChecks } from "../src/pant-wasm.js";
 import { buildPantDocument } from "../src/pipeline.js";
@@ -92,6 +96,17 @@ export async function buildDocumentFromSourceFile(
 }
 
 export { emitDocument };
+
+export function runCheck(
+  output: string,
+  opts: Omit<CheckOptions, "projectRoot" | "pantBin"> = {},
+) {
+  return runCheckWithOptions(output, {
+    projectRoot: PROJECT_ROOT,
+    pantBin: getPantBin(),
+    ...opts,
+  });
+}
 
 /**
  * Emit a PantDocument and verify that the resulting Pantagruel text

--- a/tools/ts2pant/tests/integration/e2e.test.mts
+++ b/tools/ts2pant/tests/integration/e2e.test.mts
@@ -3,7 +3,6 @@ import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { describe, it } from "node:test";
 import { extractFunctionAnnotations } from "../../src/annotations.js";
-import { runCheck } from "../../src/emit.js";
 import { createSourceFile } from "../../src/extract.js";
 import type { PantDocument } from "../../src/types.js";
 import {
@@ -12,6 +11,7 @@ import {
   buildDocument as buildDocumentFromPath,
   emitAndCheck,
   getPantBin,
+  runCheck,
 } from "../helpers.mjs";
 
 const FIXTURES = resolve(import.meta.dirname, "../fixtures");
@@ -190,6 +190,7 @@ describe("emission snapshots", () => {
 
 describe("pant --check", () => {
   const hasSolver = solverAvailable();
+  const KNOWN_SLOW_CHECKS: Set<string> = new Set();
 
   it("max.ts assertions pass", {
     skip: !hasSolver ? "z3 not available" : undefined,
@@ -307,6 +308,26 @@ describe("pant --check", () => {
       const result = runCheck(output, {
         projectRoot: PROJECT_ROOT,
         pantBin: getPantBin(),
+      });
+
+      assert.equal(result.passed, true);
+      assert.ok(result.checks.length > 0);
+      assert.ok(result.checks.every((c) => c.passed));
+    });
+  }
+
+  for (const fn of ["adjustBalanceTo", "fillUpTo", "drainTo"]) {
+    const fixture = `constructs/functions-mutating-fixed-point-while.ts:${fn}`;
+    it(`functions-mutating-fixed-point-while.ts ${fn} is checkable`, {
+      skip: !hasSolver ? "z3 not available" : undefined,
+    }, async () => {
+      const doc = await buildDocument(
+        "constructs/functions-mutating-fixed-point-while.ts",
+        fn,
+      );
+      const output = await emitAndCheck(doc);
+      const result = runCheck(output, {
+        timeoutMs: KNOWN_SLOW_CHECKS.has(fixture) ? 60_000 : 3_000,
       });
 
       assert.equal(result.passed, true);

--- a/tools/ts2pant/tests/integration/e2e.test.mts
+++ b/tools/ts2pant/tests/integration/e2e.test.mts
@@ -6,11 +6,9 @@ import { extractFunctionAnnotations } from "../../src/annotations.js";
 import { createSourceFile } from "../../src/extract.js";
 import type { PantDocument } from "../../src/types.js";
 import {
-  PROJECT_ROOT,
   assertPantTypeChecks,
   buildDocument as buildDocumentFromPath,
   emitAndCheck,
-  getPantBin,
   runCheck,
 } from "../helpers.mjs";
 
@@ -197,10 +195,7 @@ describe("pant --check", () => {
   }, async () => {
     const doc = await buildDocument("max.ts", "larger");
     const output = await emitAndCheck(doc);
-    const result = runCheck(output, {
-      projectRoot: PROJECT_ROOT,
-      pantBin: getPantBin(),
-    });
+    const result = runCheck(output);
 
     assert.equal(result.passed, true);
     assert.ok(result.checks.length > 0);
@@ -212,10 +207,7 @@ describe("pant --check", () => {
   }, async () => {
     const doc = await buildDocument("deposit.ts", "deposit");
     const output = await emitAndCheck(doc);
-    const result = runCheck(output, {
-      projectRoot: PROJECT_ROOT,
-      pantBin: getPantBin(),
-    });
+    const result = runCheck(output);
 
     assert.equal(result.passed, true);
     assert.ok(result.checks.length > 0);
@@ -227,10 +219,7 @@ describe("pant --check", () => {
   }, async () => {
     const doc = await buildDocument("apply-fee.ts", "applyFee");
     const output = await emitAndCheck(doc);
-    const result = runCheck(output, {
-      projectRoot: PROJECT_ROOT,
-      pantBin: getPantBin(),
-    });
+    const result = runCheck(output);
 
     assert.equal(result.passed, true);
     assert.ok(result.checks.length > 0);
@@ -245,10 +234,7 @@ describe("pant --check", () => {
       "sumFirstN",
     );
     const output = await emitAndCheck(doc);
-    const result = runCheck(output, {
-      projectRoot: PROJECT_ROOT,
-      pantBin: getPantBin(),
-    });
+    const result = runCheck(output);
 
     assert.equal(result.passed, true);
     assert.ok(result.checks.length > 0);
@@ -263,10 +249,7 @@ describe("pant --check", () => {
       "sumIfPositiveFirstN",
     );
     const output = await emitAndCheck(doc);
-    const result = runCheck(output, {
-      projectRoot: PROJECT_ROOT,
-      pantBin: getPantBin(),
-    });
+    const result = runCheck(output);
 
     assert.equal(result.passed, true);
     assert.ok(result.checks.length > 0);
@@ -281,10 +264,7 @@ describe("pant --check", () => {
       "setLastIndex",
     );
     const output = await emitAndCheck(doc);
-    const result = runCheck(output, {
-      projectRoot: PROJECT_ROOT,
-      pantBin: getPantBin(),
-    });
+    const result = runCheck(output);
 
     assert.equal(result.passed, true);
     assert.ok(result.checks.length > 0);
@@ -305,10 +285,7 @@ describe("pant --check", () => {
         fn,
       );
       const output = await emitAndCheck(doc);
-      const result = runCheck(output, {
-        projectRoot: PROJECT_ROOT,
-        pantBin: getPantBin(),
-      });
+      const result = runCheck(output);
 
       assert.equal(result.passed, true);
       assert.ok(result.checks.length > 0);

--- a/tools/ts2pant/tests/ir1-ssa-fixed-point.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-fixed-point.test.mts
@@ -217,6 +217,41 @@ describe("ir1-ssa-fixed-point", () => {
     assert.match(ast.strExpr(ruleDecl.body), /target \+ step \+ step/u);
   });
 
+  it("does not treat target-shaped member reads under each binders as the loop target", () => {
+    const result = lowerFixedPointLoopL1Body({
+      ...fixedPointWhile(),
+      body: {
+        kind: "assign",
+        target: balanceMember,
+        value: {
+          kind: "binop",
+          op: "add",
+          lhs: balanceMember,
+          rhs: {
+            kind: "unop",
+            op: "card",
+            arg: {
+              kind: "each",
+              binder: "a",
+              src: { kind: "var", name: "accounts" },
+              guards: [],
+              proj: {
+                kind: "member",
+                receiver: { kind: "var", name: "a" },
+                name: "balance",
+              },
+            },
+          },
+        },
+      },
+    });
+
+    assert.match(
+      result.diagnostics[0]?.reason ?? "",
+      /supports guards and updates over the mutated property only/u,
+    );
+  });
+
   it("uses the configured numeric strategy for default helper types", () => {
     const ast = getAst();
     const result = lowerFixedPointLoopL1Body(fixedPointWhile(), {

--- a/tools/ts2pant/tests/ir1-ssa-fixed-point.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-fixed-point.test.mts
@@ -152,7 +152,7 @@ describe("ir1-ssa-fixed-point", () => {
     });
     assert.match(
       source,
-      /fn--loop s: Nat0, step: Nat0, target: Nat0 => Nat0\./u,
+      /fn--loop s: Nat0, step: Nat0, target: Nat0 => Nat0 = cond/u,
     );
     assert.match(source, /balance' a = fn--loop \(balance a\) step target\./u);
   });
@@ -172,6 +172,48 @@ describe("ir1-ssa-fixed-point", () => {
       ["s1", "s", "step"],
     );
     assert.match(ast.strExpr(ruleDecl.body), /cond s1 < s =>/u);
+  });
+
+  it("inlines let-then-while preludes transitively before collecting invariants", () => {
+    const ast = getAst();
+    const result = lowerFixedPointLoopL1Body({
+      kind: "block",
+      stmts: [
+        {
+          kind: "let",
+          name: "limit",
+          value: { kind: "binop", op: "add", lhs: targetVar, rhs: stepVar },
+        },
+        {
+          kind: "let",
+          name: "cap",
+          value: {
+            kind: "binop",
+            op: "add",
+            lhs: { kind: "var", name: "limit" },
+            rhs: stepVar,
+          },
+        },
+        {
+          ...fixedPointWhile(),
+          cond: {
+            kind: "binop",
+            op: "lt",
+            lhs: balanceMember,
+            rhs: { kind: "var", name: "cap" },
+          },
+        },
+      ],
+    });
+    const ruleDecl = result.propositions[0]!;
+
+    assert.equal(ruleDecl.kind, "rule-decl");
+    assert.deepEqual(
+      ruleDecl.params.map((p) => p.name),
+      ["s", "step", "target"],
+    );
+    assert.doesNotMatch(ast.strExpr(ruleDecl.body), /\b(limit|cap)\b/u);
+    assert.match(ast.strExpr(ruleDecl.body), /target \+ step \+ step/u);
   });
 
   it("uses the configured numeric strategy for default helper types", () => {

--- a/tools/ts2pant/tests/ir1-ssa-fixed-point.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-fixed-point.test.mts
@@ -7,6 +7,7 @@ import {
   lowerFixedPointLoopL1Body,
   recognizeFixedPointLoopShape,
 } from "../src/ir1-ssa-fixed-point.js";
+import { lowerL1BodyToSsaProps } from "../src/ir1-lower-body.js";
 import { getAst, loadAst } from "../src/pant-wasm.js";
 import { newSynthCell, RealStrategy } from "../src/translate-types.js";
 
@@ -228,6 +229,101 @@ describe("ir1-ssa-fixed-point", () => {
     assert.deepEqual(
       ruleDecl.params.map((p) => ast.strTypeExpr(p.type)),
       ["Real", "Real", "Real"],
+    );
+  });
+
+  it("infers helper state and invariant types from declarations", () => {
+    const ast = getAst();
+    const flagMember: IR1Expr = {
+      kind: "member",
+      receiver: aVar,
+      name: "flag",
+    };
+    const result = lowerFixedPointLoopL1Body(
+      {
+        kind: "while",
+        cond: {
+          kind: "binop",
+          op: "and",
+          lhs: flagMember,
+          rhs: { kind: "var", name: "enabled" },
+        },
+        body: {
+          kind: "assign",
+          target: flagMember,
+          value: { kind: "lit", value: { kind: "bool", value: false } },
+        },
+      },
+      {
+        declarations: [
+          { kind: "domain", name: "Account" },
+          {
+            kind: "rule",
+            name: "flag",
+            params: [{ name: "a", type: "Account" }],
+            returnType: "Bool",
+          },
+          {
+            kind: "action",
+            label: "Run",
+            params: [
+              { name: "a", type: "Account" },
+              { name: "enabled", type: "Bool" },
+            ],
+          },
+        ],
+      },
+    );
+    const ruleDecl = result.propositions[0]!;
+
+    assert.equal(ruleDecl.kind, "rule-decl");
+    assert.equal(ast.strTypeExpr(ruleDecl.returnType), "Bool");
+    assert.deepEqual(
+      ruleDecl.params.map((p) => ast.strTypeExpr(p.type)),
+      ["Bool", "Bool"],
+    );
+  });
+
+  it("threads declaration-derived types through the body-level adapter", () => {
+    const ast = getAst();
+    const flagMember: IR1Expr = {
+      kind: "member",
+      receiver: aVar,
+      name: "flag",
+    };
+    const result = lowerL1BodyToSsaProps(
+      {
+        kind: "while",
+        cond: flagMember,
+        body: {
+          kind: "assign",
+          target: flagMember,
+          value: { kind: "lit", value: { kind: "bool", value: false } },
+        },
+      },
+      [
+        { kind: "domain", name: "Account" },
+        {
+          kind: "rule",
+          name: "flag",
+          params: [{ name: "a", type: "Account" }],
+          returnType: "Bool",
+        },
+        {
+          kind: "action",
+          label: "Run",
+          params: [{ name: "a", type: "Account" }],
+        },
+      ],
+      { applyConst: (e) => e },
+    );
+    const ruleDecl = result.propositions[0]!;
+
+    assert.equal(ruleDecl.kind, "rule-decl");
+    assert.equal(ast.strTypeExpr(ruleDecl.returnType), "Bool");
+    assert.deepEqual(
+      ruleDecl.params.map((p) => ast.strTypeExpr(p.type)),
+      ["Bool"],
     );
   });
 });

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -340,12 +340,12 @@ describe("unsupported patterns", () => {
 
     assertUnsupportedReason(
       props,
-      /local variable declaration \(let\/var or effectful const\)/u,
-      "non-matching let-then-while should fall through to let rejection",
+      /assign target must be a property access/u,
+      "non-matching let-then-while should preserve the fixed-point body rejection",
     );
   });
 
-  it("rejects bare while loop with L4 fixed-point pointer", () => {
+  it("rejects bare while loop whose guard reads a different property", () => {
     const source = `
       interface Account { total: number; lastIndex: number }
       export function bareWhile(a: Account, n: number): void {
@@ -359,8 +359,8 @@ describe("unsupported patterns", () => {
 
     assertUnsupportedReason(
       props,
-      /while loop is not a recognized bounded-counter shape; lift to L4 fixed-point lowering when that milestone ships/u,
-      "bare while should reject with L4 pointer",
+      /fixed-point while lowering supports guards and updates over the mutated property only/u,
+      "bare while should reject when guard reads outside the mutated property",
     );
   });
 
@@ -1236,6 +1236,36 @@ describe("structured iteration (for-of, forEach, reduce)", () => {
     }
   });
 
+  it("Shape A: unary iterator property increment desugars through foreach", () => {
+    const source = `
+      interface User { score: number; }
+      function f(us: User[]): void {
+        for (const u of us) { u.score++; }
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "f",
+      strategy: IntStrategy,
+    });
+    const ast = getAst();
+    const eqs = props.filter((p) => p.kind === "equation");
+    const loopEq = eqs.find(
+      (e) => e.kind === "equation" && (e.guards?.length ?? 0) > 0,
+    );
+    assert.ok(loopEq, "expected one loop equation with a guard");
+    if (loopEq?.kind === "equation") {
+      const rendered = ast.strExpr(
+        ast.forall([], loopEq.guards ?? [], ast.var("__body__")),
+      );
+      const binder = rendered.match(/all (\$\d+) in us \| /)?.[1];
+      assert.ok(binder);
+      assert.equal(ast.strExpr(loopEq.lhs), `user--score' ${binder}`);
+      assert.equal(ast.strExpr(loopEq.rhs), `user--score ${binder} + 1`);
+    }
+  });
+
   it("Shape A: conditional iterator write delegates to symbolic-execute", () => {
     const source = `
       interface User { active: boolean; score: number; }
@@ -1854,6 +1884,37 @@ describe("structured iteration (for-of, forEach, reduce)", () => {
     if (totalEq?.kind === "equation") {
       // Shape B's `x.value` read must resolve through the in-iteration
       // Shape A write `value' x = value x + 1`, not the pre-state `value x`.
+      assert.match(
+        ast.strExpr(totalEq.rhs),
+        /^account--total a \+ \(\+ over each (\$\d+) in xs \| item--value \1 \+ 1\)$/,
+      );
+    }
+  });
+
+  it("Shape B reads observe unary Shape A writes in the same iteration", () => {
+    const source = `
+      interface Account { total: number; }
+      interface Item { value: number; }
+      function f(a: Account, xs: Item[]): void {
+        for (const x of xs) {
+          x.value++;
+          a.total += x.value;
+        }
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "f",
+      strategy: IntStrategy,
+    });
+    const ast = getAst();
+    const eqs = props.filter((p) => p.kind === "equation");
+    const totalEq = eqs.find(
+      (e) => e.kind === "equation" && ast.strExpr(e.lhs) === "account--total' a",
+    );
+    assert.ok(totalEq, "expected a Shape B equation for total");
+    if (totalEq?.kind === "equation") {
       assert.match(
         ast.strExpr(totalEq.rhs),
         /^account--total a \+ \(\+ over each (\$\d+) in xs \| item--value \1 \+ 1\)$/,
@@ -2480,15 +2541,58 @@ describe("Set mutation (Stage A: interface-field .add / .delete / .clear)", () =
 });
 
 describe("fixed-point while lowering", () => {
-  it.skip("desugars let-then-while pair that fails L3 bounded recognition to ir1While", () => {
-    // PENDING Patch 4: route failed L3 let-while recognition into ir1While.
+  it("desugars let-then-while pair that fails L3 bounded recognition to ir1While", () => {
+    const source = `
+      interface Account { total: number }
+      export function growFromSeed(a: Account, seed: number, target: number): void {
+        let i = seed;
+        while (a.total < target) {
+          a.total += 1;
+        }
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBodyWithSynth(sourceFile, "growFromSeed");
+
+    assert.ok(props.some((p) => p.kind === "rule-decl"));
+    assert.ok(props.some((p) => p.kind === "equation"));
   });
 
-  it.skip("builds ir1While for a bare while loop with non-literal guard", () => {
-    // PENDING Patch 4: build ir1While for supported bare while statements.
+  it("builds ir1While for a bare while loop with non-literal guard", () => {
+    const source = `
+      interface Account { total: number }
+      export function grow(a: Account, target: number): void {
+        while (a.total < target) {
+          a.total += 1;
+        }
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBodyWithSynth(sourceFile, "grow");
+
+    const helper = props.find((p) => p.kind === "rule-decl");
+    assert.ok(helper);
+    if (helper?.kind === "rule-decl") {
+      assert.match(helper.ruleName, /^fn--loop/u);
+    }
   });
 
-  it.skip("rejects while (true) with no-observable-termination diagnostic", () => {
-    // PENDING Patch 4: reject literal-true while guards in the build pass.
+  it("rejects while (true) with no-observable-termination diagnostic", () => {
+    const source = `
+      interface Account { total: number }
+      export function spin(a: Account): void {
+        while (true) {
+          a.total += 1;
+        }
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBodyWithSynth(sourceFile, "spin");
+
+    assertUnsupportedReason(
+      props,
+      /while loop has no observable termination condition \(literal-true guard\)/u,
+      "literal-true while guard should reject in the build pass",
+    );
   });
 });


### PR DESCRIPTION
## Patch 4: ts2pant: wire build path + lower path; ship fixtures + integration tests

- Implement `buildL1LetWhileFixedPointMutation(letStmt, whileStmt, ctx)` in `tools/ts2pant/src/translate-body.ts`. Build the let's init as L1, build the while's condition as L1, build the while's body as a Block of L1 statements (no trailing-step stripping — the body's mutations are what the fixed-point lowerer will analyse). Construct `ir1Block([ir1Let(counterName, initExpr), ir1While(condExpr, bodyStmt)])`. Returns `IR1Stmt | { unsupported: string } | null` — null on shape mismatch (the let isn't a simple binding, the while's body doesn't translate, etc.) to let the existing rejection fire.
- Modify the peephole at translate-body.ts:4374. When `buildL1LetWhileMutation` returns null, before falling through to the existing branches, call `buildL1LetWhileFixedPointMutation(stmt, whileStmt, ctx)`. On non-null IR1Stmt: push to stmts, increment i, continue. On null: fall through to the existing branches (the let rejection fires as today). On `unsupported`: return that as the overall body's rejection.
- Implement `buildL1BareWhileMutation(stmt, ctx)` in `tools/ts2pant/src/translate-body.ts`. Unwrap transparent expressions from `stmt.expression`. If the unwrapped expression is `ts.SyntaxKind.TrueKeyword` (literal true), return `{ unsupported: 'while loop has no observable termination condition (literal-true guard); rewrite with a guard that depends on mutated state' }`. Otherwise build the guard as L1, build the body as L1, return `ir1While(guardExpr, bodyStmt)`.
- Modify the WhileStatement catch-all at translate-body.ts:4493. Replace the unconditional rejection with `buildL1BareWhileMutation(stmt, ctx)`. The new helper handles both the literal-true reject and the successful L4 route.
- Add `lowerFixedPointL1BodyToSsaResult(stmt, options)` adapter in `tools/ts2pant/src/ir1-lower-body.ts`. Calls `lowerFixedPointLoopL1Body` from Patch 3's module, wraps the result in the `IR1SsaBodyLowerResult` shape consistent with the scalar/collection/counter-loop arms. Catches errors and converts them to `ir1SsaBodyLowerUnsupported`.
- Add the dispatch arm in `lowerL1BodyToSsaResult` at line ~114: `if (stmt.kind === 'while') { return lowerFixedPointL1BodyToSsaResult(stmt, options); }` — placed before the existing `kind: 'for'` arm. The existing arms are unchanged.
- Create `tools/ts2pant/tests/fixtures/constructs/functions-mutating-fixed-point-while.ts` with four exported functions: `adjustBalanceTo(a: Account, target: number, step: number): void` (`while (a.balance < target) { a.balance += step; }`), `fillUpTo(a: Account, cap: number): void` (`while (a.size < cap) { a.size++; }`), `drainTo(a: Account, floor: number): void` (`while (a.balance > floor) { a.balance -= 1; }`), and `spin(a: Account): void` (`while (true) { a.tickCount++; }` — deliberate-reject fixture). The `Account` interface uses fields appropriate for each fixture (balance, size, tickCount) — keep the interface compact.
- Run `just ts2pant-test-update-snapshots` and inspect `tools/ts2pant/tests/constructs.test.mts.snapshot` for the four new fixture entries: three passing fixtures each producing a `fn--loop` recursive helper rule + a primed-equation caller; the spin fixture producing `> UNSUPPORTED:` with the literal-true diagnostic.
- Add per-passing-fixture `pant --check` integration tests in `tools/ts2pant/tests/integration/e2e.test.mts`. Use the existing `runCheck` helper. Default timeout 3000ms. Add `const KNOWN_SLOW_CHECKS: Set<string> = new Set([...])` and add any fixture whose `--check` exceeds the default (likely none for the chosen single-location fixtures, but include the constant so future fixtures have a clear extension point).
- Unskip the three Patch-4-owned `tools/ts2pant/tests/translate-body.test.mts` stubs from Patch 1 and replace each PENDING-comment body with concrete assertions.
- Run `just ts2pant-test` and `just ts2pant-test-integration` to confirm all existing tests pass and the new ones do too.

## Changes
- Implement `buildL1LetWhileFixedPointMutation(letStmt, whileStmt, ctx)` in `tools/ts2pant/src/translate-body.ts`. Build the let's init as L1, build the while's condition as L1, build the while's body as a Block of L1 statements (no trailing-step stripping — the body's mutations are what the fixed-point lowerer will analyse). Construct `ir1Block([ir1Let(counterName, initExpr), ir1While(condExpr, bodyStmt)])`. Returns `IR1Stmt | { unsupported: string } | null` — null on shape mismatch (the let isn't a simple binding, the while's body doesn't translate, etc.) to let the existing rejection fire.
- Modify the peephole at translate-body.ts:4374. When `buildL1LetWhileMutation` returns null, before falling through to the existing branches, call `buildL1LetWhileFixedPointMutation(stmt, whileStmt, ctx)`. On non-null IR1Stmt: push to stmts, increment i, continue. On null: fall through to the existing branches (the let rejection fires as today). On `unsupported`: return that as the overall body's rejection.
- Implement `buildL1BareWhileMutation(stmt, ctx)` in `tools/ts2pant/src/translate-body.ts`. Unwrap transparent expressions from `stmt.expression`. If the unwrapped expression is `ts.SyntaxKind.TrueKeyword` (literal true), return `{ unsupported: 'while loop has no observable termination condition (literal-true guard); rewrite with a guard that depends on mutated state' }`. Otherwise build the guard as L1, build the body as L1, return `ir1While(guardExpr, bodyStmt)`.
- Modify the WhileStatement catch-all at translate-body.ts:4493. Replace the unconditional rejection with `buildL1BareWhileMutation(stmt, ctx)`. The new helper handles both the literal-true reject and the successful L4 route.
- Add `lowerFixedPointL1BodyToSsaResult(stmt, options)` adapter in `tools/ts2pant/src/ir1-lower-body.ts`. Calls `lowerFixedPointLoopL1Body` from Patch 3's module, wraps the result in the `IR1SsaBodyLowerResult` shape consistent with the scalar/collection/counter-loop arms. Catches errors and converts them to `ir1SsaBodyLowerUnsupported`.
- Add the dispatch arm in `lowerL1BodyToSsaResult` at line ~114: `if (stmt.kind === 'while') { return lowerFixedPointL1BodyToSsaResult(stmt, options); }` — placed before the existing `kind: 'for'` arm. The existing arms are unchanged.
- Create `tools/ts2pant/tests/fixtures/constructs/functions-mutating-fixed-point-while.ts` with four exported functions: `adjustBalanceTo(a: Account, target: number, step: number): void` (`while (a.balance < target) { a.balance += step; }`), `fillUpTo(a: Account, cap: number): void` (`while (a.size < cap) { a.size++; }`), `drainTo(a: Account, floor: number): void` (`while (a.balance > floor) { a.balance -= 1; }`), and `spin(a: Account): void` (`while (true) { a.tickCount++; }` — deliberate-reject fixture). The `Account` interface uses fields appropriate for each fixture (balance, size, tickCount) — keep the interface compact.
- Run `just ts2pant-test-update-snapshots` and inspect `tools/ts2pant/tests/constructs.test.mts.snapshot` for the four new fixture entries: three passing fixtures each producing a `fn--loop` recursive helper rule + a primed-equation caller; the spin fixture producing `> UNSUPPORTED:` with the literal-true diagnostic.
- Add per-passing-fixture `pant --check` integration tests in `tools/ts2pant/tests/integration/e2e.test.mts`. Use the existing `runCheck` helper. Default timeout 3000ms. Add `const KNOWN_SLOW_CHECKS: Set<string> = new Set([...])` and add any fixture whose `--check` exceeds the default (likely none for the chosen single-location fixtures, but include the constant so future fixtures have a clear extension point).
- Unskip the three Patch-4-owned `tools/ts2pant/tests/translate-body.test.mts` stubs from Patch 1 and replace each PENDING-comment body with concrete assertions.
- Run `just ts2pant-test` and `just ts2pant-test-integration` to confirm all existing tests pass and the new ones do too.

## Files to Modify
- tools/ts2pant/src/translate-body.ts (modify): Add `buildL1LetWhileFixedPointMutation` for the let-then-while fall-through route. Add `buildL1BareWhileMutation` for the bare-while route with literal-true detection. Modify the existing peephole at line 4374 to call the fixed-point helper when `buildL1LetWhileMutation` returns null. Modify the WhileStatement reject at line 4493 to call `buildL1BareWhileMutation`.
- tools/ts2pant/src/ir1-lower-body.ts (modify): Add `lowerFixedPointL1BodyToSsaResult` adapter and dispatch `kind: "while"` IR1Stmt through it (sits alongside the existing kind: "for" arm).
- tools/ts2pant/tests/fixtures/constructs/functions-mutating-fixed-point-while.ts (create): Three passing fixtures (asc accumulator, asc counter, dec counter) + one literal-true reject.
- tools/ts2pant/tests/constructs.test.mts.snapshot (modify): Snapshot update after the fixture lands. Run `just ts2pant-test-update-snapshots`.
- tools/ts2pant/tests/integration/e2e.test.mts (modify): Per-fixture `pant --check` integration tests with a 3000ms default timeout. `KNOWN_SLOW_CHECKS` constant lists any fixture exceeding the default, with per-fixture rationale.
- tools/ts2pant/tests/translate-body.test.mts (modify): Unskip the three Patch-4-owned stubs from Patch 1 and replace each PENDING-comment body with concrete assertions.

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[algorithm] Cytron 1991 SSA construction (carry-forward)** — https://doi.org/10.1145/115372.115320 — The build path's `ir1While` construction is the L1 form that flows into Patch 3's SSA framework. The two-pass loop-header join discipline is unchanged from L1/L2/L3 — Patch 4's wiring just routes the right TS surface shapes to the right L1 form.

## Gameplan Specification

```
module TS2PANT_FIXED_POINT_WHILE_LOWERING.

> ════════════════════════════════
> Milestone 4 of the ts2pant general-loop SSA workstream.
> ════════════════════════════════
> After this milestone, the mutating-body translator accepts
> unbounded while loops (single mutated location, non-literal-
> true guard) and lowers them to a synthesised top-level
> recursive Pant rule. Pant's SMT backend emits the recursive
> rule as define-fun-rec, giving Z3 / CVC5 native induction
> hooks for pant --check. Literal-true and multi-location
> while bodies reject with targeted diagnostics. Three passing
> fixtures verify end-to-end through pant typecheck and
> pant --check; one deliberate-reject fixture documents the
> literal-true rejection. Documentation in AGENTS.md, the IR
> doc, and the workstream doc records the surface and marks
> the milestone landed.

TSStmt.
IR1Stmt.
WhileStmt.
Declaration.
Rule.
PropResult.
IR1SsaLoopBody.
IR1SsaLocation.
TerminationMetric.
BuildOutcome.
LowerResult.
SmtLine.
EmissionShape.
Document.
DocumentKind.
MilestoneStatus.
decl-fun-rec => EmissionShape.
decl-fun-plus-axiom => EmissionShape.
agents-md => DocumentKind.
ir-doc => DocumentKind.
workstream-doc => DocumentKind.
pending => MilestoneStatus.
landed => MilestoneStatus.

> Pant SMT emission (Patch 2).
is-recursive? r: Rule => Bool.
body-of r: Rule => IR1Stmt.
body-applies-self? r: Rule, e: IR1Stmt => Bool.
emission-shape r: Rule => EmissionShape.
emits-define-fun-rec? r: Rule, lines: [SmtLine] => Bool.
emits-declare-fun? r: Rule, lines: [SmtLine] => Bool.
emits-universal-axiom? r: Rule, lines: [SmtLine] => Bool.
logically-equivalent? a: EmissionShape, b: EmissionShape => Bool.

> ts2pant fixed-point lowering (Patches 3, 4).
is-literal-true? s: WhileStmt => Bool.
mutated-count s: WhileStmt => Nat0.
build-mutating-body s: TSStmt => BuildOutcome.
lower-result-of-while s: WhileStmt => LowerResult.
is-ir1-while? b: BuildOutcome => Bool.
is-rejection? b: BuildOutcome => Bool.
rejection-mentions-literal-true? b: BuildOutcome => Bool.
recognizer-rejects-literal-true? s: WhileStmt => Bool.
recognizer-rejects-multi-location? s: WhileStmt => Bool.
is-bare-while? s: TSStmt => Bool.
is-let-then-while-pair? s: TSStmt => Bool.
l3-bounded-recognized? s: TSStmt => Bool.
body-metric b: IR1SsaLoopBody => TerminationMetric.
null-metric? m: TerminationMetric => Bool.
emits-recursive-helper? r: LowerResult => Bool.
emits-caller-equation? r: LowerResult => Bool.
helper-name-unique? n: String => Bool.

> Documentation (Patch 5).
document-kind d: Document => DocumentKind.
document-mentions-l4-fixed-point? d: Document => Bool.
workstream-milestone-4-status => MilestoneStatus.
---

> SMT emission contract: recursive rules emit define-fun-rec,
> non-recursive rules emit declare-fun + universal-axiom.
all r: Rule | is-recursive? r <-> body-applies-self? r (body-of r).

all r: Rule, lines: [SmtLine] |
  is-recursive? r ->
    emits-define-fun-rec? r lines and ~(emits-declare-fun? r lines).

all r: Rule, lines: [SmtLine] |
  ~(is-recursive? r) ->
    emits-declare-fun? r lines and emits-universal-axiom? r lines.

logically-equivalent? decl-fun-rec decl-fun-plus-axiom.

> Build-path contract: bare while loops construct ir1While
> unless guard is literal-true; let-then-while pairs that fail
> L3 fall through to ir1While.
all s: TSStmt |
  is-bare-while? s and ~(rejection-mentions-literal-true? (build-mutating-body s)) ->
    is-ir1-while? (build-mutating-body s).

all s: TSStmt |
  is-bare-while? s ->
    (is-rejection? (build-mutating-body s) ->
      rejection-mentions-literal-true? (build-mutating-body s)).

all s: TSStmt |
  is-let-then-while-pair? s and ~(l3-bounded-recognized? s) ->
    is-ir1-while? (build-mutating-body s).

> Lowering contract: literal-true and multi-location reject;
> successful lowering produces a fixed-point loop body
> (terminationMetric: null) plus a recursive helper rule-decl
> and a caller equation.
all s: WhileStmt |
  is-literal-true? s ->
    recognizer-rejects-literal-true? s.

all s: WhileStmt |
  mutated-count s > 1 ->
    recognizer-rejects-multi-location? s.

all s: WhileStmt, b: IR1SsaLoopBody |
  ~(is-literal-true? s) and mutated-count s = 1 ->
    null-metric? (body-metric b).

all s: WhileStmt |
  ~(is-literal-true? s) and mutated-count s = 1 ->
    emits-recursive-helper? (lower-result-of-while s) and
    emits-caller-equation? (lower-result-of-while s).

> Documentation invariants.
all d: Document |
  document-kind d = agents-md ->
    document-mentions-l4-fixed-point? d.

all d: Document |
  document-kind d = ir-doc ->
    document-mentions-l4-fixed-point? d.

all d: Document |
  document-kind d = workstream-doc ->
    document-mentions-l4-fixed-point? d.

workstream-milestone-4-status = landed.
```

## Patch Specification

```
module TS2PANT_FIXED_POINT_WHILE_LOWERING_PATCH_4.

> Patch 4 activates the L4 pipeline. The build path constructs
> ir1While for two routes: let-then-while pairs that fail L3,
> and bare while loops. The lower path dispatches kind: while
> to the fixed-point lowerer from Patch 3. Three passing
> fixtures ship plus one deliberate-reject literal-true fixture.

TSStmt.
IR1Stmt.
BuildOutcome.
LowerResult.
FixtureKind.
passing => FixtureKind.
literal-true-reject => FixtureKind.

build-mutating-body s: TSStmt => BuildOutcome.
is-ir1-while? b: BuildOutcome => Bool.
is-rejection? b: BuildOutcome => Bool.
rejection-mentions-literal-true? b: BuildOutcome => Bool.
rejection-mentions-multi-location? r: LowerResult => Bool.
is-bare-while? s: TSStmt => Bool.
is-let-then-while-pair? s: TSStmt => Bool.
l3-bounded-recognized? s: TSStmt => Bool.
lower-result s: IR1Stmt => LowerResult.
emits-recursive-helper? r: LowerResult => Bool.
emits-caller-equation? r: LowerResult => Bool.
---

> Bare non-literal-true while statements build to ir1While.
all s: TSStmt |
  is-bare-while? s and ~(rejection-mentions-literal-true? (build-mutating-body s)) ->
    is-ir1-while? (build-mutating-body s).

> Literal-true while statements reject with the no-observable-termination diagnostic.
all s: TSStmt |
  is-bare-while? s ->
    (is-rejection? (build-mutating-body s) ->
      rejection-mentions-literal-true? (build-mutating-body s)).

> Let-then-while pairs that fail L3 fall through to ir1While.
all s: TSStmt |
  is-let-then-while-pair? s and ~(l3-bounded-recognized? s) ->
    is-ir1-while? (build-mutating-body s).

> Successfully-built ir1While statements lower to a recursive helper + caller equation.
all stmt: IR1Stmt |
  emits-recursive-helper? (lower-result stmt) and
  emits-caller-equation? (lower-result stmt).
```


## Implementation Notes

- Because the PR was retargeted to `master`, this patch also carries the fixed-point lowerer surface that the original gameplan treated as a dependency: `ir1-ssa-fixed-point.ts`, the `PropResult.kind === "rule-decl"` variant, and head-section emission for synthesized rule declarations.
- The fixed-point recognizer is intentionally narrow: it accepts scalar property loops where the guard and update are expressed over the same mutated property. This avoids synthesizing object-typed helper parameters or recursive helpers that depend on unrelated state reads. Existing `unboundedWhile`-style bodies that guard on one property while mutating another now reject with a targeted fixed-point diagnostic.
- Recursive helper parameters are numeric for this patch's supported scalar fixtures. That matches the current fixture surface (`number -> Int`) and keeps the helper signature simple; broader helper parameter typing is the natural follow-on if L4 expands beyond numeric scalar property loops.
- `emitDocument` now partitions synthesized rule-decl propositions into the chapter head before action declarations. This preserves Pant's "action last in head" rule while letting body lowering contribute top-level recursive helper declarations.
- I added property `++` / `--` statement support in the mutating-body L1 assignment builder so the `fillUpTo` fixture can use the requested `a.size++` spelling without special-casing the fixture.

Spec/Evidence Mapping:
- Bare and let-then-while build routes: `buildL1BareWhileMutation` and `buildL1LetWhileFixedPointMutation` in `translate-body.ts`; covered by the three fixed-point `translate-body.test.mts` assertions.
- Fixed-point lowering result: `lowerFixedPointLoopL1Body` builds an `IR1SsaLoopBody` with `terminationMetric: null`, emits a `rule-decl` helper plus caller equation, and rejects multi/non-scalar shapes; covered by fixed-point fixture snapshots and `pant --check` integration cases.
- Literal-true rejection: build-time guard check in both fixed-point while builders; covered by the `spin` construct snapshot and translate-body diagnostic test.
- End-to-end evidence: `just ts2pant-test-update-snapshots`, `just ts2pant-test`, `just ts2pant-test-integration`, and `npm run lint` all passed locally.