### PR TITLE
[ts2pant-l2-typed-mirror] Patch 2: Add comb-typed / forall / exists L1 forms; extend every IR1Expr walker

### DIFF
--- a/tools/ts2pant/src/ir1-lower.ts
+++ b/tools/ts2pant/src/ir1-lower.ts
@@ -28,8 +28,11 @@ import {
   irAppExpr,
   irAppName,
   irBinop,
+  irCombTyped,
   irCond,
   irEach,
+  irExists,
+  irForall,
   irLitNat,
   irUnop,
   irVar,
@@ -113,6 +116,31 @@ export function lowerL1Expr(e: IR1Expr): IRExpr {
         lowerL1Expr(e.proj),
       );
     }
+
+    case "comb-typed":
+      return irCombTyped(
+        e.combiner,
+        e.binder,
+        e.binderType,
+        e.guards.map(lowerL1Expr),
+        lowerL1Expr(e.proj),
+      );
+
+    case "forall":
+      return irForall(
+        e.binder,
+        e.binderType,
+        lowerL1Expr(e.body),
+        e.guard === undefined ? undefined : lowerL1Expr(e.guard),
+      );
+
+    case "exists":
+      return irExists(
+        e.binder,
+        e.binderType,
+        lowerL1Expr(e.body),
+        e.guard === undefined ? undefined : lowerL1Expr(e.guard),
+      );
 
     case "map-read": {
       // Pure / read-only path: emit the bare `App(callee, [receiver,

--- a/tools/ts2pant/src/ir1-printer.ts
+++ b/tools/ts2pant/src/ir1-printer.ts
@@ -43,6 +43,22 @@ export function formatIR1Expr(expr: IR1Expr): string {
       );
       return `each ${expr.binder} in ${formatIR1Expr(expr.src)} | ${formatIR1Expr(expr.proj)}${guards.join("")}`;
     }
