### PR TITLE
[ts2pant-opaque-vocabulary] Patch 4: Detect ts.TypeFlags.Any in mapTsType and route to UNSUPPORTED_UNKNOWN

### DIFF
--- a/tools/ts2pant/src/translate-types.ts
+++ b/tools/ts2pant/src/translate-types.ts
@@ -22,13 +22,14 @@ import type { PantDeclaration } from "./types.js";
 export const UNSUPPORTED_ANONYMOUS_RECORD = "__unsupported_anon_record__";
 
 /**
- * Sentinel returned by `mapTsType` when the TypeScript type is `unknown`.
+ * Sentinel returned by `mapTsType` when the TypeScript type is `unknown`
+ * or `any`.
  * Pantagruel is monomorphic over named domains; there is no polymorphism
- * mechanism to absorb `unknown` into. Mapping it to a fresh domain per
- * call site loses the TS author's intent ("I'll narrow this later") and
- * silently lets type errors through. The translator rejects it explicitly
- * so the user can declare a real type or interface (steering rule 1 —
- * the TS itself is ambiguous, not the recognizer).
+ * mechanism to absorb a dynamic top type into. Mapping it to a fresh
+ * domain per call site loses the TS author's intent ("I'll narrow this
+ * later") and silently lets type errors through. The translator rejects
+ * it explicitly so the user can declare a real type or interface
+ * (steering rule 1 — the TS itself is ambiguous, not the recognizer).
  *
  * The value is not a valid Pantagruel identifier so emission of a
  * signature carrying it will fail visibly rather than reference an
@@ -1145,11 +1146,11 @@ export function mapTsType(
 ): string {
   const flags = type.flags;
 
-  // Reject `unknown` explicitly. Pantagruel is monomorphic over named
-  // domains — there is no `Any`/`Unknown` top — so the only honest move is
-  // to refuse and steer the user toward a declared type. Mapping to a
-  // generic placeholder would silently let type errors through.
-  if (flags & ts.TypeFlags.Unknown) {
+  // Reject `any` / `unknown` explicitly. Pantagruel is monomorphic over
+  // named domains — there is no `Any`/`Unknown` top — so the only honest
+  // move is to refuse and steer the user toward a declared type. Mapping
+  // to a generic placeholder would silently let type errors through.
+  if (flags & ts.TypeFlags.Any || flags & ts.TypeFlags.Unknown) {
     return UNSUPPORTED_UNKNOWN;
   }
 

--- a/tools/ts2pant/tests/any-rejection.test.mts
+++ b/tools/ts2pant/tests/any-rejection.test.mts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { createSourceFileFromSource } from "../src/extract.js";
+import { translateSignature } from "../src/translate-signature.js";
+import {
+  IntStrategy,
+  UNSUPPORTED_UNKNOWN_REASON,
+} from "../src/translate-types.js";
+
+function unsupportedReason(source: string, functionName: string): string {
+  const sourceFile = createSourceFileFromSource(source);
+  const result = translateSignature(sourceFile, functionName, IntStrategy);
+  assert.equal(result.declaration.kind, "unsupported");
+  if (result.declaration.kind !== "unsupported") {
+    throw new Error("expected unsupported declaration");
+  }
+  return result.declaration.reason;
+}
+
+function reasonCause(reason: string): string {
+  return reason.slice(reason.indexOf(": ") + 2);
+}
+
+describe("any rejection", () => {
+  it("any maps to UNSUPPORTED_UNKNOWN with the same reason as unknown", () => {
+    const anyReason = unsupportedReason(
+      `
+        function withAny(value: any): number {
+          return 0;
+        }
+      `,
+      "withAny",
+    );
+    const unknownReason = unsupportedReason(
+      `
+        function withUnknown(value: unknown): number {
+          return 0;
+        }
+      `,
+      "withUnknown",
+    );
+    const anyCause = reasonCause(anyReason);
+    const unknownCause = reasonCause(unknownReason);
+
+    assert.equal(anyCause, unknownCause);
+    assert.equal(anyCause, UNSUPPORTED_UNKNOWN_REASON);
+    assert.equal(
+      anyReason,
+      `with-any param 'value': ${UNSUPPORTED_UNKNOWN_REASON}`,
+    );
+    assert.equal(
+      unknownReason,
+      `with-unknown param 'value': ${UNSUPPORTED_UNKNOWN_REASON}`,
+    );
+  });
+});

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -1214,6 +1214,26 @@ exports[`guards-if-throw.ts > withdraw 1`] = `
 "module WITHDRAW.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\n~> Withdraw @ a: Account, amount: Int, account--balance a >= amount.\\n\\n---\\n\\naccount--balance' a = account--balance a - amount.\\n"
 `;
 
+exports[`opaque-any-unknown.ts > anyArrayReturn 1`] = `
+"module ANY_ARRAY_RETURN.\\n\\n> UNSUPPORTED: any-array-return return: TS unknown is not expressible in Pantagruel; declare a specific type\\n\\n---\\n\\nany-array-return value = [value].\\n"
+`;
+
+exports[`opaque-any-unknown.ts > anyParam 1`] = `
+"module ANY_PARAM.\\n\\n> UNSUPPORTED: any-param param 'value': TS unknown is not expressible in Pantagruel; declare a specific type\\n\\n---\\n\\n> UNSUPPORTED: anyParam param 'value': TS unknown is not expressible in Pantagruel; declare a specific type.\\n"
+`;
+
+exports[`opaque-any-unknown.ts > anyReturn 1`] = `
+"module ANY_RETURN.\\n\\n> UNSUPPORTED: any-return return: TS unknown is not expressible in Pantagruel; declare a specific type\\n\\n---\\n\\nany-return value = value.\\n"
+`;
+
+exports[`opaque-any-unknown.ts > unknownParam 1`] = `
+"module UNKNOWN_PARAM.\\n\\n> UNSUPPORTED: unknown-param param 'value': TS unknown is not expressible in Pantagruel; declare a specific type\\n\\n---\\n\\n> UNSUPPORTED: unknownParam param 'value': TS unknown is not expressible in Pantagruel; declare a specific type.\\n"
+`;
+
+exports[`opaque-any-unknown.ts > unknownReturn 1`] = `
+"module UNKNOWN_RETURN.\\n\\n> UNSUPPORTED: unknown-return return: TS unknown is not expressible in Pantagruel; declare a specific type\\n\\n---\\n\\nunknown-return value = value.\\n"
+`;
+
 exports[`types-composite.ts > getBooks 1`] = `
 "module GET_BOOKS.\\n\\nLibrary.\\nlibrary--books l: Library => [String].\\nget-books lib: Library => [String].\\n\\n---\\n\\nget-books lib = library--books lib.\\n"
 `;

--- a/tools/ts2pant/tests/fixtures/constructs/opaque-any-unknown.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/opaque-any-unknown.ts
@@ -1,0 +1,21 @@
+// Dynamic TS top types reject through the UNSUPPORTED_UNKNOWN path.
+
+export function anyParam(value: any): number {
+  return value;
+}
+
+export function anyReturn(value: number): any {
+  return value;
+}
+
+export function unknownParam(value: unknown): number {
+  return 0;
+}
+
+export function unknownReturn(value: number): unknown {
+  return value;
+}
+
+export function anyArrayReturn(value: number): any[] {
+  return [value];
+}

--- a/tools/ts2pant/tests/translate-signature.test.mts
+++ b/tools/ts2pant/tests/translate-signature.test.mts
@@ -86,16 +86,16 @@ describe("numeric strategy", () => {
 describe("overloaded functions", () => {
   it("prefers implementation over overload signature", () => {
     const source = `
-      function add(a: number, b: number): number;
-      function add(a: string, b: string): string;
-      function add(a: any, b: any): any {
-        return a + b;
+      function add(a: number): number;
+      function add(a: number, b?: number): number {
+        return a + (b ?? 0);
       }
     `;
     const sourceFile = createSourceFileFromSource(source);
     const { node } = findFunction(sourceFile, "add");
     assert.ok(node.body !== undefined);
-    // Verify translateSignature uses the implementation (any params), not the first overload
+    // Verify translateSignature uses the implementation (two params), not the
+    // one-parameter overload signature.
     const result = translateSignature(sourceFile, "add", IntStrategy);
     assert.equal(result.declaration.params.length, 2);
   });
@@ -553,4 +553,3 @@ describe("@pant-type override", () => {
     assert.equal(result.declaration.params[0]?.type, "Int");
   });
 });
-


### PR DESCRIPTION
## Patch 4: Detect ts.TypeFlags.Any in mapTsType and route to UNSUPPORTED_UNKNOWN

- Add the `ts.TypeFlags.Any` branch to mapTsType returning UNSUPPORTED_UNKNOWN.
- Add the `any`/`unknown` fixture and the targeted any-rejection unit test.
- Run `npm run test:update-snapshots`; verify the diff is purely additive (new fixture functions) and no existing snapshot entry changes.

## Changes
- Add the `ts.TypeFlags.Any` branch to mapTsType returning UNSUPPORTED_UNKNOWN.
- Add the `any`/`unknown` fixture and the targeted any-rejection unit test.
- Run `npm run test:update-snapshots`; verify the diff is purely additive (new fixture functions) and no existing snapshot entry changes.

## Files to Modify
- tools/ts2pant/src/translate-types.ts (modify): In mapTsType, add an `if (flags & ts.TypeFlags.Any) return UNSUPPORTED_UNKNOWN;` check alongside the existing Unknown check (line 1152), so `any` joins the same rejection path instead of falling through to typeToString.
- tools/ts2pant/tests/fixtures/constructs/opaque-any-unknown.ts (create): New fixture file with exported functions whose signatures contain `any` and `unknown` (param and return positions, plus a composite e.g. `any[]`), so the snapshot captures the UNSUPPORTED rejection for both.
- tools/ts2pant/tests/any-rejection.test.mts (create): Unit test asserting an `any`-typed signature maps to UNSUPPORTED_UNKNOWN with the identical reason string as an `unknown`-typed signature.
- tools/ts2pant/tests/constructs.test.mts.snapshot (modify): Regenerate to add snapshot entries for the new fixture functions (their UNSUPPORTED rejection). No existing entry changes.

## Gameplan Specification

```
module TS2PANT_OPAQUE_VOCABULARY.

> End state of milestone 1. A well-typed opaque value form exists at
> both IR layers; L1 lowers to L2 preserving its sort and deriving a
> per-value identity from the origin; distinct ids emit distinct
> constants (neither asserted equal nor asserted distinct). A
> synthesized Opaque domain is registered and emitted on-use; mapTsType
> rejects both `any` and `unknown` via the same sentinel. The
> vocabulary is dormant: no translation path constructs an opaque
> value, so nothing is emitted and the snapshot corpus is unchanged.

TsType.
Sort.
SourceRef.
OpaqueId.
L1Expr.
L2Expr.
OpaqueExpr.

opaque-sort => Sort.
is-any t: TsType => Bool.
is-unknown t: TsType => Bool.
maps-to-unsupported t: TsType => Bool.
l1-opaque s: Sort, o: SourceRef => L1Expr.
l2-opaque s: Sort, i: OpaqueId => L2Expr.
origin-id o: SourceRef => OpaqueId.
lower e: L1Expr => L2Expr.
emit e: L2Expr => OpaqueExpr.
const-name i: OpaqueId => OpaqueExpr.
l1-sort e: L1Expr => Sort.
has-free-vars e: L1Expr => Bool.
used i: OpaqueId => Bool.
emitted i: OpaqueId => Bool.
---
all t: TsType | is-any t -> maps-to-unsupported t.
all t: TsType | is-unknown t -> maps-to-unsupported t.
all s: Sort, o: SourceRef | lower (l1-opaque s o) = l2-opaque s (origin-id o).
all s: Sort, i: OpaqueId | emit (l2-opaque s i) = const-name i.
all i: OpaqueId, j: OpaqueId | (const-name i = const-name j) -> i = j.
all s: Sort, o: SourceRef | l1-sort (l1-opaque s o) = s.
all s: Sort, o: SourceRef | has-free-vars (l1-opaque s o) = false.
all i: OpaqueId | used i = false.
all i: OpaqueId | emitted i = used i.
```

## Patch Specification

```
module TS2PANT_OPAQUE_VOCABULARY_PATCH_4.

> Patch 4 detects ts.TypeFlags.Any in mapTsType and routes it to the
> existing UNSUPPORTED_UNKNOWN sentinel — the same honest rejection
> unknown already produces.

TsType.

is-any t: TsType => Bool.
is-unknown t: TsType => Bool.
maps-to-unsupported t: TsType => Bool.
---
all t: TsType | is-any t -> maps-to-unsupported t.
all t: TsType | is-unknown t -> maps-to-unsupported t.
```


## Implementation Notes

- `UNSUPPORTED_UNKNOWN_REASON` was intentionally left unchanged, so `any` now presents the same user-facing diagnostic text as `unknown`; the focused unit test normalizes away the function-name prefix and compares the shared cause directly.
- One existing overload-signature test used `any` as a convenient implementation signature. Since that is now intentionally unsupported, the test fixture was rewritten to prove the same implementation-vs-overload behavior with a typed optional parameter instead of weakening the new rejection path.
- Snapshot update was additive only for `opaque-any-unknown.ts`; existing snapshot entries were unchanged.

Spec/Evidence Mapping:
- `is-any t -> maps-to-unsupported t`: `mapTsType` checks `ts.TypeFlags.Any` in `tools/ts2pant/src/translate-types.ts` and returns `UNSUPPORTED_UNKNOWN`; covered by `tools/ts2pant/tests/any-rejection.test.mts` and the `anyParam` / `anyReturn` / `anyArrayReturn` fixture snapshots.
- `is-unknown t -> maps-to-unsupported t`: existing `ts.TypeFlags.Unknown` branch remains on the same sentinel path; covered by existing unknown tests plus the new `unknownParam` / `unknownReturn` fixture snapshots.
- Required context consulted: `translate-types.ts` sentinel propagation and `constructs.test.mts` fixture auto-discovery/snapshot behavior.
- Verification run: `npm run test:update-snapshots` and `npm test`.