### PR TITLE
[ts2pant-loop-break-continue] Patch 1: Pending tests for return-value contract, L1 vocabulary expansion, build pass, and L4 lowering consumption

### DIFF
--- a/tools/ts2pant/tests/ir1-ssa-fixed-point.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-fixed-point.test.mts
@@ -361,4 +361,28 @@ describe("ir1-ssa-fixed-point", () => {
       ["Bool"],
     );
   });
+
+  describe("handle-list consumption", () => {
+    it.skip("break-handle merge produces post-loop cond per location", () => {
+      // PENDING Patch 5.
+    });
+
+    it.skip("continue-handle threads into header phi loop-back input", () => {
+      // PENDING Patch 5.
+    });
+
+    it.skip("return-handle produces function-level return-value cond", () => {
+      // PENDING Patch 5.
+    });
+
+    it.skip("throw-handle conjoins precondition with recursive-rule guard", () => {
+      // PENDING Patch 5.
+    });
+  });
+
+  describe("literal-true rejection", () => {
+    it.skip("narrows to while(true) with no reachable break/return", () => {
+      // PENDING Patch 5.
+    });
+  });
 });

--- a/tools/ts2pant/tests/ir1-ssa-lower.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-lower.test.mts
@@ -395,4 +395,18 @@ describe("ir1-ssa-lower", () => {
       );
     }
   });
+
+  describe("returnValue emission", () => {
+    it.skip("null returnValue emits no extra equation", () => {
+      // PENDING Patch 2.
+    });
+
+    it.skip("non-null returnValue emits function-level equation", () => {
+      // PENDING Patch 2.
+    });
+
+    it.skip("equation ordering is rule-modifying then return-value then frames", () => {
+      // PENDING Patch 2.
+    });
+  });
 });

--- a/tools/ts2pant/tests/ir1-substitute.test.mts
+++ b/tools/ts2pant/tests/ir1-substitute.test.mts
@@ -330,6 +330,14 @@ describe("ir1-substitute", () => {
         ),
       );
     });
+
+    it.skip("freeVarsIR1Expr handles throw-handle guard expression", () => {
+      // PENDING Patch 3.
+    });
+
+    it.skip("walker arms exhaustive over new IR1SsaLocation kind", () => {
+      // PENDING Patch 3.
+    });
   });
 
   describe("properties", () => {

--- a/tools/ts2pant/tests/ir1.test.mts
+++ b/tools/ts2pant/tests/ir1.test.mts
@@ -108,4 +108,28 @@ describe("ir1", () => {
       );
     });
   });
+
+  describe("new early-exit handles", () => {
+    it.skip("ir1SsaReturnHandle constructs return-handle shape", () => {
+      // PENDING Patch 3.
+    });
+
+    it.skip("ir1SsaThrowHandle constructs throw-handle shape with guard", () => {
+      // PENDING Patch 3.
+    });
+
+    it.skip("ir1SsaReturnValueLocation constructs return-value location kind", () => {
+      // PENDING Patch 3.
+    });
+  });
+
+  describe("IR1SsaLoopBody field defaults", () => {
+    it.skip("returnHandles defaults to empty", () => {
+      // PENDING Patch 3.
+    });
+
+    it.skip("throwHandles defaults to empty", () => {
+      // PENDING Patch 3.
+    });
+  });
 });

--- a/tools/ts2pant/tests/loop-break-continue.test.mts
+++ b/tools/ts2pant/tests/loop-break-continue.test.mts
@@ -1,0 +1,43 @@
+import { describe, it } from "node:test";
+
+describe("loop-break-continue", () => {
+  it.skip("counter loop with break translates and bumps to fixed-point", () => {
+    // PENDING Patches 5 and 6.
+  });
+
+  it.skip("counter loop with continue translates and stays bounded-quantified", () => {
+    // PENDING Patches 5 and 6.
+  });
+
+  it.skip("bounded-while with break translates and bumps to fixed-point", () => {
+    // PENDING Patches 5 and 6.
+  });
+
+  it.skip("fixed-point while with break translates", () => {
+    // PENDING Patches 5 and 6.
+  });
+
+  it.skip("fixed-point while with continue translates", () => {
+    // PENDING Patches 5 and 6.
+  });
+
+  it.skip("fixed-point while with bare return translates", () => {
+    // PENDING Patches 5 and 6.
+  });
+
+  it.skip("fixed-point while with return value translates and emits return-value equation", () => {
+    // PENDING Patches 5 and 6.
+  });
+
+  it.skip("fixed-point while with throw translates and emits iteration precondition", () => {
+    // PENDING Patches 5 and 6.
+  });
+
+  it.skip("while(true)+break translates (event-loop idiom)", () => {
+    // PENDING Patches 5 and 6.
+  });
+
+  it.skip("labeled break rejects with M7 diagnostic", () => {
+    // PENDING Patches 5 and 6.
+  });
+});


### PR DESCRIPTION
## Patch 1: Pending tests for return-value contract, L1 vocabulary expansion, build pass, and L4 lowering consumption

- Create or extend each test file with the skipped stubs enumerated in `testStubsIntroduced`.
- Each stub body contains only a PENDING comment naming the implementing patch number — no references to symbols that don't exist yet.
- Run `npm run test:unit` and confirm the files compile and the new stubs are reported as skipped.

## Changes
- Create or extend each test file with the skipped stubs enumerated in `testStubsIntroduced`.
- Each stub body contains only a PENDING comment naming the implementing patch number — no references to symbols that don't exist yet.
- Run `npm run test:unit` and confirm the files compile and the new stubs are reported as skipped.