+    case "comb-typed": {
+      const guards = expr.guards.map(
+        (guard) => `, when ${formatIR1Expr(guard)}`,
+      );
+      return `${expr.combiner} over each ${expr.binder}: ${expr.binderType} | ${formatIR1Expr(expr.proj)}${guards.join("")}`;
+    }
+    case "forall": {
+      const guard =
+        expr.guard === undefined ? "" : `, when ${formatIR1Expr(expr.guard)}`;
+      return `all ${expr.binder}: ${expr.binderType}${guard} | ${formatIR1Expr(expr.body)}`;
+    }
+    case "exists": {
+      const guard =
+        expr.guard === undefined ? "" : `, when ${formatIR1Expr(expr.guard)}`;
+      return `some ${expr.binder}: ${expr.binderType}${guard} | ${formatIR1Expr(expr.body)}`;
+    }
     case "map-read": {
       const ruleName = expr.op === "get" ? expr.ruleName : expr.keyPredName;
       return `${ruleName} ${formatAsAppArg(expr.receiver)} ${formatAsAppArg(expr.key)}`;
@@ -387,6 +403,41 @@ function consumeScalarReadsForExpr(
         readLabels,
         labeller,
       );
+    case "comb-typed":
+      for (const guard of expr.guards) {
+        cursor = consumeScalarReadsForExpr(
+          guard,
+          reads,
+          cursor,
+          readLabels,
+          labeller,
+        );
+      }
+      return consumeScalarReadsForExpr(
+        expr.proj,
+        reads,
+        cursor,
+        readLabels,
+        labeller,
+      );
+    case "forall":
+    case "exists":
+      if (expr.guard !== undefined) {
+        cursor = consumeScalarReadsForExpr(
+          expr.guard,
+          reads,
+          cursor,
+          readLabels,
+          labeller,
+        );
+      }
+      return consumeScalarReadsForExpr(
+        expr.body,
+        reads,
+        cursor,
+        readLabels,
+        labeller,
+      );
     case "var":
     case "lit":
       return cursor;
@@ -476,6 +527,29 @@ function formatIR1ExprWithSsaReads(
         expr.src,
         readLabels,
       )} | ${formatIR1ExprWithSsaReads(expr.proj, readLabels)}${guards.join("")}`;
+    }
+    case "comb-typed": {
+      const guards = expr.guards.map(
+        (guard) => `, when ${formatIR1ExprWithSsaReads(guard, readLabels)}`,
+      );
+      return `${expr.combiner} over each ${expr.binder}: ${expr.binderType} | ${formatIR1ExprWithSsaReads(
+        expr.proj,
+        readLabels,
+      )}${guards.join("")}`;
+    }
+    case "forall": {
+      const guard =
+        expr.guard === undefined
+          ? ""
+          : `, when ${formatIR1ExprWithSsaReads(expr.guard, readLabels)}`;
+      return `all ${expr.binder}: ${expr.binderType}${guard} | ${formatIR1ExprWithSsaReads(expr.body, readLabels)}`;
+    }
+    case "exists": {
+      const guard =
+        expr.guard === undefined
+          ? ""
+          : `, when ${formatIR1ExprWithSsaReads(expr.guard, readLabels)}`;
+      return `some ${expr.binder}: ${expr.binderType}${guard} | ${formatIR1ExprWithSsaReads(expr.body, readLabels)}`;
     }
     case "map-read": {
       const keyPrefix =

--- a/tools/ts2pant/src/ir1-ssa-collections.ts
+++ b/tools/ts2pant/src/ir1-ssa-collections.ts
@@ -542,6 +542,19 @@ export function collectionSsaReadExpr(
       }
       collectionSsaReadExpr(expr.proj, state);
       return expr;
+    case "comb-typed":
+      for (const guard of expr.guards) {
+        collectionSsaReadExpr(guard, state);
+      }
+      collectionSsaReadExpr(expr.proj, state);
+      return expr;
+    case "forall":
+    case "exists":
+      if (expr.guard !== undefined) {
+        collectionSsaReadExpr(expr.guard, state);
+      }
+      collectionSsaReadExpr(expr.body, state);
+      return expr;
     case "var":
     case "lit":
       return expr;
@@ -1162,6 +1175,43 @@ function lowerCollectionSsaExprToOpaque(
           lowerCollectionSsaExprToOpaque(expr.proj, state),
         ),
       );
+    case "comb-typed":
+      return state.lowerOpaque(
+        ast.eachComb(
+          [ast.param(expr.binder, ast.tName(expr.binderType))],
+          expr.guards.map((guard) =>
+            ast.gExpr(lowerCollectionSsaExprToOpaque(guard, state)),
+          ),
+          expr.combiner === "min" ? ast.combMin() : ast.combMax(),
+          lowerCollectionSsaExprToOpaque(expr.proj, state),
+        ),
+      );
+    case "forall": {
+      const guards =
+        expr.guard === undefined
+          ? []
+          : [ast.gExpr(lowerCollectionSsaExprToOpaque(expr.guard, state))];
+      return state.lowerOpaque(
+        ast.forall(
+          [ast.param(expr.binder, ast.tName(expr.binderType))],
+          guards,
+          lowerCollectionSsaExprToOpaque(expr.body, state),
+        ),
+      );
+    }
+    case "exists": {
+      const guards =
+        expr.guard === undefined
+          ? []
+          : [ast.gExpr(lowerCollectionSsaExprToOpaque(expr.guard, state))];
+      return state.lowerOpaque(
+        ast.exists(
+          [ast.param(expr.binder, ast.tName(expr.binderType))],
+          guards,
+          lowerCollectionSsaExprToOpaque(expr.body, state),
+        ),
+      );
+    }
     default: {
       const _exhaustive: never = expr;
       void _exhaustive;
@@ -1991,6 +2041,24 @@ function collectionSsaExprKeyData(expr: IR1Expr): unknown {
         expr.guards.map(collectionSsaExprKeyData),
         collectionSsaExprKeyData(expr.proj),
       ];
+    case "comb-typed":
+      return [
+        "comb-typed",
+        expr.combiner,
+        expr.binder,
+        expr.binderType,
+        expr.guards.map(collectionSsaExprKeyData),
+        collectionSsaExprKeyData(expr.proj),
+      ];
+    case "forall":
+    case "exists":
+      return [
+        expr.kind,
+        expr.binder,
+        expr.binderType,
+        expr.guard === undefined ? null : collectionSsaExprKeyData(expr.guard),
+        collectionSsaExprKeyData(expr.body),
+      ];
     case "map-read":
       return [
         "map-read",
@@ -2100,6 +2168,16 @@ function isCollectionSsaExpr(expr: IR1Expr): boolean {
         isCollectionSsaExpr(expr.src) &&
         expr.guards.every(isCollectionSsaExpr) &&
         isCollectionSsaExpr(expr.proj)
+      );
+    case "comb-typed":
+      return (
+        expr.guards.every(isCollectionSsaExpr) && isCollectionSsaExpr(expr.proj)
+      );
+    case "forall":
+    case "exists":
+      return (
+        (expr.guard === undefined || isCollectionSsaExpr(expr.guard)) &&
+        isCollectionSsaExpr(expr.body)
       );
     case "map-read":
       return (

--- a/tools/ts2pant/src/ir1-ssa-counter-loop.ts
+++ b/tools/ts2pant/src/ir1-ssa-counter-loop.ts
@@ -639,6 +639,23 @@ function exprReferencesVar(expr: IR1Expr, name: string): boolean {
         expr.guards.some((guard) => exprReferencesVar(guard, name)) ||
         exprReferencesVar(expr.proj, name)
       );
+    case "comb-typed":
+      if (expr.binder === name) {
+        return false;
+      }
+      return (
+        expr.guards.some((guard) => exprReferencesVar(guard, name)) ||
+        exprReferencesVar(expr.proj, name)
+      );
+    case "forall":
+    case "exists":
+      if (expr.binder === name) {
+        return false;
+      }
+      return (
+        (expr.guard !== undefined && exprReferencesVar(expr.guard, name)) ||
+        exprReferencesVar(expr.body, name)
+      );
     case "map-read":
       return (
         exprReferencesVar(expr.receiver, name) ||
@@ -705,6 +722,22 @@ function countMemberReads(
           0,
         ) +
         countMemberReads(expr.proj, member)
+      );
+    case "comb-typed":
+      return (
+        self +
+        expr.guards.reduce(
+          (n, guard) => n + countMemberReads(guard, member),
+          0,
+        ) +
+        countMemberReads(expr.proj, member)
+      );
+    case "forall":
+    case "exists":
+      return (
+        self +
+        (expr.guard === undefined ? 0 : countMemberReads(expr.guard, member)) +
+        countMemberReads(expr.body, member)
       );
     case "map-read":
       return (
@@ -799,6 +832,31 @@ function ir1ExprEqual(a: IR1Expr, b: IR1Expr): boolean {
         ir1ExprArrayEqual(a.guards, b.guards) &&
         ir1ExprEqual(a.proj, b.proj)
       );
+    case "comb-typed":
+      return (
+        b.kind === "comb-typed" &&
+        a.combiner === b.combiner &&
+        a.binder === b.binder &&
+        a.binderType === b.binderType &&
+        ir1ExprArrayEqual(a.guards, b.guards) &&
+        ir1ExprEqual(a.proj, b.proj)
+      );
+    case "forall":
+      return (
+        b.kind === "forall" &&
+        a.binder === b.binder &&
+        a.binderType === b.binderType &&
+        optionalIr1ExprEqual(a.guard, b.guard) &&
+        ir1ExprEqual(a.body, b.body)
+      );
+    case "exists":
+      return (
+        b.kind === "exists" &&
+        a.binder === b.binder &&
+        a.binderType === b.binderType &&
+        optionalIr1ExprEqual(a.guard, b.guard) &&
+        ir1ExprEqual(a.body, b.body)
+      );
     case "map-read":
       return (
         b.kind === "map-read" &&
@@ -835,6 +893,15 @@ function ir1ExprArrayEqual(
     a.length === b.length &&
     a.every((expr, index) => ir1ExprEqual(expr, b[index]!))
   );
+}
+
+function optionalIr1ExprEqual(
+  a: IR1Expr | undefined,
+  b: IR1Expr | undefined,
+): boolean {
+  return a === undefined || b === undefined
+    ? a === undefined && b === undefined
+    : ir1ExprEqual(a, b);
 }
 
 function rootName(expr: IR1Expr): string | null {

--- a/tools/ts2pant/src/ir1-ssa-fixed-point.ts
+++ b/tools/ts2pant/src/ir1-ssa-fixed-point.ts
@@ -552,6 +552,72 @@ function substituteLocalLets(
         proj: substituteLocalLets(proj, localLets, nextBound, resolving),
       };
     }
+    case "comb-typed": {
+      const localFreeVars = localLetValueFreeVars(localLets);
+      const binder = localFreeVars.has(expr.binder)
+        ? freshIr1Name(expr.binder, [
+            expr,
+            ...localLets.values(),
+            ...[...bound].map((name) => ir1Var(name)),
+          ])
+        : expr.binder;
+      const guards =
+        binder === expr.binder
+          ? expr.guards
+          : expr.guards.map((guard) =>
+              renameBoundVarRefs(guard, expr.binder, binder),
+            );
+      const proj =
+        binder === expr.binder
+          ? expr.proj
+          : renameBoundVarRefs(expr.proj, expr.binder, binder);
+      const nextBound = new Set(bound);
+      nextBound.add(binder);
+      return {
+        ...expr,
+        binder,
+        guards: guards.map((guard) =>
+          substituteLocalLets(guard, localLets, nextBound, resolving),
+        ),
+        proj: substituteLocalLets(proj, localLets, nextBound, resolving),
+      };
+    }
+    case "forall":
+    case "exists": {
+      const localFreeVars = localLetValueFreeVars(localLets);
+      const binder = localFreeVars.has(expr.binder)
+        ? freshIr1Name(expr.binder, [
+            expr,
+            ...localLets.values(),
+            ...[...bound].map((name) => ir1Var(name)),
+          ])
+        : expr.binder;
+      const guard =
+        expr.guard === undefined || binder === expr.binder
+          ? expr.guard
+          : renameBoundVarRefs(expr.guard, expr.binder, binder);
+      const body =
+        binder === expr.binder
+          ? expr.body
+          : renameBoundVarRefs(expr.body, expr.binder, binder);
+      const nextBound = new Set(bound);
+      nextBound.add(binder);
+      return {
+        ...expr,
+        binder,
+        ...(guard === undefined
+          ? {}
+          : {
+              guard: substituteLocalLets(
+                guard,
+                localLets,
+                nextBound,
+                resolving,
+              ),
+            }),
+        body: substituteLocalLets(body, localLets, nextBound, resolving),
+      };
+    }
     case "map-read":
       return {
         ...expr,
@@ -641,6 +707,25 @@ function collectIr1FreeVars(
       collectIr1FreeVars(expr.proj, out, nextBound);
       break;
     }
+    case "comb-typed": {
+      const nextBound = new Set(bound);
+      nextBound.add(expr.binder);
+      for (const guard of expr.guards) {
+        collectIr1FreeVars(guard, out, nextBound);
+      }
+      collectIr1FreeVars(expr.proj, out, nextBound);
+      break;
+    }
+    case "forall":
+    case "exists": {
+      const nextBound = new Set(bound);
+      nextBound.add(expr.binder);
+      if (expr.guard !== undefined) {
+        collectIr1FreeVars(expr.guard, out, nextBound);
+      }
+      collectIr1FreeVars(expr.body, out, nextBound);
+      break;
+    }
     case "map-read":
       collectIr1FreeVars(expr.receiver, out, bound);
       collectIr1FreeVars(expr.key, out, bound);
@@ -713,6 +798,27 @@ function renameBoundVarRefs(expr: IR1Expr, from: string, to: string): IR1Expr {
         src: renameBoundVarRefs(expr.src, from, to),
         guards: expr.guards.map((guard) => renameBoundVarRefs(guard, from, to)),
         proj: renameBoundVarRefs(expr.proj, from, to),
+      };
+    case "comb-typed":
+      if (expr.binder === from) {
+        return expr;
+      }
+      return {
+        ...expr,
+        guards: expr.guards.map((guard) => renameBoundVarRefs(guard, from, to)),
+        proj: renameBoundVarRefs(expr.proj, from, to),
+      };
+    case "forall":
+    case "exists":
+      if (expr.binder === from) {
+        return expr;
+      }
+      return {
+        ...expr,
+        ...(expr.guard === undefined
+          ? {}
+          : { guard: renameBoundVarRefs(expr.guard, from, to) }),
+        body: renameBoundVarRefs(expr.body, from, to),
       };
     case "map-read":
       return {
@@ -806,6 +912,21 @@ function collectAllNames(expr: IR1Expr, out: Set<string>): void {
       }
       collectAllNames(expr.proj, out);
       break;
+    case "comb-typed":
+      out.add(expr.binder);
+      for (const guard of expr.guards) {
+        collectAllNames(guard, out);
+      }
+      collectAllNames(expr.proj, out);
+      break;
+    case "forall":
+    case "exists":
+      out.add(expr.binder);
+      if (expr.guard !== undefined) {
+        collectAllNames(expr.guard, out);
+      }
+      collectAllNames(expr.body, out);
+      break;
     case "map-read":
       collectAllNames(expr.receiver, out);
       collectAllNames(expr.key, out);
@@ -872,6 +993,25 @@ function collectFreeVars(
         collectFreeVars(guard, out, excluded, nextBound);
       }
       collectFreeVars(expr.proj, out, excluded, nextBound);
+      break;
+    }
+    case "comb-typed": {
+      const nextBound = new Set(bound);
+      nextBound.add(expr.binder);
+      for (const guard of expr.guards) {
+        collectFreeVars(guard, out, excluded, nextBound);
+      }
+      collectFreeVars(expr.proj, out, excluded, nextBound);
+      break;
+    }
+    case "forall":
+    case "exists": {
+      const nextBound = new Set(bound);
+      nextBound.add(expr.binder);
+      if (expr.guard !== undefined) {
+        collectFreeVars(expr.guard, out, excluded, nextBound);
+      }
+      collectFreeVars(expr.body, out, excluded, nextBound);
       break;
     }
     case "map-read":
@@ -984,6 +1124,25 @@ function walkExpr(
         walkExpr(guard, visit, nextBound);
       }
       walkExpr(expr.proj, visit, nextBound);
+      break;
+    }
+    case "comb-typed": {
+      const nextBound = new Set(bound);
+      nextBound.add(expr.binder);
+      for (const guard of expr.guards) {
+        walkExpr(guard, visit, nextBound);
+      }
+      walkExpr(expr.proj, visit, nextBound);
+      break;
+    }
+    case "forall":
+    case "exists": {
+      const nextBound = new Set(bound);
+      nextBound.add(expr.binder);
+      if (expr.guard !== undefined) {
+        walkExpr(expr.guard, visit, nextBound);
+      }
+      walkExpr(expr.body, visit, nextBound);
       break;
     }
     case "map-read":

--- a/tools/ts2pant/src/ir1-ssa-loops.ts
+++ b/tools/ts2pant/src/ir1-ssa-loops.ts
@@ -510,6 +510,35 @@ function lowerShapeAExpr(expr: IR1Expr, state: ShapeASummaryState): OpaqueExpr {
         ],
         lowerShapeAExpr(expr.proj, state),
       );
+    case "comb-typed":
+      return ast.eachComb(
+        [ast.param(expr.binder, ast.tName(expr.binderType))],
+        expr.guards.map((guard) => ast.gExpr(lowerShapeAExpr(guard, state))),
+        expr.combiner === "min" ? ast.combMin() : ast.combMax(),
+        lowerShapeAExpr(expr.proj, state),
+      );
+    case "forall": {
+      const guards =
+        expr.guard === undefined
+          ? []
+          : [ast.gExpr(lowerShapeAExpr(expr.guard, state))];
+      return ast.forall(
+        [ast.param(expr.binder, ast.tName(expr.binderType))],
+        guards,
+        lowerShapeAExpr(expr.body, state),
+      );
+    }
+    case "exists": {
+      const guards =
+        expr.guard === undefined
+          ? []
+          : [ast.gExpr(lowerShapeAExpr(expr.guard, state))];
+      return ast.exists(
+        [ast.param(expr.binder, ast.tName(expr.binderType))],
+        guards,
+        lowerShapeAExpr(expr.body, state),
+      );
+    }
     case "map-read": {
       const callee = expr.op === "has" ? expr.keyPredName : expr.ruleName;
       return ast.app(ast.var(callee), [

--- a/tools/ts2pant/src/ir1-ssa-scalars.ts
+++ b/tools/ts2pant/src/ir1-ssa-scalars.ts
@@ -406,6 +406,19 @@ export function scalarSsaReadExpr(
       }
       scalarSsaReadExpr(expr.proj, state);
       return expr;
+    case "comb-typed":
+      for (const guard of expr.guards) {
+        scalarSsaReadExpr(guard, state);
+      }
+      scalarSsaReadExpr(expr.proj, state);
+      return expr;
+    case "forall":
+    case "exists":
+      if (expr.guard !== undefined) {
+        scalarSsaReadExpr(expr.guard, state);
+      }
+      scalarSsaReadExpr(expr.body, state);
+      return expr;
     case "var":
     case "lit":
       return expr;
@@ -685,6 +698,43 @@ function lowerScalarSsaExprToOpaque(
           lowerScalarSsaExprToOpaque(expr.proj, state),
         ),
       );
+    case "comb-typed":
+      return state.lowerOpaque(
+        ast.eachComb(
+          [ast.param(expr.binder, ast.tName(expr.binderType))],
+          expr.guards.map((guard) =>
+            ast.gExpr(lowerScalarSsaExprToOpaque(guard, state)),
+          ),
+          expr.combiner === "min" ? ast.combMin() : ast.combMax(),
+          lowerScalarSsaExprToOpaque(expr.proj, state),
+        ),
+      );
+    case "forall": {
+      const guards =
+        expr.guard === undefined
+          ? []
+          : [ast.gExpr(lowerScalarSsaExprToOpaque(expr.guard, state))];
+      return state.lowerOpaque(
+        ast.forall(
+          [ast.param(expr.binder, ast.tName(expr.binderType))],
+          guards,
+          lowerScalarSsaExprToOpaque(expr.body, state),
+        ),
+      );
+    }
+    case "exists": {
+      const guards =
+        expr.guard === undefined
+          ? []
+          : [ast.gExpr(lowerScalarSsaExprToOpaque(expr.guard, state))];
+      return state.lowerOpaque(
+        ast.exists(
+          [ast.param(expr.binder, ast.tName(expr.binderType))],
+          guards,
+          lowerScalarSsaExprToOpaque(expr.body, state),
+        ),
+      );
+    }
     case "map-read":
     case "set-read":
       throw new Error(`${expr.kind} is not a scalar SSA expression`);
@@ -963,6 +1013,15 @@ function scalarSsaExprKey(expr: IR1Expr): string {
       return `each:${expr.binder}:${scalarSsaExprKey(expr.src)}:${expr.guards
         .map(scalarSsaExprKey)
         .join(",")}:${scalarSsaExprKey(expr.proj)}`;
+    case "comb-typed":
+      return `comb-typed:${expr.combiner}:${expr.binder}:${expr.binderType}:${expr.guards
+        .map(scalarSsaExprKey)
+        .join(",")}:${scalarSsaExprKey(expr.proj)}`;
+    case "forall":
+    case "exists":
+      return `${expr.kind}:${expr.binder}:${expr.binderType}:${
+        expr.guard === undefined ? "" : scalarSsaExprKey(expr.guard)
+      }:${scalarSsaExprKey(expr.body)}`;
     case "map-read":
     case "set-read":
       throw new Error(`${expr.kind} is not a scalar SSA expression`);
@@ -1123,6 +1182,14 @@ function isScalarSsaExpr(expr: IR1Expr): boolean {
         isScalarSsaExpr(expr.src) &&
         expr.guards.every(isScalarSsaExpr) &&
         isScalarSsaExpr(expr.proj)
+      );
+    case "comb-typed":
+      return expr.guards.every(isScalarSsaExpr) && isScalarSsaExpr(expr.proj);
+    case "forall":
+    case "exists":
+      return (
+        (expr.guard === undefined || isScalarSsaExpr(expr.guard)) &&
+        isScalarSsaExpr(expr.body)
       );
     case "map-read":
     case "set-read":

--- a/tools/ts2pant/src/ir1-substitute.ts
+++ b/tools/ts2pant/src/ir1-substitute.ts
@@ -6,11 +6,14 @@ import {
   ir1Assign,
   ir1Binop,
   ir1Block,
+  ir1CombTyped,
   ir1Cond,
   ir1CondStmt,
   ir1Each,
+  ir1Exists,
   ir1ExprStmt,
   ir1For,
+  ir1Forall,
   ir1Foreach,
   ir1IsNullish,
   ir1Member,
@@ -70,6 +73,23 @@ export function freeVarsIR1Expr(expr: IR1Expr): Set<string> {
       );
       scoped.delete(expr.binder);
       return union(freeVarsIR1Expr(expr.src), scoped);
+    }
+    case "comb-typed": {
+      const scoped = union(
+        ...expr.guards.map(freeVarsIR1Expr),
+        freeVarsIR1Expr(expr.proj),
+      );
+      scoped.delete(expr.binder);
+      return scoped;
+    }
+    case "forall":
+    case "exists": {
+      const scoped = union(
+        ...(expr.guard === undefined ? [] : [freeVarsIR1Expr(expr.guard)]),
+        freeVarsIR1Expr(expr.body),
+      );
+      scoped.delete(expr.binder);
+      return scoped;
     }
     case "map-read":
       return union(freeVarsIR1Expr(expr.receiver), freeVarsIR1Expr(expr.key));
@@ -338,6 +358,78 @@ function substituteExpr(
         proj === expr.proj
         ? expr
         : ir1Each(expr.binder, src, guards, proj);
+    }
+    case "comb-typed": {
+      throwIfCaptureRisk(expr.binder, replacementFreeVars);
+      if (shadowsNeedle(expr.binder, needle)) {
+        return expr;
+      }
+      const guards = expr.guards.map((guard) =>
+        substituteExpr(guard, needle, replacement, replacementFreeVars),
+      );
+      const proj = substituteExpr(
+        expr.proj,
+        needle,
+        replacement,
+        replacementFreeVars,
+      );
+      return arrayRefEqual(guards, expr.guards) && proj === expr.proj
+        ? expr
+        : ir1CombTyped(
+            expr.combiner,
+            expr.binder,
+            expr.binderType,
+            guards,
+            proj,
+          );
+    }
+    case "forall": {
+      throwIfCaptureRisk(expr.binder, replacementFreeVars);
+      if (shadowsNeedle(expr.binder, needle)) {
+        return expr;
+      }
+      const guard =
+        expr.guard === undefined
+          ? undefined
+          : substituteExpr(
+              expr.guard,
+              needle,
+              replacement,
+              replacementFreeVars,
+            );
+      const body = substituteExpr(
+        expr.body,
+        needle,
+        replacement,
+        replacementFreeVars,
+      );
+      return guard === expr.guard && body === expr.body
+        ? expr
+        : ir1Forall(expr.binder, expr.binderType, body, guard);
+    }
+    case "exists": {
+      throwIfCaptureRisk(expr.binder, replacementFreeVars);
+      if (shadowsNeedle(expr.binder, needle)) {
+        return expr;
+      }
+      const guard =
+        expr.guard === undefined
+          ? undefined
+          : substituteExpr(
+              expr.guard,
+              needle,
+              replacement,
+              replacementFreeVars,
+            );
+      const body = substituteExpr(
+        expr.body,
+        needle,
+        replacement,
+        replacementFreeVars,
+      );
+      return guard === expr.guard && body === expr.body
+        ? expr
+        : ir1Exists(expr.binder, expr.binderType, body, guard);
     }
     case "map-read": {
       const receiver = substituteExpr(

--- a/tools/ts2pant/src/ir1.ts
+++ b/tools/ts2pant/src/ir1.ts
@@ -45,7 +45,7 @@ export type IR1Unop = IRUnop;
 // --------------------------------------------------------------------------
 
 /**
- * Layer 1 expressions. Eleven forms preserve TS-shape canonicalization:
+ * Layer 1 expressions. Fourteen forms preserve TS-shape canonicalization:
  *
  * - `var`, `lit` — literal references
  * - `binop`, `unop` — arithmetic/logical/comparison operators
@@ -62,6 +62,9 @@ export type IR1Unop = IRUnop;
  * - `each` — list comprehension. Canonical form for the functor-lift
  *   recognizer's `each n in operand | projection` output. Mirrors L2
  *   `each` and lowers structurally.
+ * - `comb-typed`, `forall`, `exists` — Pant-target binder forms.
+ *   Mirror L2's typed comprehension / quantifier vocabulary and lower
+ *   structurally.
  * - `map-read`, `set-read` — state-aware Map/Set reads (`.get`/`.has`
  *   on a Map, `.has` on a Set). Symmetric to the write-side
  *   `map-effect` / `set-effect` statement forms; mutating bodies resolve
@@ -120,6 +123,38 @@ export type IR1Expr =
       src: IR1Expr;
       guards: IR1Expr[];
       proj: IR1Expr;
+    }
+  /**
+   * Aggregate over a typed comprehension with no source. Mirrors L2
+   * `comb-typed` one-to-one and lowers structurally in `lowerL1Expr`.
+   */
+  | {
+      kind: "comb-typed";
+      combiner: "min" | "max";
+      binder: string;
+      binderType: string;
+      guards: IR1Expr[];
+      proj: IR1Expr;
+    }
+  /**
+   * Universal quantifier. Mirrors L2 `forall` one-to-one.
+   */
+  | {
+      kind: "forall";
+      binder: string;
+      binderType: string;
+      guard?: IR1Expr;
+      body: IR1Expr;
+    }
+  /**
+   * Existential quantifier. Mirrors L2 `exists` one-to-one.
+   */
+  | {
+      kind: "exists";
+      binder: string;
+      binderType: string;
+      guard?: IR1Expr;
+      body: IR1Expr;
     }
   /**
    * State-aware Map read: `m.get(k)` (`op = "get"`) or `m.has(k)`
@@ -865,7 +900,7 @@ const ir1SsaLocationEquals = (
   }
 };
 
-const ir1SsaExprEquals = (a: IR1Expr, b: IR1Expr): boolean => {
+export const ir1SsaExprEquals = (a: IR1Expr, b: IR1Expr): boolean => {
   switch (a.kind) {
     case "var": {
       if (b.kind !== "var") {
@@ -936,6 +971,40 @@ const ir1SsaExprEquals = (a: IR1Expr, b: IR1Expr): boolean => {
         ir1SsaExprEquals(a.proj, b.proj)
       );
     }
+    case "comb-typed": {
+      if (b.kind !== "comb-typed") {
+        return false;
+      }
+      return (
+        a.combiner === b.combiner &&
+        a.binder === b.binder &&
+        a.binderType === b.binderType &&
+        ir1SsaArrayEquals(a.guards, b.guards, ir1SsaExprEquals) &&
+        ir1SsaExprEquals(a.proj, b.proj)
+      );
+    }
+    case "forall": {
+      if (b.kind !== "forall") {
+        return false;
+      }
+      return (
+        a.binder === b.binder &&
+        a.binderType === b.binderType &&
+        optionalIr1SsaExprEquals(a.guard, b.guard) &&
+        ir1SsaExprEquals(a.body, b.body)
+      );
+    }
+    case "exists": {
+      if (b.kind !== "exists") {
+        return false;
+      }
+      return (
+        a.binder === b.binder &&
+        a.binderType === b.binderType &&
+        optionalIr1SsaExprEquals(a.guard, b.guard) &&
+        ir1SsaExprEquals(a.body, b.body)
+      );
+    }
     case "map-read": {
       if (b.kind !== "map-read") {
         return false;
@@ -973,6 +1042,14 @@ const ir1SsaCondArmEquals = (
   a: readonly [IR1Expr, IR1Expr],
   b: readonly [IR1Expr, IR1Expr],
 ): boolean => ir1SsaExprEquals(a[0], b[0]) && ir1SsaExprEquals(a[1], b[1]);
+
+const optionalIr1SsaExprEquals = (
+  a: IR1Expr | undefined,
+  b: IR1Expr | undefined,
+): boolean =>
+  a === undefined || b === undefined
+    ? a === undefined && b === undefined
+    : ir1SsaExprEquals(a, b);
 
 const ir1SsaArrayEquals = <T>(
   a: ReadonlyArray<T>,
@@ -1103,6 +1180,41 @@ export const ir1Each = (
   guards,
   proj,
 });
+
+export const ir1CombTyped = (
+  combiner: "min" | "max",
+  binder: string,
+  binderType: string,
+  guards: IR1Expr[],
+  proj: IR1Expr,
+): IR1Expr => ({
+  kind: "comb-typed",
+  combiner,
+  binder,
+  binderType,
+  guards,
+  proj,
+});
+
+export const ir1Forall = (
+  binder: string,
+  binderType: string,
+  body: IR1Expr,
+  guard?: IR1Expr,
+): IR1Expr =>
+  guard !== undefined
+    ? { kind: "forall", binder, binderType, guard, body }
+    : { kind: "forall", binder, binderType, body };
+
+export const ir1Exists = (
+  binder: string,
+  binderType: string,
+  body: IR1Expr,
+  guard?: IR1Expr,
+): IR1Expr =>
+  guard !== undefined
+    ? { kind: "exists", binder, binderType, guard, body }
+    : { kind: "exists", binder, binderType, body };
 
 /**
  * State-aware Map read. Mutating-body lowering resolves this form

--- a/tools/ts2pant/tests/ir1-lower.test.mts
+++ b/tools/ts2pant/tests/ir1-lower.test.mts
@@ -5,6 +5,8 @@ import {
   irBinop,
   irCombTyped,
   irCond,
+  irExists,
+  irForall,
   irLitBool,
   irLitNat,
   irUnop,
@@ -16,11 +18,14 @@ import {
   ir1Assign,
   ir1Binop,
   ir1Block,
+  ir1CombTyped,
   ir1Cond,
   ir1CondStmt,
   ir1ExprStmt,
+  ir1Exists,
   ir1For,
   ir1Foreach,
+  ir1Forall,
   ir1IsNullish,
   ir1Let,
   ir1LitBool,
@@ -231,24 +236,52 @@ describe("lowerL1Expr — is-nullish (M4 canonical nullish test)", () => {
 });
 
 describe("lowering new L1 forms", () => {
-  it.skip("comb-typed lowers via irCombTyped", () => {
-    // PENDING Patch 2.
+  it("comb-typed lowers via irCombTyped", () => {
+    const l1 = ir1CombTyped(
+      "min",
+      "j",
+      "Int",
+      [ir1Binop("ge", ir1Var("j"), ir1LitNat(0))],
+      ir1Var("j"),
+    );
+    assert.deepEqual(
+      lowerL1Expr(l1),
+      irCombTyped(
+        "min",
+        "j",
+        "Int",
+        [irBinop("ge", irVar("j", false), irLitNat(0))],
+        irVar("j", false),
+      ),
+    );
   });
 
-  it.skip("forall lowers via irForall with guard", () => {
-    // PENDING Patch 2.
+  it("forall lowers via irForall with guard", () => {
+    assert.deepEqual(
+      lowerL1Expr(ir1Forall("x", "Nat0", ir1Var("body"), ir1Var("guard"))),
+      irForall("x", "Nat0", irVar("body", false), irVar("guard", false)),
+    );
   });
 
-  it.skip("forall lowers via irForall without guard", () => {
-    // PENDING Patch 2.
+  it("forall lowers via irForall without guard", () => {
+    assert.deepEqual(
+      lowerL1Expr(ir1Forall("x", "Nat0", ir1Var("body"))),
+      irForall("x", "Nat0", irVar("body", false)),
+    );
   });
 
-  it.skip("exists lowers via irExists with guard", () => {
-    // PENDING Patch 2.
+  it("exists lowers via irExists with guard", () => {
+    assert.deepEqual(
+      lowerL1Expr(ir1Exists("x", "Nat0", ir1Var("body"), ir1Var("guard"))),
+      irExists("x", "Nat0", irVar("body", false), irVar("guard", false)),
+    );
   });
 
-  it.skip("exists lowers via irExists without guard", () => {
-    // PENDING Patch 2.
+  it("exists lowers via irExists without guard", () => {
+    assert.deepEqual(
+      lowerL1Expr(ir1Exists("x", "Nat0", ir1Var("body"))),
+      irExists("x", "Nat0", irVar("body", false)),
+    );
   });
 });
 

--- a/tools/ts2pant/tests/ir1-substitute.test.mts
+++ b/tools/ts2pant/tests/ir1-substitute.test.mts
@@ -10,11 +10,14 @@ import {
   ir1Assign,
   ir1Binop,
   ir1Block,
+  ir1CombTyped,
   ir1Cond,
   ir1Each,
+  ir1Exists,
   ir1ExprStmt,
   ir1For,
   ir1Foreach,
+  ir1Forall,
   ir1IsNullish,
   ir1Let,
   ir1LitBool,
@@ -57,16 +60,30 @@ describe("ir1-substitute", () => {
       assertSetEqual(freeVarsIR1Expr(expr), ["g", "src"]);
     });
 
-    it.skip("freeVarsIR1Expr scopes comb-typed binder", () => {
-      // PENDING Patch 2.
+    it("freeVarsIR1Expr scopes comb-typed binder", () => {
+      const expr = ir1CombTyped(
+        "min",
+        "x",
+        "Int",
+        [ir1Var("x"), ir1Var("g")],
+        ir1Binop("add", ir1Var("x"), ir1Var("y")),
+      );
+      assertSetEqual(freeVarsIR1Expr(expr), ["g", "y"]);
     });
 
-    it.skip("freeVarsIR1Expr scopes forall binder", () => {
-      // PENDING Patch 2.
+    it("freeVarsIR1Expr scopes forall binder", () => {
+      const expr = ir1Forall(
+        "x",
+        "Int",
+        ir1Binop("gt", ir1Var("x"), ir1Var("z")),
+        ir1Binop("ge", ir1Var("x"), ir1Var("lower")),
+      );
+      assertSetEqual(freeVarsIR1Expr(expr), ["lower", "z"]);
     });
 
-    it.skip("freeVarsIR1Expr scopes exists binder", () => {
-      // PENDING Patch 2.
+    it("freeVarsIR1Expr scopes exists binder", () => {
+      const expr = ir1Exists("x", "Int", ir1Binop("eq", ir1Var("x"), ir1Var("z")));
+      assertSetEqual(freeVarsIR1Expr(expr), ["z"]);
     });
 
     it("freeVarsIR1Stmt respects block / let / foreach / for binders", () => {
@@ -138,32 +155,92 @@ describe("ir1-substitute", () => {
       );
     });
 
-    it.skip("substituteIR1ExprSubtree throws under comb-typed capture", () => {
-      // PENDING Patch 2.
+    it("substituteIR1ExprSubtree throws under comb-typed capture", () => {
+      assert.throws(
+        () =>
+          substituteIR1ExprSubtree(
+            ir1CombTyped("min", "x", "Int", [], ir1Var("target")),
+            ir1Var("target"),
+            ir1Var("x"),
+          ),
+        CaptureRiskError,
+      );
     });
 
-    it.skip("substituteIR1ExprSubtree throws under forall capture", () => {
-      // PENDING Patch 2.
+    it("substituteIR1ExprSubtree throws under forall capture", () => {
+      assert.throws(
+        () =>
+          substituteIR1ExprSubtree(
+            ir1Forall("x", "Int", ir1Var("target")),
+            ir1Var("target"),
+            ir1Var("x"),
+          ),
+        CaptureRiskError,
+      );
     });
 
-    it.skip("substituteIR1ExprSubtree throws under exists capture", () => {
-      // PENDING Patch 2.
+    it("substituteIR1ExprSubtree throws under exists capture", () => {
+      assert.throws(
+        () =>
+          substituteIR1ExprSubtree(
+            ir1Exists("x", "Int", ir1Var("target")),
+            ir1Var("target"),
+            ir1Var("x"),
+          ),
+        CaptureRiskError,
+      );
     });
 
-    it.skip("substituteIR1ExprSubtree halts at shadowing comb-typed", () => {
-      // PENDING Patch 2.
+    it("substituteIR1ExprSubtree halts at shadowing comb-typed", () => {
+      const expr = ir1CombTyped(
+        "min",
+        "x",
+        "Int",
+        [ir1Var("x")],
+        ir1Member(ir1Var("x"), "p"),
+      );
+      assert.deepEqual(
+        substituteIR1ExprSubtree(expr, ir1Var("x"), ir1LitNat(0)),
+        expr,
+      );
     });
 
-    it.skip("substituteIR1ExprSubtree halts at shadowing forall", () => {
-      // PENDING Patch 2.
+    it("substituteIR1ExprSubtree halts at shadowing forall", () => {
+      const expr = ir1Forall(
+        "x",
+        "Int",
+        ir1Member(ir1Var("x"), "p"),
+        ir1Var("x"),
+      );
+      assert.deepEqual(
+        substituteIR1ExprSubtree(expr, ir1Var("x"), ir1LitNat(0)),
+        expr,
+      );
     });
 
-    it.skip("substituteIR1ExprSubtree halts at shadowing exists", () => {
-      // PENDING Patch 2.
+    it("substituteIR1ExprSubtree halts at shadowing exists", () => {
+      const expr = ir1Exists(
+        "x",
+        "Int",
+        ir1Member(ir1Var("x"), "p"),
+        ir1Var("x"),
+      );
+      assert.deepEqual(
+        substituteIR1ExprSubtree(expr, ir1Var("x"), ir1LitNat(0)),
+        expr,
+      );
     });
 
-    it.skip("arbIR1Expr includes new L1 binder forms", () => {
-      // PENDING Patch 2.
+    it("arbIR1Expr includes new L1 binder forms", () => {
+      const seen = new Set<string>();
+      for (let seed = 1; seed <= 20; seed += 1) {
+        for (const expr of fc.sample(arbIR1Expr(3), { seed, numRuns: 200 })) {
+          seen.add(expr.kind);
+        }
+      }
+      assert.equal(seen.has("comb-typed"), true);
+      assert.equal(seen.has("forall"), true);
+      assert.equal(seen.has("exists"), true);
     });
 
     it("substituteIR1ExprSubtree preserves shape outside replacement sites", () => {
@@ -370,6 +447,37 @@ function arbIR1Expr(depth = 4): fc.Arbitrary<IR1Expr> {
               .map(([binder, src, guards, proj]) =>
                 ir1Each(binder, src, guards, proj),
               ),
+            fc
+              .tuple(
+                fc.constantFrom("min", "max" as const),
+                nameArb,
+                fc.constantFrom("Nat0", "Int", "Real"),
+                fc.array(arbIR1Expr(depth - 1), { maxLength: 2 }),
+                arbIR1Expr(depth - 1),
+              )
+              .map(([combiner, binder, binderType, guards, proj]) =>
+                ir1CombTyped(combiner, binder, binderType, guards, proj),
+              ),
+            fc
+              .tuple(
+                nameArb,
+                fc.constantFrom("Nat0", "Int", "Real"),
+                arbIR1Expr(depth - 1),
+                fc.option(arbIR1Expr(depth - 1), { nil: undefined }),
+              )
+              .map(([binder, binderType, body, guard]) =>
+                ir1Forall(binder, binderType, body, guard),
+              ),
+            fc
+              .tuple(
+                nameArb,
+                fc.constantFrom("Nat0", "Int", "Real"),
+                arbIR1Expr(depth - 1),
+                fc.option(arbIR1Expr(depth - 1), { nil: undefined }),
+              )
+              .map(([binder, binderType, body, guard]) =>
+                ir1Exists(binder, binderType, body, guard),
+              ),
           ),
   })).expr;
 }
@@ -477,6 +585,17 @@ function exprContainsNeedle(
         exprContainsNeedle(expr.src, needle) ||
         expr.guards.some((guard) => exprContainsNeedle(guard, needle)) ||
         exprContainsNeedle(expr.proj, needle)
+      );
+    case "comb-typed":
+      return (
+        expr.guards.some((guard) => exprContainsNeedle(guard, needle)) ||
+        exprContainsNeedle(expr.proj, needle)
+      );
+    case "forall":
+    case "exists":
+      return (
+        (expr.guard !== undefined && exprContainsNeedle(expr.guard, needle)) ||
+        exprContainsNeedle(expr.body, needle)
       );
     case "map-read":
       return (

--- a/tools/ts2pant/tests/ir1.test.mts
+++ b/tools/ts2pant/tests/ir1.test.mts
@@ -1,29 +1,111 @@
+import assert from "node:assert/strict";
 import { describe, it } from "node:test";
+
+import {
+  ir1CombTyped,
+  ir1Exists,
+  ir1Forall,
+  ir1LitBool,
+  ir1SsaExprEquals,
+  ir1Var,
+} from "../src/ir1.js";
 
 describe("ir1", () => {
   describe("new L1 binder forms", () => {
-    it.skip("ir1CombTyped constructs comb-typed shape", () => {
-      // PENDING Patch 2.
+    it("ir1CombTyped constructs comb-typed shape", () => {
+      assert.deepEqual(
+        ir1CombTyped("min", "j", "Int", [ir1Var("g")], ir1Var("j")),
+        {
+          kind: "comb-typed",
+          combiner: "min",
+          binder: "j",
+          binderType: "Int",
+          guards: [ir1Var("g")],
+          proj: ir1Var("j"),
+        },
+      );
     });
 
-    it.skip("ir1Forall constructs forall shape", () => {
-      // PENDING Patch 2.
+    it("ir1Forall constructs forall shape", () => {
+      assert.deepEqual(ir1Forall("x", "Nat0", ir1Var("body"), ir1Var("g")), {
+        kind: "forall",
+        binder: "x",
+        binderType: "Nat0",
+        guard: ir1Var("g"),
+        body: ir1Var("body"),
+      });
     });
 
-    it.skip("ir1Exists constructs exists shape", () => {
-      // PENDING Patch 2.
+    it("ir1Exists constructs exists shape", () => {
+      assert.deepEqual(ir1Exists("x", "Nat0", ir1Var("body")), {
+        kind: "exists",
+        binder: "x",
+        binderType: "Nat0",
+        body: ir1Var("body"),
+      });
     });
 
-    it.skip("ir1SsaExprEquals compares comb-typed fields", () => {
-      // PENDING Patch 2.
+    it("ir1SsaExprEquals compares comb-typed fields", () => {
+      const base = ir1CombTyped("min", "j", "Int", [ir1Var("g")], ir1Var("j"));
+      assert.equal(ir1SsaExprEquals(base, base), true);
+      assert.equal(
+        ir1SsaExprEquals(
+          base,
+          ir1CombTyped("max", "j", "Int", [ir1Var("g")], ir1Var("j")),
+        ),
+        false,
+      );
+      assert.equal(
+        ir1SsaExprEquals(
+          base,
+          ir1CombTyped("min", "j", "Real", [ir1Var("g")], ir1Var("j")),
+        ),
+        false,
+      );
     });
 
-    it.skip("ir1SsaExprEquals compares forall fields", () => {
-      // PENDING Patch 2.
+    it("ir1SsaExprEquals compares forall fields", () => {
+      const base = ir1Forall("x", "Int", ir1Var("body"), ir1Var("guard"));
+      assert.equal(
+        ir1SsaExprEquals(
+          base,
+          ir1Forall("x", "Int", ir1Var("body"), ir1Var("guard")),
+        ),
+        true,
+      );
+      assert.equal(ir1SsaExprEquals(base, ir1Forall("x", "Int", ir1Var("body"))), false);
+      assert.equal(
+        ir1SsaExprEquals(
+          base,
+          ir1Forall("x", "Nat0", ir1Var("body"), ir1Var("guard")),
+        ),
+        false,
+      );
     });
 
-    it.skip("ir1SsaExprEquals compares exists fields", () => {
-      // PENDING Patch 2.
+    it("ir1SsaExprEquals compares exists fields", () => {
+      const base = ir1Exists("x", "Int", ir1Var("body"), ir1LitBool(true));
+      assert.equal(
+        ir1SsaExprEquals(
+          base,
+          ir1Exists("x", "Int", ir1Var("body"), ir1LitBool(true)),
+        ),
+        true,
+      );
+      assert.equal(
+        ir1SsaExprEquals(
+          base,
+          ir1Exists("y", "Int", ir1Var("body"), ir1LitBool(true)),
+        ),
+        false,
+      );
+      assert.equal(
+        ir1SsaExprEquals(
+          base,
+          ir1Exists("x", "Int", ir1Var("other"), ir1LitBool(true)),
+        ),
+        false,
+      );
     });
   });
 });


### PR DESCRIPTION
## Patch 2: Add comb-typed / forall / exists L1 forms; extend every IR1Expr walker

- In `ir1.ts`, extend the `IR1Expr` union with three new discriminated-union members: `{ kind: "comb-typed"; combiner: Combiner; binder: string; binderType: string; guards: IR1Expr[]; proj: IR1Expr }`; `{ kind: "forall"; binder: string; binderType: string; guard?: IR1Expr; body: IR1Expr }`; `{ kind: "exists"; binder: string; binderType: string; guard?: IR1Expr; body: IR1Expr }`. Match L2's `irForall` / `irExists` / `irCombTyped` constructor signatures exactly.
- Add constructors `ir1CombTyped`, `ir1Forall`, `ir1Exists` matching L2's argument order.
- Extend `ir1SsaExprEquals` with three arms. Each compares fields recursively; `binderType` is a string compare; `guards` uses the existing `ir1SsaArrayEquals(a.guards, b.guards, ir1SsaExprEquals)`.
- In `ir1-substitute.ts`, extend `freeVarsIR1Expr` with arms. `comb-typed`: `union(...e.guards.map(freeVarsIR1Expr), freeVarsIR1Expr(e.proj))`, then `scoped.delete(e.binder)`, return. `forall` / `exists`: same pattern with optional `guard` + `body` instead.
- In `ir1-substitute.ts`, extend the internal `substituteExpr` walker with arms. Each calls `throwIfCaptureRisk(e.binder, replacementFreeVars)`. If `shadowsNeedle(e.binder, needle)`, return `expr` unchanged. Otherwise recurse and reconstruct via the new constructor.
- In `ir1-lower.ts`, extend `lowerL1Expr` with three arms before `default`: `case "comb-typed": return irCombTyped(e.combiner, e.binder, e.binderType, e.guards.map(lowerL1Expr), lowerL1Expr(e.proj));` and equivalent for `forall` / `exists`.
- In `ir1-printer.ts`, extend the printer with three arms (match the existing `each` printer style).
- In `ir1-ssa-counter-loop.ts` and `ir1-ssa-fixed-point.ts`, identify every IR1Expr-exhaustive walker via `grep -n 'exhaustive: never = expr'` (and similar). Read each walker's purpose; add new arms following each idiom (recursive scope-aware traversal for free-vars / count-reads / equality walkers).
- Verify `npx tsc --noEmit` succeeds from `tools/ts2pant/` with zero errors.
- In the test files, unskip Patch-2-owned stubs and replace PENDING comments with concrete assertions. For lowering tests, construct an L1 form, call `lowerL1Expr`, assert the result equals the L2 counterpart via `irCombTyped` / `irForall` / `irExists`.
- Extend the `arbIR1Expr` generator in `tests/ir1-substitute.test.mts` (line 293) to produce the three new forms via `fc.tuple(...).map(...)` mirroring the existing `each` generator.
- Run `just ts2pant-test` to confirm all tests pass and existing fixtures' snapshots remain byte-identical.

## Changes
- In `ir1.ts`, extend the `IR1Expr` union with three new discriminated-union members: `{ kind: "comb-typed"; combiner: Combiner; binder: string; binderType: string; guards: IR1Expr[]; proj: IR1Expr }`; `{ kind: "forall"; binder: string; binderType: string; guard?: IR1Expr; body: IR1Expr }`; `{ kind: "exists"; binder: string; binderType: string; guard?: IR1Expr; body: IR1Expr }`. Match L2's `irForall` / `irExists` / `irCombTyped` constructor signatures exactly.
- Add constructors `ir1CombTyped`, `ir1Forall`, `ir1Exists` matching L2's argument order.
- Extend `ir1SsaExprEquals` with three arms. Each compares fields recursively; `binderType` is a string compare; `guards` uses the existing `ir1SsaArrayEquals(a.guards, b.guards, ir1SsaExprEquals)`.
- In `ir1-substitute.ts`, extend `freeVarsIR1Expr` with arms. `comb-typed`: `union(...e.guards.map(freeVarsIR1Expr), freeVarsIR1Expr(e.proj))`, then `scoped.delete(e.binder)`, return. `forall` / `exists`: same pattern with optional `guard` + `body` instead.
- In `ir1-substitute.ts`, extend the internal `substituteExpr` walker with arms. Each calls `throwIfCaptureRisk(e.binder, replacementFreeVars)`. If `shadowsNeedle(e.binder, needle)`, return `expr` unchanged. Otherwise recurse and reconstruct via the new constructor.
- In `ir1-lower.ts`, extend `lowerL1Expr` with three arms before `default`: `case "comb-typed": return irCombTyped(e.combiner, e.binder, e.binderType, e.guards.map(lowerL1Expr), lowerL1Expr(e.proj));` and equivalent for `forall` / `exists`.
- In `ir1-printer.ts`, extend the printer with three arms (match the existing `each` printer style).
- In `ir1-ssa-counter-loop.ts` and `ir1-ssa-fixed-point.ts`, identify every IR1Expr-exhaustive walker via `grep -n 'exhaustive: never = expr'` (and similar). Read each walker's purpose; add new arms following each idiom (recursive scope-aware traversal for free-vars / count-reads / equality walkers).
- Verify `npx tsc --noEmit` succeeds from `tools/ts2pant/` with zero errors.
- In the test files, unskip Patch-2-owned stubs and replace PENDING comments with concrete assertions. For lowering tests, construct an L1 form, call `lowerL1Expr`, assert the result equals the L2 counterpart via `irCombTyped` / `irForall` / `irExists`.
- Extend the `arbIR1Expr` generator in `tests/ir1-substitute.test.mts` (line 293) to produce the three new forms via `fc.tuple(...).map(...)` mirroring the existing `each` generator.
- Run `just ts2pant-test` to confirm all tests pass and existing fixtures' snapshots remain byte-identical.

## Files to Modify
- tools/ts2pant/src/ir1.ts (modify): Extend `IR1Expr` union with three new variants. Add constructors. Extend `ir1SsaExprEquals` with three arms.
- tools/ts2pant/src/ir1-substitute.ts (modify): Extend `freeVarsIR1Expr` and the internal `substituteExpr` walker with three arms each. Mirror the existing `each` arm's structure.
- tools/ts2pant/src/ir1-lower.ts (modify): Extend `lowerL1Expr` with three 1:1 mechanical lowering arms: L1 → L2 via `irCombTyped` / `irForall` / `irExists`.
- tools/ts2pant/src/ir1-printer.ts (modify): Extend the IR1 printer with arms for the three new forms (debug-readable output).
- tools/ts2pant/src/ir1-ssa-counter-loop.ts (modify): Extend every IR1Expr-exhaustive walker in this file (lines 652, 722, 822) with three new arms following each walker's idiom.
- tools/ts2pant/src/ir1-ssa-fixed-point.ts (modify): Extend every IR1Expr-exhaustive walker in this file (lines 577, 652, 729, 817, 886) with three new arms following each walker's idiom.
- tools/ts2pant/tests/ir1.test.mts (modify): Unskip Patch-2-owned stubs; implement concrete assertions.
- tools/ts2pant/tests/ir1-substitute.test.mts (modify): Unskip Patch-2-owned stubs; extend the `arbIR1Expr` property-test generator to produce the new forms; implement assertions.
- tools/ts2pant/tests/ir1-lower.test.mts (modify): Unskip Patch-2-owned lowering-test stubs; implement assertions.

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[pattern] Discriminated-union extension with exhaustive switch checks** — https://www.typescriptlang.org/docs/handbook/2/narrowing.html#exhaustiveness-checking — TypeScript's `const _exhaustive: never = expr;` idiom at every switch's default branch surfaces every walker over `IR1Expr` that needs new arms when the union grows. Once `tsc` succeeds with no errors after adding all arms, the implementing agent has proof that every walker is handled.

## Gameplan Specification

```
module TS2PANT_L2_TYPED_MIRROR.

