### PR TITLE
[ts2pant-ir1-substitution] Patch 6: Document the IR1 substitution discipline

### DIFF
--- a/tools/ts2pant/AGENTS.md
+++ b/tools/ts2pant/AGENTS.md
@@ -275,6 +275,17 @@ The refactored implementation using `inlineConstBindings()` with `UniqueSupply` 
 right-fold substitution makes all 5 structurally impossible. If you find yourself
 inventing workarounds for similar issues, stop and find the standard algorithm.
 
+**PR #226 (IR1-layer instance, 2026-05).** Per-site hand-rolled IR1 substitution
+walkers (`substituteL1Subtree` in `ir1-build.ts`; `substituteMemberReads` in
+`ir1-ssa-fixed-point.ts`) each carried the same capture-avoidance discipline as
+separate per-site code, surfaced for review repeatedly. The fix mirrors PR #84's:
+extract one centralised primitive (`tools/ts2pant/src/ir1-substitute.ts`) and
+delete the per-site walkers. The canonical discipline is documented in
+`tools/ts2pant/docs/intermediate-representation.md`. Standard algorithm:
+capture-avoiding substitution with binder-site enumeration (Barendregt convention;
+Baader & Nipkow Ch. 2). Future IR1 substitution sites consume the primitive instead
+of rolling their own.
+
 ## Testing
 
 Always invoke tests through `just` from the workspace root. The `package.json` `test:*` scripts are implementation detail (just dispatches to them) and skip the cross-language dep ordering — running `npm run test:integration` directly will fail with "pant binary not found" unless you've separately built it.

--- a/tools/ts2pant/docs/intermediate-representation.md
+++ b/tools/ts2pant/docs/intermediate-representation.md
@@ -207,6 +207,21 @@ write helpers would fail to register in `modifiedRules` and the
 over-strict frame would contradict the actual write — that's the
 failure mode the contract is defending against.
 
+## IR1 Substitution Discipline
+
+All IR1-level substitution goes through `substituteIR1ExprSubtree` /
+`substituteIR1StmtSubtree` in `tools/ts2pant/src/ir1-substitute.ts`.
+Hand-rolled walkers in this layer are forbidden — review will reject
+any IR1 substitution that does not use the primitive.
+
+When a future patch introduces a new IR1 binder form, the same patch
+must extend the primitive's binder-site enumeration so capture-checking
+remains exhaustive. The OCaml-backed `ast.substituteBinder` covers the
+L3 lowered `OpaqueExpr` Var-by-name case; the TS-side primitive covers
+IR1's Var and Member subtree cases. Together they enforce
+capture-avoidance discipline across every substitution surface in
+ts2pant.
+
 ## `IR1` SSA contract surface
 
 Milestone 1 adds the SSA-bearing type vocabulary and constructor helpers


### PR DESCRIPTION
## Patch 6: Document the IR1 substitution discipline

- In `tools/ts2pant/docs/intermediate-representation.md`, add a new subsection (e.g., `## IR1 Substitution Discipline`) immediately after `## SSA Foundations` or as part of the existing layering principle. Body: "All IR1-level substitution goes through `substituteIR1ExprSubtree` / `substituteIR1StmtSubtree` in `tools/ts2pant/src/ir1-substitute.ts`. Hand-rolled walkers in this layer are forbidden — review will reject any IR1 substitution that does not use the primitive. When a future patch introduces a new IR1 binder form, the same patch must extend the primitive's binder-site enumeration so capture-checking remains exhaustive. The OCaml-backed `ast.substituteBinder` covers the L3 (lowered OpaqueExpr) Var-by-name case; the new TS-side primitive covers IR1's Var and Member subtree cases. Together they enforce capture-avoidance discipline across every substitution surface in ts2pant."
- In `tools/ts2pant/AGENTS.md`'s `## PR #84 Post-Mortem` section, add a closing paragraph or sibling block: "**PR #226 (IR1-layer instance, 2026-05).** Per-site hand-rolled IR1 substitution walkers (`substituteL1Subtree` in `ir1-build.ts`; `substituteMemberReads` in `ir1-ssa-fixed-point.ts`) each carried the same capture-avoidance discipline as separate per-site code, surfaced for review repeatedly. The fix mirrors PR #84's: extract one centralised primitive (`tools/ts2pant/src/ir1-substitute.ts`) and delete the per-site walkers. Discipline documented in `tools/ts2pant/docs/intermediate-representation.md`. Standard algorithm: capture-avoiding substitution with binder-site enumeration (Barendregt convention; Baader & Nipkow Ch. 2). Future IR1 substitution sites consume the primitive instead of rolling their own."
- Confirm the additions read clearly to a fresh reader: someone landing on the IR doc must see the discipline statement before reading the L1 / L2 sections; the AGENTS.md addition must reference the IR doc as the canonical location for the discipline.

