### PR TITLE
[ts2pant-loop-break-continue] Patch 6: Fixtures + documentation updates

### DIFF
--- a/tools/ts2pant/AGENTS.md
+++ b/tools/ts2pant/AGENTS.md
@@ -258,9 +258,38 @@ Read that file before extending the IR or touching SSA-bearing code:
   records what each milestone delivered and the locked decisions.
 - **General-loop SSA Workstream.** L1 (loop SSA contract), L2 (bounded
   counter `for` lowering), L3 (bounded `let`+`while` desugar covering
-  ascending and descending counters), and L4 (fixed-point unbounded `while`
-  lowering through recursive Pant helpers emitted as `define-fun-rec`) have
+  ascending and descending counters), L4 (fixed-point unbounded `while`
+  lowering through recursive Pant helpers emitted as `define-fun-rec`), and
+  L5 (loop early-exit lowering) have
   landed — see `workstreams/ts2pant-general-loop-ssa.md`.
+
+### General-loop SSA contract surface (L1)
+
+The L1 contract lives in `src/ir1.ts` and is documented in
+`docs/intermediate-representation.md` § "General-loop SSA contract surface
+(L1)". The exported loop SSA surface includes `IR1SsaLoopHeaderJoin`,
+`IR1SsaLoopBody`, `IR1SsaTerminationMetric`, `IR1SsaBreakHandle`,
+`IR1SsaContinueHandle`, `IR1SsaReturnHandle`, `IR1SsaThrowHandle`, and the
+constructor helpers `ir1SsaOpenLoopHeader`, `ir1SsaCloseLoopHeader`,
+`ir1SsaLoopBody`, `ir1SsaTerminationMetric`, `ir1SsaBreakHandle`,
+`ir1SsaContinueHandle`, `ir1SsaReturnHandle`, `ir1SsaThrowHandle`, and
+`ir1SsaReturnValueLocation`.
+
+`IR1SsaLoopBody` carries the loop-header joins, body writes, ordinary joins,
+`breakHandles`, `continueHandles`, `returnHandles`, `throwHandles`, and the
+optional `terminationMetric`. Non-null metrics route to bounded lowering;
+null metrics route to fixed-point lowering.
+
+### Loop early-exit lowering (L5)
+
+Loop-internal early exits use the L1 handle lists. `break` handles are
+consumed by the post-loop `cond`, `continue` handles feed the header phi
+loop-back input, `return` handles feed the function-level return-value
+`cond`, and `throw` handles become iteration-precondition guards conjoined
+with the recursive rule guard. Bounded loops containing `break` or `return`
+bump to fixed-point lowering; continue-only bounded loops stay on the L2/L3
+quantified route. Labeled `break` / `continue` is deferred to M7 and must
+reject with the explicit future-work diagnostic.
 
 ## PR #84 Post-Mortem: Why Standard Algorithms Matter
 

--- a/tools/ts2pant/docs/intermediate-representation.md
+++ b/tools/ts2pant/docs/intermediate-representation.md
@@ -260,11 +260,13 @@ vocabulary in `src/ir1.ts`. The new exported names are:
 
 - Types: `IR1SsaLoopHeaderJoin`, `IR1SsaLoopBody`,
   `IR1SsaTerminationMetric`, `IR1SsaBreakHandle`,
-  `IR1SsaContinueHandle`.
+  `IR1SsaContinueHandle`, `IR1SsaReturnHandle`,
+  `IR1SsaThrowHandle`.
 - Constructor helpers: `ir1SsaOpenLoopHeader`,
   `ir1SsaCloseLoopHeader`, `ir1SsaLoopBody`,
   `ir1SsaTerminationMetric`, `ir1SsaBreakHandle`,
-  `ir1SsaContinueHandle`.
+  `ir1SsaContinueHandle`, `ir1SsaReturnHandle`,
+  `ir1SsaThrowHandle`, `ir1SsaReturnValueLocation`.
 
 Loop-header joins use a Cytron-style two-pass protocol. Builders call
 `ir1SsaOpenLoopHeader` before emitting the loop body, producing a header
@@ -282,11 +284,15 @@ downstream lowering will produce recursive Pant rule definitions. This
 milestone defines the vocabulary only and does not implement either
 lowering path.
 
-Break and continue handles are version snapshots at early-exit sites.
-Later milestones will merge break snapshots at the post-loop join and
-continue snapshots into the next iteration's header. The handle
-constructors reuse the existing version object and validate that the
-snapshot version is location-compatible.
+Break, continue, return, and throw handles are version snapshots at
+early-exit sites. Break snapshots merge at the post-loop join, continue
+snapshots feed the next iteration's header, return snapshots feed the
+function return-value continuation, and throw snapshots become
+iteration-precondition guards. The handle constructors reuse the existing
+version object and validate that the snapshot version is
+location-compatible. Return values use a synthesized per-function
+`return-value` location so return handles keep the same per-location shape
+as break and continue handles.
 
 These helpers establish the contract surface for general-loop SSA and
 enforce structural choices like closed loop bodies, location-compatible
