### PR TITLE
[ts2pant-body-lowering-completeness] Patch 3: Switch case/default clauses that are blocks ending in a return → cond

### DIFF
--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -95,6 +95,10 @@ import {
   type NumericStrategy,
   toPantTermName,
 } from "./translate-types.js";
+import {
+  type ExtractedBlockReturn,
+  extractBlockReturn,
+} from "./ts-ast-block-return.js";
 
 /**
  * Context threaded through L1 build. Mirrors the parameter set of
@@ -2382,14 +2386,13 @@ function buildFromSwitchStatement(
     if (isL1Unsupported(labelL1)) {
       return labelL1;
     }
-    const ret = extractCaseReturn(clause);
-    if (!ret) {
+    const value = lowerCaseReturnValue(clause, ctx);
+    if (value === null) {
       return {
         unsupported:
           "switch case must end with `return EXPR` (no fall-through, no break/throw cases in M1)",
       };
     }
-    const value = buildSubExpr(ret, ctx);
     if (isL1Unsupported(value)) {
       return value;
     }
@@ -2398,13 +2401,12 @@ function buildFromSwitchStatement(
 
   // Default clause.
   const defaultClause = clauses[defaultIdx] as ts.DefaultClause;
-  const defaultRet = extractCaseReturn(defaultClause);
-  if (!defaultRet) {
+  const otherwise = lowerCaseReturnValue(defaultClause, ctx);
+  if (otherwise === null) {
     return {
       unsupported: "switch default must end with `return EXPR`",
     };
   }
-  const otherwise = buildSubExpr(defaultRet, ctx);
   if (isL1Unsupported(otherwise)) {
     return otherwise;
   }
@@ -2473,12 +2475,108 @@ function buildCaseLabel(
  * any case body containing more than one statement, or with a
  * non-return last statement.
  */
