### PR TITLE
[ts2pant-l2-typed-mirror] Patch 4: Reframe the IR layering principle in docs

### DIFF
--- a/tools/ts2pant/AGENTS.md
+++ b/tools/ts2pant/AGENTS.md
@@ -248,6 +248,12 @@ Read that file before extending the IR or touching SSA-bearing code:
   (indirect-memory SSA), Knobe-Sarkar 1998 (Array SSA), and IRSC. ts2pant
   diverges from IRSC's variable SSA to location SSA — see the IR doc for the
   rationale.
+- **IRSC divergence.** IRSC's separation between FRSC (TS-shape) and IRSC
+  (SSA-pure) serves a verification-soundness purpose because IRSC has a
+  downstream consumer: the refinement-type checker. ts2pant has no
+  L2-reading verifier; the FRSC/IRSC-style separation here is for type
+  safety and inspectability only. L2 is a typed mirror of `OpaqueExpr`, not a
+  transformation IR.
 - **Imperative IR Workstream.** M1–M5 of the workstream landed; the doc
   records what each milestone delivered and the locked decisions.
 - **General-loop SSA Workstream.** L1 (loop SSA contract), L2 (bounded

--- a/tools/ts2pant/docs/intermediate-representation.md
+++ b/tools/ts2pant/docs/intermediate-representation.md
@@ -8,11 +8,14 @@
 > `workstreams/ts2pant-general-loop-ssa.md`.
 
 ts2pant lowers TypeScript through a two-layer IR before emission:
-**Layer 1** (`src/ir1.ts`) is a TS-shape imperative IR where
-normalization passes collapse syntactically equivalent surface forms
-(increment spellings, conditional families, iteration families) into a
-small canonical vocabulary, and **Layer 2** (`src/ir.ts`) is a
-Pant-shape expression IR. The pure / value-position path goes
+**Layer 1** (`src/ir1.ts`) is the canonical form after all source-level
+recognition. Normalization passes collapse syntactically equivalent
+surface forms (increment spellings, conditional families, iteration
+families) into a small canonical vocabulary, including Pant-target forms
+when source-level recognition needs them. **Layer 2** (`src/ir.ts`) is
+L1's expression subset packaged as a typed `OpaqueExpr` mirror. Its
+purpose is type-safe construction and snapshot-testable inspection, not
+transformation. The pure / value-position path goes
 TS → L1 → L2 → `OpaqueExpr`; the effect / statement-position path
 goes TS → L1 statement → IR1 SSA → `PropResult[]` (no L2 statement
 vocabulary by design).
@@ -97,7 +100,7 @@ intentional; see `workstreams/ts2pant-imperative-ir.md`
 | `Let(name, value, body)` | substituted out at emit (Pant has no `let`) | `const x = e1; ... return e2` const-binding inlining |
 | `Each(binder, src, [g], proj)` | `ast.each` | for-of Shape A/B, `?.` lowering, `.filter`/`.map` chain |
 | `Comb(combiner, init?, each)` | `ast.eachComb` (with optional binop fold for non-identity init when the combiner is a fold; min/max take no init) | `.reduce` (fold combiners), source-iterating min/max comprehensions |
-| `CombTyped(combiner, binder, binderType, guards, proj)` | `ast.eachComb` over a typed binder (no source) | μ-search (`min over each j: T, guards \| j`) — the canonical lowering target produced by `recognizeAndLowerMuSearch` in `ir1-lower.ts` |
+| `CombTyped(combiner, binder, binderType, guards, proj)` | `ast.eachComb` over a typed binder (no source) | μ-search (`min over each j: T, guards \| j`) — mirrored from L1 `comb-typed` after TS-AST → L1 recognition |
 | `Forall(binder, type, guard?, body)` | `ast.forall` | `all x: T \| ...` quantifier emission |
 | `Exists(binder, type, guard?, body)` | `ast.exists` | `some x: T \| ...` quantifier emission |
 
@@ -721,14 +724,11 @@ every union/intersection constituent to satisfy `BooleanLike`).
 via `buildL1IncrementStep` in `ir1-build.ts`. The five `+1` spellings
 (`i++`, `++i`, `i += 1`, `i = i + 1`, `i = 1 + i`) produce *byte-
 identical* L1 output — that's the M2 architectural promise. μ-search
