### PR TITLE
[ts2pant-loop-summary-unification] Patch 1: Pending tests for foreach-as-general-loop, μ-search-summary deletion, and L7 invariants

### DIFF
--- a/tools/ts2pant/tests/ir1-ssa-foreach.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-foreach.test.mts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+void assert;
+
+describe("ir1-ssa-foreach", () => {
+  it.skip("Shape A: emits one header join per mutated location", () => {
+    // PENDING Patch 3: verify Shape A foreach lowers through loop-header joins.
+  });
+
+  it.skip("Shape A: emits a synthetic iteration-source termination metric", () => {
+    // PENDING Patch 2: verify Shape A foreach carries an iteration-source metric.
+  });
+
+  it.skip(
+    "Shape A: header join's loopBackVersion equals the per-iteration write version",
+    () => {
+      // PENDING Patch 3: verify Shape A uses the degenerate header close.
+    },
+  );
+
+  it.skip("Shape A: emits a single per-element quantified equation per location", () => {
+    // PENDING Patch 3: verify Shape A preserves quantified write emission.
+  });
+
+  it.skip("Shape B: emits one header join per mutated location", () => {
+    // PENDING Patch 4: verify Shape B foreach lowers through loop-header joins.
+  });
+
+  it.skip("Shape B: emits a synthetic iteration-source termination metric", () => {
+    // PENDING Patch 2: verify Shape B foreach carries an iteration-source metric.
+  });
+
+  it.skip(
+    "Shape B: accumulator-fold write reads prior version through the header join",
+    () => {
+      // PENDING Patch 4: verify Shape B feeds accumulator writes through the header join.
+    },
+  );
+
+  it.skip("Shape B: emits one accumulator-fold equation per location", () => {
+    // PENDING Patch 4: verify Shape B preserves accumulator-fold emission.
+  });
+});

--- a/tools/ts2pant/tests/ir1-ssa-invariants.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-invariants.test.mts
@@ -1067,4 +1067,32 @@ describe("ir1-ssa-invariants", () => {
       }
     },
   );
+
+  it.skip(
+    "L7 invariant: every loop-header join has exactly one preheader and one loop-back input",
+    () => {
+      // PENDING Patch 7: verify loop-header join preheader and loop-back uniqueness.
+    },
+  );
+
+  it.skip(
+    "L7 invariant: every loop body resolves break/continue continuations to the correct join",
+    () => {
+      // PENDING Patch 7: verify loop-body continuation handle resolution.
+    },
+  );
+
+  it.skip(
+    "L7 invariant: every bounded loop carries a non-null termination metric, every fixed-point loop does not",
+    () => {
+      // PENDING Patch 7: verify metric presence by loop class.
+    },
+  );
+
+  it.skip(
+    "L7 invariant: every modified rule appears in IR1SsaProgram.modifiedRules exactly once",
+    () => {
+      // PENDING Patch 7: verify loop-modified rule frame suppression.
+    },
+  );
 });

--- a/tools/ts2pant/tests/ir1-ssa-loops.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-loops.test.mts
@@ -347,4 +347,22 @@ describe("ir1-ssa-loops", () => {
       /account--total' a = account--total a \+ \(\+ over each ([\w$]+) in items \| item--value \1\)/u,
     );
   });
+
+  it.skip(
+    "foreach Shape A call site emits IR1SsaProgram with populated loopHeaderJoins and loopBodies",
+    () => {
+      // PENDING Patch 3: verify the Shape A production call site uses general-loop SSA.
+    },
+  );
+
+  it.skip(
+    "foreach Shape B call site emits IR1SsaProgram with populated loopHeaderJoins and loopBodies",
+    () => {
+      // PENDING Patch 4: verify the Shape B production call site uses general-loop SSA.
+    },
+  );
+
+  it.skip("μ-search summary symbols are deleted from ir1-ssa-loops.ts", () => {
+    // PENDING Patch 5: verify the dead μ-search summary path is gone.
+  });
 });


### PR DESCRIPTION
## Patch 1: Pending tests for foreach-as-general-loop, μ-search-summary deletion, and L7 invariants

