### PR TITLE
Route split-form rule definitions through define-fun-rec

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -83,6 +83,12 @@ let run_smt_check env doc =
     2
   end
   else begin
+    (* Promote split-form rule definitions (declaration in chapter head +
+       matching equation in chapter body) into the same [define-fun-rec] /
+       axiom dispatch the inline body form uses. Recognised equations
+       move from chapter bodies into [env.rule_bodies]; unrecognised
+       propositions pass through unchanged. *)
+    let env, doc = Pantagruel.Collect.recognize_split_form_bodies env doc in
     let domain_bounds = Pantagruel.Smt.compute_domain_bounds !check_bound env in
     let config =
       Pantagruel.Smt.make_config ~bound:!check_bound ~steps:!check_steps

--- a/lib/ast.ml
+++ b/lib/ast.ml
@@ -446,7 +446,6 @@ type declaration =
       params : param list;
       guards : guard list;
       return_type : type_expr;
-      body : expr option;
       contexts : upper_ident list;
           (** Context footprint: "{Accounts} balance ..." *)
     }
@@ -470,15 +469,11 @@ let pp_declaration fmt = function
   | DeclDomain (Upper n) -> Format.fprintf fmt "DeclDomain (Upper %S)" n
   | DeclAlias (Upper n, t) ->
       Format.fprintf fmt "DeclAlias (Upper %S, %a)" n pp_type_expr t
-  | DeclRule { name = Lower n; params; guards; return_type; body; contexts } ->
+  | DeclRule { name = Lower n; params; guards; return_type; contexts } ->
       Format.fprintf fmt
         "DeclRule {@[name = Lower %S;@ params = %a;@ guards = %a;@ return_type \
-         = %a;@ body = %a;@ contexts = [@[%a@]]@]}"
+         = %a;@ contexts = [@[%a@]]@]}"
         n pp_params params pp_guards guards pp_type_expr return_type
-        (fun fmt -> function
-          | None -> Format.fprintf fmt "None"
-          | Some e -> Format.fprintf fmt "Some (%a)" pp_expr e)
-        body
         (Format.pp_print_list
            ~pp_sep:(fun fmt () -> Format.fprintf fmt ";@ ")
            (fun fmt (Upper u) -> Format.fprintf fmt "Upper %S" u))
@@ -506,27 +501,13 @@ let equal_declaration (d1 : declaration) (d2 : declaration) : bool =
   | DeclAlias (a, t1), DeclAlias (b, t2) ->
       equal_upper_ident a b && equal_type_expr t1 t2
   | ( DeclRule
-        {
-          name = n1;
-          params = p1;
-          guards = g1;
-          return_type = r1;
-          body = b1;
-          contexts = c1;
-        },
+        { name = n1; params = p1; guards = g1; return_type = r1; contexts = c1 },
       DeclRule
-        {
-          name = n2;
-          params = p2;
-          guards = g2;
-          return_type = r2;
-          body = b2;
-          contexts = c2;
-        } ) ->
+        { name = n2; params = p2; guards = g2; return_type = r2; contexts = c2 }
+    ) ->
       equal_lower_ident n1 n2 && equal_params p1 p2
       && List.equal equal_guard g1 g2
       && equal_type_expr r1 r2
-      && Option.equal equal_expr b1 b2
       && List.equal equal_upper_ident c1 c2
   | ( DeclAction { label = l1; params = p1; guards = g1; contexts = c1 },
       DeclAction { label = l2; params = p2; guards = g2; contexts = c2 } ) ->

--- a/lib/check.ml
+++ b/lib/check.ml
@@ -607,24 +607,7 @@ let check_rule_guards ctx (decl : declaration located) =
     Ok ()
   in
   match decl.value with
-  | DeclRule { params; guards; return_type; body; _ } -> (
-      let* () = check_guards params guards in
-      match body with
-      | None -> Ok ()
-      | Some body ->
-          let* param_bindings =
-            map_result (resolve_param_type ctx.env decl.loc) params
-          in
-          let env' = Env.with_vars param_bindings ctx.env in
-          let ctx' = { env = env'; loc = decl.loc } in
-          let* expected =
-            resolve_param_type ctx.env decl.loc
-              { param_name = Lower "_return"; param_type = return_type }
-          in
-          let _, expected_ty = expected in
-          let* actual_ty = infer_type ctx' body in
-          if is_subtype actual_ty expected_ty then Ok ()
-          else Error (TypeMismatch (expected_ty, actual_ty, decl.loc)))
+  | DeclRule { params; guards; _ } -> check_guards params guards
   | DeclAction { params; guards; _ } -> check_guards params guards
   | DeclClosure _ -> Ok () (* Closures have no guards *)
   | DeclDomain _ | DeclAlias _ -> Ok ()

--- a/lib/collect.ml
+++ b/lib/collect.ml
@@ -239,8 +239,7 @@ let collect_chapter_head ~chapter ~doc_contexts env
   (* Pass 3: Add rules/actions and register context footprints *)
   let add_rule env (decl : declaration located) =
     match decl.value with
-    | DeclRule
-        { name = Lower name; params; guards; return_type; body; contexts } ->
+    | DeclRule { name = Lower name; params; guards; return_type; contexts } ->
         let* param_types =
           map_result (fun p -> resolve_type env p.param_type decl.loc) params
         in
@@ -271,8 +270,7 @@ let collect_chapter_head ~chapter ~doc_contexts env
                 check_overload_coherence name params param_types ret_ty decl.loc
                   env
               in