-recognition and lowering live entirely in the L1/L2 layers
-(`isCanonicalMuSearchForm` and `lowerL1MuSearch` in `ir1-lower.ts`,
-producing an L2 `comb-typed` expression that emits to OpaqueExpr in
-`ir-emit.ts`). The TS-AST `recognizeLetWhilePair` is purely
-structural (consumes the let + while pair) — `translate-body.ts`
-carries no Pantagruel-target awareness for μ-search. Three
-additional `+1` spellings now translate (was just `i++`/`++i`
-pre-M2).
+recognition now fires upstream while building L1: `recognizeLetWhilePair`
+consumes the let + while pair and constructs L1 `comb-typed` through
+`buildL1MuSearchCombTyped`. L1 → L2 then lowers that form mechanically to
+L2 `comb-typed`, which emits to `OpaqueExpr` in `ir-emit.ts`. Three
+additional `+1` spellings now translate (was just `i++`/`++i` pre-M2).
 
 **M3 (imperative-ir-iteration-mutation): landed.** Historical M3 note:
 branched mutation and iteration flow through Layer 1. The build pass
@@ -956,23 +956,44 @@ exercises computed `obj[expr]` that would surface the rejection
 path. **0%.** Rejection is exercised by the deliberate-reject
 `getByDynamicKey` fixture function plus unit tests.
 
-**Layering principle.** This is the architectural commitment that
-M2 ratifies and the M2 cleanup completes:
+**Layering principle.** L1 is the canonical form after all source-level
+recognition. L2 is L1's expression subset packaged as a typed
+`OpaqueExpr` mirror; its purpose is type-safe construction and
+snapshot-testable inspection, not transformation. All recognition and
+target-shape decisions happen at TS-AST → L1; L1 → L2 is a mechanical
+1:1 lowering.
 
-1. **L1** (`ir1.ts`, `ir1-build.ts`) — canonicalized TypeScript
-   syntax. No Pantagruel-target awareness.
-2. **L1 → L2 lowering** (`ir1-lower.ts`) — the *only* layer that
-   knows Pantagruel-target patterns (μ-search recognition,
-   counter-binder substitution).
-3. **L2** (`ir.ts`) — Pantagruel-shaped expression IR. Includes
-   `comb-typed` for source-less typed comprehension (μ-search's
-   target).
+1. **TS-AST → L1** (`ir1-build.ts`, `ir1-build-body.ts`) — source-level
+   recognition, canonicalization, and target-shape decisions. This is
+   where recognizers build canonical L1 forms such as `is-nullish`,
+   `each`, or `comb-typed`.
+2. **L1 → L2 lowering** (`ir1-lower.ts`) — mechanical expression mapping
+   from canonical L1 forms to their L2 mirrors or to structural L2 shapes
+   for already-canonical L1 forms.
+3. **L2** (`ir.ts`) — typed mirror of the `OpaqueExpr` construction
+   surface. Includes `comb-typed`, `forall`, and `exists` because L1 has
+   matching canonical forms; excludes transformation-only machinery.
 4. **L2 → OpaqueExpr** (`ir-emit.ts`) — mechanical emission.
 5. **`translate-body.ts`** — TS-AST orchestrator. Wires lowering
    contexts; no target-language semantics.
 
-Deviations from this principle should be flagged in review and
-either justified explicitly or refactored.
+### L1 → L2 Recognition Discipline
+
+L1 → L2 carries no recognition decisions. New recognizers must fire at
+TS-AST → L1 and produce canonical L1 forms (for example, `comb-typed`).
+Review will reject any L1 → L2 transformation that is not a 1:1
+mechanical mapping or a structural rewrite of an already-canonical L1
+form.
+
+### L2 Is Not A Substitution Target
+
+L2 is not a substitution target. Any transformation that wants to rewrite
+an L2 expression is asking the wrong question: either build the canonical
+L1 form upstream and substitute there using the IR1 substitution primitive
+from `workstreams/ts2pant-ir1-substitution.md`, or lower to `OpaqueExpr`
+and use `ast.substituteBinder`. The typed-mirror principle has no
+exceptions; substitution-disguised-as-construction is still a
+transformation.
 
 **Closed vocabularies on both layers.** Every `IR1Expr` is one of
 the canonical L1 constructors, and every `IRExpr` is one of the ten