## Files to Modify
- tools/ts2pant/tests/ir1.test.mts (modify): Add `it.skip(...)` stubs for `ir1SsaReturnHandle` / `ir1SsaThrowHandle` / `ir1SsaReturnValueLocation` constructors and structural-equality behaviour. Add stubs for the `IR1SsaLoopBody.returnHandles` / `.throwHandles` field defaults. PENDING Patch 3.
- tools/ts2pant/tests/ir1-substitute.test.mts (modify): Add `it.skip(...)` stubs for traversal behaviour over the new handle kinds. PENDING Patch 3.
- tools/ts2pant/tests/ir1-ssa-lower.test.mts (create-or-modify): Add `it.skip(...)` stubs for the new `returnValue` emission slot: null → no return-value equation; non-null → equation emitted in correct ordering. PENDING Patch 2.
- tools/ts2pant/tests/ir1-ssa-fixed-point.test.mts (create-or-modify): Add `it.skip(...)` stubs for handle-list consumption: break-handle merge produces post-loop `cond`; continue-handle threads into header phi loop-back; return-handle produces function-level return-value `cond`; throw-handle emits precondition. PENDING Patch 5.
- tools/ts2pant/tests/loop-break-continue.test.mts (create): Add `it.skip(...)` stubs for end-to-end translation of each fixture shape (one stub per planned fixture). PENDING Patches 5 (lowering consumption) and 6 (fixtures land).

## Gameplan Specification

```
module TS2PANT_LOOP_BREAK_CONTINUE.

> ════════════════════════════════
> M5 of ts2pant General-Loop SSA: loop early-exit lowering.
> ════════════════════════════════
> After this gameplan, IR1 SSA loop bodies admit break,
> continue, return (bare and with value), and throw via
> the L1 handle vocabulary. L4 fixed-point lowering consumes
> all four handle lists: break -> post-loop cond; continue ->
> header phi loop-back input; return -> function-level
> return-value cond (using the new mutating-body return-value
> contract); throw -> iteration-precondition. Bounded loops
> with break/return bump to fixed-point; bounded loops with
> only continue stay quantified. The while(true)+break event-
> loop idiom translates. Labeled break/continue rejects with
> M7 future-work diagnostic. M6 (loop-summary-unification)
> can now target the complete general-loop machinery.

Handle.
HandleKind.
LoweringTarget.
LoopShape.
LoweringRoute.
break => HandleKind.
continue => HandleKind.
return-bare => HandleKind.
return-value => HandleKind.
throw => HandleKind.
post-loop-cond => LoweringTarget.
header-phi-loop-back => LoweringTarget.
function-return-value-cond => LoweringTarget.
iteration-precondition => LoweringTarget.
counter => LoopShape.
bounded-while => LoopShape.
fixed-point => LoopShape.
while-true-with-break => LoopShape.
quantified-route => LoweringRoute.
fixed-point-route => LoweringRoute.

kind h: Handle => HandleKind.
target-of h: Handle => LoweringTarget.
route-for shape: LoopShape, hk: HandleKind => LoweringRoute.
labeled-rejected? => Bool.
while-true-rejects-only-when-no-break-or-return? => Bool.
m6-unblocked? => Bool.
---

> Handle-to-target mapping.
all h: Handle | target-of h = post-loop-cond <-> kind h = break.
all h: Handle | target-of h = header-phi-loop-back <-> kind h = continue.
all h: Handle, kind h = return-bare | target-of h = function-return-value-cond.
all h: Handle, kind h = return-value | target-of h = function-return-value-cond.
all h: Handle | target-of h = iteration-precondition <-> kind h = throw.

> Bump-to-fixed-point routing: break/return shapes go fixed-point on bounded loops.
route-for counter break = fixed-point-route.
route-for counter return-bare = fixed-point-route.
route-for counter return-value = fixed-point-route.
route-for bounded-while break = fixed-point-route.
route-for bounded-while return-bare = fixed-point-route.
route-for bounded-while return-value = fixed-point-route.

> Continue stays quantified on bounded loops.
route-for counter continue = quantified-route.
route-for bounded-while continue = quantified-route.

> Labeled forms.
labeled-rejected?.

> while(true) narrowing.
while-true-rejects-only-when-no-break-or-return?.

> Workstream gate.
m6-unblocked?.
```

## Patch Specification

```
module TS2PANT_LOOP_BREAK_CONTINUE_PATCH_1.

> Patch 1 lands the test scaffolding for the workstream.
> Stubs are skipped; Patches 2, 3, 5, 6 unskip them with
> concrete assertions. No source behavior changes.

TestStub.
PendingFor.
patch-2 => PendingFor.
patch-3 => PendingFor.
patch-5 => PendingFor.
patch-6 => PendingFor.

stub-pending-for s: TestStub => PendingFor.
stub-skipped? s: TestStub => Bool.
---
all s: TestStub | stub-skipped? s.
```


## Implementation Notes

- Test-only patch: no production source, fixture, snapshot, or docs behavior was changed.
- Stub bodies intentionally contain only `// PENDING Patch N.` comments, so they compile against the current public surface and do not pull future constructor/type names into this patch.
- The new `loop-break-continue.test.mts` file is included in the existing `tests/*.test.mts` unit glob, so later fixture assertions can be enabled without changing the test runner.
- Spec/Evidence Mapping: `all s: TestStub | stub-skipped? s` maps to `it.skip(...)` in each touched test file. Required context consulted: `workstreams/ts2pant-general-loop-ssa.md`, `tools/ts2pant/AGENTS.md`, and the existing L1 loop-handle surface in `tools/ts2pant/src/ir1.ts`. Evidence: `npm run test:unit` passed with `skipped 29`.