### PR TITLE
[ts2pant-ir1-substitution] Patch 4: Migrate functor-lift's substituteL1Subtree to the primitive

### DIFF
--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -58,6 +58,7 @@ import {
   ir1While,
 } from "./ir1.js";
 import { lowerL1Expr } from "./ir1-lower.js";
+import { substituteIR1ExprSubtree } from "./ir1-substitute.js";
 import {
   getOperandDeclaredType,
   type NullishTranslate,
@@ -1651,10 +1652,9 @@ function allocateLiftBinder(ctx: L1BuildContext, hint: string): string {
 //    (substitution wouldn't fire) or, worse, with the operand still
 //    referenced free of the binder. The recognizer enforces this by
 //    gating on the explicit `changed` flag returned by
-//    `substituteL1Subtree` for Member operands; for Var operands, the
-//    TS-AST walk (`expressionReferencesNames`) is the precondition and
-//    post-lowering `ast.substituteBinder` is the substitution
-//    primitive.
+//    `substituteIR1ExprSubtree`'s reference-preserving result for
+//    Member operands; for Var operands, the TS-AST walk
+//    (`expressionReferencesNames`) is an early precondition.
 //
 // 3. **Referential transparency at the operand position.** The
 //    comprehension evaluates `e` once at its source position
@@ -1665,245 +1665,16 @@ function allocateLiftBinder(ctx: L1BuildContext, hint: string): string {
 //    lifted nullable types under TypeScript don't admit side effects
 //    in the comparison position the recognizer matches.
 //
-// 4. **Closed form on Var/Member.** `structuralEqualL1` only compares
-//    `Var` and `Member` shapes. The pure-L1 builder
+// 4. **Closed form on Var/Member.** `substituteIR1ExprSubtree` supports
+//    `Var` and `Member` needles. The pure-L1 builder
 //    `buildL1MemberOrVarForLift` produces only those shapes, so
 //    operand and projection trees are exhaustively comparable along
-//    the Member-operand path. For other compound forms the walker
-//    descends but the structural-match leaves never fire for a
-//    Member needle, falling out via `changed: false`.
+//    the Member-operand path.
 //
 // Future changes to this rewrite should re-verify these four
 // invariants. Adding new comparable forms (e.g., to support `App` as
-// an eligible operand) requires extending both `structuralEqualL1`
-// and the `buildL1MemberOrVarForLift` accept-set together; partial
-// extension breaks invariant 4.
-
-/**
- * Structural equality on L1 expressions, scoped to the shapes the
- * functor-lift recognizer compares: `Var` (name + primed) and `Member`
- * (name + receiver, recursing). Other forms compare false — the
- * recognizer's eligibility check builds operand and projection through
- * a pure-L1 path that produces only Var/Member trees, so any other
- * form is a structural mismatch by construction. Parens and other
- * source-level wrappers are normalized away by L1 build before this
- * function ever sees the trees.
- *
- * See the comment block above for the underlying term-rewriting
- * reference and the four soundness invariants this comparator
- * supports.
- */
-function structuralEqualL1(a: IR1Expr, b: IR1Expr): boolean {
-  if (a === b) {
-    return true;
-  }
-  if (a.kind !== b.kind) {
-    return false;
-  }
-  if (a.kind === "var" && b.kind === "var") {
-    return a.name === b.name && (a.primed ?? false) === (b.primed ?? false);
-  }
-  if (a.kind === "member" && b.kind === "member") {
-    return a.name === b.name && structuralEqualL1(a.receiver, b.receiver);
-  }
-  return false;
-}
-
-/**
- * Result of an `substituteL1Subtree` walk. `changed` reports whether
- * any subtree structurally matched `needle` and was replaced. The
- * Member-operand functor-lift path uses this to detect "operand not
- * structurally referenced" — a reference-equality check on the
- * returned tree is unreliable because the walker reconstructs every
- * compound node it traverses (e.g., `ir1Member(rec, name)`) regardless
- * of whether the recursive sub-call substituted. A projection like
- * `v.next.name` against operand `u.next` would otherwise rebuild a
- * fresh top-level Member tree even though no substitution fired,
- * letting projections that don't reference the operand silently emit
- * a comprehension body with a free variable.
- */
-interface L1SubstResult {
-  result: IR1Expr;
-  changed: boolean;
-}
-
-/**
- * Replace every subtree of `root` whose L1 form structurally equals
- * `needle` with `replacement`. The walker recurses through every L1
- * form. Returns the rewritten tree plus a `changed` flag indicating
- * whether substitution actually fired anywhere along the walk.
- *
- * This is the term-rewriting primitive that backs the functor-lift's
- * `body[e := $n]` substitution — see the comment block above
- * `structuralEqualL1` for the algorithm reference (Baader & Nipkow ch. 2)
- * and the four soundness invariants it depends on.
- *
- * Used by the functor-lift recognizer: the operand's L1 form (a `Var`
- * or `Member` chain) is replaced by a fresh `Var(binder)` inside the
- * projection's L1 form, so the comprehension body references the
- * binder rather than the operand. The projection must be in pure L1
- * for substitution to fire (no equivalent OpaqueExpr-level
- * substitution exists for arbitrary subtrees).
- */
-function substituteL1Subtree(
-  root: IR1Expr,
-  needle: IR1Expr,
-  replacement: IR1Expr,
-): L1SubstResult {
-  if (structuralEqualL1(root, needle)) {
-    return { result: replacement, changed: true };
-  }
-  switch (root.kind) {
-    case "var":
-    case "lit":
-      return { result: root, changed: false };
-    case "binop": {
-      const lhs = substituteL1Subtree(root.lhs, needle, replacement);
-      const rhs = substituteL1Subtree(root.rhs, needle, replacement);
-      const changed = lhs.changed || rhs.changed;
-      return changed
-        ? { result: ir1Binop(root.op, lhs.result, rhs.result), changed: true }
-        : { result: root, changed: false };
-    }
-    case "unop": {
-      const arg = substituteL1Subtree(root.arg, needle, replacement);
-      return arg.changed
-        ? { result: ir1Unop(root.op, arg.result), changed: true }
-        : { result: root, changed: false };
-    }
-    case "app": {
-      const callee = substituteL1Subtree(root.callee, needle, replacement);
-      const args = root.args.map((a) =>
-        substituteL1Subtree(a, needle, replacement),
-      );
-      const changed = callee.changed || args.some((a) => a.changed);
-      return changed
-        ? {
-            result: {
-              kind: "app",
-              callee: callee.result,
-              args: args.map((a) => a.result),
-            },
-            changed: true,
-          }
-        : { result: root, changed: false };
-    }
-    case "member": {
-      const recv = substituteL1Subtree(root.receiver, needle, replacement);
-      return recv.changed
-        ? { result: ir1Member(recv.result, root.name), changed: true }
-        : { result: root, changed: false };
-    }
-    case "cond": {
-      const armsRewritten = root.arms.map(([g, v]) => {
-        const gr = substituteL1Subtree(g, needle, replacement);
-        const vr = substituteL1Subtree(v, needle, replacement);
-        return { gr, vr } as const;
-      });
-      const otherwise = substituteL1Subtree(
-        root.otherwise,
-        needle,
-        replacement,
-      );
-      const changed =
-        otherwise.changed ||
-        armsRewritten.some(({ gr, vr }) => gr.changed || vr.changed);
-      if (!changed) {
-        return { result: root, changed: false };
-      }
-      const newArms = armsRewritten.map(
-        ({ gr, vr }) => [gr.result, vr.result] as const,
-      );
-      return {
-        result: ir1Cond(
-          newArms as [
-            readonly [IR1Expr, IR1Expr],
-            ...ReadonlyArray<readonly [IR1Expr, IR1Expr]>,
-          ],
-          otherwise.result,
-        ),
-        changed: true,
-      };
-    }
-    case "is-nullish": {
-      const operand = substituteL1Subtree(root.operand, needle, replacement);
-      return operand.changed
-        ? { result: ir1IsNullish(operand.result), changed: true }
-        : { result: root, changed: false };
-    }
-    case "each": {
-      // Don't recurse into the comprehension binder's scope when the
-      // binder shadows a Var-needle: substitution stops at the binding
-      // boundary. Member-needles aren't shadowed by a binder name, so
-      // `each` always recurses on `proj` for those.
-      const src = substituteL1Subtree(root.src, needle, replacement);
-      const shadowed =
-        needle.kind === "var" && !needle.primed && needle.name === root.binder;
-      const guards = shadowed
-        ? root.guards.map((g) => ({ result: g, changed: false }))
-        : root.guards.map((g) => substituteL1Subtree(g, needle, replacement));
-      const proj = shadowed
-        ? { result: root.proj, changed: false }
-        : substituteL1Subtree(root.proj, needle, replacement);
-      const changed =
-        src.changed || guards.some((g) => g.changed) || proj.changed;
-      if (!changed) {
-        return { result: root, changed: false };
-      }
-      return {
-        result: {
-          kind: "each",
-          binder: root.binder,
-          src: src.result,
-          guards: guards.map((g) => g.result),
-          proj: proj.result,
-        },
-        changed: true,
-      };
-    }
-    case "map-read": {
-      const recv = substituteL1Subtree(root.receiver, needle, replacement);
-      const key = substituteL1Subtree(root.key, needle, replacement);
-      const changed = recv.changed || key.changed;
-      return changed
-        ? {
-            result: ir1MapRead(
-              root.op,
-              root.ruleName,
-              root.keyPredName,
-              root.ownerType,
-              root.keyType,
-              recv.result,
-              key.result,
-            ),
-            changed: true,
-          }
-        : { result: root, changed: false };
-    }
-    case "set-read": {
-      const recv = substituteL1Subtree(root.receiver, needle, replacement);
-      const elem = substituteL1Subtree(root.elem, needle, replacement);
-      const changed = recv.changed || elem.changed;
-      return changed
-        ? {
-            result: ir1SetRead(
-              root.ruleName,
-              root.ownerType,
-              root.elemType,
-              recv.result,
-              elem.result,
-            ),
-            changed: true,
-          }
-        : { result: root, changed: false };
-    }
-    default: {
-      const _exhaustive: never = root;
-      void _exhaustive;
-      return { result: root, changed: false };
-    }
-  }
-}
+// an eligible operand) requires extending the shared IR1 substitution
+// primitive and the `buildL1MemberOrVarForLift` accept-set together.
 
 /**
  * Build a pure-L1 representation of `node` for the functor-lift
@@ -2037,12 +1808,11 @@ function buildL1MemberOrVarForLift(
  * Substitution strategy. Both Var and Member operands route the
  * projection through `buildSubExpr` (Var) or
  * `buildL1MemberOrVarForLift` (Member); the result is fully native
- * L1 since M6 deleted the L2-embedding adapter. The L1 rewriter
- * `substituteL1Subtree` then replaces operand-shape subtrees with
+ * L1 since M6 deleted the L2-embedding adapter. The shared IR1
+ * substitution primitive then replaces operand-shape subtrees with
  * the comprehension binder via structural matching. A Member-operand
  * projection that isn't pure L1 (e.g., a method call wrapping the
- * operand) falls
- * through.
+ * operand) falls through.
  */
 export function tryRecognizeFunctorLift(
   cand: FunctorLiftCandidate,
@@ -2179,10 +1949,10 @@ export function tryRecognizeFunctorLift(
 
   // Build the projection as native L1. Both Var and Member operands
   // route through pure-L1 builders so the projection is structurally
-  // visible at the L1 level. The L1 rewriter (`substituteL1Subtree`)
-  // then replaces operand-shape subtrees with the comprehension
-  // binder. A projection shape that the pure-L1 builder cannot
-  // represent (e.g., a call expression wrapping the operand) rejects.
+  // visible at the L1 level. The shared IR1 substitution primitive
+  // then replaces operand-shape subtrees with the comprehension binder.
+  // A projection shape that the pure-L1 builder cannot represent
+  // (e.g., a call expression wrapping the operand) rejects.
   let projectionL1: IR1Expr;
   if (operandL1.kind === "var") {
     const sub = buildSubExpr(projection, ctx);
@@ -2201,24 +1971,25 @@ export function tryRecognizeFunctorLift(
   const binderName = allocateLiftBinder(ctx, "n");
   const binderVar = ir1Var(binderName);
   // The substitution needle: for a Var operand, the operand's L1 form
-  // is `Var(operandPantName)`. The structural matcher in
-  // `substituteL1Subtree` matches `Var` by name, so it catches
-  // operand references throughout the projection.
+  // is `Var(operandPantName)`. The shared structural matcher matches
+  // `Var` by name, so it catches operand references throughout the
+  // projection.
   const needle: IR1Expr = operandL1;
 
-  // L1 rewriter: replace operand-shape subtrees with `Var(binder)`.
-  const { result: substitutedL1, changed: substitutionFired } =
-    substituteL1Subtree(projectionL1, needle, binderVar);
+  // IR1 rewriter: replace operand-shape subtrees with `Var(binder)`.
+  const substitutedL1 = substituteIR1ExprSubtree(
+    projectionL1,
+    needle,
+    binderVar,
+  );
+  const substitutionFired = substitutedL1 !== projectionL1;
 
   // The L1 rewriter is the only substitution mechanism post-M6:
   // `ast.substituteBinder` lives at the OpaqueExpr layer and cannot
   // target Member subtrees; carrying it for Var operands would split
-  // the substitution discipline by operand kind. The explicit
-  // `changed` flag is required because the walker's unconditional
-  // parent reconstruction (`ir1Member(rec, name)` and siblings)
-  // breaks reference equality even when no substitution fired,
-  // letting projections that don't reference the operand silently
-  // emit a comprehension body with a free variable.
+  // the substitution discipline by operand kind. The primitive returns
+  // the original root when no substitution fires, so reference identity
+  // is the reachability check.
   if (!substitutionFired) {
     return restore();
   }

--- a/tools/ts2pant/src/ir1-substitute.ts
+++ b/tools/ts2pant/src/ir1-substitute.ts
@@ -231,49 +231,86 @@ function substituteExpr(
     case "var":
     case "lit":
       return expr;
-    case "binop":
-      return ir1Binop(
-        expr.op,
-        substituteExpr(expr.lhs, needle, replacement, replacementFreeVars),
-        substituteExpr(expr.rhs, needle, replacement, replacementFreeVars),
+    case "binop": {
+      const lhs = substituteExpr(
+        expr.lhs,
+        needle,
+        replacement,
+        replacementFreeVars,
       );
-    case "unop":
-      return ir1Unop(
-        expr.op,
-        substituteExpr(expr.arg, needle, replacement, replacementFreeVars),
+      const rhs = substituteExpr(
+        expr.rhs,
+        needle,
+        replacement,
+        replacementFreeVars,
       );
-    case "app":
-      return ir1App(
-        substituteExpr(expr.callee, needle, replacement, replacementFreeVars),
-        expr.args.map((arg) =>
-          substituteExpr(arg, needle, replacement, replacementFreeVars),
-        ),
+      return lhs === expr.lhs && rhs === expr.rhs
+        ? expr
+        : ir1Binop(expr.op, lhs, rhs);
+    }
+    case "unop": {
+      const arg = substituteExpr(
+        expr.arg,
+        needle,
+        replacement,
+        replacementFreeVars,
       );
-    case "member":
-      return ir1Member(
-        substituteExpr(expr.receiver, needle, replacement, replacementFreeVars),
-        expr.name,
+      return arg === expr.arg ? expr : ir1Unop(expr.op, arg);
+    }
+    case "app": {
+      const callee = substituteExpr(
+        expr.callee,
+        needle,
+        replacement,
+        replacementFreeVars,
       );
-    case "cond":
-      return ir1Cond(
-        expr.arms.map(([guard, value]) => [
-          substituteExpr(guard, needle, replacement, replacementFreeVars),
-          substituteExpr(value, needle, replacement, replacementFreeVars),
-        ]) as unknown as [
-          readonly [IR1Expr, IR1Expr],
-          ...ReadonlyArray<readonly [IR1Expr, IR1Expr]>,
-        ],
-        substituteExpr(
-          expr.otherwise,
-          needle,
-          replacement,
-          replacementFreeVars,
-        ),
+      const args = expr.args.map((arg) =>
+        substituteExpr(arg, needle, replacement, replacementFreeVars),
       );
-    case "is-nullish":
-      return ir1IsNullish(
-        substituteExpr(expr.operand, needle, replacement, replacementFreeVars),
+      return callee === expr.callee && arrayRefEqual(args, expr.args)
+        ? expr
+        : ir1App(callee, args);
+    }
+    case "member": {
+      const receiver = substituteExpr(
+        expr.receiver,
+        needle,
+        replacement,
+        replacementFreeVars,
       );
+      return receiver === expr.receiver ? expr : ir1Member(receiver, expr.name);
+    }
+    case "cond": {
+      const arms = expr.arms.map(([guard, value]) => [
+        substituteExpr(guard, needle, replacement, replacementFreeVars),
+        substituteExpr(value, needle, replacement, replacementFreeVars),
+      ]) as unknown as [
+        readonly [IR1Expr, IR1Expr],
+        ...ReadonlyArray<readonly [IR1Expr, IR1Expr]>,
+      ];
+      const otherwise = substituteExpr(
+        expr.otherwise,
+        needle,
+        replacement,
+        replacementFreeVars,
+      );
+      const armsUnchanged = arms.every(
+        ([guard, value], index) =>
+          guard === expr.arms[index]![0] && value === expr.arms[index]![1],
+      );
+      return armsUnchanged && otherwise === expr.otherwise
+        ? expr
+        : ir1Cond(arms, otherwise);
+    }
+    case "is-nullish": {
+      const operand = substituteExpr(
+        expr.operand,
+        needle,
+        replacement,
+        replacementFreeVars,
+      );
+      return operand === expr.operand ? expr : ir1IsNullish(operand);
+    }
     case "each": {
       throwIfCaptureRisk(expr.binder, replacementFreeVars);
       const src = substituteExpr(
@@ -283,44 +320,67 @@ function substituteExpr(
         replacementFreeVars,
       );
       if (shadowsNeedle(expr.binder, needle)) {
-        return ir1Each(expr.binder, src, expr.guards, expr.proj);
+        return src === expr.src
+          ? expr
+          : ir1Each(expr.binder, src, expr.guards, expr.proj);
       }
-      return ir1Each(
-        expr.binder,
-        src,
-        expr.guards.map((guard) =>
-          substituteExpr(guard, needle, replacement, replacementFreeVars),
-        ),
-        substituteExpr(expr.proj, needle, replacement, replacementFreeVars),
+      const guards = expr.guards.map((guard) =>
+        substituteExpr(guard, needle, replacement, replacementFreeVars),
       );
+      const proj = substituteExpr(
+        expr.proj,
+        needle,
+        replacement,
+        replacementFreeVars,
+      );
+      return src === expr.src &&
+        arrayRefEqual(guards, expr.guards) &&
+        proj === expr.proj
+        ? expr
+        : ir1Each(expr.binder, src, guards, proj);
     }
-    case "map-read":
-      return {
-        ...expr,
-        receiver: substituteExpr(
-          expr.receiver,
-          needle,
-          replacement,
-          replacementFreeVars,
-        ),
-        key: substituteExpr(expr.key, needle, replacement, replacementFreeVars),
-      };
-    case "set-read":
-      return {
-        ...expr,
-        receiver: substituteExpr(
-          expr.receiver,
-          needle,
-          replacement,
-          replacementFreeVars,
-        ),
-        elem: substituteExpr(
-          expr.elem,
-          needle,
-          replacement,
-          replacementFreeVars,
-        ),
-      };
+    case "map-read": {
+      const receiver = substituteExpr(
+        expr.receiver,
+        needle,
+        replacement,
+        replacementFreeVars,
+      );
+      const key = substituteExpr(
+        expr.key,
+        needle,
+        replacement,
+        replacementFreeVars,
+      );
+      return receiver === expr.receiver && key === expr.key
+        ? expr
+        : {
+            ...expr,
+            receiver,
+            key,
+          };
+    }
+    case "set-read": {
+      const receiver = substituteExpr(
+        expr.receiver,
+        needle,
+        replacement,
+        replacementFreeVars,
+      );
+      const elem = substituteExpr(
+        expr.elem,
+        needle,
+        replacement,
+        replacementFreeVars,
+      );
+      return receiver === expr.receiver && elem === expr.elem
+        ? expr
+        : {
+            ...expr,
+            receiver,
+            elem,
+          };
+    }
     default: {
       const _exhaustive: never = expr;
       return _exhaustive;
@@ -734,4 +794,8 @@ function addName(source: Set<string>, name: string): Set<string> {
   const out = new Set(source);
   out.add(name);
   return out;
+}
+
+function arrayRefEqual<T>(a: readonly T[], b: readonly T[]): boolean {
+  return a.length === b.length && a.every((value, index) => value === b[index]);
 }

--- a/tools/ts2pant/tests/ir1-build-functor-lift.test.mts
+++ b/tools/ts2pant/tests/ir1-build-functor-lift.test.mts
@@ -472,11 +472,10 @@ describe("ir1-build-functor-lift", () => {
 
   it("Member operand falls through when projection isn't a Member chain", () => {
     // Projection is a method call that doesn't structurally surface
-    // the Member operand at the L1 level. The L1 rewriter
-    // (`substituteL1Subtree`) needs the operand visible as a Var/
-    // Member subterm of the projection; when the lift can't
-    // structurally connect the operand to the comprehension binder it
-    // falls through.
+    // the Member operand at the L1 level. The shared IR1 substitution
+    // primitive needs the operand visible as a Var/Member subterm of
+    // the projection; when the lift can't structurally connect the
+    // operand to the comprehension binder it falls through.
     const { candidate, ctx } = setup(
       `interface User {
          readonly name: string;

--- a/tools/ts2pant/tests/ir1-substitute.test.mts
+++ b/tools/ts2pant/tests/ir1-substitute.test.mts
@@ -140,6 +140,18 @@ describe("ir1-substitute", () => {
       );
     });
 
+    it("substituteIR1ExprSubtree preserves root identity when unchanged", () => {
+      const expr = ir1Member(ir1Member(ir1Var("u"), "profile"), "name");
+      assert.equal(
+        substituteIR1ExprSubtree(
+          expr,
+          ir1Member(ir1Var("v"), "profile"),
+          ir1Var("p"),
+        ),
+        expr,
+      );
+    });
+
     it("substituteIR1StmtSubtree threads block-scope let binders", () => {
       const stmt = ir1Block([ir1Let("x", ir1Var("x")), ir1Return(ir1Var("x"))]);
       assert.deepEqual(


### PR DESCRIPTION
## Patch 4: Migrate functor-lift's substituteL1Subtree to the primitive

- In `tools/ts2pant/src/ir1-build.ts`, identify the call site(s) of `substituteL1Subtree` (likely in `tryRecognizeFunctorLift` or a sibling helper). Note: the existing walker returns `{result, changed}`; the new primitive returns `IR1Expr` directly. Callers need to track the 'changed' flag separately if they depend on it (verify by reading caller code).
- Replace each call site with `substituteIR1ExprSubtree(haystack, needle, replacement)`. If the caller needed `changed`, derive it from `result !== haystack` (reference equality — the primitive returns the original haystack unchanged when no substitution occurs).
- Delete the `substituteL1Subtree` function definition (around line 1748).
- Delete `structuralEqualL1` if it has no other callers. Grep `structuralEqualL1` across `tools/ts2pant/src/` to confirm before deletion. If other callers exist, leave it.
- Run `just ts2pant-test` to confirm zero regression. If unit tests fail because the new primitive throws CaptureRiskError on a case the old walker silently allowed, the caller is allocating a replacement with a free var that matches a haystack binder — that's a latent bug the new primitive surfaced. Investigate and fix at the call site (allocate a fresher replacement name); do NOT relax the primitive's capture check.
- Run `just ts2pant-test-integration` to confirm functor-lift `pant --check` integration tests pass.
- Inspect the constructs snapshot diff: `git diff tools/ts2pant/tests/constructs.test.mts.snapshot`. Expect empty diff. If non-empty, abort and investigate.

## Changes
- In `tools/ts2pant/src/ir1-build.ts`, identify the call site(s) of `substituteL1Subtree` (likely in `tryRecognizeFunctorLift` or a sibling helper). Note: the existing walker returns `{result, changed}`; the new primitive returns `IR1Expr` directly. Callers need to track the 'changed' flag separately if they depend on it (verify by reading caller code).
- Replace each call site with `substituteIR1ExprSubtree(haystack, needle, replacement)`. If the caller needed `changed`, derive it from `result !== haystack` (reference equality — the primitive returns the original haystack unchanged when no substitution occurs).
- Delete the `substituteL1Subtree` function definition (around line 1748).
- Delete `structuralEqualL1` if it has no other callers. Grep `structuralEqualL1` across `tools/ts2pant/src/` to confirm before deletion. If other callers exist, leave it.
- Run `just ts2pant-test` to confirm zero regression. If unit tests fail because the new primitive throws CaptureRiskError on a case the old walker silently allowed, the caller is allocating a replacement with a free var that matches a haystack binder — that's a latent bug the new primitive surfaced. Investigate and fix at the call site (allocate a fresher replacement name); do NOT relax the primitive's capture check.
- Run `just ts2pant-test-integration` to confirm functor-lift `pant --check` integration tests pass.
- Inspect the constructs snapshot diff: `git diff tools/ts2pant/tests/constructs.test.mts.snapshot`. Expect empty diff. If non-empty, abort and investigate.

## Files to Modify
- tools/ts2pant/src/ir1-build.ts (modify): Delete `substituteL1Subtree` (and `structuralEqualL1` if only used by it). Replace its call sites in the functor-lift recognizer with `substituteIR1ExprSubtree` from `./ir1-substitute.js`.
- tools/ts2pant/tests/ir1-build-functor-lift.test.mts (modify): Spot-check that existing functor-lift unit tests still pass. Add at most one new test if a useful additional case surfaces during migration (e.g., a previously-untested capture-risk scenario that now throws); not required, the snapshot suite is the load-bearing signal.
- tools/ts2pant/tests/constructs.test.mts.snapshot (modify): Must be byte-identical after the migration. If `npm run test:update-snapshots` produces a diff for any functor-lift fixture (`expressions-functor-lift.ts`, `expressions-functor-lift-property.ts`), the migration has changed behavior and is a STOP — do not commit the diff; abort the patch.

## Gameplan Specification

```
module TS2PANT_IR1_SUBSTITUTION.

> ════════════════════════════════
> Single-milestone workstream: IR1 capture-avoiding substitution.
> ════════════════════════════════
> After this gameplan, ts2pant has one TS-side capture-avoiding
> substitution primitive that handles every IR1-level
> substitution need. The two existing hand-rolled walkers
> (substituteL1Subtree for functor-lift; substituteMemberReads
> for fixed-point) are deleted; their callers route through
> the new primitive. The primitive throws CaptureRiskError on
> capture risk, halts at Var-needle shadowing binders, and
> recurses structurally otherwise. Documentation in the IR doc
> and AGENTS.md PR #84 post-mortem establishes the discipline.

IR1Expr.
IR1Stmt.
Name.
FreeVarSet.
Walker.
Fixture.
SnapshotState.
Document.
DocumentKind.
DocumentMention.
NeedleKind.
Package.
Dependency.
substituteIR1ExprSubtree => Walker.
substituteIR1StmtSubtree => Walker.
substituteL1Subtree => Walker.
substituteMemberReads => Walker.
fast-check => Dependency.
identical => SnapshotState.
drifted => SnapshotState.
ir-doc => DocumentKind.
agents-md => DocumentKind.
substitution-discipline => DocumentMention.
pr-226-postmortem => DocumentMention.
var => NeedleKind.
member => NeedleKind.

has-dev-dependency? p: Package, d: Dependency => Bool.
walker-exists? w: Walker => Bool.
functor-lift-uses w: Walker => Bool.
fixed-point-uses w: Walker => Bool.
needle-kind n: IR1Expr => NeedleKind.
free-vars-expr e: IR1Expr => FreeVarSet.
free-vars-stmt s: IR1Stmt => FreeVarSet.
binders-of-expr e: IR1Expr => FreeVarSet.
binders-of-stmt s: IR1Stmt => FreeVarSet.
capture-risk? haystack-binders: FreeVarSet, repl-free: FreeVarSet => Bool.
substitutes-cleanly? h: IR1Expr, n: IR1Expr, r: IR1Expr => Bool.
throws-capture-error? h: IR1Expr, n: IR1Expr, r: IR1Expr => Bool.
is-identity-under-shadow? h: IR1Expr, n: IR1Expr, r: IR1Expr => Bool.
shadows-needle? binder: Name, n: IR1Expr => Bool.
snapshot-state f: Fixture => SnapshotState.
is-functor-lift-fixture? f: Fixture => Bool.
is-fixed-point-fixture? f: Fixture => Bool.
document-kind d: Document => DocumentKind.
document-mentions? d: Document, m: DocumentMention => Bool.
---

> Dependency.
all p: Package | has-dev-dependency? p fast-check.

> The new primitives exist; the old walkers do not.
walker-exists? substituteIR1ExprSubtree.
walker-exists? substituteIR1StmtSubtree.
~(walker-exists? substituteL1Subtree).
~(walker-exists? substituteMemberReads).

> Both former call sites route through the new primitive.
functor-lift-uses substituteIR1ExprSubtree.
fixed-point-uses substituteIR1ExprSubtree.

> Primitive contract: capture risk throws; clean substitution
> returns the result; shadowing binders halt the descent for
> Var needles.
all h: IR1Expr, n: IR1Expr, r: IR1Expr |
  capture-risk? (binders-of-expr h) (free-vars-expr r) <-> throws-capture-error? h n r.

all h: IR1Expr, n: IR1Expr, r: IR1Expr |
  substitutes-cleanly? h n r -> ~(throws-capture-error? h n r).

all h: IR1Expr, n: IR1Expr, r: IR1Expr, b: Name |
  needle-kind n = var and shadows-needle? b n ->
    is-identity-under-shadow? h n r.

> Snapshot equivalence on every migrated fixture.
all f: Fixture | is-functor-lift-fixture? f -> snapshot-state f = identical.
all f: Fixture | is-fixed-point-fixture? f -> snapshot-state f = identical.

> Documentation invariants.
all d: Document |
  document-kind d = ir-doc ->
    document-mentions? d substitution-discipline.

all d: Document |
  document-kind d = agents-md ->
    document-mentions? d pr-226-postmortem.
```

## Patch Specification

```
module TS2PANT_IR1_SUBSTITUTION_PATCH_4.

> Patch 4 migrates the functor-lift recognizer's
> substituteL1Subtree call to substituteIR1ExprSubtree.
> The old walker is deleted. Functor-lift fixtures'
> snapshots remain byte-identical.

Walker.
Fixture.
SnapshotState.
substituteL1Subtree => Walker.
substituteIR1ExprSubtree => Walker.
identical => SnapshotState.
drifted => SnapshotState.

functor-lift-uses w: Walker => Bool.
walker-exists? w: Walker => Bool.
snapshot-state f: Fixture => SnapshotState.
is-functor-lift-fixture? f: Fixture => Bool.
---

> Post-patch, the new primitive is the functor-lift's walker;
> the old walker is gone.
functor-lift-uses substituteIR1ExprSubtree.
~(walker-exists? substituteL1Subtree).

> Snapshot equivalence on every functor-lift fixture.
all f: Fixture | is-functor-lift-fixture? f -> snapshot-state f = identical.
```


## Implementation Notes

- The migration depends on `substituteIR1ExprSubtree` preserving root identity for no-op expression walks, so this patch tightens the primitive to return the original expression when no child changed. Patch 3's tests only asserted deep equality for no-op substitutions; without this identity guarantee, the functor-lift `changed` derivation would produce false positives for reconstructed `member` projections.
- `ir1-build.ts` now derives the former `changed` flag as `substitutedL1 !== projectionL1`. This is intentionally reference-based: the primitive owns structural matching and no-op identity, while the functor-lift recognizer only needs to know whether the operand was actually reachable in the projection.
- No snapshot files were regenerated or committed. The constructs snapshot diff was explicitly checked and remained empty.

Spec/Evidence Mapping:
- `functor-lift-uses substituteIR1ExprSubtree`: implemented in `tools/ts2pant/src/ir1-build.ts` at the functor-lift rewrite site; verified by `rg` showing no remaining `substituteL1Subtree` references.
- `~(walker-exists? substituteL1Subtree)`: old walker and `structuralEqualL1` were deleted from `tools/ts2pant/src/ir1-build.ts`; verified by `rg`.
- Functor-lift snapshot equivalence: verified by empty `git diff tools/ts2pant/tests/constructs.test.mts.snapshot`.
- Regression checks: `just ts2pant-test`, `just ts2pant-test-integration`, and `npm run lint` all passed.