--- a/workstreams/ts2pant-imperative-ir.md
+++ b/workstreams/ts2pant-imperative-ir.md
@@ -43,7 +43,8 @@ is no opt-in flag, no parallel pipeline, and no escape-hatch IR form.
 
 - Expression forms: `var`, `lit`, `binop`, `unop`, `app`, `member`
   (M5 canonical property-access form, pre-qualified at build time),
-  `cond`, `is-nullish` (M4 canonical Bool null/undefined test).
+  `cond`, `is-nullish` (M4 canonical Bool null/undefined test),
+  `each`, `comb-typed`, `forall`, `exists`, `map-read`, `set-read`.
 - Statement forms: `block`, `let`, `assign`, `cond-stmt`, `foreach`
   (with optional `body` and `foldLeaves` for Shape A + Shape B), `for`
   (declared, unused), `while` (μ-search only), `return`, `throw`
@@ -56,11 +57,11 @@ vocabulary reject with a specific `unsupported` reason.
 
 **What's on Layer 2**: `IRExpr` only — ten canonical forms (`Var`,
 `Lit`, `App`, `Cond`, `Let`, `Each`, `Comb`, `CombTyped`, `Forall`,
-`Exists`). `CombTyped` is the source-less typed comprehension added
-in M2 cleanup as μ-search's lowering target (`min over each j: T,
-guards | j`); see `ir1-lower.ts`'s `recognizeAndLowerMuSearch`. The
-L2 vocabulary is similarly closed; every `IRExpr` is one of those
-ten constructors. The L2 statement vocabulary (`IRStmt` with
+`Exists`). `CombTyped` is the source-less typed comprehension mirrored
+from L1 `comb-typed` after TS-AST → L1 μ-search recognition (`min over
+each j: T, guards | j`). The L2 vocabulary is similarly closed; every
+`IRExpr` is one of those ten constructors. The L2 statement vocabulary
+(`IRStmt` with
 `Write`, `LetIf`, `Seq`, `Assert`) and its companion
 `src/ir-subst.ts` were the speculative target of the parallel-build
 PRs (#134/#135/#137) that got closed; PR #138 deleted them once M3
@@ -341,14 +342,14 @@ exploratory.
   `buildL1IncrementStep` covering all five `+1` spellings + non-`+1`
   forms; new unit tests for vocabulary activation and step
   normalization.
-- Patch 2 (`ea32328`) — L1 builder (`buildL1LetWhile`) + L1 recognizer
-  (`isCanonicalMuSearchForm`); plumb behind `TS2PANT_USE_L1_MUSEARCH`.
+- Patch 2 (`ea32328`) — L1 builder (`buildL1LetWhile`) + then-current
+  L1 μ-search recognizer; plumb behind `TS2PANT_USE_L1_MUSEARCH`.
   Validation: byte-identical output across all 463 existing tests
   under both flag states.
 - Patch 3 (`c3dc24b`) — hard-rule cutover. Flag deleted.
   `recognizeMuSearch` renamed to `recognizeLetWhilePair` and stripped
   of all μ-search semantics (step shape, predicate-references-counter)
-  — those checks now live in `isCanonicalMuSearchForm` and the
+  — those checks moved into the then-current L1 recognizer and the
   unified `translateMuSearchInit`. Legacy `translateMuSearchInitLegacy`
   deleted. Three new fixtures (`compoundIncrementStep`,
   `explicitIncrementStep`, `explicitIncrementStepFlipped`) verify the
@@ -370,30 +371,30 @@ recognized μ-search" (now "predicate does not reference the counter"
 or "predicate has side effects") and tests were updated.
 
 **M2 cleanup (post-cutover follow-up)**: in the same PR, four
-additional commits move μ-search lowering entirely out of
-`translate-body.ts`. Articulated principle: *"L1 should be entirely
-concerned with the syntax of TypeScript; it should be completely
-unopinionated and ignorant about how TypeScript's semantics are
-translated into specific lowerings."* Concretely:
+additional commits moved μ-search lowering entirely out of
+`translate-body.ts`. A later typed-mirror refactor sharpened the
+layering principle: L1 is the canonical form after all source-level
+recognition and may carry Pant-target forms such as `comb-typed`; L1 →
+L2 is mechanical; L2 is a typed mirror of `OpaqueExpr`, not a
+transformation IR. Concretely:
 
-- L2 gains a new `comb-typed` form for source-less typed
-  comprehension — the missing vocabulary that legacy
-  `translateMuSearchInit` worked around by going directly to
-  OpaqueExpr.
-- `lowerL1MuSearch` lands in `ir1-lower.ts` carrying all μ-search
-  semantics: canonical-shape pattern match, strategy validation,
-  binder allocation (via callback), counter-binder substitution
-  (via Pant's `substituteBinder` on the lowered OpaqueExpr).
-- `buildL1LetWhile` adds the predicate-references-counter check
-  as a structural sanity check on the let+while pair.
-- `translateMuSearchInit` shrinks to a thin orchestrator that
-  wires the lowering context and delegates to the L1 → L2 →
-  OpaqueExpr pipeline. No Pantagruel-target awareness.
+- L1 and L2 both carry `comb-typed` for source-less typed comprehension
+  — the vocabulary that legacy `translateMuSearchInit` worked around by
+  going directly to OpaqueExpr.
+- μ-search recognition fires at TS-AST → L1. The recognizer validates the
+  canonical shape, strategy, binder allocation, and counter-binder
+  substitution before constructing L1 `comb-typed`.
+- `buildL1LetWhile` adds the predicate-references-counter check as a
+  structural sanity check on the let+while pair.
+- `translateMuSearchInit` remains a thin orchestrator that wires the
+  lowering context and delegates to the L1 → L2 → OpaqueExpr pipeline.
+  L1 → L2 carries no recognition decisions.
 
 Snapshot byte-equality preserved across all 8 μ-search fixtures.
 translate-body.ts net −60 lines. Side benefit: predicate is now
 translated once at L1 build (rather than twice as in pre-cleanup
-M2) — substitution happens on the lowered OpaqueExpr.
+M2) — substitution happens through the IR1 substitution primitive before
+mechanical L1 → L2 lowering.
 
 **Definition of Done**:
 - `ir1-build.ts` extends to translate increment surface forms: `i++`, `++i`,


### PR DESCRIPTION
## Patch 4: Reframe the IR layering principle in docs

- In `tools/ts2pant/docs/intermediate-representation.md`, locate the existing "Layering principle" framing (currently around `## IRExpr — 10 forms` or in an adjacent section). Replace the aspirational "L1 — canonicalized TypeScript syntax. No Pantagruel-target awareness" with the honest statement: "L1 is the canonical form after all source-level recognition. L2 is L1's expression subset packaged as a typed OpaqueExpr mirror; its purpose is type-safe construction and snapshot-testable inspection, not transformation. All recognition and target-shape decisions happen at TS-AST → L1; L1→L2 is a mechanical 1:1 lowering."
- Add a discipline statement in a clearly-labelled subsection: "L1→L2 carries no recognition decisions. New recognizers must fire at TS-AST → L1 and produce canonical L1 forms (e.g., `comb-typed`). Review will reject any L1→L2 transformation that is not a 1:1 mechanical mapping or a structural rewrite of an already-canonical L1 form."
- Add the corollary statement: "L2 is not a substitution target. Any transformation that wants to rewrite an L2 expression is asking the wrong question — either build the canonical L1 form upstream and substitute there (using the IR1 substitution primitive from `workstreams/ts2pant-ir1-substitution.md`), or lower to OpaqueExpr and use `ast.substituteBinder`. The typed-mirror principle has no exceptions; substitution-disguised-as-construction is still a transformation."
- In `tools/ts2pant/AGENTS.md`, locate the Foundational Pattern / IRSC reference. Add a note acknowledging ts2pant's divergence from IRSC: "IRSC's separation between FRSC (TS-shape) and IRSC (SSA-pure) serves a verification-soundness purpose because IRSC has a downstream consumer (the refinement-type checker). ts2pant has no L2-reading verifier; the FRSC/IRSC-style separation here is for type safety and inspectability only. L2 is a typed mirror of OpaqueExpr, not a transformation IR."
- In `workstreams/ts2pant-imperative-ir.md`, find any assertion that L1 has "no Pant-target awareness." Update to align with the post-refactor framing — L1 absorbs Pant-target forms from upstream recognition; L1→L2 is mechanical.
- Confirm the additions read clearly to a reviewer unfamiliar with the workstream's history; the discipline is only useful if future contributors discover it.