@@ -551,6 +557,49 @@ documented timeout rationale explaining why direct recursive-function solving
 is currently acceptable for that loop shape. A fixture timeout is a solver
 automation limitation, not permission to change the lowering to bounded
 unrolling in this milestone.
+
+## Loop early-exit semantics (L5)
+
+L5 consumes the L1 handle lists for loop-internal `break`, `continue`,
+`return` (bare and value), and `throw`. The lowering keeps the L4
+recursive-rule shape for fixed-point loops and the L2/L3 quantified shape
+for continue-only bounded loops; early exits are represented as
+continuation snapshots rather than reconstructed from source positions.
+
+Handle consumption is fixed by handle kind:
+
+- `break` snapshots synthesize a post-loop `cond` over the captured
+  location versions. For fixed-point loops, the recursive helper from
+  § "Fixed-point while loop lowering (L4)" returns the break snapshot when
+  the break guard fires; otherwise it follows the ordinary recursive step.
+- `continue` snapshots thread into the loop-header phi's loop-back input.
+  In the L2/L3 quantified route this is the "skip this iteration" case:
+  the projection uses the previous accumulator value under the continue
+  guard and the ordinary body value otherwise.
+- `return` snapshots feed a function-level return-value `cond`. Bare
+  returns carry only the function-exit guard; value returns also write the
+  synthesized `return-value` location before the function-level emission.
+- `throw` snapshots emit as iteration-precondition guards, conjoined with
+  the recursive rule's existing guard. This matches the existing TS
+  `if (bad) throw ...` precondition pattern outside loops; try/catch remains
+  out of scope.
+
+Routing is intentionally conservative. Any bounded counter or bounded while
+loop containing `break` or `return` bumps to the L4 fixed-point route so
+there is one termination-handling path. Continue-only bounded loops stay on
+the L2/L3 quantified route because "skip this iteration" composes with the
+existing over-each/fold shape. Throw is handled in the fixed-point route as
+an iteration precondition.
+
+The L4 literal-true rejection narrows accordingly: `while (true)` still
+rejects when the body has no reachable `break` or `return`, but the common
+event-loop shape `while (true) { ...; if (cond) break; }` now translates
+because the break guard is the observable termination condition.
+
+Labeled `break LABEL` and `continue LABEL` remain future work. They require
+a label table and target-resolution pass that the L5 handle lists do not
+need for unlabeled, innermost-loop exits, so the builder rejects labeled
+forms with the M7 diagnostic.
 
 ## Mutating-body output (no L2 IR)
 

--- a/tools/ts2pant/package.json
+++ b/tools/ts2pant/package.json
@@ -11,10 +11,10 @@
     "build:wasm": "node scripts/build-wasm.mjs",
     "build": "npm run build:wasm && tsc",
     "start": "node dist/index.js",
-    "test:unit": "npx tsx --test --test-timeout=300000 tests/*.test.mts",
+    "test:unit": "NODE_OPTIONS=--max-old-space-size=6144 npx tsx --test --test-timeout=300000 tests/*.test.mts",
     "test:integration": "npx tsx --test --test-timeout=300000 tests/integration/*.test.mts",
     "test": "npm run test:unit && npm run test:integration",
-    "test:update-snapshots": "npx tsx --test --test-update-snapshots --test-timeout=300000 tests/*.test.mts tests/integration/*.test.mts",
+    "test:update-snapshots": "NODE_OPTIONS=--max-old-space-size=6144 npx tsx --test --test-update-snapshots --test-timeout=300000 tests/*.test.mts tests/integration/*.test.mts",
     "lint": "biome check src",
     "lint:fix": "biome check --write src"
   },

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -766,6 +766,10 @@ exports[`functions-class.ts > Account.getBalance 1`] = `
 "module GET_BALANCE.\\n\\nget-balance a: Account => Int.\\n\\n---\\n\\nget-balance a = account--balance a.\\n"
 `;
 
