### PR TITLE
[ts2pant-let-mutation-ssa] Patch 3: Scalar SSA + cond-stmt accept var-target assign (dormant)

### DIFF
--- a/tools/ts2pant/src/ir1-ssa-scalars.ts
+++ b/tools/ts2pant/src/ir1-ssa-scalars.ts
@@ -316,8 +316,9 @@ export function isScalarSsaL1Body(stmt: IR1Stmt): boolean {
   switch (stmt.kind) {
     case "assign":
       return (
-        stmt.target.kind === "member" &&
-        isScalarSsaExpr(stmt.target.receiver) &&
+        ((stmt.target.kind === "member" &&
+          isScalarSsaExpr(stmt.target.receiver)) ||
+          stmt.target.kind === "var") &&
         isScalarSsaExpr(stmt.value)
       );
     case "block":
@@ -461,6 +462,24 @@ function lowerScalarAssign(
   stmt: Extract<IR1Stmt, { kind: "assign" }>,
   state: ScalarSsaState,
 ): void {
+  if (stmt.target.kind === "var") {
+    const value = scalarSsaReadExpr(stmt.value, state);
+    const key = scalarLocalBindingKey(stmt.target.name);
+    const location = state.locations.get(key);
+    if (location === undefined) {
+      throw new Error(
+        `scalar SSA: assignment to undeclared local var ${stmt.target.name}`,
+      );
+    }
+    if (location.kind !== "local-binding") {
+      throw new Error("local binding key resolved to a non-local SSA location");
+    }
+    const write = ir1SsaWrite(location, ir1SsaLocalBindingValue(value));
+    state.writes.push(write);
+    state.currentVersions.set(key, write.version);
+    state.writtenKeys.add(key);
+    return;
+  }
   if (stmt.target.kind !== "member") {
     throw new Error("scalar SSA assignment target must be a property member");
   }
@@ -566,6 +585,32 @@ function lowerScalarSsaAssignToVersions(
   stmt: Extract<IR1Stmt, { kind: "assign" }>,
   state: ScalarSsaLowerState,
 ): void {
+  if (stmt.target.kind === "var") {
+    const write = nextScalarSsaWrite(state);
+    const location = ir1SsaLocalBindingLocation(stmt.target.name);
+    if (!sameScalarSsaLocation(write.location, location, state.canonicalize)) {
+      throw new Error(
+        "scalar SSA write order did not match its local-binding location",
+      );
+    }
+    const rhs = lowerScalarSsaExprToOpaque(stmt.value, state);
+    const key = scalarLocalBindingKey(stmt.target.name);
+    const existingLocation = state.locations.get(key);
+    if (existingLocation === undefined) {
+      throw new Error(
+        `scalar SSA: assignment to undeclared local var ${stmt.target.name}`,
+      );
+    }
+    if (
+      !sameScalarSsaLocation(existingLocation, location, state.canonicalize)
+    ) {
+      throw new Error("local binding key resolved to a non-local SSA location");
+    }
+    state.currentVersions.set(key, write.version);
+    state.versionExprs.set(write.version, rhs);
+    state.writtenKeys.add(key);
+    return;
+  }
   if (stmt.target.kind !== "member") {
     throw new Error("scalar SSA assignment target must be a property member");
   }
@@ -627,6 +672,12 @@ function lowerScalarSsaCondToVersions(
 
   state.writeIndex = elseState.writeIndex;
   state.joinIndex = elseState.joinIndex;
+  for (const [version, expr] of thenState.versionExprs) {
+    state.versionExprs.set(version, expr);
+  }
+  for (const [version, expr] of elseState.versionExprs) {
+    state.versionExprs.set(version, expr);
+  }
 
   const touched = new Set([...thenState.writtenKeys, ...elseState.writtenKeys]);
   for (const key of touched) {
@@ -636,9 +687,6 @@ function lowerScalarSsaCondToVersions(
       state.locations.get(key);
     if (location === undefined) {
       throw new Error("scalar SSA branch touched an unknown location");
-    }
-    if (location.kind === "local-binding") {
-      continue;
     }
     const thenVersion =
       thenState.currentVersions.get(key) ??
@@ -960,9 +1008,6 @@ function lowerScalarCondStmt(
       state.locations.get(key);
     if (location === undefined) {
       throw new Error("scalar SSA branch touched an unknown location");
-    }
-    if (location.kind === "local-binding") {
-      continue;
     }
     const thenVersion =
       thenState.currentVersions.get(key) ??

--- a/tools/ts2pant/tests/ir1-ssa-scalars.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-scalars.test.mts
@@ -50,6 +50,19 @@ function scalarEquationRhs(stmt: Parameters<typeof lowerScalarSsaToProps>[0]) {
   return getAst().strExpr(eq.rhs);
 }
 
+function finalScalarPropertyRhs(
+  stmt: Parameters<typeof lowerScalarSsaToProps>[0],
+  ruleName: string,
+) {
+  const result = lowerScalarSsaToProps(stmt);
+  assert.deepEqual(result.diagnostics, []);
+  const entry = result.finalProperties.find(
+    (property) => property.location.ruleName === ruleName,
+  );
+  assert.notEqual(entry, undefined);
+  return getAst().strExpr(entry!.rhs);
+}
+
 before(async () => {
   await loadAst();
 });
@@ -108,6 +121,53 @@ describe("ir1-ssa-scalars", () => {
     assert.equal(propertyWrite!.location.kind, "property");
   });
 
+  it("versions a single var-target assign as a local-binding write", () => {
+    const stmt = ir1Block([
+      ir1Let("x", ir1LitNat(0)),
+      ir1Assign(ir1Var("x"), ir1LitNat(1)),
+    ]);
+
+    assert.equal(isScalarSsaL1Body(stmt), true);
+    const program = buildScalarSsaProgram(stmt);
+
+    assert.equal(program.writes.length, 2);
+    assert.equal(program.joins.length, 0);
+    assert.deepEqual(program.modifiedRules, []);
+    const [initialWrite, assignWrite] = program.writes;
+    assert.equal(initialWrite!.location.kind, "local-binding");
+    assert.equal(initialWrite!.location.name, "x");
+    assert.equal(assignWrite!.location, initialWrite!.location);
+    assert.notEqual(assignWrite!.version, initialWrite!.version);
+    assert.deepEqual(assignWrite!.value, {
+      kind: "local-binding",
+      value: ir1LitNat(1),
+    });
+  });
+
+  it("versions a chain of var-target reassignments", () => {
+    const stmt = ir1Block([
+      ir1Let("x", ir1LitNat(0)),
+      ir1Assign(ir1Var("x"), ir1LitNat(1)),
+      ir1Assign(ir1Var("x"), ir1Binop("add", ir1Var("x"), ir1LitNat(2))),
+    ]);
+    const state = makeScalarSsaState();
+
+    assert.equal(isScalarSsaL1Body(stmt), true);
+    lowerScalarSsaL1Body(stmt, state);
+
+    assert.equal(state.writes.length, 3);
+    assert.equal(state.reads.length, 1);
+    const [initialWrite, firstAssign, secondAssign] = state.writes;
+    assert.equal(firstAssign!.location, initialWrite!.location);
+    assert.equal(secondAssign!.location, initialWrite!.location);
+    assert.equal(state.reads[0]!.location, initialWrite!.location);
+    assert.equal(state.reads[0]!.version, firstAssign!.version);
+    assert.equal(
+      state.currentVersions.get("local-binding::x"),
+      secondAssign!.version,
+    );
+  });
+
   it("keeps branch-local let bindings out of scalar joins", () => {
     const stmt = ir1CondStmt([[ir1Var("g"), ir1Let("x", ir1LitNat(5))]], null);
     const state = makeScalarSsaState();
@@ -124,6 +184,75 @@ describe("ir1-ssa-scalars", () => {
         (location) => location.kind === "local-binding",
       ),
       false,
+    );
+  });
+
+  it("joins var-target assigns across cond-stmt arms", () => {
+    const balance = ir1Member(ir1Var("a"), "Account_balance");
+    const stmt = ir1Block([
+      ir1Let("x", ir1LitNat(0)),
+      ir1CondStmt(
+        [[ir1Var("g"), ir1Assign(ir1Var("x"), ir1LitNat(1))]],
+        ir1Assign(ir1Var("x"), ir1LitNat(2)),
+      ),
+      ir1Assign(balance, ir1Var("x")),
+    ]);
+
+    assert.equal(isScalarSsaL1Body(stmt), true);
+    const program = buildScalarSsaProgram(stmt);
+
+    assert.equal(program.writes.length, 4);
+    assert.equal(program.joins.length, 1);
+    const [initialWrite, thenWrite, elseWrite, propertyWrite] = program.writes;
+    const join = program.joins[0]!;
+    assert.equal(thenWrite!.location, initialWrite!.location);
+    assert.equal(elseWrite!.location, initialWrite!.location);
+    assert.equal(join.location, initialWrite!.location);
+    assert.equal(join.thenVersion, thenWrite!.version);
+    assert.equal(join.elseVersion, elseWrite!.version);
+    assert.equal(propertyWrite!.location.kind, "property");
+    assert.equal(
+      finalScalarPropertyRhs(stmt, "Account_balance"),
+      "cond g => 1, true => 2",
+    );
+  });
+
+  it("joins var-target assign against the unchanged else-arm version", () => {
+    const balance = ir1Member(ir1Var("a"), "Account_balance");
+    const stmt = ir1Block([
+      ir1Let("x", ir1LitNat(0)),
+      ir1CondStmt(
+        [[ir1Var("g"), ir1Assign(ir1Var("x"), ir1LitNat(1))]],
+        null,
+      ),
+      ir1Assign(balance, ir1Var("x")),
+    ]);
+
+    assert.equal(isScalarSsaL1Body(stmt), true);
+    const program = buildScalarSsaProgram(stmt);
+
+    assert.equal(program.writes.length, 3);
+    assert.equal(program.joins.length, 1);
+    const [initialWrite, thenWrite, propertyWrite] = program.writes;
+    const join = program.joins[0]!;
+    assert.equal(thenWrite!.location, initialWrite!.location);
+    assert.equal(join.location, initialWrite!.location);
+    assert.equal(join.thenVersion, thenWrite!.version);
+    assert.equal(join.elseVersion, initialWrite!.version);
+    assert.equal(propertyWrite!.location.kind, "property");
+    assert.equal(
+      finalScalarPropertyRhs(stmt, "Account_balance"),
+      "cond g => 1, true => 0",
+    );
+  });
+
+  it("rejects assign to an undeclared var during scalar SSA lowering", () => {
+    const stmt = ir1Assign(ir1Var("x"), ir1LitNat(1));
+
+    assert.equal(isScalarSsaL1Body(stmt), true);
+    assert.throws(
+      () => buildScalarSsaProgram(stmt),
+      /scalar SSA: assignment to undeclared local var x/u,
     );
   });
 
@@ -247,10 +376,6 @@ describe("ir1-ssa-scalars", () => {
       key: ir1Var("key"),
     };
 
-    assert.equal(
-      isScalarSsaL1Body(ir1Assign(ir1Var("x"), ir1LitNat(1))),
-      false,
-    );
     assert.equal(
       isScalarSsaL1Body(
         ir1Assign(ir1Member(mapReadReceiver, "Account_balance"), ir1LitNat(1)),


### PR DESCRIPTION
## Patch 3: Scalar SSA + cond-stmt accept var-target assign (dormant)

- Read `lowerScalarAssign` (line 460-474), `lowerScalarLet` (line 476-488), `lowerScalarSsaAssignToVersions` (line 565+), `lowerScalarCondStmt` (locate via grep), and `isScalarSsaL1Body` (line 315+) end-to-end. Map out the property-target write path and the cond-stmt join path.
- Extend `isScalarSsaL1Body`'s `case "assign":` arm: accept `target.kind === "member" && isScalarSsaExpr(target.receiver) && isScalarSsaExpr(value)` OR `target.kind === "var" && isScalarSsaExpr(value)`.
- Extend `lowerScalarAssign`: if `stmt.target.kind === "var"`, look up `key = scalarLocalBindingKey(stmt.target.name)`. The location must already exist in `state.locations` (declared by a prior IR1Stmt.let); otherwise throw a precise error (`'scalar SSA: assignment to undeclared local var <name>'`). Push a new write via `ir1SsaWrite(location, ir1SsaLocalBindingValue(value))`, update `state.currentVersions.set(key, write.version)`. Do not update `state.modifiedRules`.
- Extend `lowerScalarSsaAssignToVersions` symmetrically: when `stmt.target.kind === "var"`, the version was already allocated in pass 1; look it up via `nextScalarSsaWrite` (or equivalent — confirm by reading how `lowerScalarSsaLetToVersions` does it). Map version to the value expression.
- Extend `lowerScalarCondStmt` (and its second-pass sibling) to handle var-target assigns inside arms. The local-binding location class joins the same way property locations do — at the post-cond merge, the version is either the entry version (if the arm didn't write) or the arm's last-write version. Reuse the existing join helper if one exists.
- Add unit tests in `tests/ir1-ssa-scalars.test.mts`: (a) `lowerScalarSsaL1Body(let x = init; x = e1; x = e2;)` produces three SSA versions of the local-binding location; (b) a cond-stmt with var-target assign in the then-arm joins with the unchanged else-arm; (c) a cond-stmt with var-target assigns in both arms joins to the post-cond version; (d) assignment to a var that wasn't previously let-declared throws.
- Run `npx tsx --test --test-name-pattern='ir1-ssa-scalars' tests/ir1-ssa-scalars.test.mts` and confirm all tests pass.
- Run `npm run -s test:unit` and confirm no other test regresses (this patch is dormant — no caller yet routes a var-target assign program through this pass).
- Run `npm run -s lint` and confirm clean.

## Changes
- Read `lowerScalarAssign` (line 460-474), `lowerScalarLet` (line 476-488), `lowerScalarSsaAssignToVersions` (line 565+), `lowerScalarCondStmt` (locate via grep), and `isScalarSsaL1Body` (line 315+) end-to-end. Map out the property-target write path and the cond-stmt join path.
- Extend `isScalarSsaL1Body`'s `case "assign":` arm: accept `target.kind === "member" && isScalarSsaExpr(target.receiver) && isScalarSsaExpr(value)` OR `target.kind === "var" && isScalarSsaExpr(value)`.
- Extend `lowerScalarAssign`: if `stmt.target.kind === "var"`, look up `key = scalarLocalBindingKey(stmt.target.name)`. The location must already exist in `state.locations` (declared by a prior IR1Stmt.let); otherwise throw a precise error (`'scalar SSA: assignment to undeclared local var <name>'`). Push a new write via `ir1SsaWrite(location, ir1SsaLocalBindingValue(value))`, update `state.currentVersions.set(key, write.version)`. Do not update `state.modifiedRules`.
- Extend `lowerScalarSsaAssignToVersions` symmetrically: when `stmt.target.kind === "var"`, the version was already allocated in pass 1; look it up via `nextScalarSsaWrite` (or equivalent — confirm by reading how `lowerScalarSsaLetToVersions` does it). Map version to the value expression.
- Extend `lowerScalarCondStmt` (and its second-pass sibling) to handle var-target assigns inside arms. The local-binding location class joins the same way property locations do — at the post-cond merge, the version is either the entry version (if the arm didn't write) or the arm's last-write version. Reuse the existing join helper if one exists.
- Add unit tests in `tests/ir1-ssa-scalars.test.mts`: (a) `lowerScalarSsaL1Body(let x = init; x = e1; x = e2;)` produces three SSA versions of the local-binding location; (b) a cond-stmt with var-target assign in the then-arm joins with the unchanged else-arm; (c) a cond-stmt with var-target assigns in both arms joins to the post-cond version; (d) assignment to a var that wasn't previously let-declared throws.
- Run `npx tsx --test --test-name-pattern='ir1-ssa-scalars' tests/ir1-ssa-scalars.test.mts` and confirm all tests pass.
- Run `npm run -s test:unit` and confirm no other test regresses (this patch is dormant — no caller yet routes a var-target assign program through this pass).
- Run `npm run -s lint` and confirm clean.

## Files to Modify
- tools/ts2pant/src/ir1-ssa-scalars.ts (modify): Extend `lowerScalarAssign` (line 460), `lowerScalarSsaAssignToVersions` (line 565), and `isScalarSsaL1Body`'s assign-arm (line 315) to accept `target.kind === "var"`. Var-target assign looks up the existing local-binding location via `scalarLocalBindingKey(stmt.target.name)`, bumps the version, and pushes a write. Extend `lowerScalarCondStmt` to handle var-target assign inside arms with the appropriate post-cond joins. Symmetrical to property-target assign at every site.
- tools/ts2pant/tests/ir1-ssa-scalars.test.mts (modify): Add unit tests for var-target assign at the SSA level: single reassignment versions a local-binding location; several reassignments produce a version chain; reassignment inside a cond-stmt arm produces correct joins; assignment to an undeclared var throws.

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[paper] Cytron et al. 1991, Efficiently Computing Static Single Assignment Form** — https://doi.org/10.1145/115372.115320 — Foundational SSA construction. P3 extends the existing scalar SSA pass — which already follows Cytron's discipline for property writes and joins — to handle local-variable reassignment as the same protocol: distinct locations, per-location version chains, joins at control-flow merges. The implementing agent reads this for conceptual framing; the in-repo `ir1-ssa-scalars.ts` is the concrete precedent.
- **[paper] Knobe & Sarkar 1998, Array SSA Form** — https://doi.org/10.1145/268946.268956 — Precedent for non-syntactic-variable SSA locations. The local-binding location class (M1-landed) is the simplest case of Array SSA's per-element versioning — every local binding is a degenerate 'array of one element'. P3 extends the per-location version chain to handle reassignment, which Array SSA treats uniformly.

## Gameplan Specification

```
module TS2PANT_LET_MUTATION_SSA.

> Final state of the let-mutation-ssa milestone.
> `let` (immutable and reassigned, including in if-branches,
> in loop bodies, with destructuring assignment) is
> accepted by the translator on both pure and mutating-body
> paths. `var` rejects with a dedicated diagnostic. Closure-
> captured reassignment rejects with its own dedicated
> diagnostic — out of M2 scope.

TSDecl.
TSReassignment.
DeclKind.
const-decl => DeclKind.
let-decl => DeclKind.
var-decl => DeclKind.
Reassigned.
immutable => Reassigned.
mutated => Reassigned.
ControlContext.
straight-line => ControlContext.
cond-arm => ControlContext.
loop-body => ControlContext.
Path.
pure-path => Path.
mutating-body-path => Path.
ReassignKind.
simple => ReassignKind.
compound => ReassignKind.
incdec => ReassignKind.
destructure => ReassignKind.
closure-captured => ReassignKind.
Result.
accepted => Result.
rejected-var => Result.
rejected-closure-capture => Result.
IR1Stmt.
let-stmt => IR1Stmt.
assign-stmt => IR1Stmt.
IR1SsaLocation.
Write.
Version.

decl-kind d: TSDecl => DeclKind.
reassigned d: TSDecl => Reassigned.
classify d: TSDecl, p: Path => Result.
lowered-decl d: TSDecl => IR1Stmt.
lowered-reassign r: TSReassignment => IR1Stmt.
reassign-kind r: TSReassignment => ReassignKind.
control-context r: TSReassignment => ControlContext.
location-of s: IR1Stmt => IR1SsaLocation.
bumps-version? w: Write => Bool.
---
> Var rejects always on both paths.
all d: TSDecl, p: Path, decl-kind d = var-decl | classify d p = rejected-var.

> Const continues to be accepted as before.
all d: TSDecl, p: Path, decl-kind d = const-decl | classify d p = accepted.

> Let with no reassignment is accepted on both paths.
all d: TSDecl, p: Path, decl-kind d = let-decl and reassigned d = immutable
  | classify d p = accepted.

> Let with reassignment is accepted on both paths.
all d: TSDecl, p: Path, decl-kind d = let-decl and reassigned d = mutated
  | classify d p = accepted.

> Every non-closure-captured reassignment lowers to an assign statement.
all r: TSReassignment, reassign-kind r ~= closure-captured
  | lowered-reassign r = assign-stmt.

> Closure-captured reassignment rejects in any context.
all r: TSReassignment, reassign-kind r = closure-captured
  | lowered-reassign r ~= assign-stmt.

> Reassignment is accepted in every control context except closure capture.
all r: TSReassignment, reassign-kind r ~= closure-captured
  | control-context r = straight-line
     or control-context r = cond-arm
     or control-context r = loop-body.

> Every write bumps its location's version.
all w: Write | bumps-version? w.
```

## Patch Specification

```
module TS2PANT_LET_MUTATION_SSA_PATCH_3.

> Patch 3 extends scalar SSA and the cond-stmt handler to
> version local-binding reassignments. Var-target assign
> bumps the version of the existing location; undeclared-
> var assign rejects. Dormant — no caller invokes this
> on a var-target-assign program yet.

IR1Stmt.
IR1SsaLocation.
Version.
Write.
AssignTarget.
member-target => AssignTarget.
var-target => AssignTarget.
LocationKind.
property-kind => LocationKind.
local-binding-kind => LocationKind.
ControlContext.
straight-line => ControlContext.
cond-arm => ControlContext.

target-kind s: IR1Stmt => AssignTarget.
location-of s: IR1Stmt => IR1SsaLocation.
location-kind l: IR1SsaLocation => LocationKind.
bumps-version? s: IR1Stmt => Bool.
location-existed? s: IR1Stmt => Bool.
joins-correctly? c: ControlContext => Bool.
---
> Var-target assign requires a prior local-binding location.
all s: IR1Stmt, target-kind s = var-target | location-existed? s.

> Var-target assign bumps the local-binding version.
all s: IR1Stmt, target-kind s = var-target and location-existed? s
  | bumps-version? s and location-kind (location-of s) = local-binding-kind.

> Cond-arm var-target assigns join correctly post-cond.
joins-correctly? cond-arm.
```


## Implementation Notes

- Var-target assignment is intentionally treated as a write to an existing `local-binding` SSA location, not as a declaration path. `IR1Stmt.let` remains the only allocator for local-binding locations; assigning before a prior `let` now fails with `scalar SSA: assignment to undeclared local var <name>`.
- Cond-stmt handling had one extra wrinkle beyond the property-write path: local-binding writes are emitted as local equations, so the second SSA replay pass now merges branch `versionExprs` back into the parent state before building the post-cond join expression. Without that, branch reassignment versions existed in the SSA program but lacked lowered RHS expressions during emission.
- Branch-local `let` declarations are still excluded from parent joins because `lowerScalarLet` does not mark them as touched writes. Only reassignment to an already-declared local adds the local-binding key to `writtenKeys`, so the new join behavior is scoped to mutable local versions.
- This patch keeps `modifiedRules` unchanged for local reassignment. Local-binding writes can feed later property writes, but they do not create or frame Pant state rules themselves.

Spec/Evidence Mapping:
- Prior location required: implemented in `lowerScalarAssign` and `lowerScalarSsaAssignToVersions`; covered by `rejects assign to an undeclared var during scalar SSA lowering`.
- Local reassignment bumps versions: implemented via `ir1SsaWrite(location, ir1SsaLocalBindingValue(value))`; covered by `versions a single var-target assign as a local-binding write` and `versions a chain of var-target reassignments`.
- Cond-arm joins: implemented by removing the local-binding skip in both cond join paths and replaying branch `versionExprs`; covered by `joins var-target assigns across cond-stmt arms` and `joins var-target assign against the unchanged else-arm version`.
- Regression checks run: targeted `ir1-ssa-scalars` test, full `npm run -s test:unit`, and `npm run -s lint`.