### PR TITLE
[ts2pant-stdlib-dispatch-coverage] Patch 3: Wire built-in dispatch emission into the call-lowering path; register imports; clear the free-call-decl allowlist

### DIFF
--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -33,6 +33,7 @@
  */
 
 import ts from "typescript";
+import { lookupBuiltinByCall } from "./builtins.js";
 import { lowerExpr } from "./ir-emit.js";
 import {
   type IR1Binop,
@@ -113,6 +114,56 @@ export const isL1Unsupported = (
   r: L1BuildResult,
 ): r is { unsupported: string } =>
   typeof r === "object" && r !== null && "unsupported" in r;
+
+export function tryBuildBuiltinCall(
+  expr: ts.CallExpression,
+  ctx: L1BuildContext,
+): L1BuildResult | null {
+  if (!ctx.supply.program) {
+    return null;
+  }
+  const spec = lookupBuiltinByCall(expr, ctx.checker, ctx.supply.program);
+  if (spec === null) {
+    return null;
+  }
+  if (expr.arguments.some(ts.isSpreadElement)) {
+    return { unsupported: "call with spread arguments is unsupported" };
+  }
+
+  const args: IR1Expr[] = [];
+  if (spec.receiver === "arg") {
+    if (!ts.isPropertyAccessExpression(expr.expression)) {
+      return null;
+    }
+    const receiver = tryBuildL1PureSubExpression(expr.expression.expression, ctx);
+    if (receiver === null || isL1Unsupported(receiver)) {
+      return receiver;
+    }
+    args.push(receiver);
+  }
+  for (const arg of expr.arguments) {
+    const builtArg = tryBuildL1PureSubExpression(arg, ctx);
+    if (builtArg === null || isL1Unsupported(builtArg)) {
+      return builtArg;
+    }
+    args.push(builtArg);
+  }
+
+  let rule = spec.rule;
+  if (spec.rule === "JS_ARRAY::from" && expr.arguments.length === 1) {
+    const sourceType = mapTsType(
+      ctx.checker.getTypeAtLocation(expr.arguments[0]!),
+      ctx.checker,
+      ctx.strategy,
+      ctx.supply.synthCell,
+    );
+    if (sourceType === "[String * Int]") {
+      rule = "JS_ARRAY::from-entries";
+    }
+  }
+  ctx.supply.synthCell?.imports.add(spec.mod);
+  return ir1App(ir1Var(rule), args);
+}
 
 /**
  * L1-layering primitive: strip operationally-equivalent syntactic
@@ -644,6 +695,10 @@ export function tryBuildL1PureSubExpression(
   }
 
   if (ts.isCallExpression(expr)) {
+    const builtin = tryBuildBuiltinCall(expr, ctx);
+    if (builtin !== null) {
+      return builtin;
+    }
     if (expr.arguments.some(ts.isSpreadElement)) {
       return { unsupported: "call with spread arguments is unsupported" };
     }

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -135,7 +135,10 @@ export function tryBuildBuiltinCall(
     if (!ts.isPropertyAccessExpression(expr.expression)) {
       return null;
     }
-    const receiver = tryBuildL1PureSubExpression(expr.expression.expression, ctx);
+    const receiver = tryBuildL1PureSubExpression(
+      expr.expression.expression,
+      ctx,
+    );
     if (receiver === null || isL1Unsupported(receiver)) {
       return receiver;
     }

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -126,6 +126,13 @@ export function tryBuildBuiltinCall(
   if (spec === null) {
     return null;
   }
+  const member = callMemberName(expr.expression);
+  if (
+    expressionHasSideEffects(expr.expression, ctx.checker) ||
+    (member !== null && expressionHasSideEffects(member.receiver, ctx.checker))
+  ) {
+    return null;
+  }
   if (expr.arguments.some(ts.isSpreadElement)) {
     return { unsupported: "call with spread arguments is unsupported" };
   }

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -27,8 +27,8 @@ import {
   isL1StmtUnsupported,
   isL1Unsupported,
   lowerL1ToOpaque,
-  tryBuildL1Cardinality,
   tryBuildBuiltinCall,
+  tryBuildL1Cardinality,
   tryBuildL1PureSubExpression,
   tryRecognizeFunctorLift,
 } from "./ir1-build.js";

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -28,6 +28,7 @@ import {
   isL1Unsupported,
   lowerL1ToOpaque,
   tryBuildL1Cardinality,
+  tryBuildBuiltinCall,
   tryBuildL1PureSubExpression,
   tryRecognizeFunctorLift,
 } from "./ir1-build.js";
@@ -112,6 +113,7 @@ import type { PantDeclaration, PropResult } from "./types.js";
 export interface UniqueSupply {
   n: number;
   synthCell?: SynthCell | undefined;
+  program?: ts.Program | undefined;
   /**
    * Side-channel registry of fresh hygienic names that bind a
    * pre-built `OpaqueExpr` value. Populated by the mutating-body
@@ -127,8 +129,11 @@ export interface UniqueSupply {
    */
   opaqueAliases?: Map<string, OpaqueExpr>;
 }