+exports[`functions-mutating-bounded-while-break.ts > addWhileBelowLimit 1`] = `
+"module ADD_WHILE_BELOW_LIMIT.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\nfn--loop s: Int, n: Int => Int = cond 0 < n and s >= n => s + 1, 0 < n => fn--loop (s + 1) n, true => s.\\n~> Add-while-below-limit @ a: Account, n: Int.\\n\\n---\\n\\naccount--balance' a = fn--loop (account--balance a) n.\\n"
+`;
+
 exports[`functions-mutating-bounded-while.ts > setLastIndexDescending 1`] = `
 "module SET_LAST_INDEX_DESCENDING.\\n\\nAccount.\\naccount--total a1: Account => Int.\\naccount--last-index a1: Account => Int.\\n~> Set-last-index-descending @ a: Account, n: Int.\\n\\n---\\n\\naccount--last-index' a = (cond n > 0 => 0 + 1, true => account--last-index a).\\naccount--total' a1 = account--total a1.\\n"
 `;
@@ -906,6 +910,26 @@ exports[`functions-mutating-early-exit.ts > writeThenEarlyReturn 1`] = `
 "module WRITE_THEN_EARLY_RETURN.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--owner a1: Account => String.\\n~> Write-then-early-return @ a: Account, g: Bool.\\n\\n---\\n\\naccount--balance' a = (cond ~g => 10 + 5, true => 10).\\naccount--owner' a1 = account--owner a1.\\n"
 `;
 
+exports[`functions-mutating-fixed-point-break.ts > climbUntilBreak 1`] = `
+"module CLIMB_UNTIL_BREAK.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\nfn--loop s: Int, n: Int => Int = cond s < n and s >= n => s + 1, s < n => fn--loop (s + 1) n, true => s.\\n~> Climb-until-break @ a: Account, n: Int.\\n\\n---\\n\\naccount--balance' a = fn--loop (account--balance a) n.\\n"
+`;
+
+exports[`functions-mutating-fixed-point-continue.ts > climbUnlessZeroStep 1`] = `
+"module CLIMB_UNLESS_ZERO_STEP.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\nfn--loop s: Int, n: Int => Int = cond s < n => fn--loop (cond n = 0 => s, true => s + 1) n, true => s.\\n~> Climb-unless-zero-step @ a: Account, n: Int.\\n\\n---\\n\\naccount--balance' a = fn--loop (account--balance a) n.\\n"
+`;
+
+exports[`functions-mutating-fixed-point-return-bare.ts > climbUntilReturn 1`] = `
+"module CLIMB_UNTIL_RETURN.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\nfn--loop s: Int, n: Int => Int = cond s < n and s >= n => s + 1, s < n => fn--loop (s + 1) n, true => s.\\n~> Climb-until-return @ a: Account, n: Int.\\n\\n---\\n\\naccount--balance' a = fn--loop (account--balance a) n.\\n"
+`;
+
+exports[`functions-mutating-fixed-point-return-value.ts > climbAndReturn 1`] = `
+"module CLIMB_AND_RETURN.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\nclimb-and-return a: Account, n: Int => Int.\\nfn--loop s: Int, n: Int => Int = cond s < n and s >= n => s + 1, s < n => fn--loop (s + 1) n, true => s.\\n~> Climb-and-return @ a: Account, n: Int.\\n\\n---\\n\\naccount--balance' a = fn--loop (account--balance a) n.\\nclimb-and-return' a n = (cond account--balance a >= n => account--balance a, true => fn--loop (account--balance a) n).\\n"
+`;
+
+exports[`functions-mutating-fixed-point-throw.ts > climbUnlessInvalid 1`] = `
+"module CLIMB_UNLESS_INVALID.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\nfn--loop s: Int, n: Int => Int = cond s < n and ~(n = 0) => fn--loop (s + 1) n, true => s.\\n~> Climb-unless-invalid @ a: Account, n: Int.\\n\\n---\\n\\naccount--balance' a = fn--loop (account--balance a) n.\\n"
+`;
+
 exports[`functions-mutating-fixed-point-while.ts > adjustBalanceTo 1`] = `
 "module ADJUST_BALANCE_TO.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--size a1: Account => Int.\\naccount--tick-count a1: Account => Int.\\nfn--loop s: Int, step: Int, target: Int => Int = cond s < target => fn--loop (s + step) step target, true => s.\\n~> Adjust-balance-to @ a: Account, target: Int, step: Int.\\n\\n---\\n\\naccount--balance' a = fn--loop (account--balance a) step target.\\naccount--size' a1 = account--size a1.\\naccount--tick-count' a1 = account--tick-count a1.\\n"
 `;
@@ -920,6 +944,14 @@ exports[`functions-mutating-fixed-point-while.ts > fillUpTo 1`] = `
 
 exports[`functions-mutating-fixed-point-while.ts > spin 1`] = `
 "module SPIN.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--size a1: Account => Int.\\naccount--tick-count a1: Account => Int.\\n~> Spin @ a: Account.\\n\\n---\\n\\n> UNSUPPORTED: while loop has no observable termination condition (literal-true guard); rewrite with a guard that depends on mutated state.\\n"
