### PR TITLE
[ts2pant-ir1-substitution] Patch 2: Pending unit and property tests for IR1 substitution primitive

### DIFF
--- a/tools/ts2pant/tests/ir1-substitute.test.mts
+++ b/tools/ts2pant/tests/ir1-substitute.test.mts
@@ -1,0 +1,123 @@
+import { describe, it } from "node:test";
+
+import * as fc from "fast-check";
+
+import {
+  ir1App,
+  ir1Assign,
+  ir1Binop,
+  ir1Block,
+  ir1Cond,
+  ir1CondStmt,
+  ir1Each,
+  ir1ExprStmt,
+  ir1For,
+  ir1Foreach,
+  ir1IsNullish,
+  ir1Let,
+  ir1LitBool,
+  ir1LitNat,
+  ir1Member,
+  ir1Return,
+  ir1Throw,
+  ir1Unop,
+  ir1Var,
+  ir1While,
+  type IR1Expr,
+  type IR1Stmt,
+} from "../src/ir1.js";
+
+void fc;
+void ir1App;
+void ir1Assign;
+void ir1Binop;
+void ir1Block;
+void ir1Cond;
+void ir1CondStmt;
+void ir1Each;
+void ir1ExprStmt;
+void ir1For;
+void ir1Foreach;
+void ir1IsNullish;
+void ir1Let;
+void ir1LitBool;
+void ir1LitNat;
+void ir1Member;
+void ir1Return;
+void ir1Throw;
+void ir1Unop;
+void ir1Var;
+void ir1While;
+
+type _IR1Expr = IR1Expr;
+type _IR1Stmt = IR1Stmt;
+
+describe("ir1-substitute", () => {
+  describe("unit", () => {
+    it.skip("freeVarsIR1Expr returns vars from a leaf var", () => {
+      // PENDING Patch 3: assert leaf var free-var behavior.
+    });
+
+    it.skip("freeVarsIR1Expr ignores literals", () => {
+      // PENDING Patch 3: assert literal expressions have no free vars.
+    });
+
+    it.skip("freeVarsIR1Expr respects each binder", () => {
+      // PENDING Patch 3: assert each-binder free-var behavior.
+    });
+
+    it.skip("freeVarsIR1Stmt respects block / let / foreach / for binders", () => {
+      // PENDING Patch 3: assert statement-level free vars across block, let, foreach, and for-init binders.
+    });
+
+    it.skip("substituteIR1ExprSubtree replaces a leaf Var", () => {
+      // PENDING Patch 3: assert leaf Var replacement through the expression primitive.
+    });
+
+    it.skip("substituteIR1ExprSubtree replaces a Member subtree", () => {
+      // PENDING Patch 3: assert Member subtree replacement through the expression primitive.
+    });
+
+    it.skip("substituteIR1ExprSubtree halts at a shadowing each binder", () => {
+      // PENDING Patch 3: assert Var-needle substitution does not descend under a shadowing each binder.
+    });
+
+    it.skip("substituteIR1ExprSubtree throws CaptureRiskError on capture risk", () => {
+      // PENDING Patch 3: assert replacement free vars captured by haystack binders throw CaptureRiskError.
+    });
+
+    it.skip("substituteIR1ExprSubtree preserves shape outside replacement sites", () => {
+      // PENDING Patch 3: assert unrelated expression structure is preserved while matching subtrees are replaced.
+    });
+
+    it.skip("substituteIR1StmtSubtree threads block-scope let binders", () => {
+      // PENDING Patch 3: assert let binders affect only subsequent block statements during statement substitution.
+    });
+
+    it.skip("substituteIR1StmtSubtree handles foreach binder scope", () => {
+      // PENDING Patch 3: assert foreach binder scope covers body and fold leaves but not source.
+    });
+
+    it.skip("substituteIR1StmtSubtree handles for-init let scope", () => {
+      // PENDING Patch 3: assert for-init let binders scope over cond, step, and body.
+    });
+  });
+
+  describe("properties", () => {
+    it.skip("free vars compose under substitution", () => {
+      // PENDING Patch 3: generator skeleton uses fc.letrec for IR1Expr / IR1Stmt trees, name arbitraries from a small identifier set, and filters to no-capture cases before asserting FV(substitute(h, n, r)) = (FV(h) minus the Var needle name when applicable) union FV(r).
+    });
+
+    it.skip("substitution is idempotent when needle does not occur", () => {
+      // PENDING Patch 3: generator skeleton uses fc.letrec recursive IR1Expr / IR1Stmt trees plus a needle arbitrary filtered so the needle is absent from the haystack, then asserts substitution returns the original tree.
+    });
+
+    it.skip("substitution under shadowing binder is identity", () => {
+      // PENDING Patch 3: generator skeleton builds each / let / foreach / for-init binder wrappers around recursive IR1Expr / IR1Stmt haystacks with a Var needle matching the binder, then asserts descent halts at the binder boundary.
+    });
+
+    it.skip("capture-risk inputs throw", () => {
+      // PENDING Patch 3: generator skeleton builds haystacks with binder names drawn from replacement free vars via fc.letrec expression / statement trees, then asserts CaptureRiskError is thrown.
+    });
+  });
+});


