### PR TITLE
[ts2pant-stdlib-dispatch-coverage] Patch 2: Extend the dispatch table + lookupBuiltinByCall + deriveBuiltinSpec for Array.from, Map.prototype.*, and string-arg replace

### DIFF
--- a/tools/ts2pant/src/builtins.ts
+++ b/tools/ts2pant/src/builtins.ts
@@ -43,15 +43,20 @@ export interface BuiltinSpec {
   rule: string;
   mod: DepModuleName;
   arity: number;
+  receiver: "arg" | "none";
 }
 
 /**
  * Internal key for the dispatch table. The keys are TS surface forms
- * keyed by namespace (Math.* uses "Math.<name>"; String.prototype.*
- * uses "String.prototype.<name>") so the lookup logic can route by
- * which symbol-kind it just resolved.
+ * keyed by namespace (Math.* / Array.* use "<Namespace>.<name>";
+ * prototype methods use "<Type>.prototype.<name>") so the lookup logic
+ * can route by which symbol-kind it just resolved.
  */
-export type BuiltinKey = `Math.${string}` | `String.prototype.${string}`;
+export type BuiltinKey =
+  | `Array.${string}`
+  | `Map.prototype.${string}`
+  | `Math.${string}`
+  | `String.prototype.${string}`;
 
 const RESERVED_RULE_NAMES: ReadonlySet<string> = new Set([
   "max",
@@ -61,10 +66,15 @@ const RESERVED_RULE_NAMES: ReadonlySet<string> = new Set([
 ]);
 
 const BUILTINS: Map<BuiltinKey, { arity: number }> = new Map([
+  ["Array.from", { arity: 1 }],
+  ["Map.prototype.values", { arity: 0 }],
+  ["Map.prototype.entries", { arity: 0 }],
+  ["Map.prototype.keys", { arity: 0 }],
   ["Math.max", { arity: 2 }],
   ["Math.min", { arity: 2 }],
   ["Math.abs", { arity: 1 }],
   ["String.prototype.toUpperCase", { arity: 0 }],
+  ["String.prototype.replace", { arity: 2 }],
   ["String.prototype.indexOf", { arity: 1 }],
   ["String.prototype.endsWith", { arity: 1 }],
   ["String.prototype.includes", { arity: 1 }],
@@ -75,18 +85,48 @@ const BUILTINS: Map<BuiltinKey, { arity: number }> = new Map([
 ]);
 
 export function deriveBuiltinSpec(key: BuiltinKey, arity: number): BuiltinSpec {
-  const namespace = key.startsWith("Math.") ? "Math" : "String.prototype";
-  const method =
-    namespace === "Math"
-      ? key.slice("Math.".length)
-      : key.slice("String.prototype.".length);
-  const mod: DepModuleName = namespace === "Math" ? "JS_MATH" : "JS_STRING";
+  const namespace = getBuiltinNamespace(key);
+  const method = key.slice(`${namespace}.`.length);
+  const mod = moduleForNamespace(namespace);
+  const receiver = namespace.includes(".prototype") ? "arg" : "none";
   const kebab = method
     .replace(/([A-Z])/gu, "-$1")
     .toLowerCase()
     .replace(/^-/u, "");
   const ruleName = RESERVED_RULE_NAMES.has(kebab) ? `${kebab}-of` : kebab;
-  return { rule: `${mod}::${ruleName}`, mod, arity };
+  return { rule: `${mod}::${ruleName}`, mod, arity, receiver };
+}
+
+type BuiltinNamespace = "Array" | "Map.prototype" | "Math" | "String.prototype";
+
+function getBuiltinNamespace(key: BuiltinKey): BuiltinNamespace {
+  if (key.startsWith("Array.")) {
+    return "Array";
+  }
+  if (key.startsWith("Map.prototype.")) {
+    return "Map.prototype";
+  }
+  if (key.startsWith("Math.")) {
+    return "Math";
+  }
+  return "String.prototype";
+}
+
+function moduleForNamespace(namespace: BuiltinNamespace): DepModuleName {
+  switch (namespace) {
+    case "Array":
+      return "JS_ARRAY";
+    case "Map.prototype":
+      return "JS_MAP";
+    case "Math":
+      return "JS_MATH";
+    case "String.prototype":
+      return "JS_STRING";
+    default: {
+      const _exhaustive: never = namespace;
+      throw new Error(`Unhandled builtin namespace: ${_exhaustive}`);
+    }
+  }
 }
 
 /**
@@ -108,12 +148,12 @@ export function deriveBuiltinSpec(key: BuiltinKey, arity: number): BuiltinSpec {
  * `isDeclarationFile` alone would match the latter and silently re-bind
  * a user augmentation to the dispatch table.
  *
- * For `Math.<name>(...)` we resolve the symbol of the *receiver*
- * (the `Math` identifier) and accept it iff its declarations sit in
- * a TS default-library file. For `<receiver>.<name>(...)` where the
- * method is on `String.prototype` (e.g., `s.toUpperCase()`) we
- * resolve the symbol of the *method* and accept it iff its parent
- * declaration is the lib `String` interface.
+ * For namespace calls (`Math.<name>(...)`, `Array.<name>(...)`) we
+ * resolve the symbol of the *receiver* identifier and accept it iff
+ * its declarations sit in a TS default-library file. For prototype
+ * calls (`s.toUpperCase()`, `m.values()`) we resolve the symbol of
+ * the *method* and accept it iff its parent declaration is the
+ * corresponding lib interface.
  *
  * Once the namespace+name match, the call's argument count must equal
  * the dispatch entry's `arity` — see {@link BuiltinSpec}. Off-arity
@@ -135,6 +175,15 @@ export function lookupBuiltinByCall(
   let key: BuiltinKey | undefined;
   if (
     ts.isIdentifier(propAccess.expression) &&
+    propAccess.expression.text === "Array" &&
+    isDefaultLibSymbol(
+      checker.getSymbolAtLocation(propAccess.expression),
+      program,
+    )
+  ) {
+    key = `Array.${memberName}`;
+  } else if (
+    ts.isIdentifier(propAccess.expression) &&
     propAccess.expression.text === "Math" &&
     isDefaultLibSymbol(
       checker.getSymbolAtLocation(propAccess.expression),
@@ -146,6 +195,8 @@ export function lookupBuiltinByCall(
     const methodSymbol = checker.getSymbolAtLocation(propAccess.name);
     if (methodSymbol && isStringPrototypeMember(methodSymbol, program)) {
       key = `String.prototype.${memberName}`;
+    } else if (methodSymbol && isMapPrototypeMember(methodSymbol, program)) {
+      key = `Map.prototype.${memberName}`;
     }
   }
 
@@ -157,6 +208,14 @@ export function lookupBuiltinByCall(
     return null;
   }
   const fullSpec = deriveBuiltinSpec(key, entry.arity);
+  if (
+    key === "String.prototype.replace" &&
+    !expr.arguments.every((arg) =>
+      isStringLikeType(checker.getTypeAtLocation(arg)),
+    )
+  ) {
+    return null;
+  }
   return expr.arguments.length === fullSpec.arity ? fullSpec : null;
 }
 
@@ -177,6 +236,18 @@ function isStringPrototypeMember(
   symbol: ts.Symbol,
   program: ts.Program,
 ): boolean {
+  return isDefaultLibInterfaceMember(symbol, program, ["String"]);
+}
+
+function isMapPrototypeMember(symbol: ts.Symbol, program: ts.Program): boolean {
+  return isDefaultLibInterfaceMember(symbol, program, ["Map", "ReadonlyMap"]);
+}
+
+function isDefaultLibInterfaceMember(
+  symbol: ts.Symbol,
+  program: ts.Program,
+  interfaceNames: readonly string[],
+): boolean {
   const decls = symbol.declarations;
   if (!decls) {
     return false;
@@ -189,12 +260,19 @@ function isStringPrototypeMember(
     if (
       parent &&
       ts.isInterfaceDeclaration(parent) &&
-      parent.name.text === "String"
+      interfaceNames.includes(parent.name.text)
     ) {
       return true;
     }
   }
   return false;
+}
+
+function isStringLikeType(type: ts.Type): boolean {
+  if (type.isUnion()) {
+    return type.types.every(isStringLikeType);
+  }
+  return (type.flags & ts.TypeFlags.StringLike) !== 0;
 }
 
 const PROJECT_ROOT = resolve(import.meta.dirname, "../../..");

--- a/tools/ts2pant/tests/builtins.test.mts
+++ b/tools/ts2pant/tests/builtins.test.mts
@@ -10,6 +10,7 @@ import {
 } from "../src/builtins.js";
 import { createSourceFileFromSource, getChecker } from "../src/extract.js";
 import { assertWasmTypeChecks } from "../src/pant-wasm.js";
+import { buildDocumentFromSourceFile, emitDocument } from "./helpers.mjs";
 
 function findCallExpression(
   sourceFile: ts.SourceFile,
@@ -40,12 +41,37 @@ function lookupFromSource(
   return lookupBuiltinByCall(call, checker, program);
 }
 
+async function emitFromSource(source: string, functionName: string) {
+  const sourceFile = createSourceFileFromSource(source);
+  const doc = await buildDocumentFromSourceFile(sourceFile, functionName);
+  return emitDocument(doc);
+}
+
 describe("deriveBuiltinSpec", () => {
+  it("maps Array.* keys to JS_ARRAY", () => {
+    assert.deepEqual(deriveBuiltinSpec("Array.from", 1), {
+      rule: "JS_ARRAY::from",
+      mod: "JS_ARRAY",
+      arity: 1,
+      receiver: "none",
+    });
+  });
+
+  it("maps Map.prototype.* keys to JS_MAP", () => {
+    assert.deepEqual(deriveBuiltinSpec("Map.prototype.values", 0), {
+      rule: "JS_MAP::values",
+      mod: "JS_MAP",
+      arity: 0,
+      receiver: "arg",
+    });
+  });
+
   it("maps Math.* keys to JS_MATH", () => {
     assert.deepEqual(deriveBuiltinSpec("Math.foo", 1), {
       rule: "JS_MATH::foo",
       mod: "JS_MATH",
       arity: 1,
+      receiver: "none",
     });
   });
 
@@ -54,6 +80,7 @@ describe("deriveBuiltinSpec", () => {
       rule: "JS_STRING::foo",
       mod: "JS_STRING",
       arity: 1,
+      receiver: "arg",
     });
   });
 
@@ -62,6 +89,7 @@ describe("deriveBuiltinSpec", () => {
       rule: "JS_STRING::to-upper-case",
       mod: "JS_STRING",
       arity: 0,
+      receiver: "arg",
     });
   });
 
@@ -70,6 +98,7 @@ describe("deriveBuiltinSpec", () => {
       rule: "JS_STRING::index-of",
       mod: "JS_STRING",
       arity: 1,
+      receiver: "arg",
     });
   });
 
@@ -78,6 +107,7 @@ describe("deriveBuiltinSpec", () => {
       rule: "JS_STRING::last-index-of",
       mod: "JS_STRING",
       arity: 1,
+      receiver: "arg",
     });
   });
 
@@ -86,6 +116,7 @@ describe("deriveBuiltinSpec", () => {
       rule: "JS_MATH::max-of",
       mod: "JS_MATH",
       arity: 2,
+      receiver: "none",
     });
   });
 
@@ -94,6 +125,7 @@ describe("deriveBuiltinSpec", () => {
       rule: "JS_MATH::min-of",
       mod: "JS_MATH",
       arity: 2,
+      receiver: "none",
     });
   });
 
@@ -102,11 +134,34 @@ describe("deriveBuiltinSpec", () => {
       rule: "JS_MATH::abs",
       mod: "JS_MATH",
       arity: 1,
+      receiver: "none",
     });
     assert.deepEqual(deriveBuiltinSpec("String.prototype.indexOf", 1), {
       rule: "JS_STRING::index-of",
       mod: "JS_STRING",
       arity: 1,
+      receiver: "arg",
+    });
+  });
+
+  it("composes the full spec for new entries", () => {
+    assert.deepEqual(deriveBuiltinSpec("String.prototype.replace", 2), {
+      rule: "JS_STRING::replace",
+      mod: "JS_STRING",
+      arity: 2,
+      receiver: "arg",
+    });
+    assert.deepEqual(deriveBuiltinSpec("Array.from", 1), {
+      rule: "JS_ARRAY::from",
+      mod: "JS_ARRAY",
+      arity: 1,
+      receiver: "none",
+    });
+    assert.deepEqual(deriveBuiltinSpec("Map.prototype.entries", 0), {
+      rule: "JS_MAP::entries",
+      mod: "JS_MAP",
+      arity: 0,
+      receiver: "arg",
     });
   });
 });
@@ -120,6 +175,7 @@ describe("builtins dispatch", () => {
       rule: "JS_MATH::max-of",
       mod: "JS_MATH",
       arity: 2,
+      receiver: "none",
     });
   });
 
@@ -131,6 +187,7 @@ describe("builtins dispatch", () => {
       rule: "JS_MATH::min-of",
       mod: "JS_MATH",
       arity: 2,
+      receiver: "none",
     });
   });
 
@@ -142,6 +199,7 @@ describe("builtins dispatch", () => {
       rule: "JS_MATH::abs",
       mod: "JS_MATH",
       arity: 1,
+      receiver: "none",
     });
   });
 
@@ -153,6 +211,7 @@ describe("builtins dispatch", () => {
       rule: "JS_STRING::to-upper-case",
       mod: "JS_STRING",
       arity: 0,
+      receiver: "arg",
     });
   });
 
@@ -164,6 +223,7 @@ describe("builtins dispatch", () => {
       rule: "JS_STRING::index-of",
       mod: "JS_STRING",
       arity: 1,
+      receiver: "arg",
     });
   });
 
@@ -175,6 +235,7 @@ describe("builtins dispatch", () => {
       rule: "JS_STRING::ends-with",
       mod: "JS_STRING",
       arity: 1,
+      receiver: "arg",
     });
   });
 
@@ -186,6 +247,7 @@ describe("builtins dispatch", () => {
       rule: "JS_STRING::includes",
       mod: "JS_STRING",
       arity: 1,
+      receiver: "arg",
     });
   });
 
@@ -197,6 +259,7 @@ describe("builtins dispatch", () => {
       rule: "JS_STRING::last-index-of",
       mod: "JS_STRING",
       arity: 1,
+      receiver: "arg",
     });
   });
 
@@ -208,6 +271,7 @@ describe("builtins dispatch", () => {
       rule: "JS_STRING::starts-with",
       mod: "JS_STRING",
       arity: 1,
+      receiver: "arg",
     });
   });
 
@@ -219,6 +283,7 @@ describe("builtins dispatch", () => {
       rule: "JS_STRING::to-lower-case",
       mod: "JS_STRING",
       arity: 0,
+      receiver: "arg",
     });
   });
 
@@ -230,7 +295,115 @@ describe("builtins dispatch", () => {
       rule: "JS_STRING::trim",
       mod: "JS_STRING",
       arity: 0,
+      receiver: "arg",
     });
+  });
+
+  it("Array.from resolves to JS_ARRAY::from", () => {
+    const spec = lookupFromSource(`
+      function f(xs: number[]) { return Array.from(xs); }
+    `);
+    assert.deepEqual(spec, {
+      rule: "JS_ARRAY::from",
+      mod: "JS_ARRAY",
+      arity: 1,
+      receiver: "none",
+    });
+  });
+
+  it("Map.prototype.values resolves to JS_MAP::values", () => {
+    const spec = lookupFromSource(`
+      function f(m: Map<string, number>) { return m.values(); }
+    `);
+    assert.deepEqual(spec, {
+      rule: "JS_MAP::values",
+      mod: "JS_MAP",
+      arity: 0,
+      receiver: "arg",
+    });
+  });
+
+  it("Map.prototype.entries resolves to JS_MAP::entries", () => {
+    const spec = lookupFromSource(`
+      function f(m: Map<string, number>) { return m.entries(); }
+    `);
+    assert.deepEqual(spec, {
+      rule: "JS_MAP::entries",
+      mod: "JS_MAP",
+      arity: 0,
+      receiver: "arg",
+    });
+  });
+
+  it("Map.prototype.keys resolves to JS_MAP::keys", () => {
+    const spec = lookupFromSource(`
+      function f(m: Map<string, number>) { return m.keys(); }
+    `);
+    assert.deepEqual(spec, {
+      rule: "JS_MAP::keys",
+      mod: "JS_MAP",
+      arity: 0,
+      receiver: "arg",
+    });
+  });
+
+  it("String.prototype.replace resolves for string arguments", () => {
+    const spec = lookupFromSource(`
+      function f(s: string) { return s.replace("a", "b"); }
+    `);
+    assert.deepEqual(spec, {
+      rule: "JS_STRING::replace",
+      mod: "JS_STRING",
+      arity: 2,
+      receiver: "arg",
+    });
+  });
+
+  it("String.prototype.replace with a RegExp first argument falls through", () => {
+    const spec = lookupFromSource(`
+      function f(s: string) { return s.replace(/a/g, "b"); }
+    `);
+    assert.equal(spec, null);
+  });
+
+  it("user-shadowed Array identifier does not match Array.from", () => {
+    const spec = lookupFromSource(`
+      function f(xs: number[]) {
+        const Array = { from: (ys: number[]) => ys };
+        return Array.from(xs);
+      }
+    `);
+    assert.equal(spec, null);
+  });
+
+  it("Array.from with arity != 1 falls through", () => {
+    assert.equal(
+      lookupFromSource(`
+        function f() { return Array.from(); }
+      `),
+      null,
+    );
+    assert.equal(
+      lookupFromSource(`
+        function f(xs: number[]) { return Array.from(xs, (x) => x); }
+      `),
+      null,
+    );
+  });
+
+  it("Map iterator methods with arguments fall through", () => {
+    const spec = lookupFromSource(`
+      function f(m: Map<string, number>) { return m.values("unexpected"); }
+    `);
+    assert.equal(spec, null);
+  });
+
+  it("non-Map .values() calls fall through", () => {
+    const spec = lookupFromSource(`
+      interface Box { values(): number[]; }
+      function f(box: Box) { return box.values(); }
+    `);
+    assert.equal(spec, null);
   });
 
   it("user-shadowed Math identifier does not match Math.max (symbol-based dispatch)", () => {
@@ -386,6 +559,53 @@ describe("loadBuiltinDepModule", () => {
     const a = loadBuiltinDepModule("JS_MATH");
     const b = loadBuiltinDepModule("JS_MATH");
     assert.equal(a, b);
+  });
+});
+
+describe("builtins dispatch emission", () => {
+  it.skip("Math.max emits JS_MATH::max-of and imports JS_MATH", async () => {
+    const output = await emitFromSource(
+      "export function f(a: number, b: number) { return Math.max(a, b); }",
+      "f",
+    );
+    assert.match(output, /^import JS_MATH\.$/m);
+    assert.match(output, /JS_MATH::max-of/);
+  });
+
+  it.skip("s.toUpperCase emits JS_STRING::to-upper-case and imports JS_STRING", async () => {
+    const output = await emitFromSource(
+      "export function f(s: string) { return s.toUpperCase(); }",
+      "f",
+    );
+    assert.match(output, /^import JS_STRING\.$/m);
+    assert.match(output, /JS_STRING::to-upper-case/);
+  });
+
+  it.skip("Array.from emits JS_ARRAY::from and imports JS_ARRAY", async () => {
+    const output = await emitFromSource(
+      "export function f(xs: number[]) { return Array.from(xs); }",
+      "f",
+    );
+    assert.match(output, /^import JS_ARRAY\.$/m);
+    assert.match(output, /JS_ARRAY::from/);
+  });
+
+  it.skip("m.values emits JS_MAP::values and imports JS_MAP", async () => {
+    const output = await emitFromSource(
+      "export function f(m: Map<string, number>) { return m.values(); }",
+      "f",
+    );
+    assert.match(output, /^import JS_MAP\.$/m);
+    assert.match(output, /JS_MAP::values/);
+  });
+
+  it.skip("string-arg replace emits JS_STRING::replace", async () => {
+    const output = await emitFromSource(
+      'export function f(s: string) { return s.replace("a", "b"); }',
+      "f",
+    );
+    assert.match(output, /^import JS_STRING\.$/m);
+    assert.match(output, /JS_STRING::replace/);
   });
 });
 


### PR DESCRIPTION
## Patch 2: Extend the dispatch table + lookupBuiltinByCall + deriveBuiltinSpec for Array.from, Map.prototype.*, and string-arg replace

- Add the receiver-passing distinction to BuiltinSpec so Patch 3 knows whether to pass the receiver as the first argument (prototype methods) or omit it (namespace statics).
- Extend BuiltinKey, BUILTINS, and deriveBuiltinSpec for the new surface forms and module routing.
- Add the Array-namespace and Map-prototype resolution branches to lookupBuiltinByCall using symbol-based default-library detection (CR-6), mirroring the existing Math and String.prototype branches.
- Gate String.prototype.replace dispatch to the string-argument form only (inspect argument types; a RegExp first argument resolves to null so constReplaceRegex stays UNSUPPORTED).
- Add unit tests for all new resolutions and the null fall-through cases.
- Introduce skipped emission-test stubs (in builtins.test.mts or a new dispatch-emission test file) that Patch 3 unskips — they assert the emitted qualified reference and import line.
- Confirm no constructs snapshot changes result from this patch (dispatch resolution is still consumed only by the identifier-only pre-body gate; property-access resolution does not alter emission yet).

## Changes
- Add the receiver-passing distinction to BuiltinSpec so Patch 3 knows whether to pass the receiver as the first argument (prototype methods) or omit it (namespace statics).
- Extend BuiltinKey, BUILTINS, and deriveBuiltinSpec for the new surface forms and module routing.
- Add the Array-namespace and Map-prototype resolution branches to lookupBuiltinByCall using symbol-based default-library detection (CR-6), mirroring the existing Math and String.prototype branches.
- Gate String.prototype.replace dispatch to the string-argument form only (inspect argument types; a RegExp first argument resolves to null so constReplaceRegex stays UNSUPPORTED).
- Add unit tests for all new resolutions and the null fall-through cases.
- Introduce skipped emission-test stubs (in builtins.test.mts or a new dispatch-emission test file) that Patch 3 unskips — they assert the emitted qualified reference and import line.
- Confirm no constructs snapshot changes result from this patch (dispatch resolution is still consumed only by the identifier-only pre-body gate; property-access resolution does not alter emission yet).

## Files to Modify
- tools/ts2pant/src/builtins.ts (modify): Extend BuiltinKey with `Array.${string}` and `Map.prototype.${string}`. Add BUILTINS entries: Array.from {arity:1}, Map.prototype.values/entries/keys {arity:0}, String.prototype.replace {arity:2}. Add a `receiver: "arg" | "none"` field to BuiltinSpec (statics Math.*/Array.* = none; prototype methods String.*/Map.* = arg) and set it in deriveBuiltinSpec from the key namespace. Extend deriveBuiltinSpec module routing: Array.* → JS_ARRAY, Map.prototype.* → JS_MAP. Add an Array-namespace branch to lookupBuiltinByCall (resolve the `Array` receiver identifier as a default-library symbol, mirroring the Math branch) and a Map-prototype branch (resolve the method symbol, accept iff its parent declaration is the lib `Map`/`ReadonlyMap` interface, mirroring isStringPrototypeMember). Gate String.prototype.replace so it resolves ONLY when both arguments are string-typed (reject the regex/RegExp first-argument form to null).
- tools/ts2pant/tests/builtins.test.mts (modify): Add deriveBuiltinSpec unit tests for the new keys (Array.from → JS_ARRAY::from receiver none; Map.prototype.values → JS_MAP::values receiver arg; String.prototype.replace → JS_STRING::replace). Add lookupBuiltinByCall resolution tests: Array.from(x) resolves; m.values()/entries()/keys() on Map resolve; s.replace('a','b') resolves; s.replace(/a/g,'b') resolves to null; off-arity Array.from() / Map method with args resolve to null; a non-Map .values() (e.g. a user object) resolves to null. Introduce (skipped) emission-test stubs asserting the qualified-ref + import output that Patch 3 will implement.

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[documentation] TypeScript Compiler API (isSourceFileDefaultLibrary, getSymbolAtLocation, parent-interface checks)** — https://github.com/microsoft/TypeScript/wiki/Using-the-Compiler-API — The new Array-namespace branch resolves the `Array` identifier's symbol and accepts it iff a declaration sits in a default-library file (Program.isSourceFileDefaultLibrary), and the Map-prototype branch resolves the method symbol and checks its parent is the lib Map interface — exactly the symbol-based, not-textual dispatch the existing Math/String branches use.

## Gameplan Specification

```
module STDLIB_DISPATCH_COVERAGE.

> A TypeScript call whose callee resolves to a recognized JavaScript
> built-in (Math.*, String.prototype.*, Array.from, Map.prototype.*)
> lowers to a qualified rule reference against a hand-written
> js-stdlib EUF module, and the emitted document imports that module.
> The js-stdlib modules carry signatures only — no body axioms
> (congruence-only soundness; structural axioms are deferred to
> milestone 4).

Call.
DepModule.
Builtin.

builtin? c: Call => Bool.
dispatches c: Call => Builtin.
module-of b: Builtin => DepModule.
receiver-passed? b: Builtin => Bool.
imported d: DepModule => Bool.
typechecks? c: Call => Bool.
has-body-axioms? d: DepModule => Bool.

---

> Every dispatched built-in call references a module the document imports.
all c: Call | builtin? c -> imported (module-of (dispatches c)).

> Every dispatched built-in call type-checks: the qualified rule it
> references is declared in the imported module, so no undeclared
> identifier reaches the wasm checker.
all c: Call | builtin? c -> typechecks? c.

> EUF floor: no js-stdlib module carries body axioms in this milestone.
all d: DepModule | ~(has-body-axioms? d).
```

## Patch Specification

```
module STDLIB_DISPATCH_COVERAGE_PATCH_2.

Call.
Builtin.
DepModule.

resolves? c: Call => Bool.
builtin-of c: Call => Builtin.
module-of b: Builtin => DepModule.
receiver-passed? b: Builtin => Bool.
arity-matches? c: Call => Bool.

---

> Resolution is arity-gated: a call resolves only when its argument
> count matches the target rule's fixed arity (regex-argument replace
> and off-arity statics resolve to nothing).
all c: Call | resolves? c -> arity-matches? c.
```


## Implementation Notes

- `receiver` is derived from the builtin key namespace rather than duplicated in `BUILTINS`; namespace statics (`Math.*`, `Array.*`) get `none`, prototype methods (`String.prototype.*`, `Map.prototype.*`) get `arg`. That keeps Patch 3’s emission contract centralized without adding another table field that can drift.
- `String.prototype.replace` is checked after table lookup but before returning the spec: the fixed arity still comes from `BUILTINS`, while the string-only overload gate uses the checker’s argument types. This intentionally rejects the regex overload and any mixed/non-string form.
- Map method resolution reuses the same default-library parent-interface test shape as String, generalized to accept `Map` and `ReadonlyMap`. This avoids routing user-defined `.values()` methods or object shapes into `JS_MAP`.
- I added skipped emission tests in `builtins.test.mts` rather than a new file so Patch 3 can unskip them next to the resolver tests and reuse the existing helper setup.

Spec/Evidence Mapping:
- `resolves? c -> arity-matches? c`: implemented by `lookupBuiltinByCall` returning a spec only when `expr.arguments.length === fullSpec.arity`; covered by off-arity Math, Array.from, Map method, and String.indexOf tests.
- Regex replace resolves to nothing: implemented by the `String.prototype.replace` argument-type gate in `lookupBuiltinByCall`; covered by `s.replace(/a/g, "b")` returning `null`.
- Module routing and receiver metadata: implemented in `deriveBuiltinSpec` via namespace-derived `moduleForNamespace` and `receiver`; covered by derive tests for Array.from, Map.prototype.values/entries, String.prototype.replace, and existing Math/String entries.
- Required CR-6 context consulted: TypeScript Compiler API default-library/symbol-resolution approach, reflected in `isDefaultLibSymbol` and generalized `isDefaultLibInterfaceMember`; covered by user-shadowed `Array`/`Math`, non-Map `.values()`, and user `interface String` augmentation fall-through tests.
- No construct emission changes: verified by `NODE_OPTIONS=--max-old-space-size=6144 npx tsx --test --test-timeout=300000 tests/constructs.test.mts` and no diff in `tools/ts2pant/tests/constructs.test.mts.snapshot`.

Verification run: `npm run lint`, `npx tsc --noEmit`, `npm run test:unit`, and `npm run test:integration` passed. `npm run build` was not usable in this worktree because `dune build wasm/` failed before TypeScript compilation with a corrupted local opam `ppxlib.cmi`; the JS/wasm test suites above ran against the existing wasm bridge.