+`;
+
+exports[`functions-mutating-loop-break.ts > addUntilLimit 1`] = `
+"module ADD_UNTIL_LIMIT.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\nfn--loop s: Int, n: Int => Int = cond 0 < n and s >= n => s + 1, 0 < n => fn--loop (s + 1) n, true => s.\\n~> Add-until-limit @ a: Account, n: Int.\\n\\n---\\n\\naccount--balance' a = fn--loop (account--balance a) n.\\n"
+`;
+
+exports[`functions-mutating-loop-continue.ts > setPositiveLastIndex 1`] = `
+"module SET_POSITIVE_LAST_INDEX.\\n\\nAccount.\\naccount--last-index a1: Account => Int.\\n~> Set-positive-last-index @ a: Account, n: Int.\\n\\n---\\n\\naccount--last-index' a = (cond 0 < n => (cond n - 1 = 0 => account--last-index a, true => n - 1), true => account--last-index a).\\n"
 `;
 
 exports[`functions-mutating-loop.ts > activateActive 1`] = `
@@ -964,6 +996,10 @@ exports[`functions-mutating-loop.ts > sumPositiveAssert 1`] = `
 
 exports[`functions-mutating-loop.ts > sumScaledAssert 1`] = `
 "module SUM_SCALED_ASSERT.\\n\\nAccount.\\naccount--total a1: Account => Int.\\naccount--balance a1: Account => Int.\\nItem.\\nitem--value i: Item => Int.\\nitem--tagged i: Item => Bool.\\n~> Sum-scaled-assert @ a: Account, items: [Item], scale: Int, scale >= 0.\\n\\n---\\n\\naccount--total' a = account--total a + (+ over each x in items | item--value x).\\naccount--balance' a1 = account--balance a1.\\nitem--value' i = item--value i.\\nitem--tagged' i = item--tagged i.\\n"
+`;
+
+exports[`functions-mutating-while-true-break.ts > eventLoopUntilLimit 1`] = `
+"module EVENT_LOOP_UNTIL_LIMIT.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\nfn--loop s: Int, n: Int => Int = cond true and s >= n => s + 1, true => fn--loop (s + 1) n, true => s.\\n~> Event-loop-until-limit @ a: Account, n: Int.\\n\\n---\\n\\naccount--balance' a = fn--loop (account--balance a) n.\\n"
 `;
 
 exports[`functions-mutating.ts > deposit 1`] = `

--- a/tools/ts2pant/tests/fixtures/constructs/functions-mutating-bounded-while-break.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/functions-mutating-bounded-while-break.ts
@@ -1,0 +1,15 @@
+interface Account {
+  balance: number;
+}
+
+/** Bounded while with break; break bumps the otherwise bounded shape to L4. */
+export function addWhileBelowLimit(a: Account, n: number): void {
+  let i = 0;
+  while (i < n) {
+    a.balance = a.balance + 1;
+    if (a.balance >= n) {
+      break;
+    }
+    i++;
+  }
+}

--- a/tools/ts2pant/tests/fixtures/constructs/functions-mutating-fixed-point-break.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/functions-mutating-fixed-point-break.ts
@@ -1,0 +1,13 @@
+interface Account {
+  balance: number;
+}
+
+/** Unbounded fixed-point while with break consumed by the post-loop join. */
+export function climbUntilBreak(a: Account, n: number): void {
+  while (a.balance < n) {
+    a.balance = a.balance + 1;
+    if (a.balance >= n) {
+      break;
+    }
+  }
+}

--- a/tools/ts2pant/tests/fixtures/constructs/functions-mutating-fixed-point-continue.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/functions-mutating-fixed-point-continue.ts
@@ -1,0 +1,13 @@
+interface Account {
+  balance: number;
+}
+
+/** Unbounded fixed-point while with continue threaded to the loop header. */
+export function climbUnlessZeroStep(a: Account, n: number): void {
+  while (a.balance < n) {
+    if (n === 0) {
+      continue;
+    }
+    a.balance = a.balance + 1;
+  }
+}

--- a/tools/ts2pant/tests/fixtures/constructs/functions-mutating-fixed-point-return-bare.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/functions-mutating-fixed-point-return-bare.ts
@@ -1,0 +1,13 @@
+interface Account {
+  balance: number;
+}
+
+/** Unbounded fixed-point while with bare return as a function-level exit. */
+export function climbUntilReturn(a: Account, n: number): void {
+  while (a.balance < n) {
+    a.balance = a.balance + 1;
+    if (a.balance >= n) {
+      return;
+    }
+  }
+}