## Changes
- In `tools/ts2pant/docs/intermediate-representation.md`, add a new subsection (e.g., `## IR1 Substitution Discipline`) immediately after `## SSA Foundations` or as part of the existing layering principle. Body: "All IR1-level substitution goes through `substituteIR1ExprSubtree` / `substituteIR1StmtSubtree` in `tools/ts2pant/src/ir1-substitute.ts`. Hand-rolled walkers in this layer are forbidden — review will reject any IR1 substitution that does not use the primitive. When a future patch introduces a new IR1 binder form, the same patch must extend the primitive's binder-site enumeration so capture-checking remains exhaustive. The OCaml-backed `ast.substituteBinder` covers the L3 (lowered OpaqueExpr) Var-by-name case; the new TS-side primitive covers IR1's Var and Member subtree cases. Together they enforce capture-avoidance discipline across every substitution surface in ts2pant."
- In `tools/ts2pant/AGENTS.md`'s `## PR #84 Post-Mortem` section, add a closing paragraph or sibling block: "**PR #226 (IR1-layer instance, 2026-05).** Per-site hand-rolled IR1 substitution walkers (`substituteL1Subtree` in `ir1-build.ts`; `substituteMemberReads` in `ir1-ssa-fixed-point.ts`) each carried the same capture-avoidance discipline as separate per-site code, surfaced for review repeatedly. The fix mirrors PR #84's: extract one centralised primitive (`tools/ts2pant/src/ir1-substitute.ts`) and delete the per-site walkers. Discipline documented in `tools/ts2pant/docs/intermediate-representation.md`. Standard algorithm: capture-avoiding substitution with binder-site enumeration (Barendregt convention; Baader & Nipkow Ch. 2). Future IR1 substitution sites consume the primitive instead of rolling their own."
- Confirm the additions read clearly to a fresh reader: someone landing on the IR doc must see the discipline statement before reading the L1 / L2 sections; the AGENTS.md addition must reference the IR doc as the canonical location for the discipline.

## Files to Modify
- tools/ts2pant/docs/intermediate-representation.md (modify): Add a subsection (sibling to § "SSA Foundations") stating the discipline: all IR1 substitution goes through the new primitive; hand-rolled walkers are forbidden; new IR1 binder forms must extend the primitive's binder-site enumeration in the patch that introduces them.
- tools/ts2pant/AGENTS.md (modify): Extend the PR #84 Post-Mortem section with a sibling entry citing PR #226 as the IR1-layer instance of the same lesson — per-site hand-rolled substitution walkers recreate the same hygiene questions; one centralised primitive resolves them.

## Gameplan Specification

