### PR TITLE
[ts2pant-stdlib-batch-1] Patch 1: Refactor BUILTINS to derive rule/mod from surface-form key

### DIFF
--- a/tools/ts2pant/src/builtins.ts
+++ b/tools/ts2pant/src/builtins.ts
@@ -62,10 +62,7 @@ const BUILTINS: Map<BuiltinKey, { arity: number }> = new Map([
   ["String.prototype.indexOf", { arity: 1 }],
 ]);
 
-export function deriveBuiltinSpec(
-  key: BuiltinKey,
-  arity: number,
-): BuiltinSpec {
+export function deriveBuiltinSpec(key: BuiltinKey, arity: number): BuiltinSpec {
   const namespace = key.startsWith("Math.") ? "Math" : "String.prototype";
   const method =
     namespace === "Math"
@@ -73,9 +70,9 @@ export function deriveBuiltinSpec(
       : key.slice("String.prototype.".length);
   const mod: DepModuleName = namespace === "Math" ? "JS_MATH" : "JS_STRING";
   const kebab = method
-    .replace(/([A-Z])/g, "-$1")
+    .replace(/([A-Z])/gu, "-$1")
     .toLowerCase()
-    .replace(/^-/, "");
+    .replace(/^-/u, "");
   const ruleName = RESERVED_RULE_NAMES.has(kebab) ? `${kebab}-of` : kebab;
   return { rule: `${mod}::${ruleName}`, mod, arity };
 }

--- a/tools/ts2pant/src/builtins.ts
+++ b/tools/ts2pant/src/builtins.ts
@@ -46,20 +46,39 @@ export interface BuiltinSpec {
  * uses "String.prototype.<name>") so the lookup logic can route by
  * which symbol-kind it just resolved.
  */
-type BuiltinKey = `Math.${string}` | `String.prototype.${string}`;
+export type BuiltinKey = `Math.${string}` | `String.prototype.${string}`;
 
-const BUILTINS: Map<BuiltinKey, BuiltinSpec> = new Map([
-  ["Math.max", { rule: "JS_MATH::max-of", mod: "JS_MATH", arity: 2 }],
-  ["Math.abs", { rule: "JS_MATH::abs", mod: "JS_MATH", arity: 1 }],
-  [
-    "String.prototype.toUpperCase",
-    { rule: "JS_STRING::to-upper-case", mod: "JS_STRING", arity: 0 },
-  ],
-  [
-    "String.prototype.indexOf",
-    { rule: "JS_STRING::index-of", mod: "JS_STRING", arity: 1 },
-  ],
+const RESERVED_RULE_NAMES: ReadonlySet<string> = new Set([
+  "max",
+  "min",
+  "cond",
+  "over",
 ]);
+
+const BUILTINS: Map<BuiltinKey, { arity: number }> = new Map([
+  ["Math.max", { arity: 2 }],
+  ["Math.abs", { arity: 1 }],
+  ["String.prototype.toUpperCase", { arity: 0 }],
+  ["String.prototype.indexOf", { arity: 1 }],
+]);
+
+export function deriveBuiltinSpec(
+  key: BuiltinKey,
+  arity: number,
+): BuiltinSpec {
+  const namespace = key.startsWith("Math.") ? "Math" : "String.prototype";
+  const method =
+    namespace === "Math"
+      ? key.slice("Math.".length)
+      : key.slice("String.prototype.".length);
+  const mod: DepModuleName = namespace === "Math" ? "JS_MATH" : "JS_STRING";
+  const kebab = method
+    .replace(/([A-Z])/g, "-$1")
+    .toLowerCase()
+    .replace(/^-/, "");
+  const ruleName = RESERVED_RULE_NAMES.has(kebab) ? `${kebab}-of` : kebab;
+  return { rule: `${mod}::${ruleName}`, mod, arity };
+}
 
 /**
  * Resolve a `ts.CallExpression` to a {@link BuiltinSpec} when its
@@ -104,7 +123,7 @@ export function lookupBuiltinByCall(
   const propAccess = expr.expression;
   const memberName = propAccess.name.text;
 
-  let spec: BuiltinSpec | undefined;
+  let key: BuiltinKey | undefined;
   if (
     ts.isIdentifier(propAccess.expression) &&
     propAccess.expression.text === "Math" &&
@@ -113,18 +132,23 @@ export function lookupBuiltinByCall(
       program,
     )
   ) {
-    spec = BUILTINS.get(`Math.${memberName}`);
+    key = `Math.${memberName}`;
   } else {
     const methodSymbol = checker.getSymbolAtLocation(propAccess.name);
     if (methodSymbol && isStringPrototypeMember(methodSymbol, program)) {
-      spec = BUILTINS.get(`String.prototype.${memberName}`);
+      key = `String.prototype.${memberName}`;
     }
   }
 
-  if (!spec) {
+  if (!key) {
     return null;
   }
-  return expr.arguments.length === spec.arity ? spec : null;
+  const entry = BUILTINS.get(key);
+  if (!entry) {
+    return null;
+  }
+  const fullSpec = deriveBuiltinSpec(key, entry.arity);
+  return expr.arguments.length === fullSpec.arity ? fullSpec : null;
 }
 
 function isDefaultLibSymbol(

--- a/tools/ts2pant/tests/builtins.test.mts
+++ b/tools/ts2pant/tests/builtins.test.mts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { Project } from "ts-morph";
 import ts from "typescript";
 import {
+  deriveBuiltinSpec,
   type DepModuleName,
   loadBuiltinDepModule,
   lookupBuiltinByCall,
@@ -38,6 +39,77 @@ function lookupFromSource(
   if (!call) throw new Error("No CallExpression found in source");
   return lookupBuiltinByCall(call, checker, program);
 }
+
+describe("deriveBuiltinSpec", () => {
+  it("maps Math.* keys to JS_MATH", () => {
+    assert.deepEqual(deriveBuiltinSpec("Math.foo", 1), {
+      rule: "JS_MATH::foo",
+      mod: "JS_MATH",
+      arity: 1,
+    });
+  });
+
+  it("maps String.prototype.* keys to JS_STRING", () => {
+    assert.deepEqual(deriveBuiltinSpec("String.prototype.foo", 1), {
+      rule: "JS_STRING::foo",
+      mod: "JS_STRING",
+      arity: 1,
+    });
+  });
+
+  it("lowers toUpperCase to kebab-case", () => {
+    assert.deepEqual(deriveBuiltinSpec("String.prototype.toUpperCase", 0), {
+      rule: "JS_STRING::to-upper-case",
+      mod: "JS_STRING",
+      arity: 0,
+    });
+  });
+
+  it("lowers indexOf to kebab-case", () => {
+    assert.deepEqual(deriveBuiltinSpec("String.prototype.indexOf", 1), {
+      rule: "JS_STRING::index-of",
+      mod: "JS_STRING",
+      arity: 1,
+    });
+  });
+
+  it("lowers lastIndexOf to kebab-case", () => {
+    assert.deepEqual(deriveBuiltinSpec("String.prototype.lastIndexOf", 1), {
+      rule: "JS_STRING::last-index-of",
+      mod: "JS_STRING",
+      arity: 1,
+    });
+  });
+
+  it("suffixes reserved max rule name", () => {
+    assert.deepEqual(deriveBuiltinSpec("Math.max", 2), {
+      rule: "JS_MATH::max-of",
+      mod: "JS_MATH",
+      arity: 2,
+    });
+  });
+
+  it("suffixes reserved min rule name", () => {
+    assert.deepEqual(deriveBuiltinSpec("Math.min", 2), {
+      rule: "JS_MATH::min-of",
+      mod: "JS_MATH",
+      arity: 2,
+    });
+  });
+
+  it("composes the full spec for existing entries", () => {
+    assert.deepEqual(deriveBuiltinSpec("Math.abs", 1), {
+      rule: "JS_MATH::abs",
+      mod: "JS_MATH",
+      arity: 1,
+    });
+    assert.deepEqual(deriveBuiltinSpec("String.prototype.indexOf", 1), {
+      rule: "JS_STRING::index-of",
+      mod: "JS_STRING",
+      arity: 1,
+    });
+  });
+});
 
 describe("builtins dispatch", () => {
   it("Math.max maps to JS_MATH::max-of in JS_MATH", () => {


### PR DESCRIPTION
## Patch 1: Refactor BUILTINS to derive rule/mod from surface-form key

- Add the `RESERVED_RULE_NAMES` constant in `builtins.ts` near the top of the file (above the `BUILTINS` declaration). Initial contents: `new Set(['max', 'min', 'cond', 'over'])` per the JS_MATH header's documented reserved-token list.
- Add the `deriveBuiltinSpec` exported function. Implementation: parse the key into `[namespace, method]`; map namespace → `mod` (`'Math'` → `'JS_MATH'`; `'String.prototype'` → `'JS_STRING'`); kebab-case `method` via `method.replace(/([A-Z])/g, '-$1').toLowerCase()` then strip any leading hyphen; if the result is in `RESERVED_RULE_NAMES`, append `'-of'`; compose `rule = `${mod}::${kebab}``; return `{ rule, mod, arity }`. The function is total over valid `BuiltinKey` values.
- Shrink each of the four existing `BUILTINS` entries from `{ rule, mod, arity }` to `{ arity }`. The lookup output is unchanged because `deriveBuiltinSpec` produces byte-identical `rule` and `mod` for each existing key.
- Update `lookupBuiltinByCall` (around line 116-127): after `BUILTINS.get(...)` returns a defined entry, compute `const fullSpec = deriveBuiltinSpec(key, entry.arity)` and use `fullSpec` in the arity check and return path. The semantics — arity equality gates the return — is unchanged.
- Add the new `describe('deriveBuiltinSpec', ...)` test block in `builtins.test.mts` (place it above the existing `describe('builtins dispatch', ...)`). Each test asserts the full return shape; reserved-token tests cover both `Math.max` (entry exists in `BUILTINS`) and `Math.min` (no entry yet — `deriveBuiltinSpec` is pure).
- Run `npm run test:unit` and confirm: (a) the four existing dispatch tests pass with byte-identical assertions; (b) the new `deriveBuiltinSpec` tests pass; (c) the standalone-typecheck loop passes (no .pant module changes in this patch).

## Changes
- Add the `RESERVED_RULE_NAMES` constant in `builtins.ts` near the top of the file (above the `BUILTINS` declaration). Initial contents: `new Set(['max', 'min', 'cond', 'over'])` per the JS_MATH header's documented reserved-token list.
- Add the `deriveBuiltinSpec` exported function. Implementation: parse the key into `[namespace, method]`; map namespace → `mod` (`'Math'` → `'JS_MATH'`; `'String.prototype'` → `'JS_STRING'`); kebab-case `method` via `method.replace(/([A-Z])/g, '-$1').toLowerCase()` then strip any leading hyphen; if the result is in `RESERVED_RULE_NAMES`, append `'-of'`; compose `rule = `${mod}::${kebab}``; return `{ rule, mod, arity }`. The function is total over valid `BuiltinKey` values.
- Shrink each of the four existing `BUILTINS` entries from `{ rule, mod, arity }` to `{ arity }`. The lookup output is unchanged because `deriveBuiltinSpec` produces byte-identical `rule` and `mod` for each existing key.
- Update `lookupBuiltinByCall` (around line 116-127): after `BUILTINS.get(...)` returns a defined entry, compute `const fullSpec = deriveBuiltinSpec(key, entry.arity)` and use `fullSpec` in the arity check and return path. The semantics — arity equality gates the return — is unchanged.
- Add the new `describe('deriveBuiltinSpec', ...)` test block in `builtins.test.mts` (place it above the existing `describe('builtins dispatch', ...)`). Each test asserts the full return shape; reserved-token tests cover both `Math.max` (entry exists in `BUILTINS`) and `Math.min` (no entry yet — `deriveBuiltinSpec` is pure).
- Run `npm run test:unit` and confirm: (a) the four existing dispatch tests pass with byte-identical assertions; (b) the new `deriveBuiltinSpec` tests pass; (c) the standalone-typecheck loop passes (no .pant module changes in this patch).

## Files to Modify
- tools/ts2pant/src/builtins.ts (modify): Shrink the `BUILTINS` Map value shape from `BuiltinSpec` to `{ arity: number }`; update the four existing entries (`Math.max`, `Math.abs`, `String.prototype.toUpperCase`, `String.prototype.indexOf`). Add `RESERVED_RULE_NAMES: ReadonlySet<string>` containing `['max', 'min', 'cond', 'over']`. Add `deriveBuiltinSpec(key: BuiltinKey, arity: number): BuiltinSpec` — pure function that derives `mod` from the key's namespace prefix and `rule` from camelCase→kebab-case lowering of the method name, applying the `-of` suffix if the kebab-case result is reserved. Update `lookupBuiltinByCall` to call `deriveBuiltinSpec(key, entry.arity)` once `entry` is retrieved from `BUILTINS`. Export `deriveBuiltinSpec` so the test file can exercise it directly.
- tools/ts2pant/tests/builtins.test.mts (modify): Add a new `describe('deriveBuiltinSpec', ...)` block covering: namespace mapping (`Math.foo` → `JS_MATH`; `String.prototype.foo` → `JS_STRING`); camelCase→kebab-case (`toUpperCase` → `to-upper-case`; `indexOf` → `index-of`; `lastIndexOf` → `last-index-of`); reserved-token suffix (`Math.max` → `max-of`; `Math.min` → `min-of`); composition (`deriveBuiltinSpec('Math.max', 2)` → `{ rule: 'JS_MATH::max-of', mod: 'JS_MATH', arity: 2 }`). The four existing dispatch tests continue to pass unchanged.

## Gameplan Specification

```
module TS2PANT_STDLIB_BATCH_1.

> After all three patches: BUILTINS values shrink to {arity}; rule and
> mod derive from key; seven new entries dispatch (Math.min plus six
> String.prototype.* methods); JS_MATH gains min-of with a
> commutativity axiom; JS_STRING gains six declarations with no
> axioms.

SurfaceForm.
DepModule.
QualifiedRef.

js-math => DepModule.
js-string => DepModule.
ts-prelude => DepModule.

math-max-key => SurfaceForm.
math-min-key => SurfaceForm.
math-abs-key => SurfaceForm.
string-to-upper-key => SurfaceForm.
string-to-lower-key => SurfaceForm.
string-trim-key => SurfaceForm.
string-includes-key => SurfaceForm.
string-starts-with-key => SurfaceForm.
string-ends-with-key => SurfaceForm.
string-index-of-key => SurfaceForm.
string-last-index-of-key => SurfaceForm.

mod-of sf: SurfaceForm => DepModule.
rule-of sf: SurfaceForm => QualifiedRef.
arity-of sf: SurfaceForm => Nat0.
typechecks-standalone? m: DepModule => Bool.

---

> Dispatch table contents after this gameplan.
mod-of math-max-key = js-math.
mod-of math-min-key = js-math.
mod-of math-abs-key = js-math.
mod-of string-to-upper-key = js-string.
mod-of string-to-lower-key = js-string.
mod-of string-trim-key = js-string.
mod-of string-includes-key = js-string.
mod-of string-starts-with-key = js-string.
mod-of string-ends-with-key = js-string.
mod-of string-index-of-key = js-string.
mod-of string-last-index-of-key = js-string.

> Arities.
arity-of math-max-key = 2.
arity-of math-min-key = 2.
arity-of math-abs-key = 1.
arity-of string-to-upper-key = 0.
arity-of string-to-lower-key = 0.
arity-of string-trim-key = 0.
arity-of string-includes-key = 1.
arity-of string-starts-with-key = 1.
arity-of string-ends-with-key = 1.
arity-of string-index-of-key = 1.
arity-of string-last-index-of-key = 1.

> Every dep module typechecks standalone via wasm (unchanged set).
typechecks-standalone? js-math.
typechecks-standalone? js-string.
typechecks-standalone? ts-prelude.
```

## Patch Specification

```
module TS2PANT_STDLIB_BATCH_1_PATCH_1.

> Patch 1: BUILTINS value shape shrinks to {arity}; rule and mod
> derive from surface-form key.

SurfaceForm.
DepModule.
MethodName.
KebabName.
QualifiedRef.

js-math => DepModule.
js-string => DepModule.

mod-of sf: SurfaceForm => DepModule.
method-of sf: SurfaceForm => MethodName.
kebab-of m: MethodName => KebabName.
reserved? k: KebabName => Bool.
suffixed k: KebabName => KebabName.
rule-of sf: SurfaceForm => QualifiedRef.

math-max-key => SurfaceForm.
math-abs-key => SurfaceForm.
string-to-upper-key => SurfaceForm.
string-index-of-key => SurfaceForm.

---

> Existing entries derive to byte-identical rule names after the
> refactor. The four current dispatch tests are the proof.
mod-of math-max-key = js-math.
mod-of math-abs-key = js-math.
mod-of string-to-upper-key = js-string.
mod-of string-index-of-key = js-string.

> Kebab-cased reserved tokens get a -of suffix.
all k: KebabName | reserved? k -> suffixed k != k.
```


## Implementation Notes

- Exported `BuiltinKey` as well as `deriveBuiltinSpec` so declaration emit has a public name for the exported function signature. This is a small TypeScript API hygiene addition, not a behavioral change.
- `deriveBuiltinSpec` avoids a raw `split(".")` because `String.prototype` itself contains a dot; it branches on the known valid prefixes and slices the method name from the selected prefix.
- Spec/Evidence Mapping: existing-entry byte identity is exercised by the unchanged dispatch assertions in `tools/ts2pant/tests/builtins.test.mts`; reserved suffix behavior is covered by direct `deriveBuiltinSpec("Math.max", 2)` and `deriveBuiltinSpec("Math.min", 2)` assertions; standalone dep-module stability is covered by the existing wasm typecheck loop. Required context checked before editing: `tools/ts2pant/src/builtins.ts`, `tools/ts2pant/tests/builtins.test.mts`, and `samples/js-stdlib/JS_MATH.pant`.
- Validation run: `npm run test:unit` from `tools/ts2pant` passed with 1015 passing, 0 failing, 3 skipped.