--- a/tools/ts2pant/tests/fixtures/constructs/functions-mutating-fixed-point-return-value.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/functions-mutating-fixed-point-return-value.ts
@@ -1,0 +1,13 @@
+interface Account {
+  balance: number;
+}
+
+/** Unbounded fixed-point while with return value via the return-value location. */
+export function climbAndReturn(a: Account, n: number): number {
+  while (a.balance < n) {
+    a.balance = a.balance + 1;
+    if (a.balance >= n) {
+      return a.balance;
+    }
+  }
+}

--- a/tools/ts2pant/tests/fixtures/constructs/functions-mutating-fixed-point-throw.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/functions-mutating-fixed-point-throw.ts
@@ -1,0 +1,13 @@
+interface Account {
+  balance: number;
+}
+
+/** Unbounded fixed-point while with throw lowered as an iteration precondition. */
+export function climbUnlessInvalid(a: Account, n: number): void {
+  while (a.balance < n) {
+    if (n === 0) {
+      throw "invalid";
+    }
+    a.balance = a.balance + 1;
+  }
+}

--- a/tools/ts2pant/tests/fixtures/constructs/functions-mutating-loop-break.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/functions-mutating-loop-break.ts
@@ -1,0 +1,13 @@
+interface Account {
+  balance: number;
+}
+
+/** Counter loop with break; break-bearing bounded loops route to fixed-point. */
+export function addUntilLimit(a: Account, n: number): void {
+  for (let i = 0; i < n; i++) {
+    a.balance = a.balance + 1;
+    if (a.balance >= n) {
+      break;
+    }
+  }
+}

--- a/tools/ts2pant/tests/fixtures/constructs/functions-mutating-loop-continue.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/functions-mutating-loop-continue.ts
@@ -1,0 +1,13 @@
+interface Account {
+  lastIndex: number;
+}
+
+/** Counter loop with continue; continue-only bounded loops stay quantified. */
+export function setPositiveLastIndex(a: Account, n: number): void {
+  for (let i = 0; i < n; i++) {
+    if (i === 0) {
+      continue;
+    }
+    a.lastIndex = i;
+  }
+}

--- a/tools/ts2pant/tests/fixtures/constructs/functions-mutating-while-true-break.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/functions-mutating-while-true-break.ts
@@ -1,0 +1,13 @@
+interface Account {
+  balance: number;
+}
+
+/** while(true) event-loop idiom; the reachable break is the termination signal. */
+export function eventLoopUntilLimit(a: Account, n: number): void {
+  while (true) {
+    a.balance = a.balance + 1;
+    if (a.balance >= n) {
+      break;
+    }
+  }
+}

--- a/tools/ts2pant/tests/integration/e2e.test.mts
+++ b/tools/ts2pant/tests/integration/e2e.test.mts
@@ -312,4 +312,28 @@ describe("pant --check", () => {
       assert.ok(result.checks.every((c) => c.passed));
     });
   }
+
+  for (const [file, fn] of [
+    ["functions-mutating-loop-break.ts", "addUntilLimit"],
+    ["functions-mutating-loop-continue.ts", "setPositiveLastIndex"],
+    ["functions-mutating-bounded-while-break.ts", "addWhileBelowLimit"],
+    ["functions-mutating-fixed-point-break.ts", "climbUntilBreak"],
+    ["functions-mutating-fixed-point-continue.ts", "climbUnlessZeroStep"],
+    ["functions-mutating-fixed-point-return-bare.ts", "climbUntilReturn"],
+    ["functions-mutating-fixed-point-return-value.ts", "climbAndReturn"],
+    ["functions-mutating-fixed-point-throw.ts", "climbUnlessInvalid"],
+    ["functions-mutating-while-true-break.ts", "eventLoopUntilLimit"],
+  ] as const) {
+    it(`${file} ${fn} is checkable`, {
+      skip: !hasSolver ? "z3 not available" : undefined,
+    }, async () => {
+      const doc = await buildDocument(`constructs/${file}`, fn);
+      const output = await emitAndCheck(doc);
+      const result = runCheck(output);
+
+      assert.equal(result.passed, true);
+      assert.ok(result.checks.length > 0);
+      assert.ok(result.checks.every((c) => c.passed));
+    });
+  }
 });

--- a/workstreams/ts2pant-general-loop-ssa.md
+++ b/workstreams/ts2pant-general-loop-ssa.md
@@ -394,14 +394,26 @@ folding existing summaries.
 
 ### Milestone 5: loop-break-continue
 
+**Status**: Landed in `ts2pant-loop-break-continue`.
+
 **Definition of Done**:
