### PR TITLE
[ts2pant-loop-summary-unification] Patch 7: ts2pant: add L7 invariant tests over the unified abstraction

### DIFF
--- a/tools/ts2pant/tests/ir1-ssa-invariants.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-invariants.test.mts
@@ -6,23 +6,11 @@ import ts from "typescript";
 
 import { createSourceFile, getChecker } from "../src/extract.js";
 import {
-  buildL1AssignStmt,
-  buildL1EffectCall,
-  buildL1ForEachCall,
-  buildL1ForOfMutation,
-  buildL1IfMutation,
-  type BuildBodyCtx,
-  isUnsupported,
-} from "../src/ir1-build-body.js";
-import { lowerL1BodyToSsaProps } from "../src/ir1-lower-body.js";
-import {
-  scalarSsaBodyLowerResult,
-  collectionSsaBodyLowerResult,
-  type IR1SsaBodyLowerResult,
-} from "../src/ir1-ssa-lower.js";
-import {
+  type IR1FoldLeaf,
   type IR1SsaJoin,
   type IR1SsaLocation,
+  type IR1SsaLoopBody,
+  type IR1SsaLoopHeaderJoin,
   type IR1SsaProgram,
   type IR1SsaRead,
   type IR1SsaWrite,
@@ -30,14 +18,20 @@ import {
   ir1Assign,
   ir1Binop,
   ir1Block,
+  ir1Break,
   ir1CondStmt,
+  ir1Continue,
   ir1For,
   ir1Foreach,
+  ir1Let,
   ir1LitBool,
   ir1LitNat,
   ir1MapRead,
   ir1MapSet,
   ir1Member,
+  ir1Return,
+  ir1SetAddOrDelete,
+  ir1SetClear,
   ir1SsaInitialVersion,
   ir1SsaJoin,
   ir1SsaMapMembershipLocation,
@@ -45,12 +39,32 @@ import {
   ir1SsaPropertyLocation,
   ir1SsaRuleOfLocation,
   ir1SsaSetMembershipLocation,
-  ir1SetAddOrDelete,
-  ir1SetClear,
+  ir1Throw,
   ir1Var,
   ir1While,
 } from "../src/ir1.js";
+import {
+  type BuildBodyCtx,
+  buildL1AssignStmt,
+  buildL1EffectCall,
+  buildL1ForEachCall,
+  buildL1ForOfMutation,
+  buildL1IfMutation,
+  isUnsupported,
+} from "../src/ir1-build-body.js";
+import { lowerL1BodyToSsaProps } from "../src/ir1-lower-body.js";
 import { lowerCollectionSsaToResult } from "../src/ir1-ssa-collections.js";
+import { lowerCounterLoopL1Body } from "../src/ir1-ssa-counter-loop.js";
+import { lowerFixedPointLoopL1Body } from "../src/ir1-ssa-fixed-point.js";
+import {
+  lowerForeachShapeAAsGeneralLoop,
+  lowerForeachShapeBAsGeneralLoop,
+} from "../src/ir1-ssa-foreach.js";
+import {
+  collectionSsaBodyLowerResult,
+  type IR1SsaBodyLowerResult,
+  scalarSsaBodyLowerResult,
+} from "../src/ir1-ssa-lower.js";
 import { lowerScalarSsaToProps } from "../src/ir1-ssa-scalars.js";
 import { getAst, loadAst } from "../src/pant-wasm.js";
 import { IntStrategy } from "../src/translate-types.js";
@@ -146,7 +160,9 @@ function buildFixtureSupportedSsaBody(
   }
 
   assert.ok(stmts.length > 0, `${functionName} should produce an SSA body`);
-  return stmts.length === 1 ? stmts[0]! : ir1Block([stmts[0]!, ...stmts.slice(1)]);
+  return stmts.length === 1
+    ? stmts[0]!
+    : ir1Block([stmts[0]!, ...stmts.slice(1)]);
 }
 
 function buildSupportedFixtureStatement(
@@ -212,7 +228,8 @@ function representativePrograms(): RepresentativeProgram[] {
     {
       name: "functions-mutating.ts > deposit",
       kind: "scalar",
-      build: () => buildFixtureBodyLowerResult("functions-mutating.ts", "deposit"),
+      build: () =>
+        buildFixtureBodyLowerResult("functions-mutating.ts", "deposit"),
     },
     {
       name: "expressions-map-mutation.ts > setAndCopy",
@@ -319,12 +336,7 @@ function representativePrograms(): RepresentativeProgram[] {
         return buildScalarResult(
           ir1Block([
             ir1CondStmt(
-              [
-                [
-                  ir1Var("g"),
-                  ir1Assign(balance, ir1LitNat(1)),
-                ],
-              ],
+              [[ir1Var("g"), ir1Assign(balance, ir1LitNat(1))]],
               ir1Assign(balance, ir1LitNat(2)),
             ),
             ir1Assign(balance, ir1Binop("add", balance, ir1LitNat(1))),
@@ -358,7 +370,10 @@ function bodyLoweredRepresentativePrograms(): BodyLoweredRepresentativeProgram[]
         const sourceFile = loadFixture("functions-mutating.ts");
         const doc = await buildDocumentFromSourceFile(sourceFile, "deposit");
         return {
-          result: await buildFixtureBodyLowerResult("functions-mutating.ts", "deposit"),
+          result: await buildFixtureBodyLowerResult(
+            "functions-mutating.ts",
+            "deposit",
+          ),
           declaredRules: doc.declarations
             .filter((decl) => decl.kind === "rule")
             .map((decl) => decl.name),
@@ -388,7 +403,10 @@ function bodyLoweredRepresentativePrograms(): BodyLoweredRepresentativeProgram[]
       name: "expressions-state-aware-reads.ts > tagThenCheck",
       build: async () => {
         const sourceFile = loadFixture("expressions-state-aware-reads.ts");
-        const doc = await buildDocumentFromSourceFile(sourceFile, "tagThenCheck");
+        const doc = await buildDocumentFromSourceFile(
+          sourceFile,
+          "tagThenCheck",
+        );
         return {
           result: await buildFixtureBodyLowerResult(
             "expressions-state-aware-reads.ts",
@@ -420,7 +438,10 @@ function bodyLoweredRepresentativePrograms(): BodyLoweredRepresentativeProgram[]
       name: "functions-mutating-loop.ts > forEachActivate",
       build: async () => {
         const sourceFile = loadFixture("functions-mutating-loop.ts");
-        const doc = await buildDocumentFromSourceFile(sourceFile, "forEachActivate");
+        const doc = await buildDocumentFromSourceFile(
+          sourceFile,
+          "forEachActivate",
+        );
         return {
           result: await buildFixtureBodyLowerResult(
             "functions-mutating-loop.ts",
@@ -451,7 +472,10 @@ function bodyLoweredRepresentativePrograms(): BodyLoweredRepresentativeProgram[]
   ];
 }
 
-function walkSsaProgram(program: IR1SsaProgram, visit: SsaProgramVisitor): void {
+function walkSsaProgram(
+  program: IR1SsaProgram,
+  visit: SsaProgramVisitor,
+): void {
   for (const [index, write] of program.writes.entries()) {
     visit.onWrite?.(write, index);
   }
@@ -743,6 +767,324 @@ function assertUnsupportedDiagnosticShape(
   );
 }
 
+type LoopClass =
+  | "counter"
+  | "bounded-while"
+  | "fixed-point-while"
+  | "foreach-shape-a"
+  | "foreach-shape-b";
+
+interface LoopInvariantCase {
+  name: string;
+  loopClass: LoopClass;
+  result: IR1SsaBodyLowerResult;
+}
+
+const loopAccount = ir1Var("loopAccount");
+const loopItems = ir1Var("loopItems");
+const loopItem = ir1Var("loopItem");
+const loopTotal = ir1Member(loopAccount, "Loop_total");
+
+function counterLoopStmt(): Extract<IR1Stmt, { kind: "for" }> {
+  return ir1For(
+    ir1Let("i", ir1LitNat(0)),
+    ir1Binop("lt", ir1Var("i"), ir1Var("n")),
+    ir1Assign(ir1Var("i"), ir1Binop("add", ir1Var("i"), ir1LitNat(1))),
+    ir1Assign(loopTotal, ir1Binop("add", loopTotal, ir1Var("i"))),
+  ) as Extract<IR1Stmt, { kind: "for" }>;
+}
+
+function boundedWhileLoopStmt(): Extract<IR1Stmt, { kind: "for" }> {
+  return ir1For(
+    ir1Let("j", ir1LitNat(0)),
+    ir1Binop("lt", ir1Var("j"), ir1Var("limit")),
+    ir1Assign(ir1Var("j"), ir1Binop("add", ir1Var("j"), ir1LitNat(1))),
+    ir1Assign(loopTotal, ir1Var("j")),
+  ) as Extract<IR1Stmt, { kind: "for" }>;
+}
+
+function fixedPointLoopStmt(
+  body: IR1Stmt = ir1Assign(
+    loopTotal,
+    ir1Binop("add", loopTotal, ir1Var("step")),
+  ),
+): Extract<IR1Stmt, { kind: "while" }> {
+  return ir1While(ir1Binop("lt", loopTotal, ir1Var("target")), body) as Extract<
+    IR1Stmt,
+    { kind: "while" }
+  >;
+}
+
+function foreachShapeBFoldLeaves(): IR1FoldLeaf[] {
+  return [
+    {
+      target: loopAccount,
+      prop: "Loop_total",
+      combiner: "add",
+      outerOp: "add",
+      rhs: ir1Member(loopItem, "Item_amount"),
+      guard: null,
+    },
+  ];
+}
+
+function loopInvariantCases(): LoopInvariantCase[] {
+  const shapeA = lowerForeachShapeAAsGeneralLoop({
+    binder: "loopItem",
+    source: loopItems,
+    body: ir1Assign(ir1Member(loopItem, "Item_seen"), ir1LitBool(true)),
+  });
+  const shapeB = lowerForeachShapeBAsGeneralLoop({
+    binder: "loopItem",
+    source: loopItems,
+    foldLeaves: foreachShapeBFoldLeaves(),
+  });
+
+  return [
+    {
+      name: "counter loop",
+      loopClass: "counter",
+      result: lowerCounterLoopL1Body(counterLoopStmt()),
+    },
+    {
+      name: "bounded while loop normalized to counter SSA",
+      loopClass: "bounded-while",
+      result: lowerCounterLoopL1Body(boundedWhileLoopStmt()),
+    },
+    {
+      name: "fixed-point while loop",
+      loopClass: "fixed-point-while",
+      result: lowerFixedPointLoopL1Body(fixedPointLoopStmt()),
+    },
+    {
+      name: "foreach Shape A",
+      loopClass: "foreach-shape-a",
+      result: {
+        programs: [shapeA.program],
+        propositions: shapeA.propositions,
+        diagnostics: shapeA.diagnostics,
+        modifiedRules: shapeA.modifiedRules,
+      },
+    },
+    {
+      name: "foreach Shape B",
+      loopClass: "foreach-shape-b",
+      result: {
+        programs: [shapeB.program],
+        propositions: shapeB.propositions,
+        diagnostics: shapeB.diagnostics,
+        modifiedRules: shapeB.modifiedRules,
+      },
+    },
+  ];
+}
+
+function continuationLoopCases(): LoopInvariantCase[] {
+  const breakStmt = ir1CondStmt(
+    [[ir1Var("shouldBreak"), ir1Break()]],
+    ir1Assign(loopTotal, ir1Binop("add", loopTotal, ir1Var("step"))),
+  );
+  const continueStmt = ir1Block([
+    ir1CondStmt([[ir1Var("shouldContinue"), ir1Continue()]], null),
+    ir1Assign(loopTotal, ir1Binop("add", loopTotal, ir1Var("step"))),
+  ]);
+  const returnStmt = ir1Block([
+    ir1CondStmt([[ir1Var("shouldReturn"), ir1Return(loopTotal)]], null),
+    ir1Assign(loopTotal, ir1Binop("add", loopTotal, ir1Var("step"))),
+  ]);
+  const throwStmt = ir1Block([
+    ir1CondStmt([[ir1Var("shouldThrow"), ir1Throw(ir1Var("err"))]], null),
+    ir1Assign(loopTotal, ir1Binop("add", loopTotal, ir1Var("step"))),
+  ]);
+
+  return [
+    ...loopInvariantCases(),
+    {
+      name: "fixed-point while loop with break",
+      loopClass: "fixed-point-while",
+      result: lowerFixedPointLoopL1Body(fixedPointLoopStmt(breakStmt)),
+    },
+    {
+      name: "fixed-point while loop with continue",
+      loopClass: "fixed-point-while",
+      result: lowerFixedPointLoopL1Body(fixedPointLoopStmt(continueStmt)),
+    },
+    {
+      name: "fixed-point while loop with valued return",
+      loopClass: "fixed-point-while",
+      result: lowerFixedPointLoopL1Body(fixedPointLoopStmt(returnStmt), {
+        returnRuleName: "fn_result",
+      }),
+    },
+    {
+      name: "fixed-point while loop with throw",
+      loopClass: "fixed-point-while",
+      result: lowerFixedPointLoopL1Body(fixedPointLoopStmt(throwStmt)),
+    },
+  ];
+}
+
+function assertLoopInvariantCaseSupported(testCase: LoopInvariantCase): void {
+  assert.equal(
+    testCase.result.diagnostics.length,
+    0,
+    `${testCase.name} should lower without diagnostics`,
+  );
+  assert.ok(
+    testCase.result.programs.length > 0,
+    `${testCase.name} should emit at least one SSA program`,
+  );
+}
+
+function assertClosedLoopHeaderJoin(
+  detail: string,
+  header: IR1SsaLoopHeaderJoin,
+): void {
+  assert.equal(
+    header.kind,
+    "ssa-loop-header-join",
+    `${detail} should be a loop-header join`,
+  );
+  assert.equal(
+    locationSignature(header.preheaderVersion.location),
+    locationSignature(header.location),
+    `${detail} preheader version should match the header location`,
+  );
+  assert.ok(
+    header.loopBackVersion !== null,
+    `${detail} should have a loop-back`,
+  );
+  assert.equal(
+    locationSignature(header.loopBackVersion.location),
+    locationSignature(header.location),
+    `${detail} loop-back version should match the header location`,
+  );
+  assert.equal(header.closed, true, `${detail} should be closed`);
+}
+
+function assertLoopBodyContinuationsResolved(
+  detail: string,
+  body: IR1SsaLoopBody,
+): void {
+  const headersByLocation = new Map(
+    body.headerJoins.map((header) => [
+      locationSignature(header.location),
+      header,
+    ]),
+  );
+  const writeVersions = new Set(body.writes.map((write) => write.version));
+
+  for (const [index, handle] of body.breakHandles.entries()) {
+    const header = headersByLocation.get(locationSignature(handle.location));
+    assert.ok(
+      header !== undefined,
+      `${detail} break #${index} should match a header location`,
+    );
+    assert.ok(
+      writeVersions.has(handle.version),
+      `${detail} break #${index} should resolve to a body write reaching the post-loop join`,
+    );
+  }
+
+  for (const [index, handle] of body.continueHandles.entries()) {
+    const header = headersByLocation.get(locationSignature(handle.location));
+    assert.ok(
+      header !== undefined,
+      `${detail} continue #${index} should match a header location`,
+    );
+    assert.equal(
+      handle.version,
+      header.loopBackVersion,
+      `${detail} continue #${index} should resolve to the header loop-back version`,
+    );
+  }
+
+  for (const [index, handle] of body.returnHandles.entries()) {
+    const header = headersByLocation.get(locationSignature(handle.location));
+    assert.ok(
+      header !== undefined,
+      `${detail} return #${index} should match a header location`,
+    );
+    assert.ok(
+      writeVersions.has(handle.version),
+      `${detail} return #${index} should resolve to a body write before the function return continuation`,
+    );
+  }
+
+  for (const [index, handle] of body.throwHandles.entries()) {
+    const header = headersByLocation.get(locationSignature(handle.location));
+    assert.ok(
+      header !== undefined,
+      `${detail} throw #${index} should match a header location`,
+    );
+    assert.ok(
+      writeVersions.has(handle.version),
+      `${detail} throw #${index} should resolve to a body write guarded by the iteration precondition`,
+    );
+    assert.ok(
+      handle.guard !== null,
+      `${detail} throw #${index} should carry a guard`,
+    );
+  }
+}
+
+function assertMetricMatchesLoopClass(
+  detail: string,
+  loopClass: LoopClass,
+  body: IR1SsaLoopBody,
+): void {
+  switch (loopClass) {
+    case "counter":
+    case "bounded-while":
+      assert.equal(
+        body.terminationMetric?.kind,
+        "ssa-termination-metric",
+        `${detail} should use a counter-style termination metric`,
+      );
+      break;
+    case "foreach-shape-a":
+    case "foreach-shape-b":
+      assert.equal(
+        body.terminationMetric?.kind,
+        "ssa-iterating-source-metric",
+        `${detail} should use an iterating-source termination metric`,
+      );
+      break;
+    case "fixed-point-while":
+      assert.equal(
+        body.terminationMetric,
+        null,
+        `${detail} should not carry a termination metric`,
+      );
+      break;
+    default: {
+      const _exhaustive: never = loopClass;
+      void _exhaustive;
+    }
+  }
+}
+
+function assertLoopModifiedRulesAppearOnce(
+  detail: string,
+  program: IR1SsaProgram,
+): void {
+  const counts = new Map<string, number>();
+  for (const rule of program.modifiedRules) {
+    counts.set(rule, (counts.get(rule) ?? 0) + 1);
+  }
+
+  for (const [bodyIndex, body] of program.loopBodies.entries()) {
+    for (const [writeIndex, write] of body.writes.entries()) {
+      const rule = ir1SsaRuleOfLocation(write.location);
+      assert.equal(
+        counts.get(rule),
+        1,
+        `${detail} body #${bodyIndex} write #${writeIndex} should list ${rule} exactly once in modifiedRules`,
+      );
+    }
+  }
+}
+
 before(async () => {
   await loadAst();
 });
@@ -751,270 +1093,352 @@ describe("ir1-ssa-invariants", () => {
   void representativePrograms;
   void walkSsaProgram;
 
-  it(
-    "each write and join produces a fresh SSA version at its location",
-    async () => {
-      for (const representative of representativePrograms()) {
-        const result = await representative.build();
-        assertFreshVersionsAndJoinLocations(representative.name, result);
-      }
-    },
-  );
+  it("each write and join produces a fresh SSA version at its location", async () => {
+    for (const representative of representativePrograms()) {
+      const result = await representative.build();
+      assertFreshVersionsAndJoinLocations(representative.name, result);
+    }
+  });
 
-  it(
-    "ir1SsaJoin rejects mismatched-location inputs across all four location kinds",
-    () => {
-      const propertyBalance = ir1SsaPropertyLocation(
-        "Account_balance",
-        ir1Var("account"),
-        "balance",
+  it("ir1SsaJoin rejects mismatched-location inputs across all four location kinds", () => {
+    const propertyBalance = ir1SsaPropertyLocation(
+      "Account_balance",
+      ir1Var("account"),
+      "balance",
+    );
+    const propertyLimit = ir1SsaPropertyLocation(
+      "Account_limit",
+      ir1Var("account"),
+      "limit",
+    );
+    const mapValue = ir1SsaMapValueLocation(
+      "Account_score",
+      "Account_hasScore",
+      "Account",
+      "User",
+      ir1Var("account"),
+      ir1Var("user"),
+    );
+    const mapMembership = ir1SsaMapMembershipLocation(
+      "Account_score",
+      "Account_hasScore",
+      "Account",
+      "User",
+      ir1Var("account"),
+      ir1Var("user"),
+    );
+    const setMembership = ir1SsaSetMembershipLocation(
+      "Account_tags",
+      "Account",
+      "Tag",
+      ir1Var("account"),
+    );
+    const otherSetMembership = ir1SsaSetMembershipLocation(
+      "Account_tags",
+      "Account",
+      "Tag",
+      ir1Var("otherAccount"),
+    );
+
+    const mismatchedPairs: ReadonlyArray<
+      readonly [name: string, expected: IR1SsaLocation, actual: IR1SsaLocation]
+    > = [
+      ["property vs property", propertyLimit, propertyBalance],
+      ["property vs map-value", propertyBalance, mapValue],
+      ["property vs set-membership", propertyBalance, setMembership],
+      ["map-value vs map-membership", mapValue, mapMembership],
+      [
+        "set-membership vs set-membership receiver mismatch",
+        setMembership,
+        otherSetMembership,
+      ],
+    ];
+
+    for (const [name, expected, actual] of mismatchedPairs) {
+      const initial = ir1SsaInitialVersion(actual);
+      assert.throws(
+        () => ir1SsaJoin(expected, initial, initial),
+        /location mismatch/u,
+        `${name} should reject incompatible locations`,
       );
-      const propertyLimit = ir1SsaPropertyLocation(
-        "Account_limit",
-        ir1Var("account"),
-        "limit",
-      );
-      const mapValue = ir1SsaMapValueLocation(
-        "Account_score",
-        "Account_hasScore",
-        "Account",
-        "User",
-        ir1Var("account"),
-        ir1Var("user"),
-      );
-      const mapMembership = ir1SsaMapMembershipLocation(
-        "Account_score",
-        "Account_hasScore",
-        "Account",
-        "User",
-        ir1Var("account"),
-        ir1Var("user"),
-      );
-      const setMembership = ir1SsaSetMembershipLocation(
-        "Account_tags",
-        "Account",
-        "Tag",
-        ir1Var("account"),
-      );
-      const otherSetMembership = ir1SsaSetMembershipLocation(
-        "Account_tags",
-        "Account",
-        "Tag",
-        ir1Var("otherAccount"),
-      );
+    }
 
-      const mismatchedPairs: ReadonlyArray<
-        readonly [name: string, expected: IR1SsaLocation, actual: IR1SsaLocation]
-      > = [
-        ["property vs property", propertyLimit, propertyBalance],
-        ["property vs map-value", propertyBalance, mapValue],
-        ["property vs set-membership", propertyBalance, setMembership],
-        ["map-value vs map-membership", mapValue, mapMembership],
-        [
-          "set-membership vs set-membership receiver mismatch",
-          setMembership,
-          otherSetMembership,
-        ],
-      ];
+    const version = ir1SsaInitialVersion(propertyBalance);
+    const degenerate = ir1SsaJoin(propertyBalance, version, version);
+    assert.equal(degenerate, version);
+    assert.notEqual(degenerate.kind, "ssa-join");
+  });
 
-      for (const [name, expected, actual] of mismatchedPairs) {
-        const initial = ir1SsaInitialVersion(actual);
-        assert.throws(
-          () => ir1SsaJoin(expected, initial, initial),
-          /location mismatch/u,
-          `${name} should reject incompatible locations`,
-        );
-      }
+  it("every read resolves to a dominating version or initial version at its own location", async () => {
+    for (const representative of representativePrograms()) {
+      const result = await representative.build();
+      assertDominatingReads(representative.name, result);
+    }
+  });
 
-      const version = ir1SsaInitialVersion(propertyBalance);
-      const degenerate = ir1SsaJoin(propertyBalance, version, version);
-      assert.equal(degenerate, version);
-      assert.notEqual(degenerate.kind, "ssa-join");
-    },
-  );
+  it("every modified rule suppresses frame generation exactly once and every framed rule is unmodified", async () => {
+    for (const representative of bodyLoweredRepresentativePrograms()) {
+      const { result, declaredRules } = await representative.build();
+      assertFrameSuppression(representative.name, result, declaredRules);
+    }
+  });
 
-  it(
-    "every read resolves to a dominating version or initial version at its own location",
-    async () => {
-      for (const representative of representativePrograms()) {
-        const result = await representative.build();
-        assertDominatingReads(representative.name, result);
-      }
-    },
-  );
+  it("unsupported loops and branch shapes return targeted diagnostics with no equations or frames", async () => {
+    const mutatingSourceFile = loadFixture("functions-mutating.ts");
+    const mutatingDoc = await buildDocumentFromSourceFile(
+      mutatingSourceFile,
+      "deposit",
+    );
+    const loopDeclarations = mutatingDoc.declarations;
+    const balance = ir1Member(ir1Var("account"), "Account_balance");
 
-  it(
-    "every modified rule suppresses frame generation exactly once and every framed rule is unmodified",
-    async () => {
-      for (const representative of bodyLoweredRepresentativePrograms()) {
-        const { result, declaredRules } = await representative.build();
-        assertFrameSuppression(representative.name, result, declaredRules);
-      }
-    },
-  );
-
-  it(
-    "unsupported loops and branch shapes return targeted diagnostics with no equations or frames",
-    async () => {
-      const mutatingSourceFile = loadFixture("functions-mutating.ts");
-      const mutatingDoc = await buildDocumentFromSourceFile(
-        mutatingSourceFile,
-        "deposit",
-      );
-      const loopDeclarations = mutatingDoc.declarations;
-      const balance = ir1Member(ir1Var("account"), "Account_balance");
-
-      const unsupportedCases: Array<{
-        name: string;
-        build: () => IR1SsaBodyLowerResult;
-        reason: RegExp;
-      }> = [
-        {
-          name: "while loop on property",
-          build: () =>
-            scalarSsaBodyLowerResult(
-              lowerScalarSsaToProps(
-                ir1While(ir1LitBool(true), ir1Assign(balance, ir1LitNat(1))),
+    const unsupportedCases: Array<{
+      name: string;
+      build: () => IR1SsaBodyLowerResult;
+      reason: RegExp;
+    }> = [
+      {
+        name: "while loop on property",
+        build: () =>
+          scalarSsaBodyLowerResult(
+            lowerScalarSsaToProps(
+              ir1While(ir1LitBool(true), ir1Assign(balance, ir1LitNat(1))),
+            ),
+          ),
+        reason: /scalar SSA lowering/u,
+      },
+      {
+        name: "for loop on property",
+        build: () =>
+          scalarSsaBodyLowerResult(
+            lowerScalarSsaToProps(
+              ir1For(
+                null,
+                ir1LitBool(true),
+                null,
+                ir1Assign(balance, ir1LitNat(1)),
               ),
             ),
-          reason: /scalar SSA lowering/u,
-        },
-        {
-          name: "for loop on property",
-          build: () =>
-            scalarSsaBodyLowerResult(
-              lowerScalarSsaToProps(
-                ir1For(
-                  null,
-                  ir1LitBool(true),
-                  null,
-                  ir1Assign(balance, ir1LitNat(1)),
-                ),
+          ),
+        reason: /scalar SSA lowering/u,
+      },
+      {
+        name: "multi-arm scalar cond-stmt",
+        build: () =>
+          scalarSsaBodyLowerResult(
+            lowerScalarSsaToProps(
+              ir1CondStmt(
+                [
+                  [ir1Var("g1"), ir1Assign(balance, ir1LitNat(1))],
+                  [ir1Var("g2"), ir1Assign(balance, ir1LitNat(2))],
+                ],
+                ir1Assign(balance, ir1LitNat(3)),
               ),
             ),
-          reason: /scalar SSA lowering/u,
-        },
-        {
-          name: "multi-arm scalar cond-stmt",
-          build: () =>
-            scalarSsaBodyLowerResult(
-              lowerScalarSsaToProps(
-                ir1CondStmt(
-                  [
-                    [ir1Var("g1"), ir1Assign(balance, ir1LitNat(1))],
-                    [ir1Var("g2"), ir1Assign(balance, ir1LitNat(2))],
-                  ],
-                  ir1Assign(balance, ir1LitNat(3)),
-                ),
-              ),
-            ),
-          reason: /scalar SSA lowering/u,
-        },
-        {
-          name: "foreach Shape A assignment to non-property target",
-          build: () =>
-            lowerL1BodyToSsaProps(
-              ir1Foreach(
-                "$0",
-                ir1Var("xs"),
-                ir1Assign(ir1Var("acc"), ir1LitBool(true)),
-              ),
-              loopDeclarations,
-              { applyConst: (expr) => expr },
-            ),
-            reason:
-              /foreach Shape A summary assignment target must be a property/u,
-        },
-        {
-          name: "nested proposition-emitting loop body",
-          build: () => {
-            const inner = ir1Foreach(
-              "$1",
-              ir1Var("ys"),
-              ir1Assign(ir1Member(ir1Var("$1"), "active"), ir1LitBool(true)),
-            );
-            const outer = ir1Foreach(
+          ),
+        reason: /scalar SSA lowering/u,
+      },
+      {
+        name: "foreach Shape A assignment to non-property target",
+        build: () =>
+          lowerL1BodyToSsaProps(
+            ir1Foreach(
               "$0",
               ir1Var("xs"),
-              inner as unknown as Parameters<typeof ir1Foreach>[2],
-            );
-            return lowerL1BodyToSsaProps(outer, loopDeclarations, {
-              applyConst: (expr) => expr,
-            });
-          },
-          reason: /nested proposition-emitting loop body/u,
+              ir1Assign(ir1Var("acc"), ir1LitBool(true)),
+            ),
+            loopDeclarations,
+            { applyConst: (expr) => expr },
+          ),
+        reason: /foreach Shape A summary assignment target must be a property/u,
+      },
+      {
+        name: "nested proposition-emitting loop body",
+        build: () => {
+          const inner = ir1Foreach(
+            "$1",
+            ir1Var("ys"),
+            ir1Assign(ir1Member(ir1Var("$1"), "active"), ir1LitBool(true)),
+          );
+          const outer = ir1Foreach(
+            "$0",
+            ir1Var("xs"),
+            inner as unknown as Parameters<typeof ir1Foreach>[2],
+          );
+          return lowerL1BodyToSsaProps(outer, loopDeclarations, {
+            applyConst: (expr) => expr,
+          });
         },
-      ];
+        reason: /nested proposition-emitting loop body/u,
+      },
+    ];
 
-      for (const unsupportedCase of unsupportedCases) {
-        assertUnsupportedDiagnosticShape(
-          unsupportedCase.name,
-          unsupportedCase.build(),
-          unsupportedCase.reason,
+    for (const unsupportedCase of unsupportedCases) {
+      assertUnsupportedDiagnosticShape(
+        unsupportedCase.name,
+        unsupportedCase.build(),
+        unsupportedCase.reason,
+      );
+    }
+  });
+
+  it("the table-driven corpus satisfies all SSA invariants for scalar, Map, Set, branch, foreach Shape A, and foreach Shape B programs", async () => {
+    const representatives = representativePrograms();
+    const presentKinds = new Set(representatives.map((r) => r.kind));
+
+    for (const kind of [
+      "scalar",
+      "map",
+      "set",
+      "branch",
+      "foreach-shape-a",
+      "foreach-shape-b",
+    ] satisfies RepresentativeProgramKind[]) {
+      assert.ok(
+        presentKinds.has(kind),
+        `representativePrograms() should cover ${kind}`,
+      );
+    }
+
+    for (const representative of representatives) {
+      const result = await representative.build();
+      assertSupportedRepresentativeResult(representative.name, result);
+      assertFreshVersionsAndJoinLocations(representative.name, result);
+      assertDominatingReads(representative.name, result);
+    }
+
+    for (const representative of bodyLoweredRepresentativePrograms()) {
+      const { result, declaredRules } = await representative.build();
+      assertFrameSuppression(representative.name, result, declaredRules);
+    }
+  });
+
+  it("L7 invariant: every loop-header join has exactly one preheader and one loop-back input", () => {
+    for (const testCase of loopInvariantCases()) {
+      assertLoopInvariantCaseSupported(testCase);
+      for (const [
+        programIndex,
+        program,
+      ] of testCase.result.programs.entries()) {
+        for (const [headerIndex, header] of program.loopHeaderJoins.entries()) {
+          assertClosedLoopHeaderJoin(
+            `${testCase.name} [program ${programIndex}] header #${headerIndex}`,
+            header,
+          );
+        }
+        for (const [bodyIndex, body] of program.loopBodies.entries()) {
+          for (const [headerIndex, header] of body.headerJoins.entries()) {
+            assertClosedLoopHeaderJoin(
+              `${testCase.name} [program ${programIndex}] body #${bodyIndex} header #${headerIndex}`,
+              header,
+            );
+            assert.ok(
+              program.loopHeaderJoins.includes(header),
+              `${testCase.name} [program ${programIndex}] body #${bodyIndex} header #${headerIndex} should be registered on the program`,
+            );
+          }
+        }
+      }
+    }
+  });
+
+  it("L7 invariant: every loop body resolves break/continue continuations to the correct join", () => {
+    let observedBreak = false;
+    let observedContinue = false;
+    let observedReturn = false;
+    let observedThrow = false;
+
+    for (const testCase of continuationLoopCases()) {
+      assertLoopInvariantCaseSupported(testCase);
+      for (const [
+        programIndex,
+        program,
+      ] of testCase.result.programs.entries()) {
+        for (const [bodyIndex, body] of program.loopBodies.entries()) {
+          assertLoopBodyContinuationsResolved(
+            `${testCase.name} [program ${programIndex}] body #${bodyIndex}`,
+            body,
+          );
+          observedBreak ||= body.breakHandles.length > 0;
+          observedContinue ||= body.continueHandles.length > 0;
+          observedReturn ||= body.returnHandles.length > 0;
+          observedThrow ||= body.throwHandles.length > 0;
+        }
+      }
+      if (testCase.name.includes("valued return")) {
+        assert.ok(
+          testCase.result.returnValue !== undefined,
+          `${testCase.name} should expose the function-level return-value continuation`,
         );
       }
-    },
-  );
+    }
 
-  it(
-    "the table-driven corpus satisfies all SSA invariants for scalar, Map, Set, branch, foreach Shape A, and foreach Shape B programs",
-    async () => {
-      const representatives = representativePrograms();
-      const presentKinds = new Set(representatives.map((r) => r.kind));
+    assert.equal(
+      observedBreak,
+      true,
+      "continuation fixtures should cover break",
+    );
+    assert.equal(
+      observedContinue,
+      true,
+      "continuation fixtures should cover continue",
+    );
+    assert.equal(
+      observedReturn,
+      true,
+      "continuation fixtures should cover return",
+    );
+    assert.equal(
+      observedThrow,
+      true,
+      "continuation fixtures should cover throw",
+    );
+  });
 
-      for (const kind of [
-        "scalar",
-        "map",
-        "set",
-        "branch",
+  it("L7 invariant: every bounded loop carries a non-null termination metric, every fixed-point loop does not", () => {
+    const observed = new Set<LoopClass>();
+
+    for (const testCase of loopInvariantCases()) {
+      assertLoopInvariantCaseSupported(testCase);
+      for (const [
+        programIndex,
+        program,
+      ] of testCase.result.programs.entries()) {
+        for (const [bodyIndex, body] of program.loopBodies.entries()) {
+          observed.add(testCase.loopClass);
+          assertMetricMatchesLoopClass(
+            `${testCase.name} [program ${programIndex}] body #${bodyIndex}`,
+            testCase.loopClass,
+            body,
+          );
+        }
+      }
+    }
+
+    assert.deepEqual(
+      [...observed].sort(),
+      [
+        "bounded-while",
+        "counter",
+        "fixed-point-while",
         "foreach-shape-a",
         "foreach-shape-b",
-      ] satisfies RepresentativeProgramKind[]) {
-        assert.ok(
-          presentKinds.has(kind),
-          `representativePrograms() should cover ${kind}`,
+      ].sort(),
+    );
+  });
+
+  it("L7 invariant: every modified rule appears in IR1SsaProgram.modifiedRules exactly once", () => {
+    for (const testCase of loopInvariantCases()) {
+      assertLoopInvariantCaseSupported(testCase);
+      for (const [
+        programIndex,
+        program,
+      ] of testCase.result.programs.entries()) {
+        assertLoopModifiedRulesAppearOnce(
+          `${testCase.name} [program ${programIndex}]`,
+          program,
         );
       }
-
-      for (const representative of representatives) {
-        const result = await representative.build();
-        assertSupportedRepresentativeResult(representative.name, result);
-        assertFreshVersionsAndJoinLocations(representative.name, result);
-        assertDominatingReads(representative.name, result);
-      }
-
-      for (const representative of bodyLoweredRepresentativePrograms()) {
-        const { result, declaredRules } = await representative.build();
-        assertFrameSuppression(representative.name, result, declaredRules);
-      }
-    },
-  );
-
-  it.skip(
-    "L7 invariant: every loop-header join has exactly one preheader and one loop-back input",
-    () => {
-      // PENDING Patch 7: verify loop-header join preheader and loop-back uniqueness.
-    },
-  );
-
-  it.skip(
-    "L7 invariant: every loop body resolves break/continue continuations to the correct join",
-    () => {
-      // PENDING Patch 7: verify loop-body continuation handle resolution.
-    },
-  );
-
-  it.skip(
-    "L7 invariant: every bounded loop carries a non-null termination metric, every fixed-point loop does not",
-    () => {
-      // PENDING Patch 7: verify metric presence by loop class.
-    },
-  );
-
-  it.skip(
-    "L7 invariant: every modified rule appears in IR1SsaProgram.modifiedRules exactly once",
-    () => {
-      // PENDING Patch 7: verify loop-modified rule frame suppression.
-    },
-  );
+    }
+  });
 });


### PR DESCRIPTION
## Patch 7: ts2pant: add L7 invariant tests over the unified abstraction

- Add invariant test 1 — header-join uniqueness: for every IR1SsaProgram produced by any lowering path, assert that every `IR1SsaLoopHeaderJoin` has exactly one `preheaderVersion` and one `loopBackVersion` (i.e. `header.preheaderVersion` is set and `header.loopBackVersion` is set and `header.closed === true`). The invariant walker iterates `program.loopHeaderJoins` and checks each.
- Add invariant test 2 — continuation resolution: for every `IR1SsaLoopBody`, assert that each `breakHandle`, `continueHandle`, `returnHandle`, `throwHandle` resolves to a location compatible with either the post-loop join or the header join. The resolution check matches the L5 break/continue semantics: break handles attach to the post-loop join; continue handles attach to the header's loopBackVersion; return handles attach to the function-level return-value continuation; throw handles attach to an iteration precondition guard.
- Add invariant test 3 — metric kind by loop class: for every `IR1SsaLoopBody`, assert (a) `terminationMetric` is non-null when the body comes from a bounded loop and null when it comes from a fixed-point loop; (b) counter loops and bounded-while loops emit `terminationMetric.kind === 'ssa-termination-metric'` (the existing counter-style variant with `expr` / `lowerBound`); (c) foreach Shape A and Shape B emit `terminationMetric.kind === 'ssa-iterating-source-metric'` (the new variant carrying only `source`). The kind-by-class assertion makes the structural distinction between numeric ranking and source-exhaustion explicit at the IR level.
- Add invariant test 4 — frame suppression: for every `IR1SsaLoopBody`, assert that each rule appearing in the loop body's writes appears in `IR1SsaProgram.modifiedRules` exactly once (no duplicates, no omissions). This ensures frame generation is suppressed exactly once per modified rule.
- Each test constructs minimal IR1Stmt fixtures for each loop class (counter loop, bounded while, fixed-point while, foreach Shape A, foreach Shape B), lowers each through the appropriate helper (`lowerCounterLoopL1Body`, `lowerFixedPointLoopL1Body`, `lowerForeachShape{A,B}AsGeneralLoop`), then runs the invariant check on the resulting program. Reuse fixture-building helpers already present in the test file.
- Unskip the four Patch-7-owned stubs from Patch 1 and replace the PENDING-comment bodies with the concrete invariant checks described above.
- Run `just ts2pant-test` and confirm the new tests pass for every loop class.

## Changes
- Add invariant test 1 — header-join uniqueness: for every IR1SsaProgram produced by any lowering path, assert that every `IR1SsaLoopHeaderJoin` has exactly one `preheaderVersion` and one `loopBackVersion` (i.e. `header.preheaderVersion` is set and `header.loopBackVersion` is set and `header.closed === true`). The invariant walker iterates `program.loopHeaderJoins` and checks each.
- Add invariant test 2 — continuation resolution: for every `IR1SsaLoopBody`, assert that each `breakHandle`, `continueHandle`, `returnHandle`, `throwHandle` resolves to a location compatible with either the post-loop join or the header join. The resolution check matches the L5 break/continue semantics: break handles attach to the post-loop join; continue handles attach to the header's loopBackVersion; return handles attach to the function-level return-value continuation; throw handles attach to an iteration precondition guard.
- Add invariant test 3 — metric kind by loop class: for every `IR1SsaLoopBody`, assert (a) `terminationMetric` is non-null when the body comes from a bounded loop and null when it comes from a fixed-point loop; (b) counter loops and bounded-while loops emit `terminationMetric.kind === 'ssa-termination-metric'` (the existing counter-style variant with `expr` / `lowerBound`); (c) foreach Shape A and Shape B emit `terminationMetric.kind === 'ssa-iterating-source-metric'` (the new variant carrying only `source`). The kind-by-class assertion makes the structural distinction between numeric ranking and source-exhaustion explicit at the IR level.
- Add invariant test 4 — frame suppression: for every `IR1SsaLoopBody`, assert that each rule appearing in the loop body's writes appears in `IR1SsaProgram.modifiedRules` exactly once (no duplicates, no omissions). This ensures frame generation is suppressed exactly once per modified rule.
- Each test constructs minimal IR1Stmt fixtures for each loop class (counter loop, bounded while, fixed-point while, foreach Shape A, foreach Shape B), lowers each through the appropriate helper (`lowerCounterLoopL1Body`, `lowerFixedPointLoopL1Body`, `lowerForeachShape{A,B}AsGeneralLoop`), then runs the invariant check on the resulting program. Reuse fixture-building helpers already present in the test file.
- Unskip the four Patch-7-owned stubs from Patch 1 and replace the PENDING-comment bodies with the concrete invariant checks described above.
- Run `just ts2pant-test` and confirm the new tests pass for every loop class.

## Files to Modify
- tools/ts2pant/tests/ir1-ssa-invariants.test.mts (modify): Add four new invariant tests under a new describe block (e.g., `describe("unified loop abstraction invariants", ...)`). Unskip the four Patch-7-owned stubs from Patch 1 and replace each PENDING-comment body with a concrete invariant check. The tests must run across every loop-producing path: counter-loop, bounded-while, fixed-point-while, foreach Shape A, foreach Shape B.

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[algorithm] Cytron 1991 SSA construction** — https://doi.org/10.1145/115372.115320 — The header-join uniqueness invariant (Patch 7 invariant 1) formalises the Cytron protocol's closure invariant: every header is opened once with a preheader version, closed once with a loop-back version. The protocol's correctness depends on this; the invariant test makes it explicit.
- **[paper] Knobe & Sarkar 1998 — Array SSA Form (frame-suppression)** — https://doi.org/10.1145/268946.268956 — The frame-suppression invariant (Patch 7 invariant 4) formalises the location-SSA discipline: each modified rule appears in `modifiedRules` exactly once, suppressing frame generation exactly once. The Array SSA discipline guarantees this for per-element distinct versions; the invariant test verifies it across all loop classes.

## Gameplan Specification

```
module TS2PANT_LOOP_SUMMARY_UNIFICATION.

> ════════════════════════════════
> Milestone 6 AND Milestone 7 of the ts2pant general-loop SSA
> workstream, collapsed into a single atomic milestone.
> ════════════════════════════════
> After this milestone, foreach Shape A and Shape B lower
> through the general-loop SSA machinery
> (IR1SsaLoopHeaderJoin + IR1SsaLoopBody +
> IR1SsaTerminationMetric) rather than the legacy
> IR1SsaLoopSummary path. IR1SsaTerminationMetric is now a
> discriminated union: counter loops and bounded-while loops
> emit the existing counter-style variant (kind:
> ssa-termination-metric, expr, lowerBound); foreach Shape A
> and Shape B emit the new iterating-source variant (kind:
> ssa-iterating-source-metric, source) matching Pant's native
> all-x-in-arr semantics. Shape A's per-iteration writes do
> not feed back through the header join (degenerate close);
> Shape B's accumulator-fold writes do (Cytron inductive
> case). The IR1SsaLoopSummary type, the ir1SsaLoopSummary
> constructor, the IR1SsaProgram.loopSummaries field, the
> lowerMuSearchSummary path, and tools/ts2pant/src/ir1-ssa-loops.ts
> are all deleted. Four L7 invariant tests verify the unified
> abstraction: header-join uniqueness, continuation
> resolution, metric kind by loop class, frame suppression
> per modified rule. Pant output is byte-equivalent on every
> existing foreach fixture. Documentation marks BOTH milestone
> 6 AND milestone 7 as landed.

ForeachInput.
ForeachShape.
shape-a => ForeachShape.
shape-b => ForeachShape.
IR1SsaProgram.
IR1SsaProgramShape.
IR1SsaLoopBody.
IR1SsaLoopHeaderJoin.
IR1SsaTerminationMetric.
IR1SsaWrite.
IR1SsaVersion.
IR1SsaRuleName.
FieldName.
loop-summaries-field => FieldName.
loop-header-joins-field => FieldName.
loop-bodies-field => FieldName.
FileStatus.
file-present => FileStatus.
file-deleted => FileStatus.
Declaration.
DeletionStatus.
present => DeletionStatus.
deleted => DeletionStatus.
MuSearchSummary.
LoopClass.
counter => LoopClass.
bounded-while => LoopClass.
fixed-point-while => LoopClass.
foreach-shape-a => LoopClass.
foreach-shape-b => LoopClass.
FixtureOutput.
MetricKind.
counter-metric => MetricKind.
iterating-source-metric => MetricKind.
Document.
DocumentKind.
MilestoneStatus.
ir-doc => DocumentKind.
transformations-doc => DocumentKind.
agents-md => DocumentKind.
workstream-doc => DocumentKind.
pending => MilestoneStatus.
landed => MilestoneStatus.

> Foreach-as-general-loop helper.
input-shape i: ForeachInput => ForeachShape.
lower-result i: ForeachInput => IR1SsaProgram.
body-of p: IR1SsaProgram => IR1SsaLoopBody.
header-of b: IR1SsaLoopBody => IR1SsaLoopHeaderJoin.
metric-of b: IR1SsaLoopBody => IR1SsaTerminationMetric.
metric-kind m: IR1SsaTerminationMetric => MetricKind.
write-of b: IR1SsaLoopBody => IR1SsaWrite.
loop-back-version h: IR1SsaLoopHeaderJoin => IR1SsaVersion.
preheader-version h: IR1SsaLoopHeaderJoin => IR1SsaVersion.
write-version w: IR1SsaWrite => IR1SsaVersion.
emits-quantified-equation? p: IR1SsaProgram => Bool.
emits-accumulator-fold-equation? p: IR1SsaProgram => Bool.

> Deletion (Patches 5, 6).
shape-has-field? s: IR1SsaProgramShape, f: FieldName => Bool.
ir-ssa-loops-file-status => FileStatus.
deletion-status d: Declaration => DeletionStatus.
is-mu-search-summary? d: Declaration => Bool.
production-reachable? d: Declaration => Bool.

> L7 invariants (Patch 7).
header-has-preheader? h: IR1SsaLoopHeaderJoin => Bool.
header-has-loop-back? h: IR1SsaLoopHeaderJoin => Bool.
header-closed? h: IR1SsaLoopHeaderJoin => Bool.
body-class b: IR1SsaLoopBody => LoopClass.
non-null-metric? b: IR1SsaLoopBody => Bool.
is-bounded? c: LoopClass => Bool.
uses-counter-metric? c: LoopClass => Bool.
uses-iterating-source-metric? c: LoopClass => Bool.
continuations-resolved? b: IR1SsaLoopBody => Bool.
modified-rule-appears-once? p: IR1SsaProgram, r: IR1SsaRuleName => Bool.
body-writes-rule? b: IR1SsaLoopBody, r: IR1SsaRuleName => Bool.

> Byte-equivalent emission.
legacy-emission i: ForeachInput => FixtureOutput.
recharacterised-emission i: ForeachInput => FixtureOutput.
byte-equivalent? a: FixtureOutput, b: FixtureOutput => Bool.

> Documentation.
document-kind d: Document => DocumentKind.
document-mentions-unification? d: Document => Bool.
workstream-milestone-6-status => MilestoneStatus.
workstream-milestone-7-status => MilestoneStatus.
---

> Foreach helper contract: every foreach input lowers to an
> IR1SsaProgram carrying an iterating-source termination
> metric (the new variant introduced by Patch 2).
all i: ForeachInput, b: IR1SsaLoopBody |
  b = body-of (lower-result i) ->
    metric-kind (metric-of b) = iterating-source-metric.

> Shape A: the header join's loop-back version equals the
> per-iteration write version (degenerate close).
all i: ForeachInput, b: IR1SsaLoopBody, h: IR1SsaLoopHeaderJoin, w: IR1SsaWrite |
  input-shape i = shape-a and b = body-of (lower-result i) and
  h = header-of b and w = write-of b ->
    loop-back-version h = write-version w.

> Shape A: emits a per-element quantified equation.
all i: ForeachInput |
  input-shape i = shape-a ->
    emits-quantified-equation? (lower-result i).

> Shape B: emits an accumulator-fold equation per location.
all i: ForeachInput |
  input-shape i = shape-b ->
    emits-accumulator-fold-equation? (lower-result i).

> Byte-equivalent Pant emission on every existing fixture.
all i: ForeachInput |
  byte-equivalent? (legacy-emission i) (recharacterised-emission i).

> Type-level deletion: IR1SsaProgram has no loopSummaries
> field; retains loopHeaderJoins and loopBodies.
all s: IR1SsaProgramShape |
  ~(shape-has-field? s loop-summaries-field).

all s: IR1SsaProgramShape |
  shape-has-field? s loop-header-joins-field and
  shape-has-field? s loop-bodies-field.

> File deletion: ir1-ssa-loops.ts is gone.
ir-ssa-loops-file-status = file-deleted.

> μ-search summary symbols are deleted; the dead path is
> unreachable.
all d: Declaration |
  is-mu-search-summary? d -> deletion-status d = deleted.

all d: Declaration |
  deletion-status d = deleted -> ~(production-reachable? d).

> L7 invariant: every header join has exactly one preheader,
> one loop-back, and is closed.
all h: IR1SsaLoopHeaderJoin |
  header-has-preheader? h and header-has-loop-back? h and
  header-closed? h.

> L7 invariant: continuation handles resolve.
all b: IR1SsaLoopBody |
  continuations-resolved? b.

> L7 invariant 3a: bounded loops have non-null metrics.
all b: IR1SsaLoopBody |
  is-bounded? (body-class b) -> non-null-metric? b.

> L7 invariant 3b: counter / bounded-while emit
> counter-metric; foreach Shape A / Shape B emit
> iterating-source-metric.
all b: IR1SsaLoopBody |
  uses-counter-metric? (body-class b) ->
    metric-kind (metric-of b) = counter-metric.

all b: IR1SsaLoopBody |
  uses-iterating-source-metric? (body-class b) ->
    metric-kind (metric-of b) = iterating-source-metric.

is-bounded? counter.
is-bounded? bounded-while.
is-bounded? foreach-shape-a.
is-bounded? foreach-shape-b.
~(is-bounded? fixed-point-while).

uses-counter-metric? counter.
uses-counter-metric? bounded-while.
uses-iterating-source-metric? foreach-shape-a.
uses-iterating-source-metric? foreach-shape-b.

> L7 invariant: every modified rule appears in modifiedRules
> exactly once.
all p: IR1SsaProgram, r: IR1SsaRuleName, b: IR1SsaLoopBody |
  body-writes-rule? b r ->
    modified-rule-appears-once? p r.

> Documentation invariants.
all d: Document |
  document-kind d = ir-doc ->
    document-mentions-unification? d.

all d: Document |
  document-kind d = transformations-doc ->
    document-mentions-unification? d.

all d: Document |
  document-kind d = agents-md ->
    document-mentions-unification? d.

all d: Document |
  document-kind d = workstream-doc ->
    document-mentions-unification? d.

workstream-milestone-6-status = landed.
workstream-milestone-7-status = landed.
```

## Patch Specification

```
module TS2PANT_LOOP_SUMMARY_UNIFICATION_PATCH_7.

> Patch 7 adds the four L7 invariant tests over the unified
> abstraction. Header-join uniqueness, continuation
> resolution, metric kind by loop class, and frame
> suppression per modified rule. Tests run across counter,
> bounded-while, fixed-point, and foreach Shape A / Shape B.

IR1SsaProgram.
IR1SsaLoopHeaderJoin.
IR1SsaLoopBody.
IR1SsaTerminationMetric.
IR1SsaRuleName.
MetricKind.
counter-metric => MetricKind.
iterating-source-metric => MetricKind.
LoopClass.
counter => LoopClass.
bounded-while => LoopClass.
fixed-point-while => LoopClass.
foreach-shape-a => LoopClass.
foreach-shape-b => LoopClass.

header-has-preheader? h: IR1SsaLoopHeaderJoin => Bool.
header-has-loop-back? h: IR1SsaLoopHeaderJoin => Bool.
header-closed? h: IR1SsaLoopHeaderJoin => Bool.
body-class b: IR1SsaLoopBody => LoopClass.
body-metric b: IR1SsaLoopBody => IR1SsaTerminationMetric.
metric-kind m: IR1SsaTerminationMetric => MetricKind.
non-null-metric? b: IR1SsaLoopBody => Bool.
is-bounded? c: LoopClass => Bool.
uses-counter-metric? c: LoopClass => Bool.
uses-iterating-source-metric? c: LoopClass => Bool.
continuations-resolved? b: IR1SsaLoopBody => Bool.
modified-rule-appears-once? p: IR1SsaProgram, r: IR1SsaRuleName => Bool.
body-writes-rule? b: IR1SsaLoopBody, r: IR1SsaRuleName => Bool.
---

> Invariant 1: every header join has exactly one preheader
> and one loop-back version, and is closed.
all h: IR1SsaLoopHeaderJoin |
  header-has-preheader? h and header-has-loop-back? h and
  header-closed? h.

> Invariant 2: continuation handles resolve.
all b: IR1SsaLoopBody |
  continuations-resolved? b.

> Invariant 3a: bounded loops have non-null metrics; fixed-
> point loops have null metrics.
all b: IR1SsaLoopBody |
  is-bounded? (body-class b) -> non-null-metric? b.

> Invariant 3b: counter loops and bounded-while loops use
> counter-metric; foreach Shape A and Shape B use
> iterating-source-metric.
all b: IR1SsaLoopBody |
  uses-counter-metric? (body-class b) ->
    metric-kind (body-metric b) = counter-metric.

all b: IR1SsaLoopBody |
  uses-iterating-source-metric? (body-class b) ->
    metric-kind (body-metric b) = iterating-source-metric.

is-bounded? counter.
is-bounded? bounded-while.
is-bounded? foreach-shape-a.
is-bounded? foreach-shape-b.
~(is-bounded? fixed-point-while).

uses-counter-metric? counter.
uses-counter-metric? bounded-while.
uses-iterating-source-metric? foreach-shape-a.
uses-iterating-source-metric? foreach-shape-b.

> Invariant 4: every modified rule appears in modifiedRules
> exactly once.
all p: IR1SsaProgram, r: IR1SsaRuleName, b: IR1SsaLoopBody |
  body-writes-rule? b r ->
    modified-rule-appears-once? p r.
```


## Implementation Notes

- The bounded-while invariant fixture uses the already-normalized counter-SSA shape, because the direct loop helper surface for bounded numeric loops is `lowerCounterLoopL1Body`; raw `IR1Stmt.while` routes to fixed-point lowering at this layer. This keeps the metric-kind assertion aligned with the L3 normalized representation rather than re-testing TS AST normalization.
- Continuation resolution is asserted against the fields the current IR actually exposes. `IR1SsaBreakHandle`, `IR1SsaReturnHandle`, and `IR1SsaThrowHandle` do not carry explicit post-loop or return-value join objects; the test verifies location compatibility, body-write resolution, `continue` equality to the closed header `loopBackVersion`, throw guard presence, and valued-return exposure through `IR1SsaBodyLowerResult.returnValue`.
- I ran Biome on the touched test file for formatting. It rewrote existing import/order and formatting in that file and reported pre-existing `noSecrets` false positives on test fixture strings such as `stringToIntMap`; the final focused invariant test still passes.

Spec/Evidence Mapping:
- Header closure invariant: implemented by `assertClosedLoopHeaderJoin` over `program.loopHeaderJoins` and each `body.headerJoins`; covered by `ir1-ssa-invariants.test.mts`.
- Continuation invariant: implemented by `assertLoopBodyContinuationsResolved` with explicit break/continue/return/throw fixed-point fixtures; covered by `ir1-ssa-invariants.test.mts`.
- Metric kind invariant: implemented by `assertMetricMatchesLoopClass` across counter, bounded-while-normalized, fixed-point, foreach Shape A, and foreach Shape B fixtures; covered by `ir1-ssa-invariants.test.mts`.
- Frame suppression invariant: implemented by `assertLoopModifiedRulesAppearOnce`; covered by `ir1-ssa-invariants.test.mts`.
- Verification run: `just ts2pant-test`, `npm run build`, and focused `npx tsx --test --test-timeout=300000 tests/ir1-ssa-invariants.test.mts` all passed.