### PR TITLE
[ts2pant-body-lowering-completeness] Patch 1: Fixtures + test scaffolding for the two body-lowering shapes (allowlisted)

### DIFF
--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -82,6 +82,34 @@ exports[`expressions-array.ts > nameLengths 1`] = `
 "module NAME_LENGTHS.\\n\\nUser.\\nuser--name u: User => String.\\nuser--active u: User => Bool.\\nuser--score u: User => Int.\\nname-lengths users: [User] => [Int].\\n\\n---\\n\\nname-lengths users = (each x in users | length (user--name x)).\\n"
 `;
 
+exports[`expressions-block-early-return.ts > blockEarlyReturnBindingReferencesParam 1`] = `
+"module BLOCK_EARLY_RETURN_BINDING_REFERENCES_PARAM.\\n\\nblock-early-return-binding-references-param n: Int, offset: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: block-early-return-binding-references-param — if-with-return body must be a single return statement.\\n"
+`;
+
+exports[`expressions-block-early-return.ts > blockEarlyReturnEffectfulConstRejected 1`] = `
+"module BLOCK_EARLY_RETURN_EFFECTFUL_CONST_REJECTED.\\n\\ncompute n1: Int => Int.\\nblock-early-return-effectful-const-rejected n: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: block-early-return-effectful-const-rejected — if-with-return body must be a single return statement.\\n"
+`;
+
+exports[`expressions-block-early-return.ts > blockEarlyReturnMultipleBindings 1`] = `
+"module BLOCK_EARLY_RETURN_MULTIPLE_BINDINGS.\\n\\nblock-early-return-multiple-bindings n: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: block-early-return-multiple-bindings — if-with-return body must be a single return statement.\\n"
+`;
+
+exports[`expressions-block-early-return.ts > blockEarlyReturnMutatingMultipleBindings 1`] = `
+"module BLOCK_EARLY_RETURN_MUTATING_MULTIPLE_BINDINGS.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--limit a1: Account => Int.\\n~> Block-early-return-mutating-multiple-bindings @ a: Account, g: Bool, amount: Int.\\n\\n---\\n\\n> UNSUPPORTED: branch body must be a property assignment, Map/Set effect, or nested if.\\n"
+`;
+
+exports[`expressions-block-early-return.ts > blockEarlyReturnMutatingSingleBinding 1`] = `
+"module BLOCK_EARLY_RETURN_MUTATING_SINGLE_BINDING.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--limit a1: Account => Int.\\n~> Block-early-return-mutating-single-binding @ a: Account, g: Bool, amount: Int.\\n\\n---\\n\\n> UNSUPPORTED: branch body must be a property assignment, Map/Set effect, or nested if.\\n"
+`;
+
+exports[`expressions-block-early-return.ts > blockEarlyReturnNestedArms 1`] = `
+"module BLOCK_EARLY_RETURN_NESTED_ARMS.\\n\\nblock-early-return-nested-arms n: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: block-early-return-nested-arms — if-with-return body must be a single return statement.\\n"
+`;
+
+exports[`expressions-block-early-return.ts > blockEarlyReturnSingleBinding 1`] = `
+"module BLOCK_EARLY_RETURN_SINGLE_BINDING.\\n\\nblock-early-return-single-binding n: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: block-early-return-single-binding — if-with-return body must be a single return statement.\\n"
+`;
+
 exports[`expressions-boolean.ts > and 1`] = `
 "module AND.\\n\\nand a: Bool, b: Bool => Bool.\\n\\n---\\n\\nand a b = (a and b).\\n"
 `;
@@ -816,6 +844,26 @@ exports[`expressions-state-aware-reads.ts > setIfThenBump 1`] = `
 
 exports[`expressions-state-aware-reads.ts > tagThenCheck 1`] = `
 "module TAG_THEN_CHECK.\\n\\nTagged.\\ntagged--tags t: Tagged => [String].\\ntagged--flag t: Tagged => Bool.\\n~> Tag-then-check @ c: Tagged, x: String, gate: Bool.\\n\\n---\\n\\nall y: String | y in tagged--tags' c <-> (cond y = x => (cond gate => true, true => x in tagged--tags c), true => y in tagged--tags c).\\ntagged--flag' c = (cond gate => (cond (cond x = x => true, true => x in tagged--tags c) => true, true => tagged--flag c), true => tagged--flag c).\\n"