-IR1 SSA loop bodies admit `break` and `continue` statements, represented via
-the continuation handles from L1. Both bounded-quantified and fixed-point
-lowering paths emit Pant output consistent with the early-exit semantics the
-gameplan settles on. The continuation-merge model extends the prior
-workstream's M2 branch-continuation work without regressing M2 tests. At least
-two break-bearing and two continue-bearing fixtures pass `pant` and (where
-applicable) `pant --check`.
+IR1 SSA loop bodies admit `break`, `continue`, `return` (bare and value), and
+`throw` statements, represented via the continuation handles from L1. The
+fixed-point lowering path consumes all four handle lists: `break` emits a
+post-loop `cond`, `continue` feeds the header phi loop-back input, `return`
+feeds the function-level return-value `cond`, and `throw` contributes an
+iteration-precondition guard. Bounded loops containing `break` or `return`
+bump to fixed-point lowering; bounded loops containing only `continue` stay on
+the quantified L2/L3 route. Labeled `break` and `continue` reject with the M7
+future-work diagnostic.
+
+At least nine fixtures cover counter break, counter continue, bounded-while
+break, fixed-point break, fixed-point continue, fixed-point bare return,
+fixed-point value return, fixed-point throw, and `while (true)` plus break.
+Each fixture passes `pant` typecheck and either passes `pant --check` or
+carries a documented acceptable-timeout rationale under L4's fixture policy.
+Snapshot generation confirms prior-shipping fixture output remains
+byte-identical.
 
 **`while (true) + break` event-loop idiom in scope.** L4 rejects literal-true
 guards with a "no observable termination condition" diagnostic because the
@@ -410,10 +422,10 @@ SMT verification (infinitely many models, no further constraint). L5 unlocks
 this idiom: when the body contains a reachable `break` (or `throw` / `return`)
 guarded by a state-dependent condition, the early-exit becomes the loop's
 observable termination condition. The fixed-point lowering encodes it as
