### PR TITLE
[ts2pant-ir1-substitution] Patch 1: Add fast-check devDependency

### DIFF
--- a/tools/ts2pant/package-lock.json
+++ b/tools/ts2pant/package-lock.json
@@ -19,6 +19,7 @@
         "@biomejs/biome": "^2.4.11",
         "@types/node": "^20.0.0",
         "effect": "^3.21.0",
+        "fast-check": "^3.23.2",
         "tsx": "^4.21.0"
       }
     },

--- a/tools/ts2pant/package.json
+++ b/tools/ts2pant/package.json
@@ -27,6 +27,7 @@
     "@biomejs/biome": "^2.4.11",
     "@types/node": "^20.0.0",
     "effect": "^3.21.0",
+    "fast-check": "^3.23.2",
     "tsx": "^4.21.0"
   }
 }


### PR DESCRIPTION
## Patch 1: Add fast-check devDependency

- Add `fast-check` (latest 3.x) to the `devDependencies` block in `tools/ts2pant/package.json`.
- Run `npm install` from `tools/ts2pant/` to update `package-lock.json`.
- Verify the install succeeded by running `npx fast-check --version` or `node -e 'require("fast-check")'`.

## Changes
- Add `fast-check` (latest 3.x) to the `devDependencies` block in `tools/ts2pant/package.json`.
- Run `npm install` from `tools/ts2pant/` to update `package-lock.json`.
- Verify the install succeeded by running `npx fast-check --version` or `node -e 'require("fast-check")'`.

## Files to Modify
- tools/ts2pant/package.json (modify): Add `"fast-check": "^3.x"` to `devDependencies`.
- tools/ts2pant/package-lock.json (modify): Regenerated by `npm install`. Commit the updated lockfile.

## Gameplan Specification

```
module TS2PANT_IR1_SUBSTITUTION.

> ════════════════════════════════
> Single-milestone workstream: IR1 capture-avoiding substitution.
> ════════════════════════════════
> After this gameplan, ts2pant has one TS-side capture-avoiding
> substitution primitive that handles every IR1-level
> substitution need. The two existing hand-rolled walkers
> (substituteL1Subtree for functor-lift; substituteMemberReads
> for fixed-point) are deleted; their callers route through
> the new primitive. The primitive throws CaptureRiskError on
> capture risk, halts at Var-needle shadowing binders, and
> recurses structurally otherwise. Documentation in the IR doc
> and AGENTS.md PR #84 post-mortem establishes the discipline.

IR1Expr.
IR1Stmt.
Name.
FreeVarSet.
Walker.
Fixture.
SnapshotState.
Document.
DocumentKind.
DocumentMention.
NeedleKind.
Package.
Dependency.
substituteIR1ExprSubtree => Walker.
substituteIR1StmtSubtree => Walker.
substituteL1Subtree => Walker.
substituteMemberReads => Walker.
fast-check => Dependency.
identical => SnapshotState.
drifted => SnapshotState.
ir-doc => DocumentKind.
agents-md => DocumentKind.
substitution-discipline => DocumentMention.
pr-226-postmortem => DocumentMention.
var => NeedleKind.
member => NeedleKind.

has-dev-dependency? p: Package, d: Dependency => Bool.
walker-exists? w: Walker => Bool.
functor-lift-uses w: Walker => Bool.
fixed-point-uses w: Walker => Bool.
needle-kind n: IR1Expr => NeedleKind.
free-vars-expr e: IR1Expr => FreeVarSet.
free-vars-stmt s: IR1Stmt => FreeVarSet.
binders-of-expr e: IR1Expr => FreeVarSet.
binders-of-stmt s: IR1Stmt => FreeVarSet.
capture-risk? haystack-binders: FreeVarSet, repl-free: FreeVarSet => Bool.
substitutes-cleanly? h: IR1Expr, n: IR1Expr, r: IR1Expr => Bool.
throws-capture-error? h: IR1Expr, n: IR1Expr, r: IR1Expr => Bool.
is-identity-under-shadow? h: IR1Expr, n: IR1Expr, r: IR1Expr => Bool.
shadows-needle? binder: Name, n: IR1Expr => Bool.
snapshot-state f: Fixture => SnapshotState.
is-functor-lift-fixture? f: Fixture => Bool.
is-fixed-point-fixture? f: Fixture => Bool.
document-kind d: Document => DocumentKind.
document-mentions? d: Document, m: DocumentMention => Bool.
---

> Dependency.
all p: Package | has-dev-dependency? p fast-check.

> The new primitives exist; the old walkers do not.
walker-exists? substituteIR1ExprSubtree.
walker-exists? substituteIR1StmtSubtree.
~(walker-exists? substituteL1Subtree).
~(walker-exists? substituteMemberReads).

> Both former call sites route through the new primitive.
functor-lift-uses substituteIR1ExprSubtree.
fixed-point-uses substituteIR1ExprSubtree.

> Primitive contract: capture risk throws; clean substitution
> returns the result; shadowing binders halt the descent for
> Var needles.
all h: IR1Expr, n: IR1Expr, r: IR1Expr |
  capture-risk? (binders-of-expr h) (free-vars-expr r) <-> throws-capture-error? h n r.

all h: IR1Expr, n: IR1Expr, r: IR1Expr |
  substitutes-cleanly? h n r -> ~(throws-capture-error? h n r).

all h: IR1Expr, n: IR1Expr, r: IR1Expr, b: Name |
  needle-kind n = var and shadows-needle? b n ->
    is-identity-under-shadow? h n r.

> Snapshot equivalence on every migrated fixture.
all f: Fixture | is-functor-lift-fixture? f -> snapshot-state f = identical.
all f: Fixture | is-fixed-point-fixture? f -> snapshot-state f = identical.

> Documentation invariants.
all d: Document |
  document-kind d = ir-doc ->
    document-mentions? d substitution-discipline.

all d: Document |
  document-kind d = agents-md ->
    document-mentions? d pr-226-postmortem.
```

## Patch Specification

```
module TS2PANT_IR1_SUBSTITUTION_PATCH_1.

> Patch 1 adds the fast-check devDependency. No source
> behavior changes. The dependency becomes available for
> Patch 2's pending property tests.

Package.
Dependency.
fast-check => Dependency.

has-dev-dependency? p: Package, d: Dependency => Bool.
---
all p: Package | has-dev-dependency? p fast-check.
```


## Implementation Notes

- `npm install fast-check@^3 --save-dev` resolved the latest 3.x line to `^3.23.2`. The lockfile already contained the resolved `node_modules/fast-check` and `pure-rand` entries, so the diff only promotes `fast-check` to a direct dev dependency in the root package sections.
- Required context note: `workstreams/ts2pant-ir1-substitution.md` was not present in this worktree or adjacent searched paths, so implementation followed the patch contract and PR spec provided by the supervisor.
- Spec/Evidence Mapping: `has-dev-dependency? p fast-check` is satisfied by `tools/ts2pant/package.json` and the root package entry in `tools/ts2pant/package-lock.json`; verified with `node -e 'require("fast-check"); console.log(require("fast-check/package.json").version)'` returning `3.23.2`, `git diff --check`, and the full `npm test` suite passing.