### PR TITLE
[ts2pant-loop-summary-unification] Patch 8: Document L6+L7 unification; mark both milestones landed

### DIFF
--- a/tools/ts2pant/AGENTS.md
+++ b/tools/ts2pant/AGENTS.md
@@ -259,9 +259,12 @@ Read that file before extending the IR or touching SSA-bearing code:
 - **General-loop SSA Workstream.** L1 (loop SSA contract), L2 (bounded
   counter `for` lowering), L3 (bounded `let`+`while` desugar covering
   ascending and descending counters), L4 (fixed-point unbounded `while`
-  lowering through recursive Pant helpers emitted as `define-fun-rec`), and
-  L5 (loop early-exit lowering) have
-  landed — see `workstreams/ts2pant-general-loop-ssa.md`.
+  lowering through recursive Pant helpers emitted as `define-fun-rec`), L5
+  (loop early-exit lowering), L6 (foreach-as-general-loop unification), and
+  L7 (legacy ripout plus invariants) have landed. The workstream is
+  complete; substantive loop lowering lives in `src/ir1-ssa-counter-loop.ts`,
+  `src/ir1-ssa-fixed-point.ts`, and `src/ir1-ssa-foreach.ts`. See
+  `workstreams/ts2pant-general-loop-ssa.md`.
 
 ### General-loop SSA contract surface (L1)
 
@@ -337,7 +340,7 @@ just ts2pant-precommit                 # mirror what lefthook runs
 
 Tests are split into two suites by their dependency on the pant OCaml binary:
 