+`;
+
+exports[`expressions-switch-block-clause.ts > switchBlockClauseFallThrough 1`] = `
+"module SWITCH_BLOCK_CLAUSE_FALL_THROUGH.\\n\\nswitch-block-clause-fall-through x: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: switch-block-clause-fall-through — switch case must end with \`return EXPR\` (no fall-through, no break/throw cases in M1).\\n"
+`;
+
+exports[`expressions-switch-block-clause.ts > switchBlockClauseMultipleBindings 1`] = `
+"module SWITCH_BLOCK_CLAUSE_MULTIPLE_BINDINGS.\\n\\nswitch-block-clause-multiple-bindings x: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: switch-block-clause-multiple-bindings — switch case must end with \`return EXPR\` (no fall-through, no break/throw cases in M1).\\n"
+`;
+
+exports[`expressions-switch-block-clause.ts > switchBlockClauseNonLiteralLabel 1`] = `
+"module SWITCH_BLOCK_CLAUSE_NON_LITERAL_LABEL.\\n\\nswitch-block-clause-non-literal-label x: Int, k: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: switch-block-clause-non-literal-label — switch case label must be a literal (number/string/bool).\\n"
+`;
+
+exports[`expressions-switch-block-clause.ts > switchBlockClauseSingleBinding 1`] = `
+"module SWITCH_BLOCK_CLAUSE_SINGLE_BINDING.\\n\\nswitch-block-clause-single-binding x: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: switch-block-clause-single-binding — switch case must end with \`return EXPR\` (no fall-through, no break/throw cases in M1).\\n"
+`;
+
+exports[`expressions-switch-block-clause.ts > switchBlockClauseStringLabel 1`] = `
+"module SWITCH_BLOCK_CLAUSE_STRING_LABEL.\\n\\nswitch-block-clause-string-label s: String => Int.\\n\\n---\\n\\n> UNSUPPORTED: switch-block-clause-string-label — switch case must end with \`return EXPR\` (no fall-through, no break/throw cases in M1).\\n"
 `;
 
 exports[`expressions-template-literal.ts > concatTwo 1`] = `

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-block-early-return.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-block-early-return.ts
@@ -1,0 +1,77 @@
+interface Account {
+  balance: number;
+  limit: number;
+}
+
+export function blockEarlyReturnSingleBinding(n: number): number {
+  if (n < 0) {
+    const z = 0 - n;
+    return z;
+  }
+  return n + 1;
+}
+
+export function blockEarlyReturnMultipleBindings(n: number): number {
+  if (n < 0) {
+    const base = 0 - n;
+    const doubled = base * 2;
+    return doubled;
+  }
+  return n;
+}
+
+export function blockEarlyReturnBindingReferencesParam(
+  n: number,
+  offset: number,
+): number {
+  if (n < offset) {
+    const z = offset - n;
+    return z;
+  }
+  return n + offset;
+}
+
+export function blockEarlyReturnNestedArms(n: number): number {
+  if (n < 0) {
+    const z = 0 - n;
+    return z;
+  }
+  if (n === 0) {
+    const one = n + 1;
+    return one;
+  }
+  return n;
+}
+
+export function blockEarlyReturnMutatingSingleBinding(
+  a: Account,
+  g: boolean,
+  amount: number,
+): void {
+  if (g) {
+    const z = a.balance + amount;
+    a.balance = z;
+  }
+}
+
+export function blockEarlyReturnMutatingMultipleBindings(
+  a: Account,
+  g: boolean,
+  amount: number,
+): void {
+  if (g) {
+    const candidate = a.balance + amount;
+    const capped = candidate < a.limit ? candidate : a.limit;
+    a.balance = capped;
+  }
+}
+
+declare function compute(n: number): number;
+
+export function blockEarlyReturnEffectfulConstRejected(n: number): number {
+  if (n < 0) {
+    const z = compute(n);
+    return z;
+  }
+  return n;
+}

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-switch-block-clause.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-switch-block-clause.ts
@@ -1,0 +1,73 @@
+export function switchBlockClauseSingleBinding(x: number): number {
+  switch (x) {
+    case 0: {
+      const z = x + 10;
+      return z;
+    }
+    default: {
+      const fallback = x + 1;
+      return fallback;
+    }
+  }
+}
+
+export function switchBlockClauseMultipleBindings(x: number): number {
+  switch (x) {
+    case 0: {
+      const base = x + 1;
+      const doubled = base * 2;
+      return doubled;
+    }
+    case 1: {
+      const shifted = x + 10;
+      return shifted;
+    }
+    default: {
+      const fallback = x - 1;
+      return fallback;
+    }
+  }
+}
+
+export function switchBlockClauseStringLabel(s: string): number {
+  switch (s) {
+    case "ready": {
+      const code = 1;
+      return code;
+    }
+    default: {
+      const code = 0;
+      return code;
+    }
+  }
+}
+
+export function switchBlockClauseNonLiteralLabel(x: number, k: number): number {
+  switch (x) {
+    case k: {
+      const matched = 1;
+      return matched;
+    }
+    default: {
+      const fallback = 0;
+      return fallback;
+    }
+  }
+}
+
+export function switchBlockClauseFallThrough(x: number): number {
+  switch (x) {
+    case 0: {
+      const ignored = x + 1;
+      void ignored;
+    }
+    case 1: {
+      const matched = 1;
+      return matched;
+    }
+    default: {
+      const fallback = 0;
+      return fallback;
+    }
+  }
+}