> ════════════════════════════════
> Single-milestone workstream: L2 as a typed mirror of OpaqueExpr.
> ════════════════════════════════
> After this gameplan, L1 has comb-typed / forall / exists
> mirroring L2's CombTyped / Forall / Exists. The μ-search
> recognizer produces L1 comb-typed directly at the
> TS-AST → L1 boundary; lowerL1MuSearch and
> isCanonicalMuSearchForm are removed. L1→L2 is now a pure
> 1:1 mechanical mapping. Documentation in the IR doc + 
> AGENTS.md + imperative-IR workstream doc articulates the
> honest layering principle: L1 absorbs Pant-target forms;
> L1→L2 carries no recognition; L2 is a typed mirror, not
> a transformation IR.

IR1Form.
L2Form.
Walker.
FreeVarSet.
RecognitionSite.
IR1Shape.
SnapshotState.
Document.
DocumentKind.
comb-typed => IR1Form.
forall => IR1Form.
exists => IR1Form.
comb-typed-l2 => L2Form.
forall-l2 => L2Form.
exists-l2 => L2Form.
ts-ast-to-l1 => RecognitionSite.
l1-to-l2 => RecognitionSite.
comb-typed-l1 => IR1Shape.
block-let-while => IR1Shape.
identical => SnapshotState.
drifted => SnapshotState.
ir-doc => DocumentKind.
agents-md => DocumentKind.
imperative-ir-doc => DocumentKind.

