### PR TITLE
[ts2pant-const-binding-ssa] Patch 3: Route const bindings through IR1Let; remove inlining + purity gate

### DIFF
--- a/tools/ts2pant/src/emit.ts
+++ b/tools/ts2pant/src/emit.ts
@@ -110,10 +110,13 @@ export function emitDocument(doc: PantDocument): string {
   // in the chapter body. Splitting the rule's declaration and definition
   // across the `---` divider matches the Pantagruel grammar — see the
   // `rule-decl` arm of `renderPropResult` for the rationale.
-  const ruleDeclEquations = ruleDeclProps.map((prop) => {
+  const ruleDeclEquations = ruleDeclProps.flatMap((prop) => {
+    if (prop.body === undefined) {
+      return [];
+    }
     const argList = prop.params.map((p) => p.name).join(" ");
     const argPart = argList.length > 0 ? ` ${argList}` : "";
-    return `${prop.ruleName}${argPart} = ${getAst().strExpr(prop.body)}.`;
+    return [`${prop.ruleName}${argPart} = ${getAst().strExpr(prop.body)}.`];
   });
 
   if (bodyProps.length === 0 && ruleDeclEquations.length === 0) {

--- a/tools/ts2pant/src/ir1-build-body.ts
+++ b/tools/ts2pant/src/ir1-build-body.ts
@@ -103,7 +103,6 @@ export interface BuildBodyCtx {
   paramNames: ReadonlyMap<string, string>;
   state: SymbolicState;
   supply: UniqueSupply;
-  applyConst: (e: OpaqueExpr) => OpaqueExpr;
   /**
    * When set, this build is inside a foreach loop body. Carries the
    * TS names of iterator binders in scope so the recursive
@@ -934,8 +933,8 @@ function simulateShapeAPropertyWrite(
   if (isBodyUnsupported(valR)) {
     return { unsupported: valR.unsupported };
   }
-  const objExpr = subCtx.applyConst(bodyExpr(objR));
-  const value = subCtx.applyConst(bodyExpr(valR));
+  const objExpr = bodyExpr(objR);
+  const value = bodyExpr(valR);
   const key = symbolicKey(prop, objExpr);
   subCtx.state.writes = putCompatWrite(subCtx.state.writes, key, {
     kind: "property",

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -1325,8 +1325,8 @@ export function buildL1MemberAccess(
   // SSA builder's compatibility context), so we register it under a fresh
   // hygienic name in `supply.opaqueAliases` and return an L1 `Var`
   // referencing that name. The alias is substituted back into the
-  // OpaqueExpr at lower time via `applyOpaqueAliases` (wired into
-  // `applyConst` in the SSA builder). This keeps L1 free of
+  // OpaqueExpr at lower time via `applyOpaqueAliases` in the SSA lowerer.
+  // This keeps L1 free of
   // escape-hatch forms while preserving the read-after-write
   // semantics required for mutating-body sub-expression composition.
   if (ctx.state !== undefined && options.requireMember !== true) {

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -1869,9 +1869,7 @@ function lowerPreludeBindings(
   baseParams: ReadonlyMap<string, string>,
   supply: UniqueSupply,
   state?: SymbolicState,
-):
-  | LoweredPreludeBindings
-  | { error: string } {
+): LoweredPreludeBindings | { error: string } {
   // Phase 1: TDZ validation — reject forward/self references on TS AST.
   // For μ-search bindings, validate both the init and the predicate; the
   // predicate may reference its own counter (that's the loop), so the
@@ -4416,11 +4414,11 @@ function buildSupportedSsaMutatingBody(
         {
           checker,
           strategy,
-            paramNames: scopedParamNames,
-            state,
-            supply,
-          },
-        );
+          paramNames: scopedParamNames,
+          state,
+          supply,
+        },
+      );
       if (isUnsupported(fixedPointBuilt)) {
         return fixedPointBuilt;
       }

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -212,6 +212,25 @@ export function allocComprehensionBinder(
   return cellRegisterName(supply.synthCell, hint);
 }
 
+function allocLocalBindingName(
+  supply: UniqueSupply,
+  hint: string,
+  scopedParams: ReadonlyMap<string, string>,
+): string {
+  if (supply.synthCell) {
+    return cellRegisterName(supply.synthCell, hint);
+  }
+  const used = new Set(scopedParams.values());
+  if (!used.has(hint)) {
+    return hint;
+  }
+  let name: string;
+  do {
+    name = `${hint}${nextSupply(supply)}`;
+  } while (used.has(name));
+  return name;
+}
+
 /**
  * True when a TypeScript type includes `null`, `undefined`, or `void` —
  * i.e., when `mapTsType` will list-lift it to `[T]`. Used at `??` and `?.`
@@ -1971,7 +1990,11 @@ function lowerPreludeBindings(
           arms: [...acc.arms, [predRes.value, valRes.value] as const],
         };
       }
-      const localName = toPantTermName(binding.tsName);
+      const localName = allocLocalBindingName(
+        supply,
+        toPantTermName(binding.tsName),
+        acc.scopedParams,
+      );
       const returnType =
         binding.kind === "const"
           ? mapTsType(
@@ -1989,21 +2012,13 @@ function lowerPreludeBindings(
       }
       const initExpr =
         binding.kind === "const"
-          ? state === undefined
-            ? tryBuildL1PureSubExpression(binding.initializer, {
-                checker,
-                strategy,
-                paramNames: acc.scopedParams,
-                state,
-                supply,
-              })
-            : buildL1SubExpr(binding.initializer, {
-                checker,
-                strategy,
-                paramNames: acc.scopedParams,
-                state,
-                supply,
-              })
+          ? buildL1SubExpr(binding.initializer, {
+              checker,
+              strategy,
+              paramNames: acc.scopedParams,
+              state: state ?? makeSymbolicState(),
+              supply,
+            })
           : buildL1MuSearchCombTyped(binding.mu, {
               checker,
               strategy,
@@ -2011,13 +2026,19 @@ function lowerPreludeBindings(
               state,
               supply,
             });
-      if (initExpr === null) {
-        return {
-          tag: "error",
-          error: "unsupported pure expression in const initializer",
-        };
-      }
       if (isUnsupported(initExpr) || isL1Unsupported(initExpr)) {
+        if (
+          binding.kind === "const" &&
+          state === undefined &&
+          initExpr.unsupported.startsWith(
+            "unsupported mutating-body sub-expression:",
+          )
+        ) {
+          return {
+            tag: "error",
+            error: "unsupported pure expression in const initializer",
+          };
+        }
         return { tag: "error", error: initExpr.unsupported };
       }
       return {

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -120,10 +120,9 @@ export interface UniqueSupply {
    * `Var($N)` in L1. This keeps L1 free of OpaqueExpr-bearing nodes
    * while still surfacing read-after-write semantics.
    *
-   * Lower sites apply these substitutions via `applyOpaqueAliases`
-   * (wrapped into the call-site `applyConst`), so the final
-   * Pantagruel text contains the recorded value rather than the
-   * `$N` reference.
+   * Lower sites apply these substitutions via `applyOpaqueAliases`, so the
+   * final Pantagruel text contains the recorded value rather than the `$N`
+   * reference.
    */
   opaqueAliases?: Map<string, OpaqueExpr>;
 }
@@ -139,8 +138,7 @@ function makeUniqueSupply(synthCell?: SynthCell): UniqueSupply {
  *
  * The stored value is *eagerly resolved* against any aliases already
  * in the map: if `value` itself contains references to earlier
- * aliases (because the recorded write was canonicalized through a
- * stale `applyConst`), those get substituted out before insertion.
+ * aliases, those get substituted out before insertion.
  * This keeps the alias map flat — no `B → Var(A)` chain pointing at
  * another alias — so `applyOpaqueAliases` can substitute in a single
  * pass instead of running to fixpoint.
@@ -479,12 +477,9 @@ export type WriteEntry =
  * `modifiedProps` remains for compatibility with builder contexts that clone
  * state, but frame conditions now derive from IR1 SSA lowering results.
  *
- * `canonicalize` applies the ambient const-binding substitution to an
- * expression before it is used as a state key. Writes store keys under the
- * post-substitution form so `const x = a; x.balance = 1` and a later
- * `x.balance` read resolve to the same key. The SSA builder updates this
- * when a new const binding is inlined so the in-flight `applyConst` stays
- * in sync with the state.
+ * `canonicalize` applies ambient opaque aliases to an expression before it is
+ * used as a state key. Writes store keys under that canonical form so
+ * state-aware reads and later writes resolve to the same key.
  */
 export interface SymbolicState {
   writes: ReadonlyMap<string, WriteEntry>;
@@ -1234,17 +1229,30 @@ function translatePureBody(
     }
   }
 
-  const inlined = inlineConstBindings(
+  const prelude = lowerPreludeBindings(
     extracted.bindings,
     checker,
     strategy,
     paramNames,
     supply,
   );
-  if ("error" in inlined) {
+  if ("error" in prelude) {
     return [
-      { kind: "unsupported", reason: `${functionName} — ${inlined.error}` },
+      { kind: "unsupported", reason: `${functionName} — ${prelude.error}` },
     ];
+  }
+  const loweredLets =
+    prelude.letStmts.length === 0
+      ? ir1SsaBodyLowerSuccess()
+      : lowerL1BodyToSsaProps(
+          ir1Block(prelude.letStmts as [IR1Stmt, ...IR1Stmt[]]),
+          [],
+          {
+            applyConst: (e) => applyOpaqueAliases(e, supply),
+          },
+        );
+  if (loweredLets.diagnostics.length > 0) {
+    return loweredLets.diagnostics;
   }
 
   // Record returns: when the function returns an object literal, decompose
@@ -1271,7 +1279,7 @@ function translatePureBody(
     ts.isIfStatement(extracted.returnExpr) &&
     ifTerminalHasObjLitBranch(extracted.returnExpr, checker);
 
-  if (terminalIsObjLit && inlined.arms.length === 0) {
+  if (terminalIsObjLit && prelude.arms.length === 0) {
     return translateRecordReturn(
       extracted.returnExpr as ts.ObjectLiteralExpression,
       functionName,
@@ -1279,10 +1287,10 @@ function translatePureBody(
       node,
       checker,
       strategy,
-      inlined.scopedParams,
+      prelude.scopedParams,
       supply,
       synthCell,
-      inlined.applyTo,
+      (e) => applyOpaqueAliases(e, supply),
     );
   }
 
@@ -1311,19 +1319,19 @@ function translatePureBody(
     ts.isSwitchStatement(extracted.returnExpr) ||
     (ts.isExpression(extracted.returnExpr) &&
       isL1ConditionalForm(extracted.returnExpr, checker));
-  if (inlined.arms.length > 0 || l1IsConditionalReturn) {
+  if (prelude.arms.length > 0 || l1IsConditionalReturn) {
     const l1Ctx = {
       checker,
       strategy,
-      paramNames: inlined.scopedParams,
+      paramNames: prelude.scopedParams,
       state: undefined as SymbolicState | undefined,
       supply,
     };
     let bodyOpaque: OpaqueExpr;
     if (l1IsConditionalReturn) {
       // Build the conditional terminal as L1 first, then merge prelude
-      // arms (already OpaqueExpr from `inlineConstBindings`) at the
-      // OpaqueExpr layer. When the L1 terminal is itself a cond we
+      // early-return arms at the OpaqueExpr layer. When the L1 terminal is
+      // itself a cond we
       // splice its arms in to keep the output flat (matching the
       // legacy single-cond shape).
       const terminalL1 = buildL1Conditional(extracted.returnExpr, l1Ctx);
@@ -1337,7 +1345,7 @@ function translatePureBody(
       }
       if (terminalL1.kind === "cond") {
         const armsOpaque: Array<[OpaqueExpr, OpaqueExpr]> = [
-          ...inlined.arms.map(([g, v]) => [g, v] as [OpaqueExpr, OpaqueExpr]),
+          ...prelude.arms.map(([g, v]) => [g, v] as [OpaqueExpr, OpaqueExpr]),
           ...terminalL1.arms.map(
             ([g, v]) =>
               [lowerL1ToOpaque(g), lowerL1ToOpaque(v)] as [
@@ -1353,11 +1361,11 @@ function translatePureBody(
         bodyOpaque = ast.cond(armsOpaque);
       } else {
         const terminalOpaque = lowerL1ToOpaque(terminalL1);
-        if (inlined.arms.length === 0) {
+        if (prelude.arms.length === 0) {
           bodyOpaque = terminalOpaque;
         } else {
           bodyOpaque = ast.cond([
-            ...inlined.arms.map(([g, v]) => [g, v] as [OpaqueExpr, OpaqueExpr]),
+            ...prelude.arms.map(([g, v]) => [g, v] as [OpaqueExpr, OpaqueExpr]),
             [ast.litBool(true), terminalOpaque] as [OpaqueExpr, OpaqueExpr],
           ]);
         }
@@ -1381,7 +1389,7 @@ function translatePureBody(
         extracted.returnExpr,
         checker,
         strategy,
-        inlined.scopedParams,
+        prelude.scopedParams,
         supply,
       );
       let terminalOpaque: OpaqueExpr;
@@ -1390,7 +1398,7 @@ function translatePureBody(
           extracted.returnExpr,
           checker,
           strategy,
-          inlined.scopedParams,
+          prelude.scopedParams,
           undefined,
           supply,
         );
@@ -1412,21 +1420,9 @@ function translatePureBody(
         terminalOpaque = lowerExpr(ir);
       }
       bodyOpaque = ast.cond([
-        ...inlined.arms.map(([g, v]) => [g, v] as [OpaqueExpr, OpaqueExpr]),
+        ...prelude.arms.map(([g, v]) => [g, v] as [OpaqueExpr, OpaqueExpr]),
         [ast.litBool(true), terminalOpaque] as [OpaqueExpr, OpaqueExpr],
       ]);
-    }
-    // Apply const-binding substitutions at the OpaqueExpr layer via
-    // `substituteBinder` — semantically identical to the IR `Let`
-    // chain that lowered through the same primitive. Right-fold
-    // semantics: substitute the last binding first.
-    for (let i = inlined.translatedBindings.length - 1; i >= 0; i--) {
-      const tb = inlined.translatedBindings[i]!;
-      bodyOpaque = ast.substituteBinder(
-        bodyOpaque,
-        tb.hygienicName,
-        tb.initExpr,
-      );
     }
     rhs = bodyOpaque;
   } else if (ts.isExpression(extracted.returnExpr)) {
@@ -1434,7 +1430,7 @@ function translatePureBody(
       extracted.returnExpr,
       checker,
       strategy,
-      inlined.scopedParams,
+      prelude.scopedParams,
       supply,
     );
     let bodyOpaque: OpaqueExpr;
@@ -1452,7 +1448,7 @@ function translatePureBody(
         extracted.returnExpr,
         checker,
         strategy,
-        inlined.scopedParams,
+        prelude.scopedParams,
         undefined,
         supply,
       );
@@ -1473,14 +1469,6 @@ function translatePureBody(
     } else {
       bodyOpaque = lowerExpr(ir);
     }
-    for (let i = inlined.translatedBindings.length - 1; i >= 0; i--) {
-      const tb = inlined.translatedBindings[i]!;
-      bodyOpaque = ast.substituteBinder(
-        bodyOpaque,
-        tb.hygienicName,
-        tb.initExpr,
-      );
-    }
     rhs = bodyOpaque;
   } else {
     return [
@@ -1494,6 +1482,8 @@ function translatePureBody(
   const argExprs = params.map((p) => ast.var(p.name));
   const lhs = ast.app(ast.var(functionName), argExprs);
   return [
+    ...prelude.ruleDecls,
+    ...loweredLets.propositions,
     {
       kind: "equation",
       quantifiers: [] as OpaqueParam[],
@@ -1590,12 +1580,12 @@ function isInterfaceFieldAccess(
 
 /**
  * Extract the return expression from a function body, collecting any leading
- * const bindings with pure initializers for inline substitution.
+ * const bindings for IR1Let lowering.
  * Handles:
  *   - Single return statement
  *   - Leading const bindings + return statement
  *   - if/else with returns in both branches (produces a synthetic conditional)
- * Returns null if the body contains let/var bindings or effectful const initializers.
+ * Returns null if the body contains unsupported prelude statements.
  */
 /**
  * Recognize the Kleene μ-minimization pattern as a `let counter = init;`
@@ -1607,7 +1597,7 @@ function isInterfaceFieldAccess(
  * match: counter must be a single identifier with any initializer, and the
  * loop body must be exactly one expression statement. The L1 builder
  * validates the canonical `+1` counter step. Purity of the
- * initializer and predicate is screened in `inlineConstBindings`'s TDZ
+ * initializer and predicate is screened in `lowerPreludeBindings`'s TDZ
  * phase (alongside the sibling forward-reference check) rather than here —
  * `translateBodyExpr` has no handler for bare `++`/`--` expressions, so a
  * side-effectful init or predicate would otherwise lower silently.
@@ -1621,7 +1611,7 @@ function isInterfaceFieldAccess(
  * the let must have a single identifier declarator with an initializer,
  * the while body must be a single expression-statement (or a single-stmt
  * block thereof). μ-search semantics are applied by the L1 builder called
- * from `translateMuSearchInit`; this recognizer consumes the pair
+ * from `lowerPreludeBindings`; this recognizer consumes the pair
  * structurally so `extractReturnExpression` can keep walking.
  */
 function recognizeLetWhilePair(
@@ -1760,9 +1750,6 @@ function extractReturnExpression(
       if (!ts.isIdentifier(decl.name) || !decl.initializer) {
         return null;
       }
-      if (expressionHasSideEffects(decl.initializer, checker)) {
-        return null;
-      }
       bindings.push({
         kind: "const",
         tsName: decl.name.text,
@@ -1834,14 +1821,6 @@ function describeRejectedBody(body: ts.Block, checker: ts.TypeChecker): string {
         if (!(declList.flags & ts.NodeFlags.Const)) {
           return "let/var bindings not supported";
         }
-        for (const decl of declList.declarations) {
-          if (
-            decl.initializer &&
-            expressionHasSideEffects(decl.initializer, checker)
-          ) {
-            return "const binding with side-effectful initializer";
-          }
-        }
       }
       if (ts.isExpressionStatement(stmt)) {
         return "expression statement before return (only const / μ-search / if-early-return allowed)";
@@ -1876,31 +1855,14 @@ function describeRejectedBody(body: ts.Block, checker: ts.TypeChecker): string {
   return "non-translatable control flow";
 }
 
-/**
- * Shared const-binding inlining (let-elimination) for both pure and mutating paths.
- *
- * Three phases:
- *   1. TDZ validation on TS AST (rejects forward/self references)
- *   2. Translate initializers forward, building scopedParams incrementally
- *   3. Return a right-fold substitution closure
- *
- * The right-fold means substitutions are applied inside-out: the last binding
- * is substituted first, so each step naturally resolves references to earlier
- * bindings that are already embedded in the result.
- */
-/**
- * One translated const-binding: a hygienic name (`$N`) and the
- * already-translated initializer as an OpaqueExpr. Consumed by the
- * pure-path arm assembly in `translatePureBody`, which threads each
- * binding through `ast.substituteBinder` at the OpaqueExpr layer
- * rather than carrying the legacy `applyTo` closure.
- */
-export interface TranslatedBinding {
-  hygienicName: string;
-  initExpr: OpaqueExpr;
+interface LoweredPreludeBindings {
+  letStmts: IR1Stmt[];
+  ruleDecls: PropResult[];
+  scopedParams: ReadonlyMap<string, string>;
+  arms: ReadonlyArray<readonly [OpaqueExpr, OpaqueExpr]>;
 }
 
-export function inlineConstBindings(
+function lowerPreludeBindings(
   bindings: ConstBinding[],
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
@@ -1908,21 +1870,14 @@ export function inlineConstBindings(
   supply: UniqueSupply,
   state?: SymbolicState,
 ):
-  | {
-      applyTo: (expr: OpaqueExpr) => OpaqueExpr;
-      translatedBindings: ReadonlyArray<TranslatedBinding>;
-      scopedParams: ReadonlyMap<string, string>;
-      arms: ReadonlyArray<readonly [OpaqueExpr, OpaqueExpr]>;
-    }
+  | LoweredPreludeBindings
   | { error: string } {
-  const ast = getAst();
-
   // Phase 1: TDZ validation — reject forward/self references on TS AST.
   // For μ-search bindings, validate both the init and the predicate; the
   // predicate may reference its own counter (that's the loop), so the
   // counter is removed from the blocked set when checking the predicate.
-  // Side-effectful init or predicate (assignments, ++/--, unknown-pure
-  // calls) are also rejected here: translateBodyExpr has no explicit
+  // Side-effectful μ-search init/predicate and early-return predicate/value
+  // are also rejected here: translateBodyExpr has no explicit
   // handler for ++/-- and silently falls through to `ast.var(getText())`,
   // so without this screen a loop like `while (used.has(i++)) i++;`
   // would lower to a Pant expression containing a bogus var `"i++"`.
@@ -1970,21 +1925,14 @@ export function inlineConstBindings(
   }
 
   // Phase 2: translate initializers as a left fold, threading scopedParams
-  // and translatedBindings through the accumulator. Early-return arms are
-  // accumulated alongside (they don't introduce a name, but their predicate
-  // and value are translated under the scope visible at their position so
-  // references to earlier bindings resolve to the correct hygienic `$N`
-  // names). Errors short-circuit subsequent work via the `tag: "error"`
-  // discriminant; successful steps return a fresh map via `withParam` so no
-  // `.set`-style mutation remains.
+  // through the accumulator. Const and μ-search bindings become IR1Let
+  // statements; early-return arms are accumulated alongside.
   type Acc =
     | {
         tag: "ok";
         scopedParams: ReadonlyMap<string, string>;
-        translatedBindings: ReadonlyArray<{
-          hygienicName: string;
-          initExpr: OpaqueExpr;
-        }>;
+        letStmts: IR1Stmt[];
+        ruleDecls: PropResult[];
         arms: ReadonlyArray<readonly [OpaqueExpr, OpaqueExpr]>;
       }
     | { tag: "error"; error: string };
@@ -2020,61 +1968,94 @@ export function inlineConstBindings(
         return {
           tag: "ok",
           scopedParams: acc.scopedParams,
-          translatedBindings: acc.translatedBindings,
+          letStmts: acc.letStmts,
+          ruleDecls: acc.ruleDecls,
           arms: [...acc.arms, [predRes.value, valRes.value] as const],
         };
       }
-      const hygienicName = `$${nextSupply(supply)}`;
+      const localName = toPantTermName(binding.tsName);
+      const returnType =
+        binding.kind === "const"
+          ? mapTsType(
+              checker.getTypeAtLocation(binding.initializer),
+              checker,
+              strategy,
+              supply.synthCell,
+            )
+          : strategy.mapNumber();
+      if (isUnsupportedUnknown(returnType)) {
+        return {
+          tag: "error",
+          error: `${binding.tsName}: ${UNSUPPORTED_UNKNOWN_REASON}`,
+        };
+      }
       const initExpr =
         binding.kind === "const"
-          ? translateBindingInit(
-              binding.initializer,
+          ? state === undefined
+            ? tryBuildL1PureSubExpression(binding.initializer, {
+                checker,
+                strategy,
+                paramNames: acc.scopedParams,
+                state,
+                supply,
+              })
+            : buildL1SubExpr(binding.initializer, {
+                checker,
+                strategy,
+                paramNames: acc.scopedParams,
+                state,
+                supply,
+              })
+          : buildL1MuSearchCombTyped(binding.mu, {
               checker,
               strategy,
-              acc.scopedParams,
+              paramNames: acc.scopedParams,
               state,
               supply,
-            )
-          : translateMuSearchInit(
-              binding.mu,
-              checker,
-              strategy,
-              acc.scopedParams,
-              state,
-              supply,
-            );
-      if ("error" in initExpr) {
-        return { tag: "error", error: initExpr.error };
+            });
+      if (initExpr === null) {
+        return {
+          tag: "error",
+          error: "unsupported pure expression in const initializer",
+        };
+      }
+      if (isUnsupported(initExpr) || isL1Unsupported(initExpr)) {
+        return { tag: "error", error: initExpr.unsupported };
       }
       return {
         tag: "ok",
-        scopedParams: withParam(acc.scopedParams, binding.tsName, hygienicName),
-        translatedBindings: [
-          ...acc.translatedBindings,
-          { hygienicName, initExpr: initExpr.value },
+        scopedParams: withParam(acc.scopedParams, binding.tsName, localName),
+        ruleDecls: [
+          ...acc.ruleDecls,
+          {
+            kind: "rule-decl",
+            ruleName: localName,
+            params: [],
+            returnType: getAst().tName(returnType),
+          },
         ],
+        letStmts: [...acc.letStmts, ir1Let(localName, initExpr)],
         arms: acc.arms,
       };
     },
-    { tag: "ok", scopedParams: baseParams, translatedBindings: [], arms: [] },
+    {
+      tag: "ok",
+      scopedParams: baseParams,
+      letStmts: [],
+      ruleDecls: [],
+      arms: [],
+    },
   );
 
   if (folded.tag === "error") {
     return { error: folded.error };
   }
-
-  // Phase 3: right-fold substitution closure. `reduceRight` applies the last
-  // binding first so references to earlier bindings inside its init remain
-  // unresolved — they get substituted in subsequent iterations.
-  const { scopedParams, translatedBindings, arms } = folded;
-  const applyTo = (expr: OpaqueExpr): OpaqueExpr =>
-    translatedBindings.reduceRight(
-      (acc, { hygienicName, initExpr }) =>
-        ast.substituteBinder(acc, hygienicName, initExpr),
-      expr,
-    );
-
-  return { applyTo, translatedBindings, scopedParams, arms };
+  return {
+    letStmts: folded.letStmts,
+    ruleDecls: folded.ruleDecls,
+    scopedParams: folded.scopedParams,
+    arms: folded.arms,
+  };
 }
 
 type BindingInitResult = { value: OpaqueExpr } | { error: string };
@@ -2099,33 +2080,6 @@ function translateBindingInit(
     return { error: result.unsupported };
   }
   return { value: bodyExpr(result) };
-}
-
-/**
- * Translate a recognized μ-search prelude binding to an OpaqueExpr.
- * The recognizer constructs L1 `comb-typed` directly; L1 → L2 lowering is
- * the mechanical `comb-typed` arm in `lowerL1Expr`.
- */
-function translateMuSearchInit(
-  mu: MuSearch,
-  checker: ts.TypeChecker,
-  strategy: NumericStrategy,
-  scopedParams: ReadonlyMap<string, string>,
-  state: SymbolicState | undefined,
-  supply: UniqueSupply,
-): BindingInitResult {
-  const buildCtx = {
-    checker,
-    strategy,
-    paramNames: scopedParams,
-    state,
-    supply,
-  };
-  const combTyped = buildL1MuSearchCombTyped(mu, buildCtx);
-  if (isL1Unsupported(combTyped)) {
-    return { error: combTyped.unsupported };
-  }
-  return { value: lowerL1ToOpaque(combTyped) };
 }
 
 export function isGuardStatement(
@@ -4048,6 +4002,7 @@ function translateMutatingBody(
   if (!node.body) {
     return [];
   }
+  const localRuleDecls: PropResult[] = [];
 
   const lowered = appendFramesForUnmodifiedRules(
     lowerSupportedSsaMutatingStatements(Array.from(node.body.statements), {
@@ -4059,13 +4014,14 @@ function translateMutatingBody(
       initialPropertyValues: new Map(),
       helperNameBase: functionName,
       declarations,
+      localRuleDecls,
     }),
     declarations,
   );
   if (lowered.diagnostics.length > 0) {
     return lowered.diagnostics;
   }
-  return lowered.propositions;
+  return [...localRuleDecls, ...lowered.propositions];
 }
 
 function lowerSupportedSsaMutatingStatements(
@@ -4079,6 +4035,7 @@ function lowerSupportedSsaMutatingStatements(
     initialPropertyValues: ReadonlyMap<string, OpaqueExpr>;
     helperNameBase: string;
     declarations: readonly PantDeclaration[];
+    localRuleDecls: PropResult[];
   },
 ): IR1SsaBodyLowerResult {
   const tailReturnValue = extractTailReturnValue(stmts, ctx.checker);
@@ -4326,6 +4283,7 @@ function lowerSupportedSsaMutatingBlock(
     initialPropertyValues: ReadonlyMap<string, OpaqueExpr>;
     helperNameBase: string;
     declarations: readonly PantDeclaration[];
+    localRuleDecls: PropResult[];
   },
 ): IR1SsaBodyLowerResult {
   const body = ts.factory.createBlock(stmts, true);
@@ -4336,6 +4294,7 @@ function lowerSupportedSsaMutatingBlock(
     ctx.paramNames,
     ctx.state,
     ctx.supply,
+    ctx.localRuleDecls,
   );
 
   if (isUnsupported(ssaBody)) {
@@ -4407,13 +4366,13 @@ function buildSupportedSsaMutatingBody(
   paramNames: Map<string, string>,
   state: SymbolicState,
   supply: UniqueSupply,
+  localRuleDecls?: PropResult[],
 ): IR1Stmt | { unsupported: string } {
   const stmts: IR1Stmt[] = [];
   const scopedParamNames = new Map(paramNames);
-  let applyConstChain: (e: OpaqueExpr) => OpaqueExpr = (e) => e;
-  const applyConst = (e: OpaqueExpr): OpaqueExpr =>
-    applyOpaqueAliases(applyConstChain(e), supply);
-  setCanonicalize(state, applyConst);
+  const canonicalizeAliases = (e: OpaqueExpr): OpaqueExpr =>
+    applyOpaqueAliases(e, supply);
+  setCanonicalize(state, canonicalizeAliases);
   for (let i = 0; i < body.statements.length; i++) {
     const stmt = body.statements[i]!;
     if (isGuardStatement(stmt, checker) && !isInsideLoopBody(stmt)) {
@@ -4444,7 +4403,6 @@ function buildSupportedSsaMutatingBody(
           paramNames: scopedParamNames,
           state,
           supply,
-          applyConst,
         },
       );
       if (built !== null) {
@@ -4458,12 +4416,11 @@ function buildSupportedSsaMutatingBody(
         {
           checker,
           strategy,
-          paramNames: scopedParamNames,
-          state,
-          supply,
-          applyConst,
-        },
-      );
+            paramNames: scopedParamNames,
+            state,
+            supply,
+          },
+        );
       if (isUnsupported(fixedPointBuilt)) {
         return fixedPointBuilt;
       }
@@ -4477,14 +4434,8 @@ function buildSupportedSsaMutatingBody(
       const declList = stmt.declarationList;
       if (declList.flags & ts.NodeFlags.Const) {
         const bindings: ConstBinding[] = [];
-        let allPure = true;
         for (const decl of declList.declarations) {
-          if (
-            !ts.isIdentifier(decl.name) ||
-            !decl.initializer ||
-            expressionHasSideEffects(decl.initializer, checker)
-          ) {
-            allPure = false;
+          if (!ts.isIdentifier(decl.name) || !decl.initializer) {
             break;
           }
           bindings.push({
@@ -4493,8 +4444,8 @@ function buildSupportedSsaMutatingBody(
             initializer: decl.initializer,
           });
         }
-        if (allPure) {
-          const inlined = inlineConstBindings(
+        if (bindings.length === declList.declarations.length) {
+          const lowered = lowerPreludeBindings(
             bindings,
             checker,
             strategy,
@@ -4502,18 +4453,17 @@ function buildSupportedSsaMutatingBody(
             supply,
             state,
           );
-          if ("error" in inlined) {
-            return { unsupported: inlined.error };
+          if ("error" in lowered) {
+            return { unsupported: lowered.error };
           }
-          for (const binding of inlined.translatedBindings) {
-            registerOpaqueAlias(supply, binding.hygienicName, binding.initExpr);
+          if (localRuleDecls !== undefined) {
+            localRuleDecls.push(...lowered.ruleDecls);
           }
-          for (const [key, value] of inlined.scopedParams) {
+          stmts.push(...lowered.letStmts);
+          for (const [key, value] of lowered.scopedParams) {
             scopedParamNames.set(key, value);
           }
-          const prevChain = applyConstChain;
-          applyConstChain = (e) => prevChain(inlined.applyTo(e));
-          setCanonicalize(state, applyConst);
+          setCanonicalize(state, canonicalizeAliases);
           continue;
         }
       }
@@ -4527,7 +4477,7 @@ function buildSupportedSsaMutatingBody(
       paramNames: scopedParamNames,
       state,
       supply,
-      applyConst,
+      ...(localRuleDecls === undefined ? {} : { localRuleDecls }),
     });
     if (isUnsupported(built)) {
       return built;
@@ -4551,7 +4501,7 @@ function buildSupportedSsaStatement(
     paramNames: Map<string, string>;
     state: SymbolicState;
     supply: UniqueSupply;
-    applyConst: (e: OpaqueExpr) => OpaqueExpr;
+    localRuleDecls?: PropResult[];
   },
 ): IR1Stmt | { unsupported: string } {
   if (
@@ -4580,6 +4530,7 @@ function buildSupportedSsaStatement(
       ctx.paramNames,
       ctx.state,
       ctx.supply,
+      ctx.localRuleDecls,
     );
     return body;
   }
@@ -4642,7 +4593,10 @@ function buildSupportedSsaStatement(
 
 function buildL1BareWhileMutation(
   stmt: ts.WhileStatement,
-  ctx: BuildBodyCtx & { paramNames: Map<string, string> },
+  ctx: BuildBodyCtx & {
+    paramNames: Map<string, string>;
+    localRuleDecls?: PropResult[];
+  },
 ): IR1Stmt | { unsupported: string } {
   const expr = unwrapExpression(stmt.expression);
   if (
@@ -4666,6 +4620,7 @@ function buildL1BareWhileMutation(
         ctx.paramNames,
         ctx.state,
         ctx.supply,
+        ctx.localRuleDecls,
       )
     : buildSupportedSsaStatement(stmt.statement, ctx);
   if (isUnsupported(bodyStmt)) {
@@ -4682,7 +4637,7 @@ function buildL1ForCounterMutation(
     paramNames: Map<string, string>;
     state: SymbolicState;
     supply: UniqueSupply;
-    applyConst: (e: OpaqueExpr) => OpaqueExpr;
+    localRuleDecls?: PropResult[];
   },
 ): IR1Stmt | { unsupported: string } {
   const init = buildL1ForCounterInit(stmt.initializer);
@@ -4729,6 +4684,7 @@ function buildL1ForCounterMutation(
         ctx.paramNames,
         ctx.state,
         ctx.supply,
+        ctx.localRuleDecls,
       )
     : buildSupportedSsaStatement(stmt.statement, ctx);
   if (isUnsupported(bodyStmt)) {
@@ -4741,7 +4697,10 @@ function buildL1ForCounterMutation(
 function buildL1LetWhileFixedPointMutation(
   letStmt: ts.VariableStatement,
   whileStmt: ts.WhileStatement,
-  ctx: BuildBodyCtx & { paramNames: Map<string, string> },
+  ctx: BuildBodyCtx & {
+    paramNames: Map<string, string>;
+    localRuleDecls?: PropResult[];
+  },
 ): IR1Stmt | { unsupported: string } | null {
   const declList = letStmt.declarationList;
   if (
@@ -4785,6 +4744,7 @@ function buildL1LetWhileFixedPointMutation(
     ctx.paramNames,
     ctx.state,
     ctx.supply,
+    ctx.localRuleDecls,
   );
   if (isUnsupported(bodyStmt)) {
     return bodyStmt;
@@ -4820,7 +4780,10 @@ function containsReachableLoopExit(stmt: ts.Statement): boolean {
 function buildL1LetWhileMutation(
   letStmt: ts.VariableStatement,
   whileStmt: ts.WhileStatement,
-  ctx: BuildBodyCtx & { paramNames: Map<string, string> },
+  ctx: BuildBodyCtx & {
+    paramNames: Map<string, string>;
+    localRuleDecls?: PropResult[];
+  },
 ): IR1Stmt | null {
   const declList = letStmt.declarationList;
   if (
@@ -4882,6 +4845,7 @@ function buildL1LetWhileMutation(
     ctx.paramNames,
     ctx.state,
     ctx.supply,
+    ctx.localRuleDecls,
   );
   if (isUnsupported(bodyStmt)) {
     return null;
@@ -4931,7 +4895,7 @@ function buildL1LetWhileCounterCondition(
   ) {
     return null;
   }
-  const bound = buildL1SubExpr(cond.right, { ...ctx, applyConst: (e) => e });
+  const bound = buildL1SubExpr(cond.right, ctx);
   if (isUnsupported(bound)) {
     return null;
   }
@@ -5016,7 +4980,7 @@ function buildL1ForCounterCondition(
   if (expressionHasSideEffects(cond.right, ctx.checker)) {
     return { unsupported: "counter loop bound expression has side effects" };
   }
-  const bound = buildL1SubExpr(cond.right, { ...ctx, applyConst: (e) => e });
+  const bound = buildL1SubExpr(cond.right, ctx);
   if (isUnsupported(bound)) {
     return bound;
   }

--- a/tools/ts2pant/src/types.ts
+++ b/tools/ts2pant/src/types.ts
@@ -82,7 +82,7 @@ export type PropResult =
       ruleName: string;
       params: Array<{ name: string; type: OpaqueTypeExpr }>;
       returnType: OpaqueTypeExpr;
-      body: OpaqueExpr;
+      body?: OpaqueExpr;
     }
   | {
       kind: "assertion";

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -167,19 +167,19 @@ exports[`expressions-comparison.ts > neq 1`] = `
 `;
 
 exports[`expressions-const-bindings.ts > chainedConst 1`] = `
-"module CHAINED_CONST.\\n\\nchained-const a: Int => Int.\\n\\n---\\n\\nchained-const a = a + 1.\\n"
+"module CHAINED_CONST.\\n\\nchained-const a: Int => Int.\\nx  => Int.\\ny  => Int.\\n\\n---\\n\\nx = a.\\ny = a + 1.\\nchained-const a = y.\\n"
 `;
 
 exports[`expressions-const-bindings.ts > constInTernary 1`] = `
-"module CONST_IN_TERNARY.\\n\\nconst-in-ternary a: Int, b: Int => Int.\\n\\n---\\n\\nconst-in-ternary a b = (cond a + b > 0 => a + b, true => 0).\\n"
+"module CONST_IN_TERNARY.\\n\\nconst-in-ternary a: Int, b: Int => Int.\\nx  => Int.\\n\\n---\\n\\nx = a + b.\\nconst-in-ternary a b = (cond x > 0 => x, true => 0).\\n"
 `;
 
 exports[`expressions-const-bindings.ts > constWithPropAccess 1`] = `
-"module CONST_WITH_PROP_ACCESS.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\nconst-with-prop-access a: Account => Int.\\n\\n---\\n\\nconst-with-prop-access a = account--balance a + 1.\\n"
+"module CONST_WITH_PROP_ACCESS.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\nconst-with-prop-access a: Account => Int.\\nb  => Int.\\n\\n---\\n\\nb = account--balance a.\\nconst-with-prop-access a = b + 1.\\n"
 `;
 
 exports[`expressions-const-bindings.ts > effectfulConstRejected 1`] = `
-"module EFFECTFUL_CONST_REJECTED.\\n\\neffectful-const-rejected  => Int.\\n\\n---\\n\\n> UNSUPPORTED: effectful-const-rejected — const binding with side-effectful initializer.\\n"
+"module EFFECTFUL_CONST_REJECTED.\\n\\neffectful-const-rejected  => Int.\\nx  => Int.\\n\\n---\\n\\nx = foo.\\neffectful-const-rejected = x.\\n"
 `;
 
 exports[`expressions-const-bindings.ts > letRejected 1`] = `
@@ -187,51 +187,51 @@ exports[`expressions-const-bindings.ts > letRejected 1`] = `
 `;
 
 exports[`expressions-const-bindings.ts > simpleConst 1`] = `
-"module SIMPLE_CONST.\\n\\nsimple-const a: Int, b: Int => Int.\\n\\n---\\n\\nsimple-const a b = a + b.\\n"
+"module SIMPLE_CONST.\\n\\nsimple-const a: Int, b: Int => Int.\\nx  => Int.\\n\\n---\\n\\nx = a + b.\\nsimple-const a b = x.\\n"
 `;
 
 exports[`expressions-const-chained-impure.ts > chainedArrayCount 1`] = `
-"module CHAINED_ARRAY_COUNT.\\n\\nStringToIntMap.\\nstring-to-int-map-key m1: StringToIntMap, k: String => Bool.\\nstring-to-int-map m1: StringToIntMap, k: String, string-to-int-map-key m1 k => Int.\\nchained-array-count m: StringToIntMap => Int.\\n\\n---\\n\\n> UNSUPPORTED: chained-array-count — const binding with side-effectful initializer.\\n"
+"module CHAINED_ARRAY_COUNT.\\n\\nStringToIntMap.\\nstring-to-int-map-key m1: StringToIntMap, k: String => Bool.\\nstring-to-int-map m1: StringToIntMap, k: String, string-to-int-map-key m1 k => Int.\\nchained-array-count m: StringToIntMap => Int.\\nxs  => [Int].\\nn  => Int.\\n\\n---\\n\\nxs = (from Array) (values m).\\nn = #((from Array) (values m)).\\nchained-array-count m = n.\\n"
 `;
 
 exports[`expressions-const-chained-impure.ts > chainedReplaceTrim 1`] = `
-"module CHAINED_REPLACE_TRIM.\\n\\nchained-replace-trim s: String => String.\\n\\n---\\n\\n> UNSUPPORTED: chained-replace-trim — const binding with side-effectful initializer.\\n"
+"module CHAINED_REPLACE_TRIM.\\n\\nchained-replace-trim s: String => String.\\n\\n---\\n\\n> UNSUPPORTED: chained-replace-trim — unsupported pure expression in const initializer.\\n"
 `;
 
 exports[`expressions-const-pure-calls.ts > constChainedPure 1`] = `
-"module CONST_CHAINED_PURE.\\n\\nconst-chained-pure x: Int, y: Int => Int.\\n\\n---\\n\\nconst-chained-pure x y = max Math (abs Math x) y.\\n"
+"module CONST_CHAINED_PURE.\\n\\nconst-chained-pure x: Int, y: Int => Int.\\na  => Int.\\nb  => Int.\\n\\n---\\n\\na = (abs Math) x.\\nb = (max Math) ((abs Math) x) y.\\nconst-chained-pure x y = b.\\n"
 `;
 
 exports[`expressions-const-pure-calls.ts > constImpureCall 1`] = `
-"module CONST_IMPURE_CALL.\\n\\nconst-impure-call x: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: const-impure-call — const binding with side-effectful initializer.\\n"
+"module CONST_IMPURE_CALL.\\n\\nconst-impure-call x: Int => Int.\\nr  => Int.\\n\\n---\\n\\nr = unknownFn x.\\nconst-impure-call x = r.\\n"
 `;
 
 exports[`expressions-const-pure-calls.ts > constMathMax 1`] = `
-"module CONST_MATH_MAX.\\n\\nconst-math-max a: Int, b: Int => Int.\\n\\n---\\n\\nconst-math-max a b = max Math a b + 1.\\n"
+"module CONST_MATH_MAX.\\n\\nconst-math-max a: Int, b: Int => Int.\\nm  => Int.\\n\\n---\\n\\nm = (max Math) a b.\\nconst-math-max a b = m + 1.\\n"
 `;
 
 exports[`expressions-const-pure-calls.ts > constStringMethod 1`] = `
-"module CONST_STRING_METHOD.\\n\\nconst-string-method s: String => Int.\\n\\n---\\n\\nconst-string-method s = index-of s \\"x\\".\\n"
+"module CONST_STRING_METHOD.\\n\\nconst-string-method s: String => Int.\\ni  => Int.\\n\\n---\\n\\ni = (index-of s) \\"x\\".\\nconst-string-method s = i.\\n"
 `;
 
 exports[`expressions-const-side-effectful.ts > constArrayFromMap 1`] = `
-"module CONST_ARRAY_FROM_MAP.\\n\\nStringToIntMap.\\nstring-to-int-map-key m1: StringToIntMap, k: String => Bool.\\nstring-to-int-map m1: StringToIntMap, k: String, string-to-int-map-key m1 k => Int.\\nconst-array-from-map m: StringToIntMap => Int.\\n\\n---\\n\\n> UNSUPPORTED: const-array-from-map — const binding with side-effectful initializer.\\n"
+"module CONST_ARRAY_FROM_MAP.\\n\\nStringToIntMap.\\nstring-to-int-map-key m1: StringToIntMap, k: String => Bool.\\nstring-to-int-map m1: StringToIntMap, k: String, string-to-int-map-key m1 k => Int.\\nconst-array-from-map m: StringToIntMap => Int.\\nxs  => [Int].\\n\\n---\\n\\nxs = (from Array) (values m).\\nconst-array-from-map m = #xs.\\n"
 `;
 
 exports[`expressions-const-side-effectful.ts > constMapEntries 1`] = `
-"module CONST_MAP_ENTRIES.\\n\\nStringToIntMap.\\nstring-to-int-map-key m1: StringToIntMap, k: String => Bool.\\nstring-to-int-map m1: StringToIntMap, k: String, string-to-int-map-key m1 k => Int.\\nconst-map-entries m: StringToIntMap => Int.\\n\\n---\\n\\n> UNSUPPORTED: const-map-entries — const binding with side-effectful initializer.\\n"
+"module CONST_MAP_ENTRIES.\\n\\nStringToIntMap.\\nstring-to-int-map-key m1: StringToIntMap, k: String => Bool.\\nstring-to-int-map m1: StringToIntMap, k: String, string-to-int-map-key m1 k => Int.\\nconst-map-entries m: StringToIntMap => Int.\\nxs  => [String * Int].\\n\\n---\\n\\nxs = (from Array) (entries m).\\nconst-map-entries m = #xs.\\n"
 `;
 
 exports[`expressions-const-side-effectful.ts > constReplaceLiteral 1`] = `
-"module CONST_REPLACE_LITERAL.\\n\\nconst-replace-literal s: String => String.\\n\\n---\\n\\n> UNSUPPORTED: const-replace-literal — const binding with side-effectful initializer.\\n"
+"module CONST_REPLACE_LITERAL.\\n\\nconst-replace-literal s: String => String.\\nx  => String.\\n\\n---\\n\\nx = (replace s) \\"a\\" \\"b\\".\\nconst-replace-literal s = x.\\n"
 `;
 
 exports[`expressions-const-side-effectful.ts > constReplaceRegex 1`] = `
-"module CONST_REPLACE_REGEX.\\n\\nconst-replace-regex s: String => String.\\n\\n---\\n\\n> UNSUPPORTED: const-replace-regex — const binding with side-effectful initializer.\\n"
+"module CONST_REPLACE_REGEX.\\n\\nconst-replace-regex s: String => String.\\n\\n---\\n\\n> UNSUPPORTED: const-replace-regex — unsupported pure expression in const initializer.\\n"
 `;
 
 exports[`expressions-const-side-effectful.ts > constSetHas 1`] = `
-"module CONST_SET_HAS.\\n\\nconst-set-has s: [String], value: String => Bool.\\n\\n---\\n\\nconst-set-has s value = (value in s).\\n"
+"module CONST_SET_HAS.\\n\\nconst-set-has s: [String], value: String => Bool.\\nx  => Bool.\\n\\n---\\n\\nx = (value in s).\\nconst-set-has s value = x.\\n"
 `;
 
 exports[`expressions-equality-nullish.ts > disjunctionDifferentOperands 1`] = `
@@ -347,15 +347,15 @@ exports[`expressions-functor-lift.ts > typeofGuardLift 1`] = `
 `;
 
 exports[`expressions-if-early-return.ts > armBetweenBindings 1`] = `
-"module ARM_BETWEEN_BINDINGS.\\n\\narm-between-bindings n: Int => Int.\\n\\n---\\n\\narm-between-bindings n = (cond n + 1 < 0 => 0, true => n + 1 + (n + 1)).\\n"
+"module ARM_BETWEEN_BINDINGS.\\n\\narm-between-bindings n: Int => Int.\\na  => Int.\\nb  => Int.\\n\\n---\\n\\na = n + 1.\\nb = n + 1 + (n + 1).\\narm-between-bindings n = (cond a < 0 => 0, true => b).\\n"
 `;
 
 exports[`expressions-if-early-return.ts > armThenMuSearch 1`] = `
-"module ARM_THEN_MU_SEARCH.\\n\\narm-then-mu-search n: Int, used: [Int] => Int.\\n\\n---\\n\\narm-then-mu-search n used = (cond n < 0 => 0, true => (min over each j: Int, j >= 1, ~(j in used) | j)).\\n"
+"module ARM_THEN_MU_SEARCH.\\n\\narm-then-mu-search n: Int, used: [Int] => Int.\\nj  => Int.\\n\\n---\\n\\nj = (min over each j: Int, j >= 1, ~(j in used) | j).\\narm-then-mu-search n used = (cond n < 0 => 0, true => j).\\n"
 `;
 
 exports[`expressions-if-early-return.ts > bindingThenArm 1`] = `
-"module BINDING_THEN_ARM.\\n\\nbinding-then-arm n: Int => Int.\\n\\n---\\n\\nbinding-then-arm n = (cond n + n < 0 => 0, true => n + n).\\n"
+"module BINDING_THEN_ARM.\\n\\nbinding-then-arm n: Int => Int.\\ndoubled  => Int.\\n\\n---\\n\\ndoubled = n + n.\\nbinding-then-arm n = (cond doubled < 0 => 0, true => doubled).\\n"
 `;
 
 exports[`expressions-if-early-return.ts > singleArm 1`] = `
@@ -371,7 +371,7 @@ exports[`expressions-if-early-return.ts > unbracedArm 1`] = `
 `;
 
 exports[`expressions-ir-anchor.ts > effectiveValue 1`] = `
-"module EFFECTIVE_VALUE.\\n\\nCache.\\ncache--fallback c1: Cache => Int.\\ncache--value c1: Cache => [Int].\\neffective-value c: Cache, factor: Int => Int.\\n\\n---\\n\\neffective-value c factor = (cond factor > 0 => (cond #(cache--value c) = 0 => cache--fallback c, true => (cache--value c) 1) * factor, true => (cond #(cache--value c) = 0 => cache--fallback c, true => (cache--value c) 1)).\\n"
+"module EFFECTIVE_VALUE.\\n\\nCache.\\ncache--fallback c1: Cache => Int.\\ncache--value c1: Cache => [Int].\\neffective-value c: Cache, factor: Int => Int.\\nbase  => Int.\\n\\n---\\n\\nbase = (cond #(cache--value c) = 0 => cache--fallback c, true => (cache--value c) 1).\\neffective-value c factor = (cond factor > 0 => base * factor, true => base).\\n"
 `;
 
 exports[`expressions-literals.ts > fortyTwo 1`] = `
@@ -755,7 +755,7 @@ exports[`expressions-template-literal.ts > wrapId 1`] = `
 `;
 
 exports[`expressions-while-mu-search.ts > compoundIncrementStep 1`] = `
-"module COMPOUND_INCREMENT_STEP.\\n\\ncompound-increment-step used: [Int] => Int.\\n\\n---\\n\\ncompound-increment-step used = (min over each j: Int, j >= 1, ~(j in used) | j).\\n"
+"module COMPOUND_INCREMENT_STEP.\\n\\ncompound-increment-step used: [Int] => Int.\\ni  => Int.\\n\\n---\\n\\ni = (min over each j: Int, j >= 1, ~(j in used) | j).\\ncompound-increment-step used = i.\\n"
 `;
 
 exports[`expressions-while-mu-search.ts > compoundWhileBody 1`] = `
@@ -763,27 +763,27 @@ exports[`expressions-while-mu-search.ts > compoundWhileBody 1`] = `
 `;
 
 exports[`expressions-while-mu-search.ts > explicitIncrementStep 1`] = `
-"module EXPLICIT_INCREMENT_STEP.\\n\\nexplicit-increment-step used: [Int] => Int.\\n\\n---\\n\\nexplicit-increment-step used = (min over each j: Int, j >= 1, ~(j in used) | j).\\n"
+"module EXPLICIT_INCREMENT_STEP.\\n\\nexplicit-increment-step used: [Int] => Int.\\ni  => Int.\\n\\n---\\n\\ni = (min over each j: Int, j >= 1, ~(j in used) | j).\\nexplicit-increment-step used = i.\\n"
 `;
 
 exports[`expressions-while-mu-search.ts > explicitIncrementStepFlipped 1`] = `
-"module EXPLICIT_INCREMENT_STEP_FLIPPED.\\n\\nexplicit-increment-step-flipped used: [Int] => Int.\\n\\n---\\n\\nexplicit-increment-step-flipped used = (min over each j: Int, j >= 1, ~(j in used) | j).\\n"
+"module EXPLICIT_INCREMENT_STEP_FLIPPED.\\n\\nexplicit-increment-step-flipped used: [Int] => Int.\\ni  => Int.\\n\\n---\\n\\ni = (min over each j: Int, j >= 1, ~(j in used) | j).\\nexplicit-increment-step-flipped used = i.\\n"
 `;
 
 exports[`expressions-while-mu-search.ts > firstUnusedSuffix 1`] = `
-"module FIRST_UNUSED_SUFFIX.\\n\\nfirst-unused-suffix used: [Int] => Int.\\n\\n---\\n\\nfirst-unused-suffix used = (min over each j: Int, j >= 1, ~(j in used) | j).\\n"
+"module FIRST_UNUSED_SUFFIX.\\n\\nfirst-unused-suffix used: [Int] => Int.\\ni  => Int.\\n\\n---\\n\\ni = (min over each j: Int, j >= 1, ~(j in used) | j).\\nfirst-unused-suffix used = i.\\n"
 `;
 
 exports[`expressions-while-mu-search.ts > nextSlotPlusOne 1`] = `
-"module NEXT_SLOT_PLUS_ONE.\\n\\nnext-slot-plus-one used: [Int] => Int.\\n\\n---\\n\\nnext-slot-plus-one used = (min over each j: Int, j >= 0, ~(j in used) | j) + 1.\\n"
+"module NEXT_SLOT_PLUS_ONE.\\n\\nnext-slot-plus-one used: [Int] => Int.\\ni  => Int.\\n\\n---\\n\\ni = (min over each j: Int, j >= 0, ~(j in used) | j).\\nnext-slot-plus-one used = i + 1.\\n"
 `;
 
 exports[`expressions-while-mu-search.ts > offsetUnusedSuffix 1`] = `
-"module OFFSET_UNUSED_SUFFIX.\\n\\noffset-unused-suffix used: [Int], offset: Int => Int.\\n\\n---\\n\\noffset-unused-suffix used offset = offset + (min over each j: Int, j >= 1, ~(j in used) | j).\\n"
+"module OFFSET_UNUSED_SUFFIX.\\n\\noffset-unused-suffix used: [Int], offset: Int => Int.\\nbase  => Int.\\ni  => Int.\\n\\n---\\n\\nbase = offset.\\ni = (min over each j: Int, j >= 1, ~(j in used) | j).\\noffset-unused-suffix used offset = base + i.\\n"
 `;
 
 exports[`expressions-while-mu-search.ts > unbracedWhileBody 1`] = `
-"module UNBRACED_WHILE_BODY.\\n\\nunbraced-while-body used: [Int] => Int.\\n\\n---\\n\\nunbraced-while-body used = (min over each j: Int, j >= 1, ~(j in used) | j).\\n"
+"module UNBRACED_WHILE_BODY.\\n\\nunbraced-while-body used: [Int] => Int.\\ni  => Int.\\n\\n---\\n\\ni = (min over each j: Int, j >= 1, ~(j in used) | j).\\nunbraced-while-body used = i.\\n"
 `;
 
 exports[`functions-class.ts > Account.deposit 1`] = `
@@ -883,15 +883,15 @@ exports[`functions-mutating-conditional.ts > toggleActive 1`] = `
 `;
 
 exports[`functions-mutating-const.ts > aliasedSequentialWrites 1`] = `
-"module ALIASED_SEQUENTIAL_WRITES.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\n~> Aliased-sequential-writes @ a: Account.\\n\\n---\\n\\naccount--balance' a = 1 + 2.\\n"
+"module ALIASED_SEQUENTIAL_WRITES.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\nx  => Account.\\n~> Aliased-sequential-writes @ a: Account.\\n\\n---\\n\\nx = a.\\naccount--balance' x = 1 + 2.\\n"
 `;
 
 exports[`functions-mutating-const.ts > depositWithConst 1`] = `
-"module DEPOSIT_WITH_CONST.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\n~> Deposit-with-const @ a: Account, amount: Int.\\n\\n---\\n\\naccount--balance' a = account--balance a + amount.\\n"
+"module DEPOSIT_WITH_CONST.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\nnew-bal  => Int.\\n~> Deposit-with-const @ a: Account, amount: Int.\\n\\n---\\n\\nnew-bal = account--balance a + amount.\\naccount--balance' a = account--balance a + amount.\\n"
 `;
 
 exports[`functions-mutating-const.ts > multiConstMutating 1`] = `
-"module MULTI_CONST_MUTATING.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\n~> Multi-const-mutating @ a: Account, amount: Int, rate: Int.\\n\\n---\\n\\naccount--balance' a = account--balance a - amount * rate.\\n"
+"module MULTI_CONST_MUTATING.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\nfee  => Int.\\n~> Multi-const-mutating @ a: Account, amount: Int, rate: Int.\\n\\n---\\n\\nfee = amount * rate.\\naccount--balance' a = account--balance a - amount * rate.\\n"
 `;
 
 exports[`functions-mutating-counter-loop.ts > setLastIndex 1`] = `

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -351,7 +351,7 @@ exports[`expressions-if-early-return.ts > armBetweenBindings 1`] = `
 `;
 
 exports[`expressions-if-early-return.ts > armThenMuSearch 1`] = `
-"module ARM_THEN_MU_SEARCH.\\n\\narm-then-mu-search n: Int, used: [Int] => Int.\\nj  => Int.\\n\\n---\\n\\nj = (min over each j: Int, j >= 1, ~(j in used) | j).\\narm-then-mu-search n used = (cond n < 0 => 0, true => j).\\n"
+"module ARM_THEN_MU_SEARCH.\\n\\narm-then-mu-search n: Int, used: [Int] => Int.\\nj  => Int.\\n\\n---\\n\\nj = (min over each j1: Int, j1 >= 1, ~(j1 in used) | j1).\\narm-then-mu-search n used = (cond n < 0 => 0, true => j).\\n"
 `;
 
 exports[`expressions-if-early-return.ts > bindingThenArm 1`] = `

--- a/tools/ts2pant/tests/ir1-lower.test.mts
+++ b/tools/ts2pant/tests/ir1-lower.test.mts
@@ -558,7 +558,7 @@ describe("L2 comb-typed form (typed comprehension)", () => {
 
   it("byte-equality with a hand-built legacy eachComb", () => {
     const ast = getAst();
-    // Hand-built legacy form — what today's translateMuSearchInit emits.
+    // Hand-built legacy form kept as a byte-equality anchor.
     const legacy = ast.eachComb(
       [ast.param("j", ast.tName("Int"))],
       [

--- a/tools/ts2pant/tests/known-typecheck-failures.mts
+++ b/tools/ts2pant/tests/known-typecheck-failures.mts
@@ -68,6 +68,8 @@ export const KNOWN_TYPECHECK_FAILURES = new Map<string, string>([
   ["expressions-const-side-effectful.ts > constArrayFromMap", "free-call-decl"],
   ["expressions-const-side-effectful.ts > constMapEntries", "free-call-decl"],
   ["expressions-const-side-effectful.ts > constSetHas", "free-call-decl"],
+  ["expressions-const-pure-calls.ts > constImpureCall", "free-call-decl"],
+  ["expressions-const-bindings.ts > effectfulConstRejected", "free-call-decl"],
   ["expressions-misc.ts > asNumber", "free-call-decl"],
   ["expressions-misc.ts > nonNull", "free-call-decl"],
   ["expressions-nullish.ts > maybeBalance", "$-binder-leak"],

--- a/tools/ts2pant/tests/m2-musearch-l1.test.mts
+++ b/tools/ts2pant/tests/m2-musearch-l1.test.mts
@@ -62,14 +62,18 @@ function translate(
   if (props.length === 0) {
     return { unsupported: "no propositions", pant: null };
   }
-  const p = props[0]!;
-  if (p.kind === "unsupported") {
-    return { unsupported: p.reason, pant: null };
+  const unsupported = props.find((prop) => prop.kind === "unsupported");
+  if (unsupported !== undefined) {
+    return { unsupported: unsupported.reason, pant: null };
   }
-  if (p.kind !== "equation") {
-    return { unsupported: `non-equation: ${p.kind}`, pant: null };
+  const equations = props.filter((prop) => prop.kind === "equation");
+  if (equations.length === 0) {
+    return { unsupported: "no equation proposition", pant: null };
   }
-  return { unsupported: null, pant: getAst().strExpr(p.rhs) };
+  return {
+    unsupported: null,
+    pant: equations.map((p) => getAst().strExpr(p.rhs)).join(" ; "),
+  };
 }
 
 function buildFirstLetWhileCombTyped(source: string, name: string) {
@@ -207,14 +211,15 @@ describe("M2 μ-search L1: all five +1 spellings produce identical Pant", () => 
       outputs.push({ funcName, output: emitDocument(doc) });
     }
 
-    const rhsOutputs = outputs.map(({ funcName, output }) =>
-      extractEquationRhs(
+    const rhsOutputs = outputs.map(({ funcName, output }) => {
+      const functionRhs = extractEquationRhs(
         output,
         funcName
           .replace(/[A-Z]/gu, (c) => `-${c.toLowerCase()}`)
           .replace(/^-/, ""),
-      ),
-    );
+      );
+      return functionRhs === "i." ? extractEquationRhs(output, "i") : functionRhs;
+    });
     for (const rhs of rhsOutputs) {
       assert.match(rhs, /min over each j\d*: Int/u);
     }
@@ -274,10 +279,13 @@ describe("post-migration recognizer placement", () => {
       sourceFile,
       "firstUnusedSuffix",
     );
-    assert.equal(
-      emitDocument(doc),
-      "module FIRST_UNUSED_SUFFIX.\n\nfirst-unused-suffix used: [Int] => Int.\n\n---\n\nfirst-unused-suffix used = (min over each j: Int, j >= 1, ~(j in used) | j).\n",
+    const output = emitDocument(doc);
+    assert.match(output, /i\s+=> Int/u);
+    assert.match(
+      output,
+      /i = \(min over each j: Int, j >= 1, ~\(j in used\) \| j\)\./u,
     );
+    assert.match(output, /first-unused-suffix used = i\./u);
   });
 });
 

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -65,6 +65,22 @@ function translateBodyWithSynth(
   });
 }
 
+function finalEquation(props: readonly PropResult[]): Extract<
+  PropResult,
+  { kind: "equation" }
+> {
+  const prop = [...props].reverse().find((p) => p.kind === "equation");
+  assert.ok(prop, "expected at least one equation");
+  return prop;
+}
+
+function equationRhsText(props: readonly PropResult[]): string {
+  return props
+    .filter((p) => p.kind === "equation")
+    .map((p) => getAst().strExpr(p.rhs))
+    .join(" ; ");
+}
+
 // Tests for internal translateBody API edge cases not coverable via
 // exported fixture functions (see tests/fixtures/constructs/ for
 // exhaustive construct coverage).
@@ -84,7 +100,7 @@ describe("unsupported patterns", () => {
     assert.equal(props.length, 0);
   });
 
-  it("translates function with leading const bindings via inline substitution", () => {
+  it("translates function with leading const bindings via local equations", () => {
     const source = `
       function multi(x: number): number {
         const a = x + 1;
@@ -99,12 +115,10 @@ describe("unsupported patterns", () => {
       strategy: IntStrategy,
     });
 
-    assert.equal(props.length, 1);
-    const prop = props[0]!;
-    assert.equal(prop.kind, "equation");
+    const prop = finalEquation(props);
     if (prop.kind === "equation") {
       const ast = getAst();
-      assert.equal(ast.strExpr(prop.rhs), "(x + 1) * 2");
+      assert.equal(ast.strExpr(prop.rhs), "b");
     }
   });
 
@@ -146,7 +160,7 @@ describe("unsupported patterns", () => {
     assert.equal(props.length, 0);
   });
 
-  it("inlines triple-chained const bindings via right-fold", () => {
+  it("routes triple-chained const bindings through local equations", () => {
     const source = `
       function triple(x: number): number {
         const a = x;
@@ -162,12 +176,10 @@ describe("unsupported patterns", () => {
       strategy: IntStrategy,
     });
 
-    assert.equal(props.length, 1);
-    const prop = props[0]!;
-    assert.equal(prop.kind, "equation");
+    const prop = finalEquation(props);
     if (prop.kind === "equation") {
       const ast = getAst();
-      assert.equal(ast.strExpr(prop.rhs), "(x + 1) * x");
+      assert.equal(ast.strExpr(prop.rhs), "c");
     }
   });
 
@@ -189,7 +201,7 @@ describe("unsupported patterns", () => {
     assert.equal(props[0]?.kind, "unsupported");
   });
 
-  it("hygienic names don't collide with property accessors", () => {
+  it("local binding names don't collide with property accessors", () => {
     // Regression: const named `balance` must not collide with the
     // property accessor head `balance` in `a.balance`.
     const source = `
@@ -206,12 +218,10 @@ describe("unsupported patterns", () => {
       strategy: IntStrategy,
     });
 
-    assert.equal(props.length, 1);
-    const prop = props[0]!;
-    assert.equal(prop.kind, "equation");
+    const prop = finalEquation(props);
     if (prop.kind === "equation") {
       const ast = getAst();
-      assert.equal(ast.strExpr(prop.rhs), "account--balance a + 10");
+      assert.equal(ast.strExpr(prop.rhs), "balance + 10");
     }
   });
 
@@ -386,9 +396,7 @@ describe("unsupported patterns", () => {
       strategy: IntStrategy,
     });
 
-    assert.equal(props.length, 1);
-    const prop = props[0]!;
-    assert.equal(prop.kind, "equation");
+    const prop = finalEquation(props);
     if (prop.kind === "equation") {
       const ast = getAst();
       assert.equal(ast.strExpr(prop.rhs), "x + 1");
@@ -418,9 +426,7 @@ describe("unsupported patterns", () => {
       strategy: IntStrategy,
     });
 
-    assert.equal(props.length, 1);
-    const prop = props[0]!;
-    assert.equal(prop.kind, "equation");
+    const prop = finalEquation(props);
     if (prop.kind === "equation") {
       const ast = getAst();
       const rhs = ast.strExpr(prop.rhs);
@@ -446,9 +452,7 @@ describe("if-early-return prelude arms", () => {
       functionName: "f",
       strategy: IntStrategy,
     });
-    assert.equal(props.length, 1);
-    const prop = props[0]!;
-    assert.equal(prop.kind, "equation");
+    const prop = finalEquation(props);
     if (prop.kind === "equation") {
       const ast = getAst();
       assert.equal(ast.strExpr(prop.rhs), "cond n < 0 => 0, true => n + 1");
@@ -469,14 +473,12 @@ describe("if-early-return prelude arms", () => {
       functionName: "f",
       strategy: IntStrategy,
     });
-    assert.equal(props.length, 1);
-    const prop = props[0]!;
-    assert.equal(prop.kind, "equation");
+    const prop = finalEquation(props);
     if (prop.kind === "equation") {
       const ast = getAst();
       assert.equal(
         ast.strExpr(prop.rhs),
-        "cond n + n < 0 => 0, true => n + n",
+        "cond doubled < 0 => 0, true => doubled",
       );
     }
   });
@@ -496,14 +498,12 @@ describe("if-early-return prelude arms", () => {
       functionName: "f",
       strategy: IntStrategy,
     });
-    assert.equal(props.length, 1);
-    const prop = props[0]!;
-    assert.equal(prop.kind, "equation");
+    const prop = finalEquation(props);
     if (prop.kind === "equation") {
       const ast = getAst();
       assert.equal(
         ast.strExpr(prop.rhs),
-        "cond n + 1 < 0 => 0, true => n + 1 + (n + 1)",
+        "cond a < 0 => 0, true => b",
       );
     }
   });
@@ -522,9 +522,7 @@ describe("if-early-return prelude arms", () => {
       functionName: "f",
       strategy: IntStrategy,
     });
-    assert.equal(props.length, 1);
-    const prop = props[0]!;
-    assert.equal(prop.kind, "equation");
+    const prop = finalEquation(props);
     if (prop.kind === "equation") {
       const ast = getAst();
       assert.equal(
@@ -549,13 +547,11 @@ describe("if-early-return prelude arms", () => {
       functionName: "f",
       strategy: IntStrategy,
     });
-    assert.equal(props.length, 1);
-    const prop = props[0]!;
-    assert.equal(prop.kind, "equation");
+    const prop = finalEquation(props);
     if (prop.kind === "equation") {
       const ast = getAst();
       assert.match(ast.strExpr(prop.rhs), /^cond n < 0 => 0, true => /u);
-      assert.match(ast.strExpr(prop.rhs), /min over each j\d*: Int/u);
+      assert.match(equationRhsText(props), /min over each j\d*: Int/u);
     }
   });
 
@@ -825,9 +821,7 @@ describe("translateCallExpr", () => {
       strategy: IntStrategy,
     });
 
-    assert.equal(props.length, 1);
-    const prop = props[0]!;
-    assert.equal(prop.kind, "equation");
+    const prop = finalEquation(props);
     if (prop.kind === "equation") {
       const ast = getAst();
       assert.equal(ast.strExpr(prop.rhs), "max a b");
@@ -847,9 +841,7 @@ describe("translateCallExpr", () => {
       strategy: IntStrategy,
     });
 
-    assert.equal(props.length, 1);
-    const prop = props[0]!;
-    assert.equal(prop.kind, "equation");
+    const prop = finalEquation(props);
     if (prop.kind === "equation") {
       const ast = getAst();
       assert.equal(ast.strExpr(prop.rhs), "(to-upper-case s)");
@@ -870,9 +862,7 @@ describe("translateCallExpr", () => {
       strategy: IntStrategy,
     });
 
-    assert.equal(props.length, 1);
-    const prop = props[0]!;
-    assert.equal(prop.kind, "equation");
+    const prop = finalEquation(props);
     if (prop.kind === "equation") {
       const ast = getAst();
       assert.equal(ast.strExpr(prop.rhs), "now");
@@ -1994,17 +1984,15 @@ describe("Kleene μ-search (while-loop minimum)", () => {
       strategy: IntStrategy,
     });
 
-    assert.equal(props.length, 1);
-    const prop = props[0]!;
-    assert.equal(prop.kind, "equation");
+    const prop = finalEquation(props);
     if (prop.kind === "equation") {
       const ast = getAst();
       // Match any `jN` binder and assert consistent use throughout the
       // comprehension. The specific `N` depends on UniqueSupply slot
       // consumption and shouldn't break hygiene refactors.
       assert.match(
-        ast.strExpr(prop.rhs),
-        /^min over each (j\d+): Int, \1 >= 1, ~\(\1 in used\) \| \1$/,
+        equationRhsText(props),
+        /min over each (j\d+): Int, \1 >= 1, ~\(\1 in used\) \| \1/u,
       );
     }
   });
@@ -2026,19 +2014,17 @@ describe("Kleene μ-search (while-loop minimum)", () => {
       strategy: IntStrategy,
     });
 
-    assert.equal(props.length, 1);
-    const prop = props[0]!;
-    assert.equal(prop.kind, "equation");
+    const prop = finalEquation(props);
     if (prop.kind === "equation") {
       const ast = getAst();
       assert.match(
-        ast.strExpr(prop.rhs),
-        /^\(min over each (j\d+): Int, \1 >= 0, ~\(\1 in used\) \| \1\) \+ 1$/,
+        equationRhsText(props),
+        /min over each (j\d+): Int, \1 >= 0, ~\(\1 in used\) \| \1.*i \+ 1/u,
       );
     }
   });
 
-  it("composes μ-search with leading const bindings via shared inlining", () => {
+  it("composes μ-search with leading const bindings via local equations", () => {
     const source = `
       export function offset(used: ReadonlySet<number>, k: number): number {
         const base = k;
@@ -2056,14 +2042,12 @@ describe("Kleene μ-search (while-loop minimum)", () => {
       strategy: IntStrategy,
     });
 
-    assert.equal(props.length, 1);
-    const prop = props[0]!;
-    assert.equal(prop.kind, "equation");
+    const prop = finalEquation(props);
     if (prop.kind === "equation") {
       const ast = getAst();
       assert.match(
         ast.strExpr(prop.rhs),
-        /^k \+ \(min over each (j\d+): Int, \1 >= 1, ~\(\1 in used\) \| \1\)$/,
+        /^base \+ i$/,
       );
     }
   });
@@ -2170,14 +2154,12 @@ describe("Kleene μ-search (while-loop minimum)", () => {
       strategy: IntStrategy,
     });
 
-    assert.equal(props.length, 1);
-    const prop = props[0]!;
-    assert.equal(prop.kind, "equation");
+    const prop = finalEquation(props);
     if (prop.kind === "equation") {
       const ast = getAst();
       assert.match(
-        ast.strExpr(prop.rhs),
-        /^min over each (j\d+): Int, \1 >= 1, ~\(\1 in used\) \| \1$/,
+        equationRhsText(props),
+        /min over each (j\d+): Int, \1 >= 1, ~\(\1 in used\) \| \1/u,
       );
     }
   });
@@ -2185,7 +2167,7 @@ describe("Kleene μ-search (while-loop minimum)", () => {
   it("rejects when the initializer has side effects", () => {
     // `start++` in the init would otherwise lower to a bogus var since
     // `translateBodyExpr` has no handler for bare `++`/`--`. The TDZ
-    // phase in inlineConstBindings catches this explicitly.
+    // phase in lowerPreludeBindings catches this explicitly.
     const source = `
       export function bogusInit(used: ReadonlySet<number>, start: number): number {
         let i = start++;

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -183,6 +183,45 @@ describe("unsupported patterns", () => {
     }
   });
 
+  it("allocates collision-safe local binding names", () => {
+    const source = `
+      function collision(x: number): number {
+        const foo_bar = x;
+        const fooBar = foo_bar + 1;
+        return fooBar + foo_bar;
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBodyWithSynth(sourceFile, "collision");
+    const ast = getAst();
+    const localDecls = props
+      .filter((p) => p.kind === "rule-decl")
+      .map((p) => p.ruleName);
+
+    assert.deepEqual(localDecls, ["foo-bar", "foo-bar1"]);
+    assert.equal(ast.strExpr(finalEquation(props).rhs), "foo-bar1 + foo-bar");
+  });
+
+  it("lowers member and cardinality const initializers through L1", () => {
+    const source = `
+      interface Account { balance: number }
+      function summarize(a: Account, xs: number[]): number {
+        const balance = a.balance;
+        const count = xs.length;
+        return balance + count;
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBodyWithSynth(sourceFile, "summarize");
+    const ast = getAst();
+    const rhsText = equationRhsText(props);
+
+    assert.doesNotMatch(rhsText, /unsupported/u);
+    assert.match(rhsText, /account--balance a/u);
+    assert.match(rhsText, /#xs/u);
+    assert.equal(ast.strExpr(finalEquation(props).rhs), "balance + count");
+  });
+
   it("rejects self-referencing const (TDZ)", () => {
     const source = `
       function selfRef(x: number): number {


### PR DESCRIPTION
## Patch 3: Route const bindings through IR1Let; remove inlining + purity gate

- Lift the purity gate. Make `extractReturnExpression` collect every const binding regardless of initializer purity.
- Delete `inlineConstBindings` and every reference to it. The TypeScript compiler surfaces each call site as the patch is being written; update each to use the new IR1Let-emitting path.
- Wire the IR1 builder to produce `IR1Let` IR1Stmts from `ConstBinding[]` of kind `"const"`. The IR1 body now carries explicit binding nodes; the scalar SSA pipeline (Patch 2's contribution) versions them.
- Update snapshots: run `npm run test:update-snapshots -- --test-name-pattern 'constructs'` (or equivalent) and inspect the resulting diff. Confirm each change is the expected per-binding equation shape, not a semantic regression.
- Run the full `npm run test:unit` to confirm no other test categories regress.
- Run `npm run test:integration` to confirm the dogfood suite still passes (it doesn't depend on inlining for its current 11 functions; they're all one-liners).

## Changes
- Lift the purity gate. Make `extractReturnExpression` collect every const binding regardless of initializer purity.
- Delete `inlineConstBindings` and every reference to it. The TypeScript compiler surfaces each call site as the patch is being written; update each to use the new IR1Let-emitting path.
- Wire the IR1 builder to produce `IR1Let` IR1Stmts from `ConstBinding[]` of kind `"const"`. The IR1 body now carries explicit binding nodes; the scalar SSA pipeline (Patch 2's contribution) versions them.
- Update snapshots: run `npm run test:update-snapshots -- --test-name-pattern 'constructs'` (or equivalent) and inspect the resulting diff. Confirm each change is the expected per-binding equation shape, not a semantic regression.
- Run the full `npm run test:unit` to confirm no other test categories regress.
- Run `npm run test:integration` to confirm the dogfood suite still passes (it doesn't depend on inlining for its current 11 functions; they're all one-liners).

## Files to Modify
- tools/ts2pant/src/translate-body.ts (modify): In `extractReturnExpression` at `:1716-1791`, remove the `expressionHasSideEffects(decl.initializer, checker)` check at `:1763`. Const bindings with arbitrary initializers (TypeScript-type-checkable) are collected into `ConstBinding[]` unconditionally. Delete `inlineConstBindings` (entire function around `:1237`) and the `applyConst` closure it produces. In `describeRejectedBody` at `:1793-1864`, remove the `"const binding with side-effectful initializer"` arm — that rejection reason no longer exists. The catch-all error string at `:1849` is simplified accordingly.
- tools/ts2pant/src/ir1-build-body.ts (modify): Remove the `applyConst: (e: OpaqueExpr) => OpaqueExpr` field from the IR1 builder's sub-context (defined around `:106`) and every call site (lines 937, 938, and any others surfaced by the compiler). Add an `IR1Let`-emitting branch in the function-body construction path: each `ConstBinding` of kind `"const"` produces one `ir1Let(tsName, lowered-initializer)` IR1Stmt prepended to the body sequence. μ-search and early-return arms continue through their existing recognizers unchanged.
- tools/ts2pant/src/ir1-build.ts (modify): Update the top-level body-build path to thread `ConstBinding[]` through to the new `IR1Let`-emitting branch instead of through `inlineConstBindings`. Every reference to `substituteIR1ExprSubtree` used for const-binding inlining is removed; the substitution primitive itself remains in `ir1-substitute.ts` for unrelated uses (e.g. the IR1 capture-avoiding substitution primitive cited at `:61` and used by other lowering paths).
- tools/ts2pant/tests/constructs.test.mts.snapshot (modify): Regenerate every snapshot affected by the emission shape change. Approximately 30-50 snapshot exports change. Per-binding equations appear in the chapter body; the return expression carries binding names instead of inlined RHSes. Mechanical diff; reviewer walks it to confirm no semantic surprises.
- tools/ts2pant/tests/ir1-build-body.test.mts (modify): Any unit-level tests that exercised `inlineConstBindings` directly are removed (the function no longer exists). Any tests that asserted on the inlined emission shape are updated to assert on the new per-binding-equation shape.

## Gameplan Specification

```
module TS2PANT_CONST_BINDING_SSA.

> When this gameplan is complete: every TypeScript const binding in a
> function-body prelude is routed through IR1Let -> scalar SSA -> a
> local-binding IR1SsaLocation variant -> chapter-body equation
> emission. The inlineConstBindings infrastructure is deleted; the
> expressionHasSideEffects purity gate is no longer consulted by the
> prelude scanner. let and var continue to reject. Two helper functions
> in translate-types.ts (manglePantTypeToFragment, depModuleNameForFile)
> carry SMT-verified @pant annotations wired into the dogfood
> integration suite. Downstream Pant emission of newly-accepted builtin
> calls remains a free-call-decl gap addressed by a separate workstream.

TsConstBinding.
TsExpression.
IR1Let.
IR1SsaLocation.
IR1SsaVersion.
IR1SsaWrite.
PantOutput.
UnsupportedReason.
FunctionName.
LocationKind.
property => LocationKind.
map-value => LocationKind.
map-membership => LocationKind.
set-membership => LocationKind.
return-value => LocationKind.
local-binding => LocationKind.
side-effectful-const => UnsupportedReason.
free-call-decl => UnsupportedReason.
mangle-pant-type-to-fragment => FunctionName.
dep-module-name-for-file => FunctionName.

is-const-binding? d: TsConstBinding => Bool.
becomes-ir1-let? d: TsConstBinding, n: IR1Let => Bool.
location-kind l: IR1SsaLocation => LocationKind.
is-local-binding? l: IR1SsaLocation => Bool.
has-primed-counterpart? l: IR1SsaLocation => Bool.
has-framing-obligation? l: IR1SsaLocation => Bool.
lowers-let-statement? stmt: IR1Let, w: IR1SsaWrite => Bool.
emits-unsupported? out: PantOutput, r: UnsupportedReason => Bool.
translate-prelude bindings: TsConstBinding => PantOutput.
has-dogfood-entry? fn: FunctionName => Bool.
min-checks fn: FunctionName => Nat0.
translates-without-unsupported? fn: FunctionName => Bool.
annotations-entail? fn: FunctionName => Bool.
location-of w: IR1SsaWrite => IR1SsaLocation.
---

> The local-binding location class has no primed counterpart and no
> framing obligation.
all l: IR1SsaLocation |
  is-local-binding? l ->
    ~(has-primed-counterpart? l) and ~(has-framing-obligation? l).

> Every TS const binding becomes one IR1Let.
all d: TsConstBinding, n: IR1Let |
  becomes-ir1-let? d n -> is-const-binding? d.

> Every IR1Let lowers through scalar SSA into one versioned write
> to a local-binding location.
all stmt: IR1Let, w: IR1SsaWrite |
  lowers-let-statement? stmt w ->
    is-local-binding? (location-of w).

> The side-effectful-const unsupported reason is never produced.
all bindings: TsConstBinding, out: PantOutput |
  out = translate-prelude bindings ->
    ~(emits-unsupported? out side-effectful-const).

> The two target dogfood functions are wired with at least two
> SMT-verified annotations each.
has-dogfood-entry? mangle-pant-type-to-fragment.
has-dogfood-entry? dep-module-name-for-file.
min-checks mangle-pant-type-to-fragment >= 2.
min-checks dep-module-name-for-file >= 2.
translates-without-unsupported? mangle-pant-type-to-fragment.
translates-without-unsupported? dep-module-name-for-file.
annotations-entail? mangle-pant-type-to-fragment.
annotations-entail? dep-module-name-for-file.
```

## Patch Specification

```
module TS2PANT_CONST_BINDING_SSA_PATCH_3.

> Patch 3 wires IR1Let production through the IR1 builder, removes
> inlineConstBindings, and lifts the purity gate from
> extractReturnExpression. Every TypeScript const binding in a
> function-body prelude reaches the IR1 layer as one IR1Let IR1Stmt;
> scalar SSA versions it under a local-binding location; emission
> renders it as a chapter-body equation.

TsConstBinding.
TsExpression.
IR1Let.
IR1Stmt.
PantOutput.
UnsupportedReason.
side-effectful-const => UnsupportedReason.
free-call-decl => UnsupportedReason.

is-const-binding? d: TsConstBinding => Bool.
becomes-ir1-let? d: TsConstBinding, n: IR1Let => Bool.
emits-unsupported? out: PantOutput, r: UnsupportedReason => Bool.
translate-prelude bindings: TsConstBinding => PantOutput.
---

> Every TS const binding produces exactly one IR1Let.
all d: TsConstBinding, n: IR1Let |
  becomes-ir1-let? d n -> is-const-binding? d.

> The side-effectful-const unsupported reason is never produced.
all bindings: TsConstBinding, out: PantOutput |
  out = translate-prelude bindings ->
    ~(emits-unsupported? out side-effectful-const).

> A binding whose RHS hits a downstream emission gap surfaces as
> free-call-decl, not as the deleted side-effectful-const.
all bindings: TsConstBinding, out: PantOutput |
  out = translate-prelude bindings and emits-unsupported? out free-call-decl ->
    ~(emits-unsupported? out side-effectful-const).
```


## Implementation Notes

- Local binding equations need a head declaration to be valid Pant. I added bodyless `rule-decl` emission so bindings render as `x => T.` before `---`, then as SSA-produced equations like `x = ... .` in the chapter body. Return/action equations reference the binding name instead of duplicating the RHS.
- `lowerPreludeBindings` is the replacement for the deleted inlining path. It keeps TDZ checks, keeps side-effect screening only for μ-search init/predicate and early-return arms, maps TS names through `toPantTermName`, infers local binding types with `mapTsType`, and lowers each `const`/μ-search binding to one `IR1Let`.
- Mutating bodies use the same lowering path as pure bodies. They carry local rule declarations through a small side channel so `IR1Let` statements still lower through scalar SSA while declarations are emitted before the body separator.
- Newly accepted unresolved calls now land on the existing `free-call-decl` surface; I added the previously rejected `effectfulConstRejected` / `constImpureCall` fixtures to the known-failure allowlist for that downstream gap.

Spec/Evidence Mapping:
- Purity gate removed: `extractReturnExpression` no longer calls `expressionHasSideEffects` for const initializers; covered by constructs snapshots for the formerly rejected call fixtures.
- `const` -> `IR1Let` -> local-binding SSA -> equation: `lowerPreludeBindings` constructs `ir1Let`, and `lowerL1BodyToSsaProps` emits local-binding equations; covered by `tests/constructs.test.mts.snapshot` and `translate-body.test.mts`.
- `side-effectful-const` unsupported reason removed: no source/test references remain; newly accepted unresolved calls are represented as `free-call-decl` known failures.
- Regression checks run: `npm run build`; constructs snapshot update via `npx tsx --test --test-update-snapshots --test-timeout=300000 tests/constructs.test.mts`; `npm run test:unit`; `npm run test:integration`.