-`fix (λs. if ¬break(s) then body(s) else s)` (or the continuation-handle
-equivalent — see Open Questions below). At least one of L5's break-bearing
-fixtures must be a `while (true) { ...; if (cond) break; }` shape so the
-diagnostic L4 surfaced for this idiom resolves to a translating fixture in L5.
+the continuation-handle equivalent of `fix (λs. if ¬break(s) then body(s)
+else s)`. At least one of L5's break-bearing fixtures is a `while (true) {
+...; if (cond) break; }` shape so the diagnostic L4 surfaced for this idiom
+resolves to a translating fixture in L5.
 
 **Why this is a safe pause point**:
 Loop-shape coverage is feature-complete for this workstream's terminal scope.
@@ -432,9 +444,19 @@ Existing summary-based μ-search and foreach lowering remains unchanged.
   (`fix (λs. if guard(s) ∧ ¬break(s) then body(s) else s)`) or as a
   continuation handle consumed by the post-loop join. Affects the L4
   fixed-point encoding retroactively if the latter is chosen.
+  Resolved: continuation handles are consumed by the post-loop join.
 - Whether `continue` is represented as a body-internal goto-to-header or as
   a body-internal short-circuit. Both encodings exist in the SSA literature.
+  Resolved: continue is a short-circuit to the loop-header back-edge value.
 - How nested loops scope their break/continue targets.
+  Resolved: unlabeled exits target the innermost loop body; labeled exits are
+  deferred to M7 and rejected in M5.
+- Whether return values require a separate function-output contract.
+  Resolved: mutating bodies synthesize a per-function `return-value`
+  `IR1SsaLocation`, and lowering emits a function-level return-value equation.
+- Whether loop-internal throw is a terminal abort or a precondition.
+  Resolved: throw lowers as an iteration-precondition guard conjoined with
+  the recursive rule guard.
 
 **Unlocks**:
 Summary unification (L6) can target the now-complete general-loop machinery.


### PR DESCRIPTION
## Patch 6: Fixtures + documentation updates

- Author each of the nine fixtures as a minimal mutating-body function exercising the named shape. Each fixture is verified by `pant` typecheck and `pant --check` SMT verification (per L4's documented timeout policy where applicable).
- Generate snapshots via the test harness; confirm prior-shipping snapshots remain byte-identical.
- Author the new § 'Loop early-exit semantics (L5)' in `intermediate-representation.md` between the existing L4 section and any subsequent material. Cite the L4 section for the underlying recursive-rule shape; cite the L2/L3 sections for the quantified-with-continue path.
- Update AGENTS.md § 'General-loop SSA contract surface (L1)' to list the new handle entries inline with the break/continue entries. Add corollary § 'Loop early-exit lowering (L5)' citing the four-handle consumption pattern.
- Update `workstreams/ts2pant-general-loop-ssa.md` M5 section: Status 'Landed in `ts2pant-loop-break-continue`'; update DoD bullet list to include return/throw shapes; under Open Questions, mark each resolved with a one-line summary of the resolution.
- Run `just ts2pant-test-integration`; confirm all new fixtures' Pant output passes `pant` typecheck. Run per-fixture `pant --check`; document any acceptable-timeout cases inline in the fixture comment.

## Changes
- Author each of the nine fixtures as a minimal mutating-body function exercising the named shape. Each fixture is verified by `pant` typecheck and `pant --check` SMT verification (per L4's documented timeout policy where applicable).
- Generate snapshots via the test harness; confirm prior-shipping snapshots remain byte-identical.
- Author the new § 'Loop early-exit semantics (L5)' in `intermediate-representation.md` between the existing L4 section and any subsequent material. Cite the L4 section for the underlying recursive-rule shape; cite the L2/L3 sections for the quantified-with-continue path.
- Update AGENTS.md § 'General-loop SSA contract surface (L1)' to list the new handle entries inline with the break/continue entries. Add corollary § 'Loop early-exit lowering (L5)' citing the four-handle consumption pattern.
- Update `workstreams/ts2pant-general-loop-ssa.md` M5 section: Status 'Landed in `ts2pant-loop-break-continue`'; update DoD bullet list to include return/throw shapes; under Open Questions, mark each resolved with a one-line summary of the resolution.
- Run `just ts2pant-test-integration`; confirm all new fixtures' Pant output passes `pant` typecheck. Run per-fixture `pant --check`; document any acceptable-timeout cases inline in the fixture comment.

## Files to Modify
- tools/ts2pant/tests/fixtures/constructs/functions-mutating-loop-break.ts (create): Counter loop with `if (cond) break;`.
- tools/ts2pant/tests/fixtures/constructs/functions-mutating-loop-continue.ts (create): Counter loop with `if (cond) continue;`.
- tools/ts2pant/tests/fixtures/constructs/functions-mutating-bounded-while-break.ts (create): Bounded `while` with `if (cond) break;`.
- tools/ts2pant/tests/fixtures/constructs/functions-mutating-fixed-point-break.ts (create): Unbounded `while` with `if (cond) break;`.
- tools/ts2pant/tests/fixtures/constructs/functions-mutating-fixed-point-continue.ts (create): Unbounded `while` with `if (cond) continue;`.
- tools/ts2pant/tests/fixtures/constructs/functions-mutating-fixed-point-return-bare.ts (create): Unbounded `while` with bare `return;`.
- tools/ts2pant/tests/fixtures/constructs/functions-mutating-fixed-point-return-value.ts (create): Unbounded `while` with `return value;`.
- tools/ts2pant/tests/fixtures/constructs/functions-mutating-fixed-point-throw.ts (create): Unbounded `while` with `if (cond) throw new Error(...);`.
- tools/ts2pant/tests/fixtures/constructs/functions-mutating-while-true-break.ts (create): Event-loop idiom: `while(true) { ...; if (cond) break; }`.
- tools/ts2pant/docs/intermediate-representation.md (modify): Add new § 'Loop early-exit semantics (L5)' section covering the handle-list consumption shape, the bump-to-fixed-point routing, the narrowed while(true) rejection, and the labeled-form deferral.
- tools/ts2pant/AGENTS.md (modify): Update § 'General-loop SSA contract surface (L1)' with the return/throw handle entries and the IR1SsaLoopBody field extensions. Add § 'Loop early-exit lowering (L5)' summarising the four-handle consumption pattern.
- workstreams/ts2pant-general-loop-ssa.md (modify): Update M5 'Status' to 'Landed in `ts2pant-loop-break-continue`'. Update DoD to reflect actual scope (return + throw included; bump-to-fixed-point for break-bearing / return-bearing bounded loops; labeled deferred). Document the resolved open questions inline.

## Gameplan Specification

```
module TS2PANT_LOOP_BREAK_CONTINUE.

> ════════════════════════════════
> M5 of ts2pant General-Loop SSA: loop early-exit lowering.
> ════════════════════════════════
> After this gameplan, IR1 SSA loop bodies admit break,
> continue, return (bare and with value), and throw via
> the L1 handle vocabulary. L4 fixed-point lowering consumes
> all four handle lists: break -> post-loop cond; continue ->
> header phi loop-back input; return -> function-level
> return-value cond (using the new mutating-body return-value
> contract); throw -> iteration-precondition. Bounded loops
> with break/return bump to fixed-point; bounded loops with
> only continue stay quantified. The while(true)+break event-
> loop idiom translates. Labeled break/continue rejects with
> M7 future-work diagnostic. M6 (loop-summary-unification)
> can now target the complete general-loop machinery.