- Create `tools/ts2pant/tests/ir1-ssa-foreach.test.mts` modeled on `tests/ir1-ssa-counter-loop.test.mts`'s shape (describe block, direct constructor calls, `node:assert/strict`).
- Add skipped stubs: `it.skip("Shape A: emits one header join per mutated location", ...)`, `it.skip("Shape A: emits a synthetic iteration-source termination metric", ...)`, `it.skip("Shape A: header join's loopBackVersion equals the per-iteration write version", ...)`, `it.skip("Shape A: emits a single per-element quantified equation per location", ...)`, `it.skip("Shape B: emits one header join per mutated location", ...)`, `it.skip("Shape B: emits a synthetic iteration-source termination metric", ...)`, `it.skip("Shape B: accumulator-fold write reads prior version through the header join", ...)`, `it.skip("Shape B: emits one accumulator-fold equation per location", ...)`.
- In `tools/ts2pant/tests/ir1-ssa-loops.test.mts`, add skipped stubs: `it.skip("foreach Shape A call site emits IR1SsaProgram with populated loopHeaderJoins and loopBodies", ...)`, `it.skip("foreach Shape B call site emits IR1SsaProgram with populated loopHeaderJoins and loopBodies", ...)`, `it.skip("μ-search summary symbols are deleted from ir1-ssa-loops.ts", ...)`.
- In `tools/ts2pant/tests/ir1-ssa-invariants.test.mts`, add skipped stubs: `it.skip("L7 invariant: every loop-header join has exactly one preheader and one loop-back input", ...)`, `it.skip("L7 invariant: every loop body resolves break/continue continuations to the correct join", ...)`, `it.skip("L7 invariant: every bounded loop carries a non-null termination metric, every fixed-point loop does not", ...)`, `it.skip("L7 invariant: every modified rule appears in IR1SsaProgram.modifiedRules exactly once", ...)`.
- Each stub body contains only the PENDING comment naming the implementing patch — no constructor calls or assertions that reference Patch-2/3/4/5/6/7 symbols (those symbols / shapes do not exist yet).
- Do not modify any non-test file in this patch.

## Changes
- Create `tools/ts2pant/tests/ir1-ssa-foreach.test.mts` modeled on `tests/ir1-ssa-counter-loop.test.mts`'s shape (describe block, direct constructor calls, `node:assert/strict`).
- Add skipped stubs: `it.skip("Shape A: emits one header join per mutated location", ...)`, `it.skip("Shape A: emits a synthetic iteration-source termination metric", ...)`, `it.skip("Shape A: header join's loopBackVersion equals the per-iteration write version", ...)`, `it.skip("Shape A: emits a single per-element quantified equation per location", ...)`, `it.skip("Shape B: emits one header join per mutated location", ...)`, `it.skip("Shape B: emits a synthetic iteration-source termination metric", ...)`, `it.skip("Shape B: accumulator-fold write reads prior version through the header join", ...)`, `it.skip("Shape B: emits one accumulator-fold equation per location", ...)`.
- In `tools/ts2pant/tests/ir1-ssa-loops.test.mts`, add skipped stubs: `it.skip("foreach Shape A call site emits IR1SsaProgram with populated loopHeaderJoins and loopBodies", ...)`, `it.skip("foreach Shape B call site emits IR1SsaProgram with populated loopHeaderJoins and loopBodies", ...)`, `it.skip("μ-search summary symbols are deleted from ir1-ssa-loops.ts", ...)`.
- In `tools/ts2pant/tests/ir1-ssa-invariants.test.mts`, add skipped stubs: `it.skip("L7 invariant: every loop-header join has exactly one preheader and one loop-back input", ...)`, `it.skip("L7 invariant: every loop body resolves break/continue continuations to the correct join", ...)`, `it.skip("L7 invariant: every bounded loop carries a non-null termination metric, every fixed-point loop does not", ...)`, `it.skip("L7 invariant: every modified rule appears in IR1SsaProgram.modifiedRules exactly once", ...)`.
- Each stub body contains only the PENDING comment naming the implementing patch — no constructor calls or assertions that reference Patch-2/3/4/5/6/7 symbols (those symbols / shapes do not exist yet).
- Do not modify any non-test file in this patch.

