### PR TITLE
[ts2pant-stdlib-dispatch-coverage] Patch 1: Author JS_ARRAY / JS_MAP EUF modules + JS_STRING::replace; extend DepModuleName and the module-typecheck loop

### DIFF
--- a/samples/js-stdlib/JS_ARRAY.pant
+++ b/samples/js-stdlib/JS_ARRAY.pant
@@ -1,0 +1,24 @@
+module JS_ARRAY.
+
+> EUF rule heads for JavaScript Array.* materialization helpers.
+> ts2pant emits imports of this module from consumer specs that
+> call Array.from on built-in iterable-like values; the dispatch
+> index in tools/ts2pant/src/builtins.ts maps TS surface forms to
+> qualified references against these rules.
+>
+> Reference: Kroening & Strichman, *Decision Procedures* Ch. 4
+> (Equality with Uninterpreted Functions; congruence is the only
+> built-in axiom for opaque calls).
+>
+> No body axioms — Array.from is modeled at the EUF floor by
+> collapsing the input iterator to its materialized list. Structural
+> relationships such as cardinality are deferred to milestone 4.
+>
+> Naming: Pantagruel rules are monomorphic at a fixed arity, so the
+> fixture-required entries-list instantiation uses a sort-specific
+> head rather than overloading `from`.
+
+from xs: [Int] => [Int].
+from-entries xs: [String * Int] => [String * Int].
+
+---

--- a/samples/js-stdlib/JS_MAP.pant
+++ b/samples/js-stdlib/JS_MAP.pant
@@ -1,0 +1,28 @@
+module JS_MAP.
+
+> EUF rule heads for the JavaScript Map.prototype.* iterator helpers.
+> ts2pant emits imports of this module from consumer specs that call
+> methods like m.values() / m.entries(); the dispatch index in
+> tools/ts2pant/src/builtins.ts maps TS surface forms to qualified
+> references against these rules.
+>
+> Reference: Kroening & Strichman, *Decision Procedures* Ch. 4
+> (Equality with Uninterpreted Functions; congruence is the only
+> built-in axiom for opaque calls).
+>
+> No body axioms — Map iterators are modeled at the EUF floor by
+> collapsing them to materialized lists. Structural relationships
+> between keys, values, entries, and map cardinality are deferred to
+> milestone 4.
+>
+> This module declares the synthesized Map domain shape used by
+> ts2pant for Map<string, number> under the default Int numeric
+> strategy.
+
+StringToIntMap.
+
+values m: StringToIntMap => [Int].
+entries m: StringToIntMap => [String * Int].
+keys m: StringToIntMap => [String].
+
+---

--- a/samples/js-stdlib/JS_STRING.pant
+++ b/samples/js-stdlib/JS_STRING.pant
@@ -23,5 +23,6 @@ includes s: String, t: String => Bool.
 starts-with s: String, prefix: String => Bool.
 ends-with s: String, suffix: String => Bool.
 last-index-of s: String, t: String => Int.
+replace s: String, from: String, to: String => String.
 
 ---

--- a/tools/ts2pant/src/builtins.ts
+++ b/tools/ts2pant/src/builtins.ts
@@ -21,7 +21,12 @@ import { resolve } from "node:path";
 import ts from "typescript";
 
 /** Module name of a hand-written js-stdlib dependency module. */