## Changes
- In `tools/ts2pant/docs/intermediate-representation.md`, locate the existing "Layering principle" framing (currently around `## IRExpr — 10 forms` or in an adjacent section). Replace the aspirational "L1 — canonicalized TypeScript syntax. No Pantagruel-target awareness" with the honest statement: "L1 is the canonical form after all source-level recognition. L2 is L1's expression subset packaged as a typed OpaqueExpr mirror; its purpose is type-safe construction and snapshot-testable inspection, not transformation. All recognition and target-shape decisions happen at TS-AST → L1; L1→L2 is a mechanical 1:1 lowering."
- Add a discipline statement in a clearly-labelled subsection: "L1→L2 carries no recognition decisions. New recognizers must fire at TS-AST → L1 and produce canonical L1 forms (e.g., `comb-typed`). Review will reject any L1→L2 transformation that is not a 1:1 mechanical mapping or a structural rewrite of an already-canonical L1 form."
- Add the corollary statement: "L2 is not a substitution target. Any transformation that wants to rewrite an L2 expression is asking the wrong question — either build the canonical L1 form upstream and substitute there (using the IR1 substitution primitive from `workstreams/ts2pant-ir1-substitution.md`), or lower to OpaqueExpr and use `ast.substituteBinder`. The typed-mirror principle has no exceptions; substitution-disguised-as-construction is still a transformation."
- In `tools/ts2pant/AGENTS.md`, locate the Foundational Pattern / IRSC reference. Add a note acknowledging ts2pant's divergence from IRSC: "IRSC's separation between FRSC (TS-shape) and IRSC (SSA-pure) serves a verification-soundness purpose because IRSC has a downstream consumer (the refinement-type checker). ts2pant has no L2-reading verifier; the FRSC/IRSC-style separation here is for type safety and inspectability only. L2 is a typed mirror of OpaqueExpr, not a transformation IR."
- In `workstreams/ts2pant-imperative-ir.md`, find any assertion that L1 has "no Pant-target awareness." Update to align with the post-refactor framing — L1 absorbs Pant-target forms from upstream recognition; L1→L2 is mechanical.
- Confirm the additions read clearly to a reviewer unfamiliar with the workstream's history; the discipline is only useful if future contributors discover it.

