### PR TITLE
[ts2pant-loop-summary-unification] Patch 3: ts2pant: switch Shape A call site to new helper; delete adapter

### DIFF
--- a/tools/ts2pant/src/ir1-lower-body.ts
+++ b/tools/ts2pant/src/ir1-lower-body.ts
@@ -27,9 +27,10 @@ import {
 import { lowerCounterLoopL1Body } from "./ir1-ssa-counter-loop.js";
 import { lowerFixedPointLoopL1Body } from "./ir1-ssa-fixed-point.js";
 import {
-  lowerForeachShapeASummaries,
-  lowerForeachShapeBSummaries,
-} from "./ir1-ssa-loops.js";
+  type ForeachAsGeneralLoopResult,
+  lowerForeachShapeAAsGeneralLoop,
+} from "./ir1-ssa-foreach.js";
+import { lowerForeachShapeBSummaries } from "./ir1-ssa-loops.js";
 import {
   appendFramesForUnmodifiedRules,
   collectionSsaBodyLowerResult,
@@ -63,14 +64,14 @@ export function adaptScalarSsaLowerResult(
 }
 
 export function adaptLoopSummaryLowerResult(
-  result: ReturnType<typeof lowerForeachShapeASummaries>,
+  result: ForeachAsGeneralLoopResult,
 ): IR1SsaBodyLowerResult;
 export function adaptLoopSummaryLowerResult(
   result: ReturnType<typeof lowerForeachShapeBSummaries>,
 ): IR1SsaBodyLowerResult;
 export function adaptLoopSummaryLowerResult(
   result:
-    | ReturnType<typeof lowerForeachShapeASummaries>
+    | ForeachAsGeneralLoopResult
     | ReturnType<typeof lowerForeachShapeBSummaries>,
 ): IR1SsaBodyLowerResult {
   return loopSsaBodyLowerResult(result);
@@ -313,9 +314,9 @@ function lowerForeachL1BodyToSsaResult(
   if (stmt.body !== null) {
     results.push(
       adaptLoopSummaryLowerResult(
-        lowerForeachShapeASummaries({
+        lowerForeachShapeAAsGeneralLoop({
           binder: stmt.binder,
-          source: arrExpr,
+          source: stmt.source,
           body: stmt.body,
           lowerOpaque: options.applyConst,
           ...(options.initialPropertyValues === undefined

--- a/tools/ts2pant/src/ir1-ssa-loops.ts
+++ b/tools/ts2pant/src/ir1-ssa-loops.ts
@@ -2,7 +2,6 @@ import { lowerBinop, lowerExpr } from "./ir-emit.js";
 import {
   type IR1Expr,
   type IR1FoldLeaf,
-  type IR1ForeachBody,
   type IR1SsaLocation,
   type IR1SsaLoopSummary,
   type IR1SsaProgram,
@@ -24,11 +23,6 @@ interface LoopSummaryInputBase {
   location: IR1SsaLocation;
 }
 
-export interface ForeachShapeASummaryInput extends LoopSummaryInputBase {
-  kind: "foreach-shape-a";
-  propositions?: readonly PropResult[];
-}
-
 export interface ForeachShapeBSummaryInput extends LoopSummaryInputBase {
   kind: "foreach-shape-b";
   propositions?: readonly PropResult[];
@@ -40,7 +34,6 @@ export interface UnsupportedLoopSummaryInput {
 }
 
 export type IR1LoopSsaInput =
-  | ForeachShapeASummaryInput
   | ForeachShapeBSummaryInput
   | UnsupportedLoopSummaryInput;
 
@@ -49,15 +42,7 @@ export interface LoopSsaBuildOptions {
 }
 
 export interface ForeachSummaryLowerOptions extends LoopSsaBuildOptions {
-  input: ForeachShapeASummaryInput | ForeachShapeBSummaryInput;
-}
-
-export interface ForeachShapeASummaryOptions extends LoopSsaBuildOptions {
-  binder: string;
-  source: OpaqueExpr;
-  body: IR1ForeachBody;
-  lowerOpaque?: (e: OpaqueExpr) => OpaqueExpr;
-  initialPropertyValues?: ReadonlyMap<string, OpaqueExpr>;
+  input: ForeachShapeBSummaryInput;
 }
 
 export interface ForeachShapeBSummaryOptions extends LoopSsaBuildOptions {
@@ -71,14 +56,6 @@ export interface ForeachShapeBSummaryOptions extends LoopSsaBuildOptions {
 export interface ForeachSummaryLowerResult {
   program: IR1SsaProgram;
   summary: IR1SsaLoopSummary | null;
-  propositions: PropResult[];
-  modifiedRules: IR1SsaRuleName[];
-  diagnostics: UnsupportedDiagnostic[];
-}
-
-export interface ForeachShapeASummaryResult {
-  program: IR1SsaProgram;
-  summaries: IR1SsaLoopSummary[];
   propositions: PropResult[];
   modifiedRules: IR1SsaRuleName[];
   diagnostics: UnsupportedDiagnostic[];
@@ -164,69 +141,6 @@ export function lowerForeachSummary(
   };
 }
 
-interface ShapeAPropertyEntry {
-  location: IR1SsaLocation;
-  objExpr: OpaqueExpr;
-  value: OpaqueExpr;
-}
-
-interface ShapeASummaryState {
-  current: Map<string, ShapeAPropertyEntry>;
-  lowerOpaque: (e: OpaqueExpr) => OpaqueExpr;
-  initialPropertyValues: ReadonlyMap<string, OpaqueExpr>;
-}
-
-export function lowerForeachShapeASummaries(
-  options: ForeachShapeASummaryOptions,
-): ForeachShapeASummaryResult {
-  const state: ShapeASummaryState = {
-    current: new Map(),
-    lowerOpaque: options.lowerOpaque ?? ((e) => e),
-    initialPropertyValues: options.initialPropertyValues ?? new Map(),
-  };
-  const diagnostics: UnsupportedDiagnostic[] = [];
-
-  if (!summarizeForeachShapeABody(options.body, state, diagnostics)) {
-    const result = buildLoopSsaProgram(
-      diagnostics.map((d) => ({ kind: "unsupported", reason: d.reason })),
-      options,
-    );
-    return {
-      program: result.program,
-      summaries: [],
-      propositions: [],
-      modifiedRules: result.program.modifiedRules,
-      diagnostics: result.diagnostics,
-    };
-  }
-
-  const ast = getAst();
-  const inputs: ForeachShapeASummaryInput[] = [...state.current.values()].map(
-    (entry) => ({
-      kind: "foreach-shape-a",
-      location: entry.location,
-      propositions: [
-        {
-          kind: "equation",
-          quantifiers: [],
-          guards: [ast.gIn(options.binder, options.source)],
-          lhs: ast.app(ast.primed(entry.location.ruleName), [entry.objExpr]),
-          rhs: entry.value,
-        },
-      ],
-    }),
-  );
-
-  const result = buildLoopSsaProgram(inputs, options);
-  return {
-    program: result.program,
-    summaries: result.program.loopSummaries,
-    propositions: result.propositions,
-    modifiedRules: result.program.modifiedRules,
-    diagnostics: result.diagnostics,
-  };
-}
-
 export function lowerForeachShapeBSummaries(
   options: ForeachShapeBSummaryOptions,
 ): ForeachShapeBSummaryResult {
@@ -280,255 +194,6 @@ export function lowerForeachShapeBSummaries(
     diagnostics: result.diagnostics,
     accumulatorKeys,
   };
-}
-
-function summarizeForeachShapeABody(
-  stmt: IR1ForeachBody,
-  state: ShapeASummaryState,
-  diagnostics: UnsupportedDiagnostic[],
-): boolean {
-  switch (stmt.kind) {
-    case "assign":
-      return summarizeShapeAAssign(stmt, state, diagnostics);
-    case "block": {
-      let ok = true;
-      for (const child of stmt.stmts) {
-        if (!summarizeForeachShapeABody(child, state, diagnostics)) {
-          ok = false;
-        }
-      }
-      return ok;
-    }
-    case "cond-stmt":
-      return summarizeShapeACond(stmt, state, diagnostics);
-    default: {
-      diagnostics.push({
-        kind: "unsupported",
-        reason:
-          "nested proposition-emitting loop body is not supported — the inner proposition would escape the outer iterator scope",
-      });
-      return false;
-    }
-  }
-}
-
-function summarizeShapeAAssign(
-  stmt: Extract<IR1ForeachBody, { kind: "assign" }>,
-  state: ShapeASummaryState,
-  diagnostics: UnsupportedDiagnostic[],
-): boolean {
-  if (stmt.target.kind !== "member") {
-    diagnostics.push({
-      kind: "unsupported",
-      reason: "foreach Shape A summary assignment target must be a property",
-    });
-    return false;
-  }
-
-  const objExpr = state.lowerOpaque(
-    lowerShapeAExpr(stmt.target.receiver, state),
-  );
-  const value = state.lowerOpaque(lowerShapeAExpr(stmt.value, state));
-  const location = ir1SsaPropertyLocation(
-    stmt.target.name,
-    stmt.target.receiver,
-    stmt.target.name,
-  );
-  state.current.set(shapeAKey(stmt.target.name, objExpr), {
-    location,
-    objExpr,
-    value,
-  });
-  return true;
-}
-
-function summarizeShapeACond(
-  stmt: Extract<IR1ForeachBody, { kind: "cond-stmt" }>,
-  state: ShapeASummaryState,
-  diagnostics: UnsupportedDiagnostic[],
-): boolean {
-  if (stmt.arms.length !== 1) {
-    diagnostics.push({
-      kind: "unsupported",
-      reason: "multi-armed foreach Shape A conditional is not supported",
-    });
-    return false;
-  }
-
-  const ast = getAst();
-  const [guard, thenBody] = stmt.arms[0]!;
-  const before = new Map(state.current);
-  const thenState: ShapeASummaryState = {
-    ...state,
-    current: new Map(state.current),
-  };
-  if (!summarizeForeachShapeABody(thenBody, thenState, diagnostics)) {
-    return false;
-  }
-
-  const elseState: ShapeASummaryState = {
-    ...state,
-    current: new Map(before),
-  };
-  if (
-    stmt.otherwise !== null &&
-    !summarizeForeachShapeABody(stmt.otherwise, elseState, diagnostics)
-  ) {
-    return false;
-  }
-
-  const guardExpr = state.lowerOpaque(lowerShapeAExpr(guard, state));
-  const touched = new Set<string>();
-  for (const [key, entry] of thenState.current) {
-    if (before.get(key) !== entry) {
-      touched.add(key);
-    }
-  }
-  for (const [key, entry] of elseState.current) {
-    if (before.get(key) !== entry) {
-      touched.add(key);
-    }
-  }
-  for (const key of touched) {
-    const thenEntry = thenState.current.get(key);
-    const elseEntry = elseState.current.get(key);
-    const location = thenEntry?.location ?? elseEntry?.location;
-    const objExpr = thenEntry?.objExpr ?? elseEntry?.objExpr;
-    if (location === undefined || objExpr === undefined) {
-      continue;
-    }
-    const prior = before.get(key);
-    const fallback =
-      prior?.value ??
-      state.initialPropertyValues.get(key) ??
-      ast.app(ast.var(location.ruleName), [objExpr]);
-    const thenValue = thenEntry?.value ?? fallback;
-    const elseValue = elseEntry?.value ?? fallback;
-    const value = ast.cond([
-      [guardExpr, thenValue],
-      [ast.litBool(true), elseValue],
-    ]);
-    state.current.set(key, { location, objExpr, value });
-  }
-  return true;
-}
-
-function lowerShapeAExpr(expr: IR1Expr, state: ShapeASummaryState): OpaqueExpr {
-  const ast = getAst();
-  switch (expr.kind) {
-    case "member": {
-      const objExpr = state.lowerOpaque(lowerShapeAExpr(expr.receiver, state));
-      const key = shapeAKey(expr.name, objExpr);
-      return (
-        state.current.get(key)?.value ??
-        state.initialPropertyValues.get(key) ??
-        ast.app(ast.var(expr.name), [objExpr])
-      );
-    }
-    case "binop":
-      return ast.binop(
-        lowerBinop(expr.op),
-        lowerShapeAExpr(expr.lhs, state),
-        lowerShapeAExpr(expr.rhs, state),
-      );
-    case "unop": {
-      const op =
-        expr.op === "not"
-          ? ast.opNot()
-          : expr.op === "neg"
-            ? ast.opNeg()
-            : ast.opCard();
-      return ast.unop(op, lowerShapeAExpr(expr.arg, state));
-    }
-    case "app": {
-      const args = expr.args.map((arg) => lowerShapeAExpr(arg, state));
-      if (expr.callee.kind === "var" && !expr.callee.primed) {
-        return ast.app(ast.var(expr.callee.name), args);
-      }
-      return ast.app(lowerShapeAExpr(expr.callee, state), args);
-    }
-    case "cond": {
-      const arms: Array<[OpaqueExpr, OpaqueExpr]> = expr.arms.map(([g, v]) => [
-        lowerShapeAExpr(g, state),
-        lowerShapeAExpr(v, state),
-      ]);
-      arms.push([ast.litBool(true), lowerShapeAExpr(expr.otherwise, state)]);
-      return ast.cond(arms);
-    }
-    case "is-nullish":
-      return ast.binop(
-        ast.opEq(),
-        ast.unop(ast.opCard(), lowerShapeAExpr(expr.operand, state)),
-        ast.litNat(0),
-      );
-    case "each":
-      return ast.each(
-        [],
-        [
-          ast.gIn(expr.binder, lowerShapeAExpr(expr.src, state)),
-          ...expr.guards.map((guard) =>
-            ast.gExpr(lowerShapeAExpr(guard, state)),
-          ),
-        ],
-        lowerShapeAExpr(expr.proj, state),
-      );
-    case "comb-typed":
-      return ast.eachComb(
-        [ast.param(expr.binder, ast.tName(expr.binderType))],
-        expr.guards.map((guard) => ast.gExpr(lowerShapeAExpr(guard, state))),
-        expr.combiner === "min" ? ast.combMin() : ast.combMax(),
-        lowerShapeAExpr(expr.proj, state),
-      );
-    case "forall": {
-      const guards =
-        expr.guard === undefined
-          ? []
-          : [ast.gExpr(lowerShapeAExpr(expr.guard, state))];
-      return ast.forall(
-        [ast.param(expr.binder, ast.tName(expr.binderType))],
-        guards,
-        lowerShapeAExpr(expr.body, state),
-      );
-    }
-    case "exists": {
-      const guards =
-        expr.guard === undefined
-          ? []
-          : [ast.gExpr(lowerShapeAExpr(expr.guard, state))];
-      return ast.exists(
-        [ast.param(expr.binder, ast.tName(expr.binderType))],
-        guards,
-        lowerShapeAExpr(expr.body, state),
-      );
-    }
-    case "map-read": {
-      const callee = expr.op === "has" ? expr.keyPredName : expr.ruleName;
-      return ast.app(ast.var(callee), [
-        lowerShapeAExpr(expr.receiver, state),
-        lowerShapeAExpr(expr.key, state),
-      ]);
-    }
-    case "set-read":
-      return ast.binop(
-        ast.opIn(),
-        lowerShapeAExpr(expr.elem, state),
-        ast.app(ast.var(expr.ruleName), [
-          lowerShapeAExpr(expr.receiver, state),
-        ]),
-      );
-    case "var":
-    case "lit":
-      return lowerExpr(lowerL1Expr(expr));
-    default: {
-      const _exhaustive: never = expr;
-      void _exhaustive;
-      throw new Error("unsupported IR1 expression in foreach Shape A summary");
-    }
-  }
-}
-
-function shapeAKey(prop: string, objExpr: OpaqueExpr): string {
-  return `${prop}::${getAst().strExpr(objExpr)}`;
 }
 
 export function foreachShapeBAccumulatorKey(

--- a/tools/ts2pant/src/ir1-ssa-lower.ts
+++ b/tools/ts2pant/src/ir1-ssa-lower.ts
@@ -3,8 +3,8 @@ import type {
   CollectionSsaFinalPropertyEntry,
   CollectionSsaLowerResult,
 } from "./ir1-ssa-collections.js";
+import type { ForeachAsGeneralLoopResult } from "./ir1-ssa-foreach.js";
 import type {
-  ForeachShapeASummaryResult,
   ForeachShapeBSummaryResult,
   ForeachSummaryLowerResult,
 } from "./ir1-ssa-loops.js";
@@ -237,7 +237,7 @@ export function collectionSsaBodyLowerResult(
 export function loopSsaBodyLowerResult(
   result:
     | ForeachSummaryLowerResult
-    | ForeachShapeASummaryResult
+    | ForeachAsGeneralLoopResult
     | ForeachShapeBSummaryResult,
 ): IR1SsaBodyLowerResult {
   return ir1SsaBodyLowerResult({

--- a/tools/ts2pant/tests/ir1-ssa-invariants.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-invariants.test.mts
@@ -54,7 +54,6 @@ import {
 import { lowerCollectionSsaToResult } from "../src/ir1-ssa-collections.js";
 import { lowerScalarSsaToProps } from "../src/ir1-ssa-scalars.js";
 import {
-  lowerForeachShapeASummaries,
   lowerForeachShapeBSummaries,
 } from "../src/ir1-ssa-loops.js";
 import { getAst, loadAst } from "../src/pant-wasm.js";
@@ -789,7 +788,6 @@ before(async () => {
 describe("ir1-ssa-invariants", () => {
   void representativePrograms;
   void walkSsaProgram;
-  void lowerForeachShapeASummaries;
   void lowerForeachShapeBSummaries;
 
   it(

--- a/tools/ts2pant/tests/ir1-ssa-loops.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-loops.test.mts
@@ -7,20 +7,19 @@ import { emitDocument } from "../src/emit.js";
 import { createSourceFile } from "../src/extract.js";
 import {
   ir1Assign,
-  ir1Binop,
-  ir1Block,
-  ir1LitNat,
+  ir1Foreach,
+  ir1LitBool,
   ir1Member,
   ir1SsaPropertyLocation,
   ir1SsaRuleOfLocation,
   ir1Var,
 } from "../src/ir1.js";
+import { lowerL1BodyToSsaProps } from "../src/ir1-lower-body.js";
 import {
   buildLoopSsaProgram,
-  lowerForeachShapeASummaries,
   lowerForeachSummary,
 } from "../src/ir1-ssa-loops.js";
-import { getAst, loadAst } from "../src/pant-wasm.js";
+import { loadAst } from "../src/pant-wasm.js";
 import { buildDocumentFromSourceFile } from "./helpers.mts";
 
 before(async () => {
@@ -39,34 +38,7 @@ function extractEquationRhs(output: string): string {
 describe("ir1-ssa-loops", () => {
   // PENDING Patch 2: introduce the dedicated loop-summary SSA helper and
   // summary/version bookkeeping for supported loop-like constructs.
-  // PENDING Patch 3: route canonical mu-search lowering through loop summaries.
-  // PENDING Patch 4: route foreach Shape A lowering through loop summaries.
-  // PENDING Patch 5: route foreach Shape B lowering through loop summaries.
-
-  it("records foreach Shape A quantified writes as loop summaries", () => {
-    const location = ir1SsaPropertyLocation(
-      "Item_seen",
-      ir1Var("$item"),
-      "seen",
-    );
-    const proposition = { kind: "raw" as const, text: "quantified-write" };
-
-    const result = lowerForeachSummary({
-      input: {
-        kind: "foreach-shape-a",
-        location,
-        propositions: [proposition],
-      },
-    });
-
-    assert.deepEqual(result.diagnostics, []);
-    assert.equal(result.summary?.shape, "foreach-shape-a");
-    assert.equal(result.summary?.location, location);
-    assert.equal(result.summary?.summaryVersion.origin, "loop-summary");
-    assert.equal(result.summary?.summaryVersion.location, location);
-    assert.deepEqual(result.propositions, [proposition]);
-    assert.deepEqual(result.modifiedRules, [ir1SsaRuleOfLocation(location)]);
-  });
+  // PENDING Patch 4: route foreach Shape B lowering through general-loop SSA.
 
   it("records foreach Shape B accumulator folds as loop summaries", () => {
     const location = ir1SsaPropertyLocation(
@@ -102,39 +74,42 @@ describe("ir1-ssa-loops", () => {
   });
 
   it("creates distinct summary versions and tracks modified rules", () => {
-    const shapeALocation = ir1SsaPropertyLocation(
-      "Item_seen",
-      ir1Var("$item"),
-      "seen",
-    );
-    const shapeBLocation = ir1SsaPropertyLocation(
+    const shapeBTotalLocation = ir1SsaPropertyLocation(
       "Account_total",
       ir1Var("account"),
       "total",
     );
+    const shapeBLimitLocation = ir1SsaPropertyLocation(
+      "Account_limit",
+      ir1Var("account"),
+      "limit",
+    );
 
     const result = buildLoopSsaProgram(
       [
-        { kind: "foreach-shape-a", location: shapeALocation },
-        { kind: "foreach-shape-b", location: shapeBLocation },
+        { kind: "foreach-shape-b", location: shapeBTotalLocation },
+        { kind: "foreach-shape-b", location: shapeBLimitLocation },
       ],
-      { declaredRules: ["Account_limit"] },
+      { declaredRules: ["Account_seen"] },
     );
 
-    const [shapeA, shapeB] = result.program.loopSummaries;
-    assert.notEqual(shapeA!.summaryVersion, shapeB!.summaryVersion);
-    assert.notEqual(shapeA!.summaryVersion.id, shapeB!.summaryVersion.id);
-    assert.equal(shapeA!.summaryVersion.location, shapeALocation);
-    assert.equal(shapeB!.summaryVersion.location, shapeBLocation);
+    const [shapeBTotal, shapeBLimit] = result.program.loopSummaries;
+    assert.notEqual(shapeBTotal!.summaryVersion, shapeBLimit!.summaryVersion);
+    assert.notEqual(
+      shapeBTotal!.summaryVersion.id,
+      shapeBLimit!.summaryVersion.id,
+    );
+    assert.equal(shapeBTotal!.summaryVersion.location, shapeBTotalLocation);
+    assert.equal(shapeBLimit!.summaryVersion.location, shapeBLimitLocation);
     assert.deepEqual(
       new Set(result.program.modifiedRules),
-      new Set(["Item_seen", "Account_total"]),
+      new Set(["Account_total", "Account_limit"]),
     );
     assert.deepEqual(
       new Set(result.program.declaredRules),
-      new Set(["Item_seen", "Account_total", "Account_limit"]),
+      new Set(["Account_total", "Account_limit", "Account_seen"]),
     );
-    assert.deepEqual(result.program.framedRules, ["Account_limit"]);
+    assert.deepEqual(result.program.framedRules, ["Account_seen"]);
   });
 
   it("reports unsupported loop summary inputs without summaries", () => {
@@ -155,46 +130,6 @@ describe("ir1-ssa-loops", () => {
         reason: "general loops are not supported by loop-summary SSA",
       },
     ]);
-  });
-
-  it("represents supported in-iteration read-after-write without subState mutation", () => {
-    const item = ir1Var("$item");
-    const value = ir1Member(item, "Item_value");
-    const score = ir1Member(item, "Item_score");
-    const result = lowerForeachShapeASummaries({
-      binder: "$item",
-      source: getAst().var("items"),
-      body: ir1Block([
-        ir1Assign(value, ir1Binop("add", value, ir1LitNat(1))),
-        ir1Assign(score, value),
-      ]),
-    });
-
-    assert.deepEqual(result.diagnostics, []);
-    assert.equal(result.summaries.length, 2);
-    assert.deepEqual(
-      result.summaries.map((s) => s.shape),
-      ["foreach-shape-a", "foreach-shape-a"],
-    );
-    assert.deepEqual(
-      new Set(result.modifiedRules),
-      new Set(["Item_value", "Item_score"]),
-    );
-
-    const ast = getAst();
-    const scoreEq = result.propositions.find(
-      (p) =>
-        p.kind === "equation" && ast.strExpr(p.lhs) === "Item_score' $item",
-    );
-    assert.ok(scoreEq, "expected a quantified score write");
-    if (scoreEq?.kind === "equation") {
-      assert.equal(ast.strExpr(scoreEq.rhs), "Item_value $item + 1");
-      assert.equal(scoreEq.guards?.length, 1);
-      assert.equal(
-        ast.strExpr(ast.forall([], scoreEq.guards ?? [], ast.var("__body__"))),
-        "all $item in items | __body__",
-      );
-    }
   });
 
   it("preserves unsupported diagnostics for out-of-scope loops", () => {
@@ -292,10 +227,41 @@ describe("ir1-ssa-loops", () => {
     );
   });
 
-  it.skip(
+  it(
     "foreach Shape A call site emits IR1SsaProgram with populated loopHeaderJoins and loopBodies",
     () => {
-      // PENDING Patch 3: verify the Shape A production call site uses general-loop SSA.
+      const result = lowerL1BodyToSsaProps(
+        ir1Foreach(
+          "item0",
+          ir1Var("items"),
+          ir1Assign(
+            ir1Member(ir1Var("item0"), "Item_seen"),
+            ir1LitBool(true),
+          ),
+        ),
+        [
+          {
+            kind: "rule",
+            name: "Item_seen",
+            params: [{ name: "item0", type: "Item" }],
+            returnType: "Bool",
+          },
+        ],
+        { applyConst: (expr) => expr },
+      );
+
+      assert.deepEqual(result.diagnostics, []);
+      assert.equal(result.programs.length, 1);
+      const [program] = result.programs;
+      assert.ok(program, "expected a Shape A SSA program");
+      assert.equal(program.loopSummaries.length, 0);
+      assert.ok(program.loopHeaderJoins.length > 0);
+      assert.ok(program.loopBodies.length > 0);
+      assert.deepEqual(program.modifiedRules, ["Item_seen"]);
+      assert.equal(
+        program.loopBodies[0]?.terminationMetric?.kind,
+        "ssa-iterating-source-metric",
+      );
     },
   );
 

--- a/tools/ts2pant/tests/ir1-ssa-lower.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-lower.test.mts
@@ -26,10 +26,8 @@ import {
   ir1SsaBodyLowerSuccess,
   ir1SsaBodyLowerUnsupported,
 } from "../src/ir1-ssa-lower.js";
-import {
-  lowerForeachShapeASummaries,
-  lowerForeachShapeBSummaries,
-} from "../src/ir1-ssa-loops.js";
+import { lowerForeachShapeAAsGeneralLoop } from "../src/ir1-ssa-foreach.js";
+import { lowerForeachShapeBSummaries } from "../src/ir1-ssa-loops.js";
 import { lowerScalarSsaToProps } from "../src/ir1-ssa-scalars.js";
 import { getAst, loadAst } from "../src/pant-wasm.js";
 
@@ -173,9 +171,9 @@ describe("ir1-ssa-lower", () => {
       ),
     );
     const loop = adaptLoopSummaryLowerResult(
-      lowerForeachShapeASummaries({
+      lowerForeachShapeAAsGeneralLoop({
         binder: "item0",
-        source: getAst().var("items"),
+        source: ir1Var("items"),
         body: ir1Assign(
           ir1Member(ir1Var("item0"), "Item_seen"),
           ir1LitBool(true),
@@ -318,9 +316,9 @@ describe("ir1-ssa-lower", () => {
   it("loop summaries report propositions and modified rules through one result", () => {
     const ast = getAst();
     const shapeA = adaptLoopSummaryLowerResult(
-      lowerForeachShapeASummaries({
+      lowerForeachShapeAAsGeneralLoop({
         binder: "item0",
-        source: ast.var("items"),
+        source: ir1Var("items"),
         body: ir1Assign(
           ir1Member(ir1Var("item0"), "Item_seen"),
           ir1LitBool(true),
@@ -360,8 +358,10 @@ describe("ir1-ssa-lower", () => {
       result.programs.flatMap((program) =>
         program.loopSummaries.map((summary) => summary.shape),
       ),
-      ["foreach-shape-a", "foreach-shape-b"],
+      ["foreach-shape-b"],
     );
+    assert.equal(result.programs[0]?.loopHeaderJoins.length, 1);
+    assert.equal(result.programs[0]?.loopBodies.length, 1);
 
     const shapeAProp = result.propositions[0];
     assert.equal(shapeAProp?.kind, "equation");


### PR DESCRIPTION
## Patch 3: ts2pant: switch Shape A call site to new helper; delete adapter

- In `tools/ts2pant/src/ir1-lower-body.ts`, switch the Shape A foreach call (line 321) to use `lowerForeachShapeAAsGeneralLoop` from `./ir1-ssa-foreach.js`. Build the options struct with the same fields as before (`binder`, `source`, `body`, `lowerOpaque`, `initialPropertyValues`).
- Update the `adaptLoopSummaryLowerResult` overload at line 67-68 to take `ForeachAsGeneralLoopResult` instead of `ReturnType<typeof lowerForeachShapeASummaries>`. The wrapper logic in `loopSsaBodyLowerResult` (`tools/ts2pant/src/ir1-ssa-lower.ts:238`) is updated in this same patch.
- In `tools/ts2pant/src/ir1-ssa-lower.ts:238-243`, replace the `ForeachShapeASummaryResult` arm of the union with `ForeachAsGeneralLoopResult` (imported from `./ir1-ssa-foreach.js`). The function body is unchanged — it reads `program`, `propositions`, `modifiedRules`, `diagnostics` from the result.
- In `tools/ts2pant/src/ir1-ssa-loops.ts`, delete `lowerForeachShapeASummaries` (lines 217-266), the `ForeachShapeASummaryInput` / `ForeachShapeASummaryOptions` / `ForeachShapeASummaryResult` types (lines 32-35, 61-67, 85-91), and the Shape A internal helpers (`summarizeForeachShapeABody` at line 323, `summarizeShapeAAssign` at line 353, `summarizeShapeACond` at line 383, `lowerShapeAExpr` at line 454, `shapeAKey` at line 568, plus `ShapeAPropertyEntry` and `ShapeASummaryState`). After this patch, the file retains `buildLoopSsaProgram`, `lowerForeachShapeBSummaries`, `lowerForeachSummary`, the Shape B types, the μ-search summary symbols, the legacy `IR1LoopSsaInput` / `LoopSummaryInputBase` / `LoopSsaBuildOptions` / `LoopSsaBuildResult` types, and `foreachShapeBAccumulatorKey`.
- Delete any tests in `tools/ts2pant/tests/ir1-ssa-loops.test.mts` that exercise `lowerForeachShapeASummaries` directly. The integration-level test of the Shape A path lives in the snapshot test on `functions-mutating-loop.ts`.
- Run `just ts2pant-test` and confirm `tools/ts2pant/tests/constructs.test.mts.snapshot` does NOT change. Any byte-level drift on Shape A fixtures (`activateAll`, `activateActive`, `forEachActivate`) indicates a real bug — debug before merging. Run the full ts2pant test suite to confirm zero regressions.
- Unskip the Patch-3-owned `tools/ts2pant/tests/ir1-ssa-loops.test.mts` stub from Patch 1 and replace the PENDING-comment body with a concrete assertion.

## Changes
- In `tools/ts2pant/src/ir1-lower-body.ts`, switch the Shape A foreach call (line 321) to use `lowerForeachShapeAAsGeneralLoop` from `./ir1-ssa-foreach.js`. Build the options struct with the same fields as before (`binder`, `source`, `body`, `lowerOpaque`, `initialPropertyValues`).
- Update the `adaptLoopSummaryLowerResult` overload at line 67-68 to take `ForeachAsGeneralLoopResult` instead of `ReturnType<typeof lowerForeachShapeASummaries>`. The wrapper logic in `loopSsaBodyLowerResult` (`tools/ts2pant/src/ir1-ssa-lower.ts:238`) is updated in this same patch.
- In `tools/ts2pant/src/ir1-ssa-lower.ts:238-243`, replace the `ForeachShapeASummaryResult` arm of the union with `ForeachAsGeneralLoopResult` (imported from `./ir1-ssa-foreach.js`). The function body is unchanged — it reads `program`, `propositions`, `modifiedRules`, `diagnostics` from the result.
- In `tools/ts2pant/src/ir1-ssa-loops.ts`, delete `lowerForeachShapeASummaries` (lines 217-266), the `ForeachShapeASummaryInput` / `ForeachShapeASummaryOptions` / `ForeachShapeASummaryResult` types (lines 32-35, 61-67, 85-91), and the Shape A internal helpers (`summarizeForeachShapeABody` at line 323, `summarizeShapeAAssign` at line 353, `summarizeShapeACond` at line 383, `lowerShapeAExpr` at line 454, `shapeAKey` at line 568, plus `ShapeAPropertyEntry` and `ShapeASummaryState`). After this patch, the file retains `buildLoopSsaProgram`, `lowerForeachShapeBSummaries`, `lowerForeachSummary`, the Shape B types, the μ-search summary symbols, the legacy `IR1LoopSsaInput` / `LoopSummaryInputBase` / `LoopSsaBuildOptions` / `LoopSsaBuildResult` types, and `foreachShapeBAccumulatorKey`.
- Delete any tests in `tools/ts2pant/tests/ir1-ssa-loops.test.mts` that exercise `lowerForeachShapeASummaries` directly. The integration-level test of the Shape A path lives in the snapshot test on `functions-mutating-loop.ts`.
- Run `just ts2pant-test` and confirm `tools/ts2pant/tests/constructs.test.mts.snapshot` does NOT change. Any byte-level drift on Shape A fixtures (`activateAll`, `activateActive`, `forEachActivate`) indicates a real bug — debug before merging. Run the full ts2pant test suite to confirm zero regressions.
- Unskip the Patch-3-owned `tools/ts2pant/tests/ir1-ssa-loops.test.mts` stub from Patch 1 and replace the PENDING-comment body with a concrete assertion.

## Files to Modify
- tools/ts2pant/src/ir1-lower-body.ts (modify): Switch the call at line 321 from `lowerForeachShapeASummaries({ ... })` to `lowerForeachShapeAAsGeneralLoop({ ... })`. Update the import to reference `./ir1-ssa-foreach.js`. Update `adaptLoopSummaryLowerResult` overloads to accept `ForeachAsGeneralLoopResult` in place of `ForeachShapeASummaryResult`.
- tools/ts2pant/src/ir1-ssa-lower.ts (modify): Update `loopSsaBodyLowerResult` union at line 238-243 to accept `ForeachAsGeneralLoopResult` in place of `ForeachShapeASummaryResult`. Function body unchanged.
- tools/ts2pant/src/ir1-ssa-loops.ts (modify): Delete `lowerForeachShapeASummaries` (line 217-266) and the `ForeachShapeASummaryInput`, `ForeachShapeASummaryOptions`, `ForeachShapeASummaryResult` types. The Shape A internal helpers (`summarizeForeachShapeABody`, `summarizeShapeAAssign`, `summarizeShapeACond`, `lowerShapeAExpr`, `shapeAKey`, `ShapeAPropertyEntry`, `ShapeASummaryState`) were moved to `ir1-ssa-foreach.ts` in Patch 2 — delete them here too. The file is now substantially shorter (~250 lines).
- tools/ts2pant/tests/ir1-ssa-loops.test.mts (modify): Delete any tests in this file that exercise `lowerForeachShapeASummaries` directly (call sites and the function are gone). Unskip the Patch-3-owned stub from Patch 1 (`foreach Shape A call site emits IR1SsaProgram with populated loopHeaderJoins and loopBodies`) and replace the PENDING-comment body with a concrete assertion exercising the new call site via a hand-constructed Shape A `IR1Stmt`.

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[algorithm] Cytron 1991 SSA construction (carry-forward)** — https://doi.org/10.1145/115372.115320 — The recharacterised Shape A path satisfies the same two-pass loop-header-join protocol the L2/L3/L4 paths satisfy. Patch 3's call-site switch routes Shape A inputs through the protocol uniformly — the production translator now emits one shape of SSA program per loop class.

## Gameplan Specification

```
module TS2PANT_LOOP_SUMMARY_UNIFICATION.

> ════════════════════════════════
> Milestone 6 AND Milestone 7 of the ts2pant general-loop SSA
> workstream, collapsed into a single atomic milestone.
> ════════════════════════════════
> After this milestone, foreach Shape A and Shape B lower
> through the general-loop SSA machinery
> (IR1SsaLoopHeaderJoin + IR1SsaLoopBody +
> IR1SsaTerminationMetric) rather than the legacy
> IR1SsaLoopSummary path. IR1SsaTerminationMetric is now a
> discriminated union: counter loops and bounded-while loops
> emit the existing counter-style variant (kind:
> ssa-termination-metric, expr, lowerBound); foreach Shape A
> and Shape B emit the new iterating-source variant (kind:
> ssa-iterating-source-metric, source) matching Pant's native
> all-x-in-arr semantics. Shape A's per-iteration writes do
> not feed back through the header join (degenerate close);
> Shape B's accumulator-fold writes do (Cytron inductive
> case). The IR1SsaLoopSummary type, the ir1SsaLoopSummary
> constructor, the IR1SsaProgram.loopSummaries field, the
> lowerMuSearchSummary path, and tools/ts2pant/src/ir1-ssa-loops.ts
> are all deleted. Four L7 invariant tests verify the unified
> abstraction: header-join uniqueness, continuation
> resolution, metric kind by loop class, frame suppression
> per modified rule. Pant output is byte-equivalent on every
> existing foreach fixture. Documentation marks BOTH milestone
> 6 AND milestone 7 as landed.

ForeachInput.
ForeachShape.
shape-a => ForeachShape.
shape-b => ForeachShape.
IR1SsaProgram.
IR1SsaProgramShape.
IR1SsaLoopBody.
IR1SsaLoopHeaderJoin.
IR1SsaTerminationMetric.
IR1SsaWrite.
IR1SsaVersion.
IR1SsaRuleName.
FieldName.
loop-summaries-field => FieldName.
loop-header-joins-field => FieldName.
loop-bodies-field => FieldName.
FileStatus.
file-present => FileStatus.
file-deleted => FileStatus.
Declaration.
DeletionStatus.
present => DeletionStatus.
deleted => DeletionStatus.
MuSearchSummary.
LoopClass.
counter => LoopClass.
bounded-while => LoopClass.
fixed-point-while => LoopClass.
foreach-shape-a => LoopClass.
foreach-shape-b => LoopClass.
FixtureOutput.
MetricKind.
counter-metric => MetricKind.
iterating-source-metric => MetricKind.
Document.
DocumentKind.
MilestoneStatus.
ir-doc => DocumentKind.
transformations-doc => DocumentKind.
agents-md => DocumentKind.
workstream-doc => DocumentKind.
pending => MilestoneStatus.
landed => MilestoneStatus.

> Foreach-as-general-loop helper.
input-shape i: ForeachInput => ForeachShape.
lower-result i: ForeachInput => IR1SsaProgram.
body-of p: IR1SsaProgram => IR1SsaLoopBody.
header-of b: IR1SsaLoopBody => IR1SsaLoopHeaderJoin.
metric-of b: IR1SsaLoopBody => IR1SsaTerminationMetric.
metric-kind m: IR1SsaTerminationMetric => MetricKind.
write-of b: IR1SsaLoopBody => IR1SsaWrite.
loop-back-version h: IR1SsaLoopHeaderJoin => IR1SsaVersion.
preheader-version h: IR1SsaLoopHeaderJoin => IR1SsaVersion.
write-version w: IR1SsaWrite => IR1SsaVersion.
emits-quantified-equation? p: IR1SsaProgram => Bool.
emits-accumulator-fold-equation? p: IR1SsaProgram => Bool.

> Deletion (Patches 5, 6).
shape-has-field? s: IR1SsaProgramShape, f: FieldName => Bool.
ir-ssa-loops-file-status => FileStatus.
deletion-status d: Declaration => DeletionStatus.
is-mu-search-summary? d: Declaration => Bool.
production-reachable? d: Declaration => Bool.

> L7 invariants (Patch 7).
header-has-preheader? h: IR1SsaLoopHeaderJoin => Bool.
header-has-loop-back? h: IR1SsaLoopHeaderJoin => Bool.
header-closed? h: IR1SsaLoopHeaderJoin => Bool.
body-class b: IR1SsaLoopBody => LoopClass.
non-null-metric? b: IR1SsaLoopBody => Bool.
is-bounded? c: LoopClass => Bool.
uses-counter-metric? c: LoopClass => Bool.
uses-iterating-source-metric? c: LoopClass => Bool.
continuations-resolved? b: IR1SsaLoopBody => Bool.
modified-rule-appears-once? p: IR1SsaProgram, r: IR1SsaRuleName => Bool.
body-writes-rule? b: IR1SsaLoopBody, r: IR1SsaRuleName => Bool.

> Byte-equivalent emission.
legacy-emission i: ForeachInput => FixtureOutput.
recharacterised-emission i: ForeachInput => FixtureOutput.
byte-equivalent? a: FixtureOutput, b: FixtureOutput => Bool.

> Documentation.
document-kind d: Document => DocumentKind.
document-mentions-unification? d: Document => Bool.
workstream-milestone-6-status => MilestoneStatus.
workstream-milestone-7-status => MilestoneStatus.
---

> Foreach helper contract: every foreach input lowers to an
> IR1SsaProgram carrying an iterating-source termination
> metric (the new variant introduced by Patch 2).
all i: ForeachInput, b: IR1SsaLoopBody |
  b = body-of (lower-result i) ->
    metric-kind (metric-of b) = iterating-source-metric.

> Shape A: the header join's loop-back version equals the
> per-iteration write version (degenerate close).
all i: ForeachInput, b: IR1SsaLoopBody, h: IR1SsaLoopHeaderJoin, w: IR1SsaWrite |
  input-shape i = shape-a and b = body-of (lower-result i) and
  h = header-of b and w = write-of b ->
    loop-back-version h = write-version w.

> Shape A: emits a per-element quantified equation.
all i: ForeachInput |
  input-shape i = shape-a ->
    emits-quantified-equation? (lower-result i).

> Shape B: emits an accumulator-fold equation per location.
all i: ForeachInput |
  input-shape i = shape-b ->
    emits-accumulator-fold-equation? (lower-result i).

> Byte-equivalent Pant emission on every existing fixture.
all i: ForeachInput |
  byte-equivalent? (legacy-emission i) (recharacterised-emission i).

> Type-level deletion: IR1SsaProgram has no loopSummaries
> field; retains loopHeaderJoins and loopBodies.
all s: IR1SsaProgramShape |
  ~(shape-has-field? s loop-summaries-field).

all s: IR1SsaProgramShape |
  shape-has-field? s loop-header-joins-field and
  shape-has-field? s loop-bodies-field.

> File deletion: ir1-ssa-loops.ts is gone.
ir-ssa-loops-file-status = file-deleted.

> μ-search summary symbols are deleted; the dead path is
> unreachable.
all d: Declaration |
  is-mu-search-summary? d -> deletion-status d = deleted.

all d: Declaration |
  deletion-status d = deleted -> ~(production-reachable? d).

> L7 invariant: every header join has exactly one preheader,
> one loop-back, and is closed.
all h: IR1SsaLoopHeaderJoin |
  header-has-preheader? h and header-has-loop-back? h and
  header-closed? h.

> L7 invariant: continuation handles resolve.
all b: IR1SsaLoopBody |
  continuations-resolved? b.

> L7 invariant 3a: bounded loops have non-null metrics.
all b: IR1SsaLoopBody |
  is-bounded? (body-class b) -> non-null-metric? b.

> L7 invariant 3b: counter / bounded-while emit
> counter-metric; foreach Shape A / Shape B emit
> iterating-source-metric.
all b: IR1SsaLoopBody |
  uses-counter-metric? (body-class b) ->
    metric-kind (metric-of b) = counter-metric.

all b: IR1SsaLoopBody |
  uses-iterating-source-metric? (body-class b) ->
    metric-kind (metric-of b) = iterating-source-metric.

is-bounded? counter.
is-bounded? bounded-while.
is-bounded? foreach-shape-a.
is-bounded? foreach-shape-b.
~(is-bounded? fixed-point-while).

uses-counter-metric? counter.
uses-counter-metric? bounded-while.
uses-iterating-source-metric? foreach-shape-a.
uses-iterating-source-metric? foreach-shape-b.

> L7 invariant: every modified rule appears in modifiedRules
> exactly once.
all p: IR1SsaProgram, r: IR1SsaRuleName, b: IR1SsaLoopBody |
  body-writes-rule? b r ->
    modified-rule-appears-once? p r.

> Documentation invariants.
all d: Document |
  document-kind d = ir-doc ->
    document-mentions-unification? d.

all d: Document |
  document-kind d = transformations-doc ->
    document-mentions-unification? d.

all d: Document |
  document-kind d = agents-md ->
    document-mentions-unification? d.

all d: Document |
  document-kind d = workstream-doc ->
    document-mentions-unification? d.

workstream-milestone-6-status = landed.
workstream-milestone-7-status = landed.
```

## Patch Specification

```
module TS2PANT_LOOP_SUMMARY_UNIFICATION_PATCH_3.

> Patch 3 switches the Shape A foreach call site in
> ir1-lower-body.ts from the legacy summary adapter to the
> new general-loop helper. The Shape A adapter and its
> internal helpers are deleted from ir1-ssa-loops.ts. Pant
> emission is byte-equivalent on every existing Shape A
> fixture; snapshot tests gate.

ForeachShapeAOptions.
IR1SsaProgram.
IR1SsaLoopBody.
IR1SsaLoopHeaderJoin.
FixtureOutput.

call-site-result o: ForeachShapeAOptions => IR1SsaProgram.
program-header-joins p: IR1SsaProgram => Nat0.
program-loop-bodies p: IR1SsaProgram => Nat0.
legacy-emission o: ForeachShapeAOptions => FixtureOutput.
recharacterised-emission o: ForeachShapeAOptions => FixtureOutput.
byte-equivalent? a: FixtureOutput, b: FixtureOutput => Bool.
---

> Call site produces populated loopHeaderJoins and loopBodies.
all o: ForeachShapeAOptions, p: IR1SsaProgram |
  p = call-site-result o ->
    program-loop-bodies p > 0 and program-header-joins p > 0.

> Pant emission is byte-equivalent on every Shape A fixture.
all o: ForeachShapeAOptions |
  byte-equivalent? (legacy-emission o) (recharacterised-emission o).
```


## Implementation Notes

- Shape A now passes the original `IR1Expr` source into `lowerForeachShapeAAsGeneralLoop`; the helper owns lowering that source to Pant for emission and stores the unlowered source in the iterating-source metric. Shape B still receives the pre-lowered `OpaqueExpr` because that legacy adapter remains until Patch 4.
- I removed Shape A from the legacy `buildLoopSsaProgram` input union as part of deleting the adapter. Tests that were asserting Shape A summary bookkeeping were either removed or narrowed to the remaining Shape B / μ-search summary path, since Shape A no longer has a valid legacy summary input.
- The unskipped Patch 3 test exercises the production call site via a hand-built `ir1Foreach(...)` and asserts the emitted program has no loop summaries, populated `loopHeaderJoins` / `loopBodies`, and an `ssa-iterating-source-metric`.
- Spec/Evidence Mapping: call-site populated header/body clause is covered by `tools/ts2pant/tests/ir1-ssa-loops.test.mts` (`foreach Shape A call site emits IR1SsaProgram...`); byte-equivalent Shape A emission is covered by `just ts2pant-test` with no diff in `tools/ts2pant/tests/constructs.test.mts.snapshot`; type-surface deletion is checked by `npm run build`.