### PR TITLE
[ts2pant-loop-break-continue] Patch 5: L4 fixed-point lowering consumes handle lists; while(true) rejection narrows

### DIFF
--- a/tools/ts2pant/src/ir1-build-body.ts
+++ b/tools/ts2pant/src/ir1-build-body.ts
@@ -35,13 +35,17 @@ import {
   type IR1Stmt,
   ir1Assign,
   ir1Block,
+  ir1Break,
   ir1CondStmt,
+  ir1Continue,
   ir1Foreach,
   ir1MapDelete,
   ir1MapSet,
   ir1Member,
+  ir1Return,
   ir1SetAddOrDelete,
   ir1SetClear,
+  ir1Throw,
 } from "./ir1.js";
 import {
   buildL1MemberAccess,
@@ -1032,6 +1036,29 @@ function buildL1MutationBody(
     // Handles `else if` chains (TS parses these as nested IfStatement)
     // and inner ifs in the then-branch.
     return buildL1IfMutation(stmt, ctx);
+  }
+  if (ts.isBreakStatement(stmt)) {
+    return ir1Break();
+  }
+  if (ts.isContinueStatement(stmt)) {
+    return ir1Continue();
+  }
+  if (ts.isReturnStatement(stmt)) {
+    if (stmt.expression === undefined) {
+      return ir1Return(null);
+    }
+    const expr = buildL1SubExpr(stmt.expression, ctx);
+    return isUnsupported(expr) ? expr : ir1Return(expr);
+  }
+  if (ts.isThrowStatement(stmt)) {
+    if (expressionHasSideEffects(stmt.expression, ctx.checker)) {
+      return {
+        unsupported:
+          "branch body must be a property assignment, Map/Set effect, or nested if",
+      };
+    }
+    const expr = buildL1SubExpr(stmt.expression, ctx);
+    return isUnsupported(expr) ? expr : ir1Throw(expr);
   }
   if (ts.isExpressionStatement(stmt)) {
     // Unwrap parenthesized expressions so `(obj.p = 1);` and

--- a/tools/ts2pant/src/ir1-lower-body.ts
+++ b/tools/ts2pant/src/ir1-lower-body.ts
@@ -90,6 +90,7 @@ export interface SsaBodyLowerOptions extends LowerBodyCtx {
   synthCell?: SynthCell;
   strategy?: NumericStrategy;
   declarations?: readonly PantDeclaration[];
+  returnRuleName?: string;
 }
 
 export function lowerL1BodyToSsaProps(
@@ -124,6 +125,30 @@ function lowerL1BodyToSsaResult(
     return lowerFixedPointL1BodyToSsaResult(stmt, options);
   }
   if (stmt.kind === "for") {
+    if (hasBreakOrReturn(stmt.body)) {
+      const whileStmt: IR1Stmt = {
+        kind: "while",
+        cond: stmt.cond ?? {
+          kind: "lit",
+          value: { kind: "bool", value: true },
+        },
+        body:
+          stmt.step === null
+            ? stmt.body
+            : { kind: "block", stmts: [stmt.body, stmt.step] },
+      };
+      const stmts =
+        stmt.init === null
+          ? ([whileStmt] as [IR1Stmt])
+          : ([stmt.init, whileStmt] as [IR1Stmt, IR1Stmt]);
+      return lowerFixedPointL1BodyToSsaResult(
+        {
+          kind: "block",
+          stmts,
+        },
+        options,
+      );
+    }
     return lowerCounterLoopL1BodyToSsaResult(stmt, options);
   }
   if (
@@ -158,6 +183,38 @@ function lowerL1BodyToSsaResult(
   );
 }
 
+function hasBreakOrReturn(stmt: IR1Stmt): boolean {
+  switch (stmt.kind) {
+    case "break":
+    case "return":
+      return true;
+    case "block":
+      return stmt.stmts.some(hasBreakOrReturn);
+    case "cond-stmt":
+      return (
+        stmt.arms.some(([, body]) => hasBreakOrReturn(body)) ||
+        (stmt.otherwise !== null && hasBreakOrReturn(stmt.otherwise))
+      );
+    case "while":
+    case "for":
+    case "foreach":
+      return false;
+    case "let":
+    case "assign":
+    case "continue":
+    case "throw":
+    case "expr-stmt":
+    case "map-effect":
+    case "set-effect":
+      return false;
+    default: {
+      const _exhaustive: never = stmt;
+      void _exhaustive;
+      return false;
+    }
+  }
+}
+
 function lowerFixedPointL1BodyToSsaResult(
   stmt:
     | Extract<IR1Stmt, { kind: "while" }>
@@ -177,6 +234,9 @@ function lowerFixedPointL1BodyToSsaResult(
       ...(options.declarations === undefined
         ? {}
         : { declarations: options.declarations }),
+      ...(options.returnRuleName === undefined
+        ? {}
+        : { returnRuleName: options.returnRuleName }),
     });
   } catch (err) {
     return ir1SsaBodyLowerUnsupported(

--- a/tools/ts2pant/src/ir1-ssa-collections.ts
+++ b/tools/ts2pant/src/ir1-ssa-collections.ts
@@ -422,6 +422,8 @@ export function isCollectionSsaL1Body(stmt: IR1Stmt): boolean {
     case "for":
     case "while":
     case "return":
+    case "break":
+    case "continue":
     case "throw":
     case "let":
     case "expr-stmt":
@@ -474,6 +476,8 @@ export function lowerCollectionSsaL1Body(
     case "for":
     case "while":
     case "return":
+    case "break":
+    case "continue":
     case "throw":
     case "let":
     case "expr-stmt":
@@ -761,6 +765,8 @@ function lowerCollectionSsaStmtToVersions(
     case "for":
     case "while":
     case "return":
+    case "break":
+    case "continue":
     case "throw":
     case "let":
     case "expr-stmt":

--- a/tools/ts2pant/src/ir1-ssa-counter-loop.ts
+++ b/tools/ts2pant/src/ir1-ssa-counter-loop.ts
@@ -68,12 +68,14 @@ interface AccumulatorFoldBody {
   guard: IR1Expr | null;
   combiner: FoldCombiner;
   outerOp: "add" | "sub" | "mul" | "div" | "and" | "or";
+  continueGuards: IR1Expr[];
 }
 
 interface SimpleAssignBody {
   kind: "simple-assign";
   target: Extract<IR1Expr, { kind: "member" }>;
   rhs: IR1Expr;
+  continueGuards: IR1Expr[];
 }
 
 type CounterLoopBody = AccumulatorFoldBody | SimpleAssignBody;
@@ -164,7 +166,11 @@ export function lowerCounterLoopL1Body(
     writes: [write],
     joins: [],
     breakHandles: [],
-    continueHandles: [],
+    continueHandles: body.continueGuards.map(() => ({
+      kind: "ssa-continue-handle",
+      location: targetInfo.location,
+      version: write.version,
+    })),
     returnHandles: [],
     throwHandles: [],
     terminationMetric,
@@ -314,13 +320,29 @@ function classifyCounterLoopBody(
   counterName: string,
 ): CounterLoopBody | { unsupported: string } {
   if (stmt.kind === "block") {
-    if (stmt.stmts.length !== 1) {
+    const continueGuards: IR1Expr[] = [];
+    const rest = stmt.stmts.filter((child) => {
+      const guard = recognizeContinueGuard(child);
+      if (guard === null) {
+        return true;
+      }
+      continueGuards.push(guard);
+      return false;
+    });
+    if (rest.length !== 1) {
       return {
         unsupported:
           "bounded counter loop body must contain exactly one supported mutation",
       };
     }
-    return classifyCounterLoopBody(stmt.stmts[0]!, counterName);
+    const classified = classifyCounterLoopBody(rest[0]!, counterName);
+    if ("unsupported" in classified) {
+      return classified;
+    }
+    return {
+      ...classified,
+      continueGuards: [...classified.continueGuards, ...continueGuards],
+    };
   }
   if (stmt.kind === "cond-stmt") {
     if (
@@ -379,12 +401,18 @@ function classifyCounterLoopBody(
       guard: null,
       combiner: fold.combiner,
       outerOp: fold.outerOp,
+      continueGuards: [],
     };
   }
   if (selfReads > 0) {
     return recurrenceUnsupported();
   }
-  return { kind: "simple-assign", target: stmt.target, rhs: stmt.value };
+  return {
+    kind: "simple-assign",
+    target: stmt.target,
+    rhs: stmt.value,
+    continueGuards: [],
+  };
 }
 
 function buildTargetInfo(
@@ -433,6 +461,16 @@ function emitAccumulatorFold(
       ast.gExpr(lowerWithCounter(body.guard, shape, binderExpr, lowerOpaque)),
     );
   }
+  for (const continueGuard of body.continueGuards) {
+    guards.push(
+      ast.gExpr(
+        ast.unop(
+          ast.opNot(),
+          lowerWithCounter(continueGuard, shape, binderExpr, lowerOpaque),
+        ),
+      ),
+    );
+  }
   const folded = ast.eachComb(
     [ast.param(shape.counterPantBinder, ast.tName("Nat0"))],
     guards,
@@ -458,20 +496,63 @@ function emitSimpleAssign(
   const bound = lowerOpaque(lowerExpr(lowerL1Expr(shape.boundExpr)));
   const lastCounter = lastCounterValue(shape, bound);
   const rhs = lowerWithCounter(body.rhs, shape, lastCounter, lowerOpaque);
+  const continueGuard = lowerContinueGuardAt(
+    body.continueGuards,
+    shape,
+    lastCounter,
+    lowerOpaque,
+  );
   const loopExecutes = ast.binop(
     boundCmpToOpaque(shape.boundCmpOp),
     init,
     bound,
   );
+  const executedRhs =
+    continueGuard === null
+      ? rhs
+      : ast.cond([
+          [continueGuard, target.prior],
+          [ast.litBool(true), rhs],
+        ]);
   return {
     kind: "equation",
     quantifiers: [],
     lhs: target.lhs,
     rhs: ast.cond([
-      [loopExecutes, rhs],
+      [loopExecutes, executedRhs],
       [ast.litBool(true), target.prior],
     ]),
   };
+}
+
+function recognizeContinueGuard(stmt: IR1Stmt): IR1Expr | null {
+  if (stmt.kind === "continue") {
+    return { kind: "lit", value: { kind: "bool", value: true } };
+  }
+  if (
+    stmt.kind === "cond-stmt" &&
+    stmt.arms.length === 1 &&
+    stmt.otherwise === null &&
+    stmt.arms[0]?.[1].kind === "continue"
+  ) {
+    return stmt.arms[0][0];
+  }
+  return null;
+}
+
+function lowerContinueGuardAt(
+  guards: readonly IR1Expr[],
+  shape: CounterLoopShape,
+  counter: OpaqueExpr,
+  lowerOpaque: (e: OpaqueExpr) => OpaqueExpr,
+): OpaqueExpr | null {
+  const ast = getAst();
+  if (guards.length === 0) {
+    return null;
+  }
+  return guards
+    .map((guard) => lowerWithCounter(guard, shape, counter, lowerOpaque))
+    .reduce((lhs, rhs) => ast.binop(ast.opOr(), lhs, rhs));
 }
 
 function lastCounterValue(

--- a/tools/ts2pant/src/ir1-ssa-fixed-point.ts
+++ b/tools/ts2pant/src/ir1-ssa-fixed-point.ts
@@ -43,6 +43,7 @@ export interface FixedPointLoopLowerOptions extends LoopSsaBuildOptions {
   invariantTypes?: ReadonlyMap<string, OpaqueTypeExpr | string>;
   declarations?: readonly PantDeclaration[];
   strategy?: NumericStrategy;
+  returnRuleName?: string;
 }
 
 export interface FixedPointLoopShape {
@@ -92,7 +93,8 @@ export function recognizeFixedPointLoopShape(
   if (
     stmt.cond.kind === "lit" &&
     stmt.cond.value.kind === "bool" &&
-    stmt.cond.value.value === true
+    stmt.cond.value.value === true &&
+    !hasReachableBreakOrReturn(stmt.body)
   ) {
     return {
       unsupported:
@@ -142,6 +144,7 @@ export function lowerFixedPointLoopL1Body(
   }
   const guardExpr = substituteLocalLets(shape.guardExpr, shape.localLets);
   const valueExpr = substituteLocalLets(writeBody.value, shape.localLets);
+  const loopExits = collectLoopExits(shape.bodyStmt);
   if (
     containsNonTargetMemberRead(guardExpr, writeBody.target) ||
     containsNonTargetMemberRead(valueExpr, writeBody.target)
@@ -150,7 +153,11 @@ export function lowerFixedPointLoopL1Body(
       "fixed-point while lowering supports guards and updates over the mutated property only",
     );
   }
-  if (!containsTargetMemberRead(guardExpr, writeBody.target)) {
+  if (
+    !containsTargetMemberRead(guardExpr, writeBody.target) &&
+    loopExits.breaks.length === 0 &&
+    loopExits.returns.length === 0
+  ) {
     return ir1SsaBodyLowerUnsupported(
       "fixed-point while guard must depend on the mutated property",
     );
@@ -163,8 +170,16 @@ export function lowerFixedPointLoopL1Body(
     targetInfo.location,
   );
   const header = ir1SsaOpenLoopHeader(targetInfo.location, preheaderVersion);
+  const exitExprs = [
+    ...loopExits.breaks.map((exit) => exit.guard),
+    ...loopExits.continues.map((exit) => exit.guard),
+    ...loopExits.returns.flatMap((exit) =>
+      exit.expr === null ? [exit.guard] : [exit.guard, exit.expr],
+    ),
+    ...loopExits.throws.map((exit) => exit.guard),
+  ];
   const invariantNames = collectLoopInvariantNames(
-    [guardExpr, valueExpr],
+    [guardExpr, valueExpr, ...exitExprs],
     writeBody.target,
   );
   const stateName = allocateFreshStateName(
@@ -186,10 +201,27 @@ export function lowerFixedPointLoopL1Body(
     headerJoins: [header],
     writes: [write],
     joins: [],
-    breakHandles: [],
-    continueHandles: [],
-    returnHandles: [],
-    throwHandles: [],
+    breakHandles: loopExits.breaks.map(() => ({
+      kind: "ssa-break-handle",
+      location: targetInfo.location,
+      version: write.version,
+    })),
+    continueHandles: loopExits.continues.map(() => ({
+      kind: "ssa-continue-handle",
+      location: targetInfo.location,
+      version: write.version,
+    })),
+    returnHandles: loopExits.returns.map(() => ({
+      kind: "ssa-return-handle",
+      location: targetInfo.location,
+      version: write.version,
+    })),
+    throwHandles: loopExits.throws.map((exit) => ({
+      kind: "ssa-throw-handle",
+      location: targetInfo.location,
+      version: write.version,
+      guard: exit.guard,
+    })),
     terminationMetric: null,
   });
 
@@ -218,14 +250,53 @@ export function lowerFixedPointLoopL1Body(
       ),
     ),
   );
-  const helperCallOnEffect = ast.app(ast.var(ruleName), [
-    effect,
+  const lowerExitGuard = (guard: IR1Expr): OpaqueExpr =>
+    lowerOpaque(
+      lowerExpr(
+        lowerL1Expr(
+          substituteIR1ExprSubtree(guard, writeBody.target, stateVar),
+        ),
+      ),
+    );
+  const orOpaque = (guards: OpaqueExpr[]): OpaqueExpr | null =>
+    guards.length === 0
+      ? null
+      : guards.reduce((lhs, rhs) => ast.binop(ast.opOr(), lhs, rhs));
+  const andOpaque = (lhs: OpaqueExpr, rhs: OpaqueExpr): OpaqueExpr =>
+    ast.binop(ast.opAnd(), lhs, rhs);
+  const continueGuard = orOpaque(
+    loopExits.continues.map((exit) => lowerExitGuard(exit.guard)),
+  );
+  const loopBack =
+    continueGuard === null
+      ? effect
+      : ast.cond([
+          [continueGuard, ast.var(stateName)],
+          [ast.litBool(true), effect],
+        ]);
+  const helperCallOnLoopBack = ast.app(ast.var(ruleName), [
+    loopBack,
     ...invariantNames.map((name) => ast.var(name)),
   ]);
-  const helperBody = ast.cond([
-    [loweredGuard, helperCallOnEffect],
-    [ast.litBool(true), ast.var(stateName)],
-  ]);
+  const guardedLoopCondition = loopExits.throws
+    .map((exit) => ast.unop(ast.opNot(), lowerExitGuard(exit.guard)))
+    .reduce((acc, guard) => andOpaque(acc, guard), loweredGuard);
+  const helperArms: [OpaqueExpr, OpaqueExpr][] = [];
+  for (const exit of loopExits.breaks) {
+    helperArms.push([
+      andOpaque(guardedLoopCondition, lowerExitGuard(exit.guard)),
+      effect,
+    ]);
+  }
+  for (const exit of loopExits.returns) {
+    helperArms.push([
+      andOpaque(guardedLoopCondition, lowerExitGuard(exit.guard)),
+      effect,
+    ]);
+  }
+  helperArms.push([guardedLoopCondition, helperCallOnLoopBack]);
+  helperArms.push([ast.litBool(true), ast.var(stateName)]);
+  const helperBody = ast.cond(helperArms);
   const ruleDecl: PropResult = {
     kind: "rule-decl",
     ruleName,
@@ -266,6 +337,23 @@ export function lowerFixedPointLoopL1Body(
     programs: [program],
     propositions: [ruleDecl, callerEquation],
     modifiedRules,
+    ...(options.returnRuleName === undefined ||
+    !loopExits.returns.some((exit) => exit.expr !== null)
+      ? {}
+      : {
+          returnValue: {
+            ruleName: options.returnRuleName,
+            expression: ast.cond([
+              ...loopExits.returns
+                .filter((exit) => exit.expr !== null)
+                .map((exit): [OpaqueExpr, OpaqueExpr] => [
+                  lowerOpaque(lowerExpr(lowerL1Expr(exit.guard))),
+                  lowerOpaque(lowerExpr(lowerL1Expr(exit.expr!))),
+                ]),
+              [ast.litBool(true), callerEquation.rhs],
+            ]),
+          },
+        }),
     finalProperties: [
       {
         location: targetInfo.location,
@@ -276,6 +364,95 @@ export function lowerFixedPointLoopL1Body(
       },
     ],
   });
+}
+
+interface LoopExitInfo {
+  breaks: Array<{ guard: IR1Expr }>;
+  continues: Array<{ guard: IR1Expr }>;
+  returns: Array<{ guard: IR1Expr; expr: IR1Expr | null }>;
+  throws: Array<{ guard: IR1Expr }>;
+}
+
+function collectLoopExits(stmt: IR1Stmt): LoopExitInfo {
+  const exits: LoopExitInfo = {
+    breaks: [],
+    continues: [],
+    returns: [],
+    throws: [],
+  };
+  const trueExpr: IR1Expr = {
+    kind: "lit",
+    value: { kind: "bool", value: true },
+  };
+  const combineGuard = (outer: IR1Expr, inner: IR1Expr): IR1Expr =>
+    isTrueExpr(outer)
+      ? inner
+      : isTrueExpr(inner)
+        ? outer
+        : {
+            kind: "binop",
+            op: "and",
+            lhs: outer,
+            rhs: inner,
+          };
+  const visit = (node: IR1Stmt, guard: IR1Expr): void => {
+    switch (node.kind) {
+      case "block":
+        for (const child of node.stmts) {
+          visit(child, guard);
+        }
+        return;
+      case "cond-stmt":
+        for (const [armGuard, body] of node.arms) {
+          visit(body, combineGuard(guard, armGuard));
+        }
+        if (node.otherwise !== null) {
+          visit(node.otherwise, guard);
+        }
+        return;
+      case "break":
+        exits.breaks.push({ guard });
+        return;
+      case "continue":
+        exits.continues.push({ guard });
+        return;
+      case "return":
+        exits.returns.push({ guard, expr: node.expr });
+        return;
+      case "throw":
+        exits.throws.push({ guard });
+        return;
+      case "while":
+      case "for":
+      case "foreach":
+        return;
+      case "let":
+      case "assign":
+      case "expr-stmt":
+      case "map-effect":
+      case "set-effect":
+        return;
+      default: {
+        const _exhaustive: never = node;
+        void _exhaustive;
+      }
+    }
+  };
+  visit(stmt, trueExpr);
+  return exits;
+}
+
+function hasReachableBreakOrReturn(stmt: IR1Stmt): boolean {
+  const exits = collectLoopExits(stmt);
+  return exits.breaks.length > 0 || exits.returns.length > 0;
+}
+
+function isTrueExpr(expr: IR1Expr): boolean {
+  return (
+    expr.kind === "lit" &&
+    expr.value.kind === "bool" &&
+    expr.value.value === true
+  );
 }
 
 function buildTargetInfo(
@@ -434,6 +611,8 @@ function walkStmt(stmt: IR1Stmt, visit: (stmt: IR1Stmt) => void): void {
     case "assign":
     case "foreach":
     case "return":
+    case "break":
+    case "continue":
     case "throw":
     case "expr-stmt":
     case "map-effect":

--- a/tools/ts2pant/src/ir1-ssa-lower.ts
+++ b/tools/ts2pant/src/ir1-ssa-lower.ts
@@ -166,16 +166,18 @@ export function appendFramesForUnmodifiedRules(
         ? returnDecl.params
         : actionDecl?.kind === "action"
           ? actionDecl.params
-          : [];
-    extraEquations.push({
-      kind: "equation",
-      quantifiers: [] as OpaqueParam[],
-      lhs: ast.app(
-        ast.primed(result.returnValue.ruleName),
-        params.map((p) => ast.var(p.name)),
-      ),
-      rhs: result.returnValue.expression,
-    });
+          : null;
+    if (params !== null) {
+      extraEquations.push({
+        kind: "equation",
+        quantifiers: [] as OpaqueParam[],
+        lhs: ast.app(
+          ast.primed(result.returnValue.ruleName),
+          params.map((p) => ast.var(p.name)),
+        ),
+        rhs: result.returnValue.expression,
+      });
+    }
   }
 
   for (const decl of declarations) {

--- a/tools/ts2pant/src/ir1-ssa-scalars.ts
+++ b/tools/ts2pant/src/ir1-ssa-scalars.ts
@@ -321,6 +321,8 @@ export function isScalarSsaL1Body(stmt: IR1Stmt): boolean {
     case "for":
     case "while":
     case "return":
+    case "break":
+    case "continue":
     case "throw":
     case "let":
     case "expr-stmt":
@@ -355,6 +357,8 @@ export function lowerScalarSsaL1Body(
     case "for":
     case "while":
     case "return":
+    case "break":
+    case "continue":
     case "throw":
     case "let":
     case "expr-stmt":
@@ -508,6 +512,8 @@ function lowerScalarSsaStmtToVersions(
     case "for":
     case "while":
     case "return":
+    case "break":
+    case "continue":
     case "throw":
     case "let":
     case "expr-stmt":

--- a/tools/ts2pant/src/ir1-substitute.ts
+++ b/tools/ts2pant/src/ir1-substitute.ts
@@ -272,6 +272,9 @@ function freeVarsStmtWithScope(stmt: IR1Stmt, bound: Set<string>): Set<string> {
       return stmt.expr === null
         ? new Set()
         : without(freeVarsIR1Expr(stmt.expr), bound);
+    case "break":
+    case "continue":
+      return new Set();
     case "throw":
       return without(freeVarsIR1Expr(stmt.expr), bound);
     case "expr-stmt":
@@ -760,6 +763,9 @@ function substituteStmt(
               scopedBinders,
             ),
       );
+    case "break":
+    case "continue":
+      return stmt;
     case "throw":
       return ir1Throw(
         substituteExprRespectingScope(

--- a/tools/ts2pant/src/ir1.ts
+++ b/tools/ts2pant/src/ir1.ts
@@ -301,6 +301,10 @@ export type IR1Stmt =
   | { kind: "while"; cond: IR1Expr; body: IR1Stmt }
   /** Return statement. Optional expression for void-returning bodies. */
   | { kind: "return"; expr: IR1Expr | null }
+  /** Unlabelled loop break. Labeled forms reject in the TS build pass. */
+  | { kind: "break" }
+  /** Unlabelled loop continue. Labeled forms reject in the TS build pass. */
+  | { kind: "continue" }
   /**
    * Throw statement. Used as guard pattern (if-throw assertions).
    * Introduced in M3.
@@ -1348,6 +1352,10 @@ export const ir1Return = (expr: IR1Expr | null): IR1Stmt => ({
   kind: "return",
   expr,
 });
+
+export const ir1Break = (): IR1Stmt => ({ kind: "break" });
+
+export const ir1Continue = (): IR1Stmt => ({ kind: "continue" });
 
 // --------------------------------------------------------------------------
 // Statement constructors for forms beyond M1's active set.

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -7,10 +7,13 @@ import {
   type IR1Stmt,
   ir1Binop,
   ir1Block,
+  ir1Break,
+  ir1Continue,
   ir1For,
   ir1Let,
   ir1LitNat,
   ir1Return,
+  ir1Throw,
   ir1Var,
   ir1While,
 } from "./ir1.js";
@@ -4346,6 +4349,7 @@ function lowerSupportedSsaMutatingBlock(
     initialPropertyValues: ctx.initialPropertyValues,
     strategy: ctx.strategy,
     declarations: ctx.declarations,
+    returnRuleName: ctx.helperNameBase,
     ...(ctx.supply.synthCell === undefined
       ? {}
       : { synthCell: ctx.supply.synthCell }),
@@ -4412,7 +4416,7 @@ function buildSupportedSsaMutatingBody(
   setCanonicalize(state, applyConst);
   for (let i = 0; i < body.statements.length; i++) {
     const stmt = body.statements[i]!;
-    if (isGuardStatement(stmt, checker)) {
+    if (isGuardStatement(stmt, checker) && !isInsideLoopBody(stmt)) {
       continue;
     }
     if (
@@ -4559,6 +4563,12 @@ function buildSupportedSsaStatement(
         "labeled loop early-exit is M7 future work; remove the label or restructure",
     };
   }
+  if (ts.isBreakStatement(stmt)) {
+    return ir1Break();
+  }
+  if (ts.isContinueStatement(stmt)) {
+    return ir1Continue();
+  }
   if (ts.isLabeledStatement(stmt)) {
     return buildSupportedSsaStatement(stmt.statement, ctx);
   }
@@ -4585,6 +4595,13 @@ function buildSupportedSsaStatement(
       return expr;
     }
     return ir1Return(expr);
+  }
+  if (ts.isThrowStatement(stmt)) {
+    const expr = buildL1SubExpr(stmt.expression, ctx);
+    if (isUnsupported(expr)) {
+      return expr;
+    }
+    return ir1Throw(expr);
   }
   if (ts.isForOfStatement(stmt)) {
     return buildL1ForOfMutation(stmt, ctx);
@@ -4628,7 +4645,10 @@ function buildL1BareWhileMutation(
   ctx: BuildBodyCtx & { paramNames: Map<string, string> },
 ): IR1Stmt | { unsupported: string } {
   const expr = unwrapExpression(stmt.expression);
-  if (expr.kind === ts.SyntaxKind.TrueKeyword) {
+  if (
+    expr.kind === ts.SyntaxKind.TrueKeyword &&
+    !containsReachableLoopExit(stmt.statement)
+  ) {
     return {
       unsupported:
         "while loop has no observable termination condition (literal-true guard); rewrite with a guard that depends on mutated state",
@@ -4745,7 +4765,10 @@ function buildL1LetWhileFixedPointMutation(
     return initExpr;
   }
   const expr = unwrapExpression(whileStmt.expression);
-  if (expr.kind === ts.SyntaxKind.TrueKeyword) {
+  if (
+    expr.kind === ts.SyntaxKind.TrueKeyword &&
+    !containsReachableLoopExit(whileStmt.statement)
+  ) {
     return {
       unsupported:
         "while loop has no observable termination condition (literal-true guard); rewrite with a guard that depends on mutated state",
@@ -4767,6 +4790,31 @@ function buildL1LetWhileFixedPointMutation(
     return bodyStmt;
   }
   return ir1Block([ir1Let(decl.name.text, initExpr), ir1While(cond, bodyStmt)]);
+}
+
+function containsReachableLoopExit(stmt: ts.Statement): boolean {
+  let found = false;
+  function visit(node: ts.Node): void {
+    if (found) {
+      return;
+    }
+    if (node !== stmt && (ts.isFunctionLike(node) || ts.isClassLike(node))) {
+      return;
+    }
+    if (
+      node !== stmt &&
+      (ts.isForStatement(node) || ts.isWhileStatement(node))
+    ) {
+      return;
+    }
+    if (ts.isBreakStatement(node) || ts.isReturnStatement(node)) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  }
+  visit(stmt);
+  return found;
 }
 
 function buildL1LetWhileMutation(

--- a/tools/ts2pant/tests/ir1-ssa-fixed-point.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-fixed-point.test.mts
@@ -363,26 +363,174 @@ describe("ir1-ssa-fixed-point", () => {
   });
 
   describe("handle-list consumption", () => {
-    it.skip("break-handle merge produces post-loop cond per location", () => {
-      // PENDING Patch 5.
+    it("break-handle merge produces post-loop cond per location", () => {
+      const ast = getAst();
+      const result = lowerFixedPointLoopL1Body({
+        ...fixedPointWhile(),
+        body: {
+          kind: "block",
+          stmts: [
+            fixedPointWhile().body,
+            {
+              kind: "cond-stmt",
+              arms: [
+                [
+                  {
+                    kind: "binop",
+                    op: "ge",
+                    lhs: balanceMember,
+                    rhs: targetVar,
+                  },
+                  { kind: "break" },
+                ],
+              ],
+              otherwise: null,
+            },
+          ],
+        },
+      });
+
+      assert.deepEqual(result.diagnostics, []);
+      assert.equal(result.programs[0]!.loopBodies[0]!.breakHandles.length, 1);
+      const ruleDecl = result.propositions[0]!;
+      assert.equal(ruleDecl.kind, "rule-decl");
+      assert.match(ast.strExpr(ruleDecl.body), /cond .* >= target =>/u);
     });
 
-    it.skip("continue-handle threads into header phi loop-back input", () => {
-      // PENDING Patch 5.
+    it("continue-handle threads into header phi loop-back input", () => {
+      const ast = getAst();
+      const result = lowerFixedPointLoopL1Body({
+        ...fixedPointWhile(),
+        body: {
+          kind: "block",
+          stmts: [
+            {
+              kind: "cond-stmt",
+              arms: [
+                [
+                  {
+                    kind: "binop",
+                    op: "eq",
+                    lhs: stepVar,
+                    rhs: { kind: "lit", value: { kind: "nat", value: 0 } },
+                  },
+                  { kind: "continue" },
+                ],
+              ],
+              otherwise: null,
+            },
+            fixedPointWhile().body,
+          ],
+        },
+      });
+
+      assert.deepEqual(result.diagnostics, []);
+      assert.equal(
+        result.programs[0]!.loopBodies[0]!.continueHandles.length,
+        1,
+      );
+      const ruleDecl = result.propositions[0]!;
+      assert.equal(ruleDecl.kind, "rule-decl");
+      assert.match(ast.strExpr(ruleDecl.body), /cond step = 0 => s/u);
     });
 
-    it.skip("return-handle produces function-level return-value cond", () => {
-      // PENDING Patch 5.
+    it("return-handle produces function-level return-value cond", () => {
+      const ast = getAst();
+      const result = lowerFixedPointLoopL1Body(
+        {
+          ...fixedPointWhile(),
+          body: {
+            kind: "block",
+            stmts: [
+              fixedPointWhile().body,
+              {
+                kind: "cond-stmt",
+                arms: [
+                  [
+                    {
+                      kind: "binop",
+                      op: "ge",
+                      lhs: balanceMember,
+                      rhs: targetVar,
+                    },
+                    { kind: "return", expr: balanceMember },
+                  ],
+                ],
+                otherwise: null,
+              },
+            ],
+          },
+        },
+        { returnRuleName: "update" },
+      );
+
+      assert.deepEqual(result.diagnostics, []);
+      assert.equal(result.programs[0]!.loopBodies[0]!.returnHandles.length, 1);
+      assert.equal(result.returnValue?.ruleName, "update");
+      assert.match(
+        ast.strExpr(result.returnValue!.expression),
+        /cond balance a >= target => balance a/u,
+      );
     });
 
-    it.skip("throw-handle conjoins precondition with recursive-rule guard", () => {
-      // PENDING Patch 5.
+    it("throw-handle conjoins precondition with recursive-rule guard", () => {
+      const ast = getAst();
+      const result = lowerFixedPointLoopL1Body({
+        ...fixedPointWhile(),
+        body: {
+          kind: "block",
+          stmts: [
+            {
+              kind: "cond-stmt",
+              arms: [
+                [
+                  {
+                    kind: "binop",
+                    op: "eq",
+                    lhs: stepVar,
+                    rhs: { kind: "lit", value: { kind: "nat", value: 0 } },
+                  },
+                  {
+                    kind: "throw",
+                    expr: {
+                      kind: "lit",
+                      value: { kind: "string", value: "bad" },
+                    },
+                  },
+                ],
+              ],
+              otherwise: null,
+            },
+            fixedPointWhile().body,
+          ],
+        },
+      });
+
+      assert.deepEqual(result.diagnostics, []);
+      assert.equal(result.programs[0]!.loopBodies[0]!.throwHandles.length, 1);
+      const ruleDecl = result.propositions[0]!;
+      assert.equal(ruleDecl.kind, "rule-decl");
+      assert.match(ast.strExpr(ruleDecl.body), /~\(step = 0\)/u);
     });
   });
 
   describe("literal-true rejection", () => {
-    it.skip("narrows to while(true) with no reachable break/return", () => {
-      // PENDING Patch 5.
+    it("narrows to while(true) with no reachable break/return", () => {
+      const rejected = recognizeFixedPointLoopShape({
+        ...fixedPointWhile(),
+        cond: { kind: "lit", value: { kind: "bool", value: true } },
+      });
+      assert.ok("unsupported" in rejected);
+
+      const accepted = recognizeFixedPointLoopShape({
+        ...fixedPointWhile(),
+        cond: { kind: "lit", value: { kind: "bool", value: true } },
+        body: {
+          kind: "block",
+          stmts: [fixedPointWhile().body, { kind: "break" }],
+        },
+      });
+      assert.ok(!("unsupported" in accepted));
     });
   });
 });

--- a/tools/ts2pant/tests/loop-break-continue.test.mts
+++ b/tools/ts2pant/tests/loop-break-continue.test.mts
@@ -5,40 +5,131 @@ import { createSourceFileFromSource } from "../src/extract.js";
 import { buildDocumentFromSourceFile, emitAndCheck } from "./helpers.mjs";
 
 describe("loop-break-continue", () => {
-  it.skip("counter loop with break translates and bumps to fixed-point", () => {
-    // PENDING Patches 5 and 6.
+  async function translate(source: string): Promise<string> {
+    const sourceFile = createSourceFileFromSource(source);
+    return emitAndCheck(
+      await buildDocumentFromSourceFile(sourceFile, "update"),
+    );
+  }
+
+  it("counter loop with break translates and bumps to fixed-point", async () => {
+    const output = await translate(`
+      interface Account { balance: number; }
+      function update(a: Account, n: number): void {
+        for (let i = 0; i < n; i++) {
+          a.balance = a.balance + 1;
+          if (a.balance >= n) break;
+        }
+      }
+    `);
+    assert.doesNotMatch(output, /UNSUPPORTED/u);
   });
 
-  it.skip("counter loop with continue translates and stays bounded-quantified", () => {
-    // PENDING Patches 5 and 6.
+  it("counter loop with continue translates and stays bounded-quantified", async () => {
+    const output = await translate(`
+      interface Account { balance: number; }
+      function update(a: Account, n: number): void {
+        for (let i = 0; i < n; i++) {
+          if (i === 0) continue;
+          a.balance = i;
+        }
+      }
+    `);
+    assert.doesNotMatch(output, /UNSUPPORTED/u);
+    assert.doesNotMatch(output, /fn--loop/u);
   });
 
-  it.skip("bounded-while with break translates and bumps to fixed-point", () => {
-    // PENDING Patches 5 and 6.
+  it("bounded-while with break translates and bumps to fixed-point", async () => {
+    const output = await translate(`
+      interface Account { balance: number; }
+      function update(a: Account, n: number): void {
+        let i = 0;
+        while (i < n) {
+          a.balance = a.balance + 1;
+          if (a.balance >= n) break;
+          i++;
+        }
+      }
+    `);
+    assert.doesNotMatch(output, /UNSUPPORTED/u);
   });
 
-  it.skip("fixed-point while with break translates", () => {
-    // PENDING Patches 5 and 6.
+  it("fixed-point while with break translates", async () => {
+    const output = await translate(`
+      interface Account { balance: number; }
+      function update(a: Account, n: number): void {
+        while (a.balance < n) {
+          a.balance = a.balance + 1;
+          if (a.balance >= n) break;
+        }
+      }
+    `);
+    assert.match(output, /fn--loop/u);
   });
 
-  it.skip("fixed-point while with continue translates", () => {
-    // PENDING Patches 5 and 6.
+  it("fixed-point while with continue translates", async () => {
+    const output = await translate(`
+      interface Account { balance: number; }
+      function update(a: Account, n: number): void {
+        while (a.balance < n) {
+          if (n === 0) continue;
+          a.balance = a.balance + 1;
+        }
+      }
+    `);
+    assert.doesNotMatch(output, /UNSUPPORTED/u);
   });
 
-  it.skip("fixed-point while with bare return translates", () => {
-    // PENDING Patches 5 and 6.
+  it("fixed-point while with bare return translates", async () => {
+    const output = await translate(`
+      interface Account { balance: number; }
+      function update(a: Account, n: number): void {
+        while (a.balance < n) {
+          a.balance = a.balance + 1;
+          if (a.balance >= n) return;
+        }
+      }
+    `);
+    assert.doesNotMatch(output, /UNSUPPORTED/u);
   });
 
-  it.skip("fixed-point while with return value translates and emits return-value equation", () => {
-    // PENDING Patches 5 and 6.
+  it("fixed-point while with return value translates and emits return-value equation", async () => {
+    const output = await translate(`
+      interface Account { balance: number; }
+      function update(a: Account, n: number): number {
+        while (a.balance < n) {
+          a.balance = a.balance + 1;
+          if (a.balance >= n) return a.balance;
+        }
+      }
+    `);
+    assert.match(output, /update'/u);
   });
 
-  it.skip("fixed-point while with throw translates and emits iteration precondition", () => {
-    // PENDING Patches 5 and 6.
+  it("fixed-point while with throw translates and emits iteration precondition", async () => {
+    const output = await translate(`
+      interface Account { balance: number; }
+      function update(a: Account, n: number): void {
+        while (a.balance < n) {
+          if (n === 0) throw "bad";
+          a.balance = a.balance + 1;
+        }
+      }
+    `);
+    assert.match(output, /~\(n = 0\)/u);
   });
 
-  it.skip("while(true)+break translates (event-loop idiom)", () => {
-    // PENDING Patches 5 and 6.
+  it("while(true)+break translates (event-loop idiom)", async () => {
+    const output = await translate(`
+      interface Account { balance: number; }
+      function update(a: Account, n: number): void {
+        while (true) {
+          a.balance = a.balance + 1;
+          if (a.balance >= n) break;
+        }
+      }
+    `);
+    assert.doesNotMatch(output, /literal-true guard/u);
   });
 
   it("labeled break rejects with M7 diagnostic", async () => {


### PR DESCRIPTION
## Patch 5: L4 fixed-point lowering consumes handle lists; while(true) rejection narrows

- In `ir1-ssa-fixed-point.ts`, around line 99, narrow the literal-true rejection: continue to reject only when the loop body has no `breakHandles` and no `returnHandles`. When either is present, the post-loop `cond` synthesised from those handles supplies the observable termination condition.
- Synthesise the post-loop `cond` from `breakHandles`: for each mutated location, emit `cond <break_guard_1> => <break_snapshot_1>, <break_guard_2> => <break_snapshot_2>, ..., true => <loop_exit_snapshot>`. The `break_guard_i` is the conjunction of the if-arm guards reaching that break site.
- Reroute `continueHandles` into the header phi loop-back input: instead of the body-end version as the loop-back input, use a `cond` that branches between the continue-site's captured version and the body-end version based on whether continue was reached.
- Synthesise the function-level return-value `cond` from `returnHandles`: when return-handles exist, populate `IR1SsaLowerOutput.returnValue` (from Patch 2) with a `cond` whose arms are the per-return-site value expressions, falling through to the function's natural post-loop output as default. When the loop is the function's terminal expression, the default arm is the post-loop state; when the loop is mid-function, downstream statements continue to compose with the return-cond as their input.
- Synthesise the precondition from `throwHandles`: each throw handle's `guard` expression is conjoined as a negative precondition (`¬throw_cond(s)`) with the recursive rule's existing guard. The throw guards also surface in the function's precondition contract so callers see them.
- In `ir1-ssa-counter-loop.ts`, consume `continueHandles`: rewrite the quantified-equation projection as `cond should_continue(i) => accumulator(i-1), true => F(i)` where the comprehension's accumulator preserves the previous iteration's value when continue is reached. Counter loops with continue (but no break/return) stay quantified; counter loops with break/return don't reach this file (bumped to fixed-point by Patch 4).
- Unskip the Patch-5 stubs in `ir1-ssa-fixed-point.test.mts` and the end-to-end stubs in `loop-break-continue.test.mts` with concrete assertions (assertions check IR1 shape and OpaqueExpr structure; full Pant verification waits for Patch 6's fixtures).
- Run `just ts2pant-test` and `just ts2pant-test-integration`; confirm zero regressions on prior-shipping snapshots.

## Changes
- In `ir1-ssa-fixed-point.ts`, around line 99, narrow the literal-true rejection: continue to reject only when the loop body has no `breakHandles` and no `returnHandles`. When either is present, the post-loop `cond` synthesised from those handles supplies the observable termination condition.
- Synthesise the post-loop `cond` from `breakHandles`: for each mutated location, emit `cond <break_guard_1> => <break_snapshot_1>, <break_guard_2> => <break_snapshot_2>, ..., true => <loop_exit_snapshot>`. The `break_guard_i` is the conjunction of the if-arm guards reaching that break site.
- Reroute `continueHandles` into the header phi loop-back input: instead of the body-end version as the loop-back input, use a `cond` that branches between the continue-site's captured version and the body-end version based on whether continue was reached.
- Synthesise the function-level return-value `cond` from `returnHandles`: when return-handles exist, populate `IR1SsaLowerOutput.returnValue` (from Patch 2) with a `cond` whose arms are the per-return-site value expressions, falling through to the function's natural post-loop output as default. When the loop is the function's terminal expression, the default arm is the post-loop state; when the loop is mid-function, downstream statements continue to compose with the return-cond as their input.
- Synthesise the precondition from `throwHandles`: each throw handle's `guard` expression is conjoined as a negative precondition (`¬throw_cond(s)`) with the recursive rule's existing guard. The throw guards also surface in the function's precondition contract so callers see them.
- In `ir1-ssa-counter-loop.ts`, consume `continueHandles`: rewrite the quantified-equation projection as `cond should_continue(i) => accumulator(i-1), true => F(i)` where the comprehension's accumulator preserves the previous iteration's value when continue is reached. Counter loops with continue (but no break/return) stay quantified; counter loops with break/return don't reach this file (bumped to fixed-point by Patch 4).
- Unskip the Patch-5 stubs in `ir1-ssa-fixed-point.test.mts` and the end-to-end stubs in `loop-break-continue.test.mts` with concrete assertions (assertions check IR1 shape and OpaqueExpr structure; full Pant verification waits for Patch 6's fixtures).
- Run `just ts2pant-test` and `just ts2pant-test-integration`; confirm zero regressions on prior-shipping snapshots.

## Files to Modify
- tools/ts2pant/src/ir1-ssa-fixed-point.ts (modify): Narrow the literal-true rejection at line 99 to 'while(true) with no reachable break/return handle'. Consume `breakHandles`, `continueHandles`, `returnHandles`, `throwHandles` from the loop body into the recursive-rule emission.
- tools/ts2pant/src/ir1-ssa-counter-loop.ts (modify): Consume `continueHandles` in the quantified-equation projection: when continue handles are present, the projection becomes `cond should_continue(i) => prev_accumulator, true => F(i)` (continue threads into the comprehension's projection as a guarded short-circuit).
- tools/ts2pant/tests/ir1-ssa-fixed-point.test.mts (modify): Unskip Patch-5-owned stubs.
- tools/ts2pant/tests/loop-break-continue.test.mts (modify): Unskip Patch-5-owned end-to-end stubs.

## Gameplan Specification

```
module TS2PANT_LOOP_BREAK_CONTINUE.

> ════════════════════════════════
> M5 of ts2pant General-Loop SSA: loop early-exit lowering.
> ════════════════════════════════
> After this gameplan, IR1 SSA loop bodies admit break,
> continue, return (bare and with value), and throw via
> the L1 handle vocabulary. L4 fixed-point lowering consumes
> all four handle lists: break -> post-loop cond; continue ->
> header phi loop-back input; return -> function-level
> return-value cond (using the new mutating-body return-value
> contract); throw -> iteration-precondition. Bounded loops
> with break/return bump to fixed-point; bounded loops with
> only continue stay quantified. The while(true)+break event-
> loop idiom translates. Labeled break/continue rejects with
> M7 future-work diagnostic. M6 (loop-summary-unification)
> can now target the complete general-loop machinery.

Handle.
HandleKind.
LoweringTarget.
LoopShape.
LoweringRoute.
break => HandleKind.
continue => HandleKind.
return-bare => HandleKind.
return-value => HandleKind.
throw => HandleKind.
post-loop-cond => LoweringTarget.
header-phi-loop-back => LoweringTarget.
function-return-value-cond => LoweringTarget.
iteration-precondition => LoweringTarget.
counter => LoopShape.
bounded-while => LoopShape.
fixed-point => LoopShape.
while-true-with-break => LoopShape.
quantified-route => LoweringRoute.
fixed-point-route => LoweringRoute.

kind h: Handle => HandleKind.
target-of h: Handle => LoweringTarget.
route-for shape: LoopShape, hk: HandleKind => LoweringRoute.
labeled-rejected? => Bool.
while-true-rejects-only-when-no-break-or-return? => Bool.
m6-unblocked? => Bool.
---

> Handle-to-target mapping.
all h: Handle | target-of h = post-loop-cond <-> kind h = break.
all h: Handle | target-of h = header-phi-loop-back <-> kind h = continue.
all h: Handle, kind h = return-bare | target-of h = function-return-value-cond.
all h: Handle, kind h = return-value | target-of h = function-return-value-cond.
all h: Handle | target-of h = iteration-precondition <-> kind h = throw.

> Bump-to-fixed-point routing: break/return shapes go fixed-point on bounded loops.
route-for counter break = fixed-point-route.
route-for counter return-bare = fixed-point-route.
route-for counter return-value = fixed-point-route.
route-for bounded-while break = fixed-point-route.
route-for bounded-while return-bare = fixed-point-route.
route-for bounded-while return-value = fixed-point-route.

> Continue stays quantified on bounded loops.
route-for counter continue = quantified-route.
route-for bounded-while continue = quantified-route.

> Labeled forms.
labeled-rejected?.

> while(true) narrowing.
while-true-rejects-only-when-no-break-or-return?.

> Workstream gate.
m6-unblocked?.
```

## Patch Specification

```
module TS2PANT_LOOP_BREAK_CONTINUE_PATCH_5.

> Patch 5 lands the L4 handle-list consumption.
> Break -> post-loop cond. Continue -> header phi
> loop-back. Return -> function-level return-value cond.
> Throw -> iteration precondition. while(true) rejection
> narrows.

Handle.
LoweringTarget.
HandleList.
break-handle => Handle.
continue-handle => Handle.
return-handle => Handle.
throw-handle => Handle.
post-loop-cond => LoweringTarget.
header-phi-loop-back => LoweringTarget.
function-return-value-cond => LoweringTarget.
iteration-precondition => LoweringTarget.

target-of h: Handle => LoweringTarget.
handle-list-non-empty? hl: HandleList => Bool.
while-true-rejects? hl: HandleList => Bool.
lowering-defined? h: Handle => Bool.
---
target-of break-handle = post-loop-cond.
target-of continue-handle = header-phi-loop-back.
target-of return-handle = function-return-value-cond.
target-of throw-handle = iteration-precondition.

all hl: HandleList |
  while-true-rejects? hl <-> ~handle-list-non-empty? hl.

all h: Handle | lowering-defined? h.
```


## Implementation Notes

- The dependency branch had the SSA handle vocabulary but did not yet have L1 `break` / `continue` statement nodes, so this patch adds the minimal unlabelled L1 statement forms and keeps scalar/collection SSA paths rejecting them outside loop-specific lowering.
- Fixed-point lowering derives handle-site guards structurally from `cond-stmt` nesting (`collectLoopExits`) and emits the recursive helper body directly from those guards. The current implementation supports the simple single-mutated-property fixed-point shape already owned by L4; nested loops are intentionally treated as separate regions when collecting exits.
- Counter loops with break/return are rerouted by desugaring the `for` shape into the existing fixed-point while lowering path. Counter loops with only continue stay in `ir1-ssa-counter-loop.ts`; accumulator folds add `~continue_guard` to the comprehension guards, and simple assignments preserve the prior value under the continue guard.
- Return-value emission needs the function/action signature to build the primed return equation. The inner no-declaration lower pass now leaves unresolved `returnValue` emissions untouched; the outer declaration-aware frame pass emits the actual equation. This avoids duplicate or arity-zero return equations while preserving existing frame behavior.
- Throw-in-loop support required preserving loop-internal `if (...) throw ...` guards instead of stripping them as top-level preconditions. Effectful throw expressions still keep the previous public rejection behavior.

Spec/Evidence Mapping:
- `break -> post-loop-cond`, `continue -> header-phi-loop-back`, `return -> function-return-value-cond`, `throw -> iteration-precondition`: implemented in `tools/ts2pant/src/ir1-ssa-fixed-point.ts` and covered by `tools/ts2pant/tests/ir1-ssa-fixed-point.test.mts` handle-list consumption tests.
- Bounded break/return routes to fixed-point; continue stays quantified: implemented in `tools/ts2pant/src/ir1-lower-body.ts` and `tools/ts2pant/src/ir1-ssa-counter-loop.ts`; covered by `tools/ts2pant/tests/loop-break-continue.test.mts` counter/bounded cases.
- `while(true)+break` translates while plain `while(true)` still rejects: implemented in `recognizeFixedPointLoopShape` and TS loop build narrowing; covered by fixed-point and end-to-end loop tests.
- Verification run locally: `just ts2pant-test`, `just ts2pant-test-integration`, `just ts2pant-lint-ci`, and `just ts2pant-typecheck`.