Handle.
HandleKind.
LoweringTarget.
LoopShape.
LoweringRoute.
break => HandleKind.
continue => HandleKind.
return-bare => HandleKind.
return-value => HandleKind.
throw => HandleKind.
post-loop-cond => LoweringTarget.
header-phi-loop-back => LoweringTarget.
function-return-value-cond => LoweringTarget.
iteration-precondition => LoweringTarget.
counter => LoopShape.
bounded-while => LoopShape.
fixed-point => LoopShape.
while-true-with-break => LoopShape.
quantified-route => LoweringRoute.
fixed-point-route => LoweringRoute.

kind h: Handle => HandleKind.
target-of h: Handle => LoweringTarget.
route-for shape: LoopShape, hk: HandleKind => LoweringRoute.
labeled-rejected? => Bool.
while-true-rejects-only-when-no-break-or-return? => Bool.
m6-unblocked? => Bool.
---

> Handle-to-target mapping.
all h: Handle | target-of h = post-loop-cond <-> kind h = break.
all h: Handle | target-of h = header-phi-loop-back <-> kind h = continue.
all h: Handle, kind h = return-bare | target-of h = function-return-value-cond.
all h: Handle, kind h = return-value | target-of h = function-return-value-cond.
all h: Handle | target-of h = iteration-precondition <-> kind h = throw.

> Bump-to-fixed-point routing: break/return shapes go fixed-point on bounded loops.
route-for counter break = fixed-point-route.
route-for counter return-bare = fixed-point-route.
route-for counter return-value = fixed-point-route.
route-for bounded-while break = fixed-point-route.
route-for bounded-while return-bare = fixed-point-route.
route-for bounded-while return-value = fixed-point-route.

> Continue stays quantified on bounded loops.
route-for counter continue = quantified-route.
route-for bounded-while continue = quantified-route.

> Labeled forms.
labeled-rejected?.

> while(true) narrowing.
while-true-rejects-only-when-no-break-or-return?.

> Workstream gate.
m6-unblocked?.
```

## Patch Specification

```
module TS2PANT_LOOP_BREAK_CONTINUE_PATCH_6.

> Patch 6 lands fixtures and documentation.
> Nine new fixtures across early-exit shape x lowering target.
> Doc updates to intermediate-representation.md, AGENTS.md,
> and the workstream document.

Fixture.
Shape.
Verification.
Document.
DocumentSection.
counter-break => Shape.
counter-continue => Shape.
bounded-while-break => Shape.
fixed-point-break => Shape.
fixed-point-continue => Shape.
fixed-point-return-bare => Shape.
fixed-point-return-value => Shape.
fixed-point-throw => Shape.
while-true-break => Shape.
pant-typecheck => Verification.
pant-check-success => Verification.
pant-check-timeout-documented => Verification.
ir-doc => Document.
agents-md => Document.
workstream-doc => Document.
l5-section => DocumentSection.
m5-status => DocumentSection.

shape-of f: Fixture => Shape.
verifies? f: Fixture, v: Verification => Bool.
document-has-section? d: Document, s: DocumentSection => Bool.
---
all f: Fixture | verifies? f pant-typecheck.
all f: Fixture |
  verifies? f pant-check-success or verifies? f pant-check-timeout-documented.

document-has-section? ir-doc l5-section.
document-has-section? agents-md l5-section.
document-has-section? workstream-doc m5-status.
```


## Implementation Notes

- Added the nine fixtures as one-export, one-shape files so the construct snapshot suite records each early-exit case independently and prior fixture drift is easy to review.
- Added explicit `pant --check` integration coverage for the nine new fixtures in `tools/ts2pant/tests/integration/e2e.test.mts`; no fixture needed a documented timeout.
- The construct snapshot update initially exceeded Node's default heap when running the full unit suite. Rerunning the construct snapshot suite alone with `NODE_OPTIONS=--max-old-space-size=8192` completed successfully; the snapshot diff contains only the nine new fixture entries.

Spec/Evidence Mapping:
- Nine fixture shapes: implemented under `tools/ts2pant/tests/fixtures/constructs/functions-mutating-*.ts`; covered by `tools/ts2pant/tests/constructs.test.mts.snapshot`.
- `pant-typecheck`: construct snapshot harness uses `emitAndCheck`; verified by the successful constructs snapshot rerun.
- `pant-check-success`: all nine fixtures are covered by the new `pant --check` loop in `tools/ts2pant/tests/integration/e2e.test.mts`; verified by `just ts2pant-test-integration`.
- L5 doc sections and M5 status: updated `tools/ts2pant/docs/intermediate-representation.md`, `tools/ts2pant/AGENTS.md`, and `workstreams/ts2pant-general-loop-ssa.md`; checked with `git diff --check`.