### PR TITLE
[ts2pant-loop-summary-unification] Patch 2: ts2pant: extend IR1SsaTerminationMetric; dormant foreach-as-general-loop helper

### DIFF
--- a/tools/ts2pant/src/ir1-printer.ts
+++ b/tools/ts2pant/src/ir1-printer.ts
@@ -196,6 +196,22 @@ export function formatIR1SsaProgram(program: IR1SsaProgram): string {
     currentVersions.set(locationKey(summary.location), summary.summaryVersion);
   }
 
+  for (const body of program.loopBodies) {
+    const metric =
+      body.terminationMetric === null
+        ? "none"
+        : body.terminationMetric.kind === "ssa-termination-metric"
+          ? `remaining ${formatIR1Expr(body.terminationMetric.expr)}${
+              body.terminationMetric.lowerBound === null
+                ? ""
+                : ` >= ${formatIR1Expr(body.terminationMetric.lowerBound)}`
+            }`
+          : `iterating-source ${formatIR1Expr(body.terminationMetric.source)}`;
+    lines.push(
+      `> loop-body: headers = ${body.headerJoins.length}; writes = ${body.writes.length}; metric = ${metric}`,
+    );
+  }
+
   return lines.join("\n");
 }
 

--- a/tools/ts2pant/src/ir1-ssa-foreach.ts
+++ b/tools/ts2pant/src/ir1-ssa-foreach.ts
@@ -1,0 +1,522 @@
+import { lowerBinop, lowerExpr } from "./ir-emit.js";
+import {
+  type IR1Expr,
+  type IR1FoldLeaf,
+  type IR1ForeachBody,
+  type IR1SsaLocation,
+  type IR1SsaLoopBody,
+  type IR1SsaLoopHeaderJoin,
+  type IR1SsaProgram,
+  type IR1SsaRuleName,
+  type IR1SsaTerminationMetric,
+  type IR1SsaVersion,
+  type IR1SsaWrite,
+  ir1Binop,
+  ir1Cond,
+  ir1Member,
+  ir1SsaCloseLoopHeader,
+  ir1SsaInitialVersion,
+  ir1SsaIteratingSourceMetric,
+  ir1SsaLoopBody,
+  ir1SsaOpenLoopHeader,
+  ir1SsaPropertyLocation,
+  ir1SsaPropertyValue,
+  ir1SsaRuleOfLocation,
+  ir1SsaWrite,
+} from "./ir1.js";
+import { lowerL1Expr } from "./ir1-lower.js";
+import type { LoopSsaBuildOptions } from "./ir1-ssa-loops.js";
+import type { OpaqueExpr } from "./pant-ast.js";
+import { getAst } from "./pant-wasm.js";
+import type { PropResult } from "./types.js";
+
+type UnsupportedDiagnostic = Extract<PropResult, { kind: "unsupported" }>;
+
+export interface ShapeAAsGeneralLoopOptions extends LoopSsaBuildOptions {
+  binder: string;
+  source: IR1Expr;
+  body: IR1ForeachBody;
+  lowerOpaque?: (e: OpaqueExpr) => OpaqueExpr;
+  initialPropertyValues?: ReadonlyMap<string, OpaqueExpr>;
+}
+
+export interface ShapeBAsGeneralLoopOptions extends LoopSsaBuildOptions {
+  binder: string;
+  source: IR1Expr;
+  foldLeaves: readonly IR1FoldLeaf[];
+  lowerExpr?: (e: IR1Expr) => OpaqueExpr;
+  priorAccumulatorValues?: ReadonlyMap<string, OpaqueExpr>;
+}
+
+export interface ForeachAsGeneralLoopResult {
+  program: IR1SsaProgram;
+  propositions: PropResult[];
+  modifiedRules: IR1SsaRuleName[];
+  diagnostics: UnsupportedDiagnostic[];
+}
+
+export interface ForeachShapeBAsGeneralLoopResult
+  extends ForeachAsGeneralLoopResult {
+  accumulatorKeys: string[];
+}
+
+export interface ShapeAPropertyEntry {
+  location: Extract<IR1SsaLocation, { kind: "property" }>;
+  objExpr: OpaqueExpr;
+  value: OpaqueExpr;
+  valueExpr: IR1Expr;
+}
+
+export interface ShapeASummaryState {
+  current: Map<string, ShapeAPropertyEntry>;
+  lowerOpaque: (e: OpaqueExpr) => OpaqueExpr;
+  initialPropertyValues: ReadonlyMap<string, OpaqueExpr>;
+}
+
+export function lowerForeachShapeAAsGeneralLoop(
+  options: ShapeAAsGeneralLoopOptions,
+): ForeachAsGeneralLoopResult {
+  const state: ShapeASummaryState = {
+    current: new Map(),
+    lowerOpaque: options.lowerOpaque ?? ((e) => e),
+    initialPropertyValues: options.initialPropertyValues ?? new Map(),
+  };
+  const diagnostics: UnsupportedDiagnostic[] = [];
+
+  if (!summarizeForeachShapeABody(options.body, state, diagnostics)) {
+    return emptyForeachProgram(options, diagnostics);
+  }
+
+  const ast = getAst();
+  const loweredSource = state.lowerOpaque(
+    lowerExpr(lowerL1Expr(options.source)),
+  );
+  const metric = ir1SsaIteratingSourceMetric(options.source);
+  const loopParts = [...state.current.values()].map((entry) =>
+    buildForeachLoopBody(entry.location, entry.valueExpr, metric),
+  );
+  const propositions: PropResult[] = [...state.current.values()].map(
+    (entry) => ({
+      kind: "equation",
+      quantifiers: [],
+      guards: [ast.gIn(options.binder, loweredSource)],
+      lhs: ast.app(ast.primed(entry.location.ruleName), [entry.objExpr]),
+      rhs: entry.value,
+    }),
+  );
+  const program = buildForeachProgram(options, loopParts);
+  return {
+    program,
+    propositions,
+    modifiedRules: program.modifiedRules,
+    diagnostics,
+  };
+}
+
+export function lowerForeachShapeBAsGeneralLoop(
+  options: ShapeBAsGeneralLoopOptions,
+): ForeachShapeBAsGeneralLoopResult {
+  const ast = getAst();
+  const lower = options.lowerExpr ?? ((e) => lowerExpr(lowerL1Expr(e)));
+  const loweredSource = lower(options.source);
+  const accumulatorKeys: string[] = [];
+  const metric = ir1SsaIteratingSourceMetric(options.source);
+  const loopParts: ForeachLoopPart[] = [];
+  const propositions: PropResult[] = [];
+
+  for (const leaf of options.foldLeaves) {
+    const target = lower(leaf.target);
+    const rhs = lower(leaf.rhs);
+    const guards = [ast.gIn(options.binder, loweredSource)];
+    if (leaf.guard !== null) {
+      guards.push(ast.gExpr(lower(leaf.guard)));
+    }
+
+    const comb =
+      leaf.combiner === "add"
+        ? ast.combAdd()
+        : leaf.combiner === "mul"
+          ? ast.combMul()
+          : leaf.combiner === "and"
+            ? ast.combAnd()
+            : ast.combOr();
+    const folded = ast.eachComb([], guards, comb, rhs);
+    const key = foreachShapeBAccumulatorKey(leaf.prop, target);
+    accumulatorKeys.push(key);
+    const prior =
+      options.priorAccumulatorValues?.get(key) ??
+      ast.app(ast.var(leaf.prop), [target]);
+
+    const location = ir1SsaPropertyLocation(leaf.prop, leaf.target, leaf.prop);
+    loopParts.push(
+      buildForeachLoopBody(
+        location,
+        ir1Binop(leaf.outerOp, ir1Member(leaf.target, leaf.prop), leaf.rhs),
+        metric,
+      ),
+    );
+    propositions.push({
+      kind: "equation",
+      quantifiers: [],
+      lhs: ast.app(ast.primed(leaf.prop), [target]),
+      rhs: ast.binop(lowerBinop(leaf.outerOp), prior, folded),
+    });
+  }
+
+  const program = buildForeachProgram(options, loopParts);
+  return {
+    program,
+    propositions,
+    modifiedRules: program.modifiedRules,
+    diagnostics: [],
+    accumulatorKeys,
+  };
+}
+
+interface ForeachLoopPart {
+  header: IR1SsaLoopHeaderJoin;
+  write: IR1SsaWrite;
+  body: IR1SsaLoopBody;
+}
+
+function buildForeachLoopBody(
+  location: IR1SsaLocation,
+  value: IR1Expr,
+  terminationMetric: IR1SsaTerminationMetric,
+): ForeachLoopPart {
+  const preheaderVersion: IR1SsaVersion = ir1SsaInitialVersion(location);
+  const header = ir1SsaOpenLoopHeader(location, preheaderVersion);
+  const write = ir1SsaWrite(location, ir1SsaPropertyValue(value));
+  ir1SsaCloseLoopHeader(header, write.version);
+  const body = ir1SsaLoopBody({
+    headerJoins: [header],
+    writes: [write],
+    joins: [],
+    breakHandles: [],
+    continueHandles: [],
+    returnHandles: [],
+    throwHandles: [],
+    terminationMetric,
+  });
+  return { header, write, body };
+}
+
+function buildForeachProgram(
+  options: LoopSsaBuildOptions,
+  loopParts: readonly ForeachLoopPart[],
+): IR1SsaProgram {
+  const modifiedRules = [
+    ...new Set(
+      loopParts.map((part) => ir1SsaRuleOfLocation(part.write.location)),
+    ),
+  ];
+  const declaredRules = new Set([
+    ...(options.declaredRules ?? []),
+    ...modifiedRules,
+  ]);
+  return {
+    reads: [],
+    writes: loopParts.map((part) => part.write),
+    joins: [],
+    loopSummaries: [],
+    loopHeaderJoins: loopParts.map((part) => part.header),
+    loopBodies: loopParts.map((part) => part.body),
+    declaredRules: [...declaredRules],
+    modifiedRules,
+    framedRules: [...declaredRules].filter(
+      (rule) => !modifiedRules.includes(rule),
+    ),
+  };
+}
+
+function emptyForeachProgram(
+  options: LoopSsaBuildOptions,
+  diagnostics: readonly UnsupportedDiagnostic[],
+): ForeachAsGeneralLoopResult {
+  const program = buildForeachProgram(options, []);
+  return {
+    program,
+    propositions: [],
+    modifiedRules: program.modifiedRules,
+    diagnostics: [...diagnostics],
+  };
+}
+
+export function summarizeForeachShapeABody(
+  stmt: IR1ForeachBody,
+  state: ShapeASummaryState,
+  diagnostics: UnsupportedDiagnostic[],
+): boolean {
+  switch (stmt.kind) {
+    case "assign":
+      return summarizeShapeAAssign(stmt, state, diagnostics);
+    case "block": {
+      let ok = true;
+      for (const child of stmt.stmts) {
+        if (!summarizeForeachShapeABody(child, state, diagnostics)) {
+          ok = false;
+        }
+      }
+      return ok;
+    }
+    case "cond-stmt":
+      return summarizeShapeACond(stmt, state, diagnostics);
+    default: {
+      diagnostics.push({
+        kind: "unsupported",
+        reason:
+          "nested proposition-emitting loop body is not supported — the inner proposition would escape the outer iterator scope",
+      });
+      return false;
+    }
+  }
+}
+
+export function summarizeShapeAAssign(
+  stmt: Extract<IR1ForeachBody, { kind: "assign" }>,
+  state: ShapeASummaryState,
+  diagnostics: UnsupportedDiagnostic[],
+): boolean {
+  if (stmt.target.kind !== "member") {
+    diagnostics.push({
+      kind: "unsupported",
+      reason: "foreach Shape A summary assignment target must be a property",
+    });
+    return false;
+  }
+
+  const objExpr = state.lowerOpaque(
+    lowerShapeAExpr(stmt.target.receiver, state),
+  );
+  const value = state.lowerOpaque(lowerShapeAExpr(stmt.value, state));
+  const valueExpr = lowerShapeAExprToIR1(stmt.value, state);
+  const location = ir1SsaPropertyLocation(
+    stmt.target.name,
+    stmt.target.receiver,
+    stmt.target.name,
+  ) as Extract<IR1SsaLocation, { kind: "property" }>;
+  state.current.set(shapeAKey(stmt.target.name, objExpr), {
+    location,
+    objExpr,
+    value,
+    valueExpr,
+  });
+  return true;
+}
+
+export function summarizeShapeACond(
+  stmt: Extract<IR1ForeachBody, { kind: "cond-stmt" }>,
+  state: ShapeASummaryState,
+  diagnostics: UnsupportedDiagnostic[],
+): boolean {
+  if (stmt.arms.length !== 1) {
+    diagnostics.push({
+      kind: "unsupported",
+      reason: "multi-armed foreach Shape A conditional is not supported",
+    });
+    return false;
+  }
+
+  const ast = getAst();
+  const [guard, thenBody] = stmt.arms[0]!;
+  const before = new Map(state.current);
+  const thenState: ShapeASummaryState = {
+    ...state,
+    current: new Map(state.current),
+  };
+  if (!summarizeForeachShapeABody(thenBody, thenState, diagnostics)) {
+    return false;
+  }
+
+  const elseState: ShapeASummaryState = {
+    ...state,
+    current: new Map(before),
+  };
+  if (
+    stmt.otherwise !== null &&
+    !summarizeForeachShapeABody(stmt.otherwise, elseState, diagnostics)
+  ) {
+    return false;
+  }
+
+  const guardExpr = state.lowerOpaque(lowerShapeAExpr(guard, state));
+  const guardIr1 = lowerShapeAExprToIR1(guard, state);
+  const touched = new Set<string>();
+  for (const [key, entry] of thenState.current) {
+    if (before.get(key) !== entry) {
+      touched.add(key);
+    }
+  }
+  for (const [key, entry] of elseState.current) {
+    if (before.get(key) !== entry) {
+      touched.add(key);
+    }
+  }
+  for (const key of touched) {
+    const thenEntry = thenState.current.get(key);
+    const elseEntry = elseState.current.get(key);
+    const location = thenEntry?.location ?? elseEntry?.location;
+    const objExpr = thenEntry?.objExpr ?? elseEntry?.objExpr;
+    if (location === undefined || objExpr === undefined) {
+      continue;
+    }
+    const prior = before.get(key);
+    const fallback =
+      prior?.value ??
+      state.initialPropertyValues.get(key) ??
+      ast.app(ast.var(location.ruleName), [objExpr]);
+    const fallbackExpr =
+      prior?.valueExpr ?? ir1Member(location.receiver, location.property);
+    const thenValue = thenEntry?.value ?? fallback;
+    const elseValue = elseEntry?.value ?? fallback;
+    const thenValueExpr = thenEntry?.valueExpr ?? fallbackExpr;
+    const elseValueExpr = elseEntry?.valueExpr ?? fallbackExpr;
+    const value = ast.cond([
+      [guardExpr, thenValue],
+      [ast.litBool(true), elseValue],
+    ]);
+    const valueExpr = ir1Cond([[guardIr1, thenValueExpr]], elseValueExpr);
+    state.current.set(key, { location, objExpr, value, valueExpr });
+  }
+  return true;
+}
+
+export function lowerShapeAExpr(
+  expr: IR1Expr,
+  state: ShapeASummaryState,
+): OpaqueExpr {
+  const ast = getAst();
+  switch (expr.kind) {
+    case "member": {
+      const objExpr = state.lowerOpaque(lowerShapeAExpr(expr.receiver, state));
+      const key = shapeAKey(expr.name, objExpr);
+      return (
+        state.current.get(key)?.value ??
+        state.initialPropertyValues.get(key) ??
+        ast.app(ast.var(expr.name), [objExpr])
+      );
+    }
+    case "binop":
+      return ast.binop(
+        lowerBinop(expr.op),
+        lowerShapeAExpr(expr.lhs, state),
+        lowerShapeAExpr(expr.rhs, state),
+      );
+    case "unop": {
+      const op =
+        expr.op === "not"
+          ? ast.opNot()
+          : expr.op === "neg"
+            ? ast.opNeg()
+            : ast.opCard();
+      return ast.unop(op, lowerShapeAExpr(expr.arg, state));
+    }
+    case "app": {
+      const args = expr.args.map((arg) => lowerShapeAExpr(arg, state));
+      if (expr.callee.kind === "var" && !expr.callee.primed) {
+        return ast.app(ast.var(expr.callee.name), args);
+      }
+      return ast.app(lowerShapeAExpr(expr.callee, state), args);
+    }
+    case "cond": {
+      const arms: Array<[OpaqueExpr, OpaqueExpr]> = expr.arms.map(([g, v]) => [
+        lowerShapeAExpr(g, state),
+        lowerShapeAExpr(v, state),
+      ]);
+      arms.push([ast.litBool(true), lowerShapeAExpr(expr.otherwise, state)]);
+      return ast.cond(arms);
+    }
+    case "is-nullish":
+      return ast.binop(
+        ast.opEq(),
+        ast.unop(ast.opCard(), lowerShapeAExpr(expr.operand, state)),
+        ast.litNat(0),
+      );
+    case "each":
+      return ast.each(
+        [],
+        [
+          ast.gIn(expr.binder, lowerShapeAExpr(expr.src, state)),
+          ...expr.guards.map((guard) =>
+            ast.gExpr(lowerShapeAExpr(guard, state)),
+          ),
+        ],
+        lowerShapeAExpr(expr.proj, state),
+      );
+    case "comb-typed":
+      return ast.eachComb(
+        [ast.param(expr.binder, ast.tName(expr.binderType))],
+        expr.guards.map((guard) => ast.gExpr(lowerShapeAExpr(guard, state))),
+        expr.combiner === "min" ? ast.combMin() : ast.combMax(),
+        lowerShapeAExpr(expr.proj, state),
+      );
+    case "forall": {
+      const guards =
+        expr.guard === undefined
+          ? []
+          : [ast.gExpr(lowerShapeAExpr(expr.guard, state))];
+      return ast.forall(
+        [ast.param(expr.binder, ast.tName(expr.binderType))],
+        guards,
+        lowerShapeAExpr(expr.body, state),
+      );
+    }
+    case "exists": {
+      const guards =
+        expr.guard === undefined
+          ? []
+          : [ast.gExpr(lowerShapeAExpr(expr.guard, state))];
+      return ast.exists(
+        [ast.param(expr.binder, ast.tName(expr.binderType))],
+        guards,
+        lowerShapeAExpr(expr.body, state),
+      );
+    }
+    case "map-read": {
+      const callee = expr.op === "has" ? expr.keyPredName : expr.ruleName;
+      return ast.app(ast.var(callee), [
+        lowerShapeAExpr(expr.receiver, state),
+        lowerShapeAExpr(expr.key, state),
+      ]);
+    }
+    case "set-read":
+      return ast.binop(
+        ast.opIn(),
+        lowerShapeAExpr(expr.elem, state),
+        ast.app(ast.var(expr.ruleName), [
+          lowerShapeAExpr(expr.receiver, state),
+        ]),
+      );
+    case "var":
+    case "lit":
+      return lowerExpr(lowerL1Expr(expr));
+    default: {
+      const _exhaustive: never = expr;
+      void _exhaustive;
+      throw new Error("unsupported IR1 expression in foreach Shape A summary");
+    }
+  }
+}
+
+function lowerShapeAExprToIR1(
+  expr: IR1Expr,
+  state: ShapeASummaryState,
+): IR1Expr {
+  if (expr.kind !== "member") {
+    return expr;
+  }
+  const objExpr = state.lowerOpaque(lowerShapeAExpr(expr.receiver, state));
+  const key = shapeAKey(expr.name, objExpr);
+  return state.current.get(key)?.valueExpr ?? expr;
+}
+
+export function shapeAKey(prop: string, objExpr: OpaqueExpr): string {
+  return `${prop}::${getAst().strExpr(objExpr)}`;
+}
+
+export function foreachShapeBAccumulatorKey(
+  prop: string,
+  objExpr: OpaqueExpr,
+): string {
+  return `${prop}::${getAst().strExpr(objExpr)}`;
+}

