### PR TITLE
[ts2pant-loop-break-continue] Patch 3: L1 vocabulary: IR1SsaReturnHandle, IR1SsaThrowHandle, return-value location, IR1SsaLoopBody extension, walker arms

### DIFF
--- a/tools/ts2pant/src/ir1-printer.ts
+++ b/tools/ts2pant/src/ir1-printer.ts
@@ -84,6 +84,8 @@ export function formatIR1SsaLocation(loc: IR1SsaLocation): string {
       return `${formatIR1Expr(loc.key)} in ${formatIR1Expr(loc.receiver)}`;
     case "set-membership":
       return formatIR1Expr(loc.receiver);
+    case "return-value":
+      return `return-value ${loc.ruleName}`;
     default: {
       const _exhaustive: never = loc;
       throw new Error(
@@ -466,6 +468,8 @@ function readExpressionKey(loc: IR1SsaLocation): string {
       return `map-membership:${loc.keyPredName} ${formatAsAppArg(loc.receiver)} ${formatAsAppArg(loc.key)}`;
     case "set-membership":
       return `set-membership:${formatIR1Expr(loc.receiver)}`;
+    case "return-value":
+      return `return-value:${loc.ruleName}`;
     default: {
       const _exhaustive: never = loc;
       throw new Error(
@@ -619,6 +623,8 @@ function locationAsPrimedRule(loc: IR1SsaLocation): string {
       return `(${formatIR1Expr(loc.key)} in ${formatIR1Expr(loc.receiver)})'`;
     case "set-membership":
       return `${formatIR1Expr(loc.receiver)}'`;
+    case "return-value":
+      return `return-value' ${loc.ruleName}`;
     default: {
       const _exhaustive: never = loc;
       throw new Error(

--- a/tools/ts2pant/src/ir1-ssa-counter-loop.ts
+++ b/tools/ts2pant/src/ir1-ssa-counter-loop.ts
@@ -165,6 +165,8 @@ export function lowerCounterLoopL1Body(
     joins: [],
     breakHandles: [],
     continueHandles: [],
+    returnHandles: [],
+    throwHandles: [],
     terminationMetric,
   });
 

--- a/tools/ts2pant/src/ir1-ssa-fixed-point.ts
+++ b/tools/ts2pant/src/ir1-ssa-fixed-point.ts
@@ -188,6 +188,8 @@ export function lowerFixedPointLoopL1Body(
     joins: [],
     breakHandles: [],
     continueHandles: [],
+    returnHandles: [],
+    throwHandles: [],
     terminationMetric: null,
   });
 

--- a/tools/ts2pant/src/ir1-ssa-scalars.ts
+++ b/tools/ts2pant/src/ir1-ssa-scalars.ts
@@ -1089,6 +1089,8 @@ function sameScalarSsaLocation(
         scalarSsaCanonicalReceiverKey(left.receiver, { canonicalize }) ===
           scalarSsaCanonicalReceiverKey(right.receiver, { canonicalize })
       );
+    case "return-value":
+      return right.kind === "return-value" && left.ruleName === right.ruleName;
     default: {
       const _exhaustive: never = left;
       void _exhaustive;

--- a/tools/ts2pant/src/ir1-substitute.ts
+++ b/tools/ts2pant/src/ir1-substitute.ts
@@ -1,6 +1,9 @@
 import {
   type IR1Expr,
   type IR1FoldLeaf,
+  type IR1SsaLocation,
+  type IR1SsaLoopBody,
+  type IR1SsaValue,
   type IR1Stmt,
   ir1App,
   ir1Assign,
@@ -104,6 +107,73 @@ export function freeVarsIR1Expr(expr: IR1Expr): Set<string> {
 
 export function freeVarsIR1Stmt(stmt: IR1Stmt): Set<string> {
   return freeVarsStmtWithScope(stmt, new Set());
+}
+
+export function freeVarsIR1SsaLocation(location: IR1SsaLocation): Set<string> {
+  switch (location.kind) {
+    case "property":
+      return freeVarsIR1Expr(location.receiver);
+    case "map-value":
+    case "map-membership":
+      return union(
+        freeVarsIR1Expr(location.receiver),
+        freeVarsIR1Expr(location.key),
+      );
+    case "set-membership":
+      return freeVarsIR1Expr(location.receiver);
+    case "return-value":
+      return new Set();
+    default: {
+      const _exhaustive: never = location;
+      return _exhaustive;
+    }
+  }
+}
+
+export function freeVarsIR1SsaLoopBody(body: IR1SsaLoopBody): Set<string> {
+  return union(
+    ...body.headerJoins.flatMap((header) => [
+      freeVarsIR1SsaLocation(header.location),
+      freeVarsIR1SsaLocation(header.preheaderVersion.location),
+      ...(header.loopBackVersion === null
+        ? []
+        : [freeVarsIR1SsaLocation(header.loopBackVersion.location)]),
+    ]),
+    ...body.writes.flatMap((write) => [
+      freeVarsIR1SsaLocation(write.location),
+      freeVarsIR1SsaValue(write.value),
+    ]),
+    ...body.joins.flatMap((join) => [
+      freeVarsIR1SsaLocation(join.location),
+      freeVarsIR1SsaLocation(join.thenVersion.location),
+      freeVarsIR1SsaLocation(join.elseVersion.location),
+    ]),
+    ...body.breakHandles.flatMap((handle) => [
+      freeVarsIR1SsaLocation(handle.location),
+      freeVarsIR1SsaLocation(handle.version.location),
+    ]),
+    ...body.continueHandles.flatMap((handle) => [
+      freeVarsIR1SsaLocation(handle.location),
+      freeVarsIR1SsaLocation(handle.version.location),
+    ]),
+    ...body.returnHandles.flatMap((handle) => [
+      freeVarsIR1SsaLocation(handle.location),
+      freeVarsIR1SsaLocation(handle.version.location),
+    ]),
+    ...body.throwHandles.flatMap((handle) => [
+      freeVarsIR1SsaLocation(handle.location),
+      freeVarsIR1SsaLocation(handle.version.location),
+      freeVarsIR1Expr(handle.guard),
+    ]),
+    ...(body.terminationMetric === null
+      ? []
+      : [
+          freeVarsIR1Expr(body.terminationMetric.expr),
+          ...(body.terminationMetric.lowerBound === null
+            ? []
+            : [freeVarsIR1Expr(body.terminationMetric.lowerBound)]),
+        ]),
+  );
 }
 
 export function substituteIR1ExprSubtree(
@@ -236,6 +306,22 @@ function freeVarsFoldLeaf(leaf: IR1FoldLeaf, bound: Set<string>): Set<string> {
       ? []
       : [without(freeVarsIR1Expr(leaf.guard), bound)]),
   );
+}
+
+function freeVarsIR1SsaValue(value: IR1SsaValue): Set<string> {
+  switch (value.kind) {
+    case "property":
+    case "map-value":
+      return freeVarsIR1Expr(value.value);
+    case "map-membership":
+      return new Set();
+    case "set-membership":
+      return value.elem === null ? new Set() : freeVarsIR1Expr(value.elem);
+    default: {
+      const _exhaustive: never = value;
+      return _exhaustive;
+    }
+  }
 }
 
 function substituteExpr(

--- a/tools/ts2pant/src/ir1.ts
+++ b/tools/ts2pant/src/ir1.ts
@@ -455,6 +455,10 @@ export type IR1SsaLocation =
       ownerType: string;
       elemType: string;
       receiver: IR1Expr;
+    }
+  | {
+      kind: "return-value";
+      ruleName: IR1SsaRuleName;
     };
 
 export interface IR1SsaVersion {
@@ -560,6 +564,19 @@ export interface IR1SsaContinueHandle {
   readonly version: IR1SsaVersion;
 }
 
+export interface IR1SsaReturnHandle {
+  readonly kind: "ssa-return-handle";
+  readonly location: IR1SsaLocation;
+  readonly version: IR1SsaVersion;
+}
+
+export interface IR1SsaThrowHandle {
+  readonly kind: "ssa-throw-handle";
+  readonly location: IR1SsaLocation;
+  readonly version: IR1SsaVersion;
+  readonly guard: IR1Expr;
+}
+
 export interface IR1SsaLoopBody {
   readonly kind: "ssa-loop-body";
   readonly headerJoins: readonly IR1SsaLoopHeaderJoin[];
@@ -567,6 +584,8 @@ export interface IR1SsaLoopBody {
   readonly joins: readonly IR1SsaJoin[];
   readonly breakHandles: readonly IR1SsaBreakHandle[];
   readonly continueHandles: readonly IR1SsaContinueHandle[];
+  readonly returnHandles: readonly IR1SsaReturnHandle[];
+  readonly throwHandles: readonly IR1SsaThrowHandle[];
   readonly terminationMetric: IR1SsaTerminationMetric | null;
 }
 
@@ -638,6 +657,13 @@ export const ir1SsaSetMembershipLocation = (
   ownerType,
   elemType,
   receiver,
+});
+
+export const ir1SsaReturnValueLocation = (
+  ruleName: IR1SsaRuleName,
+): IR1SsaLocation => ({
+  kind: "return-value",
+  ruleName,
 });
 
 export const ir1SsaRuleOfLocation = (
@@ -762,12 +788,31 @@ export const ir1SsaContinueHandle = (
   return { kind: "ssa-continue-handle", location, version };
 };
 
+export const ir1SsaReturnHandle = (
+  location: IR1SsaLocation,
+  version: IR1SsaVersion,
+): IR1SsaReturnHandle => {
+  ir1SsaAssertLocationCompatible(location, version.location);
+  return { kind: "ssa-return-handle", location, version };
+};
+
+export const ir1SsaThrowHandle = (
+  location: IR1SsaLocation,
+  version: IR1SsaVersion,
+  guard: IR1Expr,
+): IR1SsaThrowHandle => {
+  ir1SsaAssertLocationCompatible(location, version.location);
+  return { kind: "ssa-throw-handle", location, version, guard };
+};
+
 export const ir1SsaLoopBody = (input: {
   readonly headerJoins?: readonly IR1SsaLoopHeaderJoin[];
   readonly writes?: readonly IR1SsaWrite[];
   readonly joins?: readonly IR1SsaJoin[];
   readonly breakHandles?: readonly IR1SsaBreakHandle[];
   readonly continueHandles?: readonly IR1SsaContinueHandle[];
+  readonly returnHandles?: readonly IR1SsaReturnHandle[];
+  readonly throwHandles?: readonly IR1SsaThrowHandle[];
   readonly terminationMetric?: IR1SsaTerminationMetric | null;
 }): IR1SsaLoopBody => {
   const headerJoins = input.headerJoins ?? [];
@@ -775,6 +820,8 @@ export const ir1SsaLoopBody = (input: {
   const joins = input.joins ?? [];
   const breakHandles = input.breakHandles ?? [];
   const continueHandles = input.continueHandles ?? [];
+  const returnHandles = input.returnHandles ?? [];
+  const throwHandles = input.throwHandles ?? [];
 
   for (const header of headerJoins) {
     if (!header.closed) {
@@ -787,6 +834,12 @@ export const ir1SsaLoopBody = (input: {
   for (const handle of continueHandles) {
     ir1SsaAssertLocationCompatible(handle.location, handle.version.location);
   }
+  for (const handle of returnHandles) {
+    ir1SsaAssertLocationCompatible(handle.location, handle.version.location);
+  }
+  for (const handle of throwHandles) {
+    ir1SsaAssertLocationCompatible(handle.location, handle.version.location);
+  }
 
   return Object.freeze({
     kind: "ssa-loop-body",
@@ -795,6 +848,8 @@ export const ir1SsaLoopBody = (input: {
     joins,
     breakHandles,
     continueHandles,
+    returnHandles,
+    throwHandles,
     terminationMetric: input.terminationMetric ?? null,
   });
 };
@@ -892,6 +947,12 @@ const ir1SsaLocationEquals = (
         a.elemType === b.elemType &&
         ir1SsaExprEquals(a.receiver, b.receiver)
       );
+    }
+    case "return-value": {
+      if (b.kind !== "return-value") {
+        return false;
+      }
+      return a.ruleName === b.ruleName;
     }
     default: {
       const _exhaustive: never = a;

--- a/tools/ts2pant/tests/ir1-substitute.test.mts
+++ b/tools/ts2pant/tests/ir1-substitute.test.mts
@@ -24,6 +24,11 @@ import {
   ir1LitNat,
   ir1Member,
   ir1Return,
+  ir1SsaInitialVersion,
+  ir1SsaLoopBody,
+  ir1SsaPropertyLocation,
+  ir1SsaReturnValueLocation,
+  ir1SsaThrowHandle,
   ir1Throw,
   ir1Unop,
   ir1Var,
@@ -32,6 +37,8 @@ import {
 import {
   CaptureRiskError,
   freeVarsIR1Expr,
+  freeVarsIR1SsaLocation,
+  freeVarsIR1SsaLoopBody,
   freeVarsIR1Stmt,
   substituteIR1ExprSubtree,
   substituteIR1StmtSubtree,
@@ -331,12 +338,24 @@ describe("ir1-substitute", () => {
       );
     });
 
-    it.skip("freeVarsIR1Expr handles throw-handle guard expression", () => {
-      // PENDING Patch 3.
+    it("freeVarsIR1Expr handles throw-handle guard expression", () => {
+      const location = ir1SsaPropertyLocation("value", ir1Var("obj"), "value");
+      const version = ir1SsaInitialVersion(location);
+      const body = ir1SsaLoopBody({
+        throwHandles: [
+          ir1SsaThrowHandle(
+            location,
+            version,
+            ir1Binop("eq", ir1Var("err"), ir1Var("limit")),
+          ),
+        ],
+      });
+
+      assertSetEqual(freeVarsIR1SsaLoopBody(body), ["err", "limit", "obj"]);
     });
 
-    it.skip("walker arms exhaustive over new IR1SsaLocation kind", () => {
-      // PENDING Patch 3.
+    it("walker arms exhaustive over new IR1SsaLocation kind", () => {
+      assertSetEqual(freeVarsIR1SsaLocation(ir1SsaReturnValueLocation("f")), []);
     });
   });
 

--- a/tools/ts2pant/tests/ir1.test.mts
+++ b/tools/ts2pant/tests/ir1.test.mts
@@ -6,6 +6,15 @@ import {
   ir1Exists,
   ir1Forall,
   ir1LitBool,
+  ir1LitNat,
+  ir1SsaInitialVersion,
+  ir1SsaLoopBody,
+  ir1SsaPropertyLocation,
+  ir1SsaPropertyValue,
+  ir1SsaReturnHandle,
+  ir1SsaReturnValueLocation,
+  ir1SsaThrowHandle,
+  ir1SsaWrite,
   ir1SsaExprEquals,
   ir1Var,
 } from "../src/ir1.js";
@@ -110,26 +119,55 @@ describe("ir1", () => {
   });
 
   describe("new early-exit handles", () => {
-    it.skip("ir1SsaReturnHandle constructs return-handle shape", () => {
-      // PENDING Patch 3.
+    it("ir1SsaReturnHandle constructs return-handle shape", () => {
+      const location = ir1SsaPropertyLocation("value", ir1Var("obj"), "value");
+      const version = ir1SsaWrite(
+        location,
+        ir1SsaPropertyValue(ir1LitNat(1)),
+      ).version;
+      const handle = ir1SsaReturnHandle(location, version);
+
+      assert.equal(handle.kind, "ssa-return-handle");
+      assert.equal(handle.location, location);
+      assert.equal(handle.version, version);
+      assert.throws(
+        () => ir1SsaReturnHandle(ir1SsaReturnValueLocation("f"), version),
+        /location mismatch/u,
+      );
     });
 
-    it.skip("ir1SsaThrowHandle constructs throw-handle shape with guard", () => {
-      // PENDING Patch 3.
+    it("ir1SsaThrowHandle constructs throw-handle shape with guard", () => {
+      const location = ir1SsaPropertyLocation("value", ir1Var("obj"), "value");
+      const version = ir1SsaInitialVersion(location);
+      const guard = ir1Var("shouldThrow");
+      const handle = ir1SsaThrowHandle(location, version, guard);
+
+      assert.equal(handle.kind, "ssa-throw-handle");
+      assert.equal(handle.location, location);
+      assert.equal(handle.version, version);
+      assert.equal(handle.guard, guard);
+      assert.throws(
+        () =>
+          ir1SsaThrowHandle(ir1SsaReturnValueLocation("f"), version, guard),
+        /location mismatch/u,
+      );
     });
 
-    it.skip("ir1SsaReturnValueLocation constructs return-value location kind", () => {
-      // PENDING Patch 3.
+    it("ir1SsaReturnValueLocation constructs return-value location kind", () => {
+      assert.deepEqual(ir1SsaReturnValueLocation("compute"), {
+        kind: "return-value",
+        ruleName: "compute",
+      });
     });
   });
 
   describe("IR1SsaLoopBody field defaults", () => {
-    it.skip("returnHandles defaults to empty", () => {
-      // PENDING Patch 3.
+    it("returnHandles defaults to empty", () => {
+      assert.deepEqual(ir1SsaLoopBody({}).returnHandles, []);
     });
 
-    it.skip("throwHandles defaults to empty", () => {
-      // PENDING Patch 3.
+    it("throwHandles defaults to empty", () => {
+      assert.deepEqual(ir1SsaLoopBody({}).throwHandles, []);
     });
   });
 });


### PR DESCRIPTION
## Patch 3: L1 vocabulary: IR1SsaReturnHandle, IR1SsaThrowHandle, return-value location, IR1SsaLoopBody extension, walker arms

- In `ir1.ts`, add interface `IR1SsaReturnHandle` mirroring `IR1SsaBreakHandle` (per-location, version-bearing). Add interface `IR1SsaThrowHandle` mirroring break/continue but with an additional `guard: IR1Expr` field carrying the throw's containing-if condition.
- In `ir1.ts`, add a `return-value` discriminator to the `IR1SsaLocation` union: `{ kind: "return-value"; ruleName: IR1SsaRuleName }`. Add constructor `ir1SsaReturnValueLocation(ruleName)` analogous to `ir1SsaPropertyLocation` (line 585).
- In `ir1.ts`, extend `IR1SsaLoopBody` (line 563) with `readonly returnHandles: readonly IR1SsaReturnHandle[]` and `readonly throwHandles: readonly IR1SsaThrowHandle[]`. Update the `ir1SsaLoopBody` constructor at line 765 to accept these optional fields with `[]` defaults; assert location compatibility in the same style as the existing breakHandles loop at lines 784+.
- In `ir1.ts`, add constructors `ir1SsaReturnHandle` (mirror line 749) and `ir1SsaThrowHandle` (mirror with guard parameter). Both assert location compatibility.
- In every IR1Expr / IR1SsaLocation-exhaustive walker across `ir1-substitute.ts`, `ir1-lower.ts`, `ir1-printer.ts`, `ir1-ssa-counter-loop.ts`, `ir1-ssa-fixed-point.ts`: add arms for the new `return-value` location kind. The semantic for non-consumer walkers (counter-loop, structural-only fixed-point) is a no-op or default-equivalent; consumer walkers (substitute traversal over throw-handle guards) get real implementations.
- Unskip the Patch-3 stubs in `ir1.test.mts` and `ir1-substitute.test.mts` with concrete assertions on the new types' construction, equality, traversal.
- Run `tsc --noEmit` and `npm run test:unit`; confirm zero compile errors and stubs pass.

## Changes
- In `ir1.ts`, add interface `IR1SsaReturnHandle` mirroring `IR1SsaBreakHandle` (per-location, version-bearing). Add interface `IR1SsaThrowHandle` mirroring break/continue but with an additional `guard: IR1Expr` field carrying the throw's containing-if condition.
- In `ir1.ts`, add a `return-value` discriminator to the `IR1SsaLocation` union: `{ kind: "return-value"; ruleName: IR1SsaRuleName }`. Add constructor `ir1SsaReturnValueLocation(ruleName)` analogous to `ir1SsaPropertyLocation` (line 585).
- In `ir1.ts`, extend `IR1SsaLoopBody` (line 563) with `readonly returnHandles: readonly IR1SsaReturnHandle[]` and `readonly throwHandles: readonly IR1SsaThrowHandle[]`. Update the `ir1SsaLoopBody` constructor at line 765 to accept these optional fields with `[]` defaults; assert location compatibility in the same style as the existing breakHandles loop at lines 784+.
- In `ir1.ts`, add constructors `ir1SsaReturnHandle` (mirror line 749) and `ir1SsaThrowHandle` (mirror with guard parameter). Both assert location compatibility.
- In every IR1Expr / IR1SsaLocation-exhaustive walker across `ir1-substitute.ts`, `ir1-lower.ts`, `ir1-printer.ts`, `ir1-ssa-counter-loop.ts`, `ir1-ssa-fixed-point.ts`: add arms for the new `return-value` location kind. The semantic for non-consumer walkers (counter-loop, structural-only fixed-point) is a no-op or default-equivalent; consumer walkers (substitute traversal over throw-handle guards) get real implementations.
- Unskip the Patch-3 stubs in `ir1.test.mts` and `ir1-substitute.test.mts` with concrete assertions on the new types' construction, equality, traversal.
- Run `tsc --noEmit` and `npm run test:unit`; confirm zero compile errors and stubs pass.

## Files to Modify
- tools/ts2pant/src/ir1.ts (modify): Add `IR1SsaReturnHandle`, `IR1SsaThrowHandle` interfaces; the `return-value` location kind in the `IR1SsaLocation` union; constructors `ir1SsaReturnHandle`, `ir1SsaThrowHandle`, `ir1SsaReturnValueLocation`. Extend `IR1SsaLoopBody` with `returnHandles` and `throwHandles` readonly array fields; update the `ir1SsaLoopBody` constructor at line 765 to accept and default the new fields.
- tools/ts2pant/src/ir1-substitute.ts (modify): Extend `freeVarsIR1Expr` and the internal walkers with arms for the throw handle's `guard` expression. Add arms for the new `return-value` location kind in any IR1SsaLocation-exhaustive walker.
- tools/ts2pant/src/ir1-lower.ts (modify): Add arms for the new `return-value` location kind in any IR1SsaLocation-exhaustive switch.
- tools/ts2pant/src/ir1-printer.ts (modify): Add printer arms for the new handle kinds and the new location kind.
- tools/ts2pant/src/ir1-ssa-counter-loop.ts (modify): Add arms for the new location kind in every IR1SsaLocation-exhaustive walker. No new lowering paths (counter loops with break/return bump to fixed-point in Patch 4).
- tools/ts2pant/src/ir1-ssa-fixed-point.ts (modify): Add arms for the new location kind and new handle kinds in every IR1SsaLocation / handle-exhaustive walker. The handle-list consumption logic lands in Patch 5; this patch is structural — exhaustive arms only.
- tools/ts2pant/tests/ir1.test.mts (modify): Unskip Patch-3-owned stubs.
- tools/ts2pant/tests/ir1-substitute.test.mts (modify): Unskip Patch-3-owned stubs.

## Gameplan Specification

```
module TS2PANT_LOOP_BREAK_CONTINUE.

> ════════════════════════════════
> M5 of ts2pant General-Loop SSA: loop early-exit lowering.
> ════════════════════════════════
> After this gameplan, IR1 SSA loop bodies admit break,
> continue, return (bare and with value), and throw via
> the L1 handle vocabulary. L4 fixed-point lowering consumes
> all four handle lists: break -> post-loop cond; continue ->
> header phi loop-back input; return -> function-level
> return-value cond (using the new mutating-body return-value
> contract); throw -> iteration-precondition. Bounded loops
> with break/return bump to fixed-point; bounded loops with
> only continue stay quantified. The while(true)+break event-
> loop idiom translates. Labeled break/continue rejects with
> M7 future-work diagnostic. M6 (loop-summary-unification)
> can now target the complete general-loop machinery.

Handle.
HandleKind.
LoweringTarget.
LoopShape.
LoweringRoute.
break => HandleKind.
continue => HandleKind.
return-bare => HandleKind.
return-value => HandleKind.
throw => HandleKind.
post-loop-cond => LoweringTarget.
header-phi-loop-back => LoweringTarget.
function-return-value-cond => LoweringTarget.
iteration-precondition => LoweringTarget.
counter => LoopShape.
bounded-while => LoopShape.
fixed-point => LoopShape.
while-true-with-break => LoopShape.
quantified-route => LoweringRoute.
fixed-point-route => LoweringRoute.

kind h: Handle => HandleKind.
target-of h: Handle => LoweringTarget.
route-for shape: LoopShape, hk: HandleKind => LoweringRoute.
labeled-rejected? => Bool.
while-true-rejects-only-when-no-break-or-return? => Bool.
m6-unblocked? => Bool.
---

> Handle-to-target mapping.
all h: Handle | target-of h = post-loop-cond <-> kind h = break.
all h: Handle | target-of h = header-phi-loop-back <-> kind h = continue.
all h: Handle, kind h = return-bare | target-of h = function-return-value-cond.
all h: Handle, kind h = return-value | target-of h = function-return-value-cond.
all h: Handle | target-of h = iteration-precondition <-> kind h = throw.

> Bump-to-fixed-point routing: break/return shapes go fixed-point on bounded loops.
route-for counter break = fixed-point-route.
route-for counter return-bare = fixed-point-route.
route-for counter return-value = fixed-point-route.
route-for bounded-while break = fixed-point-route.
route-for bounded-while return-bare = fixed-point-route.
route-for bounded-while return-value = fixed-point-route.

> Continue stays quantified on bounded loops.
route-for counter continue = quantified-route.
route-for bounded-while continue = quantified-route.

> Labeled forms.
labeled-rejected?.

> while(true) narrowing.
while-true-rejects-only-when-no-break-or-return?.

> Workstream gate.
m6-unblocked?.
```

## Patch Specification

```
module TS2PANT_LOOP_BREAK_CONTINUE_PATCH_3.

> Patch 3 lands L1 vocabulary for return + throw handles
> and the synthesised return-value location kind. Walker
> arms across every exhaustive switch site. No semantic
> change at lowering — Patches 4 and 5 own that.

Handle.
LocationKind.
Walker.
break-handle => Handle.
continue-handle => Handle.
return-handle => Handle.
throw-handle => Handle.
property => LocationKind.
map-value => LocationKind.
map-membership => LocationKind.
return-value => LocationKind.

has-arm-for-handle? w: Walker, h: Handle => Bool.
has-arm-for-location? w: Walker, l: LocationKind => Bool.
carries-guard? h: Handle => Bool.
respects-location-compat? h: Handle => Bool.
---
all w: Walker, h: Handle | has-arm-for-handle? w h.
all w: Walker, l: LocationKind | has-arm-for-location? w l.
carries-guard? throw-handle.
~(carries-guard? break-handle).
~(carries-guard? continue-handle).
~(carries-guard? return-handle).
all h: Handle | respects-location-compat? h.
```


## Implementation Notes

- `ir1-lower.ts` did not need a code change: it only lowers `IR1Expr`, not SSA locations or loop-body handles, so there was no `return-value` arm to add there. The exhaustive SSA-location sites that do exist are covered in `ir1.ts`, `ir1-printer.ts`, and `ir1-ssa-scalars.ts`; counter-loop and fixed-point constructors now explicitly pass empty `returnHandles`/`throwHandles` to keep the structural contract visible.
- The substitute support is implemented as new SSA-level free-var walkers (`freeVarsIR1SsaLocation`, `freeVarsIR1SsaLoopBody`) rather than changing `freeVarsIR1Expr`. That keeps expression traversal expression-only while still giving throw-handle guards a real traversal path.
- I did not add semantic lowering for return/throw handles in this patch. Existing L2/L3/L4 lowerers only preserve the new fields structurally; Patch 5 remains the consumer for handle semantics.

Spec/Evidence Mapping:
- `carries-guard? throw-handle`: `IR1SsaThrowHandle.guard` plus `ir1SsaThrowHandle(...)`; covered by `ir1.test.mts` and the SSA loop-body free-var test in `ir1-substitute.test.mts`.
- `respects-location-compat? h`: return/throw constructors and `ir1SsaLoopBody` validation call the same compatibility assertion used by break/continue; covered by constructor mismatch assertions.
- `has-arm-for-location? w return-value`: equality, printer/read-key/primed-rule formatting, scalar location comparison, and substitute free-var traversal all have explicit `return-value` arms.
- Static/test evidence: `npm exec tsc -- --noEmit` passed; `npm run test:unit` passed.