### PR TITLE
[ts2pant-opaque-vocabulary] Patch 2: L1 OpaqueValue form + SourceRef + arms in every IR1Expr walker

### DIFF
--- a/tools/ts2pant/src/ir1-lower.ts
+++ b/tools/ts2pant/src/ir1-lower.ts
@@ -37,7 +37,7 @@ import {
   irUnop,
   irVar,
 } from "./ir.js";
-import type { IR1Expr, SourceRef } from "./ir1.js";
+import { type IR1Expr, ir1OpaqueOriginId } from "./ir1.js";
 
 /**
  * Lower a Layer 1 expression to Layer 2 `IRExpr`.
@@ -53,7 +53,7 @@ export function lowerL1Expr(e: IR1Expr): IRExpr {
       return e;
 
     case "opaque":
-      return irOpaque(e.sort, originId(e.origin));
+      return irOpaque(e.sort, ir1OpaqueOriginId(e.origin));
 
     case "binop":
       return irBinop(e.op, lowerL1Expr(e.lhs), lowerL1Expr(e.rhs));
@@ -158,8 +158,4 @@ export function lowerL1Expr(e: IR1Expr): IRExpr {
       throw new Error("unreachable: IR1Expr");
     }
   }
-}
-
-function originId(origin: SourceRef): string {
-  return `${origin.file}:${origin.line}`;
 }

--- a/tools/ts2pant/src/ir1-lower.ts
+++ b/tools/ts2pant/src/ir1-lower.ts
@@ -33,10 +33,11 @@ import {
   irExists,
   irForall,
   irLitNat,
+  irOpaque,
   irUnop,
   irVar,
 } from "./ir.js";
-import type { IR1Expr } from "./ir1.js";
+import type { IR1Expr, SourceRef } from "./ir1.js";
 
 /**
  * Lower a Layer 1 expression to Layer 2 `IRExpr`.
@@ -50,6 +51,9 @@ export function lowerL1Expr(e: IR1Expr): IRExpr {
       // L1 `lit` and L2 `lit` share the same shape (`IR1Literal = IRLiteral`),
       // so the variant is structurally a valid `IRExpr`. Pass through.
       return e;
+
+    case "opaque":
+      return irOpaque(e.sort, originId(e.origin));
 
     case "binop":
       return irBinop(e.op, lowerL1Expr(e.lhs), lowerL1Expr(e.rhs));
@@ -154,4 +158,8 @@ export function lowerL1Expr(e: IR1Expr): IRExpr {
       throw new Error("unreachable: IR1Expr");
     }
   }
+}
+
+function originId(origin: SourceRef): string {
+  return `${origin.file}:${origin.line}`;
 }

--- a/tools/ts2pant/src/ir1-printer.ts
+++ b/tools/ts2pant/src/ir1-printer.ts
@@ -16,6 +16,8 @@ export function formatIR1Expr(expr: IR1Expr): string {
       return `${expr.name}${expr.primed === true ? "'" : ""}`;
     case "lit":
       return formatIR1Literal(expr.value);
+    case "opaque":
+      return `<opaque:${expr.sort}>`;
     case "binop":
       return `(${formatIR1Expr(expr.lhs)} ${binopGlyph(expr.op)} ${formatIR1Expr(expr.rhs)})`;
     case "unop":
@@ -485,6 +487,7 @@ function consumeScalarReadsForExpr(
       return cursor;
     }
     case "lit":
+    case "opaque":
       return cursor;
     case "map-read":
     case "set-read":
@@ -536,6 +539,8 @@ function formatIR1ExprWithSsaReads(
       );
     case "lit":
       return formatIR1Literal(expr.value);
+    case "opaque":
+      return `<opaque:${expr.sort}>`;
     case "binop":
       return `(${formatIR1ExprWithSsaReads(expr.lhs, readLabels)} ${binopGlyph(expr.op)} ${formatIR1ExprWithSsaReads(expr.rhs, readLabels)})`;
     case "unop":

--- a/tools/ts2pant/src/ir1-ssa-collections.ts
+++ b/tools/ts2pant/src/ir1-ssa-collections.ts
@@ -9,6 +9,7 @@ import {
   type IR1SsaVersion,
   type IR1SsaWrite,
   type IR1Stmt,
+  ir1OpaqueOriginId,
   ir1SsaInitialVersion,
   ir1SsaJoin,
   ir1SsaMapMembershipLocation,
@@ -2011,7 +2012,7 @@ function collectionSsaExprKeyData(expr: IR1Expr): unknown {
         "value" in expr.value ? expr.value.value : null,
       ];
     case "opaque":
-      return ["opaque", expr.sort, expr.origin.file, expr.origin.line];
+      return ["opaque", expr.sort, ir1OpaqueOriginId(expr.origin)];
     case "member":
       return ["member", collectionSsaExprKeyData(expr.receiver), expr.name];
     case "binop":

--- a/tools/ts2pant/src/ir1-ssa-collections.ts
+++ b/tools/ts2pant/src/ir1-ssa-collections.ts
@@ -558,6 +558,7 @@ export function collectionSsaReadExpr(
       return expr;
     case "var":
     case "lit":
+    case "opaque":
       return expr;
     default: {
       const _exhaustive: never = expr;
@@ -1102,6 +1103,7 @@ function lowerCollectionSsaExprToOpaque(
     }
     case "var":
     case "lit":
+    case "opaque":
       return state.lowerOpaque(
         lowerExpr(lowerL1Expr(state.canonicalize(expr))),
       );
@@ -2008,6 +2010,8 @@ function collectionSsaExprKeyData(expr: IR1Expr): unknown {
         expr.value.kind,
         "value" in expr.value ? expr.value.value : null,
       ];
+    case "opaque":
+      return ["opaque", expr.sort, expr.origin.file, expr.origin.line];
     case "member":
       return ["member", collectionSsaExprKeyData(expr.receiver), expr.name];
     case "binop":
@@ -2148,6 +2152,7 @@ function isCollectionSsaExpr(expr: IR1Expr): boolean {
   switch (expr.kind) {
     case "var":
     case "lit":
+    case "opaque":
       return true;
     case "member":
       return isCollectionSsaExpr(expr.receiver);

--- a/tools/ts2pant/src/ir1-ssa-counter-loop.ts
+++ b/tools/ts2pant/src/ir1-ssa-counter-loop.ts
@@ -9,6 +9,7 @@ import {
   type IR1Stmt,
   ir1Binop,
   ir1LitNat,
+  ir1OpaqueOriginId,
   ir1SsaCloseLoopHeader,
   ir1SsaInitialVersion,
   ir1SsaLocalBindingLocation,
@@ -908,8 +909,7 @@ function ir1ExprEqual(a: IR1Expr, b: IR1Expr): boolean {
       return (
         b.kind === "opaque" &&
         a.sort === b.sort &&
-        a.origin.file === b.origin.file &&
-        a.origin.line === b.origin.line
+        ir1OpaqueOriginId(a.origin) === ir1OpaqueOriginId(b.origin)
       );
     case "binop":
       return (

--- a/tools/ts2pant/src/ir1-ssa-counter-loop.ts
+++ b/tools/ts2pant/src/ir1-ssa-counter-loop.ts
@@ -717,6 +717,7 @@ function exprReferencesVar(expr: IR1Expr, name: string): boolean {
     case "var":
       return expr.name === name;
     case "lit":
+    case "opaque":
       return false;
     case "binop":
       return (
@@ -792,6 +793,7 @@ function countTargetReads(
   switch (expr.kind) {
     case "var":
     case "lit":
+    case "opaque":
       return self;
     case "member":
       return self + countTargetReads(expr.receiver, target);
@@ -901,6 +903,13 @@ function ir1ExprEqual(a: IR1Expr, b: IR1Expr): boolean {
         "value" in a.value &&
         "value" in b.value &&
         a.value.value === b.value.value
+      );
+    case "opaque":
+      return (
+        b.kind === "opaque" &&
+        a.sort === b.sort &&
+        a.origin.file === b.origin.file &&
+        a.origin.line === b.origin.line
       );
     case "binop":
       return (

--- a/tools/ts2pant/src/ir1-ssa-fixed-point.ts
+++ b/tools/ts2pant/src/ir1-ssa-fixed-point.ts
@@ -650,6 +650,7 @@ function substituteLocalLets(
   switch (expr.kind) {
     case "var":
     case "lit":
+    case "opaque":
       return expr;
     case "binop":
       return {
@@ -850,6 +851,7 @@ function collectIr1FreeVars(
       }
       break;
     case "lit":
+    case "opaque":
       break;
     case "binop":
       collectIr1FreeVars(expr.lhs, out, bound);
@@ -938,6 +940,7 @@ function renameBoundVarRefs(expr: IR1Expr, from: string, to: string): IR1Expr {
     case "var":
       return !expr.primed && expr.name === from ? { ...expr, name: to } : expr;
     case "lit":
+    case "opaque":
       return expr;
     case "binop":
       return {
@@ -1057,6 +1060,7 @@ function collectAllNames(expr: IR1Expr, out: Set<string>): void {
       out.add(expr.name);
       break;
     case "lit":
+    case "opaque":
       break;
     case "binop":
       collectAllNames(expr.lhs, out);
@@ -1135,6 +1139,7 @@ function collectFreeVars(
       }
       break;
     case "lit":
+    case "opaque":
       break;
     case "binop":
       collectFreeVars(expr.lhs, out, excluded, bound);
@@ -1269,6 +1274,7 @@ function walkExpr(
   switch (expr.kind) {
     case "var":
     case "lit":
+    case "opaque":
       break;
     case "binop":
       walkExpr(expr.lhs, visit, bound);

--- a/tools/ts2pant/src/ir1-ssa-foreach.ts
+++ b/tools/ts2pant/src/ir1-ssa-foreach.ts
@@ -491,6 +491,7 @@ export function lowerShapeAExpr(
       );
     case "var":
     case "lit":
+    case "opaque":
       return lowerExpr(lowerL1Expr(expr));
     default: {
       const _exhaustive: never = expr;

--- a/tools/ts2pant/src/ir1-ssa-scalars.ts
+++ b/tools/ts2pant/src/ir1-ssa-scalars.ts
@@ -9,6 +9,7 @@ import {
   type IR1SsaVersion,
   type IR1SsaWrite,
   type IR1Stmt,
+  ir1OpaqueOriginId,
   ir1SsaInitialVersion,
   ir1SsaJoin,
   ir1SsaLocalBindingLocation,
@@ -1164,7 +1165,7 @@ function scalarSsaExprKey(expr: IR1Expr): string {
     case "lit":
       return `lit:${expr.value.kind}:${"value" in expr.value ? expr.value.value : ""}`;
     case "opaque":
-      return `opaque:${expr.sort}:${expr.origin.file}:${expr.origin.line}`;
+      return `opaque:${expr.sort}:${ir1OpaqueOriginId(expr.origin)}`;
     case "member":
       return `member:${scalarSsaExprKey(expr.receiver)}:${expr.name}`;
     case "binop":

--- a/tools/ts2pant/src/ir1-ssa-scalars.ts
+++ b/tools/ts2pant/src/ir1-ssa-scalars.ts
@@ -447,6 +447,7 @@ export function scalarSsaReadExpr(
       scalarSsaReadLocalBinding(expr.name, state);
       return expr;
     case "lit":
+    case "opaque":
       return expr;
     case "map-read":
     case "set-read":
@@ -757,6 +758,7 @@ function lowerScalarSsaExprToOpaque(
       return state.lowerOpaque(lowerScalarOpaqueExpr(expr, state.canonicalize));
     }
     case "lit":
+    case "opaque":
       return state.lowerOpaque(lowerScalarOpaqueExpr(expr, state.canonicalize));
     case "binop":
       return state.lowerOpaque(
@@ -1161,6 +1163,8 @@ function scalarSsaExprKey(expr: IR1Expr): string {
       return `var:${expr.name}:${expr.primed ?? false}`;
     case "lit":
       return `lit:${expr.value.kind}:${"value" in expr.value ? expr.value.value : ""}`;
+    case "opaque":
+      return `opaque:${expr.sort}:${expr.origin.file}:${expr.origin.line}`;
     case "member":
       return `member:${scalarSsaExprKey(expr.receiver)}:${expr.name}`;
     case "binop":
@@ -1335,6 +1339,7 @@ function isScalarSsaExpr(expr: IR1Expr): boolean {
   switch (expr.kind) {
     case "var":
     case "lit":
+    case "opaque":
       return true;
     case "member":
       return isScalarSsaExpr(expr.receiver);

--- a/tools/ts2pant/src/ir1-substitute.ts
+++ b/tools/ts2pant/src/ir1-substitute.ts
@@ -47,6 +47,7 @@ export function freeVarsIR1Expr(expr: IR1Expr): Set<string> {
     case "var":
       return new Set([expr.name]);
     case "lit":
+    case "opaque":
       return new Set();
     case "binop":
       return union(freeVarsIR1Expr(expr.lhs), freeVarsIR1Expr(expr.rhs));
@@ -343,6 +344,7 @@ function substituteExpr(
   switch (expr.kind) {
     case "var":
     case "lit":
+    case "opaque":
       return expr;
     case "binop": {
       const lhs = substituteExpr(

--- a/tools/ts2pant/src/ir1.ts
+++ b/tools/ts2pant/src/ir1.ts
@@ -45,6 +45,10 @@ export interface SourceRef {
   line: number;
 }
 
+export function ir1OpaqueOriginId(origin: SourceRef): string {
+  return `${origin.file}:${origin.line}`;
+}
+
 // --------------------------------------------------------------------------
 // Expression forms (value-position)
 // --------------------------------------------------------------------------
@@ -1032,8 +1036,7 @@ export const ir1SsaExprEquals = (a: IR1Expr, b: IR1Expr): boolean => {
       }
       return (
         a.sort === b.sort &&
-        a.origin.file === b.origin.file &&
-        a.origin.line === b.origin.line
+        ir1OpaqueOriginId(a.origin) === ir1OpaqueOriginId(b.origin)
       );
     }
     case "binop": {

--- a/tools/ts2pant/src/ir1.ts
+++ b/tools/ts2pant/src/ir1.ts
@@ -40,14 +40,20 @@ export type IR1Literal = IRLiteral;
 export type IR1Binop = IRBinop;
 export type IR1Unop = IRUnop;
 
+export interface SourceRef {
+  file: string;
+  line: number;
+}
+
 // --------------------------------------------------------------------------
 // Expression forms (value-position)
 // --------------------------------------------------------------------------
 
 /**
- * Layer 1 expressions. Fourteen forms preserve TS-shape canonicalization:
+ * Layer 1 expressions. Fifteen forms preserve TS-shape canonicalization:
  *
  * - `var`, `lit` — literal references
+ * - `opaque` — value with erased structure, carrying sort + source origin
  * - `binop`, `unop` — arithmetic/logical/comparison operators
  * - `app` — function or method application (callee is itself an IR1Expr)
  * - `member` — property access; canonicalized so `obj.f` and `obj["f"]`
@@ -77,6 +83,8 @@ export type IR1Expr =
   | { kind: "var"; name: string; primed?: boolean }
   /** Literal value (nat, bool, string). */
   | { kind: "lit"; value: IR1Literal }