```
module TS2PANT_IR1_SUBSTITUTION.

> ════════════════════════════════
> Single-milestone workstream: IR1 capture-avoiding substitution.
> ════════════════════════════════
> After this gameplan, ts2pant has one TS-side capture-avoiding
> substitution primitive that handles every IR1-level
> substitution need. The two existing hand-rolled walkers
> (substituteL1Subtree for functor-lift; substituteMemberReads
> for fixed-point) are deleted; their callers route through
> the new primitive. The primitive throws CaptureRiskError on
> capture risk, halts at Var-needle shadowing binders, and
> recurses structurally otherwise. Documentation in the IR doc
> and AGENTS.md PR #84 post-mortem establishes the discipline.

IR1Expr.
IR1Stmt.
Name.
FreeVarSet.
Walker.
Fixture.
SnapshotState.
Document.
DocumentKind.
DocumentMention.
NeedleKind.
Package.
Dependency.
substituteIR1ExprSubtree => Walker.
substituteIR1StmtSubtree => Walker.
substituteL1Subtree => Walker.
substituteMemberReads => Walker.
fast-check => Dependency.
identical => SnapshotState.
drifted => SnapshotState.
ir-doc => DocumentKind.
agents-md => DocumentKind.
substitution-discipline => DocumentMention.
pr-226-postmortem => DocumentMention.
var => NeedleKind.
member => NeedleKind.

has-dev-dependency? p: Package, d: Dependency => Bool.
walker-exists? w: Walker => Bool.
functor-lift-uses w: Walker => Bool.
fixed-point-uses w: Walker => Bool.
needle-kind n: IR1Expr => NeedleKind.
free-vars-expr e: IR1Expr => FreeVarSet.
free-vars-stmt s: IR1Stmt => FreeVarSet.
binders-of-expr e: IR1Expr => FreeVarSet.
binders-of-stmt s: IR1Stmt => FreeVarSet.
capture-risk? haystack-binders: FreeVarSet, repl-free: FreeVarSet => Bool.
substitutes-cleanly? h: IR1Expr, n: IR1Expr, r: IR1Expr => Bool.
throws-capture-error? h: IR1Expr, n: IR1Expr, r: IR1Expr => Bool.
is-identity-under-shadow? h: IR1Expr, n: IR1Expr, r: IR1Expr => Bool.
shadows-needle? binder: Name, n: IR1Expr => Bool.
snapshot-state f: Fixture => SnapshotState.
is-functor-lift-fixture? f: Fixture => Bool.
is-fixed-point-fixture? f: Fixture => Bool.
document-kind d: Document => DocumentKind.
document-mentions? d: Document, m: DocumentMention => Bool.
---

> Dependency.
all p: Package | has-dev-dependency? p fast-check.

> The new primitives exist; the old walkers do not.
walker-exists? substituteIR1ExprSubtree.
walker-exists? substituteIR1StmtSubtree.
~(walker-exists? substituteL1Subtree).
~(walker-exists? substituteMemberReads).

> Both former call sites route through the new primitive.
functor-lift-uses substituteIR1ExprSubtree.
fixed-point-uses substituteIR1ExprSubtree.

> Primitive contract: capture risk throws; clean substitution
> returns the result; shadowing binders halt the descent for
> Var needles.
all h: IR1Expr, n: IR1Expr, r: IR1Expr |
  capture-risk? (binders-of-expr h) (free-vars-expr r) <-> throws-capture-error? h n r.

all h: IR1Expr, n: IR1Expr, r: IR1Expr |
  substitutes-cleanly? h n r -> ~(throws-capture-error? h n r).

all h: IR1Expr, n: IR1Expr, r: IR1Expr, b: Name |
  needle-kind n = var and shadows-needle? b n ->
    is-identity-under-shadow? h n r.

> Snapshot equivalence on every migrated fixture.
all f: Fixture | is-functor-lift-fixture? f -> snapshot-state f = identical.
all f: Fixture | is-fixed-point-fixture? f -> snapshot-state f = identical.

> Documentation invariants.
all d: Document |
  document-kind d = ir-doc ->
    document-mentions? d substitution-discipline.

all d: Document |
  document-kind d = agents-md ->
    document-mentions? d pr-226-postmortem.
```

## Patch Specification

```
module TS2PANT_IR1_SUBSTITUTION_PATCH_6.

> Patch 6 lands the discipline documentation. The IR doc
> gains a substitution-discipline subsection; AGENTS.md's
> PR #84 post-mortem section gains a PR #226 sibling entry.

Document.
DocumentKind.
DocumentMention.
ir-doc => DocumentKind.
agents-md => DocumentKind.
substitution-discipline => DocumentMention.
pr-226-postmortem => DocumentMention.

document-kind d: Document => DocumentKind.
document-mentions? d: Document, m: DocumentMention => Bool.
---

all d: Document |
  document-kind d = ir-doc ->
    document-mentions? d substitution-discipline.

all d: Document |
  document-kind d = agents-md ->
    document-mentions? d pr-226-postmortem.
```


## Implementation Notes

- Inserted the IR1 substitution discipline immediately after the SSA Foundations section, before the IR1/L1 detail sections, so a fresh reader sees the rule before the lower-level vocabulary.
- Kept the AGENTS.md addition as a sibling post-mortem paragraph rather than a new table, because the PR #226 case is one recurring class of risk rather than the five separate symptom categories from PR #84.
- Spec/Evidence Mapping: `ir-doc -> substitution-discipline` is satisfied by `tools/ts2pant/docs/intermediate-representation.md`; `agents-md -> pr-226-postmortem` is satisfied by `tools/ts2pant/AGENTS.md`. Consulted the IR doc and AGENTS.md target sections; the requested workstream file was not present in this worktree. Static check: `git diff --check` passed. No runtime tests were run because the patch is documentation-only.