### PR TITLE
[ts2pant-stdlib-batch-1] Patch 3: Add six String.prototype.* dispatches + rules in JS_STRING

### DIFF
--- a/samples/js-stdlib/JS_STRING.pant
+++ b/samples/js-stdlib/JS_STRING.pant
@@ -17,5 +17,11 @@ module JS_STRING.
 
 to-upper-case s: String => String.
 index-of s: String, t: String => Int.
+to-lower-case s: String => String.
+trim s: String => String.
+includes s: String, t: String => Bool.
+starts-with s: String, prefix: String => Bool.
+ends-with s: String, suffix: String => Bool.
+last-index-of s: String, t: String => Int.
 
 ---

--- a/tools/ts2pant/src/builtins.ts
+++ b/tools/ts2pant/src/builtins.ts
@@ -60,6 +60,12 @@ const BUILTINS: Map<BuiltinKey, { arity: number }> = new Map([
   ["Math.abs", { arity: 1 }],
   ["String.prototype.toUpperCase", { arity: 0 }],
   ["String.prototype.indexOf", { arity: 1 }],
+  ["String.prototype.endsWith", { arity: 1 }],
+  ["String.prototype.includes", { arity: 1 }],
+  ["String.prototype.lastIndexOf", { arity: 1 }],
+  ["String.prototype.startsWith", { arity: 1 }],
+  ["String.prototype.toLowerCase", { arity: 0 }],
+  ["String.prototype.trim", { arity: 0 }],
 ]);
 
 export function deriveBuiltinSpec(key: BuiltinKey, arity: number): BuiltinSpec {

--- a/tools/ts2pant/tests/builtins.test.mts
+++ b/tools/ts2pant/tests/builtins.test.mts
@@ -156,6 +156,72 @@ describe("builtins dispatch", () => {
     });
   });
 
