### PR TITLE
[ts2pant-const-binding-ssa] Patch 2: Add local-binding IR1SsaLocation variant + scalar SSA versioning (dormant)

### DIFF
--- a/tools/ts2pant/src/ir1-printer.ts
+++ b/tools/ts2pant/src/ir1-printer.ts
@@ -86,6 +86,8 @@ export function formatIR1SsaLocation(loc: IR1SsaLocation): string {
       return formatIR1Expr(loc.receiver);
     case "return-value":
       return `return-value ${loc.ruleName}`;
+    case "local-binding":
+      return loc.name;
     default: {
       const _exhaustive: never = loc;
       throw new Error(
@@ -156,7 +158,10 @@ export function formatIR1SsaProgram(program: IR1SsaProgram): string {
     const key = locationKey(write.location);
     const priorVersion = currentVersions.get(key) ?? null;
     let readLabels: ReadonlyMap<string, string>;
-    if (write.value.kind === "property") {
+    if (
+      write.value.kind === "property" ||
+      write.value.kind === "local-binding"
+    ) {
       const built = new Map<string, string>();
       readCursor = consumeScalarReadsForExpr(
         write.value.value,
@@ -168,6 +173,18 @@ export function formatIR1SsaProgram(program: IR1SsaProgram): string {
       readLabels = built;
     } else {
       readLabels = readExpressionLabels(currentVersions.values(), labeller);
+    }
+    if (write.location.kind === "local-binding") {
+      lines.push(
+        `${formatIR1SsaLocation(write.location)} = ${formatSsaWriteRhs(
+          write.value,
+          write.location,
+          priorVersion === null ? null : labeller.labelOf(priorVersion),
+          readLabels,
+        )}.    > local-binding`,
+      );
+      currentVersions.set(key, write.version);
+      continue;
     }
     lines.push(
       `${labeller.labelOf(write.version)} = ${formatSsaWriteRhs(
@@ -241,6 +258,8 @@ function formatSsaWriteRhs(
   switch (value.kind) {
     case "property":
       return formatIR1ExprWithSsaReads(value.value, readLabels);
+    case "local-binding":
+      return formatIR1ExprWithSsaReads(value.value, readLabels);
     case "map-value":
       return formatIR1ExprWithSsaReads(value.value, readLabels);
     case "map-membership":
@@ -276,7 +295,12 @@ function readExpressionLabels(
 ): Map<string, string> {
   const labels = new Map<string, string>();
   for (const version of versions) {
-    labels.set(readExpressionKey(version.location), labeller.labelOf(version));
+    labels.set(
+      readExpressionKey(version.location),
+      version.location.kind === "local-binding"
+        ? formatIR1SsaLocation(version.location)
+        : labeller.labelOf(version),
+    );
   }
   return labels;
 }
@@ -449,7 +473,17 @@ function consumeScalarReadsForExpr(
         readLabels,
         labeller,
       );
-    case "var":
+    case "var": {
+      const read = reads[cursor];
+      if (read !== undefined && read.location.kind === "local-binding") {
+        readLabels.set(
+          readExpressionKey(read.location),
+          formatIR1SsaLocation(read.location),
+        );
+        return cursor + 1;
+      }
+      return cursor;
+    }
     case "lit":
       return cursor;
     case "map-read":
@@ -479,6 +513,8 @@ function readExpressionKey(loc: IR1SsaLocation): string {
       return `set-membership:${formatIR1Expr(loc.receiver)}`;
     case "return-value":
       return `return-value:${loc.ruleName}`;
+    case "local-binding":
+      return `local-binding:${loc.name}`;
     default: {
       const _exhaustive: never = loc;
       throw new Error(
@@ -494,7 +530,10 @@ function formatIR1ExprWithSsaReads(
 ): string {
   switch (expr.kind) {
     case "var":
-      return `${expr.name}${expr.primed === true ? "'" : ""}`;
+      return (
+        readLabels.get(`local-binding:${expr.name}`) ??
+        `${expr.name}${expr.primed === true ? "'" : ""}`
+      );
     case "lit":
       return formatIR1Literal(expr.value);
     case "binop":
@@ -634,6 +673,8 @@ function locationAsPrimedRule(loc: IR1SsaLocation): string {
       return `${formatIR1Expr(loc.receiver)}'`;
     case "return-value":
       return `return-value' ${loc.ruleName}`;
+    case "local-binding":
+      return loc.name;
     default: {
       const _exhaustive: never = loc;
       throw new Error(

--- a/tools/ts2pant/src/ir1-ssa-scalars.ts
+++ b/tools/ts2pant/src/ir1-ssa-scalars.ts
@@ -637,6 +637,9 @@ function lowerScalarSsaCondToVersions(
     if (location === undefined) {
       throw new Error("scalar SSA branch touched an unknown location");
     }
+    if (location.kind === "local-binding") {
+      continue;
+    }
     const thenVersion =
       thenState.currentVersions.get(key) ??
       initialVersionFor(key, location, thenState);
@@ -957,6 +960,9 @@ function lowerScalarCondStmt(
       state.locations.get(key);
     if (location === undefined) {
       throw new Error("scalar SSA branch touched an unknown location");
+    }
+    if (location.kind === "local-binding") {
+      continue;
     }
     const thenVersion =
       thenState.currentVersions.get(key) ??

--- a/tools/ts2pant/src/ir1-ssa-scalars.ts
+++ b/tools/ts2pant/src/ir1-ssa-scalars.ts
@@ -11,6 +11,8 @@ import {
   type IR1Stmt,
   ir1SsaInitialVersion,
   ir1SsaJoin,
+  ir1SsaLocalBindingLocation,
+  ir1SsaLocalBindingValue,
   ir1SsaPropertyLocation,
   ir1SsaPropertyValue,
   ir1SsaRead,
@@ -161,6 +163,23 @@ export function lowerScalarSsaToProps(
   const ast = getAst();
   const finalProperties: ScalarSsaFinalPropertyEntry[] = [];
   const propositions: PropResult[] = [];
+  for (const write of program.writes) {
+    if (write.location.kind !== "local-binding") {
+      continue;
+    }
+    const rhs = lowerState.versionExprs.get(write.version);
+    if (rhs === undefined) {
+      throw new Error(
+        "missing lowered expression for local-binding SSA version",
+      );
+    }
+    propositions.push({
+      kind: "equation",
+      quantifiers: [],
+      lhs: ast.var(write.location.name),
+      rhs,
+    });
+  }
   for (const [key, version] of lowerState.currentVersions) {
     const location = lowerState.locations.get(key);
     if (location === undefined || location.kind !== "property") {
@@ -184,7 +203,6 @@ export function lowerScalarSsaToProps(
       rhs,
     });
   }
-
   return {
     program,
     finalProperties,
@@ -312,6 +330,8 @@ export function isScalarSsaL1Body(stmt: IR1Stmt): boolean {
         ) &&
         (stmt.otherwise === null || isScalarSsaL1Body(stmt.otherwise))
       );
+    case "let":
+      return isScalarSsaExpr(stmt.value);
     case "map-effect":
     case "set-effect":
     case "foreach":
@@ -321,7 +341,6 @@ export function isScalarSsaL1Body(stmt: IR1Stmt): boolean {
     case "break":
     case "continue":
     case "throw":
-    case "let":
     case "expr-stmt":
       return false;
     default: {
@@ -348,6 +367,9 @@ export function lowerScalarSsaL1Body(
     case "cond-stmt":
       lowerScalarCondStmt(stmt, state);
       return;
+    case "let":
+      lowerScalarLet(stmt, state);
+      return;
     case "map-effect":
     case "set-effect":
     case "foreach":
@@ -357,7 +379,6 @@ export function lowerScalarSsaL1Body(
     case "break":
     case "continue":
     case "throw":
-    case "let":
     case "expr-stmt":
       throw new Error(`${stmt.kind} is not supported by scalar SSA lowering`);
     default: {
@@ -421,6 +442,8 @@ export function scalarSsaReadExpr(
       scalarSsaReadExpr(expr.body, state);
       return expr;
     case "var":
+      scalarSsaReadLocalBinding(expr.name, state);
+      return expr;
     case "lit":
       return expr;
     case "map-read":
@@ -448,6 +471,20 @@ function lowerScalarAssign(
   state.currentVersions.set(key, write.version);
   state.writtenKeys.add(key);
   state.modifiedRules.add(ir1SsaRuleOfLocation(location));
+}
+
+function lowerScalarLet(
+  stmt: Extract<IR1Stmt, { kind: "let" }>,
+  state: ScalarSsaState,
+): void {
+  const value = scalarSsaReadExpr(stmt.value, state);
+  const location = ir1SsaLocalBindingLocation(stmt.name);
+  const key = scalarLocalBindingKey(stmt.name);
+  state.locations.set(key, location);
+  initialVersionFor(key, location, state);
+  const write = ir1SsaWrite(location, ir1SsaLocalBindingValue(value));
+  state.writes.push(write);
+  state.currentVersions.set(key, write.version);
 }
 
 interface ScalarSsaLowerState {
@@ -503,6 +540,9 @@ function lowerScalarSsaStmtToVersions(
     case "cond-stmt":
       lowerScalarSsaCondToVersions(stmt, state);
       return;
+    case "let":
+      lowerScalarSsaLetToVersions(stmt, state);
+      return;
     case "map-effect":
     case "set-effect":
     case "foreach":
@@ -512,7 +552,6 @@ function lowerScalarSsaStmtToVersions(
     case "break":
     case "continue":
     case "throw":
-    case "let":
     case "expr-stmt":
       throw new Error(`${stmt.kind} is not supported by scalar SSA lowering`);
     default: {
@@ -545,6 +584,25 @@ function lowerScalarSsaAssignToVersions(
   state.locations.set(key, location);
   state.versionExprs.set(write.version, rhs);
   state.writtenKeys.add(key);
+}
+
+function lowerScalarSsaLetToVersions(
+  stmt: Extract<IR1Stmt, { kind: "let" }>,
+  state: ScalarSsaLowerState,
+): void {
+  const write = nextScalarSsaWrite(state);
+  const location = ir1SsaLocalBindingLocation(stmt.name);
+  if (!sameScalarSsaLocation(write.location, location, state.canonicalize)) {
+    throw new Error(
+      "scalar SSA write order did not match its local-binding location",
+    );
+  }
+  const rhs = lowerScalarSsaExprToOpaque(stmt.value, state);
+  const key = scalarLocalBindingKey(stmt.name);
+  state.locations.set(key, location);
+  initialVersionFor(key, location, state);
+  state.currentVersions.set(key, write.version);
+  state.versionExprs.set(write.version, rhs);
 }
 
 function lowerScalarSsaCondToVersions(
@@ -635,7 +693,13 @@ function lowerScalarSsaExprToOpaque(
         initialVersionFor(key, location, state);
       return resolveScalarSsaVersionExpr(version, state);
     }
-    case "var":
+    case "var": {
+      const local = scalarSsaLocalBindingVersion(expr.name, state);
+      if (local !== null) {
+        return resolveScalarSsaVersionExpr(local.version, state);
+      }
+      return state.lowerOpaque(lowerScalarOpaqueExpr(expr, state.canonicalize));
+    }
     case "lit":
       return state.lowerOpaque(lowerScalarOpaqueExpr(expr, state.canonicalize));
     case "binop":
@@ -814,6 +878,7 @@ function nextScalarSsaWrite(
   state.writeIndex += 1;
   if (
     expectedRule !== undefined &&
+    write.location.kind !== "local-binding" &&
     ir1SsaRuleOfLocation(write.location) !== expectedRule
   ) {
     throw new Error("scalar SSA write sequence did not match the source order");
@@ -858,9 +923,15 @@ function lowerScalarCondStmt(
   state.writes.push(...thenState.writes, ...elseState.writes);
   state.joins.push(...thenState.joins, ...elseState.joins);
   for (const [key, location] of thenState.locations) {
+    if (location.kind === "local-binding") {
+      continue;
+    }
     state.locations.set(key, location);
   }
   for (const [key, location] of elseState.locations) {
+    if (location.kind === "local-binding") {
+      continue;
+    }
     if (!state.locations.has(key)) {
       state.locations.set(key, location);
     }
@@ -931,6 +1002,39 @@ function scalarSsaReadMember(
   return read;
 }
 
+function scalarSsaReadLocalBinding(
+  name: string,
+  state: ScalarSsaState,
+): IR1SsaRead | null {
+  const local = scalarSsaLocalBindingVersion(name, state);
+  if (local === null) {
+    return null;
+  }
+  const read = ir1SsaRead(local.location, local.version, true);
+  state.reads.push(read);
+  return read;
+}
+
+function scalarSsaLocalBindingVersion(
+  name: string,
+  state: ScalarSsaInitialVersionState & {
+    currentVersions: Map<string, IR1SsaVersion>;
+    locations: Map<string, IR1SsaLocation>;
+  },
+): { key: string; location: IR1SsaLocation; version: IR1SsaVersion } | null {
+  const key = scalarLocalBindingKey(name);
+  const location = state.locations.get(key);
+  if (location === undefined) {
+    return null;
+  }
+  if (location.kind !== "local-binding") {
+    throw new Error("local binding key resolved to a non-local SSA location");
+  }
+  const version =
+    state.currentVersions.get(key) ?? initialVersionFor(key, location, state);
+  return { key, location, version };
+}
+
 function scalarLocationForMember(
   member: Extract<IR1Expr, { kind: "member" }>,
   state: ScalarSsaLocationState,
@@ -967,6 +1071,10 @@ function initialVersionFor(
 
 function scalarPropertyKey(prop: string, receiver: string): string {
   return `${prop}::${receiver}`;
+}
+
+function scalarLocalBindingKey(name: string): string {
+  return `local-binding::${name}`;
 }
 
 function scalarOpaquePropertyKey(prop: string, receiver: OpaqueExpr): string {
@@ -1094,6 +1202,8 @@ function sameScalarSsaLocation(
       );
     case "return-value":
       return right.kind === "return-value" && left.ruleName === right.ruleName;
+    case "local-binding":
+      return right.kind === "local-binding" && left.name === right.name;
     default: {
       const _exhaustive: never = left;
       void _exhaustive;

--- a/tools/ts2pant/src/ir1-substitute.ts
+++ b/tools/ts2pant/src/ir1-substitute.ts
@@ -122,6 +122,7 @@ export function freeVarsIR1SsaLocation(location: IR1SsaLocation): Set<string> {
     case "set-membership":
       return freeVarsIR1Expr(location.receiver);
     case "return-value":
+    case "local-binding":
       return new Set();
     default: {
       const _exhaustive: never = location;
@@ -316,6 +317,7 @@ function freeVarsFoldLeaf(leaf: IR1FoldLeaf, bound: Set<string>): Set<string> {
 function freeVarsIR1SsaValue(value: IR1SsaValue): Set<string> {
   switch (value.kind) {
     case "property":
+    case "local-binding":
     case "map-value":
       return freeVarsIR1Expr(value.value);
     case "map-membership":

--- a/tools/ts2pant/src/ir1.ts
+++ b/tools/ts2pant/src/ir1.ts
@@ -463,6 +463,10 @@ export type IR1SsaLocation =
   | {
       kind: "return-value";
       ruleName: IR1SsaRuleName;
+    }
+  | {
+      kind: "local-binding";
+      name: string;
     };
 
 export interface IR1SsaVersion {
@@ -506,8 +510,14 @@ export type IR1SsaPropertyValue = {
   value: IR1Expr;
 };
 
+export type IR1SsaLocalBindingValue = {
+  kind: "local-binding";
+  value: IR1Expr;
+};
+
 export type IR1SsaValue =
   | IR1SsaPropertyValue
+  | IR1SsaLocalBindingValue
   | IR1SsaMapValue
   | IR1SsaMapMembershipValue
   | IR1SsaSetMembershipValue;
@@ -667,10 +677,32 @@ export const ir1SsaReturnValueLocation = (
   ruleName,
 });
 
+export const ir1SsaLocalBindingLocation = (
+  name: string,
+): Extract<IR1SsaLocation, { kind: "local-binding" }> => ({
+  kind: "local-binding",
+  name,
+});
+
 export const ir1SsaRuleOfLocation = (
   location: IR1SsaLocation,
-): IR1SsaRuleName =>
-  location.kind === "map-membership" ? location.keyPredName : location.ruleName;
+): IR1SsaRuleName => {
+  switch (location.kind) {
+    case "property":
+    case "map-value":
+    case "set-membership":
+    case "return-value":
+      return location.ruleName;
+    case "map-membership":
+      return location.keyPredName;
+    case "local-binding":
+      throw new Error("local-binding SSA locations do not have a rule name");
+    default: {
+      const _exhaustive: never = location;
+      return _exhaustive;
+    }
+  }
+};
 
 const ir1SsaVersion = (
   location: IR1SsaLocation,
@@ -857,6 +889,13 @@ export const ir1SsaPropertyValue = (value: IR1Expr): IR1SsaPropertyValue => ({
   value,
 });
 
+export const ir1SsaLocalBindingValue = (
+  value: IR1Expr,
+): IR1SsaLocalBindingValue => ({
+  kind: "local-binding",
+  value,
+});
+
 export const ir1SsaMapSetValue = (value: IR1Expr): IR1SsaMapValue => ({
   kind: "map-value",
   op: "set",
@@ -951,6 +990,12 @@ const ir1SsaLocationEquals = (
         return false;
       }
       return a.ruleName === b.ruleName;
+    }
+    case "local-binding": {
+      if (b.kind !== "local-binding") {
+        return false;
+      }
+      return a.name === b.name;
     }
     default: {
       const _exhaustive: never = a;

--- a/tools/ts2pant/tests/ir1-ssa-scalars.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-scalars.test.mts
@@ -108,6 +108,25 @@ describe("ir1-ssa-scalars", () => {
     assert.equal(propertyWrite!.location.kind, "property");
   });
 
+  it("keeps branch-local let bindings out of scalar joins", () => {
+    const stmt = ir1CondStmt([[ir1Var("g"), ir1Let("x", ir1LitNat(5))]], null);
+    const state = makeScalarSsaState();
+
+    assert.equal(isScalarSsaL1Body(stmt), true);
+    lowerScalarSsaL1Body(stmt, state);
+
+    assert.equal(state.writes.length, 1);
+    assert.equal(state.writes[0]!.location.kind, "local-binding");
+    assert.equal(state.joins.length, 0);
+    assert.equal(state.writtenKeys.size, 0);
+    assert.equal(
+      [...state.locations.values()].some(
+        (location) => location.kind === "local-binding",
+      ),
+      false,
+    );
+  });
+
   it("resolves compound property assignment through the dominating prior version", () => {
     const balance = ir1Member(ir1Var("a"), "Account_balance");
     const stmt = ir1Block([

--- a/tools/ts2pant/tests/ir1-ssa-scalars.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-scalars.test.mts
@@ -11,13 +11,16 @@ import {
   ir1CondStmt,
   ir1LitBool,
   ir1LitNat,
+  ir1Let,
   ir1Member,
   ir1Var,
 } from "../src/ir1.js";
 import {
   buildScalarSsaProgram,
   isScalarSsaL1Body,
+  lowerScalarSsaL1Body,
   lowerScalarSsaToProps,
+  makeScalarSsaState,
 } from "../src/ir1-ssa-scalars.js";
 import type { OpaqueExpr } from "../src/pant-ast.js";
 import { getAst, loadAst } from "../src/pant-wasm.js";
@@ -77,6 +80,32 @@ describe("ir1-ssa-scalars", () => {
     assert.equal(write.version.location, write.location);
     assert.deepEqual(write.value, { kind: "property", value: ir1LitNat(1) });
     assert.equal(scalarEquationRhs(stmt), "1");
+  });
+
+  it("versions let bindings as local-binding writes and resolves later reads", () => {
+    const stmt = ir1Block([
+      ir1Let("x", ir1LitNat(5)),
+      ir1Assign(ir1Member(ir1Var("a"), "Account_balance"), ir1Var("x")),
+    ]);
+    const state = makeScalarSsaState();
+
+    assert.equal(isScalarSsaL1Body(stmt), true);
+    lowerScalarSsaL1Body(stmt, state);
+
+    assert.equal(state.writes.length, 2);
+    assert.equal(state.reads.length, 1);
+    const [letWrite, propertyWrite] = state.writes;
+    assert.equal(letWrite!.location.kind, "local-binding");
+    assert.equal(letWrite!.location.name, "x");
+    assert.equal(letWrite!.version.location, letWrite!.location);
+    assert.deepEqual(letWrite!.value, {
+      kind: "local-binding",
+      value: ir1LitNat(5),
+    });
+    assert.equal(state.reads[0]!.location, letWrite!.location);
+    assert.equal(state.reads[0]!.version, letWrite!.version);
+    assert.equal(state.reads[0]!.dominated, true);
+    assert.equal(propertyWrite!.location.kind, "property");
   });
 
   it("resolves compound property assignment through the dominating prior version", () => {


### PR DESCRIPTION
## Patch 2: Add local-binding IR1SsaLocation variant + scalar SSA versioning (dormant)

- Add the new IR1SsaLocation variant + constructor in `ir1.ts`. The constructor mirrors the existing `ir1SsaPropertyLocation` shape.
- In `ir1-ssa-scalars.ts`, the new `lowerScalarLet` function follows the existing `lowerScalarAssign` template: it does NOT participate in branch-join machinery (a let is a single-version write, not a mutated location that joins across branches), but it DOES participate in the read-resolution pipeline so subsequent reads of the bound name resolve correctly. If `lowerScalarLet` is called with a binding whose name is already bound in `state`, it overwrites the resolution (shadowing — standard lexical scoping; the inner binding wins).
- In `ir1-printer.ts`, the new dispatch arm for `local-binding` writes follows the existing property-write template at the call site that emits primed-rule equations, but produces a non-primed equation: `<name> = <strExpr(value)>.`
- In `ir1-ssa-scalars.test.mts`, the new test exercises `lowerScalarSsaL1Body` end-to-end on a hand-constructed IR1 program containing `IR1Let` nodes. Use the existing test fixtures' pattern as a template.
- DO NOT modify `ir1-build-body.ts` or `translate-body.ts` in this patch. The IR1 builder still does NOT produce `IR1Let` nodes; the new SSA path is dormant until Patch 3 wires the producer.

## Changes
- Add the new IR1SsaLocation variant + constructor in `ir1.ts`. The constructor mirrors the existing `ir1SsaPropertyLocation` shape.
- In `ir1-ssa-scalars.ts`, the new `lowerScalarLet` function follows the existing `lowerScalarAssign` template: it does NOT participate in branch-join machinery (a let is a single-version write, not a mutated location that joins across branches), but it DOES participate in the read-resolution pipeline so subsequent reads of the bound name resolve correctly. If `lowerScalarLet` is called with a binding whose name is already bound in `state`, it overwrites the resolution (shadowing — standard lexical scoping; the inner binding wins).
- In `ir1-printer.ts`, the new dispatch arm for `local-binding` writes follows the existing property-write template at the call site that emits primed-rule equations, but produces a non-primed equation: `<name> = <strExpr(value)>.`
- In `ir1-ssa-scalars.test.mts`, the new test exercises `lowerScalarSsaL1Body` end-to-end on a hand-constructed IR1 program containing `IR1Let` nodes. Use the existing test fixtures' pattern as a template.
- DO NOT modify `ir1-build-body.ts` or `translate-body.ts` in this patch. The IR1 builder still does NOT produce `IR1Let` nodes; the new SSA path is dormant until Patch 3 wires the producer.

## Files to Modify
- tools/ts2pant/src/ir1.ts (modify): Extend `IR1SsaLocation` at `:431-466` with a new variant `{ kind: "local-binding"; name: string }`. Add constructor `ir1SsaLocalBindingLocation(name: string): Extract<IR1SsaLocation, { kind: "local-binding" }>` near the other location constructors.
- tools/ts2pant/src/ir1-printer.ts (modify): Add a dispatch arm in `formatIR1SsaLocation` for the new `local-binding` variant — render as the binding's `name` (no receiver, no rule-name prefix). The location format is used in printer output for SSA writes and reads; local bindings render as bare names. Also extend the per-write emission path so a `local-binding` write produces a chapter-body equation `<name> = <RHS>.` (no priming, no framing).
- tools/ts2pant/src/ir1-ssa-scalars.ts (modify): Replace the `throw new Error(...)` at `:360` for `case "let"` with a call to new function `lowerScalarLet(stmt, state)` which: (a) allocates a fresh `IR1SsaLocation` of kind `local-binding` via `ir1SsaLocalBindingLocation(stmt.name)`; (b) opens an initial version for the location; (c) emits a write whose value is the lowered initializer expression `stmt.value`; (d) registers the binding name → location mapping in `state` so subsequent reads of `IR1Var(stmt.name)` resolve to the binding's most-recent SSA version. Update `recognizeMutatingShape` at `:324` to return `true` for `case "let"` (the binding participates in scalar SSA). Extend `ScalarSsaState`'s read-resolution path (the function that maps `IR1Var(name)` to its current SSA version) so let-bound names resolve through the binding's version chain.
- tools/ts2pant/tests/ir1-ssa-scalars.test.mts (modify): Add test stubs (unskipped — Patch 2 is INFRA but exercises the dormant code paths directly): a unit test that constructs an IR1 program with an `ir1Let("x", ir1LitNat(5))` followed by a read of `x`, runs `lowerScalarSsaL1Body`, and verifies the resulting SSA program contains one write to a `local-binding` location and one read of the resulting version. The test does NOT exercise the translator end-to-end (that's Patch 3); it exercises the SSA layer directly.

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[paper] Knobe & Sarkar 1998 — Array SSA Form** — https://doi.org/10.1145/268946.268956 — Establishes the Memory-SSA framing: every location-with-versioned-writes obeys the same protocol regardless of whether the location is a syntactic variable, an array element, or a property reference. Local bindings under this patch are the degenerate case — one preheader version, one or more writes, no priming. The protocol carries over uniformly.
- **[paper] Chow et al. 1996 — Effective Representation of Aliases and Indirect Memory Operations in SSA Form** — https://doi.org/10.1007/3-540-61053-7_72 — Already cited in `tools/ts2pant/AGENTS.md` as the foundational reference for ts2pant's scalar property-location SSA. The new `local-binding` variant follows the same indirect-memory-operation discipline: every read of a bound name is resolved to the current version; every write creates a fresh version; the version chain is the location's history.

## Gameplan Specification

```
module TS2PANT_CONST_BINDING_SSA.

> When this gameplan is complete: every TypeScript const binding in a
> function-body prelude is routed through IR1Let -> scalar SSA -> a
> local-binding IR1SsaLocation variant -> chapter-body equation
> emission. The inlineConstBindings infrastructure is deleted; the
> expressionHasSideEffects purity gate is no longer consulted by the
> prelude scanner. let and var continue to reject. Two helper functions
> in translate-types.ts (manglePantTypeToFragment, depModuleNameForFile)
> carry SMT-verified @pant annotations wired into the dogfood
> integration suite. Downstream Pant emission of newly-accepted builtin
> calls remains a free-call-decl gap addressed by a separate workstream.

TsConstBinding.
TsExpression.
IR1Let.
IR1SsaLocation.
IR1SsaVersion.
IR1SsaWrite.
PantOutput.
UnsupportedReason.
FunctionName.
LocationKind.
property => LocationKind.
map-value => LocationKind.
map-membership => LocationKind.
set-membership => LocationKind.
return-value => LocationKind.
local-binding => LocationKind.
side-effectful-const => UnsupportedReason.
free-call-decl => UnsupportedReason.
mangle-pant-type-to-fragment => FunctionName.
dep-module-name-for-file => FunctionName.

is-const-binding? d: TsConstBinding => Bool.
becomes-ir1-let? d: TsConstBinding, n: IR1Let => Bool.
location-kind l: IR1SsaLocation => LocationKind.
is-local-binding? l: IR1SsaLocation => Bool.
has-primed-counterpart? l: IR1SsaLocation => Bool.
has-framing-obligation? l: IR1SsaLocation => Bool.
lowers-let-statement? stmt: IR1Let, w: IR1SsaWrite => Bool.
emits-unsupported? out: PantOutput, r: UnsupportedReason => Bool.
translate-prelude bindings: TsConstBinding => PantOutput.
has-dogfood-entry? fn: FunctionName => Bool.
min-checks fn: FunctionName => Nat0.
translates-without-unsupported? fn: FunctionName => Bool.
annotations-entail? fn: FunctionName => Bool.
location-of w: IR1SsaWrite => IR1SsaLocation.
---

> The local-binding location class has no primed counterpart and no
> framing obligation.
all l: IR1SsaLocation |
  is-local-binding? l ->
    ~(has-primed-counterpart? l) and ~(has-framing-obligation? l).

> Every TS const binding becomes one IR1Let.
all d: TsConstBinding, n: IR1Let |
  becomes-ir1-let? d n -> is-const-binding? d.

> Every IR1Let lowers through scalar SSA into one versioned write
> to a local-binding location.
all stmt: IR1Let, w: IR1SsaWrite |
  lowers-let-statement? stmt w ->
    is-local-binding? (location-of w).

> The side-effectful-const unsupported reason is never produced.
all bindings: TsConstBinding, out: PantOutput |
  out = translate-prelude bindings ->
    ~(emits-unsupported? out side-effectful-const).

> The two target dogfood functions are wired with at least two
> SMT-verified annotations each.
has-dogfood-entry? mangle-pant-type-to-fragment.
has-dogfood-entry? dep-module-name-for-file.
min-checks mangle-pant-type-to-fragment >= 2.
min-checks dep-module-name-for-file >= 2.
translates-without-unsupported? mangle-pant-type-to-fragment.
translates-without-unsupported? dep-module-name-for-file.
annotations-entail? mangle-pant-type-to-fragment.
annotations-entail? dep-module-name-for-file.
```

## Patch Specification

```
module TS2PANT_CONST_BINDING_SSA_PATCH_2.

> Patch 2 lands the IR1SsaLocation local-binding variant and the
> scalar SSA versioning for IR1Let. The new vocabulary is dormant
> until Patch 3 wires the IR1 builder to produce IR1Let nodes.

IR1SsaLocation.
IR1SsaVersion.
IR1Let.
IR1SsaWrite.
IR1SsaState.
LocationKind.
property => LocationKind.
map-value => LocationKind.
map-membership => LocationKind.
set-membership => LocationKind.
return-value => LocationKind.
local-binding => LocationKind.

location-kind l: IR1SsaLocation => LocationKind.
is-local-binding? l: IR1SsaLocation => Bool.
has-primed-counterpart? l: IR1SsaLocation => Bool.
has-framing-obligation? l: IR1SsaLocation => Bool.
version-of w: IR1SsaWrite => IR1SsaVersion.
location-of w: IR1SsaWrite => IR1SsaLocation.
lowers-let-statement? stmt: IR1Let, state: IR1SsaState, w: IR1SsaWrite => Bool.
---

> The local-binding variant has no primed counterpart and no
> framing obligation.
all l: IR1SsaLocation |
  is-local-binding? l ->
    ~(has-primed-counterpart? l) and ~(has-framing-obligation? l).

> Every IR1Let statement lowers through scalar SSA into one
> versioned write to a local-binding location.
all stmt: IR1Let, state: IR1SsaState, w: IR1SsaWrite |
  lowers-let-statement? stmt state w ->
    is-local-binding? (location-of w).
```


## Implementation Notes

- Added `IR1SsaLocalBindingValue` alongside the location variant so the existing value/location compatibility assertion remains intact instead of special-casing local writes.
- `local-binding` locations deliberately do not flow through rule accounting: `ir1SsaRuleOfLocation` rejects them, `lowerScalarLet` does not add `modifiedRules`, and printer emission uses a bare equation path rather than `locationAsPrimedRule`.
- Branch behavior is intentionally conservative: let writes are recorded for branch-local SSA reads, but they do not mark `writtenKeys`, and branch-created local locations are not merged into the outer scalar state. That keeps locals out of branch joins and avoids leaking a binding that only exists inside one branch.
- `lowerScalarSsaToProps` now emits local-binding equations from SSA writes before final property equations. Patch 3 can reuse this path when the builder starts producing prelude `IR1Let` nodes.
- Exhaustive consumers outside the original file list needed updates in `ir1-substitute.ts` so free-variable analysis understands local-binding locations and values.

Spec/Evidence Mapping:
- Local-binding has no primed counterpart/framing obligation: implemented by the `ir1-printer.ts` local write path and by excluding local bindings from `modifiedRules` / frame rule accounting; covered by `just ts2pant-precommit`.
- Every `IR1Let` lowers to a local-binding write: implemented in `lowerScalarLet` and `lowerScalarSsaLetToVersions`; covered by `versions let bindings as local-binding writes and resolves later reads` in `ir1-ssa-scalars.test.mts`.
- Dormant producer constraint: no changes were made to `ir1-build-body.ts` or `translate-body.ts`; existing translator tests stayed snapshot-stable under `just ts2pant-precommit`.