### PR TITLE
[ts2pant-let-mutation-ssa] Patch 1: New let-binding fixtures + known-failure allowlist entries

### DIFF
--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -374,6 +374,86 @@ exports[`expressions-ir-anchor.ts > effectiveValue 1`] = `
 "module EFFECTIVE_VALUE.\\n\\nCache.\\ncache--fallback c1: Cache => Int.\\ncache--value c1: Cache => [Int].\\neffective-value c: Cache, factor: Int => Int.\\nbase  => Int.\\n\\n---\\n\\nbase = (cond #(cache--value c) = 0 => cache--fallback c, true => (cache--value c) 1).\\neffective-value c factor = (cond factor > 0 => base * factor, true => base).\\n"
 `;
 
+exports[`expressions-let-closure-captured.ts > letForEachCapturedTotal 1`] = `
+"module LET_FOR_EACH_CAPTURED_TOTAL.\\n\\nlet-for-each-captured-total xs: [Int] => Int.\\n\\n---\\n\\n> UNSUPPORTED: let-for-each-captured-total — let/var bindings not supported.\\n"
+`;
+
+exports[`expressions-let-closure-captured.ts > letMapCapturedCount 1`] = `
+"module LET_MAP_CAPTURED_COUNT.\\n\\nlet-map-captured-count xs: [Int] => Int.\\n\\n---\\n\\n> UNSUPPORTED: let-map-captured-count — let/var bindings not supported.\\n"
+`;
+
+exports[`expressions-let-immutable.ts > chainedLet 1`] = `
+"module CHAINED_LET.\\n\\nchained-let a: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: chained-let — let/var bindings not supported.\\n"
+`;
+
+exports[`expressions-let-immutable.ts > letInTernary 1`] = `
+"module LET_IN_TERNARY.\\n\\nlet-in-ternary a: Int, b: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: let-in-ternary — let/var bindings not supported.\\n"
+`;
+
+exports[`expressions-let-immutable.ts > letMathMax 1`] = `
+"module LET_MATH_MAX.\\n\\nlet-math-max a: Int, b: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: let-math-max — let/var bindings not supported.\\n"
+`;
+
+exports[`expressions-let-immutable.ts > letWithPropAccess 1`] = `
+"module LET_WITH_PROP_ACCESS.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\nlet-with-prop-access a: Account => Int.\\n\\n---\\n\\n> UNSUPPORTED: let-with-prop-access — let/var bindings not supported.\\n"
+`;
+
+exports[`expressions-let-immutable.ts > simpleLet 1`] = `
+"module SIMPLE_LET.\\n\\nsimple-let a: Int, b: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: simple-let — let/var bindings not supported.\\n"
+`;
+
+exports[`expressions-let-mutation-branch.ts > letNestedBranch 1`] = `
+"module LET_NESTED_BRANCH.\\n\\nlet-nested-branch a: Int, b: Int, c: Int, outer: Bool, inner: Bool => Int.\\n\\n---\\n\\n> UNSUPPORTED: let-nested-branch — let/var bindings not supported.\\n"
+`;
+
+exports[`expressions-let-mutation-branch.ts > letThenElseBranch 1`] = `
+"module LET_THEN_ELSE_BRANCH.\\n\\nlet-then-else-branch a: Int, b: Int, c: Int, cond1: Bool => Int.\\n\\n---\\n\\n> UNSUPPORTED: let-then-else-branch — let/var bindings not supported.\\n"
+`;
+
+exports[`expressions-let-mutation-branch.ts > letThenOnlyBranch 1`] = `
+"module LET_THEN_ONLY_BRANCH.\\n\\nlet-then-only-branch a: Int, b: Int, cond1: Bool => Int.\\n\\n---\\n\\n> UNSUPPORTED: let-then-only-branch — let/var bindings not supported.\\n"
+`;
+
+exports[`expressions-let-mutation-loop.ts > letForLoopAccumulator 1`] = `
+"module LET_FOR_LOOP_ACCUMULATOR.\\n\\nlet-for-loop-accumulator n: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: let-for-loop-accumulator — let/var bindings not supported.\\n"
+`;
+
+exports[`expressions-let-mutation-loop.ts > letWhileAccumulator 1`] = `
+"module LET_WHILE_ACCUMULATOR.\\n\\nlet-while-accumulator limit: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: let-while-accumulator — let/var bindings not supported.\\n"
+`;
+
+exports[`expressions-let-mutation-loop.ts > letWhileCounter 1`] = `
+"module LET_WHILE_COUNTER.\\n\\nlet-while-counter limit: Int => Int.\\nn  => Int.\\n\\n---\\n\\nn = (min over each j: Int, j >= 0, ~(j < limit) | j).\\nlet-while-counter limit = n.\\n"
+`;
+
+exports[`expressions-let-mutation-straight.ts > letArrayDestructure 1`] = `
+"module LET_ARRAY_DESTRUCTURE.\\n\\nlet-array-destructure a: Int, b: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: let-array-destructure — let/var bindings not supported.\\n"
+`;
+
+exports[`expressions-let-mutation-straight.ts > letCompoundAdd 1`] = `
+"module LET_COMPOUND_ADD.\\n\\nlet-compound-add a: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: let-compound-add — let/var bindings not supported.\\n"
+`;
+
+exports[`expressions-let-mutation-straight.ts > letCompoundMultiply 1`] = `
+"module LET_COMPOUND_MULTIPLY.\\n\\nlet-compound-multiply a: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: let-compound-multiply — let/var bindings not supported.\\n"
+`;
+
+exports[`expressions-let-mutation-straight.ts > letObjectDestructure 1`] = `
+"module LET_OBJECT_DESTRUCTURE.\\n\\nlet-object-destructure a: Int, b: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: let-object-destructure — let/var bindings not supported.\\n"
+`;
+
+exports[`expressions-let-mutation-straight.ts > letOneReassignment 1`] = `
+"module LET_ONE_REASSIGNMENT.\\n\\nlet-one-reassignment a: Int, b: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: let-one-reassignment — let/var bindings not supported.\\n"
+`;
+
+exports[`expressions-let-mutation-straight.ts > letPrefixPostfix 1`] = `
+"module LET_PREFIX_POSTFIX.\\n\\nlet-prefix-postfix a: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: let-prefix-postfix — let/var bindings not supported.\\n"
+`;
+
+exports[`expressions-let-mutation-straight.ts > letSeveralReassignments 1`] = `
+"module LET_SEVERAL_REASSIGNMENTS.\\n\\nlet-several-reassignments a: Int, b: Int, c: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: let-several-reassignments — let/var bindings not supported.\\n"
+`;
+
 exports[`expressions-literals.ts > fortyTwo 1`] = `
 "module FORTY_TWO.\\n\\nforty-two  => Int.\\n\\n---\\n\\nforty-two = 42.\\n"
 `;