+  /** Opaque value with erased structure. Closed leaf. */
+  | { kind: "opaque"; sort: string; origin: SourceRef }
   /** Binary operator application. */
   | { kind: "binop"; op: IR1Binop; lhs: IR1Expr; rhs: IR1Expr }
   /** Unary operator application. */
@@ -1018,6 +1026,16 @@ export const ir1SsaExprEquals = (a: IR1Expr, b: IR1Expr): boolean => {
       }
       return a.value.kind === b.value.kind && a.value.value === b.value.value;
     }
+    case "opaque": {
+      if (b.kind !== "opaque") {
+        return false;
+      }
+      return (
+        a.sort === b.sort &&
+        a.origin.file === b.origin.file &&
+        a.origin.line === b.origin.line
+      );
+    }
     case "binop": {
       if (b.kind !== "binop") {
         return false;
@@ -1205,6 +1223,12 @@ export const ir1LitBool = (value: boolean): IR1Expr => ({
 export const ir1LitString = (value: string): IR1Expr => ({
   kind: "lit",
   value: { kind: "string", value },
+});
+
+export const ir1Opaque = (sort: string, origin: SourceRef): IR1Expr => ({
+  kind: "opaque",
+  sort,
+  origin,
 });
 
 export const ir1Binop = (

--- a/tools/ts2pant/tests/opaque-vocabulary.test.mts
+++ b/tools/ts2pant/tests/opaque-vocabulary.test.mts
@@ -2,6 +2,13 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { irOpaque } from "../src/ir.js";
 import { lowerExpr } from "../src/ir-emit.js";
+import { lowerL1Expr } from "../src/ir1-lower.js";
+import { formatIR1Expr } from "../src/ir1-printer.js";
+import {
+  freeVarsIR1Expr,
+  substituteIR1ExprSubtree,
+} from "../src/ir1-substitute.js";
+import { ir1LitNat, ir1Opaque, ir1Var } from "../src/ir1.js";
 import { OPAQUE_DOMAIN, opaqueValueRuleName } from "../src/opaque.js";
 import { loadAst } from "../src/pant-wasm.js";
 
@@ -29,7 +36,39 @@ describe("opaque vocabulary", async () => {
     assert.notEqual(sameA, other);
   });
 
-  it.skip("L1 OpaqueValue is a closed leaf across all walkers and lowers to L2 opaque", () => {
-    // TODO(ts2pant-opaque-vocabulary patch 2): implement once L1 OpaqueValue exists.
+  it("L1 OpaqueValue is a closed leaf across all walkers and lowers to L2 opaque", () => {
+    const expr = ir1Opaque(OPAQUE_DOMAIN, {
+      file: "src/example.ts",
+      line: 12,
+    });
+    const other = ir1Opaque(OPAQUE_DOMAIN, {
+      file: "src/example.ts",
+      line: 13,
+    });
+
+    assert.deepEqual([...freeVarsIR1Expr(expr)], []);
+    assert.equal(
+      substituteIR1ExprSubtree(expr, ir1Var("x"), ir1LitNat(1)),
+      expr,
+    );
+    assert.equal(formatIR1Expr(expr), "<opaque:Opaque>");
+
+    const lowered = lowerL1Expr(expr);
+    const loweredOther = lowerL1Expr(other);
+
+    assert.deepEqual(lowered, {
+      kind: "opaque",
+      sort: OPAQUE_DOMAIN,
+      id: "src/example.ts:12",
+    });
+    assert.deepEqual(loweredOther, {
+      kind: "opaque",
+      sort: OPAQUE_DOMAIN,
+      id: "src/example.ts:13",
+    });
+    if (lowered.kind !== "opaque" || loweredOther.kind !== "opaque") {
+      assert.fail("expected L1 opaque values to lower to L2 opaque values");
+    }
+    assert.notEqual(lowered.id, loweredOther.id);
   });
 });


### PR DESCRIPTION
## Patch 2: L1 OpaqueValue form + SourceRef + arms in every IR1Expr walker

- Add SourceRef and the IR1Expr opaque variant + ir1Opaque constructor in `ir1.ts`.
- Add the `opaque` arm to every exhaustive IR1Expr switch; let tsc enumerate any switch missed (the `_exhaustive: never` guards will fail to compile until all are handled).
- Treat the form as a closed leaf everywhere: no free variables, substitution returns the node, SSA passes do not rewrite it.
- In lowerL1Expr, derive the per-value identity from the origin (a stable `${file}:${line}` key) and pass it to irOpaque so distinct opaque values lower to distinct L2 constants.
- Implement the L1 round-trip unit test (incl. asserting two distinct origins lower to distinct ids) and unskip it.

## Changes
- Add SourceRef and the IR1Expr opaque variant + ir1Opaque constructor in `ir1.ts`.
- Add the `opaque` arm to every exhaustive IR1Expr switch; let tsc enumerate any switch missed (the `_exhaustive: never` guards will fail to compile until all are handled).
- Treat the form as a closed leaf everywhere: no free variables, substitution returns the node, SSA passes do not rewrite it.
- In lowerL1Expr, derive the per-value identity from the origin (a stable `${file}:${line}` key) and pass it to irOpaque so distinct opaque values lower to distinct L2 constants.
- Implement the L1 round-trip unit test (incl. asserting two distinct origins lower to distinct ids) and unskip it.

## Files to Modify
- tools/ts2pant/src/ir1.ts (modify): Add `export interface SourceRef { file: string; line: number }`, extend the IR1Expr union with `{ kind: "opaque"; sort: string; origin: SourceRef }`, and add `ir1Opaque(sort, origin)` near the other ir1* constructors.
- tools/ts2pant/src/ir1-lower.ts (modify): Add `case "opaque": return irOpaque(e.sort, originId(e.origin));` to lowerL1Expr, deriving the per-value identity from the origin (e.g. `${origin.file}:${origin.line}`).
- tools/ts2pant/src/ir1-printer.ts (modify): Add `case "opaque"` to formatIR1Expr producing a stable debug rendering (e.g. `<opaque:${expr.sort}>`).
- tools/ts2pant/src/ir1-substitute.ts (modify): Add `case "opaque"` to freeVarsIR1Expr (return empty set) and to substituteIR1Expr (return expr unchanged) — a closed leaf.
- tools/ts2pant/src/ir1-ssa-scalars.ts (modify): Add `case "opaque"` to the exhaustive IR1Expr switch, classifying it as a closed scalar leaf parallel to lit/var.
- tools/ts2pant/src/ir1-ssa-foreach.ts (modify): Add `case "opaque"` to the exhaustive IR1Expr walker (return the node unchanged).
- tools/ts2pant/src/ir1-ssa-collections.ts (modify): Add `case "opaque"` to the exhaustive IR1Expr walker (return the node unchanged).
- tools/ts2pant/src/ir1-ssa-counter-loop.ts (modify): Add `case "opaque"` to the exhaustive IR1Expr walker (return the node unchanged).
- tools/ts2pant/src/ir1-ssa-fixed-point.ts (modify): Add `case "opaque"` to substituteLocalLets and any sibling exhaustive IR1Expr switch in this file (return the node unchanged).
- tools/ts2pant/tests/opaque-vocabulary.test.mts (modify): Implement the previously-stubbed L1 round-trip test: construct ir1Opaque, assert empty free-vars, substitution-identity, a stable printer rendering, and that lowerL1Expr yields the L2 opaque form of the same sort.

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[pattern] Bindlib capture-avoiding substitution discipline** — https://lepigre.fr/ocaml-bindlib/ — The substituteIR1Expr/freeVarsIR1Expr primitives follow this discipline; the opaque leaf is a closed term, so its arm contributes the empty free-variable set and the substitution-identity case — the trivial-but-mandatory leaf of the substitution walk.

## Gameplan Specification

```
module TS2PANT_OPAQUE_VOCABULARY.

> End state of milestone 1. A well-typed opaque value form exists at
> both IR layers; L1 lowers to L2 preserving its sort and deriving a
> per-value identity from the origin; distinct ids emit distinct
> constants (neither asserted equal nor asserted distinct). A
> synthesized Opaque domain is registered and emitted on-use; mapTsType
> rejects both `any` and `unknown` via the same sentinel. The
> vocabulary is dormant: no translation path constructs an opaque
> value, so nothing is emitted and the snapshot corpus is unchanged.

TsType.
Sort.
SourceRef.
OpaqueId.
L1Expr.
L2Expr.
OpaqueExpr.

opaque-sort => Sort.
is-any t: TsType => Bool.
is-unknown t: TsType => Bool.
maps-to-unsupported t: TsType => Bool.
l1-opaque s: Sort, o: SourceRef => L1Expr.
l2-opaque s: Sort, i: OpaqueId => L2Expr.
origin-id o: SourceRef => OpaqueId.
lower e: L1Expr => L2Expr.
emit e: L2Expr => OpaqueExpr.
const-name i: OpaqueId => OpaqueExpr.
l1-sort e: L1Expr => Sort.
has-free-vars e: L1Expr => Bool.
used i: OpaqueId => Bool.
emitted i: OpaqueId => Bool.
---
all t: TsType | is-any t -> maps-to-unsupported t.
all t: TsType | is-unknown t -> maps-to-unsupported t.
all s: Sort, o: SourceRef | lower (l1-opaque s o) = l2-opaque s (origin-id o).
all s: Sort, i: OpaqueId | emit (l2-opaque s i) = const-name i.
all i: OpaqueId, j: OpaqueId | (const-name i = const-name j) -> i = j.
all s: Sort, o: SourceRef | l1-sort (l1-opaque s o) = s.
all s: Sort, o: SourceRef | has-free-vars (l1-opaque s o) = false.
all i: OpaqueId | used i = false.
all i: OpaqueId | emitted i = used i.
```

## Patch Specification

```
module TS2PANT_OPAQUE_VOCABULARY_PATCH_2.

> Patch 2 introduces the L1 OpaqueValue form carrying sort + origin,
> wires a closed-leaf arm into every exhaustive IR1Expr walker, and
> lowers it to the L2 opaque form, deriving the per-value identity
> from the origin so distinct origins yield distinct L2 ids.

Sort.
SourceRef.
OpaqueId.
L1Expr.
L2Expr.

opaque-sort => Sort.
l1-opaque s: Sort, o: SourceRef => L1Expr.
l2-opaque s: Sort, i: OpaqueId => L2Expr.
origin-id o: SourceRef => OpaqueId.
lower e: L1Expr => L2Expr.
l1-sort e: L1Expr => Sort.
has-free-vars e: L1Expr => Bool.
---
all s: Sort, o: SourceRef | lower (l1-opaque s o) = l2-opaque s (origin-id o).
all s: Sort, o: SourceRef | l1-sort (l1-opaque s o) = s.
all s: Sort, o: SourceRef | has-free-vars (l1-opaque s o) = false.
```


## Implementation Notes

- Opaque is treated as a true closed leaf, but not always identically to `var`: scalar SSA still treats `var` as a local-binding read, while `opaque` follows the literal path with no SSA read side effects.
- The L1 identity derivation is deliberately centralized in `ir1-lower.ts` as `originId(SourceRef) -> "${file}:${line}"`; the IR1 node stores only the lightweight source reference, and the L2 node carries the derived id.
- Equality/key helpers used by SSA now include `sort`, `origin.file`, and `origin.line` for opaque nodes. This keeps deterministic internal keys without adding any equality/distinctness assertion to emitted Pant.
- Spec/Evidence Mapping: `lower(l1-opaque s o) = l2-opaque s (origin-id o)` is implemented by `lowerL1Expr`'s `opaque` arm and covered by `opaque-vocabulary.test.mts`; `has-free-vars(l1-opaque s o) = false` is implemented in `freeVarsIR1Expr`; closed-leaf substitution is implemented in `substituteExpr`; exhaustive walker coverage is enforced by `tsc`.
- Verification: `npm run build`, `npm test`, and `git diff --check` passed locally.