### PR TITLE
[ts2pant-l2-typed-mirror] Patch 1: Pending tests for L1 vocabulary and μ-search migration

### DIFF
--- a/tools/ts2pant/tests/ir1-lower.test.mts
+++ b/tools/ts2pant/tests/ir1-lower.test.mts
@@ -230,6 +230,28 @@ describe("lowerL1Expr — is-nullish (M4 canonical nullish test)", () => {
   });
 });
 
+describe("lowering new L1 forms", () => {
+  it.skip("comb-typed lowers via irCombTyped", () => {
+    // PENDING Patch 2.
+  });
+
+  it.skip("forall lowers via irForall with guard", () => {
+    // PENDING Patch 2.
+  });
+
+  it.skip("forall lowers via irForall without guard", () => {
+    // PENDING Patch 2.
+  });
+
+  it.skip("exists lowers via irExists with guard", () => {
+    // PENDING Patch 2.
+  });
+
+  it.skip("exists lowers via irExists without guard", () => {
+    // PENDING Patch 2.
+  });
+});
+
 describe("L1 → L2 → OpaqueExpr — full pipeline byte-equality with legacy", () => {
   // Verifies that lowering a hand-built L1 cond through L1 → L2 → OpaqueExpr
   // produces the same Pantagruel string as a hand-built legacy `ast.cond`.

--- a/tools/ts2pant/tests/ir1-substitute.test.mts
+++ b/tools/ts2pant/tests/ir1-substitute.test.mts
@@ -57,6 +57,18 @@ describe("ir1-substitute", () => {
       assertSetEqual(freeVarsIR1Expr(expr), ["g", "src"]);
     });
 
+    it.skip("freeVarsIR1Expr scopes comb-typed binder", () => {
+      // PENDING Patch 2.
+    });
+
+    it.skip("freeVarsIR1Expr scopes forall binder", () => {
+      // PENDING Patch 2.
+    });
+
+    it.skip("freeVarsIR1Expr scopes exists binder", () => {
+      // PENDING Patch 2.
+    });
+
     it("freeVarsIR1Stmt respects block / let / foreach / for binders", () => {
       const stmt = ir1Block([
         ir1Let("x", ir1Var("seed")),
@@ -124,6 +136,34 @@ describe("ir1-substitute", () => {
           ),
         CaptureRiskError,
       );
+    });
+
+    it.skip("substituteIR1ExprSubtree throws under comb-typed capture", () => {
+      // PENDING Patch 2.
+    });
+
+    it.skip("substituteIR1ExprSubtree throws under forall capture", () => {
+      // PENDING Patch 2.
+    });
+
+    it.skip("substituteIR1ExprSubtree throws under exists capture", () => {
+      // PENDING Patch 2.
+    });
+
+    it.skip("substituteIR1ExprSubtree halts at shadowing comb-typed", () => {
+      // PENDING Patch 2.
+    });
+
+    it.skip("substituteIR1ExprSubtree halts at shadowing forall", () => {
+      // PENDING Patch 2.
+    });
+
+    it.skip("substituteIR1ExprSubtree halts at shadowing exists", () => {
+      // PENDING Patch 2.
+    });
+
+    it.skip("arbIR1Expr includes new L1 binder forms", () => {
+      // PENDING Patch 2.
     });
 
     it("substituteIR1ExprSubtree preserves shape outside replacement sites", () => {

--- a/tools/ts2pant/tests/ir1.test.mts
+++ b/tools/ts2pant/tests/ir1.test.mts
@@ -1,0 +1,29 @@
+import { describe, it } from "node:test";
+
+describe("ir1", () => {
+  describe("new L1 binder forms", () => {
+    it.skip("ir1CombTyped constructs comb-typed shape", () => {
+      // PENDING Patch 2.
+    });
+
+    it.skip("ir1Forall constructs forall shape", () => {
+      // PENDING Patch 2.
+    });
+
+    it.skip("ir1Exists constructs exists shape", () => {
+      // PENDING Patch 2.
+    });
+
+    it.skip("ir1SsaExprEquals compares comb-typed fields", () => {
+      // PENDING Patch 2.
+    });
+
+    it.skip("ir1SsaExprEquals compares forall fields", () => {
+      // PENDING Patch 2.
+    });
+
+    it.skip("ir1SsaExprEquals compares exists fields", () => {
+      // PENDING Patch 2.
+    });
+  });
+});

--- a/tools/ts2pant/tests/m2-musearch-l1.test.mts
+++ b/tools/ts2pant/tests/m2-musearch-l1.test.mts
@@ -181,6 +181,20 @@ describe("M2 μ-search L1: all five +1 spellings produce identical Pant", () => 
   });
 });
 
+describe("post-migration recognizer placement", () => {
+  it.skip("recognizeLetWhilePair produces L1 comb-typed", () => {
+    // PENDING Patch 3.
+  });
+
+  it.skip("canonical post-recognizer shape is comb-typed", () => {
+    // PENDING Patch 3.
+  });
+
+  it.skip("μ-search fixtures snapshot-equivalent", () => {
+    // PENDING Patch 3.
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Conservative rejections
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Patch 1: Pending tests for L1 vocabulary and μ-search migration

- Create `tools/ts2pant/tests/ir1.test.mts` if it doesn't exist; otherwise extend with a new `describe('new L1 binder forms', () => { ... })` block containing skipped stubs for `ir1CombTyped` / `ir1Forall` / `ir1Exists` constructor shape and `ir1SsaExprEquals` per form.
- In `tools/ts2pant/tests/ir1-substitute.test.mts`, add skipped stubs in the existing `describe('unit', ...)` block: free-vars scope for each new form; capture-risk rejection under each new binder; shadow-needle halt.
- In `tools/ts2pant/tests/ir1-lower.test.mts`, add skipped stubs in a new or existing `describe('lowering new L1 forms', ...)` block: L1 → L2 mechanical lowering for each new form (with and without guard for forall/exists).
- In `tools/ts2pant/tests/m2-musearch-l1.test.mts`, add skipped stubs in a new `describe('post-migration recognizer placement', ...)` block: `recognizeLetWhilePair` returns L1 `comb-typed` directly; μ-search snapshot-equivalence assertion for each fixture variant.
- Each stub body contains only the PENDING comment naming the implementing patch — no references to symbols that don't exist yet.
- Run `npm run test:unit` and confirm the files compile and stubs are reported as skipped.

## Changes
- Create `tools/ts2pant/tests/ir1.test.mts` if it doesn't exist; otherwise extend with a new `describe('new L1 binder forms', () => { ... })` block containing skipped stubs for `ir1CombTyped` / `ir1Forall` / `ir1Exists` constructor shape and `ir1SsaExprEquals` per form.
- In `tools/ts2pant/tests/ir1-substitute.test.mts`, add skipped stubs in the existing `describe('unit', ...)` block: free-vars scope for each new form; capture-risk rejection under each new binder; shadow-needle halt.
- In `tools/ts2pant/tests/ir1-lower.test.mts`, add skipped stubs in a new or existing `describe('lowering new L1 forms', ...)` block: L1 → L2 mechanical lowering for each new form (with and without guard for forall/exists).
- In `tools/ts2pant/tests/m2-musearch-l1.test.mts`, add skipped stubs in a new `describe('post-migration recognizer placement', ...)` block: `recognizeLetWhilePair` returns L1 `comb-typed` directly; μ-search snapshot-equivalence assertion for each fixture variant.
- Each stub body contains only the PENDING comment naming the implementing patch — no references to symbols that don't exist yet.
- Run `npm run test:unit` and confirm the files compile and stubs are reported as skipped.

## Files to Modify
- tools/ts2pant/tests/ir1.test.mts (create): If not present, create. Add `it.skip(...)` stubs for the new L1 constructors and their structural-equality behaviour. PENDING Patch 2.
- tools/ts2pant/tests/ir1-substitute.test.mts (modify): Add `it.skip(...)` stubs for free-vars scope / capture-risk / shadow-halt on each new L1 binder form. Add the property-test generator extension as a skipped stub. PENDING Patch 2.
- tools/ts2pant/tests/ir1-lower.test.mts (modify): Add `it.skip(...)` stubs for the mechanical 1:1 lowering arms. PENDING Patch 2.
- tools/ts2pant/tests/m2-musearch-l1.test.mts (modify): Add `it.skip(...)` stubs for the migration assertions: `recognizeLetWhilePair` produces L1 `comb-typed` directly; the canonical L1 form post-recognizer is `comb-typed` (not Block([Let, While])); existing μ-search fixtures snapshot-equivalent. PENDING Patch 3.

## Gameplan Specification

```
module TS2PANT_L2_TYPED_MIRROR.

> ════════════════════════════════
> Single-milestone workstream: L2 as a typed mirror of OpaqueExpr.
> ════════════════════════════════
> After this gameplan, L1 has comb-typed / forall / exists
> mirroring L2's CombTyped / Forall / Exists. The μ-search
> recognizer produces L1 comb-typed directly at the
> TS-AST → L1 boundary; lowerL1MuSearch and
> isCanonicalMuSearchForm are removed. L1→L2 is now a pure
> 1:1 mechanical mapping. Documentation in the IR doc + 
> AGENTS.md + imperative-IR workstream doc articulates the
> honest layering principle: L1 absorbs Pant-target forms;
> L1→L2 carries no recognition; L2 is a typed mirror, not
> a transformation IR.

IR1Form.
L2Form.
Walker.
FreeVarSet.
RecognitionSite.
IR1Shape.
SnapshotState.
Document.
DocumentKind.
comb-typed => IR1Form.
forall => IR1Form.
exists => IR1Form.
comb-typed-l2 => L2Form.
forall-l2 => L2Form.
exists-l2 => L2Form.
ts-ast-to-l1 => RecognitionSite.
l1-to-l2 => RecognitionSite.
comb-typed-l1 => IR1Shape.
block-let-while => IR1Shape.
identical => SnapshotState.
drifted => SnapshotState.
ir-doc => DocumentKind.
agents-md => DocumentKind.
imperative-ir-doc => DocumentKind.

has-arm-for? w: Walker, f: IR1Form => Bool.
scopes-binder? f: IR1Form, vars: FreeVarSet => Bool.
lowers-to? l1: IR1Form, l2: L2Form => Bool.
respects-capture-risk? f: IR1Form => Bool.
halts-at-shadow? f: IR1Form => Bool.
recognizer-fires-at? site: RecognitionSite => Bool.
post-recognizer-shape => IR1Shape.
snapshot-state => SnapshotState.
lower-l1-musearch-exists? => Bool.
is-canonical-musearch-form-exists? => Bool.
document-kind d: Document => DocumentKind.
mentions-layering-principle? d: Document => Bool.
mentions-no-l1-l2-recognition? d: Document => Bool.
mentions-l2-not-substitution-target? d: Document => Bool.
---

> Vocabulary contract.
all f: IR1Form, w: Walker | has-arm-for? w f.
all f: IR1Form, vars: FreeVarSet | scopes-binder? f vars.
all f: IR1Form | respects-capture-risk? f.
all f: IR1Form | halts-at-shadow? f.
lowers-to? comb-typed comb-typed-l2.
lowers-to? forall forall-l2.
lowers-to? exists exists-l2.

> Recognition has moved upstream.
recognizer-fires-at? ts-ast-to-l1.
~(recognizer-fires-at? l1-to-l2).
post-recognizer-shape = comb-typed-l1.
~(lower-l1-musearch-exists?).
~(is-canonical-musearch-form-exists?).

> Snapshot equivalence on every μ-search fixture.
snapshot-state = identical.

> Documentation invariants.
all d: Document |
  document-kind d = ir-doc ->
    mentions-layering-principle? d and
    mentions-no-l1-l2-recognition? d and
    mentions-l2-not-substitution-target? d.

all d: Document |
  document-kind d = agents-md ->
    mentions-layering-principle? d.

all d: Document |
  document-kind d = imperative-ir-doc ->
    mentions-layering-principle? d.
```

## Patch Specification

```
module TS2PANT_L2_TYPED_MIRROR_PATCH_1.

> Patch 1 lands the test scaffolding for the workstream.
> Stubs are skipped; Patches 2 and 3 unskip them with
> concrete assertions. No source behavior changes; the test
> files compile and report stubs as skipped.

TestStub.
PendingFor.
patch-2 => PendingFor.
patch-3 => PendingFor.

stub-pending-for s: TestStub => PendingFor.
stub-skipped? s: TestStub => Bool.
---
all s: TestStub | stub-skipped? s.
```


## Implementation Notes

- Kept every new pending test body comment-only, so Patch 1 has no imports or references to future symbols such as `ir1CombTyped`, `ir1Forall`, or `ir1Exists`.
- Added one extra skipped stub for the `arbIR1Expr` property-test generator extension in `ir1-substitute.test.mts`, matching the file-specific instruction even though it is not part of the shorter top-level stub list.
- Added a separate skipped μ-search shape stub for the post-recognizer canonical `comb-typed` shape, matching the file-specific instruction to distinguish direct recognizer output from snapshot equivalence.
- Required context note: `workstreams/ts2pant-l2-typed-mirror.md` was not present in this worktree; implementation used the PR/gameplan text plus the existing test files, including `tools/ts2pant/tests/ir1-substitute.test.mts`.
- Spec/Evidence Mapping: all Patch 1 `TestStub` instances are `it.skip(...)` tests with only a `PENDING Patch 2.` or `PENDING Patch 3.` comment; `npm run test:unit` passed with the files compiling and skipped tests reported (`976` tests, `948` passed, `28` skipped, `0` failed).