### PR TITLE
[ts2pant-loop-summary-unification] Patch 4: ts2pant: switch Shape B call site to new helper; delete adapter

### DIFF
--- a/tools/ts2pant/src/ir1-lower-body.ts
+++ b/tools/ts2pant/src/ir1-lower-body.ts
@@ -29,8 +29,8 @@ import { lowerFixedPointLoopL1Body } from "./ir1-ssa-fixed-point.js";
 import {
   type ForeachAsGeneralLoopResult,
   lowerForeachShapeAAsGeneralLoop,
+  lowerForeachShapeBAsGeneralLoop,
 } from "./ir1-ssa-foreach.js";
-import { lowerForeachShapeBSummaries } from "./ir1-ssa-loops.js";
 import {
   appendFramesForUnmodifiedRules,
   collectionSsaBodyLowerResult,
@@ -67,12 +67,7 @@ export function adaptLoopSummaryLowerResult(
   result: ForeachAsGeneralLoopResult,
 ): IR1SsaBodyLowerResult;
 export function adaptLoopSummaryLowerResult(
-  result: ReturnType<typeof lowerForeachShapeBSummaries>,
-): IR1SsaBodyLowerResult;
-export function adaptLoopSummaryLowerResult(
-  result:
-    | ForeachAsGeneralLoopResult
-    | ReturnType<typeof lowerForeachShapeBSummaries>,
+  result: ForeachAsGeneralLoopResult,
 ): IR1SsaBodyLowerResult {
   return loopSsaBodyLowerResult(result);
 }
@@ -308,7 +303,6 @@ function lowerForeachL1BodyToSsaResult(
   stmt: Extract<IR1Stmt, { kind: "foreach" }>,
   options: SsaBodyLowerOptions,
 ): IR1SsaBodyLowerResult {
-  const arrExpr = options.applyConst(lowerExpr(lowerL1Expr(stmt.source)));
   const results: IR1SsaBodyLowerResult[] = [];
 
   if (stmt.body !== null) {
@@ -330,9 +324,9 @@ function lowerForeachL1BodyToSsaResult(
   if (stmt.foldLeaves.length > 0) {
     results.push(
       adaptLoopSummaryLowerResult(
-        lowerForeachShapeBSummaries({
+        lowerForeachShapeBAsGeneralLoop({
           binder: stmt.binder,
-          source: arrExpr,
+          source: stmt.source,
           foldLeaves: stmt.foldLeaves,
           lowerExpr: (expr) => options.applyConst(lowerExpr(lowerL1Expr(expr))),
           priorAccumulatorValues: new Map(),

--- a/tools/ts2pant/src/ir1-ssa-loops.ts
+++ b/tools/ts2pant/src/ir1-ssa-loops.ts
@@ -1,73 +1,24 @@
-import { lowerBinop, lowerExpr } from "./ir-emit.js";
-import {
-  type IR1Expr,
-  type IR1FoldLeaf,
-  type IR1SsaLocation,
-  type IR1SsaLoopSummary,
-  type IR1SsaProgram,
-  type IR1SsaRuleName,
-  ir1SsaLoopSummary,
-  ir1SsaPropertyLocation,
-  ir1SsaRuleOfLocation,
+import type {
+  IR1SsaLoopSummary,
+  IR1SsaProgram,
+  IR1SsaRuleName,
 } from "./ir1.js";
-import { lowerL1Expr } from "./ir1-lower.js";
 import type { OpaqueExpr } from "./pant-ast.js";
-import { getAst } from "./pant-wasm.js";
 import type { PropResult } from "./types.js";
 
 export type LoopSsaShape = IR1SsaLoopSummary["shape"];
 
 type UnsupportedDiagnostic = Extract<PropResult, { kind: "unsupported" }>;
 
-interface LoopSummaryInputBase {
-  location: IR1SsaLocation;
-}
-
-export interface ForeachShapeBSummaryInput extends LoopSummaryInputBase {
-  kind: "foreach-shape-b";
-  propositions?: readonly PropResult[];
-}
-
 export interface UnsupportedLoopSummaryInput {
   kind: "unsupported";
   reason: string;
 }
 
-export type IR1LoopSsaInput =
-  | ForeachShapeBSummaryInput
-  | UnsupportedLoopSummaryInput;
+export type IR1LoopSsaInput = UnsupportedLoopSummaryInput;
 
 export interface LoopSsaBuildOptions {
   declaredRules?: Iterable<IR1SsaRuleName>;
-}
-
-export interface ForeachSummaryLowerOptions extends LoopSsaBuildOptions {
-  input: ForeachShapeBSummaryInput;
-}
-
-export interface ForeachShapeBSummaryOptions extends LoopSsaBuildOptions {
-  binder: string;
-  source: OpaqueExpr;
-  foldLeaves: readonly IR1FoldLeaf[];
-  lowerExpr?: (e: IR1Expr) => OpaqueExpr;
-  priorAccumulatorValues?: ReadonlyMap<string, OpaqueExpr>;
-}
-
-export interface ForeachSummaryLowerResult {
-  program: IR1SsaProgram;
-  summary: IR1SsaLoopSummary | null;
-  propositions: PropResult[];
-  modifiedRules: IR1SsaRuleName[];
-  diagnostics: UnsupportedDiagnostic[];
-}
-
-export interface ForeachShapeBSummaryResult {
-  program: IR1SsaProgram;
-  summaries: IR1SsaLoopSummary[];
-  propositions: PropResult[];
-  modifiedRules: IR1SsaRuleName[];
-  diagnostics: UnsupportedDiagnostic[];
-  accumulatorKeys: string[];
 }
 
 export interface LoopSsaBuildResult {
@@ -82,123 +33,27 @@ export function buildLoopSsaProgram(
   options: LoopSsaBuildOptions = {},
 ): LoopSsaBuildResult {
   const normalizedInputs = Array.isArray(inputs) ? inputs : [inputs];
-  const loopSummaries: IR1SsaLoopSummary[] = [];
-  const modifiedRules = new Set<IR1SsaRuleName>();
   const declaredRules = new Set<IR1SsaRuleName>(options.declaredRules ?? []);
-  const loweredExpr: OpaqueExpr[] = [];
-  const propositions: PropResult[] = [];
   const diagnostics: UnsupportedDiagnostic[] = [];
 
   for (const input of normalizedInputs) {
-    if (input.kind === "unsupported") {
-      diagnostics.push({ kind: "unsupported", reason: input.reason });
-      continue;
-    }
-
-    const summary = ir1SsaLoopSummary(input.kind, input.location);
-    loopSummaries.push(summary);
-
-    const modifiedRule = ir1SsaRuleOfLocation(input.location);
-    modifiedRules.add(modifiedRule);
-    declaredRules.add(modifiedRule);
-
-    if (input.propositions !== undefined) {
-      propositions.push(...input.propositions);
-    }
+    diagnostics.push({ kind: "unsupported", reason: input.reason });
   }
 
-  const framedRules = [...declaredRules].filter(
-    (rule) => !modifiedRules.has(rule),
-  );
   return {
     program: {
       reads: [],
       writes: [],
       joins: [],
-      loopSummaries,
+      loopSummaries: [],
       loopHeaderJoins: [],
       loopBodies: [],
       declaredRules: [...declaredRules],
-      modifiedRules: [...modifiedRules],
-      framedRules,
+      modifiedRules: [],
+      framedRules: [...declaredRules],
     },
-    loweredExpr,
-    propositions,
+    loweredExpr: [],
+    propositions: [],
     diagnostics,
   };
-}
-
-export function lowerForeachSummary(
-  options: ForeachSummaryLowerOptions,
-): ForeachSummaryLowerResult {
-  const result = buildLoopSsaProgram(options.input, options);
-  return {
-    program: result.program,
-    summary: result.program.loopSummaries[0] ?? null,
-    propositions: result.propositions,
-    modifiedRules: result.program.modifiedRules,
-    diagnostics: result.diagnostics,
-  };
-}
-
-export function lowerForeachShapeBSummaries(
-  options: ForeachShapeBSummaryOptions,
-): ForeachShapeBSummaryResult {
-  const ast = getAst();
-  const lower = options.lowerExpr ?? ((e) => lowerExpr(lowerL1Expr(e)));
-  const accumulatorKeys: string[] = [];
-  const inputs: ForeachShapeBSummaryInput[] = options.foldLeaves.map((leaf) => {
-    const target = lower(leaf.target);
-    const rhs = lower(leaf.rhs);
-    const guards = [ast.gIn(options.binder, options.source)];
-    if (leaf.guard !== null) {
-      guards.push(ast.gExpr(lower(leaf.guard)));
-    }
-
-    const comb =
-      leaf.combiner === "add"
-        ? ast.combAdd()
-        : leaf.combiner === "mul"
-          ? ast.combMul()
-          : leaf.combiner === "and"
-            ? ast.combAnd()
-            : ast.combOr();
-    const folded = ast.eachComb([], guards, comb, rhs);
-    const key = foreachShapeBAccumulatorKey(leaf.prop, target);
-    accumulatorKeys.push(key);
-    const prior =
-      options.priorAccumulatorValues?.get(key) ??
-      ast.app(ast.var(leaf.prop), [target]);
-
-    const location = ir1SsaPropertyLocation(leaf.prop, leaf.target, leaf.prop);
-    return {
-      kind: "foreach-shape-b",
-      location,
-      propositions: [
-        {
-          kind: "equation",
-          quantifiers: [],
-          lhs: ast.app(ast.primed(leaf.prop), [target]),
-          rhs: ast.binop(lowerBinop(leaf.outerOp), prior, folded),
-        },
-      ],
-    };
-  });
-
-  const result = buildLoopSsaProgram(inputs, options);
-  return {
-    program: result.program,
-    summaries: result.program.loopSummaries,
-    propositions: result.propositions,
-    modifiedRules: result.program.modifiedRules,
-    diagnostics: result.diagnostics,
-    accumulatorKeys,
-  };
-}
-
-export function foreachShapeBAccumulatorKey(
-  prop: string,
-  objExpr: OpaqueExpr,
-): string {
-  return `${prop}::${getAst().strExpr(objExpr)}`;
 }

--- a/tools/ts2pant/src/ir1-ssa-lower.ts
+++ b/tools/ts2pant/src/ir1-ssa-lower.ts
@@ -5,10 +5,6 @@ import type {
 } from "./ir1-ssa-collections.js";
 import type { ForeachAsGeneralLoopResult } from "./ir1-ssa-foreach.js";
 import type {
-  ForeachShapeBSummaryResult,
-  ForeachSummaryLowerResult,
-} from "./ir1-ssa-loops.js";
-import type {
   ScalarSsaFinalPropertyEntry,
   ScalarSsaLowerResult,
 } from "./ir1-ssa-scalars.js";
@@ -235,10 +231,7 @@ export function collectionSsaBodyLowerResult(
 }
 
 export function loopSsaBodyLowerResult(
-  result:
-    | ForeachSummaryLowerResult
-    | ForeachAsGeneralLoopResult
-    | ForeachShapeBSummaryResult,
+  result: ForeachAsGeneralLoopResult,
 ): IR1SsaBodyLowerResult {
   return ir1SsaBodyLowerResult({
     propositions: "propositions" in result ? result.propositions : [],

--- a/tools/ts2pant/tests/ir1-ssa-invariants.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-invariants.test.mts
@@ -53,9 +53,6 @@ import {
 } from "../src/ir1.js";
 import { lowerCollectionSsaToResult } from "../src/ir1-ssa-collections.js";
 import { lowerScalarSsaToProps } from "../src/ir1-ssa-scalars.js";
-import {
-  lowerForeachShapeBSummaries,
-} from "../src/ir1-ssa-loops.js";
 import { getAst, loadAst } from "../src/pant-wasm.js";
 import { IntStrategy } from "../src/translate-types.js";
 import { buildDocumentFromSourceFile } from "./helpers.mts";
@@ -788,7 +785,6 @@ before(async () => {
 describe("ir1-ssa-invariants", () => {
   void representativePrograms;
   void walkSsaProgram;
-  void lowerForeachShapeBSummaries;
 
   it(
     "each write, join, and summary produces a fresh SSA version at its location",

--- a/tools/ts2pant/tests/ir1-ssa-loops.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-loops.test.mts
@@ -7,18 +7,14 @@ import { emitDocument } from "../src/emit.js";
 import { createSourceFile } from "../src/extract.js";
 import {
   ir1Assign,
+  ir1Binop,
   ir1Foreach,
   ir1LitBool,
   ir1Member,
-  ir1SsaPropertyLocation,
-  ir1SsaRuleOfLocation,
   ir1Var,
 } from "../src/ir1.js";
 import { lowerL1BodyToSsaProps } from "../src/ir1-lower-body.js";
-import {
-  buildLoopSsaProgram,
-  lowerForeachSummary,
-} from "../src/ir1-ssa-loops.js";
+import { buildLoopSsaProgram } from "../src/ir1-ssa-loops.js";
 import { loadAst } from "../src/pant-wasm.js";
 import { buildDocumentFromSourceFile } from "./helpers.mts";
 
@@ -39,78 +35,6 @@ describe("ir1-ssa-loops", () => {
   // PENDING Patch 2: introduce the dedicated loop-summary SSA helper and
   // summary/version bookkeeping for supported loop-like constructs.
   // PENDING Patch 4: route foreach Shape B lowering through general-loop SSA.
-
-  it("records foreach Shape B accumulator folds as loop summaries", () => {
-    const location = ir1SsaPropertyLocation(
-      "Account_total",
-      ir1Var("account"),
-      "total",
-    );
-    const proposition = { kind: "raw" as const, text: "accumulator-fold" };
-
-    const result = lowerForeachSummary({
-      input: {
-        kind: "foreach-shape-b",
-        location,
-        propositions: [proposition],
-      },
-      declaredRules: ["Account_limit"],
-    });
-
-    assert.deepEqual(result.diagnostics, []);
-    assert.equal(result.summary?.shape, "foreach-shape-b");
-    assert.equal(result.summary?.location, location);
-    assert.equal(result.summary?.summaryVersion.origin, "loop-summary");
-    assert.equal(result.summary?.summaryVersion.location, location);
-    assert.deepEqual(result.propositions, [proposition]);
-    assert.deepEqual(result.program.modifiedRules, [
-      ir1SsaRuleOfLocation(location),
-    ]);
-    assert.deepEqual(
-      new Set(result.program.declaredRules),
-      new Set(["Account_total", "Account_limit"]),
-    );
-    assert.deepEqual(result.program.framedRules, ["Account_limit"]);
-  });
-
-  it("creates distinct summary versions and tracks modified rules", () => {
-    const shapeBTotalLocation = ir1SsaPropertyLocation(
-      "Account_total",
-      ir1Var("account"),
-      "total",
-    );
-    const shapeBLimitLocation = ir1SsaPropertyLocation(
-      "Account_limit",
-      ir1Var("account"),
-      "limit",
-    );
-
-    const result = buildLoopSsaProgram(
-      [
-        { kind: "foreach-shape-b", location: shapeBTotalLocation },
-        { kind: "foreach-shape-b", location: shapeBLimitLocation },
-      ],
-      { declaredRules: ["Account_seen"] },
-    );
-
-    const [shapeBTotal, shapeBLimit] = result.program.loopSummaries;
-    assert.notEqual(shapeBTotal!.summaryVersion, shapeBLimit!.summaryVersion);
-    assert.notEqual(
-      shapeBTotal!.summaryVersion.id,
-      shapeBLimit!.summaryVersion.id,
-    );
-    assert.equal(shapeBTotal!.summaryVersion.location, shapeBTotalLocation);
-    assert.equal(shapeBLimit!.summaryVersion.location, shapeBLimitLocation);
-    assert.deepEqual(
-      new Set(result.program.modifiedRules),
-      new Set(["Account_total", "Account_limit"]),
-    );
-    assert.deepEqual(
-      new Set(result.program.declaredRules),
-      new Set(["Account_total", "Account_limit", "Account_seen"]),
-    );
-    assert.deepEqual(result.program.framedRules, ["Account_seen"]);
-  });
 
   it("reports unsupported loop summary inputs without summaries", () => {
     const result = buildLoopSsaProgram(
@@ -265,10 +189,48 @@ describe("ir1-ssa-loops", () => {
     },
   );
 
-  it.skip(
+  it(
     "foreach Shape B call site emits IR1SsaProgram with populated loopHeaderJoins and loopBodies",
     () => {
-      // PENDING Patch 4: verify the Shape B production call site uses general-loop SSA.
+      const account = ir1Var("account");
+      const item = ir1Var("item");
+      const result = lowerL1BodyToSsaProps(
+        ir1Foreach("item", ir1Var("items"), null, [
+          {
+            target: account,
+            prop: "Account_total",
+            combiner: "add",
+            outerOp: "add",
+            rhs: ir1Member(item, "Item_value"),
+            guard: null,
+          },
+        ]),
+        [],
+        { applyConst: (expr) => expr },
+      );
+
+      assert.deepEqual(result.diagnostics, []);
+      assert.equal(result.programs.length, 1);
+      const program = result.programs[0]!;
+      assert.equal(program.loopSummaries.length, 0);
+      assert.equal(program.loopHeaderJoins.length, 1);
+      assert.equal(program.loopBodies.length, 1);
+      const body = program.loopBodies[0]!;
+      const header = body.headerJoins[0]!;
+      const write = body.writes[0]!;
+      assert.equal(header.loopBackVersion, write.version);
+      assert.equal(body.terminationMetric?.kind, "ssa-iterating-source-metric");
+      assert.equal(write.value.kind, "property");
+      if (write.value.kind === "property") {
+        assert.deepEqual(
+          write.value.value,
+          ir1Binop(
+            "add",
+            ir1Member(account, "Account_total"),
+            ir1Member(item, "Item_value"),
+          ),
+        );
+      }
     },
   );
 

--- a/tools/ts2pant/tests/ir1-ssa-lower.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-lower.test.mts
@@ -26,8 +26,10 @@ import {
   ir1SsaBodyLowerSuccess,
   ir1SsaBodyLowerUnsupported,
 } from "../src/ir1-ssa-lower.js";
-import { lowerForeachShapeAAsGeneralLoop } from "../src/ir1-ssa-foreach.js";
-import { lowerForeachShapeBSummaries } from "../src/ir1-ssa-loops.js";
+import {
+  lowerForeachShapeAAsGeneralLoop,
+  lowerForeachShapeBAsGeneralLoop,
+} from "../src/ir1-ssa-foreach.js";
 import { lowerScalarSsaToProps } from "../src/ir1-ssa-scalars.js";
 import { getAst, loadAst } from "../src/pant-wasm.js";
 
@@ -293,7 +295,6 @@ describe("ir1-ssa-lower", () => {
         modifiedRules: [],
         framedRules: ["Account_balance"],
       },
-      summary: null,
       propositions: [],
       modifiedRules: [],
       diagnostics: [
@@ -326,9 +327,9 @@ describe("ir1-ssa-lower", () => {
       }),
     );
     const shapeB = adaptLoopSummaryLowerResult(
-      lowerForeachShapeBSummaries({
+      lowerForeachShapeBAsGeneralLoop({
         binder: "item0",
-        source: ast.var("items"),
+        source: ir1Var("items"),
         foldLeaves: [
           {
             target: ir1Var("account"),
@@ -358,10 +359,12 @@ describe("ir1-ssa-lower", () => {
       result.programs.flatMap((program) =>
         program.loopSummaries.map((summary) => summary.shape),
       ),
-      ["foreach-shape-b"],
+      [],
     );
     assert.equal(result.programs[0]?.loopHeaderJoins.length, 1);
     assert.equal(result.programs[0]?.loopBodies.length, 1);
+    assert.equal(shapeB.programs[0]?.loopHeaderJoins.length, 1);
+    assert.equal(shapeB.programs[0]?.loopBodies.length, 1);
 
     const shapeAProp = result.propositions[0];
     assert.equal(shapeAProp?.kind, "equation");

--- a/tools/ts2pant/tests/ir1-ssa-propresult-lowering.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-propresult-lowering.test.mts
@@ -10,7 +10,6 @@ import {
   ir1Member,
   ir1SetAddOrDelete,
   ir1SetClear,
-  ir1SsaPropertyLocation,
   ir1Var,
 } from "../src/ir1.js";
 import { lowerCollectionSsaToResult } from "../src/ir1-ssa-collections.js";
@@ -18,7 +17,6 @@ import {
   appendFramesForUnmodifiedRules,
   ir1SsaBodyLowerSuccess,
 } from "../src/ir1-ssa-lower.js";
-import { lowerForeachSummary } from "../src/ir1-ssa-loops.js";
 import { lowerScalarSsaToProps } from "../src/ir1-ssa-scalars.js";
 import { getAst, loadAst } from "../src/pant-wasm.js";
 import type { PropResult } from "../src/types.js";
@@ -186,59 +184,6 @@ describe("ir1-ssa-propresult-lowering", () => {
           "y1 in Owner_tags' owner <-> (cond y1 = y => true, true => false)",
         );
       }
-    },
-  );
-
-  it.skip(
-    "loop summaries report propositions and modified rules through one result",
-    () => {
-      const shapeA = lowerForeachSummary({
-        input: {
-          kind: "foreach-shape-a",
-          location: ir1SsaPropertyLocation(
-            "Item_seen",
-            ir1Var("$item"),
-            "seen",
-          ),
-          propositions: [{ kind: "raw", text: "quantified-write" }],
-        },
-      });
-      const shapeB = lowerForeachSummary({
-        input: {
-          kind: "foreach-shape-b",
-          location: ir1SsaPropertyLocation(
-            "Account_total",
-            ir1Var("account"),
-            "total",
-          ),
-          propositions: [{ kind: "raw", text: "accumulator-fold" }],
-        },
-        declaredRules: ["Account_limit"],
-      });
-      const result = pendingUnifiedLowerResult({
-        declaredRules: [
-          ...shapeA.program.declaredRules,
-          ...shapeB.program.declaredRules,
-        ],
-        propositions: [...shapeA.propositions, ...shapeB.propositions],
-        modifiedRules: [...shapeA.modifiedRules, ...shapeB.modifiedRules],
-        diagnostics: [...shapeA.diagnostics, ...shapeB.diagnostics],
-      });
-
-      assert.deepEqual(result.diagnostics, []);
-      assert.deepEqual(
-        [shapeA.summary?.shape, shapeB.summary?.shape],
-        ["foreach-shape-a", "foreach-shape-b"],
-      );
-      assert.deepEqual(
-        new Set(result.modifiedRules),
-        new Set(["Item_seen", "Account_total"]),
-      );
-      assert.deepEqual(result.framedRules, ["Account_limit"]);
-      assert.deepEqual(result.propositions, [
-        { kind: "raw", text: "quantified-write" },
-        { kind: "raw", text: "accumulator-fold" },
-      ]);
     },
   );
 


### PR DESCRIPTION
## Patch 4: ts2pant: switch Shape B call site to new helper; delete adapter

- In `tools/ts2pant/src/ir1-lower-body.ts`, switch the Shape B foreach call (line 337) to use `lowerForeachShapeBAsGeneralLoop` from `./ir1-ssa-foreach.js`. Build the options struct with the same fields as before (`binder`, `source`, `foldLeaves`, `lowerExpr`, `priorAccumulatorValues`).
- Update the `adaptLoopSummaryLowerResult` overload at line 69-70 to take `ForeachAsGeneralLoopResult` instead of `ReturnType<typeof lowerForeachShapeBSummaries>`.
- In `tools/ts2pant/src/ir1-ssa-lower.ts:238-243`, drop the `ForeachShapeBSummaryResult` arm of the union (subsumed by `ForeachAsGeneralLoopResult`). After this patch, the union should contain `ForeachAsGeneralLoopResult` and `MuSearchSummaryLowerResult` (the latter deleted by Patch 5).
- In `tools/ts2pant/src/ir1-ssa-loops.ts`, delete `lowerForeachShapeBSummaries` (lines 268-321), `lowerForeachSummary` (lines 192-203), `ForeachShapeBSummaryInput` (lines 37-40), `ForeachShapeBSummaryOptions` (lines 69-75), `ForeachShapeBSummaryResult` (lines 93-100), `ForeachSummaryLowerOptions` (lines 57-59), `ForeachSummaryLowerResult` (lines 77-83), and `foreachShapeBAccumulatorKey` (lines 572-577 — moved to `ir1-ssa-foreach.ts` in Patch 2). After this patch the file retains `buildLoopSsaProgram`, `lowerMuSearchSummary` and the μ-search summary types, the legacy `IR1LoopSsaInput` / `LoopSummaryInputBase` / `LoopSsaBuildOptions` / `LoopSsaBuildResult` / `UnsupportedLoopSummaryInput` types, `LoopSsaShape`, and `MuSearchCounterType`.
- Delete any tests in `tools/ts2pant/tests/ir1-ssa-loops.test.mts` that exercise `lowerForeachShapeBSummaries` / `lowerForeachSummary` directly.
- Run `just ts2pant-test` and confirm `tools/ts2pant/tests/constructs.test.mts.snapshot` does NOT change. Any drift on Shape B fixtures (`sumAmounts`, `forEachSum`, `sumPositive`, `mixedUpdates`, `sumIntoAnon`, `deductFees`, `forEachActivate`) indicates a real bug.
- Unskip the Patch-4-owned `tools/ts2pant/tests/ir1-ssa-loops.test.mts` stub from Patch 1 and replace the PENDING-comment body with a concrete assertion.

## Changes
- In `tools/ts2pant/src/ir1-lower-body.ts`, switch the Shape B foreach call (line 337) to use `lowerForeachShapeBAsGeneralLoop` from `./ir1-ssa-foreach.js`. Build the options struct with the same fields as before (`binder`, `source`, `foldLeaves`, `lowerExpr`, `priorAccumulatorValues`).
- Update the `adaptLoopSummaryLowerResult` overload at line 69-70 to take `ForeachAsGeneralLoopResult` instead of `ReturnType<typeof lowerForeachShapeBSummaries>`.
- In `tools/ts2pant/src/ir1-ssa-lower.ts:238-243`, drop the `ForeachShapeBSummaryResult` arm of the union (subsumed by `ForeachAsGeneralLoopResult`). After this patch, the union should contain `ForeachAsGeneralLoopResult` and `MuSearchSummaryLowerResult` (the latter deleted by Patch 5).
- In `tools/ts2pant/src/ir1-ssa-loops.ts`, delete `lowerForeachShapeBSummaries` (lines 268-321), `lowerForeachSummary` (lines 192-203), `ForeachShapeBSummaryInput` (lines 37-40), `ForeachShapeBSummaryOptions` (lines 69-75), `ForeachShapeBSummaryResult` (lines 93-100), `ForeachSummaryLowerOptions` (lines 57-59), `ForeachSummaryLowerResult` (lines 77-83), and `foreachShapeBAccumulatorKey` (lines 572-577 — moved to `ir1-ssa-foreach.ts` in Patch 2). After this patch the file retains `buildLoopSsaProgram`, `lowerMuSearchSummary` and the μ-search summary types, the legacy `IR1LoopSsaInput` / `LoopSummaryInputBase` / `LoopSsaBuildOptions` / `LoopSsaBuildResult` / `UnsupportedLoopSummaryInput` types, `LoopSsaShape`, and `MuSearchCounterType`.
- Delete any tests in `tools/ts2pant/tests/ir1-ssa-loops.test.mts` that exercise `lowerForeachShapeBSummaries` / `lowerForeachSummary` directly.
- Run `just ts2pant-test` and confirm `tools/ts2pant/tests/constructs.test.mts.snapshot` does NOT change. Any drift on Shape B fixtures (`sumAmounts`, `forEachSum`, `sumPositive`, `mixedUpdates`, `sumIntoAnon`, `deductFees`, `forEachActivate`) indicates a real bug.
- Unskip the Patch-4-owned `tools/ts2pant/tests/ir1-ssa-loops.test.mts` stub from Patch 1 and replace the PENDING-comment body with a concrete assertion.

## Files to Modify
- tools/ts2pant/src/ir1-lower-body.ts (modify): Switch the call at line 337 from `lowerForeachShapeBSummaries({ ... })` to `lowerForeachShapeBAsGeneralLoop({ ... })`. Update `adaptLoopSummaryLowerResult` overloads to accept `ForeachAsGeneralLoopResult` in place of `ForeachShapeBSummaryResult`.
- tools/ts2pant/src/ir1-ssa-lower.ts (modify): Update `loopSsaBodyLowerResult` union to drop `ForeachShapeBSummaryResult` (now subsumed by `ForeachAsGeneralLoopResult` introduced in Patch 3).
- tools/ts2pant/src/ir1-ssa-loops.ts (modify): Delete `lowerForeachShapeBSummaries`, `lowerForeachSummary`, `ForeachShapeBSummaryInput`, `ForeachShapeBSummaryOptions`, `ForeachShapeBSummaryResult`, `ForeachSummaryLowerOptions`, `ForeachSummaryLowerResult`. `foreachShapeBAccumulatorKey` was moved to `ir1-ssa-foreach.ts` in Patch 2 — delete its definition here too. The file is now further shortened.
- tools/ts2pant/tests/ir1-ssa-loops.test.mts (modify): Delete tests that exercise `lowerForeachShapeBSummaries` / `lowerForeachSummary` directly. Unskip the Patch-4-owned stub from Patch 1 (`foreach Shape B call site emits IR1SsaProgram with populated loopHeaderJoins and loopBodies`) and replace the PENDING-comment body with a concrete assertion exercising the new call site via a hand-constructed Shape B `IR1Stmt`.

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[algorithm] Cytron 1991 SSA construction — inductive header-join case** — https://doi.org/10.1145/115372.115320 — Shape B's accumulator-fold is the standard inductive case the Cytron paper describes: each iteration reads the prior version through the header join, writes a new version, the close back-patches the header. Patch 4's call-site switch routes Shape B inputs through this protocol uniformly.

## Gameplan Specification

```
module TS2PANT_LOOP_SUMMARY_UNIFICATION.

> ════════════════════════════════
> Milestone 6 AND Milestone 7 of the ts2pant general-loop SSA
> workstream, collapsed into a single atomic milestone.
> ════════════════════════════════
> After this milestone, foreach Shape A and Shape B lower
> through the general-loop SSA machinery
> (IR1SsaLoopHeaderJoin + IR1SsaLoopBody +
> IR1SsaTerminationMetric) rather than the legacy
> IR1SsaLoopSummary path. IR1SsaTerminationMetric is now a
> discriminated union: counter loops and bounded-while loops
> emit the existing counter-style variant (kind:
> ssa-termination-metric, expr, lowerBound); foreach Shape A
> and Shape B emit the new iterating-source variant (kind:
> ssa-iterating-source-metric, source) matching Pant's native
> all-x-in-arr semantics. Shape A's per-iteration writes do
> not feed back through the header join (degenerate close);
> Shape B's accumulator-fold writes do (Cytron inductive
> case). The IR1SsaLoopSummary type, the ir1SsaLoopSummary
> constructor, the IR1SsaProgram.loopSummaries field, the
> lowerMuSearchSummary path, and tools/ts2pant/src/ir1-ssa-loops.ts
> are all deleted. Four L7 invariant tests verify the unified
> abstraction: header-join uniqueness, continuation
> resolution, metric kind by loop class, frame suppression
> per modified rule. Pant output is byte-equivalent on every
> existing foreach fixture. Documentation marks BOTH milestone
> 6 AND milestone 7 as landed.

ForeachInput.
ForeachShape.
shape-a => ForeachShape.
shape-b => ForeachShape.
IR1SsaProgram.
IR1SsaProgramShape.
IR1SsaLoopBody.
IR1SsaLoopHeaderJoin.
IR1SsaTerminationMetric.
IR1SsaWrite.
IR1SsaVersion.
IR1SsaRuleName.
FieldName.
loop-summaries-field => FieldName.
loop-header-joins-field => FieldName.
loop-bodies-field => FieldName.
FileStatus.
file-present => FileStatus.
file-deleted => FileStatus.
Declaration.
DeletionStatus.
present => DeletionStatus.
deleted => DeletionStatus.
MuSearchSummary.
LoopClass.
counter => LoopClass.
bounded-while => LoopClass.
fixed-point-while => LoopClass.
foreach-shape-a => LoopClass.
foreach-shape-b => LoopClass.
FixtureOutput.
MetricKind.
counter-metric => MetricKind.
iterating-source-metric => MetricKind.
Document.
DocumentKind.
MilestoneStatus.
ir-doc => DocumentKind.
transformations-doc => DocumentKind.
agents-md => DocumentKind.
workstream-doc => DocumentKind.
pending => MilestoneStatus.
landed => MilestoneStatus.

> Foreach-as-general-loop helper.
input-shape i: ForeachInput => ForeachShape.
lower-result i: ForeachInput => IR1SsaProgram.
body-of p: IR1SsaProgram => IR1SsaLoopBody.
header-of b: IR1SsaLoopBody => IR1SsaLoopHeaderJoin.
metric-of b: IR1SsaLoopBody => IR1SsaTerminationMetric.
metric-kind m: IR1SsaTerminationMetric => MetricKind.
write-of b: IR1SsaLoopBody => IR1SsaWrite.
loop-back-version h: IR1SsaLoopHeaderJoin => IR1SsaVersion.
preheader-version h: IR1SsaLoopHeaderJoin => IR1SsaVersion.
write-version w: IR1SsaWrite => IR1SsaVersion.
emits-quantified-equation? p: IR1SsaProgram => Bool.
emits-accumulator-fold-equation? p: IR1SsaProgram => Bool.

> Deletion (Patches 5, 6).
shape-has-field? s: IR1SsaProgramShape, f: FieldName => Bool.
ir-ssa-loops-file-status => FileStatus.
deletion-status d: Declaration => DeletionStatus.
is-mu-search-summary? d: Declaration => Bool.
production-reachable? d: Declaration => Bool.

> L7 invariants (Patch 7).
header-has-preheader? h: IR1SsaLoopHeaderJoin => Bool.
header-has-loop-back? h: IR1SsaLoopHeaderJoin => Bool.
header-closed? h: IR1SsaLoopHeaderJoin => Bool.
body-class b: IR1SsaLoopBody => LoopClass.
non-null-metric? b: IR1SsaLoopBody => Bool.
is-bounded? c: LoopClass => Bool.
uses-counter-metric? c: LoopClass => Bool.
uses-iterating-source-metric? c: LoopClass => Bool.
continuations-resolved? b: IR1SsaLoopBody => Bool.
modified-rule-appears-once? p: IR1SsaProgram, r: IR1SsaRuleName => Bool.
body-writes-rule? b: IR1SsaLoopBody, r: IR1SsaRuleName => Bool.

> Byte-equivalent emission.
legacy-emission i: ForeachInput => FixtureOutput.
recharacterised-emission i: ForeachInput => FixtureOutput.
byte-equivalent? a: FixtureOutput, b: FixtureOutput => Bool.

> Documentation.
document-kind d: Document => DocumentKind.
document-mentions-unification? d: Document => Bool.
workstream-milestone-6-status => MilestoneStatus.
workstream-milestone-7-status => MilestoneStatus.
---

> Foreach helper contract: every foreach input lowers to an
> IR1SsaProgram carrying an iterating-source termination
> metric (the new variant introduced by Patch 2).
all i: ForeachInput, b: IR1SsaLoopBody |
  b = body-of (lower-result i) ->
    metric-kind (metric-of b) = iterating-source-metric.

> Shape A: the header join's loop-back version equals the
> per-iteration write version (degenerate close).
all i: ForeachInput, b: IR1SsaLoopBody, h: IR1SsaLoopHeaderJoin, w: IR1SsaWrite |
  input-shape i = shape-a and b = body-of (lower-result i) and
  h = header-of b and w = write-of b ->
    loop-back-version h = write-version w.

> Shape A: emits a per-element quantified equation.
all i: ForeachInput |
  input-shape i = shape-a ->
    emits-quantified-equation? (lower-result i).

> Shape B: emits an accumulator-fold equation per location.
all i: ForeachInput |
  input-shape i = shape-b ->
    emits-accumulator-fold-equation? (lower-result i).

> Byte-equivalent Pant emission on every existing fixture.
all i: ForeachInput |
  byte-equivalent? (legacy-emission i) (recharacterised-emission i).

> Type-level deletion: IR1SsaProgram has no loopSummaries
> field; retains loopHeaderJoins and loopBodies.
all s: IR1SsaProgramShape |
  ~(shape-has-field? s loop-summaries-field).

all s: IR1SsaProgramShape |
  shape-has-field? s loop-header-joins-field and
  shape-has-field? s loop-bodies-field.

> File deletion: ir1-ssa-loops.ts is gone.
ir-ssa-loops-file-status = file-deleted.

> μ-search summary symbols are deleted; the dead path is
> unreachable.
all d: Declaration |
  is-mu-search-summary? d -> deletion-status d = deleted.

all d: Declaration |
  deletion-status d = deleted -> ~(production-reachable? d).

> L7 invariant: every header join has exactly one preheader,
> one loop-back, and is closed.
all h: IR1SsaLoopHeaderJoin |
  header-has-preheader? h and header-has-loop-back? h and
  header-closed? h.

> L7 invariant: continuation handles resolve.
all b: IR1SsaLoopBody |
  continuations-resolved? b.

> L7 invariant 3a: bounded loops have non-null metrics.
all b: IR1SsaLoopBody |
  is-bounded? (body-class b) -> non-null-metric? b.

> L7 invariant 3b: counter / bounded-while emit
> counter-metric; foreach Shape A / Shape B emit
> iterating-source-metric.
all b: IR1SsaLoopBody |
  uses-counter-metric? (body-class b) ->
    metric-kind (metric-of b) = counter-metric.

all b: IR1SsaLoopBody |
  uses-iterating-source-metric? (body-class b) ->
    metric-kind (metric-of b) = iterating-source-metric.

is-bounded? counter.
is-bounded? bounded-while.
is-bounded? foreach-shape-a.
is-bounded? foreach-shape-b.
~(is-bounded? fixed-point-while).

uses-counter-metric? counter.
uses-counter-metric? bounded-while.
uses-iterating-source-metric? foreach-shape-a.
uses-iterating-source-metric? foreach-shape-b.

> L7 invariant: every modified rule appears in modifiedRules
> exactly once.
all p: IR1SsaProgram, r: IR1SsaRuleName, b: IR1SsaLoopBody |
  body-writes-rule? b r ->
    modified-rule-appears-once? p r.

> Documentation invariants.
all d: Document |
  document-kind d = ir-doc ->
    document-mentions-unification? d.

all d: Document |
  document-kind d = transformations-doc ->
    document-mentions-unification? d.

all d: Document |
  document-kind d = agents-md ->
    document-mentions-unification? d.

all d: Document |
  document-kind d = workstream-doc ->
    document-mentions-unification? d.

workstream-milestone-6-status = landed.
workstream-milestone-7-status = landed.
```

## Patch Specification

```
module TS2PANT_LOOP_SUMMARY_UNIFICATION_PATCH_4.

> Patch 4 switches the Shape B foreach call site in
> ir1-lower-body.ts from the legacy summary adapter to the
> new general-loop helper. The Shape B adapter and its
> internal helpers are deleted from ir1-ssa-loops.ts. The
> accumulator-fold write reads the prior accumulator value
> through the IR1SsaLoopHeaderJoin's joinVersion. Pant
> emission is byte-equivalent on every existing Shape B
> fixture; snapshot tests gate.

ForeachShapeBOptions.
IR1SsaProgram.
IR1SsaLoopBody.
IR1SsaLoopHeaderJoin.
IR1SsaWrite.
IR1SsaVersion.
FixtureOutput.

call-site-result o: ForeachShapeBOptions => IR1SsaProgram.
program-header-joins p: IR1SsaProgram => Nat0.
program-loop-bodies p: IR1SsaProgram => Nat0.
write-reads-join? w: IR1SsaWrite, h: IR1SsaLoopHeaderJoin => Bool.
body-of p: IR1SsaProgram => IR1SsaLoopBody.
body-write b: IR1SsaLoopBody => IR1SsaWrite.
body-header b: IR1SsaLoopBody => IR1SsaLoopHeaderJoin.
legacy-emission o: ForeachShapeBOptions => FixtureOutput.
recharacterised-emission o: ForeachShapeBOptions => FixtureOutput.
byte-equivalent? a: FixtureOutput, b: FixtureOutput => Bool.
---

> Call site produces populated loopHeaderJoins and loopBodies.
all o: ForeachShapeBOptions, p: IR1SsaProgram |
  p = call-site-result o ->
    program-loop-bodies p > 0 and program-header-joins p > 0.

> Accumulator-fold write reads through the header join.
all o: ForeachShapeBOptions, p: IR1SsaProgram, b: IR1SsaLoopBody,
     w: IR1SsaWrite, h: IR1SsaLoopHeaderJoin |
  p = call-site-result o and b = body-of p and
  w = body-write b and h = body-header b ->
    write-reads-join? w h.

> Pant emission is byte-equivalent on every Shape B fixture.
all o: ForeachShapeBOptions |
  byte-equivalent? (legacy-emission o) (recharacterised-emission o).
```


## Implementation Notes

- Shape B now passes the original L1 `stmt.source` into `lowerForeachShapeBAsGeneralLoop`, while keeping `lowerExpr` responsible for `applyConst(lowerExpr(lowerL1Expr(...)))`. This is intentional: the new helper owns source lowering for both the iterating-source metric and emitted accumulator fold, unlike the legacy summary adapter which accepted an already-lowered `OpaqueExpr` source.
- The adapter test in `ir1-ssa-lower.test.mts` now asserts Shape B contributes `loopHeaderJoins`/`loopBodies` and no `loopSummaries`; the remaining Shape A summary assertions are left in place because Patch 4 only retires the Shape B summary path.
- A skipped prop-result lowering test that depended entirely on deleted `lowerForeachSummary` plumbing was removed rather than rewritten. That path is no longer a meaningful public surface after this patch.

Spec/Evidence Mapping:
- Call-site result has populated loop structures: `lowerForeachL1BodyToSsaResult` routes Shape B to `lowerForeachShapeBAsGeneralLoop`; covered by the unskipped `foreach Shape B call site emits IR1SsaProgram with populated loopHeaderJoins and loopBodies` test.
- Legacy Shape B adapter deletion: `lowerForeachShapeBSummaries`, `ForeachShapeBSummary*`, `ForeachSummaryLower*`, `lowerForeachSummary`, and the local accumulator-key helper are removed from `ir1-ssa-loops.ts`; `rg` showed no remaining deleted-symbol references under `tools/ts2pant/src` or `tools/ts2pant/tests`.
- Byte-equivalent emission: `just ts2pant-test` passed and `tools/ts2pant/tests/constructs.test.mts.snapshot` had no diff. `npm run build` also passed.