### PR DESCRIPTION
## Patch 2: Pending unit and property tests for IR1 substitution primitive

- Create `tools/ts2pant/tests/ir1-substitute.test.mts` modelled on existing ts2pant test files (e.g., `ir1-ssa-counter-loop.test.mts`).
- Import `fc` from `fast-check`. Import IR1 constructors from `../src/ir1.js`. Do NOT import from `../src/ir1-substitute.js` — that module does not exist yet.
- Under `describe('unit', () => { ... })`, add `it.skip(...)` stubs for: `freeVarsIR1Expr` on var/lit/each; `freeVarsIR1Stmt` on block/let/foreach/for; `substituteIR1ExprSubtree` replacing leaf Var; replacing Member; halting at shadowing each binder; throwing CaptureRiskError on capture risk; preserving structure outside replacement; `substituteIR1StmtSubtree` threading block-scope binders; handling foreach binder; handling for-init let.
- Under `describe('properties', () => { ... })`, add `it.skip(...)` stubs for: free-vars composition (FV(substitute(h, n, r)) = (FV(h) \ {n if Var}) ∪ FV(r)) under no-capture inputs; idempotence on no-occurrence; identity under shadowing binder; capture-risk inputs throw. Each stub designs the fast-check generator skeleton in a comment but does not execute (skipped).
- Each stub body contains only the PENDING comment naming Patch 3 — no references to symbols that don't exist yet.
- Run `npx tsx --test tools/ts2pant/tests/ir1-substitute.test.mts` to confirm the file compiles and stubs are reported as skipped.

## Changes
- Create `tools/ts2pant/tests/ir1-substitute.test.mts` modelled on existing ts2pant test files (e.g., `ir1-ssa-counter-loop.test.mts`).
- Import `fc` from `fast-check`. Import IR1 constructors from `../src/ir1.js`. Do NOT import from `../src/ir1-substitute.js` — that module does not exist yet.
- Under `describe('unit', () => { ... })`, add `it.skip(...)` stubs for: `freeVarsIR1Expr` on var/lit/each; `freeVarsIR1Stmt` on block/let/foreach/for; `substituteIR1ExprSubtree` replacing leaf Var; replacing Member; halting at shadowing each binder; throwing CaptureRiskError on capture risk; preserving structure outside replacement; `substituteIR1StmtSubtree` threading block-scope binders; handling foreach binder; handling for-init let.
- Under `describe('properties', () => { ... })`, add `it.skip(...)` stubs for: free-vars composition (FV(substitute(h, n, r)) = (FV(h) \ {n if Var}) ∪ FV(r)) under no-capture inputs; idempotence on no-occurrence; identity under shadowing binder; capture-risk inputs throw. Each stub designs the fast-check generator skeleton in a comment but does not execute (skipped).
- Each stub body contains only the PENDING comment naming Patch 3 — no references to symbols that don't exist yet.
- Run `npx tsx --test tools/ts2pant/tests/ir1-substitute.test.mts` to confirm the file compiles and stubs are reported as skipped.

## Files to Modify
- tools/ts2pant/tests/ir1-substitute.test.mts (create): New test file with hand-written unit-test stubs (skipped, with `// PENDING Patch 3:` comments) and a `describe('properties', ...)` block with fast-check property-test stubs.

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[library] fast-check** — https://fast-check.dev/ — Property-based testing library for TS/JS. Patch 2's property-test stubs use `fc.letrec` for recursive ADT generators (IR1Expr / IR1Stmt) and `fc.assert(fc.property(gen, prop))` for the assertion API. The stub bodies design the generator skeletons inline (as comments) without running them; Patch 3 finalises and un-skips them.

## Gameplan Specification