has-arm-for? w: Walker, f: IR1Form => Bool.
scopes-binder? f: IR1Form, vars: FreeVarSet => Bool.
lowers-to? l1: IR1Form, l2: L2Form => Bool.
respects-capture-risk? f: IR1Form => Bool.
halts-at-shadow? f: IR1Form => Bool.
recognizer-fires-at? site: RecognitionSite => Bool.
post-recognizer-shape => IR1Shape.
snapshot-state => SnapshotState.
lower-l1-musearch-exists? => Bool.
is-canonical-musearch-form-exists? => Bool.
document-kind d: Document => DocumentKind.
mentions-layering-principle? d: Document => Bool.
mentions-no-l1-l2-recognition? d: Document => Bool.
mentions-l2-not-substitution-target? d: Document => Bool.
---

> Vocabulary contract.
all f: IR1Form, w: Walker | has-arm-for? w f.
all f: IR1Form, vars: FreeVarSet | scopes-binder? f vars.
all f: IR1Form | respects-capture-risk? f.
all f: IR1Form | halts-at-shadow? f.
lowers-to? comb-typed comb-typed-l2.
lowers-to? forall forall-l2.
lowers-to? exists exists-l2.

> Recognition has moved upstream.
recognizer-fires-at? ts-ast-to-l1.
~(recognizer-fires-at? l1-to-l2).
post-recognizer-shape = comb-typed-l1.
~(lower-l1-musearch-exists?).
~(is-canonical-musearch-form-exists?).

