### PR TITLE
[ts2pant-opaque-vocabulary] Patch 1: L2 opaque IRExpr form + emit arm + shared Opaque names

### DIFF
--- a/tools/ts2pant/src/ir-build.ts
+++ b/tools/ts2pant/src/ir-build.ts
@@ -172,6 +172,7 @@ function substituteIR(expr: IRExpr, name: string, replacement: IRExpr): IRExpr {
     case "var":
       return expr.name === name && !expr.primed ? replacement : expr;
     case "lit":
+    case "opaque":
       return expr;
     case "app":
       return {

--- a/tools/ts2pant/src/ir-emit.ts
+++ b/tools/ts2pant/src/ir-emit.ts
@@ -5,7 +5,7 @@
  * The IR is read-only here; build is in `ir-build.ts` (and L1 → L2 in
  * `ir1-lower.ts`).
  *
- * Handles `Var`, `Lit`, `App` (all heads), `Cond`, `Each`, `Comb`,
+ * Handles `Var`, `Lit`, `Opaque`, `App` (all heads), `Cond`, `Each`, `Comb`,
  * `Forall`, and `Exists`. `Let` substitutes inline at lowering time
  * (Pant has no `let`). Post-M6 cleanup, no escape-hatch form remains:
  * every `IRExpr` corresponds to a native Pantagruel construct.
@@ -24,6 +24,7 @@ import {
   type IRUnop,
   isFoldComb,
 } from "./ir.js";
+import { opaqueValueRuleName } from "./opaque.js";
 import type {
   OpaqueBinop,
   OpaqueCombiner,
@@ -156,6 +157,9 @@ export function lowerExpr(e: IRExpr): OpaqueExpr {
         }
       }
     }
+
+    case "opaque":
+      return ast.var(opaqueValueRuleName(e.id));
 
     case "app":
       return lowerApp(e.head, e.args.map(lowerExpr));

--- a/tools/ts2pant/src/ir.ts
+++ b/tools/ts2pant/src/ir.ts
@@ -103,7 +103,7 @@ export type IRCombiner = IRFoldCombiner | "min" | "max";
 // --------------------------------------------------------------------------
 
 /**
- * Pure value-position IR. Ten forms total. Each form's invariants are
+ * Pure value-position IR. Eleven forms total. Each form's invariants are
  * documented inline; do not add forms ad-hoc — additions go through
  * AGENTS.md §IR review.
  */
@@ -112,6 +112,12 @@ export type IRExpr =
   | { kind: "var"; name: string; primed?: boolean }
   /** Literal value (nat, bool, string). */
   | { kind: "lit"; value: IRLiteral }
+  /**
+   * Typed mirror of an opaque-sorted `OpaqueExpr`: value-position,
+   * one-OpaqueExpr-out. `id` is the per-value identity, so distinct opaque
+   * values emit distinct nullary constants without asserting distinctness.
+   */
+  | { kind: "opaque"; sort: string; id: string }
   /**
    * Function or operator application. `head` selects the lowering
    * (named ref, binop, unop). Method calls lower with the receiver as
@@ -247,6 +253,12 @@ export const irLitBool = (value: boolean): IRExpr => ({
 export const irLitString = (value: string): IRExpr => ({
   kind: "lit",
   value: { kind: "string", value },
+});
+
+export const irOpaque = (sort: string, id: string): IRExpr => ({
+  kind: "opaque",
+  sort,
+  id,
 });
 
 export const irApp = (head: IRHead, args: IRExpr[]): IRExpr => ({

--- a/tools/ts2pant/src/ir.ts
+++ b/tools/ts2pant/src/ir.ts
@@ -103,7 +103,7 @@ export type IRCombiner = IRFoldCombiner | "min" | "max";
 // --------------------------------------------------------------------------
 
 /**
- * Pure value-position IR. Eleven forms total. Each form's invariants are
+ * Pure value-position IR. Twelve forms total. Each form's invariants are
  * documented inline; do not add forms ad-hoc — additions go through
  * AGENTS.md §IR review.
  */

--- a/tools/ts2pant/src/opaque.ts
+++ b/tools/ts2pant/src/opaque.ts
@@ -1,0 +1,17 @@
+export const OPAQUE_DOMAIN = "Opaque";
+
+/**
+ * Return the Pant-safe nullary rule name for one opaque value identity.
+ *
+ * The encoding is injective over JavaScript UTF-16 strings: it records the
+ * code-unit length and every code unit in fixed-width hexadecimal form.
+ */
+export function opaqueValueRuleName(id: string): string {
+  const codeUnits: string[] = [];
+  for (let i = 0; i < id.length; i += 1) {
+    codeUnits.push(id.charCodeAt(i).toString(16).padStart(4, "0"));
+  }
+  return codeUnits.length === 0
+    ? "opaque_value_0"
+    : `opaque_value_${id.length}_${codeUnits.join("_")}`;
+}

--- a/tools/ts2pant/tests/opaque-vocabulary.test.mts
+++ b/tools/ts2pant/tests/opaque-vocabulary.test.mts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { irOpaque } from "../src/ir.js";
+import { lowerExpr } from "../src/ir-emit.js";
+import { OPAQUE_DOMAIN, opaqueValueRuleName } from "../src/opaque.js";
+import { loadAst } from "../src/pant-wasm.js";
+
+describe("opaque vocabulary", async () => {
+  const ast = await loadAst();
+
+  it("L2 opaque lowers to a single OpaqueExpr reference", () => {
+    const id = "src/example.ts:12<$value>";
+    const expectedName = opaqueValueRuleName(id);
+
+    assert.equal(OPAQUE_DOMAIN, "Opaque");
+    assert.match(expectedName, /^[A-Za-z_][A-Za-z0-9_]*$/u);
+    assert.equal(
+      ast.strExpr(lowerExpr(irOpaque(OPAQUE_DOMAIN, id))),
+      expectedName,
+    );
+  });
+
+  it("L2 opaque ids determine constant identity", () => {
+    const sameA = ast.strExpr(lowerExpr(irOpaque(OPAQUE_DOMAIN, "same.ts:1")));
+    const sameB = ast.strExpr(lowerExpr(irOpaque(OPAQUE_DOMAIN, "same.ts:1")));
+    const other = ast.strExpr(lowerExpr(irOpaque(OPAQUE_DOMAIN, "other.ts:1")));
+
+    assert.equal(sameA, sameB);
+    assert.notEqual(sameA, other);
+  });
+
+  it.skip("L1 OpaqueValue is a closed leaf across all walkers and lowers to L2 opaque", () => {
+    // TODO(ts2pant-opaque-vocabulary patch 2): implement once L1 OpaqueValue exists.
+  });
+});


### PR DESCRIPTION
## Patch 1: L2 opaque IRExpr form + emit arm + shared Opaque names

- Create `src/opaque.ts` with `export const OPAQUE_DOMAIN = "Opaque";` and an injective `export const opaqueValueRuleName = (id: string): string => ...` that mangles the id to a Pant-safe identifier (no `$`, `<`, etc.).
- In `ir.ts`, extend the IRExpr union with `{ kind: "opaque"; sort: string; id: string }` and add `export const irOpaque = (sort: string, id: string): IRExpr => ({ kind: "opaque", sort, id });`.
- In `ir-emit.ts` lowerExpr, add `case "opaque": return <ast reference to opaqueValueRuleName(e.id)>;` using the same ast.* calls a nullary named reference uses elsewhere; keep the `_exhaustive: never` guard satisfied. Do NOT assert distinctness between constants — distinct ids yield distinct constant names, which the solver may still unify; this is the sound floor (neither force-equal nor force-distinct).
- Add the unit test for the L2 emit path (incl. distinct-id vs same-id constant references); run `npm run test:update-snapshots` only if a new snapshot is produced (none expected for existing fixtures).

## Changes
- Create `src/opaque.ts` with `export const OPAQUE_DOMAIN = "Opaque";` and an injective `export const opaqueValueRuleName = (id: string): string => ...` that mangles the id to a Pant-safe identifier (no `$`, `<`, etc.).
- In `ir.ts`, extend the IRExpr union with `{ kind: "opaque"; sort: string; id: string }` and add `export const irOpaque = (sort: string, id: string): IRExpr => ({ kind: "opaque", sort, id });`.
- In `ir-emit.ts` lowerExpr, add `case "opaque": return <ast reference to opaqueValueRuleName(e.id)>;` using the same ast.* calls a nullary named reference uses elsewhere; keep the `_exhaustive: never` guard satisfied. Do NOT assert distinctness between constants — distinct ids yield distinct constant names, which the solver may still unify; this is the sound floor (neither force-equal nor force-distinct).
- Add the unit test for the L2 emit path (incl. distinct-id vs same-id constant references); run `npm run test:update-snapshots` only if a new snapshot is produced (none expected for existing fixtures).

## Files to Modify
- tools/ts2pant/src/opaque.ts (create): New shared module exporting OPAQUE_DOMAIN = "Opaque" and an injective opaqueValueRuleName(id) helper (mangling the id to a Pant-safe constant name) so the emit arm and the synthesizer agree on names without a circular import.
- tools/ts2pant/src/ir.ts (modify): Add `{ kind: "opaque"; sort: string; id: string }` to the IRExpr union (with an inline comment noting it is the typed mirror of an opaque-sorted OpaqueExpr, value-position, one-OpaqueExpr-out; `id` is the per-value identity so distinct values emit distinct constants) and an `irOpaque(sort, id)` constructor.
- tools/ts2pant/src/ir-emit.ts (modify): Add a `case "opaque"` arm to lowerExpr (switch at line 137) that emits a reference to the per-id constant opaqueValueRuleName(e.id) via the existing ast.* wasm API; update the exhaustiveness guard. Add the arm to any other exhaustive IRExpr switch tsc flags (e.g. in emit.ts).
- tools/ts2pant/tests/opaque-vocabulary.test.mts (create): New test file. Introduce (and implement) a test that irOpaque(sort, id) lowers via lowerExpr to a single OpaqueExpr, and that two opaque values with different ids reference different constants while same-id values reference the same constant. Also introduce a skipped placeholder for the L1 round-trip test implemented in Patch 2, written so it compiles without referencing not-yet-existing L1 symbols (e.g. a `test.skip` with a TODO).

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[paper] Vekris, Cosman, Jhala — Refinement Types for TypeScript (PLDI 2016)** — https://arxiv.org/abs/1604.02480 — L2 IRExpr is the Pant-adapted IRSC mirror from this paper (cited in ir.ts). The new opaque variant follows IRSC's well-typed-node discipline: a value-position form that lowers 1:1 to one OpaqueExpr in ir-emit, not a transformation node.
- **[pattern] Uninterpreted sort encoding for dynamic value spaces (Rosette, Z3 community JS/Python encodings)** — The opaque value emits as a bare reference to a constant of an uninterpreted Opaque sort with no projection/injection functions — value present, structure erased. The emit arm declares nothing beyond that reference and adds no is-T/intify projections.

## Gameplan Specification

```
module TS2PANT_OPAQUE_VOCABULARY.

> End state of milestone 1. A well-typed opaque value form exists at
> both IR layers; L1 lowers to L2 preserving its sort and deriving a
> per-value identity from the origin; distinct ids emit distinct
> constants (neither asserted equal nor asserted distinct). A
> synthesized Opaque domain is registered and emitted on-use; mapTsType
> rejects both `any` and `unknown` via the same sentinel. The
> vocabulary is dormant: no translation path constructs an opaque
> value, so nothing is emitted and the snapshot corpus is unchanged.

TsType.
Sort.
SourceRef.
OpaqueId.
L1Expr.
L2Expr.
OpaqueExpr.

opaque-sort => Sort.
is-any t: TsType => Bool.
is-unknown t: TsType => Bool.
maps-to-unsupported t: TsType => Bool.
l1-opaque s: Sort, o: SourceRef => L1Expr.
l2-opaque s: Sort, i: OpaqueId => L2Expr.
origin-id o: SourceRef => OpaqueId.
lower e: L1Expr => L2Expr.
emit e: L2Expr => OpaqueExpr.
const-name i: OpaqueId => OpaqueExpr.
l1-sort e: L1Expr => Sort.
has-free-vars e: L1Expr => Bool.
used i: OpaqueId => Bool.
emitted i: OpaqueId => Bool.
---
all t: TsType | is-any t -> maps-to-unsupported t.
all t: TsType | is-unknown t -> maps-to-unsupported t.
all s: Sort, o: SourceRef | lower (l1-opaque s o) = l2-opaque s (origin-id o).
all s: Sort, i: OpaqueId | emit (l2-opaque s i) = const-name i.
all i: OpaqueId, j: OpaqueId | (const-name i = const-name j) -> i = j.
all s: Sort, o: SourceRef | l1-sort (l1-opaque s o) = s.
all s: Sort, o: SourceRef | has-free-vars (l1-opaque s o) = false.
all i: OpaqueId | used i = false.
all i: OpaqueId | emitted i = used i.
```

## Patch Specification

```
module TS2PANT_OPAQUE_VOCABULARY_PATCH_1.

> Patch 1 introduces the well-typed L2 opaque form (the TS-side mirror
> of an opaque-sorted OpaqueExpr) and its emit arm. Each opaque value
> carries an identity so distinct values emit distinct constants; the
> constants are neither asserted equal nor asserted distinct. Dormant:
> no caller constructs one yet, so the arm is unreachable in M1.

Sort.
OpaqueId.
L2Expr.
OpaqueExpr.

opaque-sort => Sort.
l2-opaque s: Sort, i: OpaqueId => L2Expr.
emit e: L2Expr => OpaqueExpr.
const-name i: OpaqueId => OpaqueExpr.
---
all s: Sort, i: OpaqueId | emit (l2-opaque s i) = const-name i.
all i: OpaqueId, j: OpaqueId | (const-name i = const-name j) -> i = j.
```


## Implementation Notes

- `opaqueValueRuleName` uses a deterministic UTF-16 code-unit encoding with a length prefix. That keeps the emitted name inside the conservative identifier regex while preserving injectivity for arbitrary origin/id strings, including punctuation and empty ids.
- The L2 `sort` field is intentionally carried but not inspected by `lowerExpr`; Patch 1 only emits the per-id value reference. The Opaque sort/domain declaration is still deferred to the later synthesizer patch, so existing fixture snapshots remain untouched.
- The only extra exhaustive consumer found during implementation was `substituteIR` in `ir-build.ts`; opaque is treated like `lit` there because it is a closed leaf and should not capture or substitute variables.
- No snapshot update was needed: no production translation path constructs `irOpaque` yet.

Spec/Evidence Mapping:
- `emit (l2-opaque s i) = const-name i`: `irOpaque` in `src/ir.ts` plus the `case "opaque"` arm in `src/ir-emit.ts`; covered by `tests/opaque-vocabulary.test.mts`.
- `(const-name i = const-name j) -> i = j`: implemented by the injective name encoding in `src/opaque.ts`; covered by same-id/different-id assertions and the Pant-safe regex assertion in `tests/opaque-vocabulary.test.mts`.
- Required context consulted: `tools/ts2pant/src/ir.ts`, `tools/ts2pant/src/ir-emit.ts`, and `tools/ts2pant/AGENTS.md` for the L2 mirror/value-position discipline.
- Verification run: `npx tsc --noEmit`, `npm run lint`, `npx biome check tests/opaque-vocabulary.test.mts`, focused opaque test, `npm run test:unit`, and `npm run test:integration`.