## Files to Modify
- tools/ts2pant/tests/ir1-ssa-foreach.test.mts (create): New unit test file with `it.skip` stubs for the foreach-as-general-loop helper's behaviors. Each stub carries a `// PENDING Patch <N>:` comment naming the implementing patch.
- tools/ts2pant/tests/ir1-ssa-loops.test.mts (modify): Add `it.skip` stubs for the call-site verification: `ir1-lower-body` foreach Shape A path emits IR1SsaProgram with populated loopHeaderJoins / loopBodies; same for Shape B; the μ-search summary symbols are absent from the module after Patch 5.
- tools/ts2pant/tests/ir1-ssa-invariants.test.mts (modify): Add `it.skip` stubs for the four L7 invariant tests: every IR1SsaLoopHeaderJoin has exactly one preheader and one loop-back input; every IR1SsaLoopBody resolves break/continue/return/throw continuations to the correct join; every bounded loop carries a non-null IR1SsaTerminationMetric while every fixed-point loop does not; every modified rule appears in IR1SsaProgram.modifiedRules exactly once.

## Gameplan Specification

```
module TS2PANT_LOOP_SUMMARY_UNIFICATION.

> ════════════════════════════════
> Milestone 6 AND Milestone 7 of the ts2pant general-loop SSA
> workstream, collapsed into a single atomic milestone.
> ════════════════════════════════
> After this milestone, foreach Shape A and Shape B lower
> through the general-loop SSA machinery
> (IR1SsaLoopHeaderJoin + IR1SsaLoopBody +
> IR1SsaTerminationMetric) rather than the legacy
> IR1SsaLoopSummary path. IR1SsaTerminationMetric is now a
> discriminated union: counter loops and bounded-while loops
> emit the existing counter-style variant (kind:
> ssa-termination-metric, expr, lowerBound); foreach Shape A
> and Shape B emit the new iterating-source variant (kind:
> ssa-iterating-source-metric, source) matching Pant's native
> all-x-in-arr semantics. Shape A's per-iteration writes do
> not feed back through the header join (degenerate close);
> Shape B's accumulator-fold writes do (Cytron inductive
> case). The IR1SsaLoopSummary type, the ir1SsaLoopSummary
> constructor, the IR1SsaProgram.loopSummaries field, the
> lowerMuSearchSummary path, and tools/ts2pant/src/ir1-ssa-loops.ts
> are all deleted. Four L7 invariant tests verify the unified
> abstraction: header-join uniqueness, continuation
> resolution, metric kind by loop class, frame suppression
> per modified rule. Pant output is byte-equivalent on every
> existing foreach fixture. Documentation marks BOTH milestone
> 6 AND milestone 7 as landed.

ForeachInput.
ForeachShape.
shape-a => ForeachShape.
shape-b => ForeachShape.
IR1SsaProgram.
IR1SsaProgramShape.
IR1SsaLoopBody.
IR1SsaLoopHeaderJoin.
IR1SsaTerminationMetric.
IR1SsaWrite.
IR1SsaVersion.
IR1SsaRuleName.
FieldName.
loop-summaries-field => FieldName.
loop-header-joins-field => FieldName.
loop-bodies-field => FieldName.
FileStatus.
file-present => FileStatus.
file-deleted => FileStatus.
Declaration.
DeletionStatus.
present => DeletionStatus.
deleted => DeletionStatus.
MuSearchSummary.
LoopClass.
counter => LoopClass.
bounded-while => LoopClass.
fixed-point-while => LoopClass.
foreach-shape-a => LoopClass.
foreach-shape-b => LoopClass.
FixtureOutput.
MetricKind.
counter-metric => MetricKind.
iterating-source-metric => MetricKind.
Document.
DocumentKind.
MilestoneStatus.
ir-doc => DocumentKind.
transformations-doc => DocumentKind.
agents-md => DocumentKind.
workstream-doc => DocumentKind.
pending => MilestoneStatus.
landed => MilestoneStatus.

> Foreach-as-general-loop helper.
input-shape i: ForeachInput => ForeachShape.
lower-result i: ForeachInput => IR1SsaProgram.
body-of p: IR1SsaProgram => IR1SsaLoopBody.
header-of b: IR1SsaLoopBody => IR1SsaLoopHeaderJoin.
metric-of b: IR1SsaLoopBody => IR1SsaTerminationMetric.
metric-kind m: IR1SsaTerminationMetric => MetricKind.
write-of b: IR1SsaLoopBody => IR1SsaWrite.
loop-back-version h: IR1SsaLoopHeaderJoin => IR1SsaVersion.
preheader-version h: IR1SsaLoopHeaderJoin => IR1SsaVersion.
write-version w: IR1SsaWrite => IR1SsaVersion.
emits-quantified-equation? p: IR1SsaProgram => Bool.
emits-accumulator-fold-equation? p: IR1SsaProgram => Bool.

> Deletion (Patches 5, 6).
shape-has-field? s: IR1SsaProgramShape, f: FieldName => Bool.
ir-ssa-loops-file-status => FileStatus.
deletion-status d: Declaration => DeletionStatus.
is-mu-search-summary? d: Declaration => Bool.
production-reachable? d: Declaration => Bool.

> L7 invariants (Patch 7).
header-has-preheader? h: IR1SsaLoopHeaderJoin => Bool.
header-has-loop-back? h: IR1SsaLoopHeaderJoin => Bool.
header-closed? h: IR1SsaLoopHeaderJoin => Bool.
body-class b: IR1SsaLoopBody => LoopClass.
non-null-metric? b: IR1SsaLoopBody => Bool.
is-bounded? c: LoopClass => Bool.
uses-counter-metric? c: LoopClass => Bool.
uses-iterating-source-metric? c: LoopClass => Bool.
continuations-resolved? b: IR1SsaLoopBody => Bool.
modified-rule-appears-once? p: IR1SsaProgram, r: IR1SsaRuleName => Bool.
body-writes-rule? b: IR1SsaLoopBody, r: IR1SsaRuleName => Bool.

> Byte-equivalent emission.
legacy-emission i: ForeachInput => FixtureOutput.
recharacterised-emission i: ForeachInput => FixtureOutput.
byte-equivalent? a: FixtureOutput, b: FixtureOutput => Bool.

> Documentation.
document-kind d: Document => DocumentKind.
document-mentions-unification? d: Document => Bool.
workstream-milestone-6-status => MilestoneStatus.
workstream-milestone-7-status => MilestoneStatus.
---

> Foreach helper contract: every foreach input lowers to an
> IR1SsaProgram carrying an iterating-source termination
> metric (the new variant introduced by Patch 2).
all i: ForeachInput, b: IR1SsaLoopBody |
  b = body-of (lower-result i) ->
    metric-kind (metric-of b) = iterating-source-metric.

> Shape A: the header join's loop-back version equals the
> per-iteration write version (degenerate close).
all i: ForeachInput, b: IR1SsaLoopBody, h: IR1SsaLoopHeaderJoin, w: IR1SsaWrite |
  input-shape i = shape-a and b = body-of (lower-result i) and
  h = header-of b and w = write-of b ->
    loop-back-version h = write-version w.

> Shape A: emits a per-element quantified equation.
all i: ForeachInput |
  input-shape i = shape-a ->
    emits-quantified-equation? (lower-result i).

> Shape B: emits an accumulator-fold equation per location.
all i: ForeachInput |
  input-shape i = shape-b ->
    emits-accumulator-fold-equation? (lower-result i).

> Byte-equivalent Pant emission on every existing fixture.
all i: ForeachInput |
  byte-equivalent? (legacy-emission i) (recharacterised-emission i).

> Type-level deletion: IR1SsaProgram has no loopSummaries
> field; retains loopHeaderJoins and loopBodies.
all s: IR1SsaProgramShape |
  ~(shape-has-field? s loop-summaries-field).

all s: IR1SsaProgramShape |
  shape-has-field? s loop-header-joins-field and
  shape-has-field? s loop-bodies-field.

> File deletion: ir1-ssa-loops.ts is gone.
ir-ssa-loops-file-status = file-deleted.

> μ-search summary symbols are deleted; the dead path is
> unreachable.
all d: Declaration |
  is-mu-search-summary? d -> deletion-status d = deleted.

all d: Declaration |
  deletion-status d = deleted -> ~(production-reachable? d).

> L7 invariant: every header join has exactly one preheader,
> one loop-back, and is closed.
all h: IR1SsaLoopHeaderJoin |
  header-has-preheader? h and header-has-loop-back? h and
  header-closed? h.

> L7 invariant: continuation handles resolve.
all b: IR1SsaLoopBody |
  continuations-resolved? b.

> L7 invariant 3a: bounded loops have non-null metrics.
all b: IR1SsaLoopBody |
  is-bounded? (body-class b) -> non-null-metric? b.

> L7 invariant 3b: counter / bounded-while emit
> counter-metric; foreach Shape A / Shape B emit
> iterating-source-metric.
all b: IR1SsaLoopBody |
  uses-counter-metric? (body-class b) ->
    metric-kind (metric-of b) = counter-metric.

all b: IR1SsaLoopBody |
  uses-iterating-source-metric? (body-class b) ->
    metric-kind (metric-of b) = iterating-source-metric.

is-bounded? counter.
is-bounded? bounded-while.
is-bounded? foreach-shape-a.
is-bounded? foreach-shape-b.
~(is-bounded? fixed-point-while).

uses-counter-metric? counter.
uses-counter-metric? bounded-while.
uses-iterating-source-metric? foreach-shape-a.
uses-iterating-source-metric? foreach-shape-b.

> L7 invariant: every modified rule appears in modifiedRules
> exactly once.
all p: IR1SsaProgram, r: IR1SsaRuleName, b: IR1SsaLoopBody |
  body-writes-rule? b r ->
    modified-rule-appears-once? p r.

> Documentation invariants.
all d: Document |
  document-kind d = ir-doc ->
    document-mentions-unification? d.

all d: Document |
  document-kind d = transformations-doc ->
    document-mentions-unification? d.

all d: Document |
  document-kind d = agents-md ->
    document-mentions-unification? d.

all d: Document |
  document-kind d = workstream-doc ->
    document-mentions-unification? d.

workstream-milestone-6-status = landed.
workstream-milestone-7-status = landed.
```