@@ -754,6 +834,14 @@ exports[`expressions-template-literal.ts > wrapId 1`] = `
 "module WRAP_ID.\\n\\nwrap-id s: String => String.\\n\\n---\\n\\nwrap-id s = s.\\n"
 `;
 
+exports[`expressions-var-rejected.ts > varBinding 1`] = `
+"module VAR_BINDING.\\n\\nvar-binding a: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: var-binding — let/var bindings not supported.\\n"
+`;
+
+exports[`expressions-var-rejected.ts > varReassignment 1`] = `
+"module VAR_REASSIGNMENT.\\n\\nvar-reassignment a: Int, b: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: var-reassignment — let/var bindings not supported.\\n"
+`;
+
 exports[`expressions-while-mu-search.ts > compoundIncrementStep 1`] = `
 "module COMPOUND_INCREMENT_STEP.\\n\\ncompound-increment-step used: [Int] => Int.\\ni  => Int.\\n\\n---\\n\\ni = (min over each j: Int, j >= 1, ~(j in used) | j).\\ncompound-increment-step used = i.\\n"
 `;
@@ -972,6 +1060,18 @@ exports[`functions-mutating-fixed-point-while.ts > fillUpTo 1`] = `
 
 exports[`functions-mutating-fixed-point-while.ts > spin 1`] = `
 "module SPIN.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--size a1: Account => Int.\\naccount--tick-count a1: Account => Int.\\n~> Spin @ a: Account.\\n\\n---\\n\\n> UNSUPPORTED: while loop has no observable termination condition (literal-true guard); rewrite with a guard that depends on mutated state.\\n"