-- **`tests/*.test.mts` — unit suite.** Pure translation-logic tests. No pant binary, no dune, runs in a few seconds. Coverage is organised by translation layer: TS-AST recognizers (`translate-body`, `translate-signature`, `translate-types`, `annotations`, `purity`), L1 build (`ir1-build-*`, including `cardinality`, `functor-lift`, `increment`, `nullish`, `parens`, `property`, `state-aware-reads`, `call-purity`), L1 lower (`ir1-lower`, `ir1-printer`), IR1 SSA helpers (`ir1-ssa-scalars`, `ir1-ssa-collections`, `ir1-ssa-loops`, `ir1-ssa-counter-loop`, `ir1-ssa-lower`, `ir1-ssa-propresult-lowering`), IR1 SSA contracts and invariants (`ir1-ssa-contract`, `ir1-ssa-loop-contract`, `ir1-ssa-invariants`, `ir1-ssa-ripout`, `ir1-ssa-printer`), L2 build/lower (`ir-build`, `ir-equivalence`, `emit`), and snapshot/cross-cutting (`constructs`, `m2-musearch-l1`, `l1-plumbing`, `equality-canonicalization`, `name-registry`, `pant-wasm-bundle`, `ast-equal`, `builtins`, `extract`).
+- **`tests/*.test.mts` — unit suite.** Pure translation-logic tests. No pant binary, no dune, runs in a few seconds. Coverage is organised by translation layer: TS-AST recognizers (`translate-body`, `translate-signature`, `translate-types`, `annotations`, `purity`), L1 build (`ir1-build-*`, including `cardinality`, `functor-lift`, `increment`, `nullish`, `parens`, `property`, `state-aware-reads`, `call-purity`), L1 lower (`ir1-lower`, `ir1-printer`), IR1 SSA helpers (`ir1-ssa-scalars`, `ir1-ssa-collections`, `ir1-ssa-counter-loop`, `ir1-ssa-fixed-point`, `ir1-ssa-foreach`, `ir1-ssa-lower`, `ir1-ssa-propresult-lowering`), IR1 SSA contracts and invariants (`ir1-ssa-contract`, `ir1-ssa-loop-contract`, `ir1-ssa-invariants`, `ir1-ssa-ripout`, `ir1-ssa-printer`), L2 build/lower (`ir-build`, `ir-equivalence`, `emit`), and snapshot/cross-cutting (`constructs`, `m2-musearch-l1`, `l1-plumbing`, `equality-canonicalization`, `name-registry`, `pant-wasm-bundle`, `ast-equal`, `builtins`, `extract`).
 - **`tests/integration/*.test.mts` — integration suite.** Each test invokes the `pant` binary (via `assertPantTypeChecks` or `runCheck` from `tests/helpers.mts`): `e2e` (per-fixture end-to-end including `pant --check` SMT verification) and `dogfood` (translates ts2pant's own source with ts2pant).
 
 The split exists for stability, not just performance. `getPantBin()` in `tests/helpers.mts` is **pure** — it never invokes a build. It reads `process.env.PANT_BIN` if set, otherwise checks that `${PROJECT_ROOT}/_build/default/bin/main.exe` exists, and throws with an actionable error otherwise. The build is the responsibility of the workspace-level `just build-pant` recipe (which `just ts2pant-test-integration` depends on). Stale-lock recovery + the `dune build` invocation live in the `build-pant` recipe in the root `justfile`, not in JS — orchestration belongs to the orchestrator.

--- a/tools/ts2pant/docs/intermediate-representation.md
+++ b/tools/ts2pant/docs/intermediate-representation.md
@@ -56,11 +56,13 @@ variable SSA.
 - `src/ir1.ts`, `src/ir1-build.ts`, `src/ir1-build-body.ts`,
   `src/ir1-lower.ts`, `src/ir1-lower-body.ts`,
   `src/ir1-ssa-scalars.ts`, `src/ir1-ssa-collections.ts`,
-  `src/ir1-ssa-loops.ts` — Layer 1 (TS-shape imperative IR today;
+  `src/ir1-ssa-counter-loop.ts`, `src/ir1-ssa-fixed-point.ts`,
+  `src/ir1-ssa-foreach.ts` — Layer 1 (TS-shape imperative IR today;
   the SSA-bearing contract now lives in `src/ir1.ts`, while the
   scalar SSA builder/lowerer helper owns scalar property mutation,
   the collection SSA helper owns Map/Set mutation, and the loop
-  summary helper owns μ-search plus supported foreach summaries.
+  helpers own bounded counters, fixed-point while, and supported
+  foreach lowering.
   `translate-body.ts` builds supported mutating bodies through
   `buildSupportedSsaMutatingBody` and lowers them through
   `lowerL1BodyToSsaProps`, which returns final propositions plus frames
@@ -80,9 +82,10 @@ shared Layer 1 IR:
   `PropResult[]` for supported SSA-backed bodies. Scalar property
   mutation, read-after-write, branch joins, and scalar early-exit merges
   route through `src/ir1-ssa-scalars.ts`; Map/Set mutation routes
-  through `src/ir1-ssa-collections.ts`; and μ-search plus supported
-  foreach summaries route through `src/ir1-ssa-loops.ts`. General loop
-  SSA remains out of scope. The mutating output is a list of equations +
+  through `src/ir1-ssa-collections.ts`; bounded counter loops route
+  through `src/ir1-ssa-counter-loop.ts`; fixed-point while loops route
+  through `src/ir1-ssa-fixed-point.ts`; and supported foreach loops route
+  through `src/ir1-ssa-foreach.ts`. The mutating output is a list of equations +
   frame conditions; no L2 statement vocabulary.
 
 L2 is *expression-only* — there is no L2 `IRStmt`. The asymmetry is
@@ -231,14 +234,13 @@ Milestone 1 adds the SSA-bearing type vocabulary and constructor helpers
 in `src/ir1.ts`. The key exported names are:
 
 - Types: `IR1SsaLocation`, `IR1SsaVersion`, `IR1SsaRead`,
-  `IR1SsaWrite`, `IR1SsaJoin`, `IR1SsaLoopSummary`, `IR1SsaProgram`,
-  `IR1SsaValue`.
+  `IR1SsaWrite`, `IR1SsaJoin`, `IR1SsaProgram`, `IR1SsaValue`.
 - Location helpers: `ir1SsaPropertyLocation`,
   `ir1SsaMapValueLocation`, `ir1SsaMapMembershipLocation`,
   `ir1SsaSetMembershipLocation`, `ir1SsaRuleOfLocation`.
 - Version helpers: `ir1SsaInitialVersion`.
 - Read / write / join helpers: `ir1SsaRead`, `ir1SsaWrite`,
-  `ir1SsaJoin`, `ir1SsaLoopSummary`.
+  `ir1SsaJoin`.
 - Value helpers: `ir1SsaPropertyValue`, `ir1SsaMapSetValue`,
   `ir1SsaMapMembershipValue`, `ir1SsaSetMembershipValue`,
   `ir1SsaSetClearValue`.
@@ -601,6 +603,67 @@ a label table and target-resolution pass that the L5 handle lists do not
 need for unlabeled, innermost-loop exits, so the builder rejects labeled
 forms with the M7 diagnostic.
 
+## Loop summary unification (L6+L7)
+
+L6 and L7 landed as one terminal milestone for the general-loop SSA
+workstream. Foreach Shape A and Shape B no longer lower through a parallel
+summary record; they now build ordinary `IR1SsaLoopHeaderJoin` +
+`IR1SsaLoopBody` structures through `lowerForeachShapeAAsGeneralLoop` and
+`lowerForeachShapeBAsGeneralLoop` in `src/ir1-ssa-foreach.ts`.
+
+The `IR1SsaTerminationMetric` type is now a discriminated union. Counter
+loops and bounded-while loops keep the numeric
+`{ kind: "ssa-termination-metric"; expr; lowerBound }` variant. Foreach
+uses `{ kind: "ssa-iterating-source-metric"; source }`, which records the
+finite iteration source directly instead of inventing a counter binder.
+Fixed-point while loops continue to carry `terminationMetric: null`.
+
+Shape A remains the per-element quantified equation:
+
+```pant
+all x in arr | p' x = e x.
+```
+
+Each mutated location still gets a loop-header join so the loop-body
+contract is uniform, but the close is degenerate: the header join's
+`loopBackVersion` is the same SSA version as the per-iteration write. The
+write does not feed a next iteration's value; the source-level meaning is
+Pant's native `all x in arr` quantification.
+
+Shape B remains the accumulator-fold equation:
+
+```pant
+p' a = p a + (+ over each x in arr | f x).
+```
+
+Here the write is the standard Cytron inductive case: the accumulator's
+body write feeds back through the loop-header join, and lowering emits the
+same combiner-over-each right-hand side as before. Shape B keeps the outer
+operator and the comprehension combiner separate so non-commutative outer
+updates remain explicit.
+
+The legacy summary path is gone. `IR1SsaLoopSummary`,
+`ir1SsaLoopSummary`, `IR1SsaProgram.loopSummaries`,
+`lowerMuSearchSummary`, the foreach summary adapters, and the old loop
+summary module were deleted. μ-search is recognized upstream while
+building L1 (`buildL1MuSearchCombTyped`) and lowers as a typed
+comprehension expression, not through loop SSA.
+
+The terminal invariant suite now guards the unified abstraction:
+
+- every loop-header join has one preheader input, one loop-back input, and
+  is closed;
+- every loop body resolves its break and continue handles to the expected
+  join target;
+- bounded counters and bounded while loops carry the counter metric,
+  foreach Shape A/B carry the iterating-source metric, and fixed-point
+  while carries no metric;
+- every rule modified by a loop body appears in `modifiedRules` exactly
+  once, so frame generation is suppressed exactly once.
+
+Existing foreach fixture output stayed byte-equivalent across the
+recharacterisation; the snapshot suite is the gate for that promise.
+
 ## Mutating-body output (no L2 IR)
 
 The mutating path emits `PropResult[]` directly:
@@ -615,7 +678,7 @@ The mutating path emits `PropResult[]` directly:
 
 The supported path is `lowerL1BodyToSsaProps` in
 `ir1-lower-body.ts`. It combines scalar, collection, and supported
-loop-summary lowering results, carries final property writes and
+loop lowering results, carries final property writes and
 modified rules, and appends frames for declared rules that were not
 modified. Production mutating-body lowering is
 `buildSupportedSsaMutatingBody` plus `lowerL1BodyToSsaProps`.
@@ -685,7 +748,8 @@ scalar-only cases that now execute in production:
 
 Those cases lower through IR1 SSA and then emit the same primed
 equations as before. Map/Set mutation now uses `src/ir1-ssa-collections.ts`;
-loop-summary lowering now uses `src/ir1-ssa-loops.ts`.
+loop lowering now uses `src/ir1-ssa-counter-loop.ts`,
+`src/ir1-ssa-fixed-point.ts`, and `src/ir1-ssa-foreach.ts`.
 
 ## Final architecture (post-M6)
 
@@ -704,8 +768,9 @@ with no migration flags, no escape hatches, and no parallel pipelines:
   — TS AST → L1 statement (`ir1-build-body.ts`) → `PropResult[]`.
   Scalar property mutation now routes through the dedicated SSA helper
   (`src/ir1-ssa-scalars.ts`), while Map/Set now routes through the
-  collection SSA helper (`src/ir1-ssa-collections.ts`) and loop
-  summaries route through `src/ir1-ssa-loops.ts`.
+  collection SSA helper (`src/ir1-ssa-collections.ts`); bounded counter
+  loops, fixed-point while loops, and foreach loops route through their
+  dedicated general-loop helpers.
   `buildSupportedSsaMutatingBody` and `lowerL1BodyToSsaProps` are the
   production builder/lowerer pair for final emission and frame
   derivation. No L2 statement vocabulary.
@@ -746,8 +811,10 @@ Lowering for effect-position: TS AST → Layer 1 (`ir1-build-body.ts`) →
 `buildSupportedSsaMutatingBody` → `lowerL1BodyToSsaProps` →
 `PropResult[]` (with scalar property mutation handled by
 `src/ir1-ssa-scalars.ts`, Map/Set mutation handled by
-`src/ir1-ssa-collections.ts`, and loop summaries handled by
-`src/ir1-ssa-loops.ts`).
+`src/ir1-ssa-collections.ts`, bounded counters handled by
+`src/ir1-ssa-counter-loop.ts`, fixed-point while handled by
+`src/ir1-ssa-fixed-point.ts`, and foreach handled by
+`src/ir1-ssa-foreach.ts`).
 
 The full milestone breakdown lives in
 `workstreams/ts2pant-imperative-ir.md`. Decisions on canonical forms,
@@ -785,8 +852,8 @@ branched mutation and iteration flow through Layer 1. The build pass
 `cond-stmt` for `if`-with-mutation, `foreach` for `for-of` / `forEach`
 — and the lower pass (`ir1-lower-body.ts`) does a single fold over the
 L1, threading the collection SSA from `src/ir1-ssa-collections.ts` for
-Map/Set effects and the loop-summary helper from `src/ir1-ssa-loops.ts`
-for μ-search and supported foreach / accumulator-fold shapes, then
+Map/Set effects and the foreach general-loop helper from
+`src/ir1-ssa-foreach.ts` for supported foreach / accumulator-fold shapes, then
 emitting `PropResult[]`. No L2 statement vocabulary. `Foreach.body`
 (Shape A — uniform iterator writes) emits one
 universally-quantified per-iteration equation per modified rule
@@ -803,7 +870,7 @@ pre-IR1-SSA mutating-body dispatcher (`symbolicExecute`) are all
 deleted; the production path is `buildSupportedSsaMutatingBody` +
 `buildSupportedSsaStatement` building canonical L1 forms, then
 `lowerL1BodyToSsaProps` lowering them through the SSA helpers
-(scalars / collections / loop-summary). Pure-path `.reduce` (chain
+(scalars / collections / loops). Pure-path `.reduce` (chain
 fusion via `BodyResult.pendingComprehension`) is expression-position
 and architecturally separate; it stays on `translateReduceCall`.
 

--- a/tools/ts2pant/docs/transformations.md
+++ b/tools/ts2pant/docs/transformations.md
@@ -377,22 +377,34 @@ with `init` elided when it equals the combiner identity (0 for `+`, 1 for `*`, `
 `false` for `||`). `reduceRight` is accepted only for commutative combiners; non-commutative
 ops require acc on the left.
 
+The unified loop milestone keeps the recursion-scheme framing explicit:
+bounded loops are catamorphisms and lower through `IR1SsaLoopBody` with a
+non-null `IR1SsaTerminationMetric` (counter metrics for counter/while,
+iterating-source metrics for foreach Shape A/B). Fixed-point while loops are
+hylomorphisms: the guard unfolds the state space and the recursive helper
+folds it back to the post-state, so those loop bodies carry
+`terminationMetric: null`. L6+L7 closed both halves under the same loop-body
+contract.
+
 **Invariants** (post-IR1-SSA):
-- Shape A and Shape B both lower through `lowerForeachShapeASummaries` /
-  `lowerForeachShapeBSummaries` in `src/ir1-ssa-loops.ts`, each returning an
-  `IR1SsaLoopSummary` plus the emitted equation. The loop-summary helper is the
-  single source of truth for both shapes; per-iter writes for Shape A and
-  accumulator-fold writes for Shape B share `IR1SsaProgram.modifiedRules`
-  bookkeeping.
+- Shape A and Shape B both lower through
+  `lowerForeachShapeAAsGeneralLoop` / `lowerForeachShapeBAsGeneralLoop` in
+  `src/ir1-ssa-foreach.ts`. The old `IR1SsaLoopSummary` path is gone; both
+  shapes now produce `IR1SsaLoopHeaderJoin` + `IR1SsaLoopBody` records plus
+  the same emitted equations as before.
+- Shape A's per-iteration writes degenerately close their header join:
+  the `loopBackVersion` is the write's own version, because the per-element
+  equation does not feed an accumulator into the next iteration.
+- Shape B's accumulator-fold writes use the ordinary inductive close:
+  the body write feeds back through the loop header and lowering emits
+  `prop' target = prop target OP (combOP over each x in src[, guard] | rhs)`.
 - Iter-binder writes scoped inside the iteration cannot leak past the
   comprehension — enforced structurally by `IR1ForeachBody` typing
   (Shape A bodies are a restricted subset of `IR1Stmt` that excludes
   `return`/`throw`/nested loops/`let`/`expr-stmt`).
 - Shape B `foldLeaves` carry the `outerOp` binop and the comprehension
-  `combiner` separately; lowering emits
-  `prop' target = prop target OP (combOP over each x in src[, guard] | rhs)`
-  so frame conditions for untouched properties still fire via the
-  modified-rules set.
+  `combiner` separately, so frame conditions for untouched properties still
+  fire via the modified-rules set.
 
 ## Functor-Lift Recognizer
 

--- a/workstreams/ts2pant-general-loop-ssa.md
+++ b/workstreams/ts2pant-general-loop-ssa.md
@@ -2,7 +2,7 @@
 
 ## Vision
 
-Extend IR1 SSA from today's summary-based loop handling (μ-search, foreach
+Extend IR1 SSA from the former summary-based loop handling (μ-search, foreach
 Shape A/B) to a unified treatment of general `for` and `while` loops. Bounded
 loops lower to quantified Pantagruel equations; unbounded `while` lowers to
 fixed-point / recursive rule definitions; `break` and `continue` are
@@ -14,16 +14,15 @@ specialisations of general-loop SSA rather than separate code paths.
 
 The IR1 SSA workstream (`workstreams/ts2pant-ir1-ssa.md`, M1–M7) is complete.
 IR1 SSA is the production mutating-body boundary for scalar property mutation,
-Map/Set semantics, and the three existing supported loop summaries. Loop
-handling today consists of three dedicated paths in
-`tools/ts2pant/src/ir1-ssa-loops.ts`: μ-search, foreach Shape A (quantified
-writes), and foreach Shape B (accumulator folds). The IR1 statement vocabulary
-already admits `for` and `while` shapes (constructed in
-`buildSupportedSsaMutatingBody` in `tools/ts2pant/src/translate-body.ts`), but
-`tools/ts2pant/src/ir1-lower-body.ts` rejects them with a diagnostic. An audit
-of the `IR1Expr → IRExpr → OpaqueExpr` expression pipeline confirmed it
+Map/Set semantics, and supported loop lowering. This workstream is also
+complete: bounded counter loops, bounded while loops, fixed-point while loops,
+loop early exits, and foreach Shape A/B now all lower through the general-loop
+SSA vocabulary. μ-search recognition moved upstream to L1 through
+`buildL1MuSearchCombTyped`; it is no longer a loop-summary lowering path. The
+deleted legacy summary module is recorded here only as historical context. An
+audit of the `IR1Expr → IRExpr → OpaqueExpr` expression pipeline confirmed it
 already carries loop guards, counter steps, and bound expressions without
-restructuring; no expression-path cleanup is a prerequisite.
+restructuring; no expression-path cleanup was a prerequisite.
 
 ## Key Challenges
 
@@ -465,24 +464,27 @@ Summary unification (L6) can target the now-complete general-loop machinery.
 
 ### Milestone 6: loop-summary-unification
 
+**Status**: Landed in `ts2pant-loop-summary-unification`, which collapsed L7
+into L6. See `tools/ts2pant/docs/intermediate-representation.md` section
+`## Loop summary unification (L6+L7)`.
+
 **Definition of Done**:
-The existing μ-search summary lowering in `tools/ts2pant/src/ir1-ssa-loops.ts`
-is recharacterised as a specialisation of the general-loop machinery (bounded,
-with the μ-search ranking metric and a single-equation body shape). foreach
-Shape A and Shape B summaries are similarly recharacterised. The corresponding
-builder paths in `translate-body.ts` route through the unified general-loop
-builder. All prior μ-search and foreach fixtures pass with semantically
-equivalent Pant output. Where output differs byte-for-byte, the change is
-documented in the gameplan and explicitly reviewed; semantic equivalence is
-verified by `pant --check` parity on the old and new output for each affected
-fixture.
+The former foreach Shape A and Shape B summary lowering is recharacterised as
+ordinary general-loop SSA. Both shapes build `IR1SsaLoopHeaderJoin` +
+`IR1SsaLoopBody` records in `tools/ts2pant/src/ir1-ssa-foreach.ts`; Shape A
+uses the degenerate-close discipline and Shape B uses the standard inductive
+loop-back. Foreach bodies carry the iterating-source termination metric
+variant. μ-search is not reintroduced as loop SSA: the production recognizer is
+the upstream L1 `buildL1MuSearchCombTyped` path, so the dead summary lowering
+is deleted. All prior μ-search and foreach fixtures pass; existing foreach Pant
+output remains byte-equivalent and is gated by snapshot tests.
 
 No new TS loop classes become supported or unsupported by this milestone.
 
 **Why this is a safe pause point**:
-One unified loop machinery exists. The prior dedicated summary paths still
-physically exist as thin adapters atop the general machinery, ready to be
-removed in L7. Reverting to the L5 state is a one-patch rollback.
+One unified loop machinery exists and the legacy summary paths are gone in the
+same gameplan. Reverting to the L5 state would be a one-branch rollback rather
+than a piecemeal adapter toggle.
 
 **Operator Actions Before Next Milestone**:
 - Walk the full ts2pant corpus. Confirm zero semantic regressions in
@@ -494,25 +496,32 @@ removed in L7. Reverting to the L5 state is a one-patch rollback.
   rework L6 to preserve semantically equivalent output for that fixture.
 
 **Open Questions** (resolved during `write-gameplan` for this milestone):
-- The exact recharacterisation mapping: μ-search → which general-loop shape;
-  foreach Shape A → which; foreach Shape B → which. Each mapping must be
-  exhibited on at least one existing fixture before the gameplan executes.
-- Whether byte-equivalent output is a hard requirement or whether
-  semantically equivalent output (`pant --check` parity) is sufficient.
+- Recharacterisation mapping: μ-search remains on the upstream L1 typed
+  comprehension path; foreach Shape A lowers through
+  `lowerForeachShapeAAsGeneralLoop`; foreach Shape B lowers through
+  `lowerForeachShapeBAsGeneralLoop`. The mapping is documented in the IR doc's
+  `## Loop summary unification (L6+L7)` section.
+- Byte-equivalent output is a hard requirement for existing foreach fixtures.
+  Snapshot tests enforce the byte-equivalence gate; implementers do not update
+  snapshots to accept drift in this milestone.
 
 **Unlocks**:
-Code removal in L7.
+The L7 code removal and invariant coverage were folded into the same
+gameplan, so there is no intermediate adapter-only state.
 
 ---
 
 ### Milestone 7: legacy-rip-and-invariants
 
+**Status**: Landed in `ts2pant-loop-summary-unification`, collapsed into L6.
+See `tools/ts2pant/docs/intermediate-representation.md` section
+`## Loop summary unification (L6+L7)`.
+
 **Definition of Done**:
-The thin adapters left in place at the end of L6 are removed from
-`tools/ts2pant/src/ir1-ssa-loops.ts`. The file is either deleted entirely or
-retains only general-loop helpers. `tools/ts2pant/AGENTS.md` and
-`workstreams/ts2pant-ir1-ssa.md` are updated to note that μ-search and foreach
-summaries are now general-loop SSA specialisations.
+The thin adapters left in place by the old design are removed. The legacy loop
+summary file and symbols are deleted, and `tools/ts2pant/AGENTS.md` is updated
+to note that foreach is now a general-loop SSA specialisation while μ-search
+stays on the upstream L1 typed-comprehension path.
 
 New invariant tests cover the general-loop machinery:
 
@@ -551,7 +560,9 @@ paths.
 Strictly sequential. The lowering family changes between L3 (bounded) and L4
 (fixed-point), so L4 cannot start without L3's quantification machinery to
 inherit. L5 (break/continue) and L6 (unification) both require the loop
-machinery to be feature-complete before they touch it.
+machinery to be feature-complete before they touch it. In execution, L6 and L7
+landed in one `ts2pant-loop-summary-unification` gameplan after L5, so the
+dependency edge remained conceptual but no adapter-only pause point shipped.
 
 ## Open Questions
 
@@ -572,5 +583,5 @@ their respective `write-gameplan` invocations. See each milestone's
 | break/continue is in scope, not deferred | Real TS code uses early exits routinely; deferring substantially limits the workstream's value. The continuation-merge machinery from the prior workstream's M2 provides the foundation. |
 | No standalone design-doc milestone | The workstream itself is the design document. Design decisions that gate a specific milestone live in that milestone's "Open Questions" subsection and are resolved during `write-gameplan`'s open-question dialogue. Worked-example `.pant` files are test fixtures introduced by their owning milestone, not standalone artifacts. |
 | Sequential, not parallel, milestone graph | Each milestone validates or extends the loop machinery's lowering surface. Parallel work risks landing inconsistent design assumptions in different milestones. |
-| Carry forward IR1 SSA decisions | Location SSA (not local-variable SSA), opaque versions, rule-oriented frames, semantic parity rather than byte-for-byte output parity — all inherit from `workstreams/ts2pant-ir1-ssa.md` and are not relitigated. |
+| Carry forward IR1 SSA decisions | Location SSA (not local-variable SSA), opaque versions, and rule-oriented frames inherit from `workstreams/ts2pant-ir1-ssa.md` and are not relitigated. Semantic parity remains the default compatibility bar, but L6+L7 made byte-equivalent output a hard gate for existing foreach fixtures because the recharacterisation was intended to be internal-only. |
 | No expression-path cleanup as a prerequisite | The audit confirmed `IR1Expr → IRExpr → OpaqueExpr` accepts loop guards, counter steps, and bound expressions without restructuring. Loop work pulls on the expression path as needed. |


### PR DESCRIPTION
## Patch 8: Document L6+L7 unification; mark both milestones landed

- In `tools/ts2pant/docs/intermediate-representation.md`, add the new `## Loop summary unification (L6+L7)` subsection after `## Loop break/continue (L5)`. Document the foreach-as-general-loop helper, the Shape A degenerate-close discipline, the Shape B accumulator-fold discipline, the synthetic iteration-source termination metric, the legacy-path deletion, and the L7 invariant tests. Remove the line 688 reference to `src/ir1-ssa-loops.ts`.
- In `tools/ts2pant/docs/transformations.md`, rewrite the line 380-396 `**Invariants** (post-IR1-SSA)` block: Shape A and Shape B foreach lower through `lowerForeachShape{A,B}AsGeneralLoop`; `IR1SsaLoopSummary` is gone. Add a paragraph after the Shape C bullet (line 378) noting the hylomorphism framing: catamorphisms (bounded loops including foreach) lower through `IR1SsaLoopBody` with a non-null `IR1SsaTerminationMetric`; hylomorphisms (fixed-point while) lower with `terminationMetric: null`. The unified milestone closes both halves.
- In `tools/ts2pant/AGENTS.md`, update the General-loop SSA Workstream bullet (currently lists L1/L2/L3/L4/L5 as landed) to add BOTH L6 and L7 to the landed list, noting the workstream is complete. Remove any reference to `IR1SsaLoopSummary` or `tools/ts2pant/src/ir1-ssa-loops.ts`.
- In `workstreams/ts2pant-general-loop-ssa.md`, add the landed-status line under BOTH Milestone 6 AND Milestone 7. Note that L6 and L7 were collapsed into one gameplan. Resolve the open questions inline.
- Do not modify any source file in this patch.

## Changes
- In `tools/ts2pant/docs/intermediate-representation.md`, add the new `## Loop summary unification (L6+L7)` subsection after `## Loop break/continue (L5)`. Document the foreach-as-general-loop helper, the Shape A degenerate-close discipline, the Shape B accumulator-fold discipline, the synthetic iteration-source termination metric, the legacy-path deletion, and the L7 invariant tests. Remove the line 688 reference to `src/ir1-ssa-loops.ts`.
- In `tools/ts2pant/docs/transformations.md`, rewrite the line 380-396 `**Invariants** (post-IR1-SSA)` block: Shape A and Shape B foreach lower through `lowerForeachShape{A,B}AsGeneralLoop`; `IR1SsaLoopSummary` is gone. Add a paragraph after the Shape C bullet (line 378) noting the hylomorphism framing: catamorphisms (bounded loops including foreach) lower through `IR1SsaLoopBody` with a non-null `IR1SsaTerminationMetric`; hylomorphisms (fixed-point while) lower with `terminationMetric: null`. The unified milestone closes both halves.
- In `tools/ts2pant/AGENTS.md`, update the General-loop SSA Workstream bullet (currently lists L1/L2/L3/L4/L5 as landed) to add BOTH L6 and L7 to the landed list, noting the workstream is complete. Remove any reference to `IR1SsaLoopSummary` or `tools/ts2pant/src/ir1-ssa-loops.ts`.
- In `workstreams/ts2pant-general-loop-ssa.md`, add the landed-status line under BOTH Milestone 6 AND Milestone 7. Note that L6 and L7 were collapsed into one gameplan. Resolve the open questions inline.
- Do not modify any source file in this patch.

## Files to Modify
- tools/ts2pant/docs/intermediate-representation.md (modify): Add `## Loop summary unification (L6+L7)` subsection after `## Loop break/continue (L5)`. Document the unification: foreach Shape A and Shape B lower through `lowerForeachShape{A,B}AsGeneralLoop` in `src/ir1-ssa-foreach.ts`. Shape B's writes feed back through the header join; Shape A's degenerately close the header with the write's own version. The synthetic iteration-source termination metric uses `#source - <iter-binder>` with lower bound `0`. The legacy `IR1SsaLoopSummary` type, the `IR1SsaProgram.loopSummaries` field, the `lowerMuSearchSummary` path, and `tools/ts2pant/src/ir1-ssa-loops.ts` are all deleted. Remove the line 688 reference to `src/ir1-ssa-loops.ts`.
- tools/ts2pant/docs/transformations.md (modify): Rewrite the `**Invariants** (post-IR1-SSA)` block under § Structured Iteration (line 380-396). Shape A and Shape B foreach now lower through `lowerForeachShape{A,B}AsGeneralLoop` in `src/ir1-ssa-foreach.ts`; `IR1SsaLoopSummary` and the summary path are gone. Add a paragraph under § Structured Iteration noting the hylomorphism connection: bounded loops are catamorphisms; fixed-point while is a hylomorphism; the unified machinery covers both.
- tools/ts2pant/AGENTS.md (modify): Update the General-loop SSA Workstream bullet to note BOTH L6 and L7 landed. The substantive foreach lowering lives in `tools/ts2pant/src/ir1-ssa-foreach.ts` alongside `ir1-ssa-counter-loop.ts` and `ir1-ssa-fixed-point.ts`. Remove any reference to `IR1SsaLoopSummary` or `tools/ts2pant/src/ir1-ssa-loops.ts`.
- workstreams/ts2pant-general-loop-ssa.md (modify): Add `**Status**: Landed in `ts2pant-loop-summary-unification` (which collapsed L7 into L6). See `tools/ts2pant/docs/intermediate-representation.md` section `## Loop summary unification (L6+L7)`.` under BOTH Milestone 6 AND Milestone 7. Resolve the open questions inline: recharacterisation mapping documented in the IR doc; byte-equivalent Pant output enforced via snapshot tests.

## Gameplan Specification

```
module TS2PANT_LOOP_SUMMARY_UNIFICATION.

> ════════════════════════════════
> Milestone 6 AND Milestone 7 of the ts2pant general-loop SSA
> workstream, collapsed into a single atomic milestone.
> ════════════════════════════════
> After this milestone, foreach Shape A and Shape B lower
> through the general-loop SSA machinery
> (IR1SsaLoopHeaderJoin + IR1SsaLoopBody +
> IR1SsaTerminationMetric) rather than the legacy
> IR1SsaLoopSummary path. IR1SsaTerminationMetric is now a
> discriminated union: counter loops and bounded-while loops
> emit the existing counter-style variant (kind:
> ssa-termination-metric, expr, lowerBound); foreach Shape A
> and Shape B emit the new iterating-source variant (kind:
> ssa-iterating-source-metric, source) matching Pant's native
> all-x-in-arr semantics. Shape A's per-iteration writes do
> not feed back through the header join (degenerate close);
> Shape B's accumulator-fold writes do (Cytron inductive
> case). The IR1SsaLoopSummary type, the ir1SsaLoopSummary
> constructor, the IR1SsaProgram.loopSummaries field, the
> lowerMuSearchSummary path, and tools/ts2pant/src/ir1-ssa-loops.ts
> are all deleted. Four L7 invariant tests verify the unified
> abstraction: header-join uniqueness, continuation
> resolution, metric kind by loop class, frame suppression
> per modified rule. Pant output is byte-equivalent on every
> existing foreach fixture. Documentation marks BOTH milestone
> 6 AND milestone 7 as landed.

ForeachInput.
ForeachShape.
shape-a => ForeachShape.
shape-b => ForeachShape.
IR1SsaProgram.
IR1SsaProgramShape.
IR1SsaLoopBody.
IR1SsaLoopHeaderJoin.
IR1SsaTerminationMetric.
IR1SsaWrite.
IR1SsaVersion.
IR1SsaRuleName.
FieldName.
loop-summaries-field => FieldName.
loop-header-joins-field => FieldName.
loop-bodies-field => FieldName.
FileStatus.
file-present => FileStatus.
file-deleted => FileStatus.
Declaration.
DeletionStatus.
present => DeletionStatus.
deleted => DeletionStatus.
MuSearchSummary.
LoopClass.
counter => LoopClass.
bounded-while => LoopClass.
fixed-point-while => LoopClass.
foreach-shape-a => LoopClass.
foreach-shape-b => LoopClass.
FixtureOutput.
MetricKind.
counter-metric => MetricKind.
iterating-source-metric => MetricKind.
Document.
DocumentKind.
MilestoneStatus.
ir-doc => DocumentKind.
transformations-doc => DocumentKind.
agents-md => DocumentKind.
workstream-doc => DocumentKind.
pending => MilestoneStatus.
landed => MilestoneStatus.

> Foreach-as-general-loop helper.
input-shape i: ForeachInput => ForeachShape.
lower-result i: ForeachInput => IR1SsaProgram.
body-of p: IR1SsaProgram => IR1SsaLoopBody.
header-of b: IR1SsaLoopBody => IR1SsaLoopHeaderJoin.
metric-of b: IR1SsaLoopBody => IR1SsaTerminationMetric.
metric-kind m: IR1SsaTerminationMetric => MetricKind.
write-of b: IR1SsaLoopBody => IR1SsaWrite.
loop-back-version h: IR1SsaLoopHeaderJoin => IR1SsaVersion.
preheader-version h: IR1SsaLoopHeaderJoin => IR1SsaVersion.
write-version w: IR1SsaWrite => IR1SsaVersion.
emits-quantified-equation? p: IR1SsaProgram => Bool.
emits-accumulator-fold-equation? p: IR1SsaProgram => Bool.

> Deletion (Patches 5, 6).
shape-has-field? s: IR1SsaProgramShape, f: FieldName => Bool.
ir-ssa-loops-file-status => FileStatus.
deletion-status d: Declaration => DeletionStatus.
is-mu-search-summary? d: Declaration => Bool.
production-reachable? d: Declaration => Bool.

> L7 invariants (Patch 7).
header-has-preheader? h: IR1SsaLoopHeaderJoin => Bool.
header-has-loop-back? h: IR1SsaLoopHeaderJoin => Bool.
header-closed? h: IR1SsaLoopHeaderJoin => Bool.
body-class b: IR1SsaLoopBody => LoopClass.
non-null-metric? b: IR1SsaLoopBody => Bool.
is-bounded? c: LoopClass => Bool.
uses-counter-metric? c: LoopClass => Bool.
uses-iterating-source-metric? c: LoopClass => Bool.
continuations-resolved? b: IR1SsaLoopBody => Bool.
modified-rule-appears-once? p: IR1SsaProgram, r: IR1SsaRuleName => Bool.
body-writes-rule? b: IR1SsaLoopBody, r: IR1SsaRuleName => Bool.

> Byte-equivalent emission.
legacy-emission i: ForeachInput => FixtureOutput.
recharacterised-emission i: ForeachInput => FixtureOutput.
byte-equivalent? a: FixtureOutput, b: FixtureOutput => Bool.

> Documentation.
document-kind d: Document => DocumentKind.
document-mentions-unification? d: Document => Bool.
workstream-milestone-6-status => MilestoneStatus.
workstream-milestone-7-status => MilestoneStatus.
---

> Foreach helper contract: every foreach input lowers to an
> IR1SsaProgram carrying an iterating-source termination
> metric (the new variant introduced by Patch 2).
all i: ForeachInput, b: IR1SsaLoopBody |
  b = body-of (lower-result i) ->
    metric-kind (metric-of b) = iterating-source-metric.

> Shape A: the header join's loop-back version equals the
> per-iteration write version (degenerate close).
all i: ForeachInput, b: IR1SsaLoopBody, h: IR1SsaLoopHeaderJoin, w: IR1SsaWrite |
  input-shape i = shape-a and b = body-of (lower-result i) and
  h = header-of b and w = write-of b ->
    loop-back-version h = write-version w.

> Shape A: emits a per-element quantified equation.
all i: ForeachInput |
  input-shape i = shape-a ->
    emits-quantified-equation? (lower-result i).

> Shape B: emits an accumulator-fold equation per location.
all i: ForeachInput |
  input-shape i = shape-b ->
    emits-accumulator-fold-equation? (lower-result i).

> Byte-equivalent Pant emission on every existing fixture.
all i: ForeachInput |
  byte-equivalent? (legacy-emission i) (recharacterised-emission i).

> Type-level deletion: IR1SsaProgram has no loopSummaries
> field; retains loopHeaderJoins and loopBodies.
all s: IR1SsaProgramShape |
  ~(shape-has-field? s loop-summaries-field).

all s: IR1SsaProgramShape |
  shape-has-field? s loop-header-joins-field and
  shape-has-field? s loop-bodies-field.

> File deletion: ir1-ssa-loops.ts is gone.
ir-ssa-loops-file-status = file-deleted.

> μ-search summary symbols are deleted; the dead path is
> unreachable.
all d: Declaration |
  is-mu-search-summary? d -> deletion-status d = deleted.

all d: Declaration |
  deletion-status d = deleted -> ~(production-reachable? d).

> L7 invariant: every header join has exactly one preheader,
> one loop-back, and is closed.
all h: IR1SsaLoopHeaderJoin |
  header-has-preheader? h and header-has-loop-back? h and
  header-closed? h.

> L7 invariant: continuation handles resolve.
all b: IR1SsaLoopBody |
  continuations-resolved? b.

> L7 invariant 3a: bounded loops have non-null metrics.
all b: IR1SsaLoopBody |
  is-bounded? (body-class b) -> non-null-metric? b.

> L7 invariant 3b: counter / bounded-while emit
> counter-metric; foreach Shape A / Shape B emit
> iterating-source-metric.
all b: IR1SsaLoopBody |
  uses-counter-metric? (body-class b) ->
    metric-kind (metric-of b) = counter-metric.

all b: IR1SsaLoopBody |
  uses-iterating-source-metric? (body-class b) ->
    metric-kind (metric-of b) = iterating-source-metric.

is-bounded? counter.
is-bounded? bounded-while.
is-bounded? foreach-shape-a.
is-bounded? foreach-shape-b.
~(is-bounded? fixed-point-while).

uses-counter-metric? counter.
uses-counter-metric? bounded-while.
uses-iterating-source-metric? foreach-shape-a.
uses-iterating-source-metric? foreach-shape-b.

> L7 invariant: every modified rule appears in modifiedRules
> exactly once.
all p: IR1SsaProgram, r: IR1SsaRuleName, b: IR1SsaLoopBody |
  body-writes-rule? b r ->
    modified-rule-appears-once? p r.

> Documentation invariants.
all d: Document |
  document-kind d = ir-doc ->
    document-mentions-unification? d.

all d: Document |
  document-kind d = transformations-doc ->
    document-mentions-unification? d.

all d: Document |
  document-kind d = agents-md ->
    document-mentions-unification? d.

all d: Document |
  document-kind d = workstream-doc ->
    document-mentions-unification? d.

workstream-milestone-6-status = landed.
workstream-milestone-7-status = landed.
```

## Patch Specification

```
module TS2PANT_LOOP_SUMMARY_UNIFICATION_PATCH_8.

> Patch 8 lands documentation. The IR doc gains a Loop
> summary unification (L6+L7) subsection; transformations.md
> rewrites the Structured Iteration invariants block;
> AGENTS.md updates the workstream pointer and removes
> references to IR1SsaLoopSummary; the workstream doc marks
> BOTH Milestone 6 and Milestone 7 as landed. No runtime
> invariants change.

Document.
DocumentKind.
MilestoneStatus.
ir-doc => DocumentKind.
transformations-doc => DocumentKind.
agents-md => DocumentKind.
workstream-doc => DocumentKind.
pending => MilestoneStatus.
landed => MilestoneStatus.

document-kind d: Document => DocumentKind.
document-mentions-unification? d: Document => Bool.
workstream-milestone-6-status => MilestoneStatus.
workstream-milestone-7-status => MilestoneStatus.
---

all d: Document |
  document-kind d = ir-doc ->
    document-mentions-unification? d.

all d: Document |
  document-kind d = transformations-doc ->
    document-mentions-unification? d.

all d: Document |
  document-kind d = agents-md ->
    document-mentions-unification? d.

all d: Document |
  document-kind d = workstream-doc ->
    document-mentions-unification? d.

workstream-milestone-6-status = landed.
workstream-milestone-7-status = landed.
```


## Implementation Notes

- The IR doc intentionally describes the landed `ssa-iterating-source-metric` `{ source }` variant rather than the older numeric `#source - <iter-binder>` idea that still appears in one generated PR-body bullet. The gameplan spec and implemented `IR1SsaTerminationMetric` union make the source-based variant authoritative.
- I updated adjacent architecture summaries in `intermediate-representation.md`, not only the requested line-688 reference, because they still described `src/ir1-ssa-loops.ts` as a live production path. Those edits are doc-only and keep the final architecture internally consistent.
- `tools/ts2pant/AGENTS.md` no longer mentions `IR1SsaLoopSummary` or `src/ir1-ssa-loops.ts`; the deleted symbols are mentioned only in docs that explicitly describe the legacy deletion.
- Spec/Evidence Mapping: documentation invariants are covered by the new IR-doc `Loop summary unification (L6+L7)` section, the rewritten Structured Iteration invariant block, the completed General-loop SSA Workstream note in `AGENTS.md`, and landed status lines under both Milestone 6 and Milestone 7 in `workstreams/ts2pant-general-loop-ssa.md`.
- Verification: `git diff --check` passed, and `just ts2pant-test-unit` passed with 1007 passing, 0 failing, 3 skipped.