### PR TITLE
[ts2pant-body-lowering-completeness] Patch 2: Block-bodied early-return arms (pure + mutating) → cond with inlined bindings

### DIFF
--- a/tools/ts2pant/src/ir1-build-body.ts
+++ b/tools/ts2pant/src/ir1-build-body.ts
@@ -1121,6 +1121,12 @@ function buildL1MutationBlockChildren(
               "branch const bindings must use identifier declarations with initializers",
           };
         }
+        if (ctx.iterRefs?.has(decl.name.text)) {
+          return {
+            unsupported:
+              "branch const binding cannot shadow the foreach iterator binder",
+          };
+        }
         if (expressionHasSideEffects(decl.initializer, ctx.checker)) {
           return { unsupported: "branch const initializer has side effects" };
         }

--- a/tools/ts2pant/src/ir1-build-body.ts
+++ b/tools/ts2pant/src/ir1-build-body.ts
@@ -56,6 +56,7 @@ import {
   tryBuildL1Cardinality,
   tryBuildL1PureSubExpression,
 } from "./ir1-build.js";
+import { substituteIR1StmtSubtree } from "./ir1-substitute.js";
 import type { OpaqueExpr } from "./pant-ast.js";
 import {
   ambiguousFieldMsg,
@@ -990,7 +991,6 @@ function buildL1MutationBody(
   ctx: BuildBodyCtx,
 ): BuildResult<IR1Stmt> {
   if (ts.isBlock(stmt)) {
-    const stmts: IR1Stmt[] = [];
     // Strip iterator-INDEPENDENT guard statements (`assert(...)`,
     // `if (g) throw …`) so branch-local preconditions don't surface
     // as unsupported branch bodies; this matches the top-level SSA
@@ -1015,12 +1015,9 @@ function buildL1MutationBody(
       }
       // iterator-independent guard — strip
     }
-    for (const child of children) {
-      const built = buildL1MutationBody(child, ctx);
-      if (isUnsupported(built)) {
-        return built;
-      }
-      stmts.push(built);
+    const stmts = buildL1MutationBlockChildren(children, ctx);
+    if (isUnsupported(stmts)) {
+      return stmts;
     }
     if (stmts.length === 0) {
       return { unsupported: "empty branch body" };
@@ -1075,6 +1072,113 @@ function buildL1MutationBody(
     unsupported:
       "branch body must be a property assignment, Map/Set effect, or nested if",
   };
+}
+
+function buildL1MutationBlockChildren(
+  children: readonly ts.Statement[],
+  ctx: BuildBodyCtx,
+): BuildResult<IR1Stmt[]> {
+  const hasConstBinding = children.some(
+    (child) =>
+      ts.isVariableStatement(child) &&
+      (child.declarationList.flags & ts.NodeFlags.Const) !== 0,
+  );
+  if (!hasConstBinding) {
+    const stmts: IR1Stmt[] = [];
+    for (const child of children) {
+      const built = buildL1MutationBody(child, ctx);
+      if (isUnsupported(built)) {
+        return built;
+      }
+      stmts.push(built);
+    }
+    return stmts;
+  }
+
+  let scopedParams = new Map(ctx.paramNames);
+  const substitutions: Array<{ localName: string; value: IR1Expr }> = [];
+  const built: IR1Stmt[] = [];
+  let seenNonConst = false;
+
+  for (const [idx, child] of children.entries()) {
+    if (
+      ts.isVariableStatement(child) &&
+      (child.declarationList.flags & ts.NodeFlags.Const) !== 0
+    ) {
+      if (seenNonConst) {
+        return {
+          unsupported:
+            "branch const bindings must precede property assignments or return",
+        };
+      }
+      for (const [
+        declIdx,
+        decl,
+      ] of child.declarationList.declarations.entries()) {
+        if (!ts.isIdentifier(decl.name) || decl.initializer === undefined) {
+          return {
+            unsupported:
+              "branch const bindings must use identifier declarations with initializers",
+          };
+        }
+        if (expressionHasSideEffects(decl.initializer, ctx.checker)) {
+          return { unsupported: "branch const initializer has side effects" };
+        }
+        const laterNames = new Set(
+          [
+            ...child.declarationList.declarations.slice(declIdx),
+            ...children
+              .slice(idx + 1)
+              .flatMap((s) =>
+                ts.isVariableStatement(s)
+                  ? [...s.declarationList.declarations]
+                  : [],
+              ),
+          ]
+            .map((d) => (ts.isIdentifier(d.name) ? d.name.text : null))
+            .filter((name): name is string => name !== null),
+        );
+        if (expressionReferencesNames(decl.initializer, laterNames)) {
+          return {
+            unsupported: "branch const initializer references a later binding",
+          };
+        }
+        const value = buildL1SubExpr(decl.initializer, {
+          ...ctx,
+          paramNames: scopedParams,
+        });
+        if (isUnsupported(value) || isL1Unsupported(value)) {
+          return { unsupported: value.unsupported };
+        }
+        const localName = freshHygienicBinder(ctx.supply);
+        substitutions.push({ localName, value });
+        scopedParams = new Map(scopedParams);
+        scopedParams.set(decl.name.text, localName);
+      }
+      continue;
+    }
+
+    seenNonConst = true;
+    if (ts.isReturnStatement(child) && idx !== children.length - 1) {
+      return { unsupported: "return in branch block must be final" };
+    }
+    const lowered = buildL1MutationBody(child, {
+      ...ctx,
+      paramNames: scopedParams,
+    });
+    if (isUnsupported(lowered)) {
+      return lowered;
+    }
+    built.push(lowered);
+  }
+
+  return built.map((stmt) =>
+    substitutions.reduceRight(
+      (acc, binding) =>
+        substituteIR1StmtSubtree(acc, ir1Var(binding.localName), binding.value),
+      stmt,
+    ),
+  );
 }
 
 /**

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -98,7 +98,7 @@ import {
 } from "./translate-types.js";
 import {
   type ExtractedBlockConstBinding,
-  extractBlockReturnFromStatements,
+  extractBlockReturn,
 } from "./ts-ast-block-return.js";
 import type { PantDeclaration, PropResult } from "./types.js";
 
@@ -1719,10 +1719,7 @@ function recognizeLetWhilePair(
  * branch shapes. An if with an `else` falls through to the existing
  * terminal-position handling unchanged.
  */
-function recognizeEarlyReturnArm(
-  stmt: ts.Statement,
-  checker: ts.TypeChecker,
-): {
+function recognizeEarlyReturnArm(stmt: ts.Statement): {
   predicateExpr: ts.Expression;
   valueExpr: ts.Expression;
   blockBindings: readonly ExtractedBlockConstBinding[];
@@ -1747,9 +1744,7 @@ function recognizeEarlyReturnArm(
   if (!ts.isBlock(body)) {
     return null;
   }
-  const extracted = extractBlockReturnFromStatements(
-    body.statements.filter((s) => !isGuardStatement(s, checker)),
-  );
+  const extracted = extractBlockReturn(body);
   if (extracted === null) {
     return null;
   }
@@ -1789,7 +1784,7 @@ function extractReturnExpression(
       continue;
     }
 
-    const arm = recognizeEarlyReturnArm(stmts[i]!, checker);
+    const arm = recognizeEarlyReturnArm(stmts[i]!);
     if (arm) {
       bindings.push({ kind: "earlyReturn", ...arm });
       i += 1;
@@ -1901,7 +1896,7 @@ function describeRejectedBody(body: ts.Block, checker: ts.TypeChecker): string {
         continue;
       }
       const stmt = stmts[i]!;
-      if (recognizeEarlyReturnArm(stmt, checker)) {
+      if (recognizeEarlyReturnArm(stmt)) {
         i += 1;
         continue;
       }
@@ -1964,7 +1959,7 @@ function describeRejectedBody(body: ts.Block, checker: ts.TypeChecker): string {
   if (
     ts.isIfStatement(stmt) &&
     !stmt.elseStatement &&
-    recognizeEarlyReturnArm(stmt, checker) !== null
+    recognizeEarlyReturnArm(stmt) !== null
   ) {
     return "if-without-else as final statement (use `if (P) return E` for early-return arms or add an else branch)";
   }

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -54,6 +54,7 @@ import {
   lowerScalarSsaEarlyExitMerge,
   type ScalarSsaEarlyExitPropertyInput,
 } from "./ir1-ssa-scalars.js";
+import { substituteIR1ExprSubtree } from "./ir1-substitute.js";
 import {
   getOperandDeclaredType,
   type NullishTranslate,
@@ -95,6 +96,10 @@ import {
   toPantTermName,
   UNSUPPORTED_UNKNOWN_REASON,
 } from "./translate-types.js";
+import {
+  type ExtractedBlockConstBinding,
+  extractBlockReturn,
+} from "./ts-ast-block-return.js";
 import type { PantDeclaration, PropResult } from "./types.js";
 
 // --- Const-binding inlining infrastructure (let-elimination) ---
@@ -270,6 +275,7 @@ type PreludeStmt =
       kind: "earlyReturn";
       predicateExpr: ts.Expression;
       valueExpr: ts.Expression;
+      blockBindings: readonly ExtractedBlockConstBinding[];
     };
 
 /** Names a binding introduces into scope (none for an early-return arm). */
@@ -1713,9 +1719,11 @@ function recognizeLetWhilePair(
  * branch shapes. An if with an `else` falls through to the existing
  * terminal-position handling unchanged.
  */
-function recognizeEarlyReturnArm(
-  stmt: ts.Statement,
-): { predicateExpr: ts.Expression; valueExpr: ts.Expression } | null {
+function recognizeEarlyReturnArm(stmt: ts.Statement): {
+  predicateExpr: ts.Expression;
+  valueExpr: ts.Expression;
+  blockBindings: readonly ExtractedBlockConstBinding[];
+} | null {
   if (!ts.isIfStatement(stmt)) {
     return null;
   }
@@ -1723,20 +1731,28 @@ function recognizeEarlyReturnArm(
     return null;
   }
   const body = stmt.thenStatement;
-  let returnStmt: ts.Statement | null = null;
   if (ts.isReturnStatement(body)) {
-    returnStmt = body;
-  } else if (ts.isBlock(body) && body.statements.length === 1) {
-    returnStmt = body.statements[0]!;
+    if (body.expression === undefined) {
+      return null;
+    }
+    return {
+      predicateExpr: stmt.expression,
+      valueExpr: body.expression,
+      blockBindings: [],
+    };
   }
-  if (
-    !returnStmt ||
-    !ts.isReturnStatement(returnStmt) ||
-    !returnStmt.expression
-  ) {
+  if (!ts.isBlock(body)) {
     return null;
   }
-  return { predicateExpr: stmt.expression, valueExpr: returnStmt.expression };
+  const extracted = extractBlockReturn(body);
+  if (extracted === null) {
+    return null;
+  }
+  return {
+    predicateExpr: stmt.expression,
+    valueExpr: extracted.returnExpr,
+    blockBindings: extracted.bindings,
+  };
 }
 
 function extractReturnExpression(
@@ -1890,7 +1906,7 @@ function describeRejectedBody(body: ts.Block, checker: ts.TypeChecker): string {
         if (stmt.elseStatement) {
           return "if-with-else only supported as the final statement";
         }
-        return "if-with-return body must be a single return statement";
+        return "if-with-return block must contain only const bindings followed by a return";
       }
       // A let; while pair where recognizeLetWhilePair failed — probably a
       // compound while body or non-`i++` body.
@@ -2397,6 +2413,28 @@ function lowerPreludeBindings(
       if (expressionHasSideEffects(binding.predicateExpr, checker)) {
         return { error: "early-return predicate has side effects" };
       }
+      for (const [blockIdx, blockBinding] of binding.blockBindings.entries()) {
+        if (expressionHasSideEffects(blockBinding.initializer, checker)) {
+          return { error: "early-return block const has side effects" };
+        }
+        const blockBlockedNames = new Set(
+          binding.blockBindings.slice(blockIdx).map((b) => b.tsName),
+        );
+        if (
+          expressionReferencesNames(blockBinding.initializer, blockBlockedNames)
+        ) {
+          return {
+            error:
+              "early-return block const initializer references a later binding",
+          };
+        }
+        if (expressionReferencesNames(blockBinding.initializer, blockedNames)) {
+          return {
+            error:
+              "early-return block const initializer references a later binding",
+          };
+        }
+      }
       if (expressionHasSideEffects(binding.valueExpr, checker)) {
         return { error: "early-return value has side effects" };
       }
@@ -2439,14 +2477,27 @@ function lowerPreludeBindings(
         if ("error" in predRes) {
           return { tag: "error", error: predRes.error };
         }
-        const valRes = translateBindingInit(
-          binding.valueExpr,
-          checker,
-          strategy,
-          acc.scopedParams,
-          state,
-          supply,
-        );
+        const valRes =
+          binding.blockBindings.length === 0
+            ? translateBindingInit(
+                binding.valueExpr,
+                checker,
+                strategy,
+                acc.scopedParams,
+                state,
+                supply,
+              )
+            : translateEarlyReturnBlockValue(
+                binding.blockBindings,
+                binding.valueExpr,
+                {
+                  checker,
+                  strategy,
+                  scopedParams: acc.scopedParams,
+                  state: state ?? makeSymbolicState(),
+                  supply,
+                },
+              );
         if ("error" in valRes) {
           return { tag: "error", error: valRes.error };
         }
@@ -2592,6 +2643,62 @@ function lowerPreludeBindings(
 }
 
 type BindingInitResult = { value: OpaqueExpr } | { error: string };
+
+function translateEarlyReturnBlockValue(
+  bindings: readonly ExtractedBlockConstBinding[],
+  valueExpr: ts.Expression,
+  ctx: {
+    checker: ts.TypeChecker;
+    strategy: NumericStrategy;
+    scopedParams: ReadonlyMap<string, string>;
+    state: SymbolicState;
+    supply: UniqueSupply;
+  },
+): BindingInitResult {
+  let scopedParams: ReadonlyMap<string, string> = new Map(ctx.scopedParams);
+  const substitutions: Array<{
+    localName: string;
+    value: IR1Expr;
+  }> = [];
+
+  for (const binding of bindings) {
+    const localName = allocLocalBindingName(
+      ctx.supply,
+      toPantTermName(binding.tsName),
+      scopedParams,
+    );
+    const initExpr = buildL1SubExpr(binding.initializer, {
+      checker: ctx.checker,
+      strategy: ctx.strategy,
+      paramNames: scopedParams,
+      state: ctx.state,
+      supply: ctx.supply,
+    });
+    if (isUnsupported(initExpr) || isL1Unsupported(initExpr)) {
+      return { error: initExpr.unsupported };
+    }
+    substitutions.push({ localName, value: initExpr });
+    scopedParams = withParam(scopedParams, binding.tsName, localName);
+  }
+
+  const value = buildL1SubExpr(valueExpr, {
+    checker: ctx.checker,
+    strategy: ctx.strategy,
+    paramNames: scopedParams,
+    state: ctx.state,
+    supply: ctx.supply,
+  });
+  if (isUnsupported(value) || isL1Unsupported(value)) {
+    return { error: value.unsupported };
+  }
+
+  const inlined = substitutions.reduceRight(
+    (acc, binding) =>
+      substituteIR1ExprSubtree(acc, ir1Var(binding.localName), binding.value),
+    value,
+  );
+  return { value: applyOpaqueAliases(lowerL1ToOpaque(inlined), ctx.supply) };
+}
 
 function translateBindingInit(
   initializer: ts.Expression,

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -98,7 +98,7 @@ import {
 } from "./translate-types.js";
 import {
   type ExtractedBlockConstBinding,
-  extractBlockReturn,
+  extractBlockReturnFromStatements,
 } from "./ts-ast-block-return.js";
 import type { PantDeclaration, PropResult } from "./types.js";
 
@@ -1719,7 +1719,10 @@ function recognizeLetWhilePair(
  * branch shapes. An if with an `else` falls through to the existing
  * terminal-position handling unchanged.
  */
-function recognizeEarlyReturnArm(stmt: ts.Statement): {
+function recognizeEarlyReturnArm(
+  stmt: ts.Statement,
+  checker: ts.TypeChecker,
+): {
   predicateExpr: ts.Expression;
   valueExpr: ts.Expression;
   blockBindings: readonly ExtractedBlockConstBinding[];
@@ -1744,7 +1747,9 @@ function recognizeEarlyReturnArm(stmt: ts.Statement): {
   if (!ts.isBlock(body)) {
     return null;
   }
-  const extracted = extractBlockReturn(body);
+  const extracted = extractBlockReturnFromStatements(
+    body.statements.filter((s) => !isGuardStatement(s, checker)),
+  );
   if (extracted === null) {
     return null;
   }
@@ -1784,7 +1789,7 @@ function extractReturnExpression(
       continue;
     }
 
-    const arm = recognizeEarlyReturnArm(stmts[i]!);
+    const arm = recognizeEarlyReturnArm(stmts[i]!, checker);
     if (arm) {
       bindings.push({ kind: "earlyReturn", ...arm });
       i += 1;
@@ -1896,7 +1901,7 @@ function describeRejectedBody(body: ts.Block, checker: ts.TypeChecker): string {
         continue;
       }
       const stmt = stmts[i]!;
-      if (recognizeEarlyReturnArm(stmt)) {
+      if (recognizeEarlyReturnArm(stmt, checker)) {
         i += 1;
         continue;
       }
@@ -1959,7 +1964,7 @@ function describeRejectedBody(body: ts.Block, checker: ts.TypeChecker): string {
   if (
     ts.isIfStatement(stmt) &&
     !stmt.elseStatement &&
-    recognizeEarlyReturnArm(stmt) !== null
+    recognizeEarlyReturnArm(stmt, checker) !== null
   ) {
     return "if-without-else as final statement (use `if (P) return E` for early-return arms or add an else branch)";
   }
@@ -2662,11 +2667,7 @@ function translateEarlyReturnBlockValue(
   }> = [];
 
   for (const binding of bindings) {
-    const localName = allocLocalBindingName(
-      ctx.supply,
-      toPantTermName(binding.tsName),
-      scopedParams,
-    );
+    const localName = freshHygienicBinder(ctx.supply);
     const initExpr = buildL1SubExpr(binding.initializer, {
       checker: ctx.checker,
       strategy: ctx.strategy,

--- a/tools/ts2pant/src/ts-ast-block-return.ts
+++ b/tools/ts2pant/src/ts-ast-block-return.ts
@@ -1,0 +1,51 @@
+import ts from "typescript";
+
+export interface ExtractedBlockConstBinding {
+  tsName: string;
+  initializer: ts.Expression;
+}
+
+export interface ExtractedBlockReturn {
+  bindings: readonly ExtractedBlockConstBinding[];
+  returnExpr: ts.Expression;
+}
+
+/**
+ * Extract a block shaped as `(const name = expr;)* return expr;`.
+ *
+ * This helper is deliberately TS-AST-only: purity, TDZ, and lowering checks
+ * stay with the caller because pure bodies, mutating bodies, and switch
+ * clauses have different surrounding contexts.
+ */
+export function extractBlockReturn(
+  block: ts.Block,
+): ExtractedBlockReturn | null {
+  if (block.statements.length === 0) {
+    return null;
+  }
+  const last = block.statements[block.statements.length - 1]!;
+  if (!ts.isReturnStatement(last) || last.expression === undefined) {
+    return null;
+  }
+
+  const bindings: ExtractedBlockConstBinding[] = [];
+  for (const stmt of block.statements.slice(0, -1)) {
+    if (
+      !ts.isVariableStatement(stmt) ||
+      !(stmt.declarationList.flags & ts.NodeFlags.Const)
+    ) {
+      return null;
+    }
+    for (const decl of stmt.declarationList.declarations) {
+      if (!ts.isIdentifier(decl.name) || decl.initializer === undefined) {
+        return null;
+      }
+      bindings.push({
+        tsName: decl.name.text,
+        initializer: decl.initializer,
+      });
+    }
+  }
+
+  return { bindings, returnExpr: last.expression };
+}

--- a/tools/ts2pant/src/ts-ast-block-return.ts
+++ b/tools/ts2pant/src/ts-ast-block-return.ts
@@ -20,16 +20,22 @@ export interface ExtractedBlockReturn {
 export function extractBlockReturn(
   block: ts.Block,
 ): ExtractedBlockReturn | null {
-  if (block.statements.length === 0) {
+  return extractBlockReturnFromStatements(block.statements);
+}
+
+export function extractBlockReturnFromStatements(
+  statements: readonly ts.Statement[],
+): ExtractedBlockReturn | null {
+  if (statements.length === 0) {
     return null;
   }
-  const last = block.statements[block.statements.length - 1]!;
+  const last = statements[statements.length - 1]!;
   if (!ts.isReturnStatement(last) || last.expression === undefined) {
     return null;
   }
 
   const bindings: ExtractedBlockConstBinding[] = [];
-  for (const stmt of block.statements.slice(0, -1)) {
+  for (const stmt of statements.slice(0, -1)) {
     if (
       !ts.isVariableStatement(stmt) ||
       !(stmt.declarationList.flags & ts.NodeFlags.Const)

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -83,31 +83,31 @@ exports[`expressions-array.ts > nameLengths 1`] = `
 `;
 
 exports[`expressions-block-early-return.ts > blockEarlyReturnBindingReferencesParam 1`] = `
-"module BLOCK_EARLY_RETURN_BINDING_REFERENCES_PARAM.\\n\\nblock-early-return-binding-references-param n: Int, offset: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: block-early-return-binding-references-param — if-with-return body must be a single return statement.\\n"
+"module BLOCK_EARLY_RETURN_BINDING_REFERENCES_PARAM.\\n\\nblock-early-return-binding-references-param n: Int, offset: Int => Int.\\n\\n---\\n\\nblock-early-return-binding-references-param n offset = (cond n < offset => offset - n, true => n + offset).\\n"
 `;
 
 exports[`expressions-block-early-return.ts > blockEarlyReturnEffectfulConstRejected 1`] = `
-"module BLOCK_EARLY_RETURN_EFFECTFUL_CONST_REJECTED.\\n\\ncompute n1: Int => Int.\\nblock-early-return-effectful-const-rejected n: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: block-early-return-effectful-const-rejected — if-with-return body must be a single return statement.\\n"
+"module BLOCK_EARLY_RETURN_EFFECTFUL_CONST_REJECTED.\\n\\ncompute n1: Int => Int.\\nblock-early-return-effectful-const-rejected n: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: block-early-return-effectful-const-rejected — early-return block const has side effects.\\n"
 `;
 
 exports[`expressions-block-early-return.ts > blockEarlyReturnMultipleBindings 1`] = `
-"module BLOCK_EARLY_RETURN_MULTIPLE_BINDINGS.\\n\\nblock-early-return-multiple-bindings n: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: block-early-return-multiple-bindings — if-with-return body must be a single return statement.\\n"
+"module BLOCK_EARLY_RETURN_MULTIPLE_BINDINGS.\\n\\nblock-early-return-multiple-bindings n: Int => Int.\\n\\n---\\n\\nblock-early-return-multiple-bindings n = (cond n < 0 => (0 - n) * 2, true => n).\\n"
 `;
 
 exports[`expressions-block-early-return.ts > blockEarlyReturnMutatingMultipleBindings 1`] = `
-"module BLOCK_EARLY_RETURN_MUTATING_MULTIPLE_BINDINGS.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--limit a1: Account => Int.\\n~> Block-early-return-mutating-multiple-bindings @ a: Account, g: Bool, amount: Int.\\n\\n---\\n\\n> UNSUPPORTED: branch body must be a property assignment, Map/Set effect, or nested if.\\n"
+"module BLOCK_EARLY_RETURN_MUTATING_MULTIPLE_BINDINGS.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--limit a1: Account => Int.\\n~> Block-early-return-mutating-multiple-bindings @ a: Account, g: Bool, amount: Int.\\n\\n---\\n\\naccount--balance' a = (cond g => (cond account--balance a + amount < account--limit a => account--balance a + amount, true => account--limit a), true => account--balance a).\\naccount--limit' a1 = account--limit a1.\\n"
 `;
 
 exports[`expressions-block-early-return.ts > blockEarlyReturnMutatingSingleBinding 1`] = `
-"module BLOCK_EARLY_RETURN_MUTATING_SINGLE_BINDING.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--limit a1: Account => Int.\\n~> Block-early-return-mutating-single-binding @ a: Account, g: Bool, amount: Int.\\n\\n---\\n\\n> UNSUPPORTED: branch body must be a property assignment, Map/Set effect, or nested if.\\n"
+"module BLOCK_EARLY_RETURN_MUTATING_SINGLE_BINDING.\\n\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--limit a1: Account => Int.\\n~> Block-early-return-mutating-single-binding @ a: Account, g: Bool, amount: Int.\\n\\n---\\n\\naccount--balance' a = (cond g => account--balance a + amount, true => account--balance a).\\naccount--limit' a1 = account--limit a1.\\n"
 `;
 
 exports[`expressions-block-early-return.ts > blockEarlyReturnNestedArms 1`] = `
-"module BLOCK_EARLY_RETURN_NESTED_ARMS.\\n\\nblock-early-return-nested-arms n: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: block-early-return-nested-arms — if-with-return body must be a single return statement.\\n"
+"module BLOCK_EARLY_RETURN_NESTED_ARMS.\\n\\nblock-early-return-nested-arms n: Int => Int.\\n\\n---\\n\\nblock-early-return-nested-arms n = (cond n < 0 => 0 - n, n = 0 => n + 1, true => n).\\n"
 `;
 
 exports[`expressions-block-early-return.ts > blockEarlyReturnSingleBinding 1`] = `
-"module BLOCK_EARLY_RETURN_SINGLE_BINDING.\\n\\nblock-early-return-single-binding n: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: block-early-return-single-binding — if-with-return body must be a single return statement.\\n"
+"module BLOCK_EARLY_RETURN_SINGLE_BINDING.\\n\\nblock-early-return-single-binding n: Int => Int.\\n\\n---\\n\\nblock-early-return-single-binding n = (cond n < 0 => 0 - n, true => n + 1).\\n"
 `;
 
 exports[`expressions-boolean.ts > and 1`] = `

--- a/tools/ts2pant/tests/known-typecheck-failures.mts
+++ b/tools/ts2pant/tests/known-typecheck-failures.mts
@@ -47,39 +47,12 @@
  *   - "annotation-types"  the user's `@pant` annotation is itself
  *                         ill-typed against the emitted signature
  *                         (e.g. comparing a Bool result to an Int).
- *   - "block-early-return-arm"
- *                         pending body-lowering support for block-bodied
- *                         early-return/mutating arms with const bindings.
  *   - "switch-block-clause"
  *                         pending L1 switch support for case/default
  *                         clauses that are blocks ending in a return.
  */
 export const KNOWN_TYPECHECK_FAILURES = new Map<string, string>([
   ["control-flow.ts > max", "$-binder-leak"],
-  [
-    "expressions-block-early-return.ts > blockEarlyReturnBindingReferencesParam",
-    "block-early-return-arm",
-  ],
-  [
-    "expressions-block-early-return.ts > blockEarlyReturnMutatingMultipleBindings",
-    "block-early-return-arm",
-  ],
-  [
-    "expressions-block-early-return.ts > blockEarlyReturnMutatingSingleBinding",
-    "block-early-return-arm",
-  ],
-  [
-    "expressions-block-early-return.ts > blockEarlyReturnMultipleBindings",
-    "block-early-return-arm",
-  ],
-  [
-    "expressions-block-early-return.ts > blockEarlyReturnNestedArms",
-    "block-early-return-arm",
-  ],
-  [
-    "expressions-block-early-return.ts > blockEarlyReturnSingleBinding",
-    "block-early-return-arm",
-  ],
   ["expressions-array.ts > nameLengths", "$-binder-leak"],
   ["expressions-boolean.ts > and", "$-binder-leak"],
   ["expressions-boolean.ts > or", "$-binder-leak"],

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -597,6 +597,36 @@ describe("if-early-return prelude arms", () => {
     }
   });
 
+  it("pure block-bodied early-return arm strips branch-local guards", () => {
+    const source = `
+      function assert(condition: unknown): asserts condition {
+        if (!condition) throw new Error("no");
+      }
+      export function f(n: number, ok: boolean): number {
+        if (n < 0) {
+          assert(ok);
+          const z = 0 - n;
+          return z;
+        }
+        return n + 1;
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "f",
+      strategy: IntStrategy,
+    });
+    const prop = finalEquation(props);
+    if (prop.kind === "equation") {
+      const ast = getAst();
+      assert.equal(
+        ast.strExpr(prop.rhs),
+        "cond n < 0 => 0 - n, true => n + 1",
+      );
+    }
+  });
+
   it("composes arms with a μ-search prelude", () => {
     const source = `
       export function f(n: number, used: ReadonlySet<number>): number {
@@ -1716,6 +1746,32 @@ describe("structured iteration (for-of, forEach, reduce)", () => {
       props,
       /property rooted at the iterator binder/,
       "expected the non-iter-rooted-assign rejection",
+    );
+  });
+
+  it("rejects const bindings that shadow foreach iterators inside branches", () => {
+    const source = `
+      interface Item { total: number; }
+      interface Account { total: number; }
+      function f(xs: Item[], acc: Account, g: boolean): void {
+        for (const x of xs) {
+          if (g) {
+            const x = acc;
+            x.total = 1;
+          }
+        }
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "f",
+      strategy: IntStrategy,
+    });
+    assertUnsupportedReason(
+      props,
+      /cannot shadow the foreach iterator binder/,
+      "expected the foreach iterator shadowing rejection",
     );
   });
 

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -571,9 +571,7 @@ describe("if-early-return prelude arms", () => {
     }
   });
 
-  it.skip("pure block-bodied early-return arm lowers to cond with inlined bindings", () => {
-    // PENDING Patch 2: recognize block arms containing const bindings
-    // ending in `return`, inline the bindings, and feed the existing cond.
+  it("pure block-bodied early-return arm lowers to cond with inlined bindings", () => {
     const source = `
       export function f(n: number): number {
         if (n < 0) {
@@ -622,11 +620,11 @@ describe("if-early-return prelude arms", () => {
     }
   });
 
-  it("rejects an if-with-multi-statement body in prelude position", () => {
+  it("rejects a block early-return arm with non-const local bindings", () => {
     const source = `
       export function f(n: number): number {
         if (n < 0) {
-          const x = 1;
+          let x = 1;
           return x;
         }
         return n;
@@ -641,7 +639,7 @@ describe("if-early-return prelude arms", () => {
     assert.equal(props.length, 1);
     assert.equal(props[0]?.kind, "unsupported");
     if (props[0]?.kind === "unsupported") {
-      assert.match(props[0].reason, /single return statement/u);
+      assert.match(props[0].reason, /only const bindings followed by a return/u);
     }
   });
 
@@ -874,9 +872,7 @@ describe("if-early-return prelude arms", () => {
 });
 
 describe("body-lowering completeness pending stubs", () => {
-  it.skip("mutating block-bodied arm lowers to cond post-state with inlined binding", () => {
-    // PENDING Patch 2: buildL1MutationBody accepts guarded blocks with
-    // const bindings before terminal property assignments.
+  it("mutating block-bodied arm lowers to cond post-state with inlined binding", () => {
     const source = `
       interface Account { balance: number; }
       export function f(a: Account, g: boolean, amount: number): void {

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -597,7 +597,7 @@ describe("if-early-return prelude arms", () => {
     }
   });
 
-  it("pure block-bodied early-return arm strips branch-local guards", () => {
+  it("rejects pure block-bodied early-return arms with branch-local guards", () => {
     const source = `
       function assert(condition: unknown): asserts condition {
         if (!condition) throw new Error("no");
@@ -617,12 +617,12 @@ describe("if-early-return prelude arms", () => {
       functionName: "f",
       strategy: IntStrategy,
     });
-    const prop = finalEquation(props);
-    if (prop.kind === "equation") {
-      const ast = getAst();
-      assert.equal(
-        ast.strExpr(prop.rhs),
-        "cond n < 0 => 0 - n, true => n + 1",
+    assert.equal(props.length, 1);
+    assert.equal(props[0]?.kind, "unsupported");
+    if (props[0]?.kind === "unsupported") {
+      assert.match(
+        props[0].reason,
+        /only const bindings followed by a return/u,
       );
     }
   });


### PR DESCRIPTION
## Patch 2: Block-bodied early-return arms (pure + mutating) → cond with inlined bindings

- Implement extractBlockReturn as a pure TS-AST helper, exported for reuse by Patch 3 (place it where both translate-body.ts and ir1-build.ts can import without a module cycle — relocate to a shared util if needed).
- Pure path: generalize recognizeEarlyReturnArm to accept then-blocks of (const)* + single return; inline block-local consts into the arm value via substituteIR1ExprSubtree (capture-avoiding), reusing the existing const-prelude lowering discipline so a binding referencing an earlier binding or a param resolves correctly.
- Mutating path: extend buildL1MutationBody to accept const bindings inside a guarded block, inlining them into the property-assignment / return values so the block reduces to assignments-only and feeds the existing lowerScalarSsaEarlyExitMerge cond post-state; keep rejecting effectful const initializers, loops, expression statements, and non-final returns.
- Update describeRejectedBody to drop the now-supported pure case (keep precise messages for effectful block consts).
- Clear the block-early-return-arm allowlist entries, regenerate snapshots, unskip the unit tests; confirm no unrelated snapshot churn and that the effectful-block-const negative still rejects.

## Changes
- Implement extractBlockReturn as a pure TS-AST helper, exported for reuse by Patch 3 (place it where both translate-body.ts and ir1-build.ts can import without a module cycle — relocate to a shared util if needed).
- Pure path: generalize recognizeEarlyReturnArm to accept then-blocks of (const)* + single return; inline block-local consts into the arm value via substituteIR1ExprSubtree (capture-avoiding), reusing the existing const-prelude lowering discipline so a binding referencing an earlier binding or a param resolves correctly.
- Mutating path: extend buildL1MutationBody to accept const bindings inside a guarded block, inlining them into the property-assignment / return values so the block reduces to assignments-only and feeds the existing lowerScalarSsaEarlyExitMerge cond post-state; keep rejecting effectful const initializers, loops, expression statements, and non-final returns.
- Update describeRejectedBody to drop the now-supported pure case (keep precise messages for effectful block consts).
- Clear the block-early-return-arm allowlist entries, regenerate snapshots, unskip the unit tests; confirm no unrelated snapshot churn and that the effectful-block-const negative still rejects.

## Files to Modify
- tools/ts2pant/src/translate-body.ts (modify): Add `extractBlockReturn(block)` returning the (const bindings, terminal return) of a block of const declarations ending in a single return, else null. Generalize recognizeEarlyReturnArm to accept a then-block via extractBlockReturn; in lowerPreludeBindings' earlyReturn arm, inline the block-local consts into the arm value (substituteIR1ExprSubtree or the existing const-prelude inlining) before adding the [predicate, value] pair to the cond. Update describeRejectedBody so the pure block-arm shape is no longer described as rejected; effectful/impure block consts still return null.
- tools/ts2pant/src/ir1-build-body.ts (modify): Extend buildL1MutationBody to accept const-binding statements inside a (guarded) mutation block: inline each const into the subsequent property-assignment / return values via substituteIR1ExprSubtree so the block reduces to assignments-only, which then feeds the existing lowerScalarSsaEarlyExitMerge cond post-state. Reject effectful const initializers (conservative refusal).
- tools/ts2pant/tests/known-typecheck-failures.mts (modify): Remove the block-early-return-arm entries (pure and mutating).
- tools/ts2pant/tests/constructs.test.mts.snapshot (modify): Add snapshots for the block-early-return fixtures (pure cond with inlined bindings; mutating cond post-state).
- tools/ts2pant/tests/translate-body.test.mts (modify): Unskip and implement the pure block-arm and mutating block-arm stubs; assert the binding is inlined into the arm value / assignment value.

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[algorithm] Capture-avoiding substitution** — Inlining a block-local `const z = e` into the arm's return value (pure) or into a subsequent assignment value (mutating) is substitution of `z := e`; it must be capture-avoiding (a binding may reference an earlier binding or a param). Use the in-repo substituteIR1ExprSubtree primitive rather than naive textual replacement.

## Gameplan Specification

```
module BODY_LOWERING_COMPLETENESS.

> Imperative body-lowering accepts two previously-rejected control-flow
> shapes, each reduced to the existing cond machinery: early-return arms
> (pure and mutating bodies) whose then-branch is a block of const
> bindings ending in a single return or mutation; and switch case/default
> clauses that are blocks ending in a single return. Block-local const
> bindings are inlined via capture-avoiding substitution. No new
> SMT/summary semantics.

Body.
Arm.
Clause.

block-arm? a: Arm => Bool.
arm-lowered? a: Arm => Bool.
inlines-bindings? a: Arm => Bool.
block-clause? c: Clause => Bool.
clause-lowered? c: Clause => Bool.
typechecks? b: Body => Bool.

---

> Every block-bodied early-return arm (pure or mutating) lowers, and its
> value inlines the block-local const bindings.
all a: Arm | block-arm? a -> arm-lowered? a and inlines-bindings? a.
> Every switch case/default clause that is a block ending in a return lowers.
all c: Clause | block-clause? c -> clause-lowered? c.
> Bodies built only from supported shapes type-check.
all b: Body | typechecks? b.
```

## Patch Specification

```
module BODY_LOWERING_COMPLETENESS_PATCH_2.

Arm.
block-arm? a: Arm => Bool.
lowered? a: Arm => Bool.
inlines-bindings? a: Arm => Bool.

---

> An early-return arm whose then-branch is a block of const bindings
> ending in a single return (pure body) or in a mutation/return
> (mutating body) lowers to a cond arm / cond post-state whose value
> inlines the bindings via capture-avoiding substitution.
all a: Arm | block-arm? a -> lowered? a and inlines-bindings? a.
```


## Implementation Notes

- `extractBlockReturn` lives in a new TS-AST-only utility module (`ts-ast-block-return.ts`) rather than `translate-body.ts`, so Patch 3 can reuse it from switch lowering without importing the pure-body translator or creating a module cycle.
- Pure block-arm inlining is done while the arm value is still IR1. The block-local consts are lowered left-to-right with a temporary scoped param map, then substituted right-to-left with `substituteIR1ExprSubtree`; this preserves chained bindings like `base -> doubled` without emitting block-local rule declarations.
- Mutating block consts use temporary hygienic IR1 vars and `substituteIR1StmtSubtree` over the built branch statements. This intentionally substitutes through the whole statement, so return values and assignment RHS values both benefit, while receivers would also remain coherent if a future supported shape used a const receiver.
- The pure diagnostic changed from the old "single return statement" rejection to a narrower block-shape rejection. Effectful block consts now reach the lowerer and produce the more specific `early-return block const has side effects` snapshot.
- The implementation keeps the planned conservative boundary: only leading `const` declarations inside mutating blocks are accepted; consts after mutations, effectful initializers, malformed declarations, and non-final returns still reject before SSA lowering.

Spec/Evidence Mapping:
- Patch spec `block-arm? -> lowered? and inlines-bindings?`: implemented by `recognizeEarlyReturnArm` plus `translateEarlyReturnBlockValue` for pure arms, and `buildL1MutationBlockChildren` for mutating arms.
- Required context consulted: `translate-body.ts` prelude lowering, `ir1-build-body.ts` branch-body lowering, `ir1-substitute.ts` substitution primitives, and the constructs/known-failure snapshot harness.
- Evidence: `just ts2pant-typecheck`, `just ts2pant-lint-ci`, `npm run test:update-snapshots`, and `just ts2pant-test` all passed. The block early-return allowlist entries were removed, snapshots now show inlined cond output, and the effectful const fixture still rejects with a specific reason.