+`;
+
+exports[`functions-mutating-let.ts > depositWithBranchLet 1`] = `
+"module DEPOSIT_WITH_BRANCH_LET.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--fee a1: Account => Int.\\n~> Deposit-with-branch-let @ a: Account, amount: Int, charge-fee: Bool.\\n\\n---\\n\\n> UNSUPPORTED: local variable declaration (let/var or effectful const).\\n"
+`;
+
+exports[`functions-mutating-let.ts > depositWithImmutableLet 1`] = `
+"module DEPOSIT_WITH_IMMUTABLE_LET.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--fee a1: Account => Int.\\n~> Deposit-with-immutable-let @ a: Account, amount: Int.\\n\\n---\\n\\n> UNSUPPORTED: local variable declaration (let/var or effectful const).\\n"
+`;
+
+exports[`functions-mutating-let.ts > depositWithReassignedLet 1`] = `
+"module DEPOSIT_WITH_REASSIGNED_LET.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--fee a1: Account => Int.\\n~> Deposit-with-reassigned-let @ a: Account, amount: Int.\\n\\n---\\n\\n> UNSUPPORTED: local variable declaration (let/var or effectful const).\\n"
 `;
 
 exports[`functions-mutating-loop-break.ts > addUntilLimit 1`] = `

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-let-closure-captured.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-let-closure-captured.ts
@@ -1,0 +1,18 @@
+export function letForEachCapturedTotal(xs: number[]): number {
+  let total = 0;
+  xs.forEach((v) => {
+    total += v;
+  });
+  return total;
+}
+
+export function letMapCapturedCount(xs: number[]): number {
+  let count = 0;
+  xs.map((v) => {
+    if (v > 0) {
+      count++;
+    }
+    return v;
+  });
+  return count;
+}

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-let-immutable.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-let-immutable.ts
@@ -1,0 +1,29 @@
+interface Account {
+  balance: number;
+}
+
+export function simpleLet(a: number, b: number): number {
+  let x = a + b;
+  return x;
+}
+
+export function chainedLet(a: number): number {
+  let x = a;
+  let y = x + 1;
+  return y;
+}
+
+export function letWithPropAccess(a: Account): number {
+  let b = a.balance;
+  return b + 1;
+}
+
+export function letInTernary(a: number, b: number): number {
+  let x = a + b;
+  return x > 0 ? x : 0;
+}
+
+export function letMathMax(a: number, b: number): number {
+  let m = Math.max(a, b);
+  return m + 1;
+}

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-let-mutation-branch.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-let-mutation-branch.ts
@@ -1,0 +1,40 @@
+export function letThenOnlyBranch(a: number, b: number, cond: boolean): number {
+  let x = a;
+  if (cond) {
+    x = b;
+  }
+  return x;
+}
+
+export function letThenElseBranch(
+  a: number,
+  b: number,
+  c: number,
+  cond: boolean,
+): number {
+  let x = a;
+  if (cond) {
+    x = b;
+  } else {
+    x = c;
+  }
+  return x;
+}
+
+export function letNestedBranch(
+  a: number,
+  b: number,
+  c: number,
+  outer: boolean,
+  inner: boolean,
+): number {
+  let x = a;
+  if (outer) {
+    if (inner) {
+      x = b;
+    } else {
+      x = c;
+    }
+  }
+  return x;
+}

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-let-mutation-loop.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-let-mutation-loop.ts
@@ -1,0 +1,25 @@
+export function letForLoopAccumulator(n: number): number {
+  let total = 0;
+  for (let i = 0; i < n; i++) {
+    total += i;
+  }
+  return total;
+}
+
+export function letWhileAccumulator(limit: number): number {
+  let total = 0;
+  let i = 0;
+  while (i < limit) {
+    total += i;
+    i++;
+  }
+  return total;
+}
+
+export function letWhileCounter(limit: number): number {
+  let n = 0;
+  while (n < limit) {
+    n++;
+  }
+  return n;
+}

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-let-mutation-straight.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-let-mutation-straight.ts
@@ -1,0 +1,45 @@
+export function letOneReassignment(a: number, b: number): number {
+  let x = a;
+  x = b;
+  return x;
+}
+
+export function letSeveralReassignments(a: number, b: number, c: number): number {
+  let x = a;
+  x = b;
+  x = c + 1;
+  return x;
+}
+
+export function letCompoundAdd(a: number): number {
+  let x = a;
+  x += 1;
+  return x;
+}
+
+export function letCompoundMultiply(a: number): number {
+  let x = a;
+  x *= 2;
+  return x;
+}
+
+export function letPrefixPostfix(a: number): number {
+  let x = a;
+  ++x;
+  x++;
+  return x;
+}
+
+export function letArrayDestructure(a: number, b: number): number {
+  let x = a;
+  let y = b;
+  [x, y] = [y, x];
+  return x + y;
+}
+
+export function letObjectDestructure(a: number, b: number): number {
+  let x = a;
+  let y = b;
+  ({ x, y } = { x: y, y: x });
+  return x - y;
+}

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-var-rejected.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-var-rejected.ts
@@ -1,0 +1,10 @@
+export function varBinding(a: number): number {
+  var x = a + 1;
+  return x;
+}
+
+export function varReassignment(a: number, b: number): number {
+  var x = a;
+  x = b;
+  return x;
+}