-function makeUniqueSupply(synthCell?: SynthCell): UniqueSupply {
-  return { n: 0, synthCell };
+function makeUniqueSupply(
+  synthCell?: SynthCell,
+  program?: ts.Program,
+): UniqueSupply {
+  return { n: 0, synthCell, program };
 }
 
 /**
@@ -1070,6 +1075,7 @@ export function translateBody(opts: TranslateBodyOptions): PropResult[] {
     paramNameMap,
   } = opts;
   const checker = sourceFile.getProject().getTypeChecker().compilerObject;
+  const program = sourceFile.getProject().getProgram().compilerObject;
   const { node, className } = findFunction(sourceFile, functionName);
   // Strip class qualifier for use in Pantagruel identifiers
   const baseName = toPantTermName(
@@ -1175,6 +1181,7 @@ export function translateBody(opts: TranslateBodyOptions): PropResult[] {
       strategy,
       paramNames,
       synthCell,
+      program,
     );
   } else {
     return translateMutatingBody(
@@ -1185,6 +1192,7 @@ export function translateBody(opts: TranslateBodyOptions): PropResult[] {
       paramNames,
       declarations ?? [],
       synthCell,
+      program,
     );
   }
 }
@@ -1197,6 +1205,7 @@ function translatePureBody(
   strategy: NumericStrategy,
   paramNames: ReadonlyMap<string, string>,
   synthCell?: SynthCell,
+  program?: ts.Program,
 ): PropResult[] {
   const ast = getAst();
 
@@ -1210,7 +1219,7 @@ function translatePureBody(
     return [{ kind: "unsupported", reason: `${functionName} — ${reason}` }];
   }
 
-  const supply = makeUniqueSupply(synthCell);
+  const supply = makeUniqueSupply(synthCell, program);
 
   // M4 Patch 5: functor-lift on the if-conversion shape
   //   `if (x == null) return []; return [f(x)];`
@@ -3963,6 +3972,19 @@ export function translateCallExpr(
   supply: UniqueSupply,
 ): BodyResult {
   const ast = getAst();
+  const builtin = tryBuildBuiltinCall(expr, {
+    checker,
+    strategy,
+    paramNames,
+    state,
+    supply,
+  });
+  if (builtin !== null) {
+    if (isL1Unsupported(builtin)) {
+      return { unsupported: builtin.unsupported };
+    }
+    return { expr: lowerL1ToOpaque(builtin) };
+  }
 
   // Method calls: obj.method(args)
   if (ts.isPropertyAccessExpression(expr.expression)) {
@@ -4687,6 +4709,7 @@ function translateMutatingBody(
   paramNames: Map<string, string>,
   declarations: PantDeclaration[],
   synthCell?: SynthCell,
+  program?: ts.Program,
 ): PropResult[] {
   if (!node.body) {
     return [];
@@ -4699,7 +4722,7 @@ function translateMutatingBody(
       strategy,
       paramNames,
       state: makeSymbolicState(),
-      supply: makeUniqueSupply(synthCell),
+      supply: makeUniqueSupply(synthCell, program),
       initialPropertyValues: new Map(),
       helperNameBase: functionName,
       declarations,

--- a/tools/ts2pant/src/translate-types.ts
+++ b/tools/ts2pant/src/translate-types.ts
@@ -1321,6 +1321,15 @@ export function mapTsType(
   // the unsupported string reflects the source rather than an internal
   // sentinel. Null handling for unions happens in the union branch.
 
+  const iteratorElem = getBuiltinIteratorElementType(type, checker);
+  if (iteratorElem !== null) {
+    const elem = mapTsType(iteratorElem, checker, strategy, synthCell, opts);
+    if (isUnsupportedUnknown(elem)) {
+      return UNSUPPORTED_UNKNOWN;
+    }
+    return `[${elem}]`;
+  }
+
   // Tuple (check before array since tuples are also type references)
   if (checker.isTupleType(type)) {
     const typeArgs = checker.getTypeArguments(type as ts.TypeReference);
@@ -1448,6 +1457,24 @@ export function mapTsType(
   }
 
   return checker.typeToString(type);
+}
+
+function getBuiltinIteratorElementType(
+  type: ts.Type,
+  checker: ts.TypeChecker,
+): ts.Type | null {
+  const symbolName = type.getSymbol()?.getName();
+  if (
+    symbolName !== "MapIterator" &&
+    symbolName !== "ArrayIterator" &&
+    symbolName !== "SetIterator" &&
+    symbolName !== "IterableIterator" &&
+    symbolName !== "IteratorObject"
+  ) {
+    return null;
+  }
+  const args = checker.getTypeArguments(type as ts.TypeReference);
+  return args.length === 1 ? args[0]! : null;
 }
 
 /**

--- a/tools/ts2pant/tests/builtins.test.mts
+++ b/tools/ts2pant/tests/builtins.test.mts
@@ -10,7 +10,10 @@ import {
 } from "../src/builtins.js";
 import { createSourceFileFromSource, getChecker } from "../src/extract.js";
 import { assertWasmTypeChecks } from "../src/pant-wasm.js";
-import { buildDocumentFromSourceFile, emitDocument } from "./helpers.mjs";
+import {
+  buildDocumentFromSourceFile,
+  emitAndCheck,
+} from "./helpers.mjs";
 
 function findCallExpression(
   sourceFile: ts.SourceFile,
@@ -44,7 +47,7 @@ function lookupFromSource(
 async function emitFromSource(source: string, functionName: string) {
   const sourceFile = createSourceFileFromSource(source);
   const doc = await buildDocumentFromSourceFile(sourceFile, functionName);
-  return emitDocument(doc);
+  return emitAndCheck(doc);
 }
 
 describe("deriveBuiltinSpec", () => {
@@ -563,7 +566,7 @@ describe("loadBuiltinDepModule", () => {
 });
 
 describe("builtins dispatch emission", () => {
-  it.skip("Math.max emits JS_MATH::max-of and imports JS_MATH", async () => {
+  it("Math.max emits JS_MATH::max-of and imports JS_MATH", async () => {
     const output = await emitFromSource(
       "export function f(a: number, b: number) { return Math.max(a, b); }",
       "f",
@@ -572,7 +575,7 @@ describe("builtins dispatch emission", () => {
     assert.match(output, /JS_MATH::max-of/);
   });
 
-  it.skip("s.toUpperCase emits JS_STRING::to-upper-case and imports JS_STRING", async () => {
+  it("s.toUpperCase emits JS_STRING::to-upper-case and imports JS_STRING", async () => {
     const output = await emitFromSource(
       "export function f(s: string) { return s.toUpperCase(); }",
       "f",
@@ -581,7 +584,7 @@ describe("builtins dispatch emission", () => {
     assert.match(output, /JS_STRING::to-upper-case/);
   });
 
-  it.skip("Array.from emits JS_ARRAY::from and imports JS_ARRAY", async () => {
+  it("Array.from emits JS_ARRAY::from and imports JS_ARRAY", async () => {
     const output = await emitFromSource(
       "export function f(xs: number[]) { return Array.from(xs); }",
       "f",
@@ -590,7 +593,7 @@ describe("builtins dispatch emission", () => {
     assert.match(output, /JS_ARRAY::from/);
   });
 
-  it.skip("m.values emits JS_MAP::values and imports JS_MAP", async () => {
+  it("m.values emits JS_MAP::values and imports JS_MAP", async () => {
     const output = await emitFromSource(
       "export function f(m: Map<string, number>) { return m.values(); }",
       "f",
@@ -599,7 +602,7 @@ describe("builtins dispatch emission", () => {
     assert.match(output, /JS_MAP::values/);
   });
 
-  it.skip("string-arg replace emits JS_STRING::replace", async () => {
+  it("string-arg replace emits JS_STRING::replace", async () => {
     const output = await emitFromSource(
       'export function f(s: string) { return s.replace("a", "b"); }',
       "f",

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -127,7 +127,7 @@ exports[`expressions-calls.ts > freeCall 1`] = `
 `;
 
 exports[`expressions-calls.ts > methodCall 1`] = `
-"module METHOD_CALL.\\n\\nmethod-call s: String => String.\\n\\n---\\n\\nmethod-call s = (to-upper-case s).\\n"
+"module METHOD_CALL.\\nimport JS_STRING.\\n\\nmethod-call s: String => String.\\n\\n---\\n\\nmethod-call s = JS_STRING::to-upper-case s.\\n"
 `;
 
 exports[`expressions-calls.ts > nestedCalls 1`] = `
@@ -191,7 +191,7 @@ exports[`expressions-const-bindings.ts > simpleConst 1`] = `
 `;
 
 exports[`expressions-const-chained-impure.ts > chainedArrayCount 1`] = `
-"module CHAINED_ARRAY_COUNT.\\n\\nStringToIntMap.\\nstring-to-int-map-key m1: StringToIntMap, k: String => Bool.\\nstring-to-int-map m1: StringToIntMap, k: String, string-to-int-map-key m1 k => Int.\\nchained-array-count m: StringToIntMap => Int.\\nxs  => [Int].\\nn  => Int.\\n\\n---\\n\\nxs = (from Array) (values m).\\nn = #((from Array) (values m)).\\nchained-array-count m = n.\\n"
+"module CHAINED_ARRAY_COUNT.\\nimport JS_MAP.\\nimport JS_ARRAY.\\n\\nStringToIntMap.\\nstring-to-int-map-key m1: StringToIntMap, k: String => Bool.\\nstring-to-int-map m1: StringToIntMap, k: String, string-to-int-map-key m1 k => Int.\\nchained-array-count m: StringToIntMap => Int.\\nxs  => [Int].\\nn  => Int.\\n\\n---\\n\\nxs = JS_ARRAY::from (JS_MAP::values m).\\nn = #(JS_ARRAY::from (JS_MAP::values m)).\\nchained-array-count m = n.\\n"
 `;
 
 exports[`expressions-const-chained-impure.ts > chainedReplaceTrim 1`] = `
@@ -199,7 +199,7 @@ exports[`expressions-const-chained-impure.ts > chainedReplaceTrim 1`] = `
 `;
 
 exports[`expressions-const-pure-calls.ts > constChainedPure 1`] = `
-"module CONST_CHAINED_PURE.\\n\\nconst-chained-pure x: Int, y: Int => Int.\\na  => Int.\\nb  => Int.\\n\\n---\\n\\na = (abs Math) x.\\nb = (max Math) ((abs Math) x) y.\\nconst-chained-pure x y = b.\\n"
+"module CONST_CHAINED_PURE.\\nimport JS_MATH.\\n\\nconst-chained-pure x: Int, y: Int => Int.\\na  => Int.\\nb  => Int.\\n\\n---\\n\\na = JS_MATH::abs x.\\nb = JS_MATH::max-of (JS_MATH::abs x) y.\\nconst-chained-pure x y = b.\\n"
 `;
 
 exports[`expressions-const-pure-calls.ts > constImpureCall 1`] = `
@@ -207,23 +207,23 @@ exports[`expressions-const-pure-calls.ts > constImpureCall 1`] = `
 `;
 
 exports[`expressions-const-pure-calls.ts > constMathMax 1`] = `
-"module CONST_MATH_MAX.\\n\\nconst-math-max a: Int, b: Int => Int.\\nm  => Int.\\n\\n---\\n\\nm = (max Math) a b.\\nconst-math-max a b = m + 1.\\n"
+"module CONST_MATH_MAX.\\nimport JS_MATH.\\n\\nconst-math-max a: Int, b: Int => Int.\\nm  => Int.\\n\\n---\\n\\nm = JS_MATH::max-of a b.\\nconst-math-max a b = m + 1.\\n"
 `;
 
 exports[`expressions-const-pure-calls.ts > constStringMethod 1`] = `
-"module CONST_STRING_METHOD.\\n\\nconst-string-method s: String => Int.\\ni  => Int.\\n\\n---\\n\\ni = (index-of s) \\"x\\".\\nconst-string-method s = i.\\n"
+"module CONST_STRING_METHOD.\\nimport JS_STRING.\\n\\nconst-string-method s: String => Int.\\ni  => Int.\\n\\n---\\n\\ni = JS_STRING::index-of s \\"x\\".\\nconst-string-method s = i.\\n"
 `;
 
 exports[`expressions-const-side-effectful.ts > constArrayFromMap 1`] = `
-"module CONST_ARRAY_FROM_MAP.\\n\\nStringToIntMap.\\nstring-to-int-map-key m1: StringToIntMap, k: String => Bool.\\nstring-to-int-map m1: StringToIntMap, k: String, string-to-int-map-key m1 k => Int.\\nconst-array-from-map m: StringToIntMap => Int.\\nxs  => [Int].\\n\\n---\\n\\nxs = (from Array) (values m).\\nconst-array-from-map m = #xs.\\n"
+"module CONST_ARRAY_FROM_MAP.\\nimport JS_MAP.\\nimport JS_ARRAY.\\n\\nStringToIntMap.\\nstring-to-int-map-key m1: StringToIntMap, k: String => Bool.\\nstring-to-int-map m1: StringToIntMap, k: String, string-to-int-map-key m1 k => Int.\\nconst-array-from-map m: StringToIntMap => Int.\\nxs  => [Int].\\n\\n---\\n\\nxs = JS_ARRAY::from (JS_MAP::values m).\\nconst-array-from-map m = #xs.\\n"
 `;
 
 exports[`expressions-const-side-effectful.ts > constMapEntries 1`] = `
-"module CONST_MAP_ENTRIES.\\n\\nStringToIntMap.\\nstring-to-int-map-key m1: StringToIntMap, k: String => Bool.\\nstring-to-int-map m1: StringToIntMap, k: String, string-to-int-map-key m1 k => Int.\\nconst-map-entries m: StringToIntMap => Int.\\nxs  => [String * Int].\\n\\n---\\n\\nxs = (from Array) (entries m).\\nconst-map-entries m = #xs.\\n"
+"module CONST_MAP_ENTRIES.\\nimport JS_MAP.\\nimport JS_ARRAY.\\n\\nStringToIntMap.\\nstring-to-int-map-key m1: StringToIntMap, k: String => Bool.\\nstring-to-int-map m1: StringToIntMap, k: String, string-to-int-map-key m1 k => Int.\\nconst-map-entries m: StringToIntMap => Int.\\nxs  => [String * Int].\\n\\n---\\n\\nxs = JS_ARRAY::from-entries (JS_MAP::entries m).\\nconst-map-entries m = #xs.\\n"
 `;
 
 exports[`expressions-const-side-effectful.ts > constReplaceLiteral 1`] = `
-"module CONST_REPLACE_LITERAL.\\n\\nconst-replace-literal s: String => String.\\nx  => String.\\n\\n---\\n\\nx = (replace s) \\"a\\" \\"b\\".\\nconst-replace-literal s = x.\\n"
+"module CONST_REPLACE_LITERAL.\\nimport JS_STRING.\\n\\nconst-replace-literal s: String => String.\\nx  => String.\\n\\n---\\n\\nx = JS_STRING::replace s \\"a\\" \\"b\\".\\nconst-replace-literal s = x.\\n"
 `;
 
 exports[`expressions-const-side-effectful.ts > constReplaceRegex 1`] = `
@@ -407,7 +407,7 @@ exports[`expressions-let-immutable.ts > letInTernary 1`] = `
 `;
 
 exports[`expressions-let-immutable.ts > letMathMax 1`] = `
-"module LET_MATH_MAX.\\n\\nlet-math-max a: Int, b: Int => Int.\\nm  => Int.\\n\\n---\\n\\nm = (max Math) a b.\\nlet-math-max a b = m + 1.\\n"
+"module LET_MATH_MAX.\\nimport JS_MATH.\\n\\nlet-math-max a: Int, b: Int => Int.\\nm  => Int.\\n\\n---\\n\\nm = JS_MATH::max-of a b.\\nlet-math-max a b = m + 1.\\n"
 `;
 
 exports[`expressions-let-immutable.ts > letWithPropAccess 1`] = `

--- a/tools/ts2pant/tests/ir1-build-call-purity.test.mts
+++ b/tools/ts2pant/tests/ir1-build-call-purity.test.mts
@@ -25,6 +25,7 @@ function setupReturnExpr(source: string): {
 } {
   const sourceFile = createSourceFileFromSource(source);
   const checker = getChecker(sourceFile);
+  const program = sourceFile.getProject().getProgram().compilerObject;
   const fn = sourceFile.compilerNode.statements.find(
     (stmt): stmt is ts.FunctionDeclaration =>
       ts.isFunctionDeclaration(stmt) && stmt.body !== undefined,
@@ -46,7 +47,7 @@ function setupReturnExpr(source: string): {
   if (!stmt || !ts.isReturnStatement(stmt) || !stmt.expression) {
     throw new Error("setup: expected return expression");
   }
-  const supply: UniqueSupply = { n: 0, synthCell };
+  const supply: UniqueSupply = { n: 0, synthCell, program };
   return {
     expr: stmt.expression,
     ctx: {
@@ -152,6 +153,16 @@ describe("ir1-build call purity", () => {
       }
     `);
     assert.equal(tryBuildL1PureSubExpression(bracket.expr, bracket.ctx), null);
+  });
+
+  it("does not lower a builtin call whose receiver has unknown effects", () => {
+    const { expr, ctx } = setupReturnExpr(`
+      declare function makeString(): string;
+      function f(): string {
+        return makeString().trim();
+      }
+    `);
+    assert.equal(tryBuildL1PureSubExpression(expr, ctx), null);
   });
 
   it("does not lower a higher-order call with an effectful callee", () => {

--- a/tools/ts2pant/tests/known-typecheck-failures.mts
+++ b/tools/ts2pant/tests/known-typecheck-failures.mts
@@ -18,11 +18,10 @@
  * typecheck automatically.
  *
  * Const-binding SSA deliberately moved several fixtures from prelude
- * rejection into emitted Pant that can fail later at the free-call-decl
- * boundary. Keep those entries only while the emitted document really
- * fails the wasm typecheck because a surviving call lacks a Pant
- * declaration; outputs that now typecheck, including parseable
- * `> UNSUPPORTED:` comments, should not stay on this list.
+ * rejection into emitted Pant that can fail later. The stdlib-dispatchable
+ * call fixtures have been wired through qualified imports, so no
+ * free-call-decl entries should remain here; bare-identifier ambient and
+ * non-builtin free calls get synthesized EUF heads.
  *
  * Failure classes:
  *   - "$-binder-leak"     hygienic `$N` names reach the emitted text
@@ -40,11 +39,6 @@
  *                         wasm checker path.
  *   - "list-literal"      emits `[a, b]` for tuple/array initializers
  *                         where Pant has no list literal target.
- *   - "free-call-decl"    surviving M2 gaps where a method/stdlib or
- *                         dispatch-incomplete call reaches Pant without
- *                         the needed declaration/import. Bare-identifier
- *                         ambient and non-builtin free calls should not
- *                         appear here; they get synthesized EUF heads.
  *   - "var-rejected"      local `var` binding fixture; `var` remains out of
  *                         scope and should keep a dedicated diagnostic.
  *   - "closure-captured-reassignment"
@@ -59,17 +53,8 @@ export const KNOWN_TYPECHECK_FAILURES = new Map<string, string>([
   ["expressions-array.ts > nameLengths", "$-binder-leak"],
   ["expressions-boolean.ts > and", "$-binder-leak"],
   ["expressions-boolean.ts > or", "$-binder-leak"],
-  ["expressions-calls.ts > methodCall", "free-call-decl"],
-  ["expressions-const-chained-impure.ts > chainedArrayCount", "free-call-decl"],
-  ["expressions-const-pure-calls.ts > constMathMax", "free-call-decl"],
-  ["expressions-const-pure-calls.ts > constStringMethod", "free-call-decl"],
-  ["expressions-const-pure-calls.ts > constChainedPure", "free-call-decl"],
-  ["expressions-const-side-effectful.ts > constReplaceLiteral", "free-call-decl"],
-  ["expressions-const-side-effectful.ts > constArrayFromMap", "free-call-decl"],
-  ["expressions-const-side-effectful.ts > constMapEntries", "free-call-decl"],
   ["expressions-let-closure-captured.ts > letForEachCapturedTotal", "closure-captured-reassignment"],
   ["expressions-let-closure-captured.ts > letMapCapturedCount", "closure-captured-reassignment"],
-  ["expressions-let-immutable.ts > letMathMax", "free-call-decl"],
   ["expressions-var-rejected.ts > varBinding", "var-rejected"],
   ["expressions-var-rejected.ts > varReassignment", "var-rejected"],
   ["functions-class.ts > Account.getBalance", "requires-external-context"],

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -883,7 +883,7 @@ describe("translateCallExpr", () => {
     const prop = finalEquation(props);
     if (prop.kind === "equation") {
       const ast = getAst();
-      assert.equal(ast.strExpr(prop.rhs), "(to-upper-case s)");
+      assert.equal(ast.strExpr(prop.rhs), "JS_STRING::to-upper-case s");
     }
   });
 


### PR DESCRIPTION
## Patch 3: Wire built-in dispatch emission into the call-lowering path; register imports; clear the free-call-decl allowlist

- Introduce the shared tryBuildBuiltinCall helper that performs dispatch lookup, qualified-ref application construction (receiver-passing per spec.receiver), and synthCell.imports registration.
- Wire the helper into every call-lowering site identified in CR-2 (IR1 pure-subexpr call branch, main-body property-access call path, and any legacy qualifyFieldAccess method-call site) ahead of the generic member-access fallthrough.
- Confirm imports flow through pipeline.ts's synthCell.imports → doc.imports + bundleModules bundling so `import JS_MAP.` etc. appear and the bundled module text is available to the wasm checker.
- Unskip and implement the dispatch-emission tests; assert qualified ref + import + emitAndCheck pass for Math, String, Array.from, and Map methods.
- Regenerate the nine fixture snapshots and verify no unrelated snapshot churn.
- Remove the nine free-call-decl allowlist entries; verify constReplaceRegex stays UNSUPPORTED and constSetHas stays on the `in` membership encoding.
- Run npm run -s test:unit and npm run -s test:integration; confirm zero free-call-decl entries remain and the cleared fixtures typecheck.

## Changes
- Introduce the shared tryBuildBuiltinCall helper that performs dispatch lookup, qualified-ref application construction (receiver-passing per spec.receiver), and synthCell.imports registration.
- Wire the helper into every call-lowering site identified in CR-2 (IR1 pure-subexpr call branch, main-body property-access call path, and any legacy qualifyFieldAccess method-call site) ahead of the generic member-access fallthrough.
- Confirm imports flow through pipeline.ts's synthCell.imports → doc.imports + bundleModules bundling so `import JS_MAP.` etc. appear and the bundled module text is available to the wasm checker.
- Unskip and implement the dispatch-emission tests; assert qualified ref + import + emitAndCheck pass for Math, String, Array.from, and Map methods.
- Regenerate the nine fixture snapshots and verify no unrelated snapshot churn.
- Remove the nine free-call-decl allowlist entries; verify constReplaceRegex stays UNSUPPORTED and constSetHas stays on the `in` membership encoding.
- Run npm run -s test:unit and npm run -s test:integration; confirm zero free-call-decl entries remain and the cleared fixtures typecheck.

## Files to Modify
- tools/ts2pant/src/ir1-build.ts (modify): Add tryBuildBuiltinCall(expr, ctx): IR1Expr | null — call lookupBuiltinByCall; on a hit, build ir1App(ir1Var(spec.rule), [<receiver if spec.receiver==='arg'>, ...lowered args]) and add spec.mod to ctx.supply.synthCell.imports. Consult it at the top of tryBuildL1PureSubExpression's CallExpression branch (before the buildL1MemberAccess fallthrough at ~842), returning its result when non-null.
- tools/ts2pant/src/ir1-build-body.ts (modify): Consult tryBuildBuiltinCall in the main-body property-access call path (~1115) before generic member-access lowering, so return-position built-in calls (methodCall) dispatch identically and register the import.
- tools/ts2pant/src/translate-body.ts (modify): If any surviving legacy method-call lowering site (qualifyFieldAccess-driven, ~1550/3292) still constructs the application for a recognized built-in, route it through the same shared helper / dispatch so no call-lowering site bypasses dispatch. Audit all sites; the helper is the single source of truth.
- tools/ts2pant/tests/dispatch-emission.test.mts (modify): Unskip and implement the emission-test stubs from Patch 2: assert each built-in call emits its qualified MOD::rule reference and the document imports MOD, and that the result passes emitAndCheck (wasm typecheck).
- tools/ts2pant/tests/constructs.test.mts.snapshot (modify): Regenerate the snapshots for the nine cleared fixtures so they show the qualified references and import lines (e.g. const-math-max: `import JS_MATH.` + `m = max-of a b`). No other snapshot should change.
- tools/ts2pant/tests/known-typecheck-failures.mts (modify): Remove the nine free-call-decl entries (methodCall, chainedArrayCount, constMathMax, constStringMethod, constChainedPure, constReplaceLiteral, constArrayFromMap, constMapEntries, letMathMax). Update the free-call-decl tag doc-comment to note no stdlib-dispatchable fixtures remain.

## Gameplan Specification

```
module STDLIB_DISPATCH_COVERAGE.

> A TypeScript call whose callee resolves to a recognized JavaScript
> built-in (Math.*, String.prototype.*, Array.from, Map.prototype.*)
> lowers to a qualified rule reference against a hand-written
> js-stdlib EUF module, and the emitted document imports that module.
> The js-stdlib modules carry signatures only — no body axioms
> (congruence-only soundness; structural axioms are deferred to
> milestone 4).

Call.
DepModule.
Builtin.

builtin? c: Call => Bool.
dispatches c: Call => Builtin.
module-of b: Builtin => DepModule.
receiver-passed? b: Builtin => Bool.
imported d: DepModule => Bool.
typechecks? c: Call => Bool.
has-body-axioms? d: DepModule => Bool.

---

> Every dispatched built-in call references a module the document imports.
all c: Call | builtin? c -> imported (module-of (dispatches c)).

> Every dispatched built-in call type-checks: the qualified rule it
> references is declared in the imported module, so no undeclared
> identifier reaches the wasm checker.
all c: Call | builtin? c -> typechecks? c.

> EUF floor: no js-stdlib module carries body axioms in this milestone.
all d: DepModule | ~(has-body-axioms? d).
```

## Patch Specification

```
module STDLIB_DISPATCH_COVERAGE_PATCH_3.

Call.
DepModule.
Builtin.

builtin? c: Call => Bool.
dispatches c: Call => Builtin.
module-of b: Builtin => DepModule.
emits-qualified-ref? c: Call => Bool.
imported d: DepModule => Bool.
typechecks? c: Call => Bool.

---

> A recognized built-in call emits an application of its qualified
> MOD::rule reference and the document imports MOD; therefore the
> call type-checks (no undeclared identifier reaches the wasm checker).
all c: Call | builtin? c -> emits-qualified-ref? c.
all c: Call | builtin? c -> imported (module-of (dispatches c)).
all c: Call | builtin? c -> typechecks? c.
```


## Implementation Notes

- `tryBuildBuiltinCall` lives in `ir1-build.ts` and is reused from the legacy `translateCallExpr` path. It intentionally no-ops unless `UniqueSupply.program` is present, so lower-level tests and callers that construct a bare supply keep their existing generic-call behavior.
- The helper registers imports only after receiver and argument lowering succeeds. This avoids leaking `JS_*` imports from failed builtin probes into fallback paths.
- Direct `m.values()` needed one extra type-mapping bridge: TypeScript exposes the return as `MapIterator<T>`, while the js-stdlib model intentionally collapses iterators to Pantagruel lists. `mapTsType` now maps built-in iterator references such as `MapIterator<T>` to `[T]`.
- `Array.from(m.entries())` uses the existing `JS_ARRAY::from-entries` head from the dependency patch when the argument type is `[String * Int]`. Plain `Array.from(number[])` still emits `JS_ARRAY::from`, matching the dispatch-resolution contract while preserving monomorphic Pantagruel signatures.
- No js-stdlib module bodies were added or changed in this patch; the implementation only consumes the modules and bundled imports.

Spec/Evidence Mapping:
- `builtin? c -> emits-qualified-ref? c`: `tryBuildBuiltinCall` builds `ir1App(ir1Var(rule), args)` with qualified `JS_*::rule`; covered by `builtins dispatch emission` tests and updated constructs snapshots.
- `builtin? c -> imported(module-of(dispatches c))`: `tryBuildBuiltinCall` adds `spec.mod` to `ctx.supply.synthCell.imports`; pipeline’s existing import drain emits `import JS_*.` and bundle modules; covered by emission tests using `emitAndCheck`.
- `builtin? c -> typechecks? c`: the nine formerly allowlisted fixtures were removed from `KNOWN_TYPECHECK_FAILURES` and now pass the constructs wasm typecheck path; verified by `npm run -s test:unit`.
- Regression checks: `constReplaceRegex` remains `> UNSUPPORTED`, and `constSetHas` remains the membership encoding `(value in s)` in the regenerated snapshot.
- Validation run: `npx tsc --noEmit`, `npm run -s test:unit`, and `npm run -s test:integration` all passed.