## Files to Modify
- tools/ts2pant/docs/intermediate-representation.md (modify): Rewrite the "Layering principle" subsection: replace aspirational "L1 has no Pant-target awareness" with honest "L1 is the canonical form after all source-level recognition; L2 is L1's expression subset packaged as a typed OpaqueExpr mirror. All recognition and target-shape decisions happen at TS-AST → L1; L1→L2 is a mechanical 1:1 lowering." Add the discipline statement (no L1→L2 recognition) and the corollary (L2 is not a substitution target).
- tools/ts2pant/AGENTS.md (modify): Update Foundational Pattern / IRSC references to note ts2pant's divergence from the original IRSC purpose (no L2-reading verifier; the separation is for type safety and inspectability only).
- workstreams/ts2pant-imperative-ir.md (modify): Correct the assertion that L1 has "no Pant-target awareness" to align with the post-refactor framing.

## Gameplan Specification

```
module TS2PANT_L2_TYPED_MIRROR.

> ════════════════════════════════
> Single-milestone workstream: L2 as a typed mirror of OpaqueExpr.
> ════════════════════════════════
> After this gameplan, L1 has comb-typed / forall / exists
> mirroring L2's CombTyped / Forall / Exists. The μ-search
> recognizer produces L1 comb-typed directly at the
> TS-AST → L1 boundary; lowerL1MuSearch and
> isCanonicalMuSearchForm are removed. L1→L2 is now a pure
> 1:1 mechanical mapping. Documentation in the IR doc + 
> AGENTS.md + imperative-IR workstream doc articulates the
> honest layering principle: L1 absorbs Pant-target forms;
> L1→L2 carries no recognition; L2 is a typed mirror, not
> a transformation IR.

IR1Form.
L2Form.
Walker.
FreeVarSet.
RecognitionSite.
IR1Shape.
SnapshotState.
Document.
DocumentKind.
comb-typed => IR1Form.
forall => IR1Form.
exists => IR1Form.
comb-typed-l2 => L2Form.
forall-l2 => L2Form.
exists-l2 => L2Form.
ts-ast-to-l1 => RecognitionSite.
l1-to-l2 => RecognitionSite.
comb-typed-l1 => IR1Shape.
block-let-while => IR1Shape.
identical => SnapshotState.
drifted => SnapshotState.
ir-doc => DocumentKind.
agents-md => DocumentKind.
imperative-ir-doc => DocumentKind.

has-arm-for? w: Walker, f: IR1Form => Bool.
scopes-binder? f: IR1Form, vars: FreeVarSet => Bool.
lowers-to? l1: IR1Form, l2: L2Form => Bool.
respects-capture-risk? f: IR1Form => Bool.
halts-at-shadow? f: IR1Form => Bool.
recognizer-fires-at? site: RecognitionSite => Bool.
post-recognizer-shape => IR1Shape.
snapshot-state => SnapshotState.
lower-l1-musearch-exists? => Bool.
is-canonical-musearch-form-exists? => Bool.
document-kind d: Document => DocumentKind.
mentions-layering-principle? d: Document => Bool.
mentions-no-l1-l2-recognition? d: Document => Bool.
mentions-l2-not-substitution-target? d: Document => Bool.
---

> Vocabulary contract.
all f: IR1Form, w: Walker | has-arm-for? w f.
all f: IR1Form, vars: FreeVarSet | scopes-binder? f vars.
all f: IR1Form | respects-capture-risk? f.
all f: IR1Form | halts-at-shadow? f.
lowers-to? comb-typed comb-typed-l2.
lowers-to? forall forall-l2.
lowers-to? exists exists-l2.

> Recognition has moved upstream.
recognizer-fires-at? ts-ast-to-l1.
~(recognizer-fires-at? l1-to-l2).
post-recognizer-shape = comb-typed-l1.
~(lower-l1-musearch-exists?).
~(is-canonical-musearch-form-exists?).

> Snapshot equivalence on every μ-search fixture.
snapshot-state = identical.

> Documentation invariants.
all d: Document |
  document-kind d = ir-doc ->
    mentions-layering-principle? d and
    mentions-no-l1-l2-recognition? d and
    mentions-l2-not-substitution-target? d.

all d: Document |
  document-kind d = agents-md ->
    mentions-layering-principle? d.

all d: Document |
  document-kind d = imperative-ir-doc ->
    mentions-layering-principle? d.
```

