### PR TITLE
[ts2pant-stdlib-batch-1] Patch 2: Add Math.min dispatch + min-of rule in JS_MATH

### DIFF
--- a/samples/js-stdlib/JS_MATH.pant
+++ b/samples/js-stdlib/JS_MATH.pant
@@ -15,11 +15,15 @@ module JS_MATH.
 > qualified consumer-side reference is `JS_MATH::max-of`.
 
 max-of a: Int, b: Int => Int.
+min-of a: Int, b: Int => Int.
 abs x: Int => Int.
 
 ---
 > Commutativity of max — Math.max(a, b) === Math.max(b, a) for finite Int.
 all a: Int, b: Int | max-of a b = max-of b a.
+
+> Commutativity of min — Math.min(a, b) === Math.min(b, a) for finite Int.
+all a: Int, b: Int | min-of a b = min-of b a.
 
 > Idempotence of abs — Math.abs(Math.abs(x)) === Math.abs(x).
 all x: Int | abs (abs x) = abs x.

--- a/tools/ts2pant/src/builtins.ts
+++ b/tools/ts2pant/src/builtins.ts
@@ -57,6 +57,7 @@ const RESERVED_RULE_NAMES: ReadonlySet<string> = new Set([
 
 const BUILTINS: Map<BuiltinKey, { arity: number }> = new Map([
   ["Math.max", { arity: 2 }],
+  ["Math.min", { arity: 2 }],
   ["Math.abs", { arity: 1 }],
   ["String.prototype.toUpperCase", { arity: 0 }],
   ["String.prototype.indexOf", { arity: 1 }],

--- a/tools/ts2pant/tests/builtins.test.mts
+++ b/tools/ts2pant/tests/builtins.test.mts
@@ -123,6 +123,17 @@ describe("builtins dispatch", () => {
     });
   });
 
+  it("Math.min maps to JS_MATH::min-of", () => {
+    const spec = lookupFromSource(`
+      function f(a: number, b: number) { return Math.min(a, b); }
+    `);
+    assert.deepEqual(spec, {
+      rule: "JS_MATH::min-of",
+      mod: "JS_MATH",
+      arity: 2,
+    });
+  });
+
   it("Math.abs maps to JS_MATH::abs", () => {
     const spec = lookupFromSource(`
       function f(x: number) { return Math.abs(x); }
@@ -265,6 +276,7 @@ describe("loadBuiltinDepModule", () => {
     const text = loadBuiltinDepModule("JS_MATH");
     assert.match(text, /^module JS_MATH\./m);
     assert.match(text, /max-of a: Int, b: Int => Int\./);
+    assert.match(text, /min-of a: Int, b: Int => Int\./);
     assert.match(text, /abs x: Int => Int\./);
   });
 


### PR DESCRIPTION
## Patch 2: Add Math.min dispatch + min-of rule in JS_MATH

- Append the `min-of` rule head + commutativity axiom to `samples/js-stdlib/JS_MATH.pant`. The new declaration sits adjacent to `max-of`; the new axiom sits adjacent to the `max-of` commutativity axiom in the body chapter.
- Add the `['Math.min', { arity: 2 }]` entry to `BUILTINS` in `builtins.ts`.
- Add a dispatch test asserting `lookupFromSource("function f(a: number, b: number) { return Math.min(a, b); }")` returns `{ rule: 'JS_MATH::min-of', mod: 'JS_MATH', arity: 2 }`. Add a regex match for the new rule head in the JS_MATH content test.
- Run `npm run test:unit` and confirm both new assertions pass, the JS_MATH standalone-typecheck loop still passes (the new declaration + axiom are well-formed), and no existing test regresses.

## Changes
- Append the `min-of` rule head + commutativity axiom to `samples/js-stdlib/JS_MATH.pant`. The new declaration sits adjacent to `max-of`; the new axiom sits adjacent to the `max-of` commutativity axiom in the body chapter.
- Add the `['Math.min', { arity: 2 }]` entry to `BUILTINS` in `builtins.ts`.
- Add a dispatch test asserting `lookupFromSource("function f(a: number, b: number) { return Math.min(a, b); }")` returns `{ rule: 'JS_MATH::min-of', mod: 'JS_MATH', arity: 2 }`. Add a regex match for the new rule head in the JS_MATH content test.
- Run `npm run test:unit` and confirm both new assertions pass, the JS_MATH standalone-typecheck loop still passes (the new declaration + axiom are well-formed), and no existing test regresses.

## Files to Modify
- samples/js-stdlib/JS_MATH.pant (modify): Append `min-of a: Int, b: Int => Int.` under the existing `max-of` declaration in the head chapter. In the body chapter, append `> Commutativity of min — Math.min(a, b) === Math.min(b, a) for finite Int.` followed by `all a: Int, b: Int | min-of a b = min-of b a.` parallel to the existing max-of commutativity axiom.
- tools/ts2pant/src/builtins.ts (modify): Add `['Math.min', { arity: 2 }]` to the `BUILTINS` Map (under the existing `Math.max` entry).
- tools/ts2pant/tests/builtins.test.mts (modify): Add an `it('Math.min maps to JS_MATH::min-of', ...)` dispatch test mirroring the existing `Math.max` test. Extend the `loadBuiltinDepModule('JS_MATH')` regex assertion at line 196 with `assert.match(text, /min-of a: Int, b: Int => Int\./);`.

## Gameplan Specification

```
module TS2PANT_STDLIB_BATCH_1.

> After all three patches: BUILTINS values shrink to {arity}; rule and
> mod derive from key; seven new entries dispatch (Math.min plus six
> String.prototype.* methods); JS_MATH gains min-of with a
> commutativity axiom; JS_STRING gains six declarations with no
> axioms.

SurfaceForm.
DepModule.
QualifiedRef.

js-math => DepModule.
js-string => DepModule.
ts-prelude => DepModule.

math-max-key => SurfaceForm.
math-min-key => SurfaceForm.
math-abs-key => SurfaceForm.
string-to-upper-key => SurfaceForm.
string-to-lower-key => SurfaceForm.
string-trim-key => SurfaceForm.
string-includes-key => SurfaceForm.
string-starts-with-key => SurfaceForm.
string-ends-with-key => SurfaceForm.
string-index-of-key => SurfaceForm.
string-last-index-of-key => SurfaceForm.

mod-of sf: SurfaceForm => DepModule.
rule-of sf: SurfaceForm => QualifiedRef.
arity-of sf: SurfaceForm => Nat0.
typechecks-standalone? m: DepModule => Bool.

---

> Dispatch table contents after this gameplan.
mod-of math-max-key = js-math.
mod-of math-min-key = js-math.
mod-of math-abs-key = js-math.
mod-of string-to-upper-key = js-string.
mod-of string-to-lower-key = js-string.
mod-of string-trim-key = js-string.
mod-of string-includes-key = js-string.
mod-of string-starts-with-key = js-string.
mod-of string-ends-with-key = js-string.
mod-of string-index-of-key = js-string.
mod-of string-last-index-of-key = js-string.

> Arities.
arity-of math-max-key = 2.
arity-of math-min-key = 2.
arity-of math-abs-key = 1.
arity-of string-to-upper-key = 0.
arity-of string-to-lower-key = 0.
arity-of string-trim-key = 0.
arity-of string-includes-key = 1.
arity-of string-starts-with-key = 1.
arity-of string-ends-with-key = 1.
arity-of string-index-of-key = 1.
arity-of string-last-index-of-key = 1.

> Every dep module typechecks standalone via wasm (unchanged set).
typechecks-standalone? js-math.
typechecks-standalone? js-string.
typechecks-standalone? ts-prelude.
```

## Patch Specification

```
module TS2PANT_STDLIB_BATCH_1_PATCH_2.

> Patch 2: Math.min dispatch + JS_MATH gains min-of.

SurfaceForm.
DepModule.
QualifiedRef.

js-math => DepModule.
math-min-key => SurfaceForm.
mod-of sf: SurfaceForm => DepModule.
rule-of sf: SurfaceForm => QualifiedRef.
arity-of sf: SurfaceForm => Nat0.
declares? m: DepModule, r: QualifiedRef => Bool.

---

> The Math.min surface form dispatches to js-math (JS_MATH::min-of) with arity 2.
mod-of math-min-key = js-math.
arity-of math-min-key = 2.

> JS_MATH declares min-of after this patch.
declares? js-math (rule-of math-min-key).
```


## Implementation Notes

- No deviations from the plan. Patch 1's `deriveBuiltinSpec` already handled reserved `min` names, so this patch only needed to add the arity table entry and the matching JS_MATH surface.
- The new `min-of` axiom intentionally mirrors the existing `max-of` axiom exactly: same `Int` domain, same finite-Int caveat in the doc comment, and no extra algebraic properties beyond commutativity.
- Spec/Evidence Mapping: `mod-of math-min-key = js-math` and `arity-of math-min-key = 2` are implemented by `BUILTINS` in `tools/ts2pant/src/builtins.ts` plus Patch 1 derivation; proved by `Math.min maps to JS_MATH::min-of`. `declares? js-math (rule-of math-min-key)` is implemented in `samples/js-stdlib/JS_MATH.pant`; proved by the JS_MATH content assertion and the standalone wasm typecheck loop. Required context consulted: `builtins.ts`, `builtins.test.mts`, `JS_MATH.pant`, and the cited Kroening/Strichman EUF reference page.