### PR TITLE
[ts2pant-loop-summary-unification] Patch 5: ts2pant: delete dead μ-search summary path

### DIFF
--- a/tools/ts2pant/src/ir1-lower-body.ts
+++ b/tools/ts2pant/src/ir1-lower-body.ts
@@ -29,7 +29,6 @@ import { lowerFixedPointLoopL1Body } from "./ir1-ssa-fixed-point.js";
 import {
   lowerForeachShapeASummaries,
   lowerForeachShapeBSummaries,
-  type MuSearchSummaryLowerResult,
 } from "./ir1-ssa-loops.js";
 import {
   appendFramesForUnmodifiedRules,
@@ -70,13 +69,9 @@ export function adaptLoopSummaryLowerResult(
   result: ReturnType<typeof lowerForeachShapeBSummaries>,
 ): IR1SsaBodyLowerResult;
 export function adaptLoopSummaryLowerResult(
-  result: MuSearchSummaryLowerResult,
-): IR1SsaBodyLowerResult;
-export function adaptLoopSummaryLowerResult(
   result:
     | ReturnType<typeof lowerForeachShapeASummaries>
-    | ReturnType<typeof lowerForeachShapeBSummaries>
-    | MuSearchSummaryLowerResult,
+    | ReturnType<typeof lowerForeachShapeBSummaries>,
 ): IR1SsaBodyLowerResult {
   return loopSsaBodyLowerResult(result);
 }

--- a/tools/ts2pant/src/ir1-ssa-loops.ts
+++ b/tools/ts2pant/src/ir1-ssa-loops.ts
@@ -24,11 +24,6 @@ interface LoopSummaryInputBase {
   location: IR1SsaLocation;
 }
 
-export interface MuSearchSummaryInput extends LoopSummaryInputBase {
-  kind: "mu-search";
-  loweredExpr?: OpaqueExpr;
-}
-
 export interface ForeachShapeASummaryInput extends LoopSummaryInputBase {
   kind: "foreach-shape-a";
   propositions?: readonly PropResult[];
@@ -45,7 +40,6 @@ export interface UnsupportedLoopSummaryInput {
 }
 
 export type IR1LoopSsaInput =
-  | MuSearchSummaryInput
   | ForeachShapeASummaryInput
   | ForeachShapeBSummaryInput
   | UnsupportedLoopSummaryInput;
@@ -99,31 +93,6 @@ export interface ForeachShapeBSummaryResult {
   accumulatorKeys: string[];
 }
 
-export type MuSearchCounterType = "Int";
-
-/**
- * Preconditions:
- * - caller already validated canonical μ-search form
- * - `binder` is fresh with respect to `predicateExpr`
- * - `counterType` is a discrete well-ordered numeric type
- */
-export interface MuSearchSummaryLowerOptions extends LoopSsaBuildOptions {
-  location: IR1SsaLocation;
-  counterType: MuSearchCounterType;
-  counterPantName: string;
-  binder: string;
-  initExpr: OpaqueExpr;
-  predicateExpr: OpaqueExpr;
-}
-
-export interface MuSearchSummaryLowerResult {
-  program: IR1SsaProgram;
-  summary: IR1SsaLoopSummary | null;
-  loweredExpr: OpaqueExpr | null;
-  modifiedRules: IR1SsaRuleName[];
-  diagnostics: UnsupportedDiagnostic[];
-}
-
 export interface LoopSsaBuildResult {
   program: IR1SsaProgram;
   loweredExpr: OpaqueExpr[];
@@ -155,13 +124,6 @@ export function buildLoopSsaProgram(
     const modifiedRule = ir1SsaRuleOfLocation(input.location);
     modifiedRules.add(modifiedRule);
     declaredRules.add(modifiedRule);
-
-    if (input.kind === "mu-search") {
-      if (input.loweredExpr !== undefined) {
-        loweredExpr.push(input.loweredExpr);
-      }
-      continue;
-    }
 
     if (input.propositions !== undefined) {
       propositions.push(...input.propositions);
@@ -574,42 +536,4 @@ export function foreachShapeBAccumulatorKey(
   objExpr: OpaqueExpr,
 ): string {
   return `${prop}::${getAst().strExpr(objExpr)}`;
-}
-
-export function lowerMuSearchSummary(
-  options: MuSearchSummaryLowerOptions,
-): MuSearchSummaryLowerResult {
-  const result = buildLoopSsaProgram(
-    {
-      kind: "mu-search",
-      location: options.location,
-    },
-    options,
-  );
-
-  const ast = getAst();
-  const predicateOpaque = ast.substituteBinder(
-    options.predicateExpr,
-    options.counterPantName,
-    ast.var(options.binder),
-  );
-  const loweredExpr = ast.eachComb(
-    [ast.param(options.binder, ast.tName(options.counterType))],
-    [
-      ast.gExpr(
-        ast.binop(ast.opGe(), ast.var(options.binder), options.initExpr),
-      ),
-      ast.gExpr(ast.unop(ast.opNot(), predicateOpaque)),
-    ],
-    ast.combMin(),
-    ast.var(options.binder),
-  );
-
-  return {
-    program: result.program,
-    summary: result.program.loopSummaries[0] ?? null,
-    loweredExpr,
-    modifiedRules: result.program.modifiedRules,
-    diagnostics: result.diagnostics,
-  };
 }

--- a/tools/ts2pant/src/ir1-ssa-lower.ts
+++ b/tools/ts2pant/src/ir1-ssa-lower.ts
@@ -7,7 +7,6 @@ import type {
   ForeachShapeASummaryResult,
   ForeachShapeBSummaryResult,
   ForeachSummaryLowerResult,
-  MuSearchSummaryLowerResult,
 } from "./ir1-ssa-loops.js";
 import type {
   ScalarSsaFinalPropertyEntry,
@@ -239,8 +238,7 @@ export function loopSsaBodyLowerResult(
   result:
     | ForeachSummaryLowerResult
     | ForeachShapeASummaryResult
-    | ForeachShapeBSummaryResult
-    | MuSearchSummaryLowerResult,
+    | ForeachShapeBSummaryResult,
 ): IR1SsaBodyLowerResult {
   return ir1SsaBodyLowerResult({
     propositions: "propositions" in result ? result.propositions : [],

--- a/tools/ts2pant/tests/ir1-ssa-invariants.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-invariants.test.mts
@@ -14,9 +14,6 @@ import {
   type BuildBodyCtx,
   isUnsupported,
 } from "../src/ir1-build-body.js";
-import {
-  adaptLoopSummaryLowerResult,
-} from "../src/ir1-lower-body.js";
 import { lowerL1BodyToSsaProps } from "../src/ir1-lower-body.js";
 import {
   scalarSsaBodyLowerResult,
@@ -54,17 +51,13 @@ import {
   ir1Var,
   ir1While,
 } from "../src/ir1.js";
-import { lowerExpr } from "../src/ir-emit.js";
-import { lowerL1Expr } from "../src/ir1-lower.js";
 import { lowerCollectionSsaToResult } from "../src/ir1-ssa-collections.js";
 import { lowerScalarSsaToProps } from "../src/ir1-ssa-scalars.js";
 import {
   lowerForeachShapeASummaries,
   lowerForeachShapeBSummaries,
-  lowerMuSearchSummary,
 } from "../src/ir1-ssa-loops.js";
 import { getAst, loadAst } from "../src/pant-wasm.js";
-import { freshHygienicBinder, type UniqueSupply } from "../src/translate-body.js";
 import { IntStrategy } from "../src/translate-types.js";
 import { buildDocumentFromSourceFile } from "./helpers.mts";
 
@@ -76,8 +69,7 @@ type RepresentativeProgramKind =
   | "set"
   | "branch"
   | "foreach-shape-a"
-  | "foreach-shape-b"
-  | "mu-search";
+  | "foreach-shape-b";
 
 interface RepresentativeProgram {
   name: string;
@@ -211,29 +203,6 @@ function buildSupportedFixtureStatement(
   return {
     unsupported: "statement is not supported by Patch 1's fixture bridge",
   };
-}
-
-async function buildMuSearchFixtureResult(): Promise<IR1SsaBodyLowerResult> {
-  const sourceFile = loadFixture("expressions-while-mu-search.ts");
-  await buildDocumentFromSourceFile(sourceFile, "firstUnusedSuffix");
-  const supply: UniqueSupply = { n: 0 };
-  const binder = freshHygienicBinder(supply);
-  return adaptLoopSummaryLowerResult(
-    lowerMuSearchSummary({
-      location: ir1SsaPropertyLocation(
-        "Name_firstUnusedSuffix",
-        ir1Var("name"),
-        "firstUnusedSuffix",
-      ),
-      counterType: "Int",
-      counterPantName: "i",
-      binder,
-      initExpr: getAst().litNat(1),
-      predicateExpr: lowerExpr(
-        lowerL1Expr(ir1Binop("in", ir1Var(binder), ir1Var("used"))),
-      ),
-    }),
-  );
 }
 
 function buildCollectionResult(stmt: IR1Stmt): IR1SsaBodyLowerResult {
@@ -383,11 +352,6 @@ function representativePrograms(): RepresentativeProgram[] {
       kind: "foreach-shape-b",
       build: () =>
         buildFixtureBodyLowerResult("functions-mutating-loop.ts", "forEachSum"),
-    },
-    {
-      name: "expressions-while-mu-search.ts > firstUnusedSuffix",
-      kind: "mu-search",
-      build: () => buildMuSearchFixtureResult(),
     },
   ];
 }
@@ -1034,7 +998,7 @@ describe("ir1-ssa-invariants", () => {
   );
 
   it(
-    "the table-driven corpus satisfies all SSA invariants for scalar, Map, Set, branch, foreach Shape A, foreach Shape B, and μ-search programs",
+    "the table-driven corpus satisfies all SSA invariants for scalar, Map, Set, branch, foreach Shape A, and foreach Shape B programs",
     async () => {
       const representatives = representativePrograms();
       const presentKinds = new Set(representatives.map((r) => r.kind));
@@ -1046,7 +1010,6 @@ describe("ir1-ssa-invariants", () => {
         "branch",
         "foreach-shape-a",
         "foreach-shape-b",
-        "mu-search",
       ] satisfies RepresentativeProgramKind[]) {
         assert.ok(
           presentKinds.has(kind),

--- a/tools/ts2pant/tests/ir1-ssa-loops.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-loops.test.mts
@@ -1,10 +1,10 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { before, describe, it } from "node:test";
 
 import { emitDocument } from "../src/emit.js";
 import { createSourceFile } from "../src/extract.js";
-import { lowerExpr } from "../src/ir-emit.js";
 import {
   ir1Assign,
   ir1Binop,
@@ -15,12 +15,10 @@ import {
   ir1SsaRuleOfLocation,
   ir1Var,
 } from "../src/ir1.js";
-import { lowerL1Expr } from "../src/ir1-lower.js";
 import {
   buildLoopSsaProgram,
   lowerForeachShapeASummaries,
   lowerForeachSummary,
-  lowerMuSearchSummary,
 } from "../src/ir1-ssa-loops.js";
 import { getAst, loadAst } from "../src/pant-wasm.js";
 import { buildDocumentFromSourceFile } from "./helpers.mts";
@@ -44,60 +42,6 @@ describe("ir1-ssa-loops", () => {
   // PENDING Patch 3: route canonical mu-search lowering through loop summaries.
   // PENDING Patch 4: route foreach Shape A lowering through loop summaries.
   // PENDING Patch 5: route foreach Shape B lowering through loop summaries.
-
-  it("records canonical mu-search as a loop summary", () => {
-    const location = ir1SsaPropertyLocation(
-      "Name_firstUnusedSuffix",
-      ir1Var("name"),
-      "firstUnusedSuffix",
-    );
-
-    const result = buildLoopSsaProgram({
-      kind: "mu-search",
-      location,
-    });
-
-    assert.deepEqual(result.diagnostics, []);
-    assert.equal(result.program.loopSummaries.length, 1);
-    assert.deepEqual(result.program.modifiedRules, [
-      ir1SsaRuleOfLocation(location),
-    ]);
-
-    const [summary] = result.program.loopSummaries;
-    assert.equal(summary!.shape, "mu-search");
-    assert.equal(summary!.location, location);
-    assert.equal(summary!.summaryVersion.origin, "loop-summary");
-    assert.equal(summary!.summaryVersion.location, location);
-  });
-
-  it("lowers mu-search summaries to the existing min-over-each shape", () => {
-    const location = ir1SsaPropertyLocation(
-      "Name_firstUnusedSuffix",
-      ir1Var("name"),
-      "firstUnusedSuffix",
-    );
-
-    const result = lowerMuSearchSummary({
-      location,
-      counterType: "Int",
-      counterPantName: "i",
-      binder: "j1",
-      initExpr: lowerExpr(lowerL1Expr(ir1LitNat(1))),
-      predicateExpr: lowerExpr(
-        lowerL1Expr(ir1Binop("in", ir1Var("i"), ir1Var("used"))),
-      ),
-    });
-
-    assert.deepEqual(result.diagnostics, []);
-    assert.equal(result.summary?.shape, "mu-search");
-    assert.equal(result.summary?.location, location);
-    assert.equal(result.summary?.summaryVersion.location, location);
-    assert.ok(result.loweredExpr !== null);
-    assert.equal(
-      getAst().strExpr(result.loweredExpr!),
-      "min over each j1: Int, j1 >= 1, ~(j1 in used) | j1",
-    );
-  });
 
   it("records foreach Shape A quantified writes as loop summaries", () => {
     const location = ir1SsaPropertyLocation(
@@ -362,7 +306,13 @@ describe("ir1-ssa-loops", () => {
     },
   );
 
-  it.skip("μ-search summary symbols are deleted from ir1-ssa-loops.ts", () => {
-    // PENDING Patch 5: verify the dead μ-search summary path is gone.
+  it("μ-search summary symbols are deleted from ir1-ssa-loops.ts", () => {
+    const source = readFileSync(
+      resolve(import.meta.dirname, "../src/ir1-ssa-loops.ts"),
+      "utf8",
+    );
+
+    assert.doesNotMatch(source, /lowerMuSearchSummary/u);
+    assert.doesNotMatch(source, /MuSearchSummaryInput/u);
   });
 });

--- a/tools/ts2pant/tests/ir1-ssa-lower.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-lower.test.mts
@@ -29,7 +29,6 @@ import {
 import {
   lowerForeachShapeASummaries,
   lowerForeachShapeBSummaries,
-  lowerMuSearchSummary,
 } from "../src/ir1-ssa-loops.js";
 import { lowerScalarSsaToProps } from "../src/ir1-ssa-scalars.js";
 import { getAst, loadAst } from "../src/pant-wasm.js";
@@ -348,34 +347,20 @@ describe("ir1-ssa-lower", () => {
         ],
       }),
     );
-    const muSearch = adaptLoopSummaryLowerResult(
-      lowerMuSearchSummary({
-        location: ir1SsaPropertyLocation(
-          "Name_firstUnusedSuffix",
-          ir1Var("name"),
-          "firstUnusedSuffix",
-        ),
-        counterType: "Int",
-        counterPantName: "i",
-        binder: "j1",
-        initExpr: ast.litNat(1),
-        predicateExpr: ast.binop(ast.opIn(), ast.var("i"), ast.var("used")),
-      }),
-    );
-    const result = combineIR1SsaBodyLowerResults(shapeA, shapeB, muSearch);
+    const result = combineIR1SsaBodyLowerResults(shapeA, shapeB);
 
     assert.equal(result.diagnostics.length, 0);
     assert.equal(result.propositions.length, 2);
     assert.deepEqual(
       new Set(result.modifiedRules),
-      new Set(["Item_seen", "Account_total", "Name_firstUnusedSuffix"]),
+      new Set(["Item_seen", "Account_total"]),
     );
-    assert.equal(result.programs.length, 3);
+    assert.equal(result.programs.length, 2);
     assert.deepEqual(
       result.programs.flatMap((program) =>
         program.loopSummaries.map((summary) => summary.shape),
       ),
-      ["foreach-shape-a", "foreach-shape-b", "mu-search"],
+      ["foreach-shape-a", "foreach-shape-b"],
     );
 
     const shapeAProp = result.propositions[0];


### PR DESCRIPTION
## Patch 5: ts2pant: delete dead μ-search summary path

- In `tools/ts2pant/src/ir1-ssa-loops.ts`, delete `MuSearchCounterType` (line 102), `MuSearchSummaryInput` (lines 27-30), `MuSearchSummaryLowerOptions` (lines 110-117), `MuSearchSummaryLowerResult` (lines 119-125), and `lowerMuSearchSummary` (lines 579-615). Confirm no other code in the file references these symbols (the `IR1LoopSsaInput` union union arm `MuSearchSummaryInput` is also removed).
- In `tools/ts2pant/src/ir1-lower-body.ts`, remove the import of `MuSearchSummaryLowerResult` (line 32) and the `adaptLoopSummaryLowerResult` overload that accepts it (lines 72-74).
- In `tools/ts2pant/src/ir1-ssa-lower.ts`, remove the `MuSearchSummaryLowerResult` import and its arm from the `loopSsaBodyLowerResult` union (line 243).
- Delete the `lowerMuSearchSummary` test blocks in `tools/ts2pant/tests/ir1-ssa-loops.test.mts:80`, `tools/ts2pant/tests/ir1-ssa-invariants.test.mts:222`, and `tools/ts2pant/tests/ir1-ssa-lower.test.mts:352`. Confirm the test file structure remains valid (other tests in each file still pass).
- Unskip the Patch-5-owned stub in `tools/ts2pant/tests/ir1-ssa-loops.test.mts` (`μ-search summary symbols are deleted from ir1-ssa-loops.ts`). The test reads `tools/ts2pant/src/ir1-ssa-loops.ts` from disk via `node:fs` and asserts the file does NOT contain `lowerMuSearchSummary` or `MuSearchSummaryInput`. This is a smoke test that catches any future re-introduction.
- Run `just ts2pant-test` and confirm zero regressions. TypeScript must compile with no errors.

## Changes
- In `tools/ts2pant/src/ir1-ssa-loops.ts`, delete `MuSearchCounterType` (line 102), `MuSearchSummaryInput` (lines 27-30), `MuSearchSummaryLowerOptions` (lines 110-117), `MuSearchSummaryLowerResult` (lines 119-125), and `lowerMuSearchSummary` (lines 579-615). Confirm no other code in the file references these symbols (the `IR1LoopSsaInput` union union arm `MuSearchSummaryInput` is also removed).
- In `tools/ts2pant/src/ir1-lower-body.ts`, remove the import of `MuSearchSummaryLowerResult` (line 32) and the `adaptLoopSummaryLowerResult` overload that accepts it (lines 72-74).
- In `tools/ts2pant/src/ir1-ssa-lower.ts`, remove the `MuSearchSummaryLowerResult` import and its arm from the `loopSsaBodyLowerResult` union (line 243).
- Delete the `lowerMuSearchSummary` test blocks in `tools/ts2pant/tests/ir1-ssa-loops.test.mts:80`, `tools/ts2pant/tests/ir1-ssa-invariants.test.mts:222`, and `tools/ts2pant/tests/ir1-ssa-lower.test.mts:352`. Confirm the test file structure remains valid (other tests in each file still pass).
- Unskip the Patch-5-owned stub in `tools/ts2pant/tests/ir1-ssa-loops.test.mts` (`μ-search summary symbols are deleted from ir1-ssa-loops.ts`). The test reads `tools/ts2pant/src/ir1-ssa-loops.ts` from disk via `node:fs` and asserts the file does NOT contain `lowerMuSearchSummary` or `MuSearchSummaryInput`. This is a smoke test that catches any future re-introduction.
- Run `just ts2pant-test` and confirm zero regressions. TypeScript must compile with no errors.

## Files to Modify
- tools/ts2pant/src/ir1-ssa-loops.ts (modify): Delete `lowerMuSearchSummary` (lines 579-615), `MuSearchSummaryInput` (lines 27-30), `MuSearchSummaryLowerOptions` (lines 110-117), `MuSearchSummaryLowerResult` (lines 119-125), and `MuSearchCounterType` (line 102). After this patch, the only remaining symbols in the file are `buildLoopSsaProgram`, `IR1LoopSsaInput`, `LoopSummaryInputBase`, `UnsupportedLoopSummaryInput`, `LoopSsaBuildOptions`, `LoopSsaBuildResult`, and `LoopSsaShape` (all deleted in Patch 6).
- tools/ts2pant/src/ir1-lower-body.ts (modify): Remove the `MuSearchSummaryLowerResult` import (line 32) and the `adaptLoopSummaryLowerResult` overload that accepts it (line 72-74).
- tools/ts2pant/src/ir1-ssa-lower.ts (modify): Remove the `MuSearchSummaryLowerResult` arm from the `loopSsaBodyLowerResult` union at line 243.
- tools/ts2pant/tests/ir1-ssa-loops.test.mts (modify): Delete the `lowerMuSearchSummary` test at line 80 and any related μ-search summary tests. Unskip the Patch-5-owned stub from Patch 1 (`μ-search summary symbols are deleted from ir1-ssa-loops.ts`) and replace the PENDING-comment body with an assertion that reads `tools/ts2pant/src/ir1-ssa-loops.ts` from disk and verifies neither `lowerMuSearchSummary` nor `MuSearchSummaryInput` appear in the file.
- tools/ts2pant/tests/ir1-ssa-invariants.test.mts (modify): Delete the `lowerMuSearchSummary` exercise at line 222 and any related μ-search summary tests. The structural invariants (location-compatibility, dominating reads, frame partitioning) need no μ-search-specific case.
- tools/ts2pant/tests/ir1-ssa-lower.test.mts (modify): Delete the `lowerMuSearchSummary` exercise at line 352 and any related μ-search summary tests.

## Gameplan Specification

```
module TS2PANT_LOOP_SUMMARY_UNIFICATION.

> ════════════════════════════════
> Milestone 6 AND Milestone 7 of the ts2pant general-loop SSA
> workstream, collapsed into a single atomic milestone.
> ════════════════════════════════
> After this milestone, foreach Shape A and Shape B lower
> through the general-loop SSA machinery
> (IR1SsaLoopHeaderJoin + IR1SsaLoopBody +
> IR1SsaTerminationMetric) rather than the legacy
> IR1SsaLoopSummary path. IR1SsaTerminationMetric is now a
> discriminated union: counter loops and bounded-while loops
> emit the existing counter-style variant (kind:
> ssa-termination-metric, expr, lowerBound); foreach Shape A
> and Shape B emit the new iterating-source variant (kind:
> ssa-iterating-source-metric, source) matching Pant's native
> all-x-in-arr semantics. Shape A's per-iteration writes do
> not feed back through the header join (degenerate close);
> Shape B's accumulator-fold writes do (Cytron inductive
> case). The IR1SsaLoopSummary type, the ir1SsaLoopSummary
> constructor, the IR1SsaProgram.loopSummaries field, the
> lowerMuSearchSummary path, and tools/ts2pant/src/ir1-ssa-loops.ts
> are all deleted. Four L7 invariant tests verify the unified
> abstraction: header-join uniqueness, continuation
> resolution, metric kind by loop class, frame suppression
> per modified rule. Pant output is byte-equivalent on every
> existing foreach fixture. Documentation marks BOTH milestone
> 6 AND milestone 7 as landed.

ForeachInput.
ForeachShape.
shape-a => ForeachShape.
shape-b => ForeachShape.
IR1SsaProgram.
IR1SsaProgramShape.
IR1SsaLoopBody.
IR1SsaLoopHeaderJoin.
IR1SsaTerminationMetric.
IR1SsaWrite.
IR1SsaVersion.
IR1SsaRuleName.
FieldName.
loop-summaries-field => FieldName.
loop-header-joins-field => FieldName.
loop-bodies-field => FieldName.
FileStatus.
file-present => FileStatus.
file-deleted => FileStatus.
Declaration.
DeletionStatus.
present => DeletionStatus.
deleted => DeletionStatus.
MuSearchSummary.
LoopClass.
counter => LoopClass.
bounded-while => LoopClass.
fixed-point-while => LoopClass.
foreach-shape-a => LoopClass.
foreach-shape-b => LoopClass.
FixtureOutput.
MetricKind.
counter-metric => MetricKind.
iterating-source-metric => MetricKind.
Document.
DocumentKind.
MilestoneStatus.
ir-doc => DocumentKind.
transformations-doc => DocumentKind.
agents-md => DocumentKind.
workstream-doc => DocumentKind.
pending => MilestoneStatus.
landed => MilestoneStatus.

> Foreach-as-general-loop helper.
input-shape i: ForeachInput => ForeachShape.
lower-result i: ForeachInput => IR1SsaProgram.
body-of p: IR1SsaProgram => IR1SsaLoopBody.
header-of b: IR1SsaLoopBody => IR1SsaLoopHeaderJoin.
metric-of b: IR1SsaLoopBody => IR1SsaTerminationMetric.
metric-kind m: IR1SsaTerminationMetric => MetricKind.
write-of b: IR1SsaLoopBody => IR1SsaWrite.
loop-back-version h: IR1SsaLoopHeaderJoin => IR1SsaVersion.
preheader-version h: IR1SsaLoopHeaderJoin => IR1SsaVersion.
write-version w: IR1SsaWrite => IR1SsaVersion.
emits-quantified-equation? p: IR1SsaProgram => Bool.
emits-accumulator-fold-equation? p: IR1SsaProgram => Bool.

> Deletion (Patches 5, 6).
shape-has-field? s: IR1SsaProgramShape, f: FieldName => Bool.
ir-ssa-loops-file-status => FileStatus.
deletion-status d: Declaration => DeletionStatus.
is-mu-search-summary? d: Declaration => Bool.
production-reachable? d: Declaration => Bool.

> L7 invariants (Patch 7).
header-has-preheader? h: IR1SsaLoopHeaderJoin => Bool.
header-has-loop-back? h: IR1SsaLoopHeaderJoin => Bool.
header-closed? h: IR1SsaLoopHeaderJoin => Bool.
body-class b: IR1SsaLoopBody => LoopClass.
non-null-metric? b: IR1SsaLoopBody => Bool.
is-bounded? c: LoopClass => Bool.
uses-counter-metric? c: LoopClass => Bool.
uses-iterating-source-metric? c: LoopClass => Bool.
continuations-resolved? b: IR1SsaLoopBody => Bool.
modified-rule-appears-once? p: IR1SsaProgram, r: IR1SsaRuleName => Bool.
body-writes-rule? b: IR1SsaLoopBody, r: IR1SsaRuleName => Bool.

> Byte-equivalent emission.
legacy-emission i: ForeachInput => FixtureOutput.
recharacterised-emission i: ForeachInput => FixtureOutput.
byte-equivalent? a: FixtureOutput, b: FixtureOutput => Bool.

> Documentation.
document-kind d: Document => DocumentKind.
document-mentions-unification? d: Document => Bool.
workstream-milestone-6-status => MilestoneStatus.
workstream-milestone-7-status => MilestoneStatus.
---

> Foreach helper contract: every foreach input lowers to an
> IR1SsaProgram carrying an iterating-source termination
> metric (the new variant introduced by Patch 2).
all i: ForeachInput, b: IR1SsaLoopBody |
  b = body-of (lower-result i) ->
    metric-kind (metric-of b) = iterating-source-metric.

> Shape A: the header join's loop-back version equals the
> per-iteration write version (degenerate close).
all i: ForeachInput, b: IR1SsaLoopBody, h: IR1SsaLoopHeaderJoin, w: IR1SsaWrite |
  input-shape i = shape-a and b = body-of (lower-result i) and
  h = header-of b and w = write-of b ->
    loop-back-version h = write-version w.

> Shape A: emits a per-element quantified equation.
all i: ForeachInput |
  input-shape i = shape-a ->
    emits-quantified-equation? (lower-result i).

> Shape B: emits an accumulator-fold equation per location.
all i: ForeachInput |
  input-shape i = shape-b ->
    emits-accumulator-fold-equation? (lower-result i).

> Byte-equivalent Pant emission on every existing fixture.
all i: ForeachInput |
  byte-equivalent? (legacy-emission i) (recharacterised-emission i).

> Type-level deletion: IR1SsaProgram has no loopSummaries
> field; retains loopHeaderJoins and loopBodies.
all s: IR1SsaProgramShape |
  ~(shape-has-field? s loop-summaries-field).

all s: IR1SsaProgramShape |
  shape-has-field? s loop-header-joins-field and
  shape-has-field? s loop-bodies-field.

> File deletion: ir1-ssa-loops.ts is gone.
ir-ssa-loops-file-status = file-deleted.

> μ-search summary symbols are deleted; the dead path is
> unreachable.
all d: Declaration |
  is-mu-search-summary? d -> deletion-status d = deleted.

all d: Declaration |
  deletion-status d = deleted -> ~(production-reachable? d).

> L7 invariant: every header join has exactly one preheader,
> one loop-back, and is closed.
all h: IR1SsaLoopHeaderJoin |
  header-has-preheader? h and header-has-loop-back? h and
  header-closed? h.

> L7 invariant: continuation handles resolve.
all b: IR1SsaLoopBody |
  continuations-resolved? b.

> L7 invariant 3a: bounded loops have non-null metrics.
all b: IR1SsaLoopBody |
  is-bounded? (body-class b) -> non-null-metric? b.

> L7 invariant 3b: counter / bounded-while emit
> counter-metric; foreach Shape A / Shape B emit
> iterating-source-metric.
all b: IR1SsaLoopBody |
  uses-counter-metric? (body-class b) ->
    metric-kind (metric-of b) = counter-metric.

all b: IR1SsaLoopBody |
  uses-iterating-source-metric? (body-class b) ->
    metric-kind (metric-of b) = iterating-source-metric.

is-bounded? counter.
is-bounded? bounded-while.
is-bounded? foreach-shape-a.
is-bounded? foreach-shape-b.
~(is-bounded? fixed-point-while).

uses-counter-metric? counter.
uses-counter-metric? bounded-while.
uses-iterating-source-metric? foreach-shape-a.
uses-iterating-source-metric? foreach-shape-b.

> L7 invariant: every modified rule appears in modifiedRules
> exactly once.
all p: IR1SsaProgram, r: IR1SsaRuleName, b: IR1SsaLoopBody |
  body-writes-rule? b r ->
    modified-rule-appears-once? p r.

> Documentation invariants.
all d: Document |
  document-kind d = ir-doc ->
    document-mentions-unification? d.

all d: Document |
  document-kind d = transformations-doc ->
    document-mentions-unification? d.

all d: Document |
  document-kind d = agents-md ->
    document-mentions-unification? d.

all d: Document |
  document-kind d = workstream-doc ->
    document-mentions-unification? d.

workstream-milestone-6-status = landed.
workstream-milestone-7-status = landed.
```

## Patch Specification

```
module TS2PANT_LOOP_SUMMARY_UNIFICATION_PATCH_5.

> Patch 5 deletes the dead μ-search summary path:
> lowerMuSearchSummary, MuSearchSummaryInput,
> MuSearchSummaryLowerOptions, MuSearchSummaryLowerResult,
> MuSearchCounterType, plus the tests that exercised them.
> μ-search recognition remains via buildL1MuSearchCombTyped
> upstream at TS-AST → L1; the production path is unaffected.

Declaration.
MuSearchSummary.
DeletionStatus.
present => DeletionStatus.
deleted => DeletionStatus.

deletion-status d: Declaration => DeletionStatus.
is-mu-search-summary? d: Declaration => Bool.
production-reachable? d: Declaration => Bool.
---

> Every μ-search-summary declaration is deleted.
all d: Declaration |
  is-mu-search-summary? d -> deletion-status d = deleted.

> No deleted declaration is production-reachable
> (vacuously true once deleted).
all d: Declaration |
  deletion-status d = deleted -> ~(production-reachable? d).
```


## Implementation Notes

- Kept the live μ-search translation path intact. The remaining μ-search references are the upstream TS-AST -> L1 recognizer/emitter (`buildL1MuSearchCombTyped` and `translateMuSearchInit`) plus their existing regression tests; only the dead IR1 SSA summary adapter surface was removed.
- The invariant corpus no longer includes a hand-built μ-search summary representative, because that representative exercised only the deleted legacy path. Existing end-to-end μ-search fixture coverage still runs through production translation and continued to pass.
- `buildLoopSsaProgram` now only accepts foreach summary inputs plus unsupported diagnostics. Its `loweredExpr` field is left in place for Patch 6’s broader legacy infrastructure deletion, but this patch removes the only producer that appended to it.
- Spec/Evidence Mapping: deleted μ-search-summary declarations -> `tools/ts2pant/src/ir1-ssa-loops.ts` and the adapter union arms in `ir1-lower-body.ts` / `ir1-ssa-lower.ts`; smoke coverage -> `ir1-ssa-loops.test.mts` asserts the deleted symbol names are absent from the source file; production reachability check -> repository search leaves no `lowerMuSearchSummary` / `MuSearchSummary*` references outside the smoke-test string literals; verification -> `just ts2pant-test` and `npm run build` both passed.