+  it("s.endsWith(q) resolves to JS_STRING::ends-with", () => {
+    const spec = lookupFromSource(`
+      function f(s: string, q: string) { return s.endsWith(q); }
+    `);
+    assert.deepEqual(spec, {
+      rule: "JS_STRING::ends-with",
+      mod: "JS_STRING",
+      arity: 1,
+    });
+  });
+
+  it("s.includes(t) resolves to JS_STRING::includes", () => {
+    const spec = lookupFromSource(`
+      function f(s: string, t: string) { return s.includes(t); }
+    `);
+    assert.deepEqual(spec, {
+      rule: "JS_STRING::includes",
+      mod: "JS_STRING",
+      arity: 1,
+    });
+  });
+
+  it("s.lastIndexOf(t) resolves to JS_STRING::last-index-of", () => {
+    const spec = lookupFromSource(`
+      function f(s: string, t: string) { return s.lastIndexOf(t); }
+    `);
+    assert.deepEqual(spec, {
+      rule: "JS_STRING::last-index-of",
+      mod: "JS_STRING",
+      arity: 1,
+    });
+  });
+
+  it("s.startsWith(p) resolves to JS_STRING::starts-with", () => {
+    const spec = lookupFromSource(`
+      function f(s: string, p: string) { return s.startsWith(p); }
+    `);
+    assert.deepEqual(spec, {
+      rule: "JS_STRING::starts-with",
+      mod: "JS_STRING",
+      arity: 1,
+    });
+  });
+
+  it("s.toLowerCase() resolves to JS_STRING::to-lower-case", () => {
+    const spec = lookupFromSource(`
+      function f(s: string) { return s.toLowerCase(); }
+    `);
+    assert.deepEqual(spec, {
+      rule: "JS_STRING::to-lower-case",
+      mod: "JS_STRING",
+      arity: 0,
+    });
+  });
+
+  it("s.trim() resolves to JS_STRING::trim", () => {
+    const spec = lookupFromSource(`
+      function f(s: string) { return s.trim(); }
+    `);
+    assert.deepEqual(spec, {
+      rule: "JS_STRING::trim",
+      mod: "JS_STRING",
+      arity: 0,
+    });
+  });
+
   it("user-shadowed Math identifier does not match Math.max (symbol-based dispatch)", () => {
     // The shadowing `const Math` declares a fresh symbol whose declaration
     // sits in the user's source file, not in a TS lib .d.ts. The lookup
@@ -273,6 +339,12 @@ describe("loadBuiltinDepModule", () => {
     assert.match(text, /^module JS_STRING\./m);
     assert.match(text, /to-upper-case s: String => String\./);
     assert.match(text, /index-of s: String, t: String => Int\./);
+    assert.match(text, /to-lower-case s: String => String\./);
+    assert.match(text, /trim s: String => String\./);
+    assert.match(text, /includes s: String, t: String => Bool\./);
+    assert.match(text, /starts-with s: String, prefix: String => Bool\./);
+    assert.match(text, /ends-with s: String, suffix: String => Bool\./);
+    assert.match(text, /last-index-of s: String, t: String => Int\./);
   });
 
   it("caches the loaded module text across calls", () => {


### PR DESCRIPTION
## Patch 3: Add six String.prototype.* dispatches + rules in JS_STRING

- Append the six rule heads to `samples/js-stdlib/JS_STRING.pant` directly under the existing `index-of` declaration. Maintain the existing head/body chapter separator. No body axioms.
- Add the six `BUILTINS` entries in `builtins.ts`. Order: alphabetical by method name (`endsWith`, `includes`, `lastIndexOf`, `startsWith`, `toLowerCase`, `trim`) for predictable diffs.
- Add six dispatch tests in `builtins.test.mts`, one per new entry. Each asserts the full `{ rule, mod, arity }` shape. Add six regex assertions in the `loadBuiltinDepModule('JS_STRING')` test to guard the new rule heads.
- Run `npm run test:unit` and confirm all six new dispatch tests pass, all six new content regexes pass, the JS_STRING standalone-typecheck loop still passes, and no existing test regresses.

## Changes
- Append the six rule heads to `samples/js-stdlib/JS_STRING.pant` directly under the existing `index-of` declaration. Maintain the existing head/body chapter separator. No body axioms.
- Add the six `BUILTINS` entries in `builtins.ts`. Order: alphabetical by method name (`endsWith`, `includes`, `lastIndexOf`, `startsWith`, `toLowerCase`, `trim`) for predictable diffs.
- Add six dispatch tests in `builtins.test.mts`, one per new entry. Each asserts the full `{ rule, mod, arity }` shape. Add six regex assertions in the `loadBuiltinDepModule('JS_STRING')` test to guard the new rule heads.
- Run `npm run test:unit` and confirm all six new dispatch tests pass, all six new content regexes pass, the JS_STRING standalone-typecheck loop still passes, and no existing test regresses.

## Files to Modify
- samples/js-stdlib/JS_STRING.pant (modify): Append six rule heads under the existing `index-of`: `to-lower-case s: String => String.`, `trim s: String => String.`, `includes s: String, t: String => Bool.`, `starts-with s: String, prefix: String => Bool.`, `ends-with s: String, suffix: String => Bool.`, `last-index-of s: String, t: String => Int.`. No body axioms — the existing module posture is conservative for JS string semantics.
- tools/ts2pant/src/builtins.ts (modify): Add six `String.prototype.*` entries to `BUILTINS`: `toLowerCase` (arity 0), `trim` (arity 0), `includes` (arity 1), `startsWith` (arity 1), `endsWith` (arity 1), `lastIndexOf` (arity 1). Group them under the existing `String.prototype.toUpperCase` entry.
- tools/ts2pant/tests/builtins.test.mts (modify): Add six dispatch tests, one per new entry, mirroring the existing `s.toUpperCase()` and `s.indexOf(t)` shape. Extend the `loadBuiltinDepModule('JS_STRING')` regex assertions to include the six new rule heads.

## Gameplan Specification

```
module TS2PANT_STDLIB_BATCH_1.

> After all three patches: BUILTINS values shrink to {arity}; rule and
> mod derive from key; seven new entries dispatch (Math.min plus six
> String.prototype.* methods); JS_MATH gains min-of with a
> commutativity axiom; JS_STRING gains six declarations with no
> axioms.

SurfaceForm.
DepModule.
QualifiedRef.

js-math => DepModule.
js-string => DepModule.
ts-prelude => DepModule.

math-max-key => SurfaceForm.
math-min-key => SurfaceForm.
math-abs-key => SurfaceForm.
string-to-upper-key => SurfaceForm.
string-to-lower-key => SurfaceForm.
string-trim-key => SurfaceForm.
string-includes-key => SurfaceForm.
string-starts-with-key => SurfaceForm.
string-ends-with-key => SurfaceForm.
string-index-of-key => SurfaceForm.
string-last-index-of-key => SurfaceForm.

mod-of sf: SurfaceForm => DepModule.
rule-of sf: SurfaceForm => QualifiedRef.
arity-of sf: SurfaceForm => Nat0.
typechecks-standalone? m: DepModule => Bool.

---

> Dispatch table contents after this gameplan.
mod-of math-max-key = js-math.
mod-of math-min-key = js-math.
mod-of math-abs-key = js-math.
mod-of string-to-upper-key = js-string.
mod-of string-to-lower-key = js-string.
mod-of string-trim-key = js-string.
mod-of string-includes-key = js-string.
mod-of string-starts-with-key = js-string.
mod-of string-ends-with-key = js-string.
mod-of string-index-of-key = js-string.
mod-of string-last-index-of-key = js-string.

> Arities.
arity-of math-max-key = 2.
arity-of math-min-key = 2.
arity-of math-abs-key = 1.
arity-of string-to-upper-key = 0.
arity-of string-to-lower-key = 0.
arity-of string-trim-key = 0.
arity-of string-includes-key = 1.
arity-of string-starts-with-key = 1.
arity-of string-ends-with-key = 1.
arity-of string-index-of-key = 1.
arity-of string-last-index-of-key = 1.

> Every dep module typechecks standalone via wasm (unchanged set).
typechecks-standalone? js-math.
typechecks-standalone? js-string.
typechecks-standalone? ts-prelude.
```

## Patch Specification

```
module TS2PANT_STDLIB_BATCH_1_PATCH_3.

> Patch 3: six String.prototype.* dispatches + JS_STRING gains six rule heads.

SurfaceForm.
DepModule.
QualifiedRef.

js-string => DepModule.

string-to-lower-key => SurfaceForm.
string-trim-key => SurfaceForm.
string-includes-key => SurfaceForm.
string-starts-with-key => SurfaceForm.
string-ends-with-key => SurfaceForm.
string-last-index-of-key => SurfaceForm.

mod-of sf: SurfaceForm => DepModule.
rule-of sf: SurfaceForm => QualifiedRef.
arity-of sf: SurfaceForm => Nat0.

---

> Each new String.prototype.* surface form dispatches to js-string.
mod-of string-to-lower-key = js-string.
mod-of string-trim-key = js-string.
mod-of string-includes-key = js-string.
mod-of string-starts-with-key = js-string.
mod-of string-ends-with-key = js-string.
mod-of string-last-index-of-key = js-string.

> Arities are stable.
arity-of string-to-lower-key = 0.
arity-of string-trim-key = 0.
arity-of string-includes-key = 1.
arity-of string-starts-with-key = 1.
arity-of string-ends-with-key = 1.
arity-of string-last-index-of-key = 1.
```


## Implementation Notes

- The six new `BUILTINS` rows rely entirely on the Patch 1 `deriveBuiltinSpec` path; there are no per-entry `rule` or `mod` overrides in this patch. The new rows are ordered as requested among themselves, while the pre-existing string entries remain untouched to keep this patch's diff narrow against the dependency branch.
- `JS_STRING.pant` remains declaration-only after the chapter separator. The new predicate-like rules intentionally use bare names (`includes`, `starts-with`, `ends-with`) so the derived kebab-case names match the table without boolean-specific special cases.
- Required context consulted: `tools/ts2pant/src/builtins.ts`, `tools/ts2pant/tests/builtins.test.mts`, and `samples/js-stdlib/JS_STRING.pant`.
- Spec/Evidence Mapping: new `mod-of ... = js-string` clauses map to `lookupBuiltinByCall` resolving each added `String.prototype.*` key to `deriveBuiltinSpec(...).mod === "JS_STRING"`; covered by the six new dispatch assertions in `builtins.test.mts`.
- Spec/Evidence Mapping: new arity clauses map to the six `{ arity }` table entries in `builtins.ts`; covered by the same dispatch assertions' full `{ rule, mod, arity }` checks.
- Spec/Evidence Mapping: `JS_STRING` six-declaration requirement maps to the appended rule heads in `samples/js-stdlib/JS_STRING.pant`; covered by six `loadBuiltinDepModule("JS_STRING")` regex assertions and the existing standalone WASM typecheck loop. `npm run test:unit` passed locally.