-export type DepModuleName = "JS_MATH" | "JS_STRING" | "TS_PRELUDE";
+export type DepModuleName =
+  | "JS_MATH"
+  | "JS_STRING"
+  | "TS_PRELUDE"
+  | "JS_ARRAY"
+  | "JS_MAP";
 
 /**
  * Dispatch entry: `rule` is the qualified Pantagruel rule reference a

--- a/tools/ts2pant/tests/builtins.test.mts
+++ b/tools/ts2pant/tests/builtins.test.mts
@@ -357,6 +357,29 @@ describe("loadBuiltinDepModule", () => {
     assert.match(text, /starts-with s: String, prefix: String => Bool\./);
     assert.match(text, /ends-with s: String, suffix: String => Bool\./);
     assert.match(text, /last-index-of s: String, t: String => Int\./);
+    assert.match(
+      text,
+      /replace s: String, from: String, to: String => String\./,
+    );
+  });
+
+  it("loadBuiltinDepModule('JS_ARRAY') returns the on-disk text", () => {
+    const text = loadBuiltinDepModule("JS_ARRAY");
+    assert.match(text, /^module JS_ARRAY\./m);
+    assert.match(text, /from xs: \[Int\] => \[Int\]\./);
+    assert.match(
+      text,
+      /from-entries xs: \[String \* Int\] => \[String \* Int\]\./,
+    );
+  });
+
+  it("loadBuiltinDepModule('JS_MAP') returns the on-disk text", () => {
+    const text = loadBuiltinDepModule("JS_MAP");
+    assert.match(text, /^module JS_MAP\./m);
+    assert.match(text, /StringToIntMap\./);
+    assert.match(text, /values m: StringToIntMap => \[Int\]\./);
+    assert.match(text, /entries m: StringToIntMap => \[String \* Int\]\./);
+    assert.match(text, /keys m: StringToIntMap => \[String\]\./);
   });
 
   it("caches the loaded module text across calls", () => {
@@ -368,7 +391,9 @@ describe("loadBuiltinDepModule", () => {
 
 describe("hand-written js-stdlib modules typecheck", () => {
   for (const name of [
+    "JS_ARRAY",
     "JS_MATH",
+    "JS_MAP",
     "JS_STRING",
     "TS_PRELUDE",
   ] satisfies DepModuleName[]) {


### PR DESCRIPTION
## Patch 1: Author JS_ARRAY / JS_MAP EUF modules + JS_STRING::replace; extend DepModuleName and the module-typecheck loop

- Decide the concrete element-sort instantiations for JS_ARRAY::from and JS_MAP::{values,entries,keys} that the fixture corpus requires (Map<string,number> ⇒ values:[Int], entries:[String * Int], keys:[String]). Pant rules are fixed-arity and monomorphic per sort; declare the heads against the sorts the emitter produces (CR-4), parameterizing by the synthesized Map domain name where applicable.
- Author JS_ARRAY.pant and JS_MAP.pant with a module doc-comment in the JS_MATH style: cite Kroening & Strichman Ch. 4, state signatures-only / no-body-axioms, and note milestone-4 is the home for any structural axiom.
- Add the replace head to JS_STRING.pant.
- Extend DepModuleName in builtins.ts.
- Extend the builtins.test.mts module-typecheck loop and loadBuiltinDepModule assertions to cover JS_ARRAY and JS_MAP.
- Run `pant samples/js-stdlib/JS_ARRAY.pant`, `JS_MAP.pant`, `JS_STRING.pant` to confirm each parses/typechecks standalone.

## Changes
- Decide the concrete element-sort instantiations for JS_ARRAY::from and JS_MAP::{values,entries,keys} that the fixture corpus requires (Map<string,number> ⇒ values:[Int], entries:[String * Int], keys:[String]). Pant rules are fixed-arity and monomorphic per sort; declare the heads against the sorts the emitter produces (CR-4), parameterizing by the synthesized Map domain name where applicable.
- Author JS_ARRAY.pant and JS_MAP.pant with a module doc-comment in the JS_MATH style: cite Kroening & Strichman Ch. 4, state signatures-only / no-body-axioms, and note milestone-4 is the home for any structural axiom.
- Add the replace head to JS_STRING.pant.
- Extend DepModuleName in builtins.ts.
- Extend the builtins.test.mts module-typecheck loop and loadBuiltinDepModule assertions to cover JS_ARRAY and JS_MAP.
- Run `pant samples/js-stdlib/JS_ARRAY.pant`, `JS_MAP.pant`, `JS_STRING.pant` to confirm each parses/typechecks standalone.

## Files to Modify
- samples/js-stdlib/JS_ARRAY.pant (create): New module JS_ARRAY. EUF head for Array.from collapsing an iterable to its materialized list. Provide the element-sort instantiations the corpus needs (the fixtures use Map value/entry lists: [Int] and [String * Int]); follow the JS_MATH header convention (module doc-comment citing Kroening & Strichman, signatures only, no body axioms). One chapter, heads before `---`, empty body.
- samples/js-stdlib/JS_MAP.pant (create): New module JS_MAP. EUF heads `values`, `entries`, `keys` taking the receiver Map and returning the materialized element list ([V], [K * V], [K]). The Map receiver sort is the synthesized domain ts2pant assigns (see CR-4 mapTsType); declare a domain placeholder consistent with how the emitter references it, or accept the receiver via the same domain name the consumer document declares. Signatures only, no body axioms, JS_MATH-style header.
- samples/js-stdlib/JS_STRING.pant (modify): Add `replace s: String, from: String, to: String => String.` to the rule-head block. Keep the existing 'no body axioms — JS string semantics are brittle' header note (replace is also left unaxiomatized).
- tools/ts2pant/src/builtins.ts (modify): Extend the DepModuleName union to `"JS_MATH" | "JS_STRING" | "TS_PRELUDE" | "JS_ARRAY" | "JS_MAP"`. (Table/dispatch logic is Patch 2.) Confirm loadBuiltinDepModule resolves the new files by name (no change needed beyond the union since it builds the path from the name).
- tools/ts2pant/tests/builtins.test.mts (modify): Add JS_ARRAY and JS_MAP to the `hand-written js-stdlib modules typecheck` loop so each new module is wasm-typechecked standalone; add a loadBuiltinDepModule assertion for the new modules' heads (mirroring the JS_MATH/JS_STRING assertions).

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[paper] Kroening & Strichman, Decision Procedures Ch. 4 (Equality with Uninterpreted Functions)** — https://www.decision-procedures.org/ — The new modules declare EUF rule heads with congruence as the only axiom and no body propositions; this chapter is the soundness justification for signatures-only modeling and is already cited in the JS_MATH/JS_STRING headers the new modules mirror.
- **[pattern] In-repo js-stdlib dispatch architecture** — JS_ARRAY/JS_MAP replicate the JS_MATH/JS_STRING module shape verbatim: doc-comment header, kebab rule names, reserved-name `-of` suffixing, signatures-only heads on the samples CI typecheck path. Read JS_MATH.pant as the template.

## Gameplan Specification

```
module STDLIB_DISPATCH_COVERAGE.

> A TypeScript call whose callee resolves to a recognized JavaScript
> built-in (Math.*, String.prototype.*, Array.from, Map.prototype.*)
> lowers to a qualified rule reference against a hand-written
> js-stdlib EUF module, and the emitted document imports that module.
> The js-stdlib modules carry signatures only — no body axioms
> (congruence-only soundness; structural axioms are deferred to
> milestone 4).

Call.
DepModule.
Builtin.

builtin? c: Call => Bool.
dispatches c: Call => Builtin.
module-of b: Builtin => DepModule.
receiver-passed? b: Builtin => Bool.
imported d: DepModule => Bool.
typechecks? c: Call => Bool.
has-body-axioms? d: DepModule => Bool.

---

> Every dispatched built-in call references a module the document imports.
all c: Call | builtin? c -> imported (module-of (dispatches c)).

> Every dispatched built-in call type-checks: the qualified rule it
> references is declared in the imported module, so no undeclared
> identifier reaches the wasm checker.
all c: Call | builtin? c -> typechecks? c.

> EUF floor: no js-stdlib module carries body axioms in this milestone.
all d: DepModule | ~(has-body-axioms? d).
```

## Patch Specification

```
module STDLIB_DISPATCH_COVERAGE_PATCH_1.

DepModule.
Rule.

declares d: DepModule, r: Rule => Bool.
has-signature? r: Rule => Bool.
has-body-axiom? r: Rule => Bool.
typechecks? d: DepModule => Bool.

---

> New js-stdlib rule heads have signatures and no body axioms (EUF
> floor; congruence-only soundness, axioms deferred to milestone 4).
all r: Rule | has-signature? r and ~(has-body-axiom? r).
> Each new module type-checks standalone via the wasm checker.
all d: DepModule | typechecks? d.
```


## Implementation Notes

- `JS_ARRAY` exposes the values-list instantiation as `from xs: [Int] => [Int]` and the entry-list instantiation as `from-entries xs: [String * Int] => [String * Int]`. This is the only intentional deviation from the literal `JS_ARRAY::from` phrasing: Pantagruel does not support same-arity type overloading, so two `from/1` heads with different list element sorts would be rejected as duplicate rules.
- `JS_MAP` declares `StringToIntMap` locally because that is the synthesized domain name produced for `Map<string, number>` under the default `Int` numeric strategy. The imported rule signatures and consumer-local synthesized declarations compare by the same domain name, matching the existing map synthesis convention.
- The new modules have empty bodies after `---`; no structural relationship between `values`, `entries`, `keys`, `Array.from`, or `#` cardinality is asserted here.

Spec/Evidence Mapping:
- New rule heads have signatures and no body axioms: `samples/js-stdlib/JS_ARRAY.pant`, `samples/js-stdlib/JS_MAP.pant`, and the added `JS_STRING::replace` head. Checked by standalone `dune exec pant -- samples/js-stdlib/{JS_ARRAY,JS_MAP,JS_STRING}.pant` and the wasm module loop in `tools/ts2pant/tests/builtins.test.mts`.
- New dep modules are loadable by the builtins loader: `DepModuleName` now includes `JS_ARRAY` and `JS_MAP`; `loadBuiltinDepModule` assertions cover both modules and their heads.
- Required context consulted: existing `JS_MATH` / `JS_STRING` module shape, `builtins.ts` loader shape, and `mapTsType` map-domain synthesis (`StringToIntMap`).