```
module TS2PANT_IR1_SUBSTITUTION.

> ════════════════════════════════
> Single-milestone workstream: IR1 capture-avoiding substitution.
> ════════════════════════════════
> After this gameplan, ts2pant has one TS-side capture-avoiding
> substitution primitive that handles every IR1-level
> substitution need. The two existing hand-rolled walkers
> (substituteL1Subtree for functor-lift; substituteMemberReads
> for fixed-point) are deleted; their callers route through
> the new primitive. The primitive throws CaptureRiskError on
> capture risk, halts at Var-needle shadowing binders, and
> recurses structurally otherwise. Documentation in the IR doc
> and AGENTS.md PR #84 post-mortem establishes the discipline.

IR1Expr.
IR1Stmt.
Name.
FreeVarSet.
Walker.
Fixture.
SnapshotState.
Document.
DocumentKind.
DocumentMention.
NeedleKind.
Package.
Dependency.
substituteIR1ExprSubtree => Walker.
substituteIR1StmtSubtree => Walker.
substituteL1Subtree => Walker.
substituteMemberReads => Walker.
fast-check => Dependency.
identical => SnapshotState.
drifted => SnapshotState.
ir-doc => DocumentKind.
agents-md => DocumentKind.
substitution-discipline => DocumentMention.
pr-226-postmortem => DocumentMention.
var => NeedleKind.
member => NeedleKind.

has-dev-dependency? p: Package, d: Dependency => Bool.
walker-exists? w: Walker => Bool.
functor-lift-uses w: Walker => Bool.
fixed-point-uses w: Walker => Bool.
needle-kind n: IR1Expr => NeedleKind.
free-vars-expr e: IR1Expr => FreeVarSet.
free-vars-stmt s: IR1Stmt => FreeVarSet.
binders-of-expr e: IR1Expr => FreeVarSet.
binders-of-stmt s: IR1Stmt => FreeVarSet.
capture-risk? haystack-binders: FreeVarSet, repl-free: FreeVarSet => Bool.
substitutes-cleanly? h: IR1Expr, n: IR1Expr, r: IR1Expr => Bool.
throws-capture-error? h: IR1Expr, n: IR1Expr, r: IR1Expr => Bool.
is-identity-under-shadow? h: IR1Expr, n: IR1Expr, r: IR1Expr => Bool.
shadows-needle? binder: Name, n: IR1Expr => Bool.
snapshot-state f: Fixture => SnapshotState.
is-functor-lift-fixture? f: Fixture => Bool.
is-fixed-point-fixture? f: Fixture => Bool.
document-kind d: Document => DocumentKind.
document-mentions? d: Document, m: DocumentMention => Bool.
---

> Dependency.
all p: Package | has-dev-dependency? p fast-check.

> The new primitives exist; the old walkers do not.
walker-exists? substituteIR1ExprSubtree.
walker-exists? substituteIR1StmtSubtree.
~(walker-exists? substituteL1Subtree).
~(walker-exists? substituteMemberReads).

> Both former call sites route through the new primitive.
functor-lift-uses substituteIR1ExprSubtree.
fixed-point-uses substituteIR1ExprSubtree.

> Primitive contract: capture risk throws; clean substitution
> returns the result; shadowing binders halt the descent for
> Var needles.
all h: IR1Expr, n: IR1Expr, r: IR1Expr |
  capture-risk? (binders-of-expr h) (free-vars-expr r) <-> throws-capture-error? h n r.

all h: IR1Expr, n: IR1Expr, r: IR1Expr |
  substitutes-cleanly? h n r -> ~(throws-capture-error? h n r).

all h: IR1Expr, n: IR1Expr, r: IR1Expr, b: Name |
  needle-kind n = var and shadows-needle? b n ->
    is-identity-under-shadow? h n r.

> Snapshot equivalence on every migrated fixture.
all f: Fixture | is-functor-lift-fixture? f -> snapshot-state f = identical.
all f: Fixture | is-fixed-point-fixture? f -> snapshot-state f = identical.

> Documentation invariants.
all d: Document |
  document-kind d = ir-doc ->
    document-mentions? d substitution-discipline.

all d: Document |
  document-kind d = agents-md ->
    document-mentions? d pr-226-postmortem.
```

## Patch Specification

```
module TS2PANT_IR1_SUBSTITUTION_PATCH_2.

> Patch 2 lands the test scaffolding for the substitution
> primitive. Stubs are skipped; Patch 3 unskips them with
> concrete assertions. No source behavior changes; the
> test file compiles and reports stubs as skipped.

TestStub.
PendingFor.
patch-3 => PendingFor.

stub-pending-for s: TestStub => PendingFor.
stub-skipped? s: TestStub => Bool.
---
all s: TestStub | stub-pending-for s = patch-3 -> stub-skipped? s.
```


## Implementation Notes

- The scaffold intentionally imports `fast-check` and IR1 constructors now, but keeps all future primitive/free-var symbols out of the file. Top-level `void` references preserve those imports as real compile-time coverage while keeping every skipped stub body limited to a single `PENDING Patch 3` comment.
- I split the `freeVarsIR1Expr` coverage into separate skipped stubs for leaf vars, literals, and `each` binders. That is slightly more granular than the PR body's grouped wording, but covers the same acceptance criterion and gives Patch 3 clearer landing points.
- Required context consulted: `tools/ts2pant/src/ir1.ts` for the current binder vocabulary and `tools/ts2pant/tests/ir1-ssa-counter-loop.test.mts` for local test structure. The named workstream markdown path was not present in this worktree, so I treated the supplied gameplan text as the authoritative workstream context.
- Spec/Evidence Mapping: every introduced stub is `it.skip(...)` and every body is a Patch 3 pending comment in `tools/ts2pant/tests/ir1-substitute.test.mts`; `npx tsx --test tools/ts2pant/tests/ir1-substitute.test.mts` reports 16 skipped tests, 0 failures.