> Snapshot equivalence on every μ-search fixture.
snapshot-state = identical.

> Documentation invariants.
all d: Document |
  document-kind d = ir-doc ->
    mentions-layering-principle? d and
    mentions-no-l1-l2-recognition? d and
    mentions-l2-not-substitution-target? d.

all d: Document |
  document-kind d = agents-md ->
    mentions-layering-principle? d.

all d: Document |
  document-kind d = imperative-ir-doc ->
    mentions-layering-principle? d.
```

## Patch Specification

```
module TS2PANT_L2_TYPED_MIRROR_PATCH_2.

> Patch 2 extends L1 with three new binder-introducing
> forms mirroring L2. Each form has a constructor, an arm
> in every IR1Expr-exhaustive walker (structural equality,
> free-vars scope, substitution with capture-check and
> shadow-halt, mechanical L1→L2 lowering, debug printer,
> ssa-loop walkers). The new vocabulary is consumed by
> Patch 3's recognizer migration.

IR1Form.
L2Form.
Walker.
FreeVarSet.
comb-typed => IR1Form.
forall => IR1Form.
exists => IR1Form.
comb-typed-l2 => L2Form.
forall-l2 => L2Form.
exists-l2 => L2Form.
free-vars-walker => Walker.
substitute-walker => Walker.
equality-walker => Walker.
lowering-walker => Walker.
printer-walker => Walker.
ssa-counter-walker => Walker.
ssa-fixed-point-walker => Walker.

