### PR TITLE
[ts2pant-ir1-substitution] Patch 5: Migrate fixed-point's substituteMemberReads to the primitive

### DIFF
--- a/tools/ts2pant/src/ir1-ssa-fixed-point.ts
+++ b/tools/ts2pant/src/ir1-ssa-fixed-point.ts
@@ -18,6 +18,7 @@ import {
   ir1Var,
 } from "./ir1.js";
 import { lowerL1Expr } from "./ir1-lower.js";
+import { substituteIR1ExprSubtree } from "./ir1-substitute.js";
 import type { LoopSsaBuildOptions } from "./ir1-ssa-loops.js";
 import {
   type IR1SsaBodyLowerResult,
@@ -170,7 +171,7 @@ export function lowerFixedPointLoopL1Body(
     stateAvoidanceNames([guardExpr, valueExpr], writeBody.target),
   );
   const stateVar = ir1Var(stateName);
-  const effectExpr = substituteMemberReads(
+  const effectExpr = substituteIR1ExprSubtree(
     valueExpr,
     writeBody.target,
     stateVar,
@@ -210,7 +211,9 @@ export function lowerFixedPointLoopL1Body(
   const effect = lowerOpaque(lowerExpr(lowerL1Expr(effectExpr)));
   const loweredGuard = lowerOpaque(
     lowerExpr(
-      lowerL1Expr(substituteMemberReads(guardExpr, writeBody.target, stateVar)),
+      lowerL1Expr(
+        substituteIR1ExprSubtree(guardExpr, writeBody.target, stateVar),
+      ),
     ),
   );
   const helperCallOnEffect = ast.app(ast.var(ruleName), [
@@ -722,114 +725,6 @@ function renameBoundVarRefs(expr: IR1Expr, from: string, to: string): IR1Expr {
         ...expr,
         receiver: renameBoundVarRefs(expr.receiver, from, to),
         elem: renameBoundVarRefs(expr.elem, from, to),
-      };
-    default: {
-      const _exhaustive: never = expr;
-      void _exhaustive;
-      return expr;
-    }
-  }
-}
-
-function substituteMemberReads(
-  expr: IR1Expr,
-  member: Extract<IR1Expr, { kind: "member" }>,
-  replacement: IR1Expr,
-  bound: ReadonlySet<string> = new Set(),
-): IR1Expr {
-  if (sameUnshadowedMemberExpr(expr, member, bound)) {
-    return replacement;
-  }
-  switch (expr.kind) {
-    case "var":
-    case "lit":
-      return expr;
-    case "binop":
-      return {
-        ...expr,
-        lhs: substituteMemberReads(expr.lhs, member, replacement, bound),
-        rhs: substituteMemberReads(expr.rhs, member, replacement, bound),
-      };
-    case "unop":
-      return {
-        ...expr,
-        arg: substituteMemberReads(expr.arg, member, replacement, bound),
-      };
-    case "app":
-      return {
-        ...expr,
-        callee: substituteMemberReads(expr.callee, member, replacement, bound),
-        args: expr.args.map((arg) =>
-          substituteMemberReads(arg, member, replacement, bound),
-        ),
-      };
-    case "member":
-      return {
-        ...expr,
-        receiver: substituteMemberReads(
-          expr.receiver,
-          member,
-          replacement,
-          bound,
-        ),
-      };
-    case "cond":
-      return {
-        ...expr,
-        arms: expr.arms.map(([guard, value]) => [
-          substituteMemberReads(guard, member, replacement, bound),
-          substituteMemberReads(value, member, replacement, bound),
-        ]),
-        otherwise: substituteMemberReads(
-          expr.otherwise,
-          member,
-          replacement,
-          bound,
-        ),
-      };
-    case "is-nullish":
-      return {
-        ...expr,
-        operand: substituteMemberReads(
-          expr.operand,
-          member,
-          replacement,
-          bound,
-        ),
-      };
-    case "each": {
-      const nextBound = new Set(bound);
-      nextBound.add(expr.binder);
-      return {
-        ...expr,
-        src: substituteMemberReads(expr.src, member, replacement, bound),
-        guards: expr.guards.map((guard) =>
-          substituteMemberReads(guard, member, replacement, nextBound),
-        ),
-        proj: substituteMemberReads(expr.proj, member, replacement, nextBound),
-      };
-    }
-    case "map-read":
-      return {
-        ...expr,
-        receiver: substituteMemberReads(
-          expr.receiver,
-          member,
-          replacement,
-          bound,
-        ),
-        key: substituteMemberReads(expr.key, member, replacement, bound),
-      };
-    case "set-read":
-      return {
-        ...expr,
-        receiver: substituteMemberReads(
-          expr.receiver,
-          member,
-          replacement,
-          bound,
-        ),
-        elem: substituteMemberReads(expr.elem, member, replacement, bound),
       };
     default: {
       const _exhaustive: never = expr;

--- a/tools/ts2pant/src/ir1-ssa-fixed-point.ts
+++ b/tools/ts2pant/src/ir1-ssa-fixed-point.ts
@@ -18,13 +18,13 @@ import {
   ir1Var,
 } from "./ir1.js";
 import { lowerL1Expr } from "./ir1-lower.js";
-import { substituteIR1ExprSubtree } from "./ir1-substitute.js";
 import type { LoopSsaBuildOptions } from "./ir1-ssa-loops.js";
 import {
   type IR1SsaBodyLowerResult,
   ir1SsaBodyLowerSuccess,
   ir1SsaBodyLowerUnsupported,
 } from "./ir1-ssa-lower.js";
+import { substituteIR1ExprSubtree } from "./ir1-substitute.js";
 import { registerName } from "./name-registry.js";
 import type { OpaqueExpr, OpaqueTypeExpr } from "./pant-ast.js";
 import { getAst } from "./pant-wasm.js";


### PR DESCRIPTION
## Patch 5: Migrate fixed-point's substituteMemberReads to the primitive

- In `tools/ts2pant/src/ir1-ssa-fixed-point.ts`, identify the call sites of `substituteMemberReads` (line 128, 158, and any others). They likely look like `substituteMemberReads(expr, member, stateVar)`.
- Replace each call site with `substituteIR1ExprSubtree(expr, member, stateVar)`. The signature matches.
- Delete the `substituteMemberReads` function definition (around line 358 onward, ~80 lines of recursive switch).
- Run `just ts2pant-test` to confirm zero regression. The user-`s` collision regression test (added in PR #226) verifies the primitive's capture-check correctly fires when the loop body contains a `s` variable shadowing the state binder — the new primitive should pass this with the same fresh-binder allocation logic the caller already does.
- Run `just ts2pant-test-integration` to confirm fixed-point `pant --check` integration tests pass.
- Inspect the constructs snapshot diff: `git diff tools/ts2pant/tests/constructs.test.mts.snapshot`. Expect empty diff. If non-empty, abort and investigate.

## Changes
- In `tools/ts2pant/src/ir1-ssa-fixed-point.ts`, identify the call sites of `substituteMemberReads` (line 128, 158, and any others). They likely look like `substituteMemberReads(expr, member, stateVar)`.
- Replace each call site with `substituteIR1ExprSubtree(expr, member, stateVar)`. The signature matches.
- Delete the `substituteMemberReads` function definition (around line 358 onward, ~80 lines of recursive switch).
- Run `just ts2pant-test` to confirm zero regression. The user-`s` collision regression test (added in PR #226) verifies the primitive's capture-check correctly fires when the loop body contains a `s` variable shadowing the state binder — the new primitive should pass this with the same fresh-binder allocation logic the caller already does.
- Run `just ts2pant-test-integration` to confirm fixed-point `pant --check` integration tests pass.
- Inspect the constructs snapshot diff: `git diff tools/ts2pant/tests/constructs.test.mts.snapshot`. Expect empty diff. If non-empty, abort and investigate.

## Files to Modify
- tools/ts2pant/src/ir1-ssa-fixed-point.ts (modify): Delete `substituteMemberReads`. Replace its call sites in the fixed-point lowerer with `substituteIR1ExprSubtree` from `./ir1-substitute.js`.
- tools/ts2pant/tests/ir1-ssa-fixed-point.test.mts (modify): Spot-check that existing fixed-point unit tests still pass. The user-`s` collision regression test added in PR #226 should still pass via the new primitive.
- tools/ts2pant/tests/constructs.test.mts.snapshot (modify): Must be byte-identical after the migration. If `npm run test:update-snapshots` produces a diff for `functions-mutating-fixed-point-while.ts`, the migration has changed behavior and is a STOP — do not commit the diff; abort the patch.

## Gameplan Specification

```
module TS2PANT_IR1_SUBSTITUTION.

> ════════════════════════════════
> Single-milestone workstream: IR1 capture-avoiding substitution.
> ════════════════════════════════
> After this gameplan, ts2pant has one TS-side capture-avoiding
> substitution primitive that handles every IR1-level
> substitution need. The two existing hand-rolled walkers
> (substituteL1Subtree for functor-lift; substituteMemberReads
> for fixed-point) are deleted; their callers route through
> the new primitive. The primitive throws CaptureRiskError on
> capture risk, halts at Var-needle shadowing binders, and
> recurses structurally otherwise. Documentation in the IR doc
> and AGENTS.md PR #84 post-mortem establishes the discipline.

IR1Expr.
IR1Stmt.
Name.
FreeVarSet.
Walker.
Fixture.
SnapshotState.
Document.
DocumentKind.
DocumentMention.
NeedleKind.
Package.
Dependency.
substituteIR1ExprSubtree => Walker.
substituteIR1StmtSubtree => Walker.
substituteL1Subtree => Walker.
substituteMemberReads => Walker.
fast-check => Dependency.
identical => SnapshotState.
drifted => SnapshotState.
ir-doc => DocumentKind.
agents-md => DocumentKind.
substitution-discipline => DocumentMention.
pr-226-postmortem => DocumentMention.
var => NeedleKind.
member => NeedleKind.

has-dev-dependency? p: Package, d: Dependency => Bool.
walker-exists? w: Walker => Bool.
functor-lift-uses w: Walker => Bool.
fixed-point-uses w: Walker => Bool.
needle-kind n: IR1Expr => NeedleKind.
free-vars-expr e: IR1Expr => FreeVarSet.
free-vars-stmt s: IR1Stmt => FreeVarSet.
binders-of-expr e: IR1Expr => FreeVarSet.
binders-of-stmt s: IR1Stmt => FreeVarSet.
capture-risk? haystack-binders: FreeVarSet, repl-free: FreeVarSet => Bool.
substitutes-cleanly? h: IR1Expr, n: IR1Expr, r: IR1Expr => Bool.
throws-capture-error? h: IR1Expr, n: IR1Expr, r: IR1Expr => Bool.
is-identity-under-shadow? h: IR1Expr, n: IR1Expr, r: IR1Expr => Bool.
shadows-needle? binder: Name, n: IR1Expr => Bool.
snapshot-state f: Fixture => SnapshotState.
is-functor-lift-fixture? f: Fixture => Bool.
is-fixed-point-fixture? f: Fixture => Bool.
document-kind d: Document => DocumentKind.
document-mentions? d: Document, m: DocumentMention => Bool.
---

> Dependency.
all p: Package | has-dev-dependency? p fast-check.

> The new primitives exist; the old walkers do not.
walker-exists? substituteIR1ExprSubtree.
walker-exists? substituteIR1StmtSubtree.
~(walker-exists? substituteL1Subtree).
~(walker-exists? substituteMemberReads).

> Both former call sites route through the new primitive.
functor-lift-uses substituteIR1ExprSubtree.
fixed-point-uses substituteIR1ExprSubtree.

> Primitive contract: capture risk throws; clean substitution
> returns the result; shadowing binders halt the descent for
> Var needles.
all h: IR1Expr, n: IR1Expr, r: IR1Expr |
  capture-risk? (binders-of-expr h) (free-vars-expr r) <-> throws-capture-error? h n r.

all h: IR1Expr, n: IR1Expr, r: IR1Expr |
  substitutes-cleanly? h n r -> ~(throws-capture-error? h n r).

all h: IR1Expr, n: IR1Expr, r: IR1Expr, b: Name |
  needle-kind n = var and shadows-needle? b n ->
    is-identity-under-shadow? h n r.

> Snapshot equivalence on every migrated fixture.
all f: Fixture | is-functor-lift-fixture? f -> snapshot-state f = identical.
all f: Fixture | is-fixed-point-fixture? f -> snapshot-state f = identical.

> Documentation invariants.
all d: Document |
  document-kind d = ir-doc ->
    document-mentions? d substitution-discipline.

all d: Document |
  document-kind d = agents-md ->
    document-mentions? d pr-226-postmortem.
```

## Patch Specification

```
module TS2PANT_IR1_SUBSTITUTION_PATCH_5.

> Patch 5 migrates the fixed-point lowerer's
> substituteMemberReads calls to substituteIR1ExprSubtree.
> The old walker is deleted. Fixed-point fixtures'
> snapshots remain byte-identical.

Walker.
Fixture.
SnapshotState.
substituteMemberReads => Walker.
substituteIR1ExprSubtree => Walker.
identical => SnapshotState.
drifted => SnapshotState.

fixed-point-uses w: Walker => Bool.
walker-exists? w: Walker => Bool.
snapshot-state f: Fixture => SnapshotState.
is-fixed-point-fixture? f: Fixture => Bool.
---

fixed-point-uses substituteIR1ExprSubtree.
~(walker-exists? substituteMemberReads).

all f: Fixture | is-fixed-point-fixture? f -> snapshot-state f = identical.
```


## Implementation Notes

- This migration is intentionally mechanical: fixed-point lowering still allocates the fresh `stateVar` before substitution, and the only behavioral change is delegating traversal/capture checks to `substituteIR1ExprSubtree`.
- I did not modify `ir1-ssa-fixed-point.test.mts`; the existing unit and integration coverage already exercises this path, and the constructs snapshot stayed byte-identical.
- Required context note: `workstreams/ts2pant-ir1-substitution.md` was not present in this worktree, so I used the in-prompt gameplan/spec plus the predecessor fixed-point implementation and snapshot gate as the authoritative context available locally.

Spec/Evidence Mapping:
- `fixed-point-uses substituteIR1ExprSubtree`: [tools/ts2pant/src/ir1-ssa-fixed-point.ts](/Users/zax/worktrees/ts2pant-ir1-substitution/patch-5/tools/ts2pant/src/ir1-ssa-fixed-point.ts) now imports the primitive and calls it for both the effect expression and loop guard rewrite.
- `~(walker-exists? substituteMemberReads)`: `rg "substituteMemberReads" tools/ts2pant/src` returns no matches after deleting the local recursive walker.
- Fixed-point snapshots remain `identical`: `git diff tools/ts2pant/tests/constructs.test.mts.snapshot` was empty.
- Verification: `just ts2pant-test` passed, and the explicit `just ts2pant-test-integration` run passed.