-              let body = Option.map (fun body -> (decl.value, body)) body in
-              Ok (Env.add_rule ?body name proc_ty decl.loc ~chapter env)
+              Ok (Env.add_rule name proc_ty decl.loc ~chapter env)
         in
         let env = Env.add_rule_guards name params guards env in
         (* Add rule to each context's member list *)
@@ -432,7 +430,7 @@ let recognize_rule_definition_eq
           List.find_map
             (fun (decl : Ast.declaration Ast.located) ->
               match[@warning "-4"] decl.value with
-              | DeclRule { name = Lower dn; params; body = None; _ }
+              | DeclRule { name = Lower dn; params; _ }
                 when dn = rule_name
                      && List.length params = List.length arg_names
                      && List.equal String.equal arg_names

--- a/lib/collect.ml
+++ b/lib/collect.ml
@@ -458,10 +458,17 @@ let recognize_split_form_bodies (env : Env.t) (doc : Ast.document) :
           match[@warning "-4"]
             recognize_rule_definition_eq chapter.head prop.value
           with
-          | Some ((DeclRule { name = Lower name; params; _ } as decl), body) ->
+          | Some ((DeclRule { name = Lower name; params; _ } as decl), body)
+            -> (
               let arity = List.length params in
-              let env = Env.attach_rule_body name arity decl body env in
-              (acc, env)
+              match Env.lookup_rule_body_arity name arity env with
+              | Some _ ->
+                  (* Keep duplicate equations in the body so they are not
+                     silently discarded by overwriting [rule_bodies]. *)
+                  (prop :: acc, env)
+              | None ->
+                  let env = Env.attach_rule_body name arity decl body env in
+                  (acc, env))
           | Some _ | None -> (prop :: acc, env))
         ([], env) chapter.body
     in

--- a/lib/collect.ml
+++ b/lib/collect.ml
@@ -402,6 +402,82 @@ let collect_chapter_head ~chapter ~doc_contexts env
 
   Ok final_env
 
+(** Try to recognize a chapter-body proposition as a split-form rule definition
+    equation: `<rule-name> <param-name>* = <body>`. The LHS must be an
+    application of a declared rule (in [chapter_head], same chapter) to bare
+    variable references that exactly match the rule's parameter names in order —
+    equivalent to the inline form `<name> <params> => <type> = <body>.` modulo
+    the chapter divider. Returns [Some (decl, body)] if matched, [None]
+    otherwise. *)
+let recognize_rule_definition_eq
+    (chapter_head : Ast.declaration Ast.located list) (e : Ast.expr) :
+    (Ast.declaration * Ast.expr) option =
+  let arg_to_name (e : Ast.expr) : string option =
+    match[@warning "-4"] e with EVar (Lower an) -> Some an | _ -> None
+  in
+  let match_lhs (e : Ast.expr) : (string * string list) option =
+    match[@warning "-4"] e with
+    | EApp (EVar (Lower n), args) ->
+        let arg_names = List.filter_map arg_to_name args in
+        if List.length arg_names = List.length args then Some (n, arg_names)
+        else None
+    | EVar (Lower n) -> Some (n, [])
+    | _ -> None
+  in
+  match[@warning "-4"] e with
+  | EBinop (OpEq, lhs, rhs) -> (
+      match match_lhs lhs with
+      | None -> None
+      | Some (rule_name, arg_names) ->
+          List.find_map
+            (fun (decl : Ast.declaration Ast.located) ->
+              match[@warning "-4"] decl.value with
+              | DeclRule { name = Lower dn; params; body = None; _ }
+                when dn = rule_name
+                     && List.length params = List.length arg_names
+                     && List.equal String.equal arg_names
+                          (List.map
+                             (fun (p : Ast.param) ->
+                               Ast.lower_name p.param_name)
+                             params) ->
+                  Some (decl.value, rhs)
+              | _ -> None)
+            chapter_head)
+  | _ -> None
+
+(** Walk each chapter's body looking for split-form rule definition equations.
+    Matched equations are registered as rule bodies in [env.rule_bodies] (so the
+    SMT layer routes recursive ones to [define-fun-rec] exactly as inline bodies
+    do) and removed from the chapter body (so the same equation is not also
+    re-emitted as a quantified axiom). Returns the updated [env] and document.
+*)
+let recognize_split_form_bodies (env : Env.t) (doc : Ast.document) :
+    Env.t * Ast.document =
+  let process_chapter env (chapter : Ast.chapter) =
+    let body', env =
+      List.fold_left
+        (fun (acc, env) (prop : Ast.expr Ast.located) ->
+          match[@warning "-4"]
+            recognize_rule_definition_eq chapter.head prop.value
+          with
+          | Some ((DeclRule { name = Lower name; params; _ } as decl), body) ->
+              let arity = List.length params in
+              let env = Env.attach_rule_body name arity decl body env in
+              (acc, env)
+          | Some _ | None -> (prop :: acc, env))
+        ([], env) chapter.body
+    in
+    ({ chapter with body = List.rev body' }, env)
+  in
+  let chapters', env =
+    List.fold_left
+      (fun (acc, env) chapter ->
+        let chapter', env = process_chapter env chapter in
+        (chapter' :: acc, env))
+      ([], env) doc.chapters
+  in
+  (env, { doc with chapters = List.rev chapters' })
+
 (** Collect all declarations from document (Pass 1) *)
 let collect_all ~base_env (doc : document) : (Env.t, collect_error) result =
   let mod_name = Option.fold ~none:"" ~some:Ast.upper_name doc.module_name in

--- a/lib/collect.mli
+++ b/lib/collect.mli
@@ -36,3 +36,12 @@ val resolve_type :
 val collect_all :
   base_env:Env.t -> Ast.document -> (Env.t, collect_error) result
 (** Collect all declarations from a document *)
+
+val recognize_split_form_bodies : Env.t -> Ast.document -> Env.t * Ast.document
+(** Recognize and consume chapter-body equations that define rules declared in
+    the same chapter's head. Each matched equation `<rule-name> <param-names> =
+    <body>.` is attached to its declaration via [Env.attach_rule_body] and
+    removed from the chapter body, so the SMT layer routes it through the same
+    [define-fun-rec] / quantified axiom dispatch as inline rule-body
+    declarations. Equations that do not match a declaration (or whose arguments
+    do not exactly mirror the declared parameter names) are left in place. *)

--- a/lib/env.ml
+++ b/lib/env.ml
@@ -188,21 +188,16 @@ let expr_applies_name target e =
   in
   go [] e
 
-(** Add a rule to the term namespace, keyed by [(name, arity)]. *)
-let add_rule ?body name ty loc ~chapter env =
+(** Add a rule to the term namespace, keyed by [(name, arity)]. Rule bodies are
+    attached separately, after Pass 1, by [Collect.recognize_split_form_bodies]
+    via [attach_rule_body] — the parser no longer accepts an inline body in the
+    declaration. *)
+let add_rule name ty loc ~chapter env =
   let entry =
     { kind = KRule ty; loc; module_origin = None; decl_chapter = chapter }
   in
   let arity = arity_of_ty ty in
-  let rule_bodies =
-    match body with
-    | None -> env.rule_bodies
-    | Some (decl, expr) ->
-        TermMap.add (name, arity)
-          (decl, expr, expr_applies_name name expr)
-          env.rule_bodies
-  in
-  { env with terms = TermMap.add (name, arity) entry env.terms; rule_bodies }
+  { env with terms = TermMap.add (name, arity) entry env.terms }
 
 (** Attach a body to an already-declared rule. The rule must have been
     registered via [add_rule] (without a body) earlier in the same pass; this

--- a/lib/env.ml
+++ b/lib/env.ml
@@ -204,6 +204,17 @@ let add_rule ?body name ty loc ~chapter env =
   in
   { env with terms = TermMap.add (name, arity) entry env.terms; rule_bodies }
 
+(** Attach a body to an already-declared rule. The rule must have been
+    registered via [add_rule] (without a body) earlier in the same pass; this
+    function is the counterpart for split-form definitions where the declaration
+    sits in the chapter head and the equation in the chapter body. The
+    recursive-self-reference flag is computed identically to [add_rule]'s
+    inline-body path so downstream SMT emission cannot distinguish the two
+    forms. *)
+let attach_rule_body name arity decl body env =
+  let entry = (decl, body, expr_applies_name name body) in
+  { env with rule_bodies = TermMap.add (name, arity) entry env.rule_bodies }
+
 (** Add a closure rule to the term namespace, keyed by [(name, arity)]. *)
 let add_closure name ty target loc ~chapter env =
   let entry =

--- a/lib/env.mli
+++ b/lib/env.mli
@@ -43,6 +43,14 @@ val add_rule :
 val add_closure :
   string -> Types.ty -> string -> Ast.loc -> chapter:int -> t -> t
 
+val attach_rule_body : string -> int -> Ast.declaration -> Ast.expr -> t -> t
+(** Attach a body expression to an already-declared rule, populating the
+    [rule_bodies] map. The recursive-self-reference flag is computed by scanning
+    [body] for applications of [name]. Used by the SMT pipeline to route
+    split-form rule definitions (declaration in the chapter head
+    + matching equation in the body) through the same [define-fun-rec] / axiom
+      dispatch as inline-body rule declarations. *)
+
 val add_var : string -> Types.ty -> t -> t
 val with_action : string -> t -> t
 val clear_action : t -> t

--- a/lib/env.mli
+++ b/lib/env.mli
@@ -30,15 +30,7 @@ val add_type_entry : string -> entry -> t -> t
 val add_term_entry : string -> entry -> t -> t
 val add_domain : string -> Ast.loc -> chapter:int -> t -> t
 val add_alias : string -> Types.ty -> Ast.loc -> chapter:int -> t -> t
-
-val add_rule :
-  ?body:Ast.declaration * Ast.expr ->
-  string ->
-  Types.ty ->
-  Ast.loc ->
-  chapter:int ->
-  t ->
-  t
+val add_rule : string -> Types.ty -> Ast.loc -> chapter:int -> t -> t
 
 val add_closure :
   string -> Types.ty -> string -> Ast.loc -> chapter:int -> t -> t

--- a/lib/json_output.ml
+++ b/lib/json_output.ml
@@ -247,7 +247,7 @@ let decl_to_json env (decl_loc : declaration located) =
             ("type", type_expr_to_json te);
           ]
         @ match resolved with Some t -> [ ("resolved", t) ] | None -> [])
-  | DeclRule { name; params; guards; return_type; body; contexts } ->
+  | DeclRule { name; params; guards; return_type; contexts } ->
       let name = Ast.lower_name name in
       (* Look up resolved type for the specific overload whose arity matches
          this declaration's param count. *)
@@ -278,9 +278,6 @@ let decl_to_json env (decl_loc : declaration located) =
                );
              ]
            else [])
-        @ (match body with
-          | Some e -> [ ("body", expr_to_json e) ]
-          | None -> [])
         @ match resolved with Some t -> [ ("resolved", t) ] | None -> [])
   | DeclAction { label; params; guards; contexts } ->
       let param_tys =

--- a/lib/markdown_output.ml
+++ b/lib/markdown_output.ml
@@ -284,7 +284,7 @@ let pp_guard procs fmt = function
 let pp_declaration procs fmt = function
   | DeclDomain (Upper name) -> fprintf fmt "`%s`." name
   | DeclAlias (Upper name, te) -> fprintf fmt "`%s` = %a." name pp_type_expr te
-  | DeclRule { name; params; guards; return_type; body; contexts } ->
+  | DeclRule { name; params; guards; return_type; contexts } ->
       if contexts <> [] then
         fprintf fmt "{%a} "
           (pp_print_list ~pp_sep:pp_params_sep (fun fmt (Upper c) ->
@@ -298,7 +298,6 @@ let pp_declaration procs fmt = function
           (pp_print_list ~pp_sep:pp_params_sep (pp_guard procs))
           guards;
       fprintf fmt " ⇒ %a" pp_type_expr return_type;
-      Option.iter (fun body -> fprintf fmt " = %a" (pp_expr procs) body) body;
       fprintf fmt "."
   | DeclAction { label; params; guards; contexts } ->
       (match contexts with

--- a/lib/parser.mly
+++ b/lib/parser.mly
@@ -120,18 +120,6 @@ declaration:
         params;
         guards;
         return_type = ret;
-        body = None;
-        contexts = List.map (fun c -> Upper c) ctxs;
-      }) }
-  | LBRACE ctxs=separated_nonempty_list(COMMA, UPPER_IDENT) RBRACE
-    name=LOWER_IDENT pg=rule_params_guards DARROW ret=type_expr EQ body=expr DOT
-    { let (params, guards) = pg in
-      located_with_doc $startpos $endpos (DeclRule {
-        name = Lower name;
-        params;
-        guards;
-        return_type = ret;
-        body = Some body;
         contexts = List.map (fun c -> Upper c) ctxs;
       }) }
   | name=LOWER_IDENT pg=rule_params_guards DARROW ret=type_expr DOT
@@ -141,17 +129,6 @@ declaration:
         params;
         guards;
         return_type = ret;
-        body = None;
-        contexts = [];
-      }) }
-  | name=LOWER_IDENT pg=rule_params_guards DARROW ret=type_expr EQ body=expr DOT
-    { let (params, guards) = pg in
-      located_with_doc $startpos $endpos (DeclRule {
-        name = Lower name;
-        params;
-        guards;
-        return_type = ret;
-        body = Some body;
         contexts = [];
       }) }
   | name=LOWER_IDENT pg=rule_params_guards DARROW ret=type_expr EQ CLOSURE target=LOWER_IDENT DOT

--- a/lib/pretty.ml
+++ b/lib/pretty.ml
@@ -273,8 +273,7 @@ let pp_guard fmt = function
 let pp_declaration fmt = function
   | DeclDomain (Upper name) -> fprintf fmt "%s." name
   | DeclAlias (Upper name, te) -> fprintf fmt "%s = %a." name pp_type_expr te
-  | DeclRule { name = Lower name; params; guards; return_type; body; contexts }
-    ->
+  | DeclRule { name = Lower name; params; guards; return_type; contexts } ->
       if contexts <> [] then
         fprintf fmt "{%a} "
           (pp_print_list ~pp_sep:pp_sep_comma (fun fmt c ->
@@ -286,7 +285,6 @@ let pp_declaration fmt = function
       if guards <> [] then
         fprintf fmt ", %a" (pp_print_list ~pp_sep:pp_sep_comma pp_guard) guards;
       fprintf fmt " => %a" pp_type_expr return_type;
-      Option.iter (fun body -> fprintf fmt " = %a" pp_expr body) body;
       fprintf fmt "."
   | DeclAction { label; params; guards; contexts } ->
       (match contexts with

--- a/lib/smt.ml
+++ b/lib/smt.ml
@@ -1172,14 +1172,6 @@ let translate_proposition config env (e : expr) =
             in
             Printf.sprintf "(=> %s %s)" guard_conj smt_expr)
 
-let is_rule_recursive (decl : Ast.declaration) : bool =
-  match decl with
-  | DeclRule { name = Lower name; body = Some body; _ } ->
-      Smt_expr.expr_applies_name name body
-  | DeclRule { body = None; _ }
-  | DeclDomain _ | DeclAlias _ | DeclAction _ | DeclClosure _ ->
-      false
-
 let emit_rule_recursive config (env : Env.t) (decl : Ast.declaration)
     (body : Ast.expr) : string =
   match decl with

--- a/lib/smt.ml
+++ b/lib/smt.ml
@@ -1180,9 +1180,10 @@ let is_rule_recursive (decl : Ast.declaration) : bool =
   | DeclDomain _ | DeclAlias _ | DeclAction _ | DeclClosure _ ->
       false
 
-let emit_rule_recursive config (env : Env.t) (decl : Ast.declaration) : string =
+let emit_rule_recursive config (env : Env.t) (decl : Ast.declaration)
+    (body : Ast.expr) : string =
   match decl with
-  | DeclRule { name = Lower name; params; return_type; body = Some body; _ } ->
+  | DeclRule { name = Lower name; params; return_type; _ } ->
       let args =
         List.map
           (fun (p : Ast.param) ->
@@ -1223,9 +1224,8 @@ let emit_rule_recursive config (env : Env.t) (decl : Ast.declaration) : string =
       Printf.sprintf "(define-fun-rec %s (%s) %s %s)"
         (smt_rule_name env name (List.length params))
         (String.concat " " args) ret body_smt
-  | DeclRule { body = None; _ }
   | DeclDomain _ | DeclAlias _ | DeclAction _ | DeclClosure _ ->
-      invalid_arg "emit_rule_recursive: expected a rule declaration with a body"
+      invalid_arg "emit_rule_recursive: expected a rule declaration"
 
 let emit_rule_axiom config env (decl : Ast.declaration) body : string =
   match decl with
@@ -1280,7 +1280,7 @@ let emit_rule_definitions config env =
   Env.fold_rule_bodies
     (fun _name _arity (decl, body, recursive) acc ->
       let line =
-        if recursive then emit_rule_recursive config env decl
+        if recursive then emit_rule_recursive config env decl body
         else emit_rule_axiom config env decl body
       in
       line :: acc)

--- a/test/test_normalize.ml
+++ b/test/test_normalize.ml
@@ -20,7 +20,6 @@ let test_decl_name () =
             params = [];
             guards = [];
             return_type = TName (Upper "Bool");
-            body = None;
             contexts = [];
           }));
   check string "action" "Do thing"
@@ -53,7 +52,6 @@ let test_is_type_decl () =
             params = [];
             guards = [];
             return_type = TName (Upper "Bool");
-            body = None;
             contexts = [];
           }));
   check bool "action" false
@@ -84,7 +82,6 @@ let test_is_action () =
             params = [];
             guards = [];
             return_type = TName (Upper "Bool");
-            body = None;
             contexts = [];
           }))
 

--- a/test/test_pretty.ml
+++ b/test/test_pretty.ml
@@ -181,7 +181,6 @@ let test_decl_rule () =
               [ { param_name = Lower "x"; param_type = TName (Upper "Nat") } ];
             guards = [];
             return_type = TName (Upper "Bool");
-            body = None;
             contexts = [];
           }))
 
@@ -195,7 +194,6 @@ let test_decl_rule_with_guards () =
               [ { param_name = Lower "x"; param_type = TName (Upper "Nat") } ];
             guards = [ GExpr (EBinop (OpGt, EVar (Lower "x"), ELitNat 0)) ];
             return_type = TName (Upper "Bool");
-            body = None;
             contexts = [];
           }))
 
@@ -209,7 +207,6 @@ let test_decl_rule_with_context () =
               [ { param_name = Lower "x"; param_type = TName (Upper "Nat") } ];
             guards = [];
             return_type = TName (Upper "Bool");
-            body = None;
             contexts = [ Upper "Ctx" ];
           }))
 

--- a/test/test_smt.ml
+++ b/test/test_smt.ml
@@ -227,6 +227,22 @@ let test_split_form_nullary_self_reference () =
   | Some r -> check bool "nullary recursive rule detected" true r
   | None -> fail "expected nullary rule body in env"
 
+let test_duplicate_split_form_equation_kept_in_body () =
+  let env, doc =
+    parse_and_collect
+      "module Test.\n\
+       next x: Int => Int.\n\
+       ---\n\
+       next x = x + 1.\n\
+       next x = x + 2.\n"
+  in
+  let env, doc = Collect.recognize_split_form_bodies env doc in
+  (match Env.lookup_rule_body_arity "next" 1 env with
+  | Some _ -> ()
+  | None -> fail "expected first rule body in env");
+  let chapter = List.hd doc.chapters in
+  check int "duplicate equation remains in body" 1 (List.length chapter.body)
+
 let test_recursive_rule_emits_define_fun_rec () =
   let env, doc =
     parse_and_collect
@@ -1370,6 +1386,8 @@ let integration_tests =
     test_case
       "split-form nullary recursive rule detected at attach_rule_body time"
       `Quick test_split_form_nullary_self_reference;
+    test_case "duplicate split-form equation remains in chapter body" `Quick
+      test_duplicate_split_form_equation_kept_in_body;
     test_case
       "recursive rule emits define-fun-rec form with body and skips \
        declare-fun line"

--- a/test/test_smt.ml
+++ b/test/test_smt.ml
@@ -237,11 +237,25 @@ let test_duplicate_split_form_equation_kept_in_body () =
        next x = x + 2.\n"
   in
   let env, doc = Collect.recognize_split_form_bodies env doc in
-  (match Env.lookup_rule_body_arity "next" 1 env with
-  | Some _ -> ()
+  (match[@warning "-4"] Env.lookup_rule_body_arity "next" 1 env with
+  | Some (_decl, EBinop (OpAdd, EVar (Lower "x"), ELitNat 1), _recursive) -> ()
+  | Some (_decl, body, _recursive) ->
+      fail
+        (Printf.sprintf "expected attached x + 1 body, got %s"
+           (Ast.show_expr body))
   | None -> fail "expected first rule body in env");
   let chapter = List.hd doc.chapters in
-  check int "duplicate equation remains in body" 1 (List.length chapter.body)
+  check int "duplicate equation remains in body" 1 (List.length chapter.body);
+  match[@warning "-4"] (List.hd chapter.body).value with
+  | EBinop
+      ( OpEq,
+        EApp (EVar (Lower "next"), [ EVar (Lower "x") ]),
+        EBinop (OpAdd, EVar (Lower "x"), ELitNat 2) ) ->
+      ()
+  | prop ->
+      fail
+        (Printf.sprintf "expected retained x + 2 equation, got %s"
+           (Ast.show_expr prop))
 
 let test_recursive_rule_emits_define_fun_rec () =
   let env, doc =

--- a/test/test_smt.ml
+++ b/test/test_smt.ml
@@ -196,38 +196,46 @@ let test_function_declarations () =
   check bool "has balance_prime decl" true
     (contains decls "(declare-fun balance_prime (Account) Int)")
 
-let test_is_rule_recursive_detects_self_reference () =
-  let _env, doc =
+(* Recursion is detected at [Env.attach_rule_body] time by scanning the
+   equation's RHS for references to the rule's own name. The flag rides
+   in the [rule_bodies] triple and drives the [define-fun-rec] vs.
+   [(assert (forall ...))] dispatch in [emit_rule_definitions]. *)
+let lookup_recursive env name arity =
+  match Env.lookup_rule_body_arity name arity env with
+  | Some (_decl, _body, recursive) -> Some recursive
+  | None -> None
+
+let test_split_form_recursive_self_reference () =
+  let env, doc =
     parse_and_collect
       "module Test.\n\
-       loop x: Int => Int = cond x > 0 => loop (x - 1), true => x.\n\
+       loop x: Int => Int.\n\
        ---\n\
-       loop 0 = 0.\n"
+       loop x = cond x > 0 => loop (x - 1), true => x.\n"
   in
-  match (List.hd doc.chapters).head with
-  | decl :: _ ->
-      check bool "recursive rule detected" true
-        (Smt.is_rule_recursive decl.value)
-  | [] -> fail "expected rule declaration"
+  let env, _doc = Collect.recognize_split_form_bodies env doc in
+  match lookup_recursive env "loop" 1 with
+  | Some r -> check bool "recursive rule detected" true r
+  | None -> fail "expected rule body in env"
 
-let test_is_rule_recursive_detects_nullary_self_reference () =
-  let _env, doc =
-    parse_and_collect "module Test.\nloop => Bool = loop.\n---\nloop.\n"
+let test_split_form_nullary_self_reference () =
+  let env, doc =
+    parse_and_collect "module Test.\nloop => Bool.\n---\nloop = loop.\n"
   in
-  match (List.hd doc.chapters).head with
-  | decl :: _ ->
-      check bool "nullary recursive rule detected" true
-        (Smt.is_rule_recursive decl.value)
-  | [] -> fail "expected nullary rule declaration"
+  let env, _doc = Collect.recognize_split_form_bodies env doc in
+  match lookup_recursive env "loop" 0 with
+  | Some r -> check bool "nullary recursive rule detected" true r
+  | None -> fail "expected nullary rule body in env"
 
 let test_recursive_rule_emits_define_fun_rec () =
-  let env, _doc =
+  let env, doc =
     parse_and_collect
       "module Test.\n\
-       loop x: Int => Int = cond x > 0 => loop (x - 1), true => x.\n\
+       loop x: Int => Int.\n\
        ---\n\
-       loop 0 = 0.\n"
+       loop x = cond x > 0 => loop (x - 1), true => x.\n"
   in
+  let env, _doc = Collect.recognize_split_form_bodies env doc in
   let smt = Smt.generate_preamble_with_rule_bodies config env in
   check bool "has define-fun-rec" true
     (contains smt "(define-fun-rec loop ((x Int)) Int");
@@ -242,13 +250,12 @@ let test_recursive_rule_emits_define_fun_rec () =
 let test_non_recursive_rule_emits_existing_shape () =
   let env, doc =
     parse_and_collect
-      "module Test.\nnext x: Int => Int = x + 1.\n---\nnext 0 = 1.\n"
+      "module Test.\nnext x: Int => Int.\n---\nnext x = x + 1.\n"
   in
-  (match (List.hd doc.chapters).head with
-  | decl :: _ ->
-      check bool "non-recursive rule not detected" false
-        (Smt.is_rule_recursive decl.value)
-  | [] -> fail "expected rule declaration");
+  let env, _doc = Collect.recognize_split_form_bodies env doc in
+  (match lookup_recursive env "next" 1 with
+  | Some r -> check bool "non-recursive rule not detected" false r
+  | None -> fail "expected rule body in env");
   let smt = Smt.generate_preamble_with_rule_bodies config env in
   check bool "has declare-fun" true
     (contains smt "(declare-fun next (Int) Int)");
@@ -1358,10 +1365,11 @@ let integration_tests =
   [
     test_case "domain preamble" `Quick test_preamble_domains_simple;
     test_case "function declarations" `Quick test_function_declarations;
-    test_case "is_rule_recursive detects self-referential rule body" `Quick
-      test_is_rule_recursive_detects_self_reference;
-    test_case "is_rule_recursive detects nullary self-referential rule body"
-      `Quick test_is_rule_recursive_detects_nullary_self_reference;
+    test_case "split-form recursive rule detected at attach_rule_body time"
+      `Quick test_split_form_recursive_self_reference;
+    test_case
+      "split-form nullary recursive rule detected at attach_rule_body time"
+      `Quick test_split_form_nullary_self_reference;
     test_case
       "recursive rule emits define-fun-rec form with body and skips \
        declare-fun line"

--- a/test/test_util.ml
+++ b/test/test_util.ml
@@ -320,7 +320,6 @@ let gen_chapter (world : gen_world) : Ast.chapter QCheck2.Gen.t =
                  params;
                  guards = [];
                  return_type = ret;
-                 body = None;
                  contexts = [];
                }))
         world.rules

--- a/tools/ts2pant/src/annotations.ts
+++ b/tools/ts2pant/src/annotations.ts
@@ -45,49 +45,52 @@ export interface AnnotationResult {
 export function extractAnnotations(node: ts.Node): AnnotationResult {
   const propositions: PantAnnotation[] = [];
   const typeOverrides: PantTypeOverride[] = [];
-  let openBlockText: string | null = null;
 
-  for (const tag of jsDocTags(node)) {
-    const name = tag.tagName.text;
-    if (openBlockText !== null) {
-      if (name === "pant-end") {
-        const text = openBlockText.trim();
-        if (text.length > 0) {
-          propositions.push({ text });
-        }
-        openBlockText = null;
-      }
-      // Any other tag while a block is open is silently dropped —
-      // mixing additional tags inside a `@pant-begin`/`@pant-end`
-      // block is not part of the supported grammar.
-      continue;
-    }
+  for (const tags of jsDocTagBlocks(node)) {
+    let openBlockText: string | null = null;
 
-    switch (name) {
-      case "pant": {
-        const text = tagComment(tag).trim();
-        if (text.length > 0) {
-          propositions.push({ text });
+    for (const tag of tags) {
+      const name = tag.tagName.text;
+      if (openBlockText !== null) {
+        if (name === "pant-end") {
+          const text = openBlockText.trim();
+          if (text.length > 0) {
+            propositions.push({ text });
+          }
+          openBlockText = null;
         }
-        break;
+        // Any other tag while a block is open is silently dropped —
+        // mixing additional tags inside a `@pant-begin`/`@pant-end`
+        // block is not part of the supported grammar.
+        continue;
       }
-      case "pant-begin":
-        openBlockText = tagComment(tag);
-        break;
-      case "pant-end":
-        // Stray `@pant-end` without a matching `@pant-begin`: drop.
-        break;
-      case "pant-type": {
-        const override = parseTypeOverride(tagComment(tag));
-        if (override !== null) {
-          typeOverrides.push(override);
+
+      switch (name) {
+        case "pant": {
+          const text = tagComment(tag).trim();
+          if (text.length > 0) {
+            propositions.push({ text });
+          }
+          break;
         }
-        break;
+        case "pant-begin":
+          openBlockText = tagComment(tag);
+          break;
+        case "pant-end":
+          // Stray `@pant-end` without a matching `@pant-begin`: drop.
+          break;
+        case "pant-type": {
+          const override = parseTypeOverride(tagComment(tag));
+          if (override !== null) {
+            typeOverrides.push(override);
+          }
+          break;
+        }
+        default:
+          // Foreign JSDoc tags (@param, @returns, etc.) are not part of
+          // this module's surface and pass through untouched.
+          break;
       }
-      default:
-        // Foreign JSDoc tags (@param, @returns, etc.) are not part of
-        // this module's surface and pass through untouched.
-        break;
     }
   }
 
@@ -136,14 +139,14 @@ function tagComment(tag: ts.JSDocTag): string {
  * `@inheritDoc`, which is not behaviour we want here — each annotated
  * function owns its own propositions.
  */
-function jsDocTags(node: ts.Node): readonly ts.JSDocTag[] {
-  const tags: ts.JSDocTag[] = [];
+function jsDocTagBlocks(node: ts.Node): readonly (readonly ts.JSDocTag[])[] {
+  const blocks: ts.JSDocTag[][] = [];
   for (const child of ts.getJSDocCommentsAndTags(node)) {
     if (ts.isJSDoc(child) && child.tags !== undefined) {
-      tags.push(...child.tags);
+      blocks.push([...child.tags]);
     }
   }
-  return tags;
+  return blocks;
 }
 
 // ===========================================================================

--- a/tools/ts2pant/src/annotations.ts
+++ b/tools/ts2pant/src/annotations.ts
@@ -20,64 +20,74 @@ export interface AnnotationResult {
 }
 
 /**
- * Parse @pant annotations from raw JSDoc comment text (the content
- * between the opening and closing delimiters).
+ * Three line-oriented forms are recognised inside a `/** ... *\/` block
+ * attached to a function declaration:
  *
- * Recognises three forms:
- *   @pant <proposition>           — single-line proposition
- *   @pant-begin ... @pant-end     — multi-line proposition block
- *   @pant-type name: Type         — numeric type override
+ *   `\@pant <proposition>`        — Pantagruel proposition (may span
+ *                                    multiple continuation lines; the
+ *                                    JSDoc parser folds them into the
+ *                                    tag's comment field naturally).
+ *   `\@pant-begin ... \@pant-end` — Equivalent to a multi-line `\@pant`;
+ *                                    retained for source-level
+ *                                    readability. Lexically the
+ *                                    `\@pant-begin` tag's comment field
+ *                                    already carries the block body;
+ *                                    `\@pant-end` is a closing marker
+ *                                    with no payload.
+ *   `\@pant-type name: Type`      — type override for a TS parameter.
+ *
+ * All lexical concerns (comment-range scanning, `* ` decorator strip,
+ * tag-name tokenisation, continuation-line folding) are delegated to
+ * the TypeScript compiler's JSDoc parser. The only grammar this module
+ * owns is the `name: Type` split for `\@pant-type` and the trivial
+ * dispatch between the four tag kinds.
  */
-export function parseAnnotations(text: string): AnnotationResult {
+export function extractAnnotations(node: ts.Node): AnnotationResult {
   const propositions: PantAnnotation[] = [];
   const typeOverrides: PantTypeOverride[] = [];
+  let openBlockText: string | null = null;
 
-  // Strip leading `*` and whitespace from each line (JSDoc formatting).
-  const lines = text.split("\n").map((l) => l.replace(/^\s*\*?\s?/u, ""));
-
-  let inBlock = false;
-  let blockLines: string[] = [];
-
-  for (const line of lines) {
-    const trimmed = line.trimEnd();
-
-    if (inBlock) {
-      if (/^@pant-end\b/u.test(trimmed.trimStart())) {
-        const blockText = blockLines.join("\n").trim();
-        if (blockText) {
-          propositions.push({ text: blockText });
+  for (const tag of jsDocTags(node)) {
+    const name = tag.tagName.text;
+    if (openBlockText !== null) {
+      if (name === "pant-end") {
+        const text = openBlockText.trim();
+        if (text.length > 0) {
+          propositions.push({ text });
         }
-        inBlock = false;
-        blockLines = [];
-      } else {
-        blockLines.push(trimmed);
+        openBlockText = null;
       }
+      // Any other tag while a block is open is silently dropped —
+      // mixing additional tags inside a `@pant-begin`/`@pant-end`
+      // block is not part of the supported grammar.
       continue;
     }
 
-    if (/^@pant-begin\b/u.test(trimmed.trimStart())) {
-      inBlock = true;
-      blockLines = [];
-      continue;
-    }
-
-    // @pant-type name: Type
-    const typeMatch = trimmed.match(/^\s*@pant-type\s+(\w+)\s*:\s*(.+)$/u);
-    if (typeMatch) {
-      const typeName = typeMatch[2]?.trim();
-      if (typeName) {
-        typeOverrides.push({ name: typeMatch[1]!, type: typeName });
+    switch (name) {
+      case "pant": {
+        const text = tagComment(tag).trim();
+        if (text.length > 0) {
+          propositions.push({ text });
+        }
+        break;
       }
-      continue;
-    }
-
-    // @pant <proposition>  (but not @pant-begin, @pant-end, @pant-type)
-    const pantMatch = trimmed.match(/^\s*@pant\s+(.+)$/u);
-    if (pantMatch) {
-      const propText = pantMatch[1]?.trim();
-      if (propText) {
-        propositions.push({ text: propText });
+      case "pant-begin":
+        openBlockText = tagComment(tag);
+        break;
+      case "pant-end":
+        // Stray `@pant-end` without a matching `@pant-begin`: drop.
+        break;
+      case "pant-type": {
+        const override = parseTypeOverride(tagComment(tag));
+        if (override !== null) {
+          typeOverrides.push(override);
+        }
+        break;
       }
+      default:
+        // Foreign JSDoc tags (@param, @returns, etc.) are not part of
+        // this module's surface and pass through untouched.
+        break;
     }
   }
 
@@ -85,44 +95,60 @@ export function parseAnnotations(text: string): AnnotationResult {
 }
 
 /**
- * Extract @pant annotations from JSDoc comments attached to a TypeScript
- * AST node. Walks all leading comment ranges and parses any that are
- * JSDoc-style (`/** ... *​/`).
+ * Split a `@pant-type` tag's comment into `name` and `type`. Returns
+ * `null` when the shape doesn't match `<name>:<type>` with non-empty
+ * halves after trimming.
  */
-export function extractAnnotations(
-  node: ts.Node,
-  sourceFile: ts.SourceFile,
-): AnnotationResult {
-  const result: AnnotationResult = { propositions: [], typeOverrides: [] };
-
-  const fullText = sourceFile.getFullText();
-  const commentRanges = ts.getLeadingCommentRanges(
-    fullText,
-    node.getFullStart(),
-  );
-
-  if (!commentRanges) {
-    return result;
+function parseTypeOverride(comment: string): PantTypeOverride | null {
+  const colonIdx = comment.indexOf(":");
+  if (colonIdx < 0) {
+    return null;
   }
-
-  for (const range of commentRanges) {
-    const commentText = fullText.slice(range.pos, range.end);
-
-    // Only process JSDoc-style comments.
-    if (!commentText.startsWith("/**")) {
-      continue;
-    }
-
-    // Strip /** and */ delimiters.
-    const inner = commentText.slice(3, -2);
-    const parsed = parseAnnotations(inner);
-
-    result.propositions.push(...parsed.propositions);
-    result.typeOverrides.push(...parsed.typeOverrides);
+  const name = comment.slice(0, colonIdx).trim();
+  const type = comment.slice(colonIdx + 1).trim();
+  if (name.length === 0 || type.length === 0) {
+    return null;
   }
-
-  return result;
+  return { name, type };
 }
+
+/**
+ * Extract the plain-text comment payload of a JSDoc tag. The compiler
+ * represents tag comments as either a flat string or a `NodeArray` of
+ * `JSDocComment` parts (when the comment contains embedded constructs
+ * like `{@link ...}`); both shapes flatten to a single string by
+ * concatenating the parts' `.text`.
+ */
+function tagComment(tag: ts.JSDocTag): string {
+  const c = tag.comment;
+  if (c === undefined) {
+    return "";
+  }
+  if (typeof c === "string") {
+    return c;
+  }
+  return c.map((part) => part.text).join("");
+}
+
+/**
+ * Collect every JSDoc tag declared on `node` itself (not on its
+ * ancestors). `ts.getJSDocTags` walks the inheritance chain to support
+ * `@inheritDoc`, which is not behaviour we want here — each annotated
+ * function owns its own propositions.
+ */
+function jsDocTags(node: ts.Node): readonly ts.JSDocTag[] {
+  const tags: ts.JSDocTag[] = [];
+  for (const child of ts.getJSDocCommentsAndTags(node)) {
+    if (ts.isJSDoc(child) && child.tags !== undefined) {
+      tags.push(...child.tags);
+    }
+  }
+  return tags;
+}
+
+// ===========================================================================
+// Function-by-name extraction (unchanged surface)
+// ===========================================================================
 
 /** Combined proposition texts + type overrides from a function's JSDoc. */
 export interface FunctionAnnotations {
@@ -131,15 +157,15 @@ export interface FunctionAnnotations {
 }
 
 /**
- * Find a function by name and extract both @pant propositions and
- * @pant-type overrides in a single JSDoc pass.
+ * Find a function by name and extract both \@pant propositions and
+ * \@pant-type overrides in a single JSDoc pass.
  */
 export function extractFunctionAnnotationsAndOverrides(
   sourceFile: SourceFile,
   functionName: string,
 ): FunctionAnnotations {
   const { node } = findFunction(sourceFile, functionName);
-  const result = extractAnnotations(node, sourceFile.compilerNode);
+  const result = extractAnnotations(node);
   return {
     propositionTexts: result.propositions.map((p) => p.text),
     typeOverrides: new Map(result.typeOverrides.map((o) => [o.name, o.type])),
@@ -147,7 +173,7 @@ export function extractFunctionAnnotationsAndOverrides(
 }
 
 /**
- * Convenience wrapper: find a function by name and extract its @pant
+ * Convenience wrapper: find a function by name and extract its \@pant
  * proposition texts as plain strings.
  */
 export function extractFunctionAnnotations(
@@ -159,7 +185,7 @@ export function extractFunctionAnnotations(
 }
 
 /**
- * Convenience wrapper: find a function by name and extract its @pant-type
+ * Convenience wrapper: find a function by name and extract its \@pant-type
  * overrides as a Map from TS parameter name to Pantagruel type string.
  */
 export function extractFunctionTypeOverrides(

--- a/tools/ts2pant/src/emit.ts
+++ b/tools/ts2pant/src/emit.ts
@@ -55,10 +55,15 @@ function renderPropResult(prop: PropResult): string {
       return ast.strExpr(ast.forall(prop.quantifiers, guards, prop.body));
     }
     case "rule-decl": {
+      // Header form only: `<name> <params> => <returnType>`. The
+      // equation `<name> <args> = <body>.` is emitted separately into
+      // the chapter body by `emitDocument` — the Pantagruel grammar
+      // production for rules has no body slot; rule definitions must
+      // live below the `---` divider as equations.
       const params = prop.params
         .map((p) => `${p.name}: ${ast.strTypeExpr(p.type)}`)
         .join(", ");
-      return `${prop.ruleName} ${params} => ${ast.strTypeExpr(prop.returnType)} = ${ast.strExpr(prop.body)}`;
+      return `${prop.ruleName} ${params} => ${ast.strTypeExpr(prop.returnType)}`;
     }
     case "unsupported":
       return `> UNSUPPORTED: ${prop.reason}`;
@@ -100,10 +105,24 @@ export function emitDocument(doc: PantDocument): string {
   lines.push("---");
   lines.push("");
 
-  if (bodyProps.length === 0) {
+  // For each `rule-decl` PropResult emitted in the head as a bare
+  // declaration, emit the corresponding equation `<name> <args> = <body>.`
+  // in the chapter body. Splitting the rule's declaration and definition
+  // across the `---` divider matches the Pantagruel grammar — see the
+  // `rule-decl` arm of `renderPropResult` for the rationale.
+  const ruleDeclEquations = ruleDeclProps.map((prop) => {
+    const argList = prop.params.map((p) => p.name).join(" ");
+    const argPart = argList.length > 0 ? ` ${argList}` : "";
+    return `${prop.ruleName}${argPart} = ${getAst().strExpr(prop.body)}.`;
+  });
+
+  if (bodyProps.length === 0 && ruleDeclEquations.length === 0) {
     // Keep chapter body non-empty (required when a check block is present).
     lines.push("true.");
   } else {
+    for (const line of ruleDeclEquations) {
+      lines.push(line);
+    }
     for (const prop of bodyProps) {
       lines.push(`${renderPropResult(prop)}.`);
     }

--- a/tools/ts2pant/tests/annotations.test.mts
+++ b/tools/ts2pant/tests/annotations.test.mts
@@ -1,19 +1,12 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import ts from "typescript";
-import {
-  parseAnnotations,
-  extractAnnotations,
-  type AnnotationResult,
-} from "../src/annotations.js";
+import { extractAnnotations } from "../src/annotations.js";
 
 // ---------------------------------------------------------------------------
 // Helper: create a SourceFile from raw TS source and find the first function
 // ---------------------------------------------------------------------------
-function firstFunction(source: string): {
-  node: ts.FunctionDeclaration;
-  sourceFile: ts.SourceFile;
-} {
+function firstFunction(source: string): ts.FunctionDeclaration {
   const sourceFile = ts.createSourceFile(
     "test.ts",
     source,
@@ -27,184 +20,112 @@ function firstFunction(source: string): {
     }
   });
   if (!fn) throw new Error("No function declaration found in source");
-  return { node: fn, sourceFile };
+  return fn;
 }
 
-// ---------------------------------------------------------------------------
-// parseAnnotations — raw text parsing
-// ---------------------------------------------------------------------------
-describe("parseAnnotations", () => {
+/** Wrap a JSDoc body in `/** ... *\/` + a dummy function declaration. */
+function functionWithJsDoc(body: string): ts.FunctionDeclaration {
+  return firstFunction(
+    `/**\n${body}\n */\nfunction subject(): void {}\n`,
+  );
+}
+
+describe("extractAnnotations", () => {
   it("extracts a single @pant proposition", () => {
-    const text = `
-     * Some description.
-     * @pant result f x = x + 1
-     `;
-    const result = parseAnnotations(text);
+    const node = functionWithJsDoc(" * @pant result f x = x + 1");
+    const result = extractAnnotations(node);
     assert.equal(result.propositions.length, 1);
     assert.equal(result.propositions[0].text, "result f x = x + 1");
     assert.equal(result.typeOverrides.length, 0);
   });
 
   it("extracts multiple @pant propositions", () => {
-    const text = `
-     * @pant result f x >= 0
-     * @pant result f x <= 100
-     `;
-    const result = parseAnnotations(text);
+    const node = functionWithJsDoc(
+      " * @pant result f x >= 0\n * @pant result f x <= 100",
+    );
+    const result = extractAnnotations(node);
     assert.equal(result.propositions.length, 2);
     assert.equal(result.propositions[0].text, "result f x >= 0");
     assert.equal(result.propositions[1].text, "result f x <= 100");
   });
 
   it("extracts a multi-line @pant-begin / @pant-end block", () => {
-    const text = `
-     * @pant-begin
-     * all x: Nat |
-     *   result f x >= 0
-     * @pant-end
-     `;
-    const result = parseAnnotations(text);
+    const node = functionWithJsDoc(
+      " * @pant-begin\n" +
+        " * all x: Nat |\n" +
+        " *   result f x >= 0\n" +
+        " * @pant-end",
+    );
+    const result = extractAnnotations(node);
     assert.equal(result.propositions.length, 1);
-    assert.equal(result.propositions[0].text, "all x: Nat |\n  result f x >= 0");
+    assert.ok(result.propositions[0].text.includes("all x: Nat |"));
+    assert.ok(result.propositions[0].text.includes("result f x >= 0"));
   });
 
   it("extracts @pant-type overrides", () => {
-    const text = `
-     * @pant-type amount: Nat
-     * @pant-type rate: Real
-     `;
-    const result = parseAnnotations(text);
+    const node = functionWithJsDoc(
+      " * @pant-type amount: Nat\n * @pant-type rate: Real",
+    );
+    const result = extractAnnotations(node);
     assert.equal(result.propositions.length, 0);
     assert.equal(result.typeOverrides.length, 2);
-    assert.equal(result.typeOverrides[0].name, "amount");
-    assert.equal(result.typeOverrides[0].type, "Nat");
-    assert.equal(result.typeOverrides[1].name, "rate");
-    assert.equal(result.typeOverrides[1].type, "Real");
+    assert.deepEqual(result.typeOverrides[0], { name: "amount", type: "Nat" });
+    assert.deepEqual(result.typeOverrides[1], { name: "rate", type: "Real" });
   });
 
-  it("returns empty result for no annotations", () => {
-    const text = `
-     * Just a regular JSDoc comment.
-     * @param x - a number
-     * @returns the result
-     `;
-    const result = parseAnnotations(text);
+  it("returns empty result for JSDoc without @pant tags", () => {
+    const node = functionWithJsDoc(
+      " * Just a regular JSDoc comment.\n" +
+        " * @param x - a number\n" +
+        " * @returns the result",
+    );
+    const result = extractAnnotations(node);
     assert.equal(result.propositions.length, 0);
     assert.equal(result.typeOverrides.length, 0);
   });
 
   it("skips empty @pant tags", () => {
-    const text = `
-     * @pant
-     `;
-    const result = parseAnnotations(text);
+    const node = functionWithJsDoc(" * @pant");
+    const result = extractAnnotations(node);
     assert.equal(result.propositions.length, 0);
   });
 
   it("handles mixed annotations and type overrides", () => {
-    const text = `
-     * @pant-type n: Nat0
-     * @pant result factorial n >= 1
-     * @pant-begin
-     * all m: Nat0 |
-     *   result factorial m >= 1
-     * @pant-end
-     `;
-    const result = parseAnnotations(text);
+    const node = functionWithJsDoc(
+      " * @pant-type n: Nat0\n" +
+        " * @pant result factorial n >= 1\n" +
+        " * @pant-begin\n" +
+        " * all m: Nat0 |\n" +
+        " *   result factorial m >= 1\n" +
+        " * @pant-end",
+    );
+    const result = extractAnnotations(node);
     assert.equal(result.typeOverrides.length, 1);
-    assert.equal(result.typeOverrides[0].name, "n");
-    assert.equal(result.typeOverrides[0].type, "Nat0");
+    assert.deepEqual(result.typeOverrides[0], { name: "n", type: "Nat0" });
     assert.equal(result.propositions.length, 2);
     assert.equal(result.propositions[0].text, "result factorial n >= 1");
-    assert.equal(result.propositions[1].text,
-      "all m: Nat0 |\n  result factorial m >= 1",
-    );
+    assert.ok(result.propositions[1].text.includes("all m: Nat0 |"));
+    assert.ok(result.propositions[1].text.includes("result factorial m >= 1"));
   });
 
   it("ignores empty @pant-begin / @pant-end blocks", () => {
-    const text = `
-     * @pant-begin
-     * @pant-end
-     `;
-    const result = parseAnnotations(text);
+    const node = functionWithJsDoc(" * @pant-begin\n * @pant-end");
+    const result = extractAnnotations(node);
     assert.equal(result.propositions.length, 0);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// extractAnnotations — TS compiler API integration
-// ---------------------------------------------------------------------------
-describe("extractAnnotations", () => {
-  it("extracts annotations from a JSDoc comment on a function", () => {
-    const source = `
-/**
- * Add two numbers.
- * @pant result add a b = a + b
- */
-function add(a: number, b: number): number {
-  return a + b;
-}
-`;
-    const { node, sourceFile } = firstFunction(source);
-    const result = extractAnnotations(node, sourceFile);
-    assert.equal(result.propositions.length, 1);
-    assert.equal(result.propositions[0].text, "result add a b = a + b");
   });
 
   it("returns empty for function with no JSDoc", () => {
-    const source = `
-function noop(): void {}
-`;
-    const { node, sourceFile } = firstFunction(source);
-    const result = extractAnnotations(node, sourceFile);
+    const node = firstFunction("function noop(): void {}\n");
+    const result = extractAnnotations(node);
     assert.equal(result.propositions.length, 0);
     assert.equal(result.typeOverrides.length, 0);
   });
 
-  it("returns empty for function with plain (non-JSDoc) comment", () => {
-    const source = `
-// @pant this should not be extracted
-function noop(): void {}
-`;
-    const { node, sourceFile } = firstFunction(source);
-    const result = extractAnnotations(node, sourceFile);
+  it("ignores plain (non-JSDoc) comments", () => {
+    const node = firstFunction(
+      "// @pant this should not be extracted\nfunction noop(): void {}\n",
+    );
+    const result = extractAnnotations(node);
     assert.equal(result.propositions.length, 0);
-  });
-
-  it("extracts @pant-type from JSDoc on a function", () => {
-    const source = `
-/**
- * @pant-type amount: Nat
- * @pant result withdraw amount >= 0
- */
-function withdraw(amount: number): number {
-  return amount;
-}
-`;
-    const { node, sourceFile } = firstFunction(source);
-    const result = extractAnnotations(node, sourceFile);
-    assert.equal(result.typeOverrides.length, 1);
-    assert.equal(result.typeOverrides[0].name, "amount");
-    assert.equal(result.typeOverrides[0].type, "Nat");
-    assert.equal(result.propositions.length, 1);
-  });
-
-  it("extracts multi-line block from JSDoc", () => {
-    const source = `
-/**
- * @pant-begin
- * all x: Nat |
- *   result f x > 0
- * @pant-end
- */
-function f(x: number): number {
-  return x + 1;
-}
-`;
-    const { node, sourceFile } = firstFunction(source);
-    const result = extractAnnotations(node, sourceFile);
-    assert.equal(result.propositions.length, 1);
-    assert.ok(result.propositions[0].text.includes("all x: Nat |"));
-    assert.ok(result.propositions[0].text.includes("result f x > 0"));
   });
 });

--- a/tools/ts2pant/tests/annotations.test.mts
+++ b/tools/ts2pant/tests/annotations.test.mts
@@ -73,6 +73,26 @@ describe("extractAnnotations", () => {
     assert.deepEqual(result.typeOverrides[1], { name: "rate", type: "Real" });
   });
 
+  it("resets @pant-begin state for each JSDoc block", () => {
+    const node = firstFunction(
+      "/**\n" +
+        " * @pant-begin\n" +
+        " * unterminated block\n" +
+        " */\n" +
+        "/**\n" +
+        " * @pant result subject = 1\n" +
+        " * @pant-type value: Nat\n" +
+        " */\n" +
+        "function subject(): void {}\n",
+    );
+    const result = extractAnnotations(node);
+    assert.deepEqual(
+      result.propositions.map((p) => p.text),
+      ["result subject = 1"],
+    );
+    assert.deepEqual(result.typeOverrides, [{ name: "value", type: "Nat" }]);
+  });
+
   it("returns empty result for JSDoc without @pant tags", () => {
     const node = functionWithJsDoc(
       " * Just a regular JSDoc comment.\n" +

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -767,7 +767,7 @@ exports[`functions-class.ts > Account.getBalance 1`] = `
 `;
 
 exports[`functions-mutating-bounded-while-break.ts > addWhileBelowLimit 1`] = `
-"module ADD_WHILE_BELOW_LIMIT.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\nfn--loop s: Int, n: Int => Int = cond 0 < n and s >= n => s + 1, 0 < n => fn--loop (s + 1) n, true => s.\\n~> Add-while-below-limit @ a: Account, n: Int.\\n\\n---\\n\\naccount--balance' a = fn--loop (account--balance a) n.\\n"
+"module ADD_WHILE_BELOW_LIMIT.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\nfn--loop s: Int, n: Int => Int.\\n~> Add-while-below-limit @ a: Account, n: Int.\\n\\n---\\n\\nfn--loop s n = cond 0 < n and s >= n => s + 1, 0 < n => fn--loop (s + 1) n, true => s.\\naccount--balance' a = fn--loop (account--balance a) n.\\n"
 `;
 
 exports[`functions-mutating-bounded-while.ts > setLastIndexDescending 1`] = `
@@ -911,35 +911,35 @@ exports[`functions-mutating-early-exit.ts > writeThenEarlyReturn 1`] = `
 `;
 
 exports[`functions-mutating-fixed-point-break.ts > climbUntilBreak 1`] = `
-"module CLIMB_UNTIL_BREAK.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\nfn--loop s: Int, n: Int => Int = cond s < n and s >= n => s + 1, s < n => fn--loop (s + 1) n, true => s.\\n~> Climb-until-break @ a: Account, n: Int.\\n\\n---\\n\\naccount--balance' a = fn--loop (account--balance a) n.\\n"
+"module CLIMB_UNTIL_BREAK.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\nfn--loop s: Int, n: Int => Int.\\n~> Climb-until-break @ a: Account, n: Int.\\n\\n---\\n\\nfn--loop s n = cond s < n and s >= n => s + 1, s < n => fn--loop (s + 1) n, true => s.\\naccount--balance' a = fn--loop (account--balance a) n.\\n"
 `;
 
 exports[`functions-mutating-fixed-point-continue.ts > climbUnlessZeroStep 1`] = `
-"module CLIMB_UNLESS_ZERO_STEP.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\nfn--loop s: Int, n: Int => Int = cond s < n => fn--loop (cond n = 0 => s, true => s + 1) n, true => s.\\n~> Climb-unless-zero-step @ a: Account, n: Int.\\n\\n---\\n\\naccount--balance' a = fn--loop (account--balance a) n.\\n"
+"module CLIMB_UNLESS_ZERO_STEP.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\nfn--loop s: Int, n: Int => Int.\\n~> Climb-unless-zero-step @ a: Account, n: Int.\\n\\n---\\n\\nfn--loop s n = cond s < n => fn--loop (cond n = 0 => s, true => s + 1) n, true => s.\\naccount--balance' a = fn--loop (account--balance a) n.\\n"
 `;
 
 exports[`functions-mutating-fixed-point-return-bare.ts > climbUntilReturn 1`] = `
-"module CLIMB_UNTIL_RETURN.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\nfn--loop s: Int, n: Int => Int = cond s < n and s >= n => s + 1, s < n => fn--loop (s + 1) n, true => s.\\n~> Climb-until-return @ a: Account, n: Int.\\n\\n---\\n\\naccount--balance' a = fn--loop (account--balance a) n.\\n"
+"module CLIMB_UNTIL_RETURN.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\nfn--loop s: Int, n: Int => Int.\\n~> Climb-until-return @ a: Account, n: Int.\\n\\n---\\n\\nfn--loop s n = cond s < n and s >= n => s + 1, s < n => fn--loop (s + 1) n, true => s.\\naccount--balance' a = fn--loop (account--balance a) n.\\n"
 `;
 
 exports[`functions-mutating-fixed-point-return-value.ts > climbAndReturn 1`] = `
-"module CLIMB_AND_RETURN.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\nclimb-and-return a: Account, n: Int => Int.\\nfn--loop s: Int, n: Int => Int = cond s < n and s >= n => s + 1, s < n => fn--loop (s + 1) n, true => s.\\n~> Climb-and-return @ a: Account, n: Int.\\n\\n---\\n\\naccount--balance' a = fn--loop (account--balance a) n.\\nclimb-and-return' a n = (cond account--balance a >= n => account--balance a, true => fn--loop (account--balance a) n).\\n"
+"module CLIMB_AND_RETURN.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\nclimb-and-return a: Account, n: Int => Int.\\nfn--loop s: Int, n: Int => Int.\\n~> Climb-and-return @ a: Account, n: Int.\\n\\n---\\n\\nfn--loop s n = cond s < n and s >= n => s + 1, s < n => fn--loop (s + 1) n, true => s.\\naccount--balance' a = fn--loop (account--balance a) n.\\nclimb-and-return' a n = (cond account--balance a >= n => account--balance a, true => fn--loop (account--balance a) n).\\n"
 `;
 
 exports[`functions-mutating-fixed-point-throw.ts > climbUnlessInvalid 1`] = `
-"module CLIMB_UNLESS_INVALID.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\nfn--loop s: Int, n: Int => Int = cond s < n and ~(n = 0) => fn--loop (s + 1) n, true => s.\\n~> Climb-unless-invalid @ a: Account, n: Int.\\n\\n---\\n\\naccount--balance' a = fn--loop (account--balance a) n.\\n"
+"module CLIMB_UNLESS_INVALID.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\nfn--loop s: Int, n: Int => Int.\\n~> Climb-unless-invalid @ a: Account, n: Int.\\n\\n---\\n\\nfn--loop s n = cond s < n and ~(n = 0) => fn--loop (s + 1) n, true => s.\\naccount--balance' a = fn--loop (account--balance a) n.\\n"
 `;
 
 exports[`functions-mutating-fixed-point-while.ts > adjustBalanceTo 1`] = `
-"module ADJUST_BALANCE_TO.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--size a1: Account => Int.\\naccount--tick-count a1: Account => Int.\\nfn--loop s: Int, step: Int, target: Int => Int = cond s < target => fn--loop (s + step) step target, true => s.\\n~> Adjust-balance-to @ a: Account, target: Int, step: Int.\\n\\n---\\n\\naccount--balance' a = fn--loop (account--balance a) step target.\\naccount--size' a1 = account--size a1.\\naccount--tick-count' a1 = account--tick-count a1.\\n"
+"module ADJUST_BALANCE_TO.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--size a1: Account => Int.\\naccount--tick-count a1: Account => Int.\\nfn--loop s: Int, step: Int, target: Int => Int.\\n~> Adjust-balance-to @ a: Account, target: Int, step: Int.\\n\\n---\\n\\nfn--loop s step target = cond s < target => fn--loop (s + step) step target, true => s.\\naccount--balance' a = fn--loop (account--balance a) step target.\\naccount--size' a1 = account--size a1.\\naccount--tick-count' a1 = account--tick-count a1.\\n"
 `;
 
 exports[`functions-mutating-fixed-point-while.ts > drainTo 1`] = `
-"module DRAIN_TO.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--size a1: Account => Int.\\naccount--tick-count a1: Account => Int.\\nfn--loop s: Int, floor: Int => Int = cond s > floor => fn--loop (s - 1) floor, true => s.\\n~> Drain-to @ a: Account, floor: Int.\\n\\n---\\n\\naccount--balance' a = fn--loop (account--balance a) floor.\\naccount--size' a1 = account--size a1.\\naccount--tick-count' a1 = account--tick-count a1.\\n"
+"module DRAIN_TO.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--size a1: Account => Int.\\naccount--tick-count a1: Account => Int.\\nfn--loop s: Int, floor: Int => Int.\\n~> Drain-to @ a: Account, floor: Int.\\n\\n---\\n\\nfn--loop s floor = cond s > floor => fn--loop (s - 1) floor, true => s.\\naccount--balance' a = fn--loop (account--balance a) floor.\\naccount--size' a1 = account--size a1.\\naccount--tick-count' a1 = account--tick-count a1.\\n"
 `;
 
 exports[`functions-mutating-fixed-point-while.ts > fillUpTo 1`] = `
-"module FILL_UP_TO.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--size a1: Account => Int.\\naccount--tick-count a1: Account => Int.\\nfn--loop s: Int, cap: Int => Int = cond s < cap => fn--loop (s + 1) cap, true => s.\\n~> Fill-up-to @ a: Account, cap: Int.\\n\\n---\\n\\naccount--size' a = fn--loop (account--size a) cap.\\naccount--balance' a1 = account--balance a1.\\naccount--tick-count' a1 = account--tick-count a1.\\n"
+"module FILL_UP_TO.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--size a1: Account => Int.\\naccount--tick-count a1: Account => Int.\\nfn--loop s: Int, cap: Int => Int.\\n~> Fill-up-to @ a: Account, cap: Int.\\n\\n---\\n\\nfn--loop s cap = cond s < cap => fn--loop (s + 1) cap, true => s.\\naccount--size' a = fn--loop (account--size a) cap.\\naccount--balance' a1 = account--balance a1.\\naccount--tick-count' a1 = account--tick-count a1.\\n"
 `;
 
 exports[`functions-mutating-fixed-point-while.ts > spin 1`] = `
@@ -947,7 +947,7 @@ exports[`functions-mutating-fixed-point-while.ts > spin 1`] = `
 `;
 
 exports[`functions-mutating-loop-break.ts > addUntilLimit 1`] = `
-"module ADD_UNTIL_LIMIT.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\nfn--loop s: Int, n: Int => Int = cond 0 < n and s >= n => s + 1, 0 < n => fn--loop (s + 1) n, true => s.\\n~> Add-until-limit @ a: Account, n: Int.\\n\\n---\\n\\naccount--balance' a = fn--loop (account--balance a) n.\\n"
+"module ADD_UNTIL_LIMIT.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\nfn--loop s: Int, n: Int => Int.\\n~> Add-until-limit @ a: Account, n: Int.\\n\\n---\\n\\nfn--loop s n = cond 0 < n and s >= n => s + 1, 0 < n => fn--loop (s + 1) n, true => s.\\naccount--balance' a = fn--loop (account--balance a) n.\\n"
 `;
 
 exports[`functions-mutating-loop-continue.ts > setPositiveLastIndex 1`] = `
@@ -999,7 +999,7 @@ exports[`functions-mutating-loop.ts > sumScaledAssert 1`] = `
 `;
 
 exports[`functions-mutating-while-true-break.ts > eventLoopUntilLimit 1`] = `
-"module EVENT_LOOP_UNTIL_LIMIT.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\nfn--loop s: Int, n: Int => Int = cond true and s >= n => s + 1, true => fn--loop (s + 1) n, true => s.\\n~> Event-loop-until-limit @ a: Account, n: Int.\\n\\n---\\n\\naccount--balance' a = fn--loop (account--balance a) n.\\n"
+"module EVENT_LOOP_UNTIL_LIMIT.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\nfn--loop s: Int, n: Int => Int.\\n~> Event-loop-until-limit @ a: Account, n: Int.\\n\\n---\\n\\nfn--loop s n = cond true and s >= n => s + 1, true => fn--loop (s + 1) n, true => s.\\naccount--balance' a = fn--loop (account--balance a) n.\\n"
 `;
 
 exports[`functions-mutating.ts > deposit 1`] = `

--- a/tools/ts2pant/tests/ir1-ssa-fixed-point.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-fixed-point.test.mts
@@ -151,10 +151,13 @@ describe("ir1-ssa-fixed-point", () => {
       propositions: result.propositions,
       checks: [],
     });
+    // Header (above `---`): bare rule declaration, no body.
     assert.match(
       source,
-      /fn--loop s: Nat0, step: Nat0, target: Nat0 => Nat0 = cond/u,
+      /fn--loop s: Nat0, step: Nat0, target: Nat0 => Nat0\./u,
     );
+    // Body (below `---`): equation form with the cond body.
+    assert.match(source, /fn--loop s step target = cond/u);
     assert.match(source, /balance' a = fn--loop \(balance a\) step target\./u);
   });
 

--- a/wasm/pant_wasm.ml
+++ b/wasm/pant_wasm.ml
@@ -462,7 +462,6 @@ let () =
              params = js_array_to_list params;
              guards = js_array_to_list guards;
              return_type = returnType;
-             body = None;
              contexts = [];
            }
 


### PR DESCRIPTION
## Summary

- Teach Pant's SMT layer to recognise chapter-body equations as definitions of declared rules, so recursive ones emit `(define-fun-rec ...)` without requiring inline-body grammar.
- Walk back `d21fb10`'s inline `<name> <params> => <type> = <body>.` production: with the recognition pass in place, the inline form is structurally redundant and Pantagruel keeps a single declaration shape (rules declare in the chapter head, equations define in the chapter body).
- ts2pant emits `rule-decl` split across the `---` divider, matching every other dogfood fixture's emit shape. Update affected snapshots and the unit-test regex that pinned the old inline shape.
- Independent: ts2pant's annotation parser is rewritten to use `ts.getJSDocTags` instead of hand-rolled regex scanning — the standard library + TypeScript compiler API replace ~250 lines of character-level OCaml-style helpers with ~70 lines of straightforward dispatch.

## Background

The L4 fixed-point loop lowering (`8bb1231`, May 21) shipped a ts2pant emit shape — `fn--loop s: Int, n: Int => Int = cond ...` — that combined a rule declaration and its body on one line. A sibling commit on the same day (`d21fb10`) added the corresponding Pant grammar production and SMT lowering for inline rule bodies. The two together made the L4 fixtures verify, but at the cost of introducing a second declaration shape in Pantagruel whose only purpose was to carry the inline body.

The SMT semantics of an inline `body = Some` declaration are: route through `(define-fun-rec ...)` when the body references the rule's own name; otherwise emit a quantified axiom. None of that machinery is intrinsically tied to the inline syntax — the equivalent (declaration in head, equation in body) already lives in Pantagruel's grammar, and the SMT layer can match the two halves up at lowering time.

## What changed

### Pant

- `Env.attach_rule_body`: attach a body expression to an already-declared rule's `rule_bodies` entry, computing the recursive-self-reference flag with `expr_applies_name` (same path `Env.add_rule`'s inline-body case used).
- `Collect.recognize_split_form_bodies`: walks each chapter body, matches equations of shape `<rule-name> <param-names> = <body>.` against same-chapter declarations (LHS must be the rule applied to bare references of its parameter names, in order), attaches the body to the env, and removes the equation from the chapter body so it isn't also emitted as a duplicate quantified axiom.
- `Smt.emit_rule_recursive` now takes the body as an explicit argument instead of pulling it from `decl.body`, so it works uniformly for whatever shape the body arrived through. (After grammar walkback, that's only the split form.)
- `bin/main run_smt_check` invokes the new pass between `check_with_imports` and `Smt.generate_queries`. The wasm checker doesn't need the pass — it only runs typecheck, not SMT.
- Grammar walkback: the two `<name> params => type = body.` productions in `lib/parser.mly` are removed; the `body : expr option` field on `DeclRule` is removed; `Smt.is_rule_recursive` (which keyed off `body = Some`) is dead and removed; `Env.add_rule` drops its `?body` optional parameter. Pattern matches that used `_` to ignore the field adapt automatically; pattern matches that named it explicitly (lib/ast.ml's pp/equal, lib/check.ml's guard checker, lib/json_output.ml, lib/markdown_output.ml, lib/pretty.ml) are updated.

### ts2pant

- `src/emit.ts`: `rule-decl` PropResult now renders as a bare declaration in the chapter head (`<name> <params> => <returnType>.`) plus a separate equation in the chapter body (`<name> <args> = <body>.`). Splits the prior inline emission across the chapter divider.
- Snapshot/test updates for the 14 fixed-point and loop-break/continue fixtures whose `rule-decl` emission shape changed correspondingly. `ir1-ssa-fixed-point.test.mts`'s regex assertion is updated to match the split form.
- `src/annotations.ts`: replaces the hand-rolled regex-based JSDoc scanner with `ts.getJSDocTags`. The application-level grammar this module owns is reduced to the `name: Type` split for `@pant-type` and the trivial dispatch between the four tag kinds. `parseAnnotations(text)` is removed from the public surface (it existed only because of hand-rolled text parsing); the tests reshape to AST-based input via the existing `firstFunction` helper.

## Verification

SMT output is byte-identical between the prior inline form and the new split form — both emit `(define-fun-rec fn__loop ((s Int) (n Int)) Int (ite (< s n) (fn__loop (+ s 1) n) s))` for the fixed-point fixtures.

## Test plan

- [x] `dune build` clean (with grammar walkback, no inline-body productions)
- [x] `dune build @fmt` clean
- [x] `dune runtest` — full Pant test suite passes
- [x] ts2pant `npm run test:unit` — 1004/1004 pass (3 skipped, z3-dependent)
- [x] ts2pant `npm run test:integration` — 60/60 pass, including every `pant --check` recursive fixture (`fillUpTo`, `drainTo`, `climbUntilBreak`, `climbUnlessZeroStep`, `climbUntilReturn`, `climbAndReturn`, `climbUnlessInvalid`, `eventLoopUntilLimit`, `adjustBalanceTo`, `addUntilLimit`, etc.)
- [x] Wasm bundle rebuilt and tests re-run against fresh wasm

🤖 Generated with [Claude Code](https://claude.com/claude-code)