+function lowerCaseReturnValue(
+  clause: ts.CaseClause | ts.DefaultClause,
+  ctx: L1BuildContext,
+): L1BuildResult | null {
+  const extracted = extractCaseReturn(clause);
+  if (extracted === null) {
+    return null;
+  }
+  if (extracted.bindings.length === 0) {
+    return buildSubExpr(extracted.returnExpr, ctx);
+  }
+  return lowerBlockReturnValue(extracted, ctx);
+}
+
+function lowerBlockReturnValue(
+  extracted: ExtractedBlockReturn,
+  ctx: L1BuildContext,
+): L1BuildResult {
+  let scopedParams: ReadonlyMap<string, string> = new Map(ctx.paramNames);
+  const substitutions: Array<{ localName: string; value: IR1Expr }> = [];
+
+  for (const [idx, binding] of extracted.bindings.entries()) {
+    if (expressionHasSideEffects(binding.initializer, ctx.checker)) {
+      return { unsupported: "switch block const has side effects" };
+    }
+    const blockedNames = new Set(
+      extracted.bindings.slice(idx).map((b) => b.tsName),
+    );
+    if (expressionReferencesNames(binding.initializer, blockedNames)) {
+      return {
+        unsupported:
+          "switch block const initializer references a later binding",
+      };
+    }
+
+    const value = buildSubExpr(binding.initializer, {
+      ...ctx,
+      paramNames: scopedParams,
+    });
+    if (isL1Unsupported(value)) {
+      return value;
+    }
+    const localName = allocateSwitchBlockLocalName(
+      toPantTermName(binding.tsName),
+      scopedParams,
+      ctx.supply,
+    );
+    substitutions.push({ localName, value });
+    scopedParams = withParam(scopedParams, binding.tsName, localName);
+  }
+
+  if (expressionHasSideEffects(extracted.returnExpr, ctx.checker)) {
+    return { unsupported: "switch block return value has side effects" };
+  }
+  const value = buildSubExpr(extracted.returnExpr, {
+    ...ctx,
+    paramNames: scopedParams,
+  });
+  if (isL1Unsupported(value)) {
+    return value;
+  }
+
+  return substitutions.reduceRight(
+    (acc, binding) =>
+      substituteIR1ExprSubtree(acc, ir1Var(binding.localName), binding.value),
+    value,
+  );
+}
+
+function allocateSwitchBlockLocalName(
+  hint: string,
+  scopedParams: ReadonlyMap<string, string>,
+  supply: UniqueSupply,
+): string {
+  if (supply.synthCell) {
+    return cellRegisterName(supply.synthCell, hint);
+  }
+  const used = new Set(scopedParams.values());
+  if (!used.has(hint)) {
+    return hint;
+  }
+  let name: string;
+  do {
+    name = `${hint}${supply.n}`;
+    supply.n += 1;
+  } while (used.has(name));
+  return name;
+}
+
+function withParam<K, V>(m: ReadonlyMap<K, V>, k: K, v: V): ReadonlyMap<K, V> {
+  const next = new Map(m);
+  next.set(k, v);
+  return next;
+}
+
 function extractCaseReturn(
   clause: ts.CaseClause | ts.DefaultClause,
-): ts.Expression | null {
+): ExtractedBlockReturn | null {
   // Filter to the structural body. Each case body is a list of
-  // statements at the top level (TS doesn't wrap them in a Block by
-  // default). M1 requires exactly one statement: `return EXPR;`.
+  // statements at the top level (TS doesn't wrap them in a Block by default).
+  // M1 requires exactly one effective statement: either `return EXPR;` or a
+  // block shaped as `(const name = expr;)* return expr;`.
   const stmts = clause.statements;
   if (stmts.length === 0) {
     // Empty case body = fall-through. Reject.
@@ -2491,22 +2589,16 @@ function extractCaseReturn(
   if (lastIdx > 0 && stmts[lastIdx]!.kind === ts.SyntaxKind.BreakStatement) {
     lastIdx--;
   }
-  const last: ts.Statement = stmts[lastIdx]!;
-  // Accept `{ return EXPR; }` block.
-  if (
-    ts.isBlock(last) &&
-    last.statements.length === 1 &&
-    ts.isReturnStatement(last.statements[0]!) &&
-    last.statements[0]!.expression
-  ) {
-    return last.statements[0]!.expression!;
-  }
   // Only one effective statement allowed (after trailing-break trim).
   if (lastIdx !== 0) {
     return null;
   }
+  const last: ts.Statement = stmts[lastIdx]!;
+  if (ts.isBlock(last)) {
+    return extractBlockReturn(last);
+  }
   if (ts.isReturnStatement(last) && last.expression) {
-    return last.expression;
+    return { bindings: [], returnExpr: last.expression };
   }
   return null;
 }

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -2517,11 +2517,7 @@ function lowerBlockReturnValue(
     if (isL1Unsupported(value)) {
       return value;
     }
-    const localName = allocateSwitchBlockLocalName(
-      toPantTermName(binding.tsName),
-      scopedParams,
-      ctx.supply,
-    );
+    const localName = freshHygienicBinder(ctx.supply);
     substitutions.push({ localName, value });
     scopedParams = withParam(scopedParams, binding.tsName, localName);
   }
@@ -2542,26 +2538,6 @@ function lowerBlockReturnValue(
       substituteIR1ExprSubtree(acc, ir1Var(binding.localName), binding.value),
     value,
   );
-}
-
-function allocateSwitchBlockLocalName(
-  hint: string,
-  scopedParams: ReadonlyMap<string, string>,
-  supply: UniqueSupply,
-): string {
-  if (supply.synthCell) {
-    return cellRegisterName(supply.synthCell, hint);
-  }
-  const used = new Set(scopedParams.values());
-  if (!used.has(hint)) {
-    return hint;
-  }
-  let name: string;
-  do {
-    name = `${hint}${supply.n}`;
-    supply.n += 1;
-  } while (used.has(name));
-  return name;
 }
 
 function withParam<K, V>(m: ReadonlyMap<K, V>, k: K, v: V): ReadonlyMap<K, V> {

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -851,7 +851,7 @@ exports[`expressions-switch-block-clause.ts > switchBlockClauseFallThrough 1`] =
 `;
 
 exports[`expressions-switch-block-clause.ts > switchBlockClauseMultipleBindings 1`] = `
-"module SWITCH_BLOCK_CLAUSE_MULTIPLE_BINDINGS.\\n\\nswitch-block-clause-multiple-bindings x: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: switch-block-clause-multiple-bindings — switch case must end with \`return EXPR\` (no fall-through, no break/throw cases in M1).\\n"
+"module SWITCH_BLOCK_CLAUSE_MULTIPLE_BINDINGS.\\n\\nswitch-block-clause-multiple-bindings x: Int => Int.\\n\\n---\\n\\nswitch-block-clause-multiple-bindings x = (cond x = 0 => (x + 1) * 2, x = 1 => x + 10, true => x - 1).\\n"
 `;
 
 exports[`expressions-switch-block-clause.ts > switchBlockClauseNonLiteralLabel 1`] = `
@@ -859,11 +859,11 @@ exports[`expressions-switch-block-clause.ts > switchBlockClauseNonLiteralLabel 1
 `;
 
 exports[`expressions-switch-block-clause.ts > switchBlockClauseSingleBinding 1`] = `
-"module SWITCH_BLOCK_CLAUSE_SINGLE_BINDING.\\n\\nswitch-block-clause-single-binding x: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: switch-block-clause-single-binding — switch case must end with \`return EXPR\` (no fall-through, no break/throw cases in M1).\\n"
+"module SWITCH_BLOCK_CLAUSE_SINGLE_BINDING.\\n\\nswitch-block-clause-single-binding x: Int => Int.\\n\\n---\\n\\nswitch-block-clause-single-binding x = (cond x = 0 => x + 10, true => x + 1).\\n"
 `;
 
 exports[`expressions-switch-block-clause.ts > switchBlockClauseStringLabel 1`] = `
-"module SWITCH_BLOCK_CLAUSE_STRING_LABEL.\\n\\nswitch-block-clause-string-label s: String => Int.\\n\\n---\\n\\n> UNSUPPORTED: switch-block-clause-string-label — switch case must end with \`return EXPR\` (no fall-through, no break/throw cases in M1).\\n"
+"module SWITCH_BLOCK_CLAUSE_STRING_LABEL.\\n\\nswitch-block-clause-string-label s: String => Int.\\n\\n---\\n\\nswitch-block-clause-string-label s = (cond s = \\"ready\\" => 1, true => 0).\\n"
 `;
 
 exports[`expressions-template-literal.ts > concatTwo 1`] = `

--- a/tools/ts2pant/tests/known-typecheck-failures.mts
+++ b/tools/ts2pant/tests/known-typecheck-failures.mts
@@ -47,9 +47,6 @@
  *   - "annotation-types"  the user's `@pant` annotation is itself
  *                         ill-typed against the emitted signature
  *                         (e.g. comparing a Bool result to an Int).
- *   - "switch-block-clause"
- *                         pending L1 switch support for case/default
- *                         clauses that are blocks ending in a return.
  */
 export const KNOWN_TYPECHECK_FAILURES = new Map<string, string>([
   ["control-flow.ts > max", "$-binder-leak"],
@@ -58,18 +55,6 @@ export const KNOWN_TYPECHECK_FAILURES = new Map<string, string>([
   ["expressions-boolean.ts > or", "$-binder-leak"],
   ["expressions-let-closure-captured.ts > letForEachCapturedTotal", "closure-captured-reassignment"],
   ["expressions-let-closure-captured.ts > letMapCapturedCount", "closure-captured-reassignment"],
-  [
-    "expressions-switch-block-clause.ts > switchBlockClauseMultipleBindings",
-    "switch-block-clause",
-  ],
-  [
-    "expressions-switch-block-clause.ts > switchBlockClauseSingleBinding",
-    "switch-block-clause",
-  ],
-  [
-    "expressions-switch-block-clause.ts > switchBlockClauseStringLabel",
-    "switch-block-clause",
-  ],
   ["expressions-var-rejected.ts > varBinding", "var-rejected"],
   ["expressions-var-rejected.ts > varReassignment", "var-rejected"],
   ["functions-class.ts > Account.getBalance", "requires-external-context"],

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -931,9 +931,7 @@ describe("body-lowering completeness pending stubs", () => {
     }
   });
 
-  it.skip("switch block clause lowers to cond", () => {
-    // PENDING Patch 3: extract const bindings plus terminal return from
-    // switch case/default blocks and inline them into the cond arms.
+  it("switch block clause lowers to cond", () => {
     const source = `
       export function f(x: number): number {
         switch (x) {


### PR DESCRIPTION
## Patch 3: Switch case/default clauses that are blocks ending in a return → cond

- Reuse extractBlockReturn (Patch 2) to recognize block clauses ending in a single return; import it from its shared location.
- Inline clause-local consts into the case's return value before it becomes a cond arm value; the existing buildFromSwitchStatement eq(discriminant,label) cond assembly is unchanged.
- Confirm non-literal-label and fall-through switches still reach their existing UNSUPPORTED messages (negative fixtures).
- Clear the switch-block-clause allowlist entries, regenerate snapshots, unskip the unit test.

## Changes
- Reuse extractBlockReturn (Patch 2) to recognize block clauses ending in a single return; import it from its shared location.
- Inline clause-local consts into the case's return value before it becomes a cond arm value; the existing buildFromSwitchStatement eq(discriminant,label) cond assembly is unchanged.
- Confirm non-literal-label and fall-through switches still reach their existing UNSUPPORTED messages (negative fixtures).
- Clear the switch-block-clause allowlist entries, regenerate snapshots, unskip the unit test.

## Files to Modify
- tools/ts2pant/src/ir1-build.ts (modify): Extend extractCaseReturn to accept a clause that is a block of (const)* + single `return E`, reusing extractBlockReturn from Patch 2 (imported from its shared location to avoid a module cycle). Inline the clause-local consts into the returned value. Leave buildCaseLabel (non-literal labels ~2464) and the fall-through guard (~2389) rejections unchanged.
- tools/ts2pant/tests/known-typecheck-failures.mts (modify): Remove the switch-block-clause entries; leave the non-literal-label and fall-through negatives.
- tools/ts2pant/tests/constructs.test.mts.snapshot (modify): Add snapshots for the switch-block-clause fixtures.
- tools/ts2pant/tests/translate-body.test.mts (modify): Unskip and implement the switch-block-clause cond stub.

## Gameplan Specification

```
module BODY_LOWERING_COMPLETENESS.

> Imperative body-lowering accepts two previously-rejected control-flow
> shapes, each reduced to the existing cond machinery: early-return arms
> (pure and mutating bodies) whose then-branch is a block of const
> bindings ending in a single return or mutation; and switch case/default
> clauses that are blocks ending in a single return. Block-local const
> bindings are inlined via capture-avoiding substitution. No new
> SMT/summary semantics.

Body.
Arm.
Clause.

block-arm? a: Arm => Bool.
arm-lowered? a: Arm => Bool.
inlines-bindings? a: Arm => Bool.
block-clause? c: Clause => Bool.
clause-lowered? c: Clause => Bool.
typechecks? b: Body => Bool.

---

> Every block-bodied early-return arm (pure or mutating) lowers, and its
> value inlines the block-local const bindings.
all a: Arm | block-arm? a -> arm-lowered? a and inlines-bindings? a.
> Every switch case/default clause that is a block ending in a return lowers.
all c: Clause | block-clause? c -> clause-lowered? c.
> Bodies built only from supported shapes type-check.
all b: Body | typechecks? b.
```

## Patch Specification

```
module BODY_LOWERING_COMPLETENESS_PATCH_3.

Clause.
block-clause? c: Clause => Bool.
lowered? c: Clause => Bool.

---

> A switch case/default clause that is a block ending in a single
> return lowers to a cond arm (reusing the block-return extraction).
> Non-literal labels and fall-through remain rejected.
all c: Clause | block-clause? c -> lowered? c.
```


## Implementation Notes

- `extractCaseReturn` now returns the shared `ExtractedBlockReturn` shape for both plain `return E` clauses and block clauses. The switch assembly still only sees an already-lowered arm value, so the existing `eq(discriminant, label)` cond construction was left unchanged.
- Clause-local const names are allocated only as temporary L1 substitution targets. They are never emitted as Pant declarations; after reducing substitutions right-to-left, the final cond arm contains the inlined values directly.
- I kept the structural fall-through guard conservative: after trimming a trailing `break`, a case/default must still have exactly one effective top-level statement. This preserves the existing rejection surface for fall-through and multi-statement case bodies while allowing the one supported block shape.
- Spec/Evidence Mapping:
  - `block-clause? c -> lowered? c`: implemented by `lowerCaseReturnValue` / `lowerBlockReturnValue` in `tools/ts2pant/src/ir1-build.ts`; snapshots now show cond output for single-binding, multi-binding, and string-label block clauses.
  - `Non-literal labels and fall-through remain rejected`: `buildCaseLabel` is unchanged and `extractCaseReturn` still returns `null` for fall-through; the negative construct snapshots remain UNSUPPORTED.
  - Required context consulted: `ir1-build.ts`, `ir1-substitute.ts`, `known-typecheck-failures.mts`, `constructs.test.mts`, `helpers.mts`, and `translate-body.test.mts`.
  - Verification: `just ts2pant-test-unit`, `just ts2pant-test-integration`, `just ts2pant-lint-ci`, and `npx tsc --noEmit` all passed under the shared `/Users/zax/code-src/pantagruel` opam switch.