### PR TITLE
[ts2pant-free-call-opaque-floor] Patch 1: Opaque-fallback type mapping reusing the opaque-vocabulary domain (dormant)

### DIFF
--- a/tools/ts2pant/src/translate-types.ts
+++ b/tools/ts2pant/src/translate-types.ts
@@ -1110,25 +1110,26 @@ export function cellIsUsed(cell: SynthCell, name: string): boolean {
   return cell.registry.used.has(toPantTermName(name));
 }
 
-/** Cell-mutating wrapper that drains both Map and Record synth decls.
- *  Emits Maps first so Record accessor-rule return types can reference
- *  any Map domain registered bottom-up. Incremental: each call returns
+/** Cell-mutating wrapper that drains Opaque, Map, and Record synth decls.
+ *  Emits Opaque first so Map/Record decls can reference it, then Maps so
+ *  Record accessor-rule return types can reference any Map domain registered
+ *  bottom-up. Incremental: each call returns
  *  only the entries added since the previous drain.
  *
  *  Tuple-constructor synth is *not* drained here — tuple constructors
  *  emit to a separate per-source-file dep module via
  *  `emitTupleCtorModule`, not into the consumer document's head. */
 export function cellEmitSynth(cell: SynthCell): PantDeclaration[] {
+  const opaqueR = emitOpaqueSynthDecls(cell.opaqueSynth, cell.registry);
+  cell.opaqueSynth = opaqueR.synth;
+  cell.registry = opaqueR.registry;
   const mapR = emitSynthDecls(cell.synth, cell.registry);
   cell.synth = mapR.synth;
   cell.registry = mapR.registry;
   const recR = emitRecordSynthDecls(cell.recordSynth, cell.registry);
   cell.recordSynth = recR.synth;
   cell.registry = recR.registry;
-  const opaqueR = emitOpaqueSynthDecls(cell.opaqueSynth, cell.registry);
-  cell.opaqueSynth = opaqueR.synth;
-  cell.registry = opaqueR.registry;
-  return [...mapR.decls, ...recR.decls, ...opaqueR.decls];
+  return [...opaqueR.decls, ...mapR.decls, ...recR.decls];
 }
 
 /**
@@ -1304,9 +1305,10 @@ export function mapTsType(
   // to a generic placeholder would silently let type errors through.
   if (flags & ts.TypeFlags.Any || flags & ts.TypeFlags.Unknown) {
     if (opts?.opaqueFallback) {
-      if (synthCell) {
-        cellRegisterOpaqueDomain(synthCell);
+      if (!synthCell) {
+        return UNSUPPORTED_UNKNOWN;
       }
+      cellRegisterOpaqueDomain(synthCell);
       return OPAQUE_DOMAIN;
     }
     return UNSUPPORTED_UNKNOWN;

--- a/tools/ts2pant/src/translate-types.ts
+++ b/tools/ts2pant/src/translate-types.ts
@@ -511,13 +511,27 @@ export interface OpaqueSynthEntry {
 export interface OpaqueSynth {
   readonly byId: ReadonlyMap<string, OpaqueSynthEntry>;
   readonly emitted: ReadonlySet<string>;
+  readonly needsDomain: boolean;
+  readonly domainEmitted: boolean;
 }
 
 /**
  * @pant all s: String | ~(s in emitted emptyOpaqueSynth).
  */
 export function emptyOpaqueSynth(): OpaqueSynth {
-  return { byId: new Map(), emitted: new Set() };
+  return {
+    byId: new Map(),
+    emitted: new Set(),
+    needsDomain: false,
+    domainEmitted: false,
+  };
+}
+
+export function registerOpaqueDomain(synth: OpaqueSynth): OpaqueSynth {
+  if (synth.needsDomain) {
+    return synth;
+  }
+  return { ...synth, needsDomain: true };
 }
 
 export function registerOpaqueValue(
@@ -531,7 +545,10 @@ export function registerOpaqueValue(
   const entry: OpaqueSynthEntry = { id, rule: opaqueValueRuleName(id) };
   const newById = new Map(synth.byId);
   newById.set(id, entry);
-  return { entry, synth: { byId: newById, emitted: synth.emitted } };
+  return {
+    entry,
+    synth: { ...synth, byId: newById, needsDomain: true },
+  };
 }
 
 /**
@@ -556,16 +573,18 @@ export function emitOpaqueSynthDecls(
 ): { decls: PantDeclaration[]; synth: OpaqueSynth; registry: NameRegistry } {
   const decls: PantDeclaration[] = [];
   const newEmitted = new Set(synth.emitted);
-  const shouldEmitDomain = synth.emitted.size === 0;
-  let emittedAny = false;
+  const hasUnemittedValue = [...synth.byId.keys()].some(
+    (id) => !newEmitted.has(id),
+  );
+  let domainEmitted = synth.domainEmitted;
+  if (!domainEmitted && (synth.needsDomain || hasUnemittedValue)) {
+    decls.push({ kind: "domain", name: OPAQUE_DOMAIN });
+    domainEmitted = true;
+  }
   for (const [id, entry] of synth.byId) {
     if (newEmitted.has(id)) {
       continue;
     }
-    if (shouldEmitDomain && !emittedAny) {
-      decls.push({ kind: "domain", name: OPAQUE_DOMAIN });
-    }
-    emittedAny = true;
     newEmitted.add(id);
     decls.push({
       kind: "rule",
@@ -576,7 +595,7 @@ export function emitOpaqueSynthDecls(
   }
   return {
     decls,
-    synth: { byId: synth.byId, emitted: newEmitted },
+    synth: { ...synth, emitted: newEmitted, domainEmitted },
     registry,
   };
 }
@@ -1048,6 +1067,11 @@ export function cellRegisterOpaqueValue(
   return r.entry;
 }
 
+/** Cell-mutating wrapper around `registerOpaqueDomain`. */
+export function cellRegisterOpaqueDomain(cell: SynthCell): void {
+  cell.opaqueSynth = registerOpaqueDomain(cell.opaqueSynth);
+}
+
 /**
  * Cell read-through for `lookupOpaqueValue`.
  *
@@ -1235,6 +1259,10 @@ export const IntStrategy: NumericStrategy = {
   },
 };
 
+export interface MapTsTypeOptions {
+  readonly opaqueFallback?: boolean;
+}
+
 export const RealStrategy: NumericStrategy = {
   mapNumber() {
     return "Real";
@@ -1257,6 +1285,7 @@ export function mapTsType(
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
   synthCell?: SynthCell,
+  opts?: MapTsTypeOptions,
 ): string {
   const flags = type.flags;
 
@@ -1265,6 +1294,12 @@ export function mapTsType(
   // move is to refuse and steer the user toward a declared type. Mapping
   // to a generic placeholder would silently let type errors through.
   if (flags & ts.TypeFlags.Any || flags & ts.TypeFlags.Unknown) {
+    if (opts?.opaqueFallback) {
+      if (synthCell) {
+        cellRegisterOpaqueDomain(synthCell);
+      }
+      return OPAQUE_DOMAIN;
+    }
     return UNSUPPORTED_UNKNOWN;
   }
 
@@ -1286,7 +1321,7 @@ export function mapTsType(
   if (checker.isTupleType(type)) {
     const typeArgs = checker.getTypeArguments(type as ts.TypeReference);
     const elements = typeArgs.map((t) =>
-      mapTsType(t, checker, strategy, synthCell),
+      mapTsType(t, checker, strategy, synthCell, opts),
     );
     if (elements.some(isUnsupportedUnknown)) {
       return UNSUPPORTED_UNKNOWN;
@@ -1298,7 +1333,7 @@ export function mapTsType(
   if (checker.isArrayType(type)) {
     const typeArgs = checker.getTypeArguments(type as ts.TypeReference);
     if (typeArgs.length === 1) {
-      const elem = mapTsType(typeArgs[0]!, checker, strategy, synthCell);
+      const elem = mapTsType(typeArgs[0]!, checker, strategy, synthCell, opts);
       if (isUnsupportedUnknown(elem)) {
         return UNSUPPORTED_UNKNOWN;
       }
@@ -1313,7 +1348,7 @@ export function mapTsType(
   if (isSetType(type)) {
     const typeArgs = checker.getTypeArguments(type as ts.TypeReference);
     if (typeArgs.length === 1) {
-      const elem = mapTsType(typeArgs[0]!, checker, strategy, synthCell);
+      const elem = mapTsType(typeArgs[0]!, checker, strategy, synthCell, opts);
       if (isUnsupportedUnknown(elem)) {
         return UNSUPPORTED_UNKNOWN;
       }
@@ -1329,8 +1364,8 @@ export function mapTsType(
   if (isMapType(type) && synthCell) {
     const typeArgs = checker.getTypeArguments(type as ts.TypeReference);
     if (typeArgs.length === 2) {
-      const kType = mapTsType(typeArgs[0]!, checker, strategy, synthCell);
-      const vType = mapTsType(typeArgs[1]!, checker, strategy, synthCell);
+      const kType = mapTsType(typeArgs[0]!, checker, strategy, synthCell, opts);
+      const vType = mapTsType(typeArgs[1]!, checker, strategy, synthCell, opts);
       // Propagate `unknown` rather than registering a Map keyed by or
       // valued in the sentinel — that would synthesize a domain like
       // `__unsupported_unknown__ToIntMap` (the underscore-only sentinel
@@ -1365,7 +1400,7 @@ export function mapTsType(
       return checker.typeToString(type);
     }
     const parts = nonNullTypes.map((t) =>
-      mapTsType(t, checker, strategy, synthCell),
+      mapTsType(t, checker, strategy, synthCell, opts),
     );
     if (parts.some(isUnsupportedUnknown)) {
       return UNSUPPORTED_UNKNOWN;
@@ -1393,6 +1428,7 @@ export function mapTsType(
         checker,
         strategy,
         synthCell,
+        opts,
       );
       if (domain !== null) {
         return domain;
@@ -1423,6 +1459,7 @@ function registerAnonymousRecord(
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
   synthCell: SynthCell,
+  opts?: MapTsTypeOptions,
 ): string | null {
   const properties = type.getProperties();
   const fields: RecordSynthField[] = [];
@@ -1440,7 +1477,7 @@ function registerAnonymousRecord(
     if (!propType) {
       return null;
     }
-    const mapped = mapTsType(propType, checker, strategy, synthCell);
+    const mapped = mapTsType(propType, checker, strategy, synthCell, opts);
     // Propagate `unknown` as the specific UNSUPPORTED_UNKNOWN sentinel
     // so the outer `mapTsType` anonymous-record branch can pass it back
     // to *its* caller — otherwise nested shapes like `[{ x: unknown },

--- a/tools/ts2pant/src/translate-types.ts
+++ b/tools/ts2pant/src/translate-types.ts
@@ -511,27 +511,21 @@ export interface OpaqueSynthEntry {
 export interface OpaqueSynth {
   readonly byId: ReadonlyMap<string, OpaqueSynthEntry>;
   readonly emitted: ReadonlySet<string>;
-  readonly needsDomain: boolean;
-  readonly domainEmitted: boolean;
 }
+
+const opaqueSynthNeedsDomain = new WeakSet<OpaqueSynth>();
+const opaqueSynthDomainEmitted = new WeakSet<OpaqueSynth>();
 
 /**
  * @pant all s: String | ~(s in emitted emptyOpaqueSynth).
  */
 export function emptyOpaqueSynth(): OpaqueSynth {
-  return {
-    byId: new Map(),
-    emitted: new Set(),
-    needsDomain: false,
-    domainEmitted: false,
-  };
+  return { byId: new Map(), emitted: new Set() };
 }
 
 export function registerOpaqueDomain(synth: OpaqueSynth): OpaqueSynth {
-  if (synth.needsDomain) {
-    return synth;
-  }
-  return { ...synth, needsDomain: true };
+  opaqueSynthNeedsDomain.add(synth);
+  return synth;
 }
 
 export function registerOpaqueValue(
@@ -545,9 +539,14 @@ export function registerOpaqueValue(
   const entry: OpaqueSynthEntry = { id, rule: opaqueValueRuleName(id) };
   const newById = new Map(synth.byId);
   newById.set(id, entry);
+  const next = { byId: newById, emitted: synth.emitted };
+  opaqueSynthNeedsDomain.add(next);
+  if (opaqueSynthDomainEmitted.has(synth)) {
+    opaqueSynthDomainEmitted.add(next);
+  }
   return {
     entry,
-    synth: { ...synth, byId: newById, needsDomain: true },
+    synth: next,
   };
 }
 
@@ -576,8 +575,11 @@ export function emitOpaqueSynthDecls(
   const hasUnemittedValue = [...synth.byId.keys()].some(
     (id) => !newEmitted.has(id),
   );
-  let domainEmitted = synth.domainEmitted;
-  if (!domainEmitted && (synth.needsDomain || hasUnemittedValue)) {
+  let domainEmitted = opaqueSynthDomainEmitted.has(synth);
+  if (
+    !domainEmitted &&
+    (opaqueSynthNeedsDomain.has(synth) || hasUnemittedValue)
+  ) {
     decls.push({ kind: "domain", name: OPAQUE_DOMAIN });
     domainEmitted = true;
   }
@@ -593,9 +595,16 @@ export function emitOpaqueSynthDecls(
       returnType: OPAQUE_DOMAIN,
     });
   }
+  const next = { byId: synth.byId, emitted: newEmitted };
+  if (opaqueSynthNeedsDomain.has(synth)) {
+    opaqueSynthNeedsDomain.add(next);
+  }
+  if (domainEmitted) {
+    opaqueSynthDomainEmitted.add(next);
+  }
   return {
     decls,
-    synth: { ...synth, emitted: newEmitted, domainEmitted },
+    synth: next,
     registry,
   };
 }

--- a/tools/ts2pant/tests/translate-types.test.mts
+++ b/tools/ts2pant/tests/translate-types.test.mts
@@ -215,6 +215,117 @@ describe("recursive type following", () => {
 });
 
 describe("mapTsType", () => {
+  it("opaque fallback maps `any` to the shared Opaque sort", async () => {
+    await loadAst();
+    const cell = newSynthCell();
+    const source = `interface Foo { val: any; }`;
+    const sourceFile = createSourceFileFromSource(source);
+    const checker = getChecker(sourceFile);
+    const prop = extractAllTypes(sourceFile).interfaces[0].properties[0];
+
+    assert.equal(
+      mapTsType(prop.type, checker, IntStrategy, cell, {
+        opaqueFallback: true,
+      }),
+      OPAQUE_DOMAIN,
+    );
+    assert.deepEqual(cellEmitSynth(cell), [
+      { kind: "domain", name: OPAQUE_DOMAIN },
+    ]);
+    assert.deepEqual(cellEmitSynth(cell), []);
+  });
+
+  it("opaque fallback maps `unknown` to the shared Opaque sort", async () => {
+    await loadAst();
+    const cell = newSynthCell();
+    const source = `interface Foo { val: unknown; }`;
+    const sourceFile = createSourceFileFromSource(source);
+    const checker = getChecker(sourceFile);
+    const prop = extractAllTypes(sourceFile).interfaces[0].properties[0];
+
+    assert.equal(
+      mapTsType(prop.type, checker, IntStrategy, cell, {
+        opaqueFallback: true,
+      }),
+      OPAQUE_DOMAIN,
+    );
+    assert.deepEqual(cellEmitSynth(cell), [
+      { kind: "domain", name: OPAQUE_DOMAIN },
+    ]);
+  });
+
+  it("opaque fallback leaves concrete types unchanged", async () => {
+    await loadAst();
+    const cell = newSynthCell();
+    const source = `interface Foo { val: number; }`;
+    const sourceFile = createSourceFileFromSource(source);
+    const checker = getChecker(sourceFile);
+    const prop = extractAllTypes(sourceFile).interfaces[0].properties[0];
+
+    assert.equal(
+      mapTsType(prop.type, checker, IntStrategy, cell, {
+        opaqueFallback: true,
+      }),
+      "Int",
+    );
+    assert.deepEqual(cellEmitSynth(cell), []);
+  });
+
+  it("opaque fallback disabled keeps `any` and `unknown` unsupported", () => {
+    const source = `interface Foo { anyVal: any; unknownVal: unknown; }`;
+    const sourceFile = createSourceFileFromSource(source);
+    const checker = getChecker(sourceFile);
+    const [anyProp, unknownProp] = extractAllTypes(
+      sourceFile,
+    ).interfaces[0].properties;
+
+    assert.equal(
+      mapTsType(anyProp.type, checker, IntStrategy),
+      UNSUPPORTED_UNKNOWN,
+    );
+    assert.equal(
+      mapTsType(unknownProp.type, checker, IntStrategy),
+      UNSUPPORTED_UNKNOWN,
+    );
+  });
+
+  it("opaque fallback domain emission dedupes with opaque value emission", async () => {
+    await loadAst();
+    const cell = newSynthCell();
+    const source = `interface Foo { val: any; }`;
+    const sourceFile = createSourceFileFromSource(source);
+    const checker = getChecker(sourceFile);
+    const prop = extractAllTypes(sourceFile).interfaces[0].properties[0];
+
+    assert.equal(
+      mapTsType(prop.type, checker, IntStrategy, cell, {
+        opaqueFallback: true,
+      }),
+      OPAQUE_DOMAIN,
+    );
+    cellRegisterOpaqueValue(cell, "foo.ts:1");
+
+    assert.deepEqual(cellEmitSynth(cell), [
+      { kind: "domain", name: OPAQUE_DOMAIN },
+      {
+        kind: "rule",
+        name: opaqueValueRuleName("foo.ts:1"),
+        params: [],
+        returnType: OPAQUE_DOMAIN,
+      },
+    ]);
+
+    cellRegisterOpaqueValue(cell, "foo.ts:2");
+    assert.deepEqual(cellEmitSynth(cell), [
+      {
+        kind: "rule",
+        name: opaqueValueRuleName("foo.ts:2"),
+        params: [],
+        returnType: OPAQUE_DOMAIN,
+      },
+    ]);
+  });
+
   it("top-level undefined falls through to checker.typeToString", () => {
     // Lone null/undefined/void has no Pantagruel encoding. mapTsType no
     // longer returns an internal sentinel; it falls through to

--- a/tools/ts2pant/tests/translate-types.test.mts
+++ b/tools/ts2pant/tests/translate-types.test.mts
@@ -289,6 +289,20 @@ describe("mapTsType", () => {
     );
   });
 
+  it("opaque fallback without a synth cell keeps `any` unsupported", () => {
+    const source = `interface Foo { val: any; }`;
+    const sourceFile = createSourceFileFromSource(source);
+    const checker = getChecker(sourceFile);
+    const prop = extractAllTypes(sourceFile).interfaces[0].properties[0];
+
+    assert.equal(
+      mapTsType(prop.type, checker, IntStrategy, undefined, {
+        opaqueFallback: true,
+      }),
+      UNSUPPORTED_UNKNOWN,
+    );
+  });
+
   it("opaque fallback domain emission dedupes with opaque value emission", async () => {
     await loadAst();
     const cell = newSynthCell();
@@ -314,6 +328,59 @@ describe("mapTsType", () => {
         returnType: OPAQUE_DOMAIN,
       },
     ]);
+
+    cellRegisterOpaqueValue(cell, "foo.ts:2");
+    assert.deepEqual(cellEmitSynth(cell), [
+      {
+        kind: "rule",
+        name: opaqueValueRuleName("foo.ts:2"),
+        params: [],
+        returnType: OPAQUE_DOMAIN,
+      },
+    ]);
+  });
+
+  it("opaque fallback propagates through nested composite positions", async () => {
+    await loadAst();
+    const cell = newSynthCell();
+    const source = `interface Foo { val: Map<string, any[]>; }`;
+    const sourceFile = createSourceFileFromSource(source);
+    const checker = getChecker(sourceFile);
+    const prop = extractAllTypes(sourceFile).interfaces[0].properties[0];
+
+    assert.equal(
+      mapTsType(prop.type, checker, IntStrategy, cell, {
+        opaqueFallback: true,
+      }),
+      "StringToListOpaqueMap",
+    );
+
+    const decls = cellEmitSynth(cell);
+    assert.equal(decls.length, 4);
+    assert.deepEqual(decls[0], { kind: "domain", name: OPAQUE_DOMAIN });
+    assert.deepEqual(decls[1], {
+      kind: "domain",
+      name: "StringToListOpaqueMap",
+    });
+    assert.deepEqual(decls[2], {
+      kind: "rule",
+      name: "string-to-list-opaque-map-key",
+      params: [
+        { name: "m", type: "StringToListOpaqueMap" },
+        { name: "k", type: "String" },
+      ],
+      returnType: "Bool",
+    });
+    assert.equal(decls[3].kind, "rule");
+    if (decls[3].kind !== "rule") {
+      throw new Error("expected map value rule");
+    }
+    assert.equal(decls[3].name, "string-to-list-opaque-map");
+    assert.deepEqual(decls[3].params, [
+      { name: "m", type: "StringToListOpaqueMap" },
+      { name: "k", type: "String" },
+    ]);
+    assert.equal(decls[3].returnType, "[Opaque]");
 
     cellRegisterOpaqueValue(cell, "foo.ts:2");
     assert.deepEqual(cellEmitSynth(cell), [


### PR DESCRIPTION
## Patch 1: Opaque-fallback type mapping reusing the opaque-vocabulary domain (dormant)

- Read `mapTsType` (translate-types.ts around line 1161), how the UNSUPPORTED_UNKNOWN sentinel flows through translateSignature (translate-signature.ts:1466,1499), and the opaque-vocabulary API in `opaque.ts` + the `OpaqueSynth` / `cellRegisterOpaqueValue` additions from PR #272 (a priorMilestone).
- Add an `opts?: { opaqueFallback?: boolean }` parameter to `mapTsType`. When set and the type is any/unknown, return `OPAQUE_DOMAIN` and trigger the SynthCell on-use domain emission (reuse the #272 mechanism — do not emit a fresh domain decl inline, so there is exactly one `Opaque.` regardless of which workstream triggered it). Otherwise behave exactly as today.
- Confirm the reused emission path yields a single `{ kind: "domain", name: OPAQUE_DOMAIN }` declaration via `cellEmitSynth`, deduped against any opaque-VALUE registrations from #272.
- Add unit tests in translate-types.test.mts: any -> OPAQUE_DOMAIN (with opaqueFallback); unknown -> OPAQUE_DOMAIN; concrete types unaffected; without opaqueFallback, any/unknown still returns the UNSUPPORTED_UNKNOWN sentinel; the Opaque domain is emitted exactly once.
- Run `npx tsx --test tests/translate-types.test.mts`; confirm pass. Run `npm run -s test:unit` and `npm run -s lint`; confirm no regression (dormant — no caller sets opaqueFallback yet).

## Changes
- Read `mapTsType` (translate-types.ts around line 1161), how the UNSUPPORTED_UNKNOWN sentinel flows through translateSignature (translate-signature.ts:1466,1499), and the opaque-vocabulary API in `opaque.ts` + the `OpaqueSynth` / `cellRegisterOpaqueValue` additions from PR #272 (a priorMilestone).
- Add an `opts?: { opaqueFallback?: boolean }` parameter to `mapTsType`. When set and the type is any/unknown, return `OPAQUE_DOMAIN` and trigger the SynthCell on-use domain emission (reuse the #272 mechanism — do not emit a fresh domain decl inline, so there is exactly one `Opaque.` regardless of which workstream triggered it). Otherwise behave exactly as today.
- Confirm the reused emission path yields a single `{ kind: "domain", name: OPAQUE_DOMAIN }` declaration via `cellEmitSynth`, deduped against any opaque-VALUE registrations from #272.
- Add unit tests in translate-types.test.mts: any -> OPAQUE_DOMAIN (with opaqueFallback); unknown -> OPAQUE_DOMAIN; concrete types unaffected; without opaqueFallback, any/unknown still returns the UNSUPPORTED_UNKNOWN sentinel; the Opaque domain is emitted exactly once.
- Run `npx tsx --test tests/translate-types.test.mts`; confirm pass. Run `npm run -s test:unit` and `npm run -s lint`; confirm no regression (dormant — no caller sets opaqueFallback yet).

## Files to Modify
- tools/ts2pant/src/translate-types.ts (modify): Add an opt-in `opaqueFallback` option to the TS type-to-sort mapping: when set and the type is any/unknown, return `OPAQUE_DOMAIN` (from `./opaque.js`) and register the domain need on the SynthCell via the opaque-vocabulary `OpaqueSynth` mechanism (PR #272) so `Opaque.` is emitted once. Default (no opts) is unchanged — the main signature path still poisons any/unknown.
- tools/ts2pant/tests/translate-types.test.mts (modify): Add unit tests: any → Opaque sort (with opaqueFallback); unknown → Opaque sort; concrete types unaffected; without opaqueFallback, any/unknown still returns the UNSUPPORTED_UNKNOWN sentinel.

## Gameplan Specification

```
module TS2PANT_FREE_CALL_OPAQUE_FLOOR.

> Final state of the free-call-opaque-floor milestone.
> Every bare-identifier free call (ambient declare-function
> or other non-builtin, non-in-project function) gets a
> synthesized typed rule head. any/unknown positions map to
> a minimal local Opaque domain. The floor is pure EUF.
> Method/stdlib and in-BUILTINS-dispatch-incomplete calls
> remain deferred to M2.

Call.
Callee.
ambient => Callee.
non-builtin-free => Callee.
in-project => Callee.
builtin => Callee.
action-callee => Callee.
RuleHead.
Position.
any-unknown => Position.
concrete => Position.
Sort.
opaque-sort => Sort.
concrete-sort => Sort.
Typecheck.
passes => Typecheck.
dangles => Typecheck.
Axiom.

callee-of c: Call => Callee.
synthesizes-head? c: Call => Bool.
head-of c: Call => RuleHead.
sort-at h: RuleHead, p: Position => Sort.
has-axiom? h: RuleHead => Bool.
typecheck c: Call => Typecheck.
---
> Ambient and other non-builtin free calls synthesize a head.
all c: Call, callee-of c = ambient | synthesizes-head? c.
all c: Call, callee-of c = non-builtin-free | synthesizes-head? c.

> Builtin / in-project / action callees do not (M2 or existing path).
all c: Call, callee-of c = builtin | ~(synthesizes-head? c).
all c: Call, callee-of c = in-project | ~(synthesizes-head? c).
all c: Call, callee-of c = action-callee | ~(synthesizes-head? c).

> A synthesized free call type-checks (no dangling identifier).
all c: Call, synthesizes-head? c | typecheck c = passes.

> any/unknown positions map to Opaque; concrete positions stay concrete.
all h: RuleHead | sort-at h any-unknown = opaque-sort.
all h: RuleHead | sort-at h concrete = concrete-sort.

> The floor is pure EUF — synthesized heads carry no body axioms.
all h: RuleHead | ~(has-axiom? h).
```

## Patch Specification

```
module TS2PANT_FREE_CALL_OPAQUE_FLOOR_PATCH_1.

> Patch 1 introduces a minimal Opaque domain and an opt-in
> opaque-fallback type mapping. Dormant — no caller enables
> the fallback yet. The default path still poisons any/unknown.

TSType.
Sort.
opaque-sort => Sort.
unsupported-sentinel => Sort.
concrete-sort => Sort.
Fallback.
enabled => Fallback.
disabled => Fallback.

any-or-unknown? t: TSType => Bool.
map-sort t: TSType, f: Fallback => Sort.
---
> With the fallback enabled, any/unknown maps to the Opaque sort.
all t: TSType, any-or-unknown? t | map-sort t enabled = opaque-sort.

> With the fallback disabled, any/unknown stays the unsupported sentinel.
all t: TSType, any-or-unknown? t | map-sort t disabled = unsupported-sentinel.

> Concrete types are unaffected by the fallback flag.
all t: TSType, ~(any-or-unknown? t) | map-sort t enabled = concrete-sort.
```


## Implementation Notes

- Added a domain-only path to `OpaqueSynth` (`needsDomain` / `domainEmitted`) instead of registering a synthetic opaque value just to force `Opaque.` emission. This keeps fallback type mapping from introducing extra nullary constants, while preserving the existing opaque-value behavior.
- `registerOpaqueValue` now also marks the domain as needed, so the old value-registration path still emits `Opaque.` on first drain. `cellEmitSynth` remains the only emission boundary, and later opaque values do not re-emit the domain after a fallback-only drain.
- The new `mapTsType` option is intentionally a trailing optional parameter, so existing callers keep the default reject/poison behavior without churn. Recursive composite mapping forwards the option so nested `any` / `unknown` positions can use the same fallback when a future caller opts in.
- The requested workstream file `workstreams/ts2pant-free-call-decl-synthesis.md` was not present in this worktree; I used the prompt-provided gameplan/spec text plus the existing `ts2pant-any-unknown-opaque.md`, `translate-signature.ts`, `opaque.ts`, `types.ts`, and `emit.ts` as context.

Spec/Evidence Mapping:
- Fallback enabled maps `any` / `unknown` to `Opaque`: `mapTsType` top-type branch in `tools/ts2pant/src/translate-types.ts`; covered by `opaque fallback maps any...` and `opaque fallback maps unknown...`.
- Fallback disabled preserves `UNSUPPORTED_UNKNOWN`: unchanged default branch in `mapTsType`; covered by `opaque fallback disabled keeps any and unknown unsupported`.
- Concrete types are unaffected: normal branches still run when top-type flags are absent; covered by `opaque fallback leaves concrete types unchanged`.
- Single `Opaque.` emission and dedupe with opaque-value registrations: `registerOpaqueDomain`, `registerOpaqueValue`, and `emitOpaqueSynthDecls`; covered by `opaque fallback domain emission dedupes with opaque value emission`.
- Verification run: `npx tsx --test tests/translate-types.test.mts`, `npm run -s test:unit`, `npm run -s lint`, and `git diff --check` all passed.