### PR TITLE
[ts2pant-ir1-substitution] Patch 3: Implement IR1 substitution primitive; un-skip tests

### DIFF
--- a/tools/ts2pant/src/ir1-substitute.ts
+++ b/tools/ts2pant/src/ir1-substitute.ts
@@ -1,0 +1,737 @@
+import {
+  type IR1Expr,
+  type IR1FoldLeaf,
+  type IR1Stmt,
+  ir1App,
+  ir1Assign,
+  ir1Binop,
+  ir1Block,
+  ir1Cond,
+  ir1CondStmt,
+  ir1Each,
+  ir1ExprStmt,
+  ir1For,
+  ir1Foreach,
+  ir1IsNullish,
+  ir1Member,
+  ir1Return,
+  ir1Throw,
+  ir1Unop,
+  ir1While,
+} from "./ir1.js";
+
+type SupportedNeedle = Extract<IR1Expr, { kind: "var" | "member" }>;
+
+export class CaptureRiskError extends Error {
+  binderName: string;
+  capturedVar: string;
+
+  constructor(binderName: string, capturedVar: string) {
+    super(
+      `IR1 substitution would capture free var '${capturedVar}' under binder '${binderName}'`,
+    );
+    this.name = "CaptureRiskError";
+    this.binderName = binderName;
+    this.capturedVar = capturedVar;
+  }
+}
+
+export function freeVarsIR1Expr(expr: IR1Expr): Set<string> {
+  switch (expr.kind) {
+    case "var":
+      return new Set([expr.name]);
+    case "lit":
+      return new Set();
+    case "binop":
+      return union(freeVarsIR1Expr(expr.lhs), freeVarsIR1Expr(expr.rhs));
+    case "unop":
+      return freeVarsIR1Expr(expr.arg);
+    case "app":
+      return union(
+        freeVarsIR1Expr(expr.callee),
+        ...expr.args.map(freeVarsIR1Expr),
+      );
+    case "member":
+      return freeVarsIR1Expr(expr.receiver);
+    case "cond":
+      return union(
+        ...expr.arms.flatMap(([guard, value]) => [
+          freeVarsIR1Expr(guard),
+          freeVarsIR1Expr(value),
+        ]),
+        freeVarsIR1Expr(expr.otherwise),
+      );
+    case "is-nullish":
+      return freeVarsIR1Expr(expr.operand);
+    case "each": {
+      const scoped = union(
+        ...expr.guards.map(freeVarsIR1Expr),
+        freeVarsIR1Expr(expr.proj),
+      );
+      scoped.delete(expr.binder);
+      return union(freeVarsIR1Expr(expr.src), scoped);
+    }
+    case "map-read":
+      return union(freeVarsIR1Expr(expr.receiver), freeVarsIR1Expr(expr.key));
+    case "set-read":
+      return union(freeVarsIR1Expr(expr.receiver), freeVarsIR1Expr(expr.elem));
+    default: {
+      const _exhaustive: never = expr;
+      return _exhaustive;
+    }
+  }
+}
+
+export function freeVarsIR1Stmt(stmt: IR1Stmt): Set<string> {
+  return freeVarsStmtWithScope(stmt, new Set());
+}
+
+export function substituteIR1ExprSubtree(
+  haystack: IR1Expr,
+  needle: IR1Expr,
+  replacement: IR1Expr,
+): IR1Expr {
+  const supportedNeedle = assertSupportedNeedle(needle);
+  const replacementFreeVars = freeVarsIR1Expr(replacement);
+  return substituteExpr(
+    haystack,
+    supportedNeedle,
+    replacement,
+    replacementFreeVars,
+  );
+}
+
+export function substituteIR1StmtSubtree(
+  haystack: IR1Stmt,
+  needle: IR1Expr,
+  replacement: IR1Expr,
+): IR1Stmt {
+  const supportedNeedle = assertSupportedNeedle(needle);
+  const replacementFreeVars = freeVarsIR1Expr(replacement);
+  return substituteStmt(
+    haystack,
+    supportedNeedle,
+    replacement,
+    replacementFreeVars,
+    new Set(),
+  );
+}
+
+function freeVarsStmtWithScope(stmt: IR1Stmt, bound: Set<string>): Set<string> {
+  switch (stmt.kind) {
+    case "block": {
+      let inScope = new Set(bound);
+      const free = new Set<string>();
+      for (const child of stmt.stmts) {
+        addAll(free, freeVarsStmtWithScope(child, inScope));
+        if (child.kind === "let") {
+          inScope = addName(inScope, child.name);
+        }
+      }
+      return free;
+    }
+    case "let":
+      return without(freeVarsIR1Expr(stmt.value), bound);
+    case "assign":
+      return without(
+        union(freeVarsIR1Expr(stmt.target), freeVarsIR1Expr(stmt.value)),
+        bound,
+      );
+    case "cond-stmt":
+      return union(
+        ...stmt.arms.flatMap(([guard, body]) => [
+          without(freeVarsIR1Expr(guard), bound),
+          freeVarsStmtWithScope(body, bound),
+        ]),
+        ...(stmt.otherwise === null
+          ? []
+          : [freeVarsStmtWithScope(stmt.otherwise, bound)]),
+      );
+    case "foreach": {
+      const scoped = addName(bound, stmt.binder);
+      return union(
+        without(freeVarsIR1Expr(stmt.source), bound),
+        ...(stmt.body === null
+          ? []
+          : [freeVarsStmtWithScope(stmt.body, scoped)]),
+        ...stmt.foldLeaves.map((leaf) => freeVarsFoldLeaf(leaf, scoped)),
+      );
+    }
+    case "for": {
+      const free = new Set<string>();
+      let inScope = new Set(bound);
+      if (stmt.init !== null) {
+        addAll(free, freeVarsStmtWithScope(stmt.init, inScope));
+        inScope = extendWithForInitBinders(inScope, stmt.init);
+      }
+      if (stmt.cond !== null) {
+        addAll(free, without(freeVarsIR1Expr(stmt.cond), inScope));
+      }
+      if (stmt.step !== null) {
+        addAll(free, freeVarsStmtWithScope(stmt.step, inScope));
+      }
+      addAll(free, freeVarsStmtWithScope(stmt.body, inScope));
+      return free;
+    }
+    case "while":
+      return union(
+        without(freeVarsIR1Expr(stmt.cond), bound),
+        freeVarsStmtWithScope(stmt.body, bound),
+      );
+    case "return":
+      return stmt.expr === null
+        ? new Set()
+        : without(freeVarsIR1Expr(stmt.expr), bound);
+    case "throw":
+      return without(freeVarsIR1Expr(stmt.expr), bound);
+    case "expr-stmt":
+      return without(freeVarsIR1Expr(stmt.expr), bound);
+    case "map-effect":
+      return union(
+        without(freeVarsIR1Expr(stmt.objExpr), bound),
+        without(freeVarsIR1Expr(stmt.keyExpr), bound),
+        ...(stmt.valueExpr === null
+          ? []
+          : [without(freeVarsIR1Expr(stmt.valueExpr), bound)]),
+      );
+    case "set-effect":
+      return union(
+        without(freeVarsIR1Expr(stmt.objExpr), bound),
+        ...(stmt.elemExpr === null
+          ? []
+          : [without(freeVarsIR1Expr(stmt.elemExpr), bound)]),
+      );
+    default: {
+      const _exhaustive: never = stmt;
+      return _exhaustive;
+    }
+  }
+}
+
+function freeVarsFoldLeaf(leaf: IR1FoldLeaf, bound: Set<string>): Set<string> {
+  return union(
+    without(freeVarsIR1Expr(leaf.target), bound),
+    without(freeVarsIR1Expr(leaf.rhs), bound),
+    ...(leaf.guard === null
+      ? []
+      : [without(freeVarsIR1Expr(leaf.guard), bound)]),
+  );
+}
+
+function substituteExpr(
+  expr: IR1Expr,
+  needle: SupportedNeedle,
+  replacement: IR1Expr,
+  replacementFreeVars: Set<string>,
+): IR1Expr {
+  if (ir1ExprStructurallyEqual(expr, needle)) {
+    return replacement;
+  }
+  switch (expr.kind) {
+    case "var":
+    case "lit":
+      return expr;
+    case "binop":
+      return ir1Binop(
+        expr.op,
+        substituteExpr(expr.lhs, needle, replacement, replacementFreeVars),
+        substituteExpr(expr.rhs, needle, replacement, replacementFreeVars),
+      );
+    case "unop":
+      return ir1Unop(
+        expr.op,
+        substituteExpr(expr.arg, needle, replacement, replacementFreeVars),
+      );
+    case "app":
+      return ir1App(
+        substituteExpr(expr.callee, needle, replacement, replacementFreeVars),
+        expr.args.map((arg) =>
+          substituteExpr(arg, needle, replacement, replacementFreeVars),
+        ),
+      );
+    case "member":
+      return ir1Member(
+        substituteExpr(expr.receiver, needle, replacement, replacementFreeVars),
+        expr.name,
+      );
+    case "cond":
+      return ir1Cond(
+        expr.arms.map(([guard, value]) => [
+          substituteExpr(guard, needle, replacement, replacementFreeVars),
+          substituteExpr(value, needle, replacement, replacementFreeVars),
+        ]) as unknown as [
+          readonly [IR1Expr, IR1Expr],
+          ...ReadonlyArray<readonly [IR1Expr, IR1Expr]>,
+        ],
+        substituteExpr(
+          expr.otherwise,
+          needle,
+          replacement,
+          replacementFreeVars,
+        ),
+      );
+    case "is-nullish":
+      return ir1IsNullish(
+        substituteExpr(expr.operand, needle, replacement, replacementFreeVars),
+      );
+    case "each": {
+      throwIfCaptureRisk(expr.binder, replacementFreeVars);
+      const src = substituteExpr(
+        expr.src,
+        needle,
+        replacement,
+        replacementFreeVars,
+      );
+      if (shadowsNeedle(expr.binder, needle)) {
+        return ir1Each(expr.binder, src, expr.guards, expr.proj);
+      }
+      return ir1Each(
+        expr.binder,
+        src,
+        expr.guards.map((guard) =>
+          substituteExpr(guard, needle, replacement, replacementFreeVars),
+        ),
+        substituteExpr(expr.proj, needle, replacement, replacementFreeVars),
+      );
+    }
+    case "map-read":
+      return {
+        ...expr,
+        receiver: substituteExpr(
+          expr.receiver,
+          needle,
+          replacement,
+          replacementFreeVars,
+        ),
+        key: substituteExpr(expr.key, needle, replacement, replacementFreeVars),
+      };
+    case "set-read":
+      return {
+        ...expr,
+        receiver: substituteExpr(
+          expr.receiver,
+          needle,
+          replacement,
+          replacementFreeVars,
+        ),
+        elem: substituteExpr(
+          expr.elem,
+          needle,
+          replacement,
+          replacementFreeVars,
+        ),
+      };
+    default: {
+      const _exhaustive: never = expr;
+      return _exhaustive;
+    }
+  }
+}
+
+function substituteStmt(
+  stmt: IR1Stmt,
+  needle: SupportedNeedle,
+  replacement: IR1Expr,
+  replacementFreeVars: Set<string>,
+  scopedBinders: Set<string>,
+): IR1Stmt {
+  switch (stmt.kind) {
+    case "block": {
+      let inScope = new Set(scopedBinders);
+      const stmts = stmt.stmts.map((child) => {
+        const rewritten = substituteStmt(
+          child,
+          needle,
+          replacement,
+          replacementFreeVars,
+          inScope,
+        );
+        if (child.kind === "let") {
+          throwIfCaptureRisk(child.name, replacementFreeVars);
+          inScope = addName(inScope, child.name);
+        }
+        return rewritten;
+      });
+      return ir1Block(stmts as [IR1Stmt, ...IR1Stmt[]]);
+    }
+    case "let":
+      return {
+        ...stmt,
+        value: substituteExprRespectingScope(
+          stmt.value,
+          needle,
+          replacement,
+          replacementFreeVars,
+          scopedBinders,
+        ),
+      };
+    case "assign":
+      return ir1Assign(
+        substituteExprRespectingScope(
+          stmt.target,
+          needle,
+          replacement,
+          replacementFreeVars,
+          scopedBinders,
+        ),
+        substituteExprRespectingScope(
+          stmt.value,
+          needle,
+          replacement,
+          replacementFreeVars,
+          scopedBinders,
+        ),
+      );
+    case "cond-stmt":
+      return ir1CondStmt(
+        stmt.arms.map(([guard, body]) => [
+          substituteExprRespectingScope(
+            guard,
+            needle,
+            replacement,
+            replacementFreeVars,
+            scopedBinders,
+          ),
+          substituteStmt(
+            body,
+            needle,
+            replacement,
+            replacementFreeVars,
+            scopedBinders,
+          ),
+        ]) as unknown as [
+          readonly [IR1Expr, IR1Stmt],
+          ...ReadonlyArray<readonly [IR1Expr, IR1Stmt]>,
+        ],
+        stmt.otherwise === null
+          ? null
+          : substituteStmt(
+              stmt.otherwise,
+              needle,
+              replacement,
+              replacementFreeVars,
+              scopedBinders,
+            ),
+      );
+    case "foreach": {
+      const source = substituteExprRespectingScope(
+        stmt.source,
+        needle,
+        replacement,
+        replacementFreeVars,
+        scopedBinders,
+      );
+      throwIfCaptureRisk(stmt.binder, replacementFreeVars);
+      if (shadowsNeedle(stmt.binder, needle)) {
+        return ir1Foreach(stmt.binder, source, stmt.body, stmt.foldLeaves);
+      }
+      const innerScope = addName(scopedBinders, stmt.binder);
+      return ir1Foreach(
+        stmt.binder,
+        source,
+        stmt.body === null
+          ? null
+          : (substituteStmt(
+              stmt.body,
+              needle,
+              replacement,
+              replacementFreeVars,
+              innerScope,
+            ) as typeof stmt.body),
+        stmt.foldLeaves.map((leaf) =>
+          substituteFoldLeaf(
+            leaf,
+            needle,
+            replacement,
+            replacementFreeVars,
+            innerScope,
+          ),
+        ),
+      );
+    }
+    case "for": {
+      const init =
+        stmt.init === null
+          ? null
+          : substituteStmt(
+              stmt.init,
+              needle,
+              replacement,
+              replacementFreeVars,
+              scopedBinders,
+            );
+      const innerScope =
+        stmt.init === null
+          ? scopedBinders
+          : extendWithForInitBinders(scopedBinders, stmt.init);
+      return ir1For(
+        init,
+        stmt.cond === null
+          ? null
+          : substituteExprRespectingScope(
+              stmt.cond,
+              needle,
+              replacement,
+              replacementFreeVars,
+              innerScope,
+            ),
+        stmt.step === null
+          ? null
+          : substituteStmt(
+              stmt.step,
+              needle,
+              replacement,
+              replacementFreeVars,
+              innerScope,
+            ),
+        substituteStmt(
+          stmt.body,
+          needle,
+          replacement,
+          replacementFreeVars,
+          innerScope,
+        ),
+      );
+    }
+    case "while":
+      return ir1While(
+        substituteExprRespectingScope(
+          stmt.cond,
+          needle,
+          replacement,
+          replacementFreeVars,
+          scopedBinders,
+        ),
+        substituteStmt(
+          stmt.body,
+          needle,
+          replacement,
+          replacementFreeVars,
+          scopedBinders,
+        ),
+      );
+    case "return":
+      return ir1Return(
+        stmt.expr === null
+          ? null
+          : substituteExprRespectingScope(
+              stmt.expr,
+              needle,
+              replacement,
+              replacementFreeVars,
+              scopedBinders,
+            ),
+      );
+    case "throw":
+      return ir1Throw(
+        substituteExprRespectingScope(
+          stmt.expr,
+          needle,
+          replacement,
+          replacementFreeVars,
+          scopedBinders,
+        ),
+      );
+    case "expr-stmt":
+      return ir1ExprStmt(
+        substituteExprRespectingScope(
+          stmt.expr,
+          needle,
+          replacement,
+          replacementFreeVars,
+          scopedBinders,
+        ),
+      );
+    case "map-effect": {
+      const objExpr = substituteExprRespectingScope(
+        stmt.objExpr,
+        needle,
+        replacement,
+        replacementFreeVars,
+        scopedBinders,
+      );
+      const keyExpr = substituteExprRespectingScope(
+        stmt.keyExpr,
+        needle,
+        replacement,
+        replacementFreeVars,
+        scopedBinders,
+      );
+      if (stmt.op === "delete") {
+        return { ...stmt, objExpr, keyExpr, valueExpr: null };
+      }
+      return {
+        ...stmt,
+        objExpr,
+        keyExpr,
+        valueExpr: substituteExprRespectingScope(
+          stmt.valueExpr,
+          needle,
+          replacement,
+          replacementFreeVars,
+          scopedBinders,
+        ),
+      };
+    }
+    case "set-effect": {
+      const objExpr = substituteExprRespectingScope(
+        stmt.objExpr,
+        needle,
+        replacement,
+        replacementFreeVars,
+        scopedBinders,
+      );
+      if (stmt.op === "clear") {
+        return { ...stmt, objExpr, elemExpr: null };
+      }
+      return {
+        ...stmt,
+        objExpr,
+        elemExpr: substituteExprRespectingScope(
+          stmt.elemExpr,
+          needle,
+          replacement,
+          replacementFreeVars,
+          scopedBinders,
+        ),
+      };
+    }
+    default: {
+      const _exhaustive: never = stmt;
+      return _exhaustive;
+    }
+  }
+}
+
+function substituteExprRespectingScope(
+  expr: IR1Expr,
+  needle: SupportedNeedle,
+  replacement: IR1Expr,
+  replacementFreeVars: Set<string>,
+  scopedBinders: Set<string>,
+): IR1Expr {
+  for (const binder of scopedBinders) {
+    throwIfCaptureRisk(binder, replacementFreeVars);
+    if (shadowsNeedle(binder, needle)) {
+      return expr;
+    }
+  }
+  return substituteExpr(expr, needle, replacement, replacementFreeVars);
+}
+
+function substituteFoldLeaf(
+  leaf: IR1FoldLeaf,
+  needle: SupportedNeedle,
+  replacement: IR1Expr,
+  replacementFreeVars: Set<string>,
+  scopedBinders: Set<string>,
+): IR1FoldLeaf {
+  return {
+    ...leaf,
+    target: substituteExprRespectingScope(
+      leaf.target,
+      needle,
+      replacement,
+      replacementFreeVars,
+      scopedBinders,
+    ),
+    rhs: substituteExprRespectingScope(
+      leaf.rhs,
+      needle,
+      replacement,
+      replacementFreeVars,
+      scopedBinders,
+    ),
+    guard:
+      leaf.guard === null
+        ? null
+        : substituteExprRespectingScope(
+            leaf.guard,
+            needle,
+            replacement,
+            replacementFreeVars,
+            scopedBinders,
+          ),
+  };
+}
+
+function extendWithForInitBinders(
+  scopedBinders: Set<string>,
+  init: IR1Stmt,
+): Set<string> {
+  if (init.kind !== "let") {
+    return scopedBinders;
+  }
+  return addName(scopedBinders, init.name);
+}
+
+function assertSupportedNeedle(needle: IR1Expr): SupportedNeedle {
+  if (needle.kind === "var" || needle.kind === "member") {
+    return needle;
+  }
+  throw new Error(`unsupported needle kind: ${needle.kind}`);
+}
+
+function ir1ExprStructurallyEqual(a: IR1Expr, b: SupportedNeedle): boolean {
+  if (a.kind !== b.kind) {
+    return false;
+  }
+  if (a.kind === "var" && b.kind === "var") {
+    return a.name === b.name && (a.primed ?? false) === (b.primed ?? false);
+  }
+  if (a.kind === "member" && b.kind === "member") {
+    return (
+      a.name === b.name &&
+      ir1ExprStructurallyEqualReceiver(a.receiver, b.receiver)
+    );
+  }
+  return false;
+}
+
+function ir1ExprStructurallyEqualReceiver(a: IR1Expr, b: IR1Expr): boolean {
+  if (b.kind === "var" || b.kind === "member") {
+    return ir1ExprStructurallyEqual(a, b);
+  }
+  return false;
+}
+
+function shadowsNeedle(binder: string, needle: SupportedNeedle): boolean {
+  return needle.kind === "var" && !needle.primed && needle.name === binder;
+}
+
+function throwIfCaptureRisk(
+  binderName: string,
+  replacementFreeVars: Set<string>,
+): void {
+  if (replacementFreeVars.has(binderName)) {
+    throw new CaptureRiskError(binderName, binderName);
+  }
+}
+
+function union(...sets: Set<string>[]): Set<string> {
+  const out = new Set<string>();
+  for (const set of sets) {
+    addAll(out, set);
+  }
+  return out;
+}
+
+function addAll(target: Set<string>, source: Set<string>): void {
+  for (const value of source) {
+    target.add(value);
+  }
+}
+
+function without(source: Set<string>, names: Set<string>): Set<string> {
+  const out = new Set(source);
+  for (const name of names) {
+    out.delete(name);
+  }
+  return out;
+}
+
+function addName(source: Set<string>, name: string): Set<string> {
+  const out = new Set(source);
+  out.add(name);
+  return out;
+}

