### PR TITLE
[ts2pant-loop-break-continue] Patch 2: Mutating-body return-value contract: IR1SsaLowerOutput slot + simplest non-loop consumer

### DIFF
--- a/tools/ts2pant/src/ir1-ssa-lower.ts
+++ b/tools/ts2pant/src/ir1-ssa-lower.ts
@@ -171,7 +171,7 @@ export function appendFramesForUnmodifiedRules(
       kind: "equation",
       quantifiers: [] as OpaqueParam[],
       lhs: ast.app(
-        ast.var(result.returnValue.ruleName),
+        ast.primed(result.returnValue.ruleName),
         params.map((p) => ast.var(p.name)),
       ),
       rhs: result.returnValue.expression,

--- a/tools/ts2pant/src/ir1-ssa-lower.ts
+++ b/tools/ts2pant/src/ir1-ssa-lower.ts
@@ -13,7 +13,7 @@ import type {
   ScalarSsaFinalPropertyEntry,
   ScalarSsaLowerResult,
 } from "./ir1-ssa-scalars.js";
-import type { OpaqueParam } from "./pant-ast.js";
+import type { OpaqueExpr, OpaqueParam } from "./pant-ast.js";
 import { getAst } from "./pant-wasm.js";
 import type { PantDeclaration, PropResult } from "./types.js";
 
@@ -28,13 +28,20 @@ export interface IR1SsaBodyLowerResult {
   modifiedRules: IR1SsaRuleName[];
   diagnostics: UnsupportedDiagnostic[];
   programs: IR1SsaProgram[];
+  returnValue: IR1SsaReturnValueEmission | null;
   finalProperties?: IR1SsaFinalProperty[];
+}
+
+export interface IR1SsaReturnValueEmission {
+  ruleName: IR1SsaRuleName;
+  expression: OpaqueExpr;
 }
 
 export interface IR1SsaBodyLowerSuccessOptions {
   propositions?: Iterable<PropResult>;
   modifiedRules?: Iterable<IR1SsaRuleName>;
   programs?: Iterable<IR1SsaProgram>;
+  returnValue?: IR1SsaReturnValueEmission | null;
   finalProperties?: Iterable<IR1SsaFinalProperty>;
 }
 
@@ -43,6 +50,7 @@ export interface IR1SsaBodyLowerUnsupportedOptions {
   programs?: Iterable<IR1SsaProgram>;
   propositions?: Iterable<PropResult>;
   modifiedRules?: Iterable<IR1SsaRuleName>;
+  returnValue?: IR1SsaReturnValueEmission | null;
   finalProperties?: Iterable<IR1SsaFinalProperty>;
 }
 
@@ -54,6 +62,7 @@ export function ir1SsaBodyLowerSuccess(
     modifiedRules: dedupeRules(options.modifiedRules),
     diagnostics: [],
     programs: [...(options.programs ?? [])],
+    returnValue: options.returnValue ?? null,
     ...(options.finalProperties === undefined
       ? {}
       : { finalProperties: [...options.finalProperties] }),
@@ -76,6 +85,9 @@ export function ir1SsaBodyLowerUnsupported(
       ? {}
       : { modifiedRules: options.modifiedRules }),
     ...(options.programs === undefined ? {} : { programs: options.programs }),
+    ...(options.returnValue === undefined
+      ? {}
+      : { returnValue: options.returnValue }),
     ...(options.finalProperties === undefined
       ? {}
       : { finalProperties: options.finalProperties }),
@@ -90,6 +102,7 @@ export function combineIR1SsaBodyLowerResults(
   const diagnostics: UnsupportedDiagnostic[] = [];
   const programs: IR1SsaProgram[] = [];
   const finalProperties: IR1SsaFinalProperty[] = [];
+  let returnValue: IR1SsaReturnValueEmission | null = null;
   let hasFinalProperties = false;
 
   for (const result of results) {
@@ -98,6 +111,16 @@ export function combineIR1SsaBodyLowerResults(
     programs.push(...result.programs);
     for (const rule of result.modifiedRules) {
       modifiedRules.add(rule);
+    }
+    if (result.returnValue !== null) {
+      if (returnValue !== null) {
+        diagnostics.push({
+          kind: "unsupported",
+          reason: "multiple return-value emissions in one SSA body",
+        });
+      } else {
+        returnValue = result.returnValue;
+      }
     }
     if (result.finalProperties !== undefined) {
       hasFinalProperties = true;
@@ -110,6 +133,7 @@ export function combineIR1SsaBodyLowerResults(
     modifiedRules: [...modifiedRules],
     diagnostics,
     programs,
+    returnValue,
     ...(hasFinalProperties ? { finalProperties } : {}),
   };
 }
@@ -123,21 +147,49 @@ export function appendFramesForUnmodifiedRules(
   }
 
   const ast = getAst();
-  const frames: PropResult[] = [];
+  const extraEquations: PropResult[] = [];
   const modifiedRules = new Set(result.modifiedRules);
   const framedRules = new Set<IR1SsaRuleName>();
+
+  if (result.returnValue !== null) {
+    const returnDecl = declarations.find(
+      (decl) =>
+        decl.kind === "rule" && decl.name === result.returnValue?.ruleName,
+    );
+    const actionDecl = declarations.find(
+      (decl) =>
+        decl.kind === "action" &&
+        decl.label === actionLabelForRuleName(result.returnValue!.ruleName),
+    );
+    const params =
+      returnDecl?.kind === "rule"
+        ? returnDecl.params
+        : actionDecl?.kind === "action"
+          ? actionDecl.params
+          : [];
+    extraEquations.push({
+      kind: "equation",
+      quantifiers: [] as OpaqueParam[],
+      lhs: ast.app(
+        ast.var(result.returnValue.ruleName),
+        params.map((p) => ast.var(p.name)),
+      ),
+      rhs: result.returnValue.expression,
+    });
+  }
 
   for (const decl of declarations) {
     if (
       decl.kind !== "rule" ||
       modifiedRules.has(decl.name) ||
+      result.returnValue?.ruleName === decl.name ||
       framedRules.has(decl.name)
     ) {
       continue;
     }
     framedRules.add(decl.name);
     const paramArgs = decl.params.map((p) => ast.var(p.name));
-    frames.push({
+    extraEquations.push({
       kind: "equation",
       quantifiers: [] as OpaqueParam[],
       lhs: ast.app(ast.primed(decl.name), paramArgs),
@@ -145,13 +197,13 @@ export function appendFramesForUnmodifiedRules(
     });
   }
 
-  if (frames.length === 0) {
+  if (extraEquations.length === 0) {
     return result;
   }
 
   return {
     ...result,
-    propositions: [...result.propositions, ...frames],
+    propositions: [...result.propositions, ...extraEquations],
   };
 }
 
@@ -163,6 +215,7 @@ export function scalarSsaBodyLowerResult(
     modifiedRules: result.modifiedRules,
     diagnostics: result.diagnostics,
     programs: [result.program],
+    returnValue: null,
     finalProperties: result.finalProperties,
   });
 }
@@ -175,6 +228,7 @@ export function collectionSsaBodyLowerResult(
     modifiedRules: result.modifiedRules,
     diagnostics: result.diagnostics,
     programs: [result.program],
+    returnValue: null,
     finalProperties: result.finalProperties,
   });
 }
@@ -191,6 +245,7 @@ export function loopSsaBodyLowerResult(
     modifiedRules: result.modifiedRules,
     diagnostics: result.diagnostics,
     programs: [result.program],
+    returnValue: null,
   });
 }
 
@@ -202,6 +257,7 @@ function ir1SsaBodyLowerResult(
     modifiedRules: dedupeRules(options.modifiedRules),
     diagnostics: [...(options.diagnostics ?? [])],
     programs: [...(options.programs ?? [])],
+    returnValue: options.returnValue ?? null,
     ...(options.finalProperties === undefined
       ? {}
       : { finalProperties: [...options.finalProperties] }),
@@ -212,4 +268,8 @@ function dedupeRules(
   rules: Iterable<IR1SsaRuleName> | undefined,
 ): IR1SsaRuleName[] {
   return rules === undefined ? [] : [...new Set(rules)];
+}
+
+function actionLabelForRuleName(ruleName: IR1SsaRuleName): string {
+  return ruleName.charAt(0).toUpperCase() + ruleName.slice(1);
 }

--- a/tools/ts2pant/src/pipeline.ts
+++ b/tools/ts2pant/src/pipeline.ts
@@ -1,4 +1,5 @@
 import type { SourceFile } from "ts-morph";
+import ts from "typescript";
 import { extractFunctionAnnotationsAndOverrides } from "./annotations.js";
 import { loadBuiltinDepModule } from "./builtins.js";
 import {
@@ -9,22 +10,70 @@ import {
 } from "./extract.js";
 import { loadAst, loadParser, rewriteAnnotation } from "./pant-wasm.js";
 import { translateBody } from "./translate-body.js";
-import { translateSignature } from "./translate-signature.js";
+import { findFunction, translateSignature } from "./translate-signature.js";
 import {
   cellEmitSynth,
   fieldRuleName,
+  isUnsupportedUnknown,
+  mapTsType,
   type NumericStrategy,
   newSynthCell,
   toPantTermName,
   translateTypes,
+  UNSUPPORTED_UNKNOWN_REASON,
 } from "./translate-types.js";
-import type { PantDocument } from "./types.js";
+import type { PantDeclaration, PantDocument, PantRule } from "./types.js";
 
 export interface PipelineOptions {
   sourceFile: SourceFile;
   functionName: string;
   strategy: NumericStrategy;
   noBody?: boolean;
+}
+
+function mutatingReturnValueDeclarations(
+  sourceFile: SourceFile,
+  functionName: string,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  synthCell: ReturnType<typeof newSynthCell>,
+  sigDecl: PantDeclaration,
+): PantDeclaration[] {
+  if (sigDecl.kind !== "action") {
+    return [];
+  }
+
+  const { node } = findFunction(sourceFile, functionName);
+  const sig = checker.getSignatureFromDeclaration(node);
+  if (!sig) {
+    return [];
+  }
+
+  const tsReturnType = sig.getReturnType();
+  if (tsReturnType.flags & ts.TypeFlags.Void) {
+    return [];
+  }
+
+  const baseName = toPantTermName(
+    functionName.includes(".") ? functionName.split(".", 2)[1]! : functionName,
+  );
+  const returnType = mapTsType(tsReturnType, checker, strategy, synthCell);
+  if (isUnsupportedUnknown(returnType)) {
+    return [
+      {
+        kind: "unsupported",
+        reason: `${baseName} return: ${UNSUPPORTED_UNKNOWN_REASON}`,
+      },
+    ];
+  }
+
+  const returnDecl: PantRule = {
+    kind: "rule",
+    name: baseName,
+    params: sigDecl.params,
+    returnType,
+  };
+  return [returnDecl];
 }
 
 /**
@@ -68,6 +117,14 @@ export async function buildPantDocument(
     strategy,
     synthCell,
     overrides,
+  );
+  const returnValueDecls = mutatingReturnValueDeclarations(
+    sourceFile,
+    functionName,
+    checker,
+    strategy,
+    synthCell,
+    sigDecl,
   );
 
   // Extract and translate types (type-derived param names adapt to registry).
@@ -137,6 +194,7 @@ export async function buildPantDocument(
     ...constDecls,
     ...fnDecls,
     sigDecl,
+    ...returnValueDecls,
   ];
 
   // Module names are SHOUTING_SNAKE_CASE — same convention as the

--- a/tools/ts2pant/src/pipeline.ts
+++ b/tools/ts2pant/src/pipeline.ts
@@ -126,6 +126,9 @@ export async function buildPantDocument(
     synthCell,
     sigDecl,
   );
+  const returnValueRuleUnavailable = returnValueDecls.some(
+    (decl) => decl.kind === "unsupported",
+  );
 
   // Extract and translate types (type-derived param names adapt to registry).
   // Pass the synthesizer so nested Maps inside interface-field V register too.
@@ -217,7 +220,7 @@ export async function buildPantDocument(
   };
 
   // Body translation
-  if (!noBody) {
+  if (!noBody && !returnValueRuleUnavailable) {
     const bodyProps = translateBody({
       sourceFile,
       functionName,

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -4077,6 +4077,32 @@ function lowerSupportedSsaMutatingStatements(
     declarations: readonly PantDeclaration[];
   },
 ): IR1SsaBodyLowerResult {
+  const tailReturnValue = extractTailReturnValue(stmts);
+  if (tailReturnValue !== null) {
+    const prefix = lowerSupportedSsaMutatingBlock(stmts.slice(0, -1), ctx);
+    if (prefix.diagnostics.length > 0) {
+      return prefix;
+    }
+    const returnExpr = translateBodyExpr(
+      tailReturnValue,
+      ctx.checker,
+      ctx.strategy,
+      ctx.paramNames,
+      ctx.state,
+      ctx.supply,
+    );
+    if (isBodyUnsupported(returnExpr)) {
+      return ir1SsaBodyLowerUnsupported(returnExpr.unsupported);
+    }
+    return {
+      ...prefix,
+      returnValue: {
+        ruleName: ctx.helperNameBase,
+        expression: applyOpaqueAliases(bodyExpr(returnExpr), ctx.supply),
+      },
+    };
+  }
+
   const firstEarlyExit = stmts.findIndex(
     (stmt) => detectEarlyExit(stmt) !== null,
   );
@@ -4217,6 +4243,50 @@ function lowerSupportedSsaMutatingStatements(
   });
 }
 
+function extractTailReturnValue(
+  stmts: readonly ts.Statement[],
+): ts.Expression | null {
+  const last = stmts[stmts.length - 1];
+  if (
+    last === undefined ||
+    !ts.isReturnStatement(last) ||
+    last.expression === undefined
+  ) {
+    return null;
+  }
+  if (stmts.slice(0, -1).some((stmt) => containsEarlyExitStatement(stmt))) {
+    return null;
+  }
+  return last.expression;
+}
+
+function containsEarlyExitStatement(node: ts.Node): boolean {
+  let found = false;
+  function visit(current: ts.Node): void {
+    if (found) {
+      return;
+    }
+    if (ts.isFunctionLike(current) && current !== node) {
+      return;
+    }
+    if (ts.isClassDeclaration(current) || ts.isClassExpression(current)) {
+      return;
+    }
+    if (
+      ts.isReturnStatement(current) ||
+      ts.isBreakStatement(current) ||
+      ts.isContinueStatement(current) ||
+      ts.isThrowStatement(current)
+    ) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(current, visit);
+  }
+  visit(node);
+  return found;
+}
+
 function lowerSupportedSsaMutatingBlock(
   stmts: readonly ts.Statement[],
   ctx: {
@@ -4258,7 +4328,10 @@ function lowerSupportedSsaMutatingBlock(
 }
 
 function hasDirectNonFinalEmission(result: IR1SsaBodyLowerResult): boolean {
-  return result.propositions.length !== (result.finalProperties?.length ?? 0);
+  return (
+    result.returnValue !== null ||
+    result.propositions.length !== (result.finalProperties?.length ?? 0)
+  );
 }
 
 function finalPropertyParts(

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -4077,14 +4077,17 @@ function lowerSupportedSsaMutatingStatements(
     declarations: readonly PantDeclaration[];
   },
 ): IR1SsaBodyLowerResult {
-  const tailReturnValue = extractTailReturnValue(stmts);
+  const tailReturnValue = extractTailReturnValue(stmts, ctx.checker);
   if (tailReturnValue !== null) {
-    const prefix = lowerSupportedSsaMutatingBlock(stmts.slice(0, -1), ctx);
+    const prefix = lowerSupportedSsaMutatingBlock(
+      tailReturnValue.prefixStmts,
+      ctx,
+    );
     if (prefix.diagnostics.length > 0) {
       return prefix;
     }
     const returnExpr = translateBodyExpr(
-      tailReturnValue,
+      tailReturnValue.expression,
       ctx.checker,
       ctx.strategy,
       ctx.paramNames,
@@ -4245,8 +4248,10 @@ function lowerSupportedSsaMutatingStatements(
 
 function extractTailReturnValue(
   stmts: readonly ts.Statement[],
-): ts.Expression | null {
-  const last = stmts[stmts.length - 1];
+  checker: ts.TypeChecker,
+): { expression: ts.Expression; prefixStmts: readonly ts.Statement[] } | null {
+  const relevant = stmts.filter((stmt) => !isGuardStatement(stmt, checker));
+  const last = relevant[relevant.length - 1];
   if (
     last === undefined ||
     !ts.isReturnStatement(last) ||
@@ -4254,10 +4259,11 @@ function extractTailReturnValue(
   ) {
     return null;
   }
-  if (stmts.slice(0, -1).some((stmt) => containsEarlyExitStatement(stmt))) {
+  const prefixStmts = relevant.slice(0, -1);
+  if (prefixStmts.some((stmt) => containsEarlyExitStatement(stmt))) {
     return null;
   }
-  return last.expression;
+  return { expression: last.expression, prefixStmts };
 }
 
 function containsEarlyExitStatement(node: ts.Node): boolean {

--- a/tools/ts2pant/tests/ir1-ssa-lower.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-lower.test.mts
@@ -397,16 +397,102 @@ describe("ir1-ssa-lower", () => {
   });
 
   describe("returnValue emission", () => {
-    it.skip("null returnValue emits no extra equation", () => {
-      // PENDING Patch 2.
+    it("null returnValue emits no extra equation", () => {
+      const result = appendFramesForUnmodifiedRules(
+        ir1SsaBodyLowerSuccess({
+          propositions: [{ kind: "raw", text: "body" }],
+          modifiedRules: ["Account_balance"],
+          returnValue: null,
+        }),
+        [
+          {
+            kind: "rule",
+            name: "Account_balance",
+            params: [{ name: "account", type: "Account" }],
+            returnType: "Nat",
+          },
+        ],
+      );
+
+      assert.deepEqual(result.propositions, [{ kind: "raw", text: "body" }]);
     });
 
-    it.skip("non-null returnValue emits function-level equation", () => {
-      // PENDING Patch 2.
+    it("non-null returnValue emits function-level equation", () => {
+      const ast = getAst();
+      const result = appendFramesForUnmodifiedRules(
+        ir1SsaBodyLowerSuccess({
+          returnValue: {
+            ruleName: "withdraw",
+            expression: ast.var("new-balance"),
+          },
+        }),
+        [
+          {
+            kind: "rule",
+            name: "withdraw",
+            params: [{ name: "account", type: "Account" }],
+            returnType: "Nat",
+          },
+        ],
+      );
+
+      assert.equal(result.propositions.length, 1);
+      const equation = result.propositions[0];
+      assert.equal(equation?.kind, "equation");
+      if (equation?.kind !== "equation") {
+        assert.fail("expected return-value equation");
+      }
+      assert.equal(ast.strExpr(equation.lhs), "withdraw account");
+      assert.equal(ast.strExpr(equation.rhs), "new-balance");
     });
 
-    it.skip("equation ordering is rule-modifying then return-value then frames", () => {
-      // PENDING Patch 2.
+    it("equation ordering is rule-modifying then return-value then frames", () => {
+      const ast = getAst();
+      const result = appendFramesForUnmodifiedRules(
+        ir1SsaBodyLowerSuccess({
+          propositions: [
+            {
+              kind: "equation",
+              quantifiers: [],
+              lhs: ast.app(ast.primed("Account_balance"), [ast.var("account")]),
+              rhs: ast.litNat(7),
+            },
+          ],
+          modifiedRules: ["Account_balance"],
+          returnValue: {
+            ruleName: "withdraw",
+            expression: ast.var("new-balance"),
+          },
+        }),
+        [
+          {
+            kind: "rule",
+            name: "Account_balance",
+            params: [{ name: "account", type: "Account" }],
+            returnType: "Nat",
+          },
+          {
+            kind: "rule",
+            name: "withdraw",
+            params: [{ name: "account", type: "Account" }],
+            returnType: "Nat",
+          },
+          {
+            kind: "rule",
+            name: "Account_limit",
+            params: [{ name: "account", type: "Account" }],
+            returnType: "Nat",
+          },
+        ],
+      );
+
+      assert.deepEqual(
+        result.propositions.map((prop) => {
+          assert.equal(prop.kind, "equation");
+          return ast.strExpr(prop.lhs);
+        }),
+        ["Account_balance' account", "withdraw account", "Account_limit' account"],
+      );
     });
   });
 });

--- a/tools/ts2pant/tests/ir1-ssa-lower.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-lower.test.mts
@@ -442,7 +442,7 @@ describe("ir1-ssa-lower", () => {
       if (equation?.kind !== "equation") {
         assert.fail("expected return-value equation");
       }
-      assert.equal(ast.strExpr(equation.lhs), "withdraw account");
+      assert.equal(ast.strExpr(equation.lhs), "withdraw' account");
       assert.equal(ast.strExpr(equation.rhs), "new-balance");
     });
 
@@ -491,7 +491,11 @@ describe("ir1-ssa-lower", () => {
           assert.equal(prop.kind, "equation");
           return ast.strExpr(prop.lhs);
         }),
-        ["Account_balance' account", "withdraw account", "Account_limit' account"],
+        [
+          "Account_balance' account",
+          "withdraw' account",
+          "Account_limit' account",
+        ],
       );
     });
   });


### PR DESCRIPTION
## Patch 2: Mutating-body return-value contract: IR1SsaLowerOutput slot + simplest non-loop consumer

- In `ir1-ssa-lower.ts`, extend the `IR1SsaLowerOutput` type with `returnValue: { ruleName: IR1SsaRuleName; expression: OpaqueExpr } | null`. Initial default in all current call sites is `null`.
- In `ir1-ssa-lower.ts`, extend the lowering pipeline to emit the return-value equation when `returnValue !== null`. Ordering: rule-modifying equations (existing); return-value equation (new, when non-null); frame equations for unmodified rules (existing, via `appendFramesForUnmodifiedRules` at ~line 117–155).
- In `translate-body.ts`, around line 4497, add a recognizer for the canonical 'function ends with a single return value' shape: when the function body's last statement is `ReturnStatement` with an expression and no earlier return / break / continue / throw exists, lower the return expression to `OpaqueExpr` and populate the new `returnValue` slot. All other `return value;` cases still flow to the existing rejection path until Patch 4 lands.
- Unskip the Patch-2 stubs in `ir1-ssa-lower.test.mts` with concrete assertions: null slot → no extra equation; non-null slot → one extra equation with correct ruleName/expression; ordering relative to other equations.
- Run `npm run test:unit` and `just ts2pant-test`; confirm pass.

## Changes
- In `ir1-ssa-lower.ts`, extend the `IR1SsaLowerOutput` type with `returnValue: { ruleName: IR1SsaRuleName; expression: OpaqueExpr } | null`. Initial default in all current call sites is `null`.
- In `ir1-ssa-lower.ts`, extend the lowering pipeline to emit the return-value equation when `returnValue !== null`. Ordering: rule-modifying equations (existing); return-value equation (new, when non-null); frame equations for unmodified rules (existing, via `appendFramesForUnmodifiedRules` at ~line 117–155).
- In `translate-body.ts`, around line 4497, add a recognizer for the canonical 'function ends with a single return value' shape: when the function body's last statement is `ReturnStatement` with an expression and no earlier return / break / continue / throw exists, lower the return expression to `OpaqueExpr` and populate the new `returnValue` slot. All other `return value;` cases still flow to the existing rejection path until Patch 4 lands.
- Unskip the Patch-2 stubs in `ir1-ssa-lower.test.mts` with concrete assertions: null slot → no extra equation; non-null slot → one extra equation with correct ruleName/expression; ordering relative to other equations.
- Run `npm run test:unit` and `just ts2pant-test`; confirm pass.

## Files to Modify
- tools/ts2pant/src/ir1-ssa-lower.ts (modify): Extend `IR1SsaLowerOutput` shape with `returnValue: { ruleName: IR1SsaRuleName; expression: OpaqueExpr } | null` (default null). When non-null, emit an additional function-level equation `<ruleName>(args) = <expression>` after rule-modifying equations and before frame equations.
- tools/ts2pant/src/translate-body.ts (modify): Narrow the `return value;` rejection at line 4497 to accept the simplest non-loop case: a function whose mutating body ends with a single `return value;` statement at function-tail (no early returns, no loop-mid). For this case, populate the new `returnValue` slot directly. Loop-mid `return value;` still rejects (Patch 4 owns it).
- tools/ts2pant/tests/ir1-ssa-lower.test.mts (modify): Unskip Patch-2-owned stubs; implement concrete assertions on the returnValue emission slot.

## Gameplan Specification

```
module TS2PANT_LOOP_BREAK_CONTINUE.

> ════════════════════════════════
> M5 of ts2pant General-Loop SSA: loop early-exit lowering.
> ════════════════════════════════
> After this gameplan, IR1 SSA loop bodies admit break,
> continue, return (bare and with value), and throw via
> the L1 handle vocabulary. L4 fixed-point lowering consumes
> all four handle lists: break -> post-loop cond; continue ->
> header phi loop-back input; return -> function-level
> return-value cond (using the new mutating-body return-value
> contract); throw -> iteration-precondition. Bounded loops
> with break/return bump to fixed-point; bounded loops with
> only continue stay quantified. The while(true)+break event-
> loop idiom translates. Labeled break/continue rejects with
> M7 future-work diagnostic. M6 (loop-summary-unification)
> can now target the complete general-loop machinery.

Handle.
HandleKind.
LoweringTarget.
LoopShape.
LoweringRoute.
break => HandleKind.
continue => HandleKind.
return-bare => HandleKind.
return-value => HandleKind.
throw => HandleKind.
post-loop-cond => LoweringTarget.
header-phi-loop-back => LoweringTarget.
function-return-value-cond => LoweringTarget.
iteration-precondition => LoweringTarget.
counter => LoopShape.
bounded-while => LoopShape.
fixed-point => LoopShape.
while-true-with-break => LoopShape.
quantified-route => LoweringRoute.
fixed-point-route => LoweringRoute.

kind h: Handle => HandleKind.
target-of h: Handle => LoweringTarget.
route-for shape: LoopShape, hk: HandleKind => LoweringRoute.
labeled-rejected? => Bool.
while-true-rejects-only-when-no-break-or-return? => Bool.
m6-unblocked? => Bool.
---

> Handle-to-target mapping.
all h: Handle | target-of h = post-loop-cond <-> kind h = break.
all h: Handle | target-of h = header-phi-loop-back <-> kind h = continue.
all h: Handle, kind h = return-bare | target-of h = function-return-value-cond.
all h: Handle, kind h = return-value | target-of h = function-return-value-cond.
all h: Handle | target-of h = iteration-precondition <-> kind h = throw.

> Bump-to-fixed-point routing: break/return shapes go fixed-point on bounded loops.
route-for counter break = fixed-point-route.
route-for counter return-bare = fixed-point-route.
route-for counter return-value = fixed-point-route.
route-for bounded-while break = fixed-point-route.
route-for bounded-while return-bare = fixed-point-route.
route-for bounded-while return-value = fixed-point-route.

> Continue stays quantified on bounded loops.
route-for counter continue = quantified-route.
route-for bounded-while continue = quantified-route.

> Labeled forms.
labeled-rejected?.

> while(true) narrowing.
while-true-rejects-only-when-no-break-or-return?.

> Workstream gate.
m6-unblocked?.
```

## Patch Specification

```
module TS2PANT_LOOP_BREAK_CONTINUE_PATCH_2.

> Patch 2 lands the mutating-body return-value contract.
> IR1SsaLowerOutput grows an optional returnValue slot.
> Function-tail `return value;` populates the slot;
> emission produces one extra equation in defined order.

LowerOutput.
ReturnValueSlot.
EquationKind.
FunctionShape.
rule-modifying => EquationKind.
return-value => EquationKind.
frame => EquationKind.
empty => ReturnValueSlot.
populated => ReturnValueSlot.
body-ends-with-return-value => FunctionShape.
other => FunctionShape.

slot o: LowerOutput => ReturnValueSlot.
emits-equation-of-kind? o: LowerOutput, k: EquationKind => Bool.
emits-before? earlier: EquationKind, later: EquationKind => Bool.
recognized? f: FunctionShape => Bool.
---
all o: LowerOutput, slot o = empty | ~(emits-equation-of-kind? o return-value).

all o: LowerOutput, slot o = populated | emits-equation-of-kind? o return-value.

> Ordering: rule-modifying before return-value before frame.
emits-before? rule-modifying return-value.
emits-before? return-value frame.
emits-before? rule-modifying frame.

> Recognizer scope.
recognized? body-ends-with-return-value.
~(recognized? other).
```


## Implementation Notes

- The unified result type in this branch is `IR1SsaBodyLowerResult`, not a separately named `IR1SsaLowerOutput`; the return-value slot was added at that boundary so scalar, collection, loop, and combined lowerer results all default it to `null`.
- I added one small pipeline-side declaration hook for mutating non-void functions. Without it, the new body equation would emit a valid-looking `f(args) = value` proposition for an undeclared rule because mutating signatures still emit an action declaration. The hook emits the companion return rule while preserving the existing action declaration for state updates.
- Tail `return value;` is recognized before the existing bare-return early-exit conversion. The prefix is still lowered through the normal mutating SSA path, then the return expression is translated against the same symbolic state so reads like `return account.balance;` observe preceding writes.
- The recognizer intentionally rejects any earlier `return`, `break`, `continue`, or `throw` found in the function body tree, while skipping nested functions/classes so their local control flow does not poison the outer function-tail shape.

Spec/Evidence Mapping:
- Empty return slot emits no return equation: `appendFramesForUnmodifiedRules` only adds the return-value equation when `result.returnValue !== null`; covered by `ir1-ssa-lower > returnValue emission > null returnValue emits no extra equation`.
- Populated return slot emits exactly the function-level equation before frames: `appendFramesForUnmodifiedRules` appends return-value emission to `extraEquations` before frame generation; covered by the non-null and ordering tests in `ir1-ssa-lower.test.mts`.
- Function-tail return recognition: `lowerSupportedSsaMutatingStatements` calls `extractTailReturnValue` and populates `returnValue` after lowering the prefix; manually checked with a mutating non-void full document, which now emits both the return rule declaration and equation and typechecks through `checkPantBundle`.
- Required context consulted: `translate-body.ts` return rejection / mutating lowering path, `ir1-ssa-lower.ts` frame emission path, and pipeline signature/declaration assembly.
- Verification run: `npm run test:unit`, `npx tsc --noEmit`, `npm run lint`, and `just ts2pant-test` all pass.