## Patch Specification

```
module TS2PANT_L2_TYPED_MIRROR_PATCH_4.

> Patch 4 reframes the IR layering principle in docs. The
> IR doc, AGENTS.md, and the imperative-IR workstream doc
> are updated to articulate the honest layering: L1 absorbs
> Pant-target forms; L1→L2 is mechanical; L2 is a typed
> mirror, not a transformation IR.

Document.
DocumentKind.
ir-doc => DocumentKind.
agents-md => DocumentKind.
imperative-ir-doc => DocumentKind.

document-kind d: Document => DocumentKind.
mentions-layering-principle? d: Document => Bool.
mentions-no-l1-l2-recognition? d: Document => Bool.
mentions-l2-not-substitution-target? d: Document => Bool.
---

all d: Document |
  document-kind d = ir-doc ->
    mentions-layering-principle? d and
    mentions-no-l1-l2-recognition? d and
    mentions-l2-not-substitution-target? d.

all d: Document |
  document-kind d = agents-md ->
    mentions-layering-principle? d.

all d: Document |
  document-kind d = imperative-ir-doc ->
    mentions-layering-principle? d.
```


## Implementation Notes

- Kept this patch docs-only. I did not add lint enforcement or code guards; the discipline is stated in the IR doc where future IR contributors are already directed to look.
- Updated a few nearby stale μ-search references while touching the requested sections, so reviewers do not see the new rule contradicted by adjacent historical prose. Historical milestone entries still describe the old rollout, but no longer name removed functions as if they are current extension points.
- The listed `workstreams/ts2pant-l2-typed-mirror.md` context file was not present in this worktree. I used the prompt’s authoritative gameplan text plus the three target docs and current code comments around `buildL1MuSearchCombTyped` / `lowerL1Expr` as the effective context.

Spec/Evidence Mapping:
- `ir-doc` layering / no-recognition / no-substitution clauses: implemented in `tools/ts2pant/docs/intermediate-representation.md` under `Layering principle`, `L1 -> L2 Recognition Discipline`, and `L2 Is Not A Substitution Target`; verified with text search and `git diff --check`.
- `agents-md` layering clause: implemented in `tools/ts2pant/AGENTS.md` as the IRSC divergence note; verified with text search.
- `imperative-ir-doc` layering clause: implemented in `workstreams/ts2pant-imperative-ir.md` by replacing the old no-Pant-target-awareness framing with the typed-mirror framing; verified with text search.