--- a/tools/ts2pant/src/ir1-substitute.ts
+++ b/tools/ts2pant/src/ir1-substitute.ts
@@ -167,12 +167,14 @@ export function freeVarsIR1SsaLoopBody(body: IR1SsaLoopBody): Set<string> {
     ]),
     ...(body.terminationMetric === null
       ? []
-      : [
-          freeVarsIR1Expr(body.terminationMetric.expr),
-          ...(body.terminationMetric.lowerBound === null
-            ? []
-            : [freeVarsIR1Expr(body.terminationMetric.lowerBound)]),
-        ]),
+      : body.terminationMetric.kind === "ssa-termination-metric"
+        ? [
+            freeVarsIR1Expr(body.terminationMetric.expr),
+            ...(body.terminationMetric.lowerBound === null
+              ? []
+              : [freeVarsIR1Expr(body.terminationMetric.lowerBound)]),
+          ]
+        : [freeVarsIR1Expr(body.terminationMetric.source)]),
   );
 }
 

--- a/tools/ts2pant/src/ir1.ts
+++ b/tools/ts2pant/src/ir1.ts
@@ -550,11 +550,16 @@ export interface IR1SsaLoopHeaderJoin {
   closed: boolean;
 }
 
-export interface IR1SsaTerminationMetric {
-  readonly kind: "ssa-termination-metric";
-  readonly expr: IR1Expr;
-  readonly lowerBound: IR1Expr | null;
-}
+export type IR1SsaTerminationMetric =
+  | {
+      readonly kind: "ssa-termination-metric";
+      readonly expr: IR1Expr;
+      readonly lowerBound: IR1Expr | null;
+    }
+  | {
+      readonly kind: "ssa-iterating-source-metric";
+      readonly source: IR1Expr;
+    };
 
 export interface IR1SsaBreakHandle {
   readonly kind: "ssa-break-handle";
@@ -774,6 +779,13 @@ export const ir1SsaTerminationMetric = (
   kind: "ssa-termination-metric",
   expr,
   lowerBound,
+});
+
+export const ir1SsaIteratingSourceMetric = (
+  source: IR1Expr,
+): IR1SsaTerminationMetric => ({
+  kind: "ssa-iterating-source-metric",
+  source,
 });
 
 export const ir1SsaBreakHandle = (

--- a/tools/ts2pant/tests/ir1-ssa-foreach.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-foreach.test.mts
@@ -1,44 +1,200 @@
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import { before, describe, it } from "node:test";
 
-void assert;
+import {
+  type IR1FoldLeaf,
+  ir1Assign,
+  ir1Binop,
+  ir1Block,
+  ir1LitBool,
+  ir1LitNat,
+  ir1Member,
+  ir1Var,
+} from "../src/ir1.js";
+import {
+  lowerForeachShapeAAsGeneralLoop,
+  lowerForeachShapeBAsGeneralLoop,
+} from "../src/ir1-ssa-foreach.js";
+import { getAst, loadAst } from "../src/pant-wasm.js";
+
+before(async () => {
+  await loadAst();
+});
+
+const item = ir1Var("item");
+const source = ir1Var("items");
+const account = ir1Var("account");
+
+function lowerShapeA() {
+  return lowerForeachShapeAAsGeneralLoop({
+    binder: "item",
+    source,
+    body: ir1Block([
+      ir1Assign(ir1Member(item, "Item_seen"), ir1LitBool(true)),
+      ir1Assign(ir1Member(item, "Item_score"), ir1LitNat(7)),
+    ]),
+  });
+}
+
+function shapeBFoldLeaves(): IR1FoldLeaf[] {
+  return [
+    {
+      target: account,
+      prop: "Account_total",
+      combiner: "add",
+      outerOp: "add",
+      rhs: ir1Member(item, "Item_amount"),
+      guard: null,
+    },
+    {
+      target: account,
+      prop: "Account_count",
+      combiner: "add",
+      outerOp: "add",
+      rhs: ir1LitNat(1),
+      guard: ir1Binop("gt", ir1Member(item, "Item_amount"), ir1LitNat(0)),
+    },
+  ];
+}
+
+function lowerShapeB() {
+  return lowerForeachShapeBAsGeneralLoop({
+    binder: "item",
+    source,
+    foldLeaves: shapeBFoldLeaves(),
+  });
+}
 
 describe("ir1-ssa-foreach", () => {
-  it.skip("Shape A: emits one header join per mutated location", () => {
-    // PENDING Patch 3: verify Shape A foreach lowers through loop-header joins.
+  it("Shape A: emits one header join per mutated location", () => {
+    const result = lowerShapeA();
+
+    assert.deepEqual(result.diagnostics, []);
+    assert.equal(result.program.loopHeaderJoins.length, 2);
+    assert.equal(result.program.loopBodies.length, 2);
+    for (const body of result.program.loopBodies) {
+      assert.equal(body.headerJoins.length, 1);
+      assert.equal(body.headerJoins[0]?.closed, true);
+      assert.ok(result.program.loopHeaderJoins.includes(body.headerJoins[0]!));
+    }
   });
 
-  it.skip("Shape A: emits a synthetic iteration-source termination metric", () => {
-    // PENDING Patch 2: verify Shape A foreach carries an iteration-source metric.
+  it("Shape A: emits a synthetic iteration-source termination metric", () => {
+    const result = lowerShapeA();
+
+    for (const body of result.program.loopBodies) {
+      const metric = body.terminationMetric;
+      assert.equal(metric?.kind, "ssa-iterating-source-metric");
+      if (metric?.kind === "ssa-iterating-source-metric") {
+        assert.deepEqual(metric.source, source);
+      }
+    }
   });
 
-  it.skip(
+  it(
     "Shape A: header join's loopBackVersion equals the per-iteration write version",
     () => {
-      // PENDING Patch 3: verify Shape A uses the degenerate header close.
+      const result = lowerShapeA();
+
+      for (const body of result.program.loopBodies) {
+        const header = body.headerJoins[0]!;
+        const write = body.writes[0]!;
+        assert.equal(header.loopBackVersion, write.version);
+      }
     },
   );
 
-  it.skip("Shape A: emits a single per-element quantified equation per location", () => {
-    // PENDING Patch 3: verify Shape A preserves quantified write emission.
+  it("Shape A: emits a single per-element quantified equation per location", () => {
+    const ast = getAst();
+    const result = lowerShapeA();
+
+    assert.equal(result.propositions.length, 2);
+    assert.deepEqual(
+      result.propositions.map((prop) =>
+        prop.kind === "equation" ? ast.strExpr(prop.lhs) : "",
+      ),
+      ["Item_seen' item", "Item_score' item"],
+    );
+    for (const prop of result.propositions) {
+      assert.equal(prop.kind, "equation");
+      if (prop.kind === "equation") {
+        assert.equal(prop.guards?.length, 1);
+      }
+    }
   });
 
-  it.skip("Shape B: emits one header join per mutated location", () => {
-    // PENDING Patch 4: verify Shape B foreach lowers through loop-header joins.
+  it("Shape B: emits one header join per mutated location", () => {
+    const result = lowerShapeB();
+
+    assert.deepEqual(result.diagnostics, []);
+    assert.equal(result.program.loopHeaderJoins.length, 2);
+    assert.equal(result.program.loopBodies.length, 2);
+    assert.deepEqual(result.program.modifiedRules, [
+      "Account_total",
+      "Account_count",
+    ]);
   });
 
-  it.skip("Shape B: emits a synthetic iteration-source termination metric", () => {
-    // PENDING Patch 2: verify Shape B foreach carries an iteration-source metric.
+  it("Shape B: emits a synthetic iteration-source termination metric", () => {
+    const result = lowerShapeB();
+
+    for (const body of result.program.loopBodies) {
+      const metric = body.terminationMetric;
+      assert.equal(metric?.kind, "ssa-iterating-source-metric");
+      if (metric?.kind === "ssa-iterating-source-metric") {
+        assert.deepEqual(metric.source, source);
+      }
+    }
   });
 
-  it.skip(
+  it(
     "Shape B: accumulator-fold write reads prior version through the header join",
     () => {
-      // PENDING Patch 4: verify Shape B feeds accumulator writes through the header join.
+      const result = lowerShapeB();
+
+      for (const body of result.program.loopBodies) {
+        const header = body.headerJoins[0]!;
+        const write = body.writes[0]!;
+        assert.equal(header.loopBackVersion, write.version);
+        assert.notEqual(header.loopBackVersion, header.preheaderVersion);
+        assert.equal(write.value.kind, "property");
+        if (write.value.kind === "property") {
+          assert.equal(write.value.value.kind, "binop");
+          if (write.value.value.kind === "binop") {
+            assert.deepEqual(
+              write.value.value.lhs,
+              ir1Member(account, write.location.ruleName),
+            );
+          }
+        }
+      }
     },
   );
 
-  it.skip("Shape B: emits one accumulator-fold equation per location", () => {
-    // PENDING Patch 4: verify Shape B preserves accumulator-fold emission.
+  it("Shape B: emits one accumulator-fold equation per location", () => {
+    const ast = getAst();
+    const result = lowerShapeB();
+
+    assert.equal(result.propositions.length, 2);
+    assert.deepEqual(
+      result.propositions.map((prop) =>
+        prop.kind === "equation" ? ast.strExpr(prop.lhs) : "",
+      ),
+      ["Account_total' account", "Account_count' account"],
+    );
+    assert.equal(result.propositions[0]?.kind, "equation");
+    if (result.propositions[0]?.kind === "equation") {
+      assert.equal(
+        ast.strExpr(result.propositions[0].rhs),
+        "Account_total account + (+ over each item in items | Item_amount item)",
+      );
+    }
+    assert.equal(result.propositions[1]?.kind, "equation");
+    if (result.propositions[1]?.kind === "equation") {
+      assert.equal(
+        ast.strExpr(result.propositions[1].rhs),
+        "Account_count account + (+ over each item in items, Item_amount item > 0 | 1)",
+      );
+    }
   });
 });


### PR DESCRIPTION
## Patch 2: ts2pant: extend IR1SsaTerminationMetric; dormant foreach-as-general-loop helper

- In `tools/ts2pant/src/ir1.ts` (around line 553), change `IR1SsaTerminationMetric` from a single `interface` to a discriminated union `type`: the existing counter-style variant stays as `{ kind: "ssa-termination-metric"; expr: IR1Expr; lowerBound: IR1Expr | null }`; add `{ kind: "ssa-iterating-source-metric"; source: IR1Expr }` as the second arm. The existing `ir1SsaTerminationMetric(expr, lowerBound)` constructor is unchanged. Add `ir1SsaIteratingSourceMetric(source: IR1Expr): IR1SsaTerminationMetric` that returns `{ kind: "ssa-iterating-source-metric", source }`.
- Confirm the existing L2 / L3 / L4 emitters (`ir1-ssa-counter-loop.ts`, `ir1-ssa-fixed-point.ts`) compile unchanged — they import the existing `ir1SsaTerminationMetric` constructor and that signature is unchanged. The type union is the only structural change; consumers that did not dispatch on `kind` continue to work because the existing field shape (`kind: "ssa-termination-metric"`, `expr`, `lowerBound`) is preserved in the first arm.
- In `tools/ts2pant/src/ir1-printer.ts`, locate every site that reads `IR1SsaLoopBody.terminationMetric`. Each must dispatch on `metric.kind`: `"ssa-termination-metric"` prints `expr` / `lowerBound` as today; `"ssa-iterating-source-metric"` prints the `source` expression. If the printer currently reads `metric.expr` directly without dispatch, the new variant would type-error; the dispatch arm is therefore both functional and a type-safety enforcement.
- Create `tools/ts2pant/src/ir1-ssa-foreach.ts` with the module shape mirroring `tools/ts2pant/src/ir1-ssa-counter-loop.ts`. Imports `IR1SsaLoopBody`, `IR1SsaLoopHeaderJoin`, `IR1SsaTerminationMetric`, `IR1SsaWrite`, `ir1SsaCloseLoopHeader`, `ir1SsaInitialVersion`, `ir1SsaIteratingSourceMetric`, `ir1SsaLoopBody`, `ir1SsaOpenLoopHeader`, `ir1SsaPropertyValue`, `ir1SsaWrite` from `./ir1.js`. Does NOT import `ir1Binop`, `ir1Unop`, `ir1Var`, `ir1LitNat` for metric construction — the iterating-source variant carries only the source expression.
- Move from `tools/ts2pant/src/ir1-ssa-loops.ts` to this new module: `summarizeForeachShapeABody`, `summarizeShapeAAssign`, `summarizeShapeACond`, `lowerShapeAExpr`, `shapeAKey`, `ShapeAPropertyEntry`, `ShapeASummaryState`, `foreachShapeBAccumulatorKey`. These are the Shape A / Shape B internals the new helpers need; the originals stay in `ir1-ssa-loops.ts` until Patches 3 / 4 delete them.
- Implement `lowerForeachShapeAAsGeneralLoop(options: ShapeAAsGeneralLoopOptions): ForeachAsGeneralLoopResult`. Walk the Shape A body to collect the per-mutated-location writes. For each mutated location, build the program: `preheaderVersion = ir1SsaInitialVersion(location)`; `header = ir1SsaOpenLoopHeader(location, preheaderVersion)`; `write = ir1SsaWrite(location, ir1SsaPropertyValue(value))`; `ir1SsaCloseLoopHeader(header, write.version)` (Shape A's `loopBackVersion === write.version` — degenerate close); `terminationMetric = ir1SsaIteratingSourceMetric(sourceIR1Expr)` (the IR1 form of the foreach `source`); assemble `IR1SsaLoopBody`. Aggregate one program with all per-location header joins / writes / bodies. Emit one `kind: 'equation'` per location with `lhs: ast.app(ast.primed(location.ruleName), [objExpr])`, `rhs: bodyValue`, guards `[ast.gIn(binder, source)]`. Return `ForeachAsGeneralLoopResult` with the program, propositions, modifiedRules, and diagnostics. NOTE: this patch ships the helper with `loopSummaries: []` on the constructed IR1SsaProgram; Patch 6 removes the field everywhere.
- Implement `lowerForeachShapeBAsGeneralLoop(options: ShapeBAsGeneralLoopOptions): ForeachAsGeneralLoopResult`. For each fold leaf, build the program similarly but with accumulator-fold semantics: the write reads the prior accumulator value through the header join (the body's value expression references `header.joinVersion`'s read); the emission `rhs` is `ast.binop(lowerBinop(leaf.outerOp), prior, folded)` where `folded` is the comprehension `ast.eachComb([], guards, comb, rhs)` and `prior` defaults to `ast.app(ast.var(leaf.prop), [target])` (carry forward the existing accumulator-key lookup from `lowerForeachShapeBSummaries`). Attach the same iterating-source termination metric via `ir1SsaIteratingSourceMetric(sourceIR1Expr)`. Close the header with the write's version (the back-edge). Return the aggregated program plus per-location accumulator-fold propositions and the `accumulatorKeys` array.
- Both helpers reuse `lowerBinop`, `lowerExpr` from `./ir-emit.js`, `lowerL1Expr` from `./ir1-lower.js`, `getAst` from `./pant-wasm.js`. Do NOT introduce new combinator vocabulary.
- Unskip the eight Patch-2-owned stubs in `tools/ts2pant/tests/ir1-ssa-foreach.test.mts` and replace each PENDING-comment body with concrete assertions exercising the helper's emission shape on hand-constructed Shape A / Shape B inputs. Assertions check: `result.program.loopHeaderJoins.length === <mutated location count>`, `result.program.loopBodies.length === <expected>`, each body's `terminationMetric.kind === "ssa-iterating-source-metric"` and `metric.source` references the foreach source, each body's `headerJoins[0].loopBackVersion` equals the corresponding write version for Shape A (degenerate case), each body's `headerJoins[0].loopBackVersion` differs from `preheaderVersion` for Shape B (accumulator-fold case).
- No caller in this patch consumes the new foreach helper — the existing `ir1-ssa-loops.ts` summary entry points remain unchanged and continue to call the legacy `buildLoopSsaProgram` path. Patch 3 and Patch 4 switch the call sites.

## Changes
- In `tools/ts2pant/src/ir1.ts` (around line 553), change `IR1SsaTerminationMetric` from a single `interface` to a discriminated union `type`: the existing counter-style variant stays as `{ kind: "ssa-termination-metric"; expr: IR1Expr; lowerBound: IR1Expr | null }`; add `{ kind: "ssa-iterating-source-metric"; source: IR1Expr }` as the second arm. The existing `ir1SsaTerminationMetric(expr, lowerBound)` constructor is unchanged. Add `ir1SsaIteratingSourceMetric(source: IR1Expr): IR1SsaTerminationMetric` that returns `{ kind: "ssa-iterating-source-metric", source }`.
- Confirm the existing L2 / L3 / L4 emitters (`ir1-ssa-counter-loop.ts`, `ir1-ssa-fixed-point.ts`) compile unchanged — they import the existing `ir1SsaTerminationMetric` constructor and that signature is unchanged. The type union is the only structural change; consumers that did not dispatch on `kind` continue to work because the existing field shape (`kind: "ssa-termination-metric"`, `expr`, `lowerBound`) is preserved in the first arm.
- In `tools/ts2pant/src/ir1-printer.ts`, locate every site that reads `IR1SsaLoopBody.terminationMetric`. Each must dispatch on `metric.kind`: `"ssa-termination-metric"` prints `expr` / `lowerBound` as today; `"ssa-iterating-source-metric"` prints the `source` expression. If the printer currently reads `metric.expr` directly without dispatch, the new variant would type-error; the dispatch arm is therefore both functional and a type-safety enforcement.
- Create `tools/ts2pant/src/ir1-ssa-foreach.ts` with the module shape mirroring `tools/ts2pant/src/ir1-ssa-counter-loop.ts`. Imports `IR1SsaLoopBody`, `IR1SsaLoopHeaderJoin`, `IR1SsaTerminationMetric`, `IR1SsaWrite`, `ir1SsaCloseLoopHeader`, `ir1SsaInitialVersion`, `ir1SsaIteratingSourceMetric`, `ir1SsaLoopBody`, `ir1SsaOpenLoopHeader`, `ir1SsaPropertyValue`, `ir1SsaWrite` from `./ir1.js`. Does NOT import `ir1Binop`, `ir1Unop`, `ir1Var`, `ir1LitNat` for metric construction — the iterating-source variant carries only the source expression.
- Move from `tools/ts2pant/src/ir1-ssa-loops.ts` to this new module: `summarizeForeachShapeABody`, `summarizeShapeAAssign`, `summarizeShapeACond`, `lowerShapeAExpr`, `shapeAKey`, `ShapeAPropertyEntry`, `ShapeASummaryState`, `foreachShapeBAccumulatorKey`. These are the Shape A / Shape B internals the new helpers need; the originals stay in `ir1-ssa-loops.ts` until Patches 3 / 4 delete them.
- Implement `lowerForeachShapeAAsGeneralLoop(options: ShapeAAsGeneralLoopOptions): ForeachAsGeneralLoopResult`. Walk the Shape A body to collect the per-mutated-location writes. For each mutated location, build the program: `preheaderVersion = ir1SsaInitialVersion(location)`; `header = ir1SsaOpenLoopHeader(location, preheaderVersion)`; `write = ir1SsaWrite(location, ir1SsaPropertyValue(value))`; `ir1SsaCloseLoopHeader(header, write.version)` (Shape A's `loopBackVersion === write.version` — degenerate close); `terminationMetric = ir1SsaIteratingSourceMetric(sourceIR1Expr)` (the IR1 form of the foreach `source`); assemble `IR1SsaLoopBody`. Aggregate one program with all per-location header joins / writes / bodies. Emit one `kind: 'equation'` per location with `lhs: ast.app(ast.primed(location.ruleName), [objExpr])`, `rhs: bodyValue`, guards `[ast.gIn(binder, source)]`. Return `ForeachAsGeneralLoopResult` with the program, propositions, modifiedRules, and diagnostics. NOTE: this patch ships the helper with `loopSummaries: []` on the constructed IR1SsaProgram; Patch 6 removes the field everywhere.
- Implement `lowerForeachShapeBAsGeneralLoop(options: ShapeBAsGeneralLoopOptions): ForeachAsGeneralLoopResult`. For each fold leaf, build the program similarly but with accumulator-fold semantics: the write reads the prior accumulator value through the header join (the body's value expression references `header.joinVersion`'s read); the emission `rhs` is `ast.binop(lowerBinop(leaf.outerOp), prior, folded)` where `folded` is the comprehension `ast.eachComb([], guards, comb, rhs)` and `prior` defaults to `ast.app(ast.var(leaf.prop), [target])` (carry forward the existing accumulator-key lookup from `lowerForeachShapeBSummaries`). Attach the same iterating-source termination metric via `ir1SsaIteratingSourceMetric(sourceIR1Expr)`. Close the header with the write's version (the back-edge). Return the aggregated program plus per-location accumulator-fold propositions and the `accumulatorKeys` array.
- Both helpers reuse `lowerBinop`, `lowerExpr` from `./ir-emit.js`, `lowerL1Expr` from `./ir1-lower.js`, `getAst` from `./pant-wasm.js`. Do NOT introduce new combinator vocabulary.
- Unskip the eight Patch-2-owned stubs in `tools/ts2pant/tests/ir1-ssa-foreach.test.mts` and replace each PENDING-comment body with concrete assertions exercising the helper's emission shape on hand-constructed Shape A / Shape B inputs. Assertions check: `result.program.loopHeaderJoins.length === <mutated location count>`, `result.program.loopBodies.length === <expected>`, each body's `terminationMetric.kind === "ssa-iterating-source-metric"` and `metric.source` references the foreach source, each body's `headerJoins[0].loopBackVersion` equals the corresponding write version for Shape A (degenerate case), each body's `headerJoins[0].loopBackVersion` differs from `preheaderVersion` for Shape B (accumulator-fold case).
- No caller in this patch consumes the new foreach helper — the existing `ir1-ssa-loops.ts` summary entry points remain unchanged and continue to call the legacy `buildLoopSsaProgram` path. Patch 3 and Patch 4 switch the call sites.

## Files to Modify
- tools/ts2pant/src/ir1.ts (modify): Extend `IR1SsaTerminationMetric` from a single interface into a discriminated union. Add `{ kind: "ssa-iterating-source-metric"; source: IR1Expr }` as a new variant and `ir1SsaIteratingSourceMetric(source)` as its constructor. Existing `ir1SsaTerminationMetric(expr, lowerBound)` constructor unchanged.
- tools/ts2pant/src/ir1-printer.ts (modify): Add a dispatch arm for the new `"ssa-iterating-source-metric"` variant wherever the printer walks `IR1SsaLoopBody.terminationMetric`. Counter / bounded-while loops continue to print the `expr` / `lowerBound` pair; foreach prints the `source`.
- tools/ts2pant/src/ir1-ssa-foreach.ts (create): New module exporting `lowerForeachShapeAAsGeneralLoop`, `lowerForeachShapeBAsGeneralLoop`, and `foreachShapeBAccumulatorKey`. Mirrors `ir1-ssa-counter-loop.ts` in file layout. Builds `IR1SsaLoopHeaderJoin` + `IR1SsaLoopBody` + iterating-source `IR1SsaTerminationMetric` for each foreach input. Emits the same propositions as today's `lowerForeachShape{A,B}Summaries`. The Shape A subset of `IR1Stmt` helpers (`summarizeForeachShapeABody`, `summarizeShapeAAssign`, `summarizeShapeACond`, `lowerShapeAExpr`, `shapeAKey`) and the `ShapeAPropertyEntry` / `ShapeASummaryState` interfaces move from `ir1-ssa-loops.ts` to this new module.
- tools/ts2pant/tests/ir1-ssa-foreach.test.mts (modify): Remove `.skip` from every stub introduced in Patch 1. Replace each PENDING-comment body with concrete assertions exercising the helper's emission shape on hand-constructed Shape A / Shape B inputs.

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[algorithm] Cytron 1991 SSA construction** — https://doi.org/10.1145/115372.115320 — Use `ir1SsaOpenLoopHeader` → emit body writes → `ir1SsaCloseLoopHeader` exactly as `ir1-ssa-counter-loop.ts:149-154` does. For Shape A's degenerate single-iteration case, close the header with the write's own version (`loopBackVersion = write.version`); the join semantically becomes a no-op but the contract is satisfied. For Shape B's accumulator fold, the close happens after the body's read-modify-write completes — the standard inductive shape.
- **[paper] Knobe & Sarkar 1998 — Array SSA Form** — https://doi.org/10.1145/268946.268956 — Per-element distinct SSA versions for array writes — the foreach Shape A discipline. Each element receives its own write, but the location-SSA chain treats them uniformly via the loop-header join. This is the formal name for what Patch 2 implements: array SSA specialised to the foreach quantified-write case.
- **[paper] Meijer, Fokkinga, Paterson FPCA 1991 — Bananas/Lenses/Envelopes** — https://maartenfokkinga.github.io/utwente/mmf91m.pdf — Shape A and Shape B are both instances of `foldr : (a -> b -> b) -> b -> [a] -> b`. Recharacterising them as general-loop SSA preserves the catamorphism framing — the loop body's writes are the algebra; the iteration-source termination metric is the structural recursion's well-founded order; the absence of a fixed-point recursion (because `terminationMetric` is non-null and bounded) marks them as catamorphisms rather than hylomorphisms.

## Gameplan Specification

```
module TS2PANT_LOOP_SUMMARY_UNIFICATION.

> ════════════════════════════════
> Milestone 6 AND Milestone 7 of the ts2pant general-loop SSA
> workstream, collapsed into a single atomic milestone.
> ════════════════════════════════
> After this milestone, foreach Shape A and Shape B lower
> through the general-loop SSA machinery
> (IR1SsaLoopHeaderJoin + IR1SsaLoopBody +
> IR1SsaTerminationMetric) rather than the legacy
> IR1SsaLoopSummary path. IR1SsaTerminationMetric is now a
> discriminated union: counter loops and bounded-while loops
> emit the existing counter-style variant (kind:
> ssa-termination-metric, expr, lowerBound); foreach Shape A
> and Shape B emit the new iterating-source variant (kind:
> ssa-iterating-source-metric, source) matching Pant's native
> all-x-in-arr semantics. Shape A's per-iteration writes do
> not feed back through the header join (degenerate close);
> Shape B's accumulator-fold writes do (Cytron inductive
> case). The IR1SsaLoopSummary type, the ir1SsaLoopSummary
> constructor, the IR1SsaProgram.loopSummaries field, the
> lowerMuSearchSummary path, and tools/ts2pant/src/ir1-ssa-loops.ts
> are all deleted. Four L7 invariant tests verify the unified
> abstraction: header-join uniqueness, continuation
> resolution, metric kind by loop class, frame suppression
> per modified rule. Pant output is byte-equivalent on every
> existing foreach fixture. Documentation marks BOTH milestone
> 6 AND milestone 7 as landed.

ForeachInput.
ForeachShape.
shape-a => ForeachShape.
shape-b => ForeachShape.
IR1SsaProgram.
IR1SsaProgramShape.
IR1SsaLoopBody.
IR1SsaLoopHeaderJoin.
IR1SsaTerminationMetric.
IR1SsaWrite.
IR1SsaVersion.
IR1SsaRuleName.
FieldName.
loop-summaries-field => FieldName.
loop-header-joins-field => FieldName.
loop-bodies-field => FieldName.
FileStatus.
file-present => FileStatus.
file-deleted => FileStatus.
Declaration.
DeletionStatus.
present => DeletionStatus.
deleted => DeletionStatus.
MuSearchSummary.
LoopClass.
counter => LoopClass.
bounded-while => LoopClass.
fixed-point-while => LoopClass.
foreach-shape-a => LoopClass.
foreach-shape-b => LoopClass.
FixtureOutput.
MetricKind.
counter-metric => MetricKind.
iterating-source-metric => MetricKind.
Document.
DocumentKind.
MilestoneStatus.
ir-doc => DocumentKind.
transformations-doc => DocumentKind.
agents-md => DocumentKind.
workstream-doc => DocumentKind.
pending => MilestoneStatus.
landed => MilestoneStatus.

> Foreach-as-general-loop helper.
input-shape i: ForeachInput => ForeachShape.
lower-result i: ForeachInput => IR1SsaProgram.
body-of p: IR1SsaProgram => IR1SsaLoopBody.
header-of b: IR1SsaLoopBody => IR1SsaLoopHeaderJoin.
metric-of b: IR1SsaLoopBody => IR1SsaTerminationMetric.
metric-kind m: IR1SsaTerminationMetric => MetricKind.
write-of b: IR1SsaLoopBody => IR1SsaWrite.
loop-back-version h: IR1SsaLoopHeaderJoin => IR1SsaVersion.
preheader-version h: IR1SsaLoopHeaderJoin => IR1SsaVersion.
write-version w: IR1SsaWrite => IR1SsaVersion.
emits-quantified-equation? p: IR1SsaProgram => Bool.
emits-accumulator-fold-equation? p: IR1SsaProgram => Bool.

> Deletion (Patches 5, 6).
shape-has-field? s: IR1SsaProgramShape, f: FieldName => Bool.
ir-ssa-loops-file-status => FileStatus.
deletion-status d: Declaration => DeletionStatus.
is-mu-search-summary? d: Declaration => Bool.
production-reachable? d: Declaration => Bool.

> L7 invariants (Patch 7).
header-has-preheader? h: IR1SsaLoopHeaderJoin => Bool.
header-has-loop-back? h: IR1SsaLoopHeaderJoin => Bool.
header-closed? h: IR1SsaLoopHeaderJoin => Bool.
body-class b: IR1SsaLoopBody => LoopClass.
non-null-metric? b: IR1SsaLoopBody => Bool.
is-bounded? c: LoopClass => Bool.
uses-counter-metric? c: LoopClass => Bool.
uses-iterating-source-metric? c: LoopClass => Bool.
continuations-resolved? b: IR1SsaLoopBody => Bool.
modified-rule-appears-once? p: IR1SsaProgram, r: IR1SsaRuleName => Bool.
body-writes-rule? b: IR1SsaLoopBody, r: IR1SsaRuleName => Bool.

> Byte-equivalent emission.
legacy-emission i: ForeachInput => FixtureOutput.
recharacterised-emission i: ForeachInput => FixtureOutput.
byte-equivalent? a: FixtureOutput, b: FixtureOutput => Bool.

> Documentation.
document-kind d: Document => DocumentKind.
document-mentions-unification? d: Document => Bool.
workstream-milestone-6-status => MilestoneStatus.
workstream-milestone-7-status => MilestoneStatus.
---

> Foreach helper contract: every foreach input lowers to an
> IR1SsaProgram carrying an iterating-source termination
> metric (the new variant introduced by Patch 2).
all i: ForeachInput, b: IR1SsaLoopBody |
  b = body-of (lower-result i) ->
    metric-kind (metric-of b) = iterating-source-metric.

> Shape A: the header join's loop-back version equals the
> per-iteration write version (degenerate close).
all i: ForeachInput, b: IR1SsaLoopBody, h: IR1SsaLoopHeaderJoin, w: IR1SsaWrite |
  input-shape i = shape-a and b = body-of (lower-result i) and
  h = header-of b and w = write-of b ->
    loop-back-version h = write-version w.

> Shape A: emits a per-element quantified equation.
all i: ForeachInput |
  input-shape i = shape-a ->
    emits-quantified-equation? (lower-result i).

> Shape B: emits an accumulator-fold equation per location.
all i: ForeachInput |
  input-shape i = shape-b ->
    emits-accumulator-fold-equation? (lower-result i).

> Byte-equivalent Pant emission on every existing fixture.
all i: ForeachInput |
  byte-equivalent? (legacy-emission i) (recharacterised-emission i).

> Type-level deletion: IR1SsaProgram has no loopSummaries
> field; retains loopHeaderJoins and loopBodies.
all s: IR1SsaProgramShape |
  ~(shape-has-field? s loop-summaries-field).

all s: IR1SsaProgramShape |
  shape-has-field? s loop-header-joins-field and
  shape-has-field? s loop-bodies-field.

> File deletion: ir1-ssa-loops.ts is gone.
ir-ssa-loops-file-status = file-deleted.

> μ-search summary symbols are deleted; the dead path is
> unreachable.
all d: Declaration |
  is-mu-search-summary? d -> deletion-status d = deleted.

all d: Declaration |
  deletion-status d = deleted -> ~(production-reachable? d).

> L7 invariant: every header join has exactly one preheader,
> one loop-back, and is closed.
all h: IR1SsaLoopHeaderJoin |
  header-has-preheader? h and header-has-loop-back? h and
  header-closed? h.

> L7 invariant: continuation handles resolve.
all b: IR1SsaLoopBody |
  continuations-resolved? b.

> L7 invariant 3a: bounded loops have non-null metrics.
all b: IR1SsaLoopBody |
  is-bounded? (body-class b) -> non-null-metric? b.

> L7 invariant 3b: counter / bounded-while emit
> counter-metric; foreach Shape A / Shape B emit
> iterating-source-metric.
all b: IR1SsaLoopBody |
  uses-counter-metric? (body-class b) ->
    metric-kind (metric-of b) = counter-metric.

all b: IR1SsaLoopBody |
  uses-iterating-source-metric? (body-class b) ->
    metric-kind (metric-of b) = iterating-source-metric.

is-bounded? counter.
is-bounded? bounded-while.
is-bounded? foreach-shape-a.
is-bounded? foreach-shape-b.
~(is-bounded? fixed-point-while).

uses-counter-metric? counter.
uses-counter-metric? bounded-while.
uses-iterating-source-metric? foreach-shape-a.
uses-iterating-source-metric? foreach-shape-b.

> L7 invariant: every modified rule appears in modifiedRules
> exactly once.
all p: IR1SsaProgram, r: IR1SsaRuleName, b: IR1SsaLoopBody |
  body-writes-rule? b r ->
    modified-rule-appears-once? p r.

> Documentation invariants.
all d: Document |
  document-kind d = ir-doc ->
    document-mentions-unification? d.

all d: Document |
  document-kind d = transformations-doc ->
    document-mentions-unification? d.

all d: Document |
  document-kind d = agents-md ->
    document-mentions-unification? d.

all d: Document |
  document-kind d = workstream-doc ->
    document-mentions-unification? d.

workstream-milestone-6-status = landed.
workstream-milestone-7-status = landed.
```

## Patch Specification

```
module TS2PANT_LOOP_SUMMARY_UNIFICATION_PATCH_2.

> Patch 2 extends IR1SsaTerminationMetric with a new
> iterating-source variant and lands the dormant
> foreach-as-general-loop helper. The existing counter-style
> variant is unchanged; the new variant carries only a source
> expression (no synthesized counter binder). Shape A and
> Shape B foreach inputs build IR1SsaLoopHeaderJoin +
> IR1SsaLoopBody + the iterating-source metric. Shape A's
> per-iteration write does not feed back through the header
> join (degenerate close); Shape B's accumulator fold does.
> No production caller consumes the new helper; capability is
> dormant until Patches 3 and 4 switch the call sites.

ForeachInput.
IR1SsaProgram.
IR1SsaLoopBody.
IR1SsaLoopHeaderJoin.
IR1SsaTerminationMetric.
MetricKind.
counter-metric => MetricKind.
iterating-source-metric => MetricKind.
IR1SsaWrite.
IR1SsaVersion.
PropResult.
ForeachShape.
shape-a => ForeachShape.
shape-b => ForeachShape.

input-shape i: ForeachInput => ForeachShape.
lower-result i: ForeachInput => IR1SsaProgram.
body-of p: IR1SsaProgram => IR1SsaLoopBody.
header-of b: IR1SsaLoopBody => IR1SsaLoopHeaderJoin.
metric-of b: IR1SsaLoopBody => IR1SsaTerminationMetric.
metric-kind m: IR1SsaTerminationMetric => MetricKind.
write-of b: IR1SsaLoopBody => IR1SsaWrite.
loop-back-version h: IR1SsaLoopHeaderJoin => IR1SsaVersion.
preheader-version h: IR1SsaLoopHeaderJoin => IR1SsaVersion.
write-version w: IR1SsaWrite => IR1SsaVersion.
emits-quantified-equation? p: IR1SsaProgram => Bool.
emits-accumulator-fold-equation? p: IR1SsaProgram => Bool.
---

> Both foreach shapes emit the iterating-source metric kind.
all i: ForeachInput, b: IR1SsaLoopBody |
  b = body-of (lower-result i) ->
    metric-kind (metric-of b) = iterating-source-metric.

> Shape A: the header join's loop-back version equals the
> per-iteration write version (degenerate close).
all i: ForeachInput, b: IR1SsaLoopBody, h: IR1SsaLoopHeaderJoin, w: IR1SsaWrite |
  input-shape i = shape-a and b = body-of (lower-result i) and
  h = header-of b and w = write-of b ->
    loop-back-version h = write-version w.

> Shape A: emits a per-element quantified equation per
> mutated location.
all i: ForeachInput |
  input-shape i = shape-a ->
    emits-quantified-equation? (lower-result i).

> Shape B: emits an accumulator-fold equation per mutated
> location.
all i: ForeachInput |
  input-shape i = shape-b ->
    emits-accumulator-fold-equation? (lower-result i).

> Shape B: write reads prior version through the header join.
all i: ForeachInput, b: IR1SsaLoopBody, w: IR1SsaWrite, h: IR1SsaLoopHeaderJoin |
  input-shape i = shape-b and b = body-of (lower-result i) and
  w = write-of b and h = header-of b ->
    loop-back-version h = write-version w.
```


## Implementation Notes

- The new foreach helper takes the foreach source as an `IR1Expr` and lowers it internally for Pant guards. This keeps the termination metric structurally tied to the IR1 source while preserving the legacy proposition text shape.
- `ir1-substitute.ts` also needed a metric-kind dispatch so free-variable collection includes `ssa-iterating-source-metric.source`; otherwise the new union would compile in the main contract but fail in substitution/free-var consumers.
- `ir1-printer.ts` now prints loop-body metric summaries when `program.loopBodies` is populated. Existing legacy summary output remains unchanged; the new arm exists mainly to make future loop-body printer paths type-safe for both metric variants.
- Shape B’s SSA write value is represented as a property read-modify-write expression (`prop target OP rhs`) over the same location, then closed with the write version. There is no separate `IR1SsaRead` object in this dormant helper; the header/write/body structure is what records the loop-back protocol until later patches wire it into production lowering.

Spec/Evidence Mapping:
- Iterating-source metric variant: `tools/ts2pant/src/ir1.ts` (`IR1SsaTerminationMetric`, `ir1SsaIteratingSourceMetric`); proven by `npm run build` and the Shape A/B metric assertions in `tools/ts2pant/tests/ir1-ssa-foreach.test.mts`.
- Shape A degenerate close: `lowerForeachShapeAAsGeneralLoop` -> `buildForeachLoopBody`; proven by the loop-back equals write-version test.
- Shape B accumulator fold shape: `lowerForeachShapeBAsGeneralLoop`; proven by accumulator proposition text assertions and the loop-back/preheader/write-version assertions.
- Dormant production behavior: no existing `ir1-lower-body.ts` call site was changed; full `npm test` passed with legacy foreach fixtures unchanged.
- Static and regression checks run: `npm run lint`, `npm run build`, focused `ir1-ssa-foreach` test, and full `npm test`.