--- a/tools/ts2pant/tests/ir1-substitute.test.mts
+++ b/tools/ts2pant/tests/ir1-substitute.test.mts
@@ -1,14 +1,16 @@
+import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import * as fc from "fast-check";
 
 import {
+  type IR1Expr,
+  type IR1Stmt,
   ir1App,
   ir1Assign,
   ir1Binop,
   ir1Block,
   ir1Cond,
-  ir1CondStmt,
   ir1Each,
   ir1ExprStmt,
   ir1For,
@@ -23,101 +25,445 @@ import {
   ir1Unop,
   ir1Var,
   ir1While,
-  type IR1Expr,
-  type IR1Stmt,
 } from "../src/ir1.js";
-
-void fc;
-void ir1App;
-void ir1Assign;
-void ir1Binop;
-void ir1Block;
-void ir1Cond;
-void ir1CondStmt;
-void ir1Each;
-void ir1ExprStmt;
-void ir1For;
-void ir1Foreach;
-void ir1IsNullish;
-void ir1Let;
-void ir1LitBool;
-void ir1LitNat;
-void ir1Member;
-void ir1Return;
-void ir1Throw;
-void ir1Unop;
-void ir1Var;
-void ir1While;
+import {
+  CaptureRiskError,
+  freeVarsIR1Expr,
+  freeVarsIR1Stmt,
+  substituteIR1ExprSubtree,
+  substituteIR1StmtSubtree,
+} from "../src/ir1-substitute.js";
 
 type _IR1Expr = IR1Expr;
 type _IR1Stmt = IR1Stmt;
 
 describe("ir1-substitute", () => {
   describe("unit", () => {
-    it.skip("freeVarsIR1Expr returns vars from a leaf var", () => {
-      // PENDING Patch 3: assert leaf var free-var behavior.
+    it("freeVarsIR1Expr returns vars from a leaf var", () => {
+      assertSetEqual(freeVarsIR1Expr(ir1Var("x")), ["x"]);
     });
 
-    it.skip("freeVarsIR1Expr ignores literals", () => {
-      // PENDING Patch 3: assert literal expressions have no free vars.
+    it("freeVarsIR1Expr ignores literals", () => {
+      assertSetEqual(freeVarsIR1Expr(ir1LitNat(1)), []);
     });
 
-    it.skip("freeVarsIR1Expr respects each binder", () => {
-      // PENDING Patch 3: assert each-binder free-var behavior.
+    it("freeVarsIR1Expr respects each binder", () => {
+      const expr = ir1Each(
+        "x",
+        ir1Var("src"),
+        [ir1Var("x"), ir1Var("g")],
+        ir1Var("x"),
+      );
+      assertSetEqual(freeVarsIR1Expr(expr), ["g", "src"]);
     });
 
-    it.skip("freeVarsIR1Stmt respects block / let / foreach / for binders", () => {
-      // PENDING Patch 3: assert statement-level free vars across block, let, foreach, and for-init binders.
+    it("freeVarsIR1Stmt respects block / let / foreach / for binders", () => {
+      const stmt = ir1Block([
+        ir1Let("x", ir1Var("seed")),
+        ir1Foreach(
+          "y",
+          ir1Var("xs"),
+          ir1Assign(ir1Member(ir1Var("y"), "p"), ir1Var("x")),
+          [
+            {
+              target: ir1Var("acc"),
+              prop: "total",
+              combiner: "add",
+              outerOp: "add",
+              rhs: ir1Var("y"),
+              guard: ir1Var("x"),
+            },
+          ],
+        ),
+        ir1For(
+          ir1Let("i", ir1Var("start")),
+          ir1Var("i"),
+          ir1Assign(ir1Var("i"), ir1Var("x")),
+          ir1Return(ir1Var("i")),
+        ),
+      ]);
+      assertSetEqual(freeVarsIR1Stmt(stmt), ["acc", "seed", "start", "xs"]);
     });
 
-    it.skip("substituteIR1ExprSubtree replaces a leaf Var", () => {
-      // PENDING Patch 3: assert leaf Var replacement through the expression primitive.
+    it("substituteIR1ExprSubtree replaces a leaf Var", () => {
+      assert.deepEqual(
+        substituteIR1ExprSubtree(ir1Var("x"), ir1Var("x"), ir1LitNat(1)),
+        ir1LitNat(1),
+      );
     });
 
-    it.skip("substituteIR1ExprSubtree replaces a Member subtree", () => {
-      // PENDING Patch 3: assert Member subtree replacement through the expression primitive.
+    it("substituteIR1ExprSubtree replaces a Member subtree", () => {
+      const haystack = ir1Member(ir1Member(ir1Var("u"), "profile"), "name");
+      const needle = ir1Member(ir1Var("u"), "profile");
+      assert.deepEqual(
+        substituteIR1ExprSubtree(haystack, needle, ir1Var("p")),
+        ir1Member(ir1Var("p"), "name"),
+      );
     });
 
-    it.skip("substituteIR1ExprSubtree halts at a shadowing each binder", () => {
-      // PENDING Patch 3: assert Var-needle substitution does not descend under a shadowing each binder.
+    it("substituteIR1ExprSubtree halts at a shadowing each binder", () => {
+      const expr = ir1Each(
+        "x",
+        ir1Var("xs"),
+        [ir1Var("x")],
+        ir1Member(ir1Var("x"), "p"),
+      );
+      assert.deepEqual(
+        substituteIR1ExprSubtree(expr, ir1Var("x"), ir1LitNat(0)),
+        ir1Each("x", ir1Var("xs"), [ir1Var("x")], ir1Member(ir1Var("x"), "p")),
+      );
     });
 
-    it.skip("substituteIR1ExprSubtree throws CaptureRiskError on capture risk", () => {
-      // PENDING Patch 3: assert replacement free vars captured by haystack binders throw CaptureRiskError.
+    it("substituteIR1ExprSubtree throws CaptureRiskError on capture risk", () => {
+      assert.throws(
+        () =>
+          substituteIR1ExprSubtree(
+            ir1Each("x", ir1Var("xs"), [], ir1Var("y")),
+            ir1Var("y"),
+            ir1Var("x"),
+          ),
+        CaptureRiskError,
+      );
     });
 
-    it.skip("substituteIR1ExprSubtree preserves shape outside replacement sites", () => {
-      // PENDING Patch 3: assert unrelated expression structure is preserved while matching subtrees are replaced.
+    it("substituteIR1ExprSubtree preserves shape outside replacement sites", () => {
+      const expr = ir1Cond(
+        [[ir1Var("g"), ir1Binop("add", ir1Var("x"), ir1LitNat(1))]],
+        ir1Unop("not", ir1Var("done")),
+      );
+      assert.deepEqual(
+        substituteIR1ExprSubtree(expr, ir1Var("x"), ir1Var("z")),
+        ir1Cond(
+          [[ir1Var("g"), ir1Binop("add", ir1Var("z"), ir1LitNat(1))]],
+          ir1Unop("not", ir1Var("done")),
+        ),
+      );
     });
 
-    it.skip("substituteIR1StmtSubtree threads block-scope let binders", () => {
-      // PENDING Patch 3: assert let binders affect only subsequent block statements during statement substitution.
+    it("substituteIR1StmtSubtree threads block-scope let binders", () => {
+      const stmt = ir1Block([ir1Let("x", ir1Var("x")), ir1Return(ir1Var("x"))]);
+      assert.deepEqual(
+        substituteIR1StmtSubtree(stmt, ir1Var("x"), ir1LitNat(1)),
+        ir1Block([ir1Let("x", ir1LitNat(1)), ir1Return(ir1Var("x"))]),
+      );
     });
 
-    it.skip("substituteIR1StmtSubtree handles foreach binder scope", () => {
-      // PENDING Patch 3: assert foreach binder scope covers body and fold leaves but not source.
+    it("substituteIR1StmtSubtree handles foreach binder scope", () => {
+      const stmt = ir1Foreach(
+        "x",
+        ir1Var("x"),
+        ir1Assign(ir1Member(ir1Var("x"), "p"), ir1Var("x")),
+        [
+          {
+            target: ir1Var("x"),
+            prop: "q",
+            combiner: "add",
+            outerOp: "add",
+            rhs: ir1Var("x"),
+            guard: null,
+          },
+        ],
+      );
+      assert.deepEqual(
+        substituteIR1StmtSubtree(stmt, ir1Var("x"), ir1LitNat(7)),
+        ir1Foreach(
+          "x",
+          ir1LitNat(7),
+          ir1Assign(ir1Member(ir1Var("x"), "p"), ir1Var("x")),
+          [
+            {
+              target: ir1Var("x"),
+              prop: "q",
+              combiner: "add",
+              outerOp: "add",
+              rhs: ir1Var("x"),
+              guard: null,
+            },
+          ],
+        ),
+      );
     });
 
-    it.skip("substituteIR1StmtSubtree handles for-init let scope", () => {
-      // PENDING Patch 3: assert for-init let binders scope over cond, step, and body.
+    it("substituteIR1StmtSubtree handles for-init let scope", () => {
+      const stmt = ir1For(
+        ir1Let("i", ir1Var("i")),
+        ir1Var("i"),
+        ir1Assign(ir1Var("i"), ir1Var("i")),
+        ir1Return(ir1Var("i")),
+      );
+      assert.deepEqual(
+        substituteIR1StmtSubtree(stmt, ir1Var("i"), ir1LitNat(0)),
+        ir1For(
+          ir1Let("i", ir1LitNat(0)),
+          ir1Var("i"),
+          ir1Assign(ir1Var("i"), ir1Var("i")),
+          ir1Return(ir1Var("i")),
+        ),
+      );
     });
   });
 
   describe("properties", () => {
-    it.skip("free vars compose under substitution", () => {
-      // PENDING Patch 3: generator skeleton uses fc.letrec for IR1Expr / IR1Stmt trees, name arbitraries from a small identifier set, and filters to no-capture cases before asserting FV(substitute(h, n, r)) = (FV(h) minus the Var needle name when applicable) union FV(r).
+    it("free vars compose under substitution", () => {
+      fc.assert(
+        fc.property(arbIR1Expr(), (expr) => {
+          const rewritten = substituteIR1ExprSubtree(
+            expr,
+            ir1Var("a"),
+            ir1LitNat(0),
+          );
+          const expected = freeVarsIR1Expr(expr);
+          expected.delete("a");
+          assertSetEqual(freeVarsIR1Expr(rewritten), [...expected]);
+        }),
+      );
     });
 
-    it.skip("substitution is idempotent when needle does not occur", () => {
-      // PENDING Patch 3: generator skeleton uses fc.letrec recursive IR1Expr / IR1Stmt trees plus a needle arbitrary filtered so the needle is absent from the haystack, then asserts substitution returns the original tree.
+    it("substitution is idempotent when needle does not occur", () => {
+      fc.assert(
+        fc.property(arbIR1Expr(), arbIR1Stmt(), (expr, stmt) => {
+          const needle = ir1Var("z");
+          assert(!exprContainsNeedle(expr, needle));
+          assert.deepEqual(
+            substituteIR1ExprSubtree(expr, needle, ir1LitNat(0)),
+            expr,
+          );
+          assert.deepEqual(
+            substituteIR1StmtSubtree(stmt, needle, ir1LitNat(0)),
+            stmt,
+          );
+        }),
+      );
     });
 
-    it.skip("substitution under shadowing binder is identity", () => {
-      // PENDING Patch 3: generator skeleton builds each / let / foreach / for-init binder wrappers around recursive IR1Expr / IR1Stmt haystacks with a Var needle matching the binder, then asserts descent halts at the binder boundary.
+    it("substitution under shadowing binder is identity", () => {
+      fc.assert(
+        fc.property(arbIR1Expr(), (body) => {
+          const expr = ir1Each("a", ir1Var("src"), [body], body);
+          assert.deepEqual(
+            substituteIR1ExprSubtree(expr, ir1Var("a"), ir1LitNat(0)),
+            expr,
+          );
+        }),
+      );
     });
 
-    it.skip("capture-risk inputs throw", () => {
-      // PENDING Patch 3: generator skeleton builds haystacks with binder names drawn from replacement free vars via fc.letrec expression / statement trees, then asserts CaptureRiskError is thrown.
+    it("capture-risk inputs throw", () => {
+      fc.assert(
+        fc.property(nameArb, (name) => {
+          assert.throws(
+            () =>
+              substituteIR1ExprSubtree(
+                ir1Each(name, ir1Var("src"), [], ir1Var("target")),
+                ir1Var("target"),
+                ir1Var(name),
+              ),
+            CaptureRiskError,
+          );
+          assert.throws(
+            () =>
+              substituteIR1StmtSubtree(
+                ir1Foreach(name, ir1Var("src"), ir1Return(ir1Var("target"))),
+                ir1Var("target"),
+                ir1Var(name),
+              ),
+            CaptureRiskError,
+          );
+        }),
+      );
     });
   });
 });
+
+const names = ["a", "b", "c", "d", "e", "f"] as const;
+const nameArb = fc.constantFrom(...names);
+
+function arbIR1Expr(depth = 4): fc.Arbitrary<IR1Expr> {
+  return fc.letrec<{ expr: IR1Expr }>(() => ({
+    expr:
+      depth <= 0
+        ? arbLeafExpr()
+        : fc.oneof(
+            arbLeafExpr(),
+            fc
+              .tuple(arbIR1Expr(depth - 1), fc.constantFrom("p", "q"))
+              .map(([receiver, name]) => ir1Member(receiver, name)),
+            fc
+              .tuple(arbIR1Expr(depth - 1), arbIR1Expr(depth - 1))
+              .map(([lhs, rhs]) => ir1Binop("add", lhs, rhs)),
+            arbIR1Expr(depth - 1).map((arg) => ir1Unop("not", arg)),
+            fc
+              .tuple(
+                arbIR1Expr(depth - 1),
+                fc.array(arbIR1Expr(depth - 1), { maxLength: 2 }),
+              )
+              .map(([callee, args]) => ir1App(callee, args)),
+            arbIR1Expr(depth - 1).map((operand) => ir1IsNullish(operand)),
+            fc
+              .tuple(
+                arbIR1Expr(depth - 1),
+                arbIR1Expr(depth - 1),
+                arbIR1Expr(depth - 1),
+              )
+              .map(([guard, value, otherwise]) =>
+                ir1Cond([[guard, value]], otherwise),
+              ),
+            fc
+              .tuple(
+                nameArb,
+                arbIR1Expr(depth - 1),
+                fc.array(arbIR1Expr(depth - 1), { maxLength: 2 }),
+                arbIR1Expr(depth - 1),
+              )
+              .map(([binder, src, guards, proj]) =>
+                ir1Each(binder, src, guards, proj),
+              ),
+          ),
+  })).expr;
+}
+
+function arbIR1Stmt(depth = 4): fc.Arbitrary<IR1Stmt> {
+  return fc.letrec<{ stmt: IR1Stmt }>(() => ({
+    stmt:
+      depth <= 0
+        ? arbLeafStmt()
+        : fc.oneof(
+            arbLeafStmt(),
+            fc
+              .tuple(nameArb, arbIR1Expr(depth - 1))
+              .map(([name, value]) => ir1Let(name, value)),
+            fc
+              .tuple(arbIR1Expr(depth - 1), arbIR1Expr(depth - 1))
+              .map(([target, value]) => ir1Assign(target, value)),
+            fc
+              .array(arbIR1Stmt(depth - 1), { minLength: 2, maxLength: 3 })
+              .map((stmts) => ir1Block(stmts as [IR1Stmt, ...IR1Stmt[]])),
+            fc
+              .tuple(nameArb, arbIR1Expr(depth - 1), arbIR1Stmt(depth - 1))
+              .map(([binder, source, body]) =>
+                ir1Foreach(
+                  binder,
+                  source,
+                  body as Extract<IR1Stmt, { kind: "assign" }>,
+                  [],
+                ),
+              ),
+            fc
+              .tuple(
+                nameArb,
+                arbIR1Expr(depth - 1),
+                arbIR1Expr(depth - 1),
+                arbIR1Stmt(depth - 1),
+              )
+              .map(([binder, initValue, cond, body]) =>
+                ir1For(ir1Let(binder, initValue), cond, null, body),
+              ),
+            fc
+              .tuple(arbIR1Expr(depth - 1), arbIR1Stmt(depth - 1))
+              .map(([cond, body]) => ir1While(cond, body)),
+          ),
+  })).stmt;
+}
+
+function arbLeafExpr(): fc.Arbitrary<IR1Expr> {
+  return fc.oneof(
+    nameArb.map((name) => ir1Var(name)),
+    fc.boolean().map(ir1LitBool),
+    fc.nat(10).map(ir1LitNat),
+  );
+}
+
+function arbLeafStmt(): fc.Arbitrary<IR1Stmt> {
+  return fc.oneof(
+    arbIR1Expr(0).map(ir1Return),
+    arbIR1Expr(0).map(ir1Throw),
+    arbIR1Expr(0).map(ir1ExprStmt),
+  );
+}
+
+function assertSetEqual(actual: Set<string>, expected: Iterable<string>): void {
+  assert.deepEqual([...actual].sort(), [...expected].sort());
+}
+
+function exprContainsNeedle(
+  expr: IR1Expr,
+  needle: Extract<IR1Expr, { kind: "var" | "member" }>,
+): boolean {
+  if (exprNeedleEqual(expr, needle)) {
+    return true;
+  }
+  switch (expr.kind) {
+    case "var":
+    case "lit":
+      return false;
+    case "binop":
+      return (
+        exprContainsNeedle(expr.lhs, needle) ||
+        exprContainsNeedle(expr.rhs, needle)
+      );
+    case "unop":
+      return exprContainsNeedle(expr.arg, needle);
+    case "app":
+      return (
+        exprContainsNeedle(expr.callee, needle) ||
+        expr.args.some((arg) => exprContainsNeedle(arg, needle))
+      );
+    case "member":
+      return exprContainsNeedle(expr.receiver, needle);
+    case "cond":
+      return (
+        expr.arms.some(
+          ([guard, value]) =>
+            exprContainsNeedle(guard, needle) ||
+            exprContainsNeedle(value, needle),
+        ) || exprContainsNeedle(expr.otherwise, needle)
+      );
+    case "is-nullish":
+      return exprContainsNeedle(expr.operand, needle);
+    case "each":
+      return (
+        exprContainsNeedle(expr.src, needle) ||
+        expr.guards.some((guard) => exprContainsNeedle(guard, needle)) ||
+        exprContainsNeedle(expr.proj, needle)
+      );
+    case "map-read":
+      return (
+        exprContainsNeedle(expr.receiver, needle) ||
+        exprContainsNeedle(expr.key, needle)
+      );
+    case "set-read":
+      return (
+        exprContainsNeedle(expr.receiver, needle) ||
+        exprContainsNeedle(expr.elem, needle)
+      );
+    default: {
+      const _exhaustive: never = expr;
+      return _exhaustive;
+    }
+  }
+}
+
+function exprNeedleEqual(
+  expr: IR1Expr,
+  needle: Extract<IR1Expr, { kind: "var" | "member" }>,
+): boolean {
+  if (expr.kind !== needle.kind) {
+    return false;
+  }
+  if (expr.kind === "var" && needle.kind === "var") {
+    return (
+      expr.name === needle.name &&
+      (expr.primed ?? false) === (needle.primed ?? false)
+    );
+  }
+  if (expr.kind === "member" && needle.kind === "member") {
+    return (
+      expr.name === needle.name &&
+      exprNeedleEqual(
+        expr.receiver,
+        needle.receiver as Extract<IR1Expr, { kind: "var" | "member" }>,
+      )
+    );
+  }
+  return false;
+}


### PR DESCRIPTION
## Patch 3: Implement IR1 substitution primitive; un-skip tests

- Create `tools/ts2pant/src/ir1-substitute.ts`. Import IR1 types and constructors from `./ir1.js`.
- Export `class CaptureRiskError extends Error { binderName: string; capturedVar: string; constructor(binderName, capturedVar) { super(`IR1 substitution would capture free var '${capturedVar}' under binder '${binderName}'`); this.binderName = binderName; this.capturedVar = capturedVar; } }`.
- Implement `freeVarsIR1Expr(expr: IR1Expr): Set<string>`. Recurse over every IR1Expr kind. For `var`, return `{name}`. For binder-introducing forms (`each`), return `freeVars(children) \ {binder}`. For non-binder forms, return the union of children's free vars.
- Implement `freeVarsIR1Stmt(stmt: IR1Stmt): Set<string>`. Recurse over every IR1Stmt kind. For `block`, fold over statements left-to-right, accumulating free vars and removing names introduced by `let` statements as scope is extended. For `foreach`, return `freeVars(source) ∪ (freeVars(body) \ {binder})`. For `for`, accumulate similarly through init/cond/step/body. For `let`, return `freeVars(value)` (the name is in scope only for SUBSEQUENT statements, not for the let's own value).
- Implement `substituteIR1ExprSubtree(haystack, needle, replacement)`. Compute `freeVarsIR1Expr(replacement)` once. Recurse over haystack: (a) if `haystack` structurally equals `needle`, return `replacement`; (b) at each binder-introducing form, check `freeVarsOfReplacement ∩ {binder} ≠ ∅` → throw `CaptureRiskError(binder, captured)`; check if `needle.kind === 'var' && needle.name === binder` → halt (return haystack unchanged); otherwise recurse into children with binder added to scope context; (c) for non-binder forms, recurse into children and reconstruct.
- Implement `substituteIR1StmtSubtree(haystack, needle, replacement)`. Same recursion discipline; threads block-scope binders via a `scopedBinders: Set<string>` parameter that grows as `let` statements are traversed within a block.
- Restrict `needle` to `kind: 'var'` or `kind: 'member'`. Other kinds throw `Error('unsupported needle kind: ...')`.
- Structural-equality helper for needle matching: a private `ir1ExprStructurallyEqual(a, b): boolean` that recursively compares Var and Member shapes (mirrors the existing `structuralEqualL1` in `ir1-build.ts` — read that for reference, but re-implement here so the module is self-contained).
- In `tools/ts2pant/tests/ir1-substitute.test.mts`, remove `.skip` from every stub from Patch 2. Replace PENDING-comment bodies with concrete assertions. Unit tests build hand-coded IR1 trees via the `ir1*` constructors and call the primitive directly. Property tests build fc.Arbitrary generators using `fc.letrec`.
- Property test generators: design `arbIR1Expr` and `arbIR1Stmt` with bounded depth (≤4) and a curated set of var names ('a' through 'f'). Random binders pulled from the same name set so collisions occur naturally. The generators do NOT need full IR1 coverage — they need binder-rich shapes that exercise the scope logic.
- Add a `.gitignore` entry or biome config exclusion if fast-check's run-time output pollutes CI logs (unlikely; check after first run).
- Run `npx tsx --test tools/ts2pant/tests/ir1-substitute.test.mts` and confirm all tests pass.

## Changes
- Create `tools/ts2pant/src/ir1-substitute.ts`. Import IR1 types and constructors from `./ir1.js`.
- Export `class CaptureRiskError extends Error { binderName: string; capturedVar: string; constructor(binderName, capturedVar) { super(`IR1 substitution would capture free var '${capturedVar}' under binder '${binderName}'`); this.binderName = binderName; this.capturedVar = capturedVar; } }`.
- Implement `freeVarsIR1Expr(expr: IR1Expr): Set<string>`. Recurse over every IR1Expr kind. For `var`, return `{name}`. For binder-introducing forms (`each`), return `freeVars(children) \ {binder}`. For non-binder forms, return the union of children's free vars.
- Implement `freeVarsIR1Stmt(stmt: IR1Stmt): Set<string>`. Recurse over every IR1Stmt kind. For `block`, fold over statements left-to-right, accumulating free vars and removing names introduced by `let` statements as scope is extended. For `foreach`, return `freeVars(source) ∪ (freeVars(body) \ {binder})`. For `for`, accumulate similarly through init/cond/step/body. For `let`, return `freeVars(value)` (the name is in scope only for SUBSEQUENT statements, not for the let's own value).
- Implement `substituteIR1ExprSubtree(haystack, needle, replacement)`. Compute `freeVarsIR1Expr(replacement)` once. Recurse over haystack: (a) if `haystack` structurally equals `needle`, return `replacement`; (b) at each binder-introducing form, check `freeVarsOfReplacement ∩ {binder} ≠ ∅` → throw `CaptureRiskError(binder, captured)`; check if `needle.kind === 'var' && needle.name === binder` → halt (return haystack unchanged); otherwise recurse into children with binder added to scope context; (c) for non-binder forms, recurse into children and reconstruct.
- Implement `substituteIR1StmtSubtree(haystack, needle, replacement)`. Same recursion discipline; threads block-scope binders via a `scopedBinders: Set<string>` parameter that grows as `let` statements are traversed within a block.
- Restrict `needle` to `kind: 'var'` or `kind: 'member'`. Other kinds throw `Error('unsupported needle kind: ...')`.
- Structural-equality helper for needle matching: a private `ir1ExprStructurallyEqual(a, b): boolean` that recursively compares Var and Member shapes (mirrors the existing `structuralEqualL1` in `ir1-build.ts` — read that for reference, but re-implement here so the module is self-contained).
- In `tools/ts2pant/tests/ir1-substitute.test.mts`, remove `.skip` from every stub from Patch 2. Replace PENDING-comment bodies with concrete assertions. Unit tests build hand-coded IR1 trees via the `ir1*` constructors and call the primitive directly. Property tests build fc.Arbitrary generators using `fc.letrec`.
- Property test generators: design `arbIR1Expr` and `arbIR1Stmt` with bounded depth (≤4) and a curated set of var names ('a' through 'f'). Random binders pulled from the same name set so collisions occur naturally. The generators do NOT need full IR1 coverage — they need binder-rich shapes that exercise the scope logic.
- Add a `.gitignore` entry or biome config exclusion if fast-check's run-time output pollutes CI logs (unlikely; check after first run).
- Run `npx tsx --test tools/ts2pant/tests/ir1-substitute.test.mts` and confirm all tests pass.

## Files to Modify
- tools/ts2pant/src/ir1-substitute.ts (create): New module exporting `CaptureRiskError`, `freeVarsIR1Expr`, `freeVarsIR1Stmt`, `substituteIR1ExprSubtree`, `substituteIR1StmtSubtree`. Walks every IR1Expr and IR1Stmt form. Threads in-scope binders; throws `CaptureRiskError` on capture risk; halts at Var-needle shadowing binder; recurses structurally otherwise.
- tools/ts2pant/tests/ir1-substitute.test.mts (modify): Remove `.skip` from every `it.skip(...)` introduced in Patch 2. Replace each PENDING-comment body with concrete assertions. Property tests use `fc.assert(fc.property(gen, prop), { numRuns: 100 })` (default) or higher for stress.

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[pattern] Barendregt convention** — https://en.wikipedia.org/wiki/Lambda_calculus#The_Barendregt_convention — The primitive enforces a relaxed form of the Barendregt convention: replacement's free vars must not intersect haystack binders. Violations throw `CaptureRiskError`. This is the foundational invariant; the capture-check is one line of set intersection per binder encountered during the recursion.
- **[paper] Baader & Nipkow, Term Rewriting and All That, Ch. 2** — https://www.cambridge.org/core/books/term-rewriting-and-all-that/F825D78F9EE1C7C0BE2C61D04F89E6DA — Positions, subterms, substitution. The walker's structural recursion follows the textbook discipline: identify the position (subterm matches needle?), substitute or recurse, respecting binder scope as a position-partitioning device. Read Ch. 2 if uncertain about edge cases like needle ≡ haystack (return replacement directly without descent) or empty subtree handling.
- **[library] fast-check** — https://fast-check.dev/ — Property tests use `fc.letrec` to build recursive `Arbitrary<IR1Expr>` and `Arbitrary<IR1Stmt>` generators. The properties (free-vars composition, idempotence, shadowing identity, capture rejection) are encoded as `fc.assert(fc.property(...))`. `fc.commands` is overkill for this primitive; plain property assertions suffice. Default `numRuns: 100` is fine; bump per property if specific bugs slip through.

## Gameplan Specification

```
module TS2PANT_IR1_SUBSTITUTION.

> ════════════════════════════════
> Single-milestone workstream: IR1 capture-avoiding substitution.
> ════════════════════════════════
> After this gameplan, ts2pant has one TS-side capture-avoiding
> substitution primitive that handles every IR1-level
> substitution need. The two existing hand-rolled walkers
> (substituteL1Subtree for functor-lift; substituteMemberReads
> for fixed-point) are deleted; their callers route through
> the new primitive. The primitive throws CaptureRiskError on
> capture risk, halts at Var-needle shadowing binders, and
> recurses structurally otherwise. Documentation in the IR doc
> and AGENTS.md PR #84 post-mortem establishes the discipline.

IR1Expr.
IR1Stmt.
Name.
FreeVarSet.
Walker.
Fixture.
SnapshotState.
Document.
DocumentKind.
DocumentMention.
NeedleKind.
Package.
Dependency.
substituteIR1ExprSubtree => Walker.
substituteIR1StmtSubtree => Walker.
substituteL1Subtree => Walker.
substituteMemberReads => Walker.
fast-check => Dependency.
identical => SnapshotState.
drifted => SnapshotState.
ir-doc => DocumentKind.
agents-md => DocumentKind.
substitution-discipline => DocumentMention.
pr-226-postmortem => DocumentMention.
var => NeedleKind.
member => NeedleKind.

has-dev-dependency? p: Package, d: Dependency => Bool.
walker-exists? w: Walker => Bool.
functor-lift-uses w: Walker => Bool.
fixed-point-uses w: Walker => Bool.
needle-kind n: IR1Expr => NeedleKind.
free-vars-expr e: IR1Expr => FreeVarSet.
free-vars-stmt s: IR1Stmt => FreeVarSet.
binders-of-expr e: IR1Expr => FreeVarSet.
binders-of-stmt s: IR1Stmt => FreeVarSet.
capture-risk? haystack-binders: FreeVarSet, repl-free: FreeVarSet => Bool.
substitutes-cleanly? h: IR1Expr, n: IR1Expr, r: IR1Expr => Bool.
throws-capture-error? h: IR1Expr, n: IR1Expr, r: IR1Expr => Bool.
is-identity-under-shadow? h: IR1Expr, n: IR1Expr, r: IR1Expr => Bool.
shadows-needle? binder: Name, n: IR1Expr => Bool.
snapshot-state f: Fixture => SnapshotState.
is-functor-lift-fixture? f: Fixture => Bool.
is-fixed-point-fixture? f: Fixture => Bool.
document-kind d: Document => DocumentKind.
document-mentions? d: Document, m: DocumentMention => Bool.
---

> Dependency.
all p: Package | has-dev-dependency? p fast-check.

> The new primitives exist; the old walkers do not.
walker-exists? substituteIR1ExprSubtree.
walker-exists? substituteIR1StmtSubtree.
~(walker-exists? substituteL1Subtree).
~(walker-exists? substituteMemberReads).

> Both former call sites route through the new primitive.
functor-lift-uses substituteIR1ExprSubtree.
fixed-point-uses substituteIR1ExprSubtree.

> Primitive contract: capture risk throws; clean substitution
> returns the result; shadowing binders halt the descent for
> Var needles.
all h: IR1Expr, n: IR1Expr, r: IR1Expr |
  capture-risk? (binders-of-expr h) (free-vars-expr r) <-> throws-capture-error? h n r.

all h: IR1Expr, n: IR1Expr, r: IR1Expr |
  substitutes-cleanly? h n r -> ~(throws-capture-error? h n r).

all h: IR1Expr, n: IR1Expr, r: IR1Expr, b: Name |
  needle-kind n = var and shadows-needle? b n ->
    is-identity-under-shadow? h n r.

> Snapshot equivalence on every migrated fixture.
all f: Fixture | is-functor-lift-fixture? f -> snapshot-state f = identical.
all f: Fixture | is-fixed-point-fixture? f -> snapshot-state f = identical.

> Documentation invariants.
all d: Document |
  document-kind d = ir-doc ->
    document-mentions? d substitution-discipline.

all d: Document |
  document-kind d = agents-md ->
    document-mentions? d pr-226-postmortem.
```

## Patch Specification

```
module TS2PANT_IR1_SUBSTITUTION_PATCH_3.

> Patch 3 implements the capture-avoiding substitution
> primitive. Replacement's free vars must not collide with
> haystack binders; violations throw CaptureRiskError.
> Var needles whose names match a binder halt at the binder
> boundary (substitution does not descend into shadowed
> scope). Non-binder forms recurse structurally.

IR1Expr.
IR1Stmt.
Name.
FreeVarSet.
SubResult.
NeedleKind.
var => NeedleKind.
member => NeedleKind.

needle-kind n: IR1Expr => NeedleKind.
free-vars-expr e: IR1Expr => FreeVarSet.
free-vars-stmt s: IR1Stmt => FreeVarSet.
binders-of-expr e: IR1Expr => FreeVarSet.
binders-of-stmt s: IR1Stmt => FreeVarSet.
capture-risk? haystack-binders: FreeVarSet, repl-free: FreeVarSet => Bool.
substitutes-cleanly? h: IR1Expr, n: IR1Expr, r: IR1Expr => Bool.
throws-capture-error? h: IR1Expr, n: IR1Expr, r: IR1Expr => Bool.
is-identity-under-shadow? h: IR1Expr, n: IR1Expr, r: IR1Expr => Bool.
shadows-needle? binder: Name, n: IR1Expr => Bool.
---

> Capture-risk detection: replacement free vars intersecting
> haystack binders cause a throw.
all h: IR1Expr, n: IR1Expr, r: IR1Expr |
  capture-risk? (binders-of-expr h) (free-vars-expr r) <-> throws-capture-error? h n r.

> Clean substitution returns a result with composed free vars
> (the no-capture path).
all h: IR1Expr, n: IR1Expr, r: IR1Expr |
  substitutes-cleanly? h n r -> ~(throws-capture-error? h n r).

> A Var needle whose name matches a binder halts at that binder
> (substitution under shadow is identity for that subtree).
all h: IR1Expr, n: IR1Expr, r: IR1Expr, b: Name |
  needle-kind n = var and shadows-needle? b n ->
    is-identity-under-shadow? h n r.
```


## Implementation Notes

- Capture checks are intentionally scope-entry checks, not occurrence-sensitive checks. If a replacement free var collides with an IR1 binder whose scope the walker enters, the primitive throws even if that specific scope might not contain a matching needle; this keeps the caller contract simple and matches the patch spec's binder/free-var intersection invariant.
- Statement substitution treats `let` exactly as a block-scoped binder for subsequent statements only. A `let` value is rewritten under the incoming scope, then the binder is added for later siblings; `for` init `let` binders are added for `cond`, `step`, and `body`.
- `each` source is still rewritten when the `each` binder shadows a Var needle, because the source is outside the binder's scope. Guards and projection are left unchanged under shadow.
- The structural matcher remains deliberately narrow: only Var and Member needles are accepted, and Member equality bottoms out through Var/Member receiver chains. This preserves the predecessor walkers' intended matching surface without making arbitrary IR1 structural equality part of this API.

Spec/Evidence Mapping:
- Capture-risk rejection: `throwIfCaptureRisk` plus binder-entry calls in `substituteExpr`, `substituteStmt`, and `substituteExprRespectingScope`; covered by `substituteIR1ExprSubtree throws CaptureRiskError on capture risk` and `capture-risk inputs throw`.
- Shadowing halt: `shadowsNeedle` and the `each`/block-scope/`foreach`/`for` scope handling; covered by the shadowing unit tests and `substitution under shadowing binder is identity`.
- Exhaustive IR1 traversal: `freeVarsIR1Expr`, `freeVarsIR1Stmt`, `substituteExpr`, and `substituteStmt` each have discriminated-union exhaustive `never` checks; verified by `npx tsc --noEmit`.
- Static/runtime checks run: `npx tsx --test tools/ts2pant/tests/ir1-substitute.test.mts`, `npx tsc --noEmit`, and `npx biome check src tests/ir1-substitute.test.mts`.