--- a/tools/ts2pant/tests/fixtures/constructs/functions-mutating-let.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/functions-mutating-let.ts
@@ -1,0 +1,27 @@
+interface Account {
+  balance: number;
+  fee: number;
+}
+
+export function depositWithImmutableLet(a: Account, amount: number): void {
+  let newBal = a.balance + amount;
+  a.balance = newBal;
+}
+
+export function depositWithReassignedLet(a: Account, amount: number): void {
+  let newBal = a.balance;
+  newBal += amount;
+  a.balance = newBal;
+}
+
+export function depositWithBranchLet(
+  a: Account,
+  amount: number,
+  chargeFee: boolean,
+): void {
+  let delta = amount;
+  if (chargeFee) {
+    delta = amount - a.fee;
+  }
+  a.balance += delta;
+}

--- a/tools/ts2pant/tests/known-typecheck-failures.mts
+++ b/tools/ts2pant/tests/known-typecheck-failures.mts
@@ -43,6 +43,14 @@
  *   - "free-call-decl"    user calls a TS function that ts2pant doesn't
  *                         translate; the call survives but no Pant
  *                         declaration is synthesized for the callee.
+ *   - "let-rejected"      local `let` binding fixture reserved for the
+ *                         let-mutation SSA workstream; currently rejected
+ *                         before emission.
+ *   - "var-rejected"      local `var` binding fixture; `var` remains out of
+ *                         scope and should keep a dedicated diagnostic.
+ *   - "closure-captured-reassignment"
+ *                         reassignment through a closure-captured `let`;
+ *                         deliberately out of M2 scope.
  *   - "annotation-types"  the user's `@pant` annotation is itself
  *                         ill-typed against the emitted signature
  *                         (e.g. comparing a Bool result to an Int).