--- a/tools/ts2pant/tests/known-typecheck-failures.mts
+++ b/tools/ts2pant/tests/known-typecheck-failures.mts
@@ -47,14 +47,56 @@
  *   - "annotation-types"  the user's `@pant` annotation is itself
  *                         ill-typed against the emitted signature
  *                         (e.g. comparing a Bool result to an Int).
+ *   - "block-early-return-arm"
+ *                         pending body-lowering support for block-bodied
+ *                         early-return/mutating arms with const bindings.
+ *   - "switch-block-clause"
+ *                         pending L1 switch support for case/default
+ *                         clauses that are blocks ending in a return.
  */
 export const KNOWN_TYPECHECK_FAILURES = new Map<string, string>([
   ["control-flow.ts > max", "$-binder-leak"],
+  [
+    "expressions-block-early-return.ts > blockEarlyReturnBindingReferencesParam",
+    "block-early-return-arm",
+  ],
+  [
+    "expressions-block-early-return.ts > blockEarlyReturnMutatingMultipleBindings",
+    "block-early-return-arm",
+  ],
+  [
+    "expressions-block-early-return.ts > blockEarlyReturnMutatingSingleBinding",
+    "block-early-return-arm",
+  ],
+  [
+    "expressions-block-early-return.ts > blockEarlyReturnMultipleBindings",
+    "block-early-return-arm",
+  ],
+  [
+    "expressions-block-early-return.ts > blockEarlyReturnNestedArms",
+    "block-early-return-arm",
+  ],
+  [
+    "expressions-block-early-return.ts > blockEarlyReturnSingleBinding",
+    "block-early-return-arm",
+  ],
   ["expressions-array.ts > nameLengths", "$-binder-leak"],
   ["expressions-boolean.ts > and", "$-binder-leak"],
   ["expressions-boolean.ts > or", "$-binder-leak"],
   ["expressions-let-closure-captured.ts > letForEachCapturedTotal", "closure-captured-reassignment"],
   ["expressions-let-closure-captured.ts > letMapCapturedCount", "closure-captured-reassignment"],
+  [
+    "expressions-switch-block-clause.ts > switchBlockClauseMultipleBindings",
+    "switch-block-clause",
+  ],
+  [
+    "expressions-switch-block-clause.ts > switchBlockClauseSingleBinding",
+    "switch-block-clause",
+  ],
+  [
+    "expressions-switch-block-clause.ts > switchBlockClauseStringLabel",
+    "switch-block-clause",
+  ],
   ["expressions-var-rejected.ts > varBinding", "var-rejected"],
   ["expressions-var-rejected.ts > varReassignment", "var-rejected"],
   ["functions-class.ts > Account.getBalance", "requires-external-context"],

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -571,6 +571,34 @@ describe("if-early-return prelude arms", () => {
     }
   });
 
+  it.skip("pure block-bodied early-return arm lowers to cond with inlined bindings", () => {
+    // PENDING Patch 2: recognize block arms containing const bindings
+    // ending in `return`, inline the bindings, and feed the existing cond.
+    const source = `
+      export function f(n: number): number {
+        if (n < 0) {
+          const z = 0 - n;
+          return z;
+        }
+        return n + 1;
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "f",
+      strategy: IntStrategy,
+    });
+    const prop = finalEquation(props);
+    if (prop.kind === "equation") {
+      const ast = getAst();
+      assert.equal(
+        ast.strExpr(prop.rhs),
+        "cond n < 0 => 0 - n, true => n + 1",
+      );
+    }
+  });
+
   it("composes arms with a μ-search prelude", () => {
     const source = `
       export function f(n: number, used: ReadonlySet<number>): number {
@@ -841,6 +869,72 @@ describe("if-early-return prelude arms", () => {
     assert.equal(props[0]?.kind, "unsupported");
     if (props[0]?.kind === "unsupported") {
       assert.match(props[0].reason, /if-without-else as final statement/u);
+    }
+  });
+});
+
+describe("body-lowering completeness pending stubs", () => {
+  it.skip("mutating block-bodied arm lowers to cond post-state with inlined binding", () => {
+    // PENDING Patch 2: buildL1MutationBody accepts guarded blocks with
+    // const bindings before terminal property assignments.
+    const source = `
+      interface Account { balance: number; }
+      export function f(a: Account, g: boolean, amount: number): void {
+        if (g) {
+          const z = a.balance + amount;
+          a.balance = z;
+        }
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "f",
+      strategy: IntStrategy,
+    });
+    const equations = props.filter((p) => p.kind === "equation");
+    assert.equal(equations.length, 1);
+    const eq = equations[0]!;
+    if (eq.kind === "equation") {
+      const ast = getAst();
+      assert.equal(ast.strExpr(eq.lhs), "account--balance' a");
+      assert.equal(
+        ast.strExpr(eq.rhs),
+        "cond g => account--balance a + amount, true => account--balance a",
+      );
+    }
+  });
+
+  it.skip("switch block clause lowers to cond", () => {
+    // PENDING Patch 3: extract const bindings plus terminal return from
+    // switch case/default blocks and inline them into the cond arms.
+    const source = `
+      export function f(x: number): number {
+        switch (x) {
+          case 0: {
+            const z = x + 10;
+            return z;
+          }
+          default: {
+            const fallback = x + 1;
+            return fallback;
+          }
+        }
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "f",
+      strategy: IntStrategy,
+    });
+    const prop = finalEquation(props);
+    if (prop.kind === "equation") {
+      const ast = getAst();
+      assert.equal(
+        ast.strExpr(prop.rhs),
+        "cond x = 0 => x + 10, true => x + 1",
+      );
     }
   });
 });


### PR DESCRIPTION
## Patch 1: Fixtures + test scaffolding for the two body-lowering shapes (allowlisted)

- Author the two fixture files with both positive (target shape) and negative (must-stay-rejected) functions, so the behavior patches can prove both the new support and the preserved refusals.
- Add known-typecheck-failures entries for the positive fixtures under the two new tags; add the tag descriptions to the file header comment.
- Add skipped unit-test stubs (pure block-arm cond, mutating block-arm cond post-state, switch-block-clause cond) referencing the implementing patch in a PENDING comment.
- Run the constructs suite to confirm the new fixtures are picked up and allowlisted (no wasm typecheck runs on them yet); confirm no existing snapshot changes.

## Changes
- Author the two fixture files with both positive (target shape) and negative (must-stay-rejected) functions, so the behavior patches can prove both the new support and the preserved refusals.
- Add known-typecheck-failures entries for the positive fixtures under the two new tags; add the tag descriptions to the file header comment.
- Add skipped unit-test stubs (pure block-arm cond, mutating block-arm cond post-state, switch-block-clause cond) referencing the implementing patch in a PENDING comment.
- Run the constructs suite to confirm the new fixtures are picked up and allowlisted (no wasm typecheck runs on them yet); confirm no existing snapshot changes.

## Files to Modify
- tools/ts2pant/tests/fixtures/constructs/expressions-block-early-return.ts (create): Fixtures: pure-body `if (P) { const z = …; return z; } return E;` (single binding, multiple bindings, binding referencing a param, nested arms) AND mutating-body `if (P) { const z = …; a.field = z; }` shapes. Plus a negative fixture with an effectful const initializer inside the block (must stay UNSUPPORTED). Each is a standalone exported function.
- tools/ts2pant/tests/fixtures/constructs/expressions-switch-block-clause.ts (create): Switch fixtures whose case/default clauses are blocks of const bindings ending in a single return; plus a negative fixture with a non-literal label and one with fall-through (which must stay UNSUPPORTED).
- tools/ts2pant/tests/known-typecheck-failures.mts (modify): Register the new positive fixtures under new tags (block-early-return-arm, switch-block-clause) and document the tags in the header comment, so the wasm typecheck is skipped until the behavior patches clear them. Negative fixtures (effectful block const, non-literal label, fall-through) are entered under their existing/legacy tags and stay.
- tools/ts2pant/tests/translate-body.test.mts (modify): Add skipped (it.skip) unit-test stubs asserting the emitted cond shapes for a pure block-arm, a mutating block-arm, and a switch-block-clause, marked PENDING for Patches 2/3.

## Gameplan Specification

```
module BODY_LOWERING_COMPLETENESS.

> Imperative body-lowering accepts two previously-rejected control-flow
> shapes, each reduced to the existing cond machinery: early-return arms
> (pure and mutating bodies) whose then-branch is a block of const
> bindings ending in a single return or mutation; and switch case/default
> clauses that are blocks ending in a single return. Block-local const
> bindings are inlined via capture-avoiding substitution. No new
> SMT/summary semantics.

Body.
Arm.
Clause.

block-arm? a: Arm => Bool.
arm-lowered? a: Arm => Bool.
inlines-bindings? a: Arm => Bool.
block-clause? c: Clause => Bool.
clause-lowered? c: Clause => Bool.
typechecks? b: Body => Bool.

---

> Every block-bodied early-return arm (pure or mutating) lowers, and its
> value inlines the block-local const bindings.
all a: Arm | block-arm? a -> arm-lowered? a and inlines-bindings? a.
> Every switch case/default clause that is a block ending in a return lowers.
all c: Clause | block-clause? c -> clause-lowered? c.
> Bodies built only from supported shapes type-check.
all b: Body | typechecks? b.
```

## Patch Specification

```
module BODY_LOWERING_COMPLETENESS_PATCH_1.

> Fixtures + test scaffolding for the two shapes; allowlisted so the
> wasm typecheck is skipped until the behavior patches land. No
> source-logic change.

Fixture.
known-failure? x: Fixture => Bool.
exercises-shape? x: Fixture => Bool.

---

> Every new positive fixture exercises a target shape and is allowlisted.
all x: Fixture | exercises-shape? x -> known-failure? x.
```


## Implementation Notes

- Positive fixtures are allowlisted even though today they still emit `UNSUPPORTED`; this keeps Patch 1 aligned with the follow-up behavior patches, where those snapshots should start emitting `cond` before wasm typecheck is re-enabled by removing the allowlist rows.
- The negative fixtures are intentionally not added to `known-typecheck-failures`: they already emit explicit `UNSUPPORTED` lines, and `emitAndCheck` skips wasm for deliberate rejections while still snapshotting the exact refusal. This preserves the rejection contract without broadening the typecheck-failure allowlist.
- The switch fall-through negative uses a non-returning first case block followed by the next case, so it exercises the existing “case must end with `return EXPR`” path rather than a non-literal-label or default-order rejection.
- Spec/Evidence Mapping:
  - `exercises-shape? x -> known-failure? x`: positive block-arm fixtures are registered in `tools/ts2pant/tests/known-typecheck-failures.mts` under `block-early-return-arm`; positive switch block-clause fixtures are registered under `switch-block-clause`.
  - Fixture coverage: `tools/ts2pant/tests/fixtures/constructs/expressions-block-early-return.ts` covers single binding, multiple bindings, param-referencing binding, multiple early-return arms, mutating block arms, and effectful-const rejection; `expressions-switch-block-clause.ts` covers numeric/string block clauses plus non-literal and fall-through refusals.
  - Required context consulted: `known-typecheck-failures.mts`, `constructs.test.mts`, `constructs.test.mts.snapshot`, and `helpers.mts`.
  - Evidence: `just ts2pant-precommit` passed, including biome, `tsc --noEmit`, wasm build, unit tests, and integration tests.