## Patch Specification

```
module TS2PANT_LOOP_SUMMARY_UNIFICATION_PATCH_1.

> Patch 1 lands the test scaffolding for the unified L6 + L7
> milestone. Stubs are skipped; Patches 2 through 7 unskip
> them in place with concrete assertions. No runtime
> invariants change.

TestStub.
PendingFor.
patch-2 => PendingFor.
patch-3 => PendingFor.
patch-4 => PendingFor.
patch-5 => PendingFor.
patch-6 => PendingFor.
patch-7 => PendingFor.

stub-pending-for s: TestStub => PendingFor.
---
true.
```


## Implementation Notes

- Kept the new tests strictly as skipped scaffolding. The only executable statement in the new foreach test file is `void assert;`, which keeps the requested `node:assert/strict` import present without adding assertions or references to future Patch 2-7 symbols.
- Inserted the call-site and invariant stubs at the end of their existing `describe` blocks so the current legacy-summary tests remain untouched for later patches to replace or delete deliberately.
- Spec/Evidence Mapping: Patch 1's `stub-pending-for` scaffolding is represented by the new skipped cases in `tools/ts2pant/tests/ir1-ssa-foreach.test.mts`, `tools/ts2pant/tests/ir1-ssa-loops.test.mts`, and `tools/ts2pant/tests/ir1-ssa-invariants.test.mts`; the required context was `workstreams/ts2pant-general-loop-ssa.md` Milestones 6 and 7; verification was `just ts2pant-test-unit` and `just ts2pant-test-integration`, both passing.