@@ -71,6 +79,31 @@ export const KNOWN_TYPECHECK_FAILURES = new Map<string, string>([
   ["expressions-const-side-effectful.ts > constMapEntries", "free-call-decl"],
   ["expressions-const-pure-calls.ts > constImpureCall", "free-call-decl"],
   ["expressions-const-bindings.ts > effectfulConstRejected", "free-call-decl"],
+  ["expressions-let-closure-captured.ts > letForEachCapturedTotal", "closure-captured-reassignment"],
+  ["expressions-let-closure-captured.ts > letMapCapturedCount", "closure-captured-reassignment"],
+  ["expressions-let-immutable.ts > simpleLet", "let-rejected"],
+  ["expressions-let-immutable.ts > chainedLet", "let-rejected"],
+  ["expressions-let-immutable.ts > letWithPropAccess", "let-rejected"],
+  ["expressions-let-immutable.ts > letInTernary", "let-rejected"],
+  ["expressions-let-immutable.ts > letMathMax", "free-call-decl"],
+  ["expressions-let-mutation-branch.ts > letThenOnlyBranch", "let-rejected"],
+  ["expressions-let-mutation-branch.ts > letThenElseBranch", "let-rejected"],
+  ["expressions-let-mutation-branch.ts > letNestedBranch", "let-rejected"],
+  ["expressions-let-mutation-loop.ts > letForLoopAccumulator", "let-rejected"],
+  ["expressions-let-mutation-loop.ts > letWhileAccumulator", "let-rejected"],
+  ["expressions-let-mutation-loop.ts > letWhileCounter", "let-rejected"],
+  ["expressions-let-mutation-straight.ts > letOneReassignment", "let-rejected"],
+  ["expressions-let-mutation-straight.ts > letSeveralReassignments", "let-rejected"],
+  ["expressions-let-mutation-straight.ts > letCompoundAdd", "let-rejected"],
+  ["expressions-let-mutation-straight.ts > letCompoundMultiply", "let-rejected"],
+  ["expressions-let-mutation-straight.ts > letPrefixPostfix", "let-rejected"],
+  ["expressions-let-mutation-straight.ts > letArrayDestructure", "let-rejected"],
+  ["expressions-let-mutation-straight.ts > letObjectDestructure", "let-rejected"],
+  ["expressions-var-rejected.ts > varBinding", "var-rejected"],
+  ["expressions-var-rejected.ts > varReassignment", "var-rejected"],
+  ["functions-mutating-let.ts > depositWithImmutableLet", "let-rejected"],
+  ["functions-mutating-let.ts > depositWithReassignedLet", "let-rejected"],
+  ["functions-mutating-let.ts > depositWithBranchLet", "let-rejected"],
   ["functions-class.ts > Account.getBalance", "requires-external-context"],
   ["functions-class.ts > Account.deposit", "requires-external-context"],
   ["types-composite.ts > getPoint", "list-literal"],


### PR DESCRIPTION
## Patch 1: New let-binding fixtures + known-failure allowlist entries

- Survey existing const-binding fixtures (`expressions-const-bindings.ts`, `expressions-const-pure-calls.ts`) to mirror naming and shape conventions.
- Create `expressions-let-immutable.ts` with 4-6 exported test functions: simple `let x = a + b; return x;`; chained immutable lets `let x = a; let y = x + 1; return y;`; immutable let with property access RHS; immutable let used inside ternary; immutable let with pure-call RHS (e.g. `let m = Math.max(a, b); return m + 1;`).
- Create `expressions-let-mutation-straight.ts` with 5-7 exported test functions: one reassignment; several reassignments; compound (`x += 1`, `x *= 2`); prefix/postfix `++x`/`x++`; destructuring `[x, y] = [...]` and `({x, y} = ...)`.
- Create `expressions-let-mutation-branch.ts` with 2-3 exported test functions: then-only branch reassignment (`let x = a; if (cond) { x = b; } return x;`); then+else (`if (cond) { x = b; } else { x = c; }`); nested if reassignment.
- Create `expressions-let-mutation-loop.ts` with 2-3 exported test functions: counter-loop accumulator (`let total = 0; for (let i = 0; i < n; i++) total += i; return total;` — also exercises the foreach Shape B / bounded-counter path); bounded-while accumulator; `let n = 0; while (n < limit) { n++; } return n;` (note the overlap with μ-search — the μ-search recognizer should still take precedence on the canonical shape).
- Create `expressions-let-closure-captured.ts` with 1-2 exported test functions: `let total = 0; xs.forEach(v => total += v); return total;` and similar — these MUST reject in M2.
- Create `expressions-var-rejected.ts` with 1-2 functions: `var x = ...; return x;` and `var x = ...; x = e; return x;` to ensure the dedicated message surfaces.
- Create `functions-mutating-let.ts` with 2-3 test functions that combine parameter property mutation with let bindings (immutable and reassigned).
- Add allowlist entries in `tools/ts2pant/tests/known-typecheck-failures.mts` for every newly-introduced fixture function. Use failure-class tags `let-rejected`, `var-rejected`, `closure-captured-reassignment`, or existing `free-call-decl`.
- Run `npm run -s test:unit` and confirm the new fixture functions are picked up by the constructs harness and reported as known-failures (expected during P1).

## Changes
- Survey existing const-binding fixtures (`expressions-const-bindings.ts`, `expressions-const-pure-calls.ts`) to mirror naming and shape conventions.
- Create `expressions-let-immutable.ts` with 4-6 exported test functions: simple `let x = a + b; return x;`; chained immutable lets `let x = a; let y = x + 1; return y;`; immutable let with property access RHS; immutable let used inside ternary; immutable let with pure-call RHS (e.g. `let m = Math.max(a, b); return m + 1;`).
- Create `expressions-let-mutation-straight.ts` with 5-7 exported test functions: one reassignment; several reassignments; compound (`x += 1`, `x *= 2`); prefix/postfix `++x`/`x++`; destructuring `[x, y] = [...]` and `({x, y} = ...)`.
- Create `expressions-let-mutation-branch.ts` with 2-3 exported test functions: then-only branch reassignment (`let x = a; if (cond) { x = b; } return x;`); then+else (`if (cond) { x = b; } else { x = c; }`); nested if reassignment.
- Create `expressions-let-mutation-loop.ts` with 2-3 exported test functions: counter-loop accumulator (`let total = 0; for (let i = 0; i < n; i++) total += i; return total;` — also exercises the foreach Shape B / bounded-counter path); bounded-while accumulator; `let n = 0; while (n < limit) { n++; } return n;` (note the overlap with μ-search — the μ-search recognizer should still take precedence on the canonical shape).
- Create `expressions-let-closure-captured.ts` with 1-2 exported test functions: `let total = 0; xs.forEach(v => total += v); return total;` and similar — these MUST reject in M2.
- Create `expressions-var-rejected.ts` with 1-2 functions: `var x = ...; return x;` and `var x = ...; x = e; return x;` to ensure the dedicated message surfaces.
- Create `functions-mutating-let.ts` with 2-3 test functions that combine parameter property mutation with let bindings (immutable and reassigned).
- Add allowlist entries in `tools/ts2pant/tests/known-typecheck-failures.mts` for every newly-introduced fixture function. Use failure-class tags `let-rejected`, `var-rejected`, `closure-captured-reassignment`, or existing `free-call-decl`.
- Run `npm run -s test:unit` and confirm the new fixture functions are picked up by the constructs harness and reported as known-failures (expected during P1).

## Files to Modify
- tools/ts2pant/tests/fixtures/constructs/expressions-let-immutable.ts (create): Fixture covering never-reassigned `let` shapes: single immutable let, chained immutable lets, immutable let with property access RHS, immutable let inside ternary use, immutable let with pure-call RHS that previously surfaced as `free-call-decl`.
- tools/ts2pant/tests/fixtures/constructs/expressions-let-mutation-straight.ts (create): Fixture covering mutable `let` in straight-line code: one reassignment, several reassignments, compound assignment (`+=`, `*=`), pre/post `++`/`--`, plus destructuring assignment (`[x, y] = expr;` and `({x, y} = expr);`).
- tools/ts2pant/tests/fixtures/constructs/expressions-let-mutation-branch.ts (create): Fixture covering mutable `let` reassigned inside an if-branch — exercises SSA cond-stmt + var-target assign interaction. Both then-only and then+else reassignment shapes.
- tools/ts2pant/tests/fixtures/constructs/expressions-let-mutation-loop.ts (create): Fixture covering mutable `let` reassigned inside a loop body — exercises general-loop SSA + local-binding location interaction. Shapes: counter-loop accumulator (`let total = 0; for (...) total += ...;`), bounded-while accumulator (`let n = 0; while (n < limit) { n++; }`).
- tools/ts2pant/tests/fixtures/constructs/expressions-let-closure-captured.ts (create): Fixture covering closure-captured reassignment (`let total = 0; xs.forEach(v => total += v); return total;`) — must surface the dedicated rejection diagnostic. OUT of M2 scope; allowlist tag `closure-captured-reassignment`.
- tools/ts2pant/tests/fixtures/constructs/expressions-var-rejected.ts (create): Fixture covering `var` declarations — must surface the dedicated `var bindings are not supported (use let or const)` diagnostic (post-P2).
- tools/ts2pant/tests/fixtures/constructs/functions-mutating-let.ts (create): Fixture covering mutable `let` inside mutating-body functions (functions that ALSO mutate parameter properties). Exercises the mutating-body path's let acceptance. Snapshot will be generated by P2/P4.
- tools/ts2pant/tests/known-typecheck-failures.mts (modify): Add allowlist entries for every new fixture function — tagged with failure classes `let-rejected` (most), `var-rejected` (var fixtures), `closure-captured-reassignment` (closure fixtures), plus existing `free-call-decl` where applicable. P2 and P4 remove entries as those patches enable corresponding fixtures.

## Gameplan Specification

```
module TS2PANT_LET_MUTATION_SSA.

> Final state of the let-mutation-ssa milestone.
> `let` (immutable and reassigned, including in if-branches,
> in loop bodies, with destructuring assignment) is
> accepted by the translator on both pure and mutating-body
> paths. `var` rejects with a dedicated diagnostic. Closure-
> captured reassignment rejects with its own dedicated
> diagnostic — out of M2 scope.

TSDecl.
TSReassignment.
DeclKind.
const-decl => DeclKind.
let-decl => DeclKind.
var-decl => DeclKind.
Reassigned.
immutable => Reassigned.
mutated => Reassigned.
ControlContext.
straight-line => ControlContext.
cond-arm => ControlContext.
loop-body => ControlContext.
Path.
pure-path => Path.
mutating-body-path => Path.
ReassignKind.
simple => ReassignKind.
compound => ReassignKind.
incdec => ReassignKind.
destructure => ReassignKind.
closure-captured => ReassignKind.
Result.
accepted => Result.
rejected-var => Result.
rejected-closure-capture => Result.
IR1Stmt.
let-stmt => IR1Stmt.
assign-stmt => IR1Stmt.
IR1SsaLocation.
Write.
Version.

decl-kind d: TSDecl => DeclKind.
reassigned d: TSDecl => Reassigned.
classify d: TSDecl, p: Path => Result.
lowered-decl d: TSDecl => IR1Stmt.
lowered-reassign r: TSReassignment => IR1Stmt.
reassign-kind r: TSReassignment => ReassignKind.
control-context r: TSReassignment => ControlContext.
location-of s: IR1Stmt => IR1SsaLocation.
bumps-version? w: Write => Bool.
---
> Var rejects always on both paths.
all d: TSDecl, p: Path, decl-kind d = var-decl | classify d p = rejected-var.

> Const continues to be accepted as before.
all d: TSDecl, p: Path, decl-kind d = const-decl | classify d p = accepted.

> Let with no reassignment is accepted on both paths.
all d: TSDecl, p: Path, decl-kind d = let-decl and reassigned d = immutable
  | classify d p = accepted.

> Let with reassignment is accepted on both paths.
all d: TSDecl, p: Path, decl-kind d = let-decl and reassigned d = mutated
  | classify d p = accepted.

> Every non-closure-captured reassignment lowers to an assign statement.
all r: TSReassignment, reassign-kind r ~= closure-captured
  | lowered-reassign r = assign-stmt.

> Closure-captured reassignment rejects in any context.
all r: TSReassignment, reassign-kind r = closure-captured
  | lowered-reassign r ~= assign-stmt.

> Reassignment is accepted in every control context except closure capture.
all r: TSReassignment, reassign-kind r ~= closure-captured
  | control-context r = straight-line
     or control-context r = cond-arm
     or control-context r = loop-body.

> Every write bumps its location's version.
all w: Write | bumps-version? w.
```

## Patch Specification

```
module TS2PANT_LET_MUTATION_SSA_PATCH_1.

> Patch 1 introduces fixture files and allowlist entries.
> No source behavior changes — fixtures rely on existing
> rejection paths; allowlist entries gate the test runner.

Fixture.
AllowlistEntry.
FailureClass.
let-rejected => FailureClass.
var-rejected => FailureClass.
closure-captured-reassignment => FailureClass.
free-call-decl => FailureClass.

failure-class e: AllowlistEntry => FailureClass.
fixture-of e: AllowlistEntry => Fixture.
---
some e: AllowlistEntry | failure-class e = let-rejected.
some e: AllowlistEntry | failure-class e = var-rejected.
some e: AllowlistEntry | failure-class e = closure-captured-reassignment.
```


## Implementation Notes

- Added constructs snapshots for the new fixtures so reviewers can see the current P1 baseline output. Most new pure-path `let`/`var` fixtures still snapshot the existing `let/var bindings not supported` diagnostic; mutating-body fixtures snapshot the existing `local variable declaration (let/var or effectful const)` diagnostic.
- One intentional wrinkle: `expressions-let-mutation-loop.ts > letWhileCounter` already translates today through the existing μ-search recognizer. I kept the fixture because the plan explicitly calls out this canonical overlap and the snapshot proves μ-search still takes precedence before the later mutable-let SSA patches.
- `letMathMax` is allowlisted as `free-call-decl` rather than `let-rejected` because once immutable `let` is accepted, its remaining expected boundary is the same surviving call-declaration gap as the existing `constMathMax` fixture.
- Spec/Evidence Mapping:
  - Fixture coverage: new files under `tools/ts2pant/tests/fixtures/constructs/` cover immutable, straight-line mutation, branch mutation, loop mutation, closure-captured reassignment, `var`, and mutating-body `let` cases after surveying the existing const fixtures.
  - Allowlist classes: `tools/ts2pant/tests/known-typecheck-failures.mts` now includes `let-rejected`, `var-rejected`, and `closure-captured-reassignment` entries, plus the existing `free-call-decl` class where applicable.
  - Evidence: `NODE_OPTIONS=--max-old-space-size=6144 npx tsx --test --test-update-snapshots --test-timeout=300000 tests/constructs.test.mts` refreshed only the new construct snapshots; `npm run -s test:unit` passed with `1056` passing, `3` skipped, `0` failed.