has-arm-for? w: Walker, f: IR1Form => Bool.
scopes-binder? f: IR1Form, vars: FreeVarSet => Bool.
lowers-to? l1: IR1Form, l2: L2Form => Bool.
respects-capture-risk? f: IR1Form => Bool.
halts-at-shadow? f: IR1Form => Bool.
---

> Every IR1Expr-exhaustive walker has arms for each new form.
all f: IR1Form, w: Walker | has-arm-for? w f.

> Free-vars walker scopes binders correctly.
all f: IR1Form, vars: FreeVarSet | scopes-binder? f vars.

> Substitution arms respect capture-risk and shadowing.
all f: IR1Form | respects-capture-risk? f.
all f: IR1Form | halts-at-shadow? f.

> L1 → L2 lowering arms are 1:1 mechanical.
lowers-to? comb-typed comb-typed-l2.
lowers-to? forall forall-l2.
lowers-to? exists exists-l2.
```


## Implementation Notes

- `tsc` surfaced additional exhaustive IR1 walkers beyond the narrower patch prose (`ir1-ssa-collections.ts`, `ir1-ssa-loops.ts`, `ir1-ssa-scalars.ts`). I updated those too so the new union members are accepted everywhere the current codebase treats `IR1Expr` exhaustively.
- The SSA helper additions are structural pass-throughs: scalar/collection/Shape-A lowering builds the same typed Pant forms as L2 emission (`eachComb`, `forall`, `exists`), while key/read predicates recurse into guards/projections/bodies using the same binder scope rules as `each`.
- `ir1SsaExprEquals` was exported so the Patch-2 unit stubs can directly assert the new equality behavior; it was already the internal structural equality gate for SSA location/value compatibility.
- Spec/Evidence Mapping: vocabulary and lowering are in `tools/ts2pant/src/ir1.ts` and `tools/ts2pant/src/ir1-lower.ts`; free-var/capture/shadow handling is in `tools/ts2pant/src/ir1-substitute.ts`; exhaustive walker coverage is proven by `npx tsc --noEmit`; behavior is covered by the unskipped `ir1`, `ir1-substitute`, and `ir1-lower` tests plus `just ts2pant-test`.
- Verification completed before the base retarget notice: `npx tsc --noEmit`, targeted `tsx` tests for the modified test files, and `just ts2pant-test` all passed with no snapshot file changes.