### PR TITLE
Add guard-analysis & discriminated-union workstreams; close free-call-decl

### DIFF
--- a/workstreams/ts2pant-discriminated-union.md
+++ b/workstreams/ts2pant-discriminated-union.md
@@ -1,0 +1,310 @@
+# Workstream: ts2pant Discriminated-Union Handling
+
+## Vision
+
+Give ts2pant first-class support for TypeScript discriminated unions: a value
+of `type Shape = {kind:"circle";r} | {kind:"square";s}` translates to a single
+Pantagruel domain with a discriminant rule and per-variant field rules guarded
+by the discriminant literal, and `if (x.kind === "circle") … x.r …` /
+`switch (x.kind)` narrowing discharges those guards so variant-field access is
+provable. The end state turns today's `> UNSUPPORTED: ambiguous owner` refusal
+into sound, entailing tagged-union semantics — unblocking self-translation of
+ts2pant's own discriminated-union-heavy code (`IR1Expr`, `IR1Stmt`, the
+translator result types) and any user code that models sum types this way.
+
+## Current State
+
+ts2pant has **no awareness of discriminated unions as a concept** and **no type
+narrowing at all** (confirmed: narrowing is explicitly deferred at
+`ir1-build.ts:1173` — "literal-union narrowing is deferred to a follow-up;
+uniform rejection" — and `nullish-recognizer.ts` deliberately avoids relying on
+TS flow-narrowing). Today each union member is encoded as its **own synthesized
+record domain joined by Pant's sum `+`** (`tag x: KindRRec + KindSRec => …`),
+and field access goes through the generic `resolveFieldOwner` /
+`collectFieldOwners` path (`translate-types.ts` ~870/895):
+
+- A field unique to one member resolves to that member's accessor and "works"
+  (e.g. `radius x = kind-r-rec--r x`) — but possibly **unsoundly**, since the
+  accessor is applied to the whole union.
+- A field on ≥2 distinct owners (the discriminant `.kind`, or a field
+  independently declared on each member) returns `ambiguous` and the access is
+  **refused** (`ir1-build.ts:1346`, `translate-body.ts:1582`).
+
+There is no discriminant detection, no literal-tag handling, and no
+variant-membership concept. The closest existing machinery is the **Map
+guarded-rule encoding** (`entriesKey c k` guards `entries c k`), which is exactly
+the shape this workstream generalizes.
+
+## Key Challenges
+
+- **The encoding must be sound without narrowing, and entail with it.** The
+  guarded-rule encoding (`shape--r s: Shape, shape--kind s = "circle" => Int`)
+  is sound by construction even before narrowing exists — the guard simply isn't
+  discharged, identical to how `.get(k)!` produces a guarded `entries` rule
+  today. The open question is whether it **entails** under z3 once narrowing
+  discharges the guard (string-literal-equality guards, variant disjointness).
+  This is a measurement, not an assumption — hence the survey milestone.
+
+- **Narrowing is greenfield and the hardest part.** Reading `x.kind` is trivial
+  under this encoding (a plain rule), but the *value* of DUs is narrowing:
+  inside `if (x.kind === "circle")`, the guard `shape--kind x = "circle"` must
+  flow into the branch context so `shape--r x` is discharged. ts2pant has no
+  flow-narrowing layer, and the any/unknown-opaque workstream already flagged
+  that "TS flow narrowing … does not always survive ts2pant's intermediate
+  representations." M3 therefore builds **local intra-function narrowing on top
+  of the guard-analysis workstream's flow-narrowing layer**, rather than a
+  bespoke mechanism (see Decisions).
+
+- **It is a migration, not just an addition.** The tagged encoding replaces the
+  `+`-of-records encoding for discriminated unions — including the currently-
+  "working" unique-field case — so M1 is a behavior change to existing output,
+  and the full retirement of `+`-records (for non-discriminated unions, nested
+  unions, intersections) is staged into M4 to bound regression risk.
+
+- **Structural detection only — no field-name special-casing.** Per a hard
+  project constraint, the translator must NOT recognize `.kind` / `_tag` /
+  `type` by name. "Discriminated" is a structural property: a field present on
+  every union member whose type is a *distinct literal* on each member. Any
+  union lacking such a field stays on the existing refusal/`+`-records path.
+
+- **Variant-field guards interact with the SSA/mutation and switch paths.**
+  Field access inside `switch (x.kind)` clauses and `if` branches must thread
+  the discriminant guard through the same machinery that lowers conditionals and
+  (eventually) mutations.
+
+## Established Precedents
+
+- **existing-implementation — In-repo Map guarded-rule encoding** —
+  `tools/ts2pant/src/translate-types.ts` + `tools/ts2pant/tests/fixtures/constructs/expressions-map.ts`
+  The direct template for the whole workstream: `Map<K,V>` on a field expands to
+  `entriesKey c k: … => Bool` (membership predicate) + `entries c k: …, entriesKey c k => V`
+  (value rule guarded by the predicate), and the `congruence` fixture shows it
+  entails under z3. The DU encoding is the same shape — a discriminant rule plus
+  per-variant field rules guarded by `discriminant = literal` — synthesized
+  through the same synth-cell infrastructure (`cellRegisterMap`-style
+  registration, `emitXSynthDecls`-style emission). Every milestone touches this.
+
+- **algorithm — McCarthy theory of arrays + guarded (Dafny-style) preconditions** —
+  https://doi.org/10.1145/321033.321034
+  The semantic model for guarded field access: a variant field is a partial
+  function defined only where its discriminant guard holds, mirroring
+  McCarthy select guarded by a membership/precondition predicate (the same
+  framing the Map encoding cites). Shapes M1's guarded rules and M3's
+  guard-discharge obligation.
+
+- **paper — Kroening & Strichman, Decision Procedures Ch. 4 (EUF)** —
+  https://www.decision-procedures.org/
+  The discriminant rule and per-variant field rules are uninterpreted functions;
+  soundness rests on congruence, and the discriminant-literal guards add only
+  sound equalities. The survey (M2) measures entailment against this floor; M3's
+  narrowing must not introduce an unsound axiom.
+
+## Milestones
+
+### Milestone 1: du-tagged-encoding
+
+**Definition of Done**:
+- A TypeScript union detected as **discriminated** — structurally: a field
+  present on every member whose type is a distinct literal (string/number/bool)
+  on each member, with no field-name special-casing — synthesizes a single Pant
+  domain with: a discriminant rule (`shape--kind s: Shape => String`) and, for
+  each member, that member's field accessor rules **guarded by the discriminant
+  literal** (`shape--r s: Shape, shape--kind s = "circle" => Int`). Registered
+  via the synth-cell infrastructure and emitted alongside the existing
+  record/map synth decls.
+- Field access on a discriminated-union receiver emits the guarded rule
+  application (discriminant read is unguarded; variant-field read carries its
+  guard), replacing the `ambiguous owner` refusal **and** the current
+  unique-field `+`-records accessor for discriminated unions.
+- Non-discriminated unions, intersections, and nested unions are untouched —
+  they keep the existing `+`-records encoding / ambiguous refusal.
+- No narrowing: variant-field reads are well-formed but their guards are not yet
+  discharged (sound-by-guard, identical to `Map.get` today). Fixtures
+  type-check; entailment of variant-field assertions is not yet expected.
+
+**Why this is a safe pause point**: Discriminated unions now emit a sound,
+type-checking tagged encoding instead of a refusal; nothing regresses for
+non-discriminated unions (untouched path). Variant-field assertions may not
+entail yet, but no emitted document is unsound — the guards are present and
+simply undischarged, exactly the established Map-encoding posture. If the team
+stops here, ts2pant emits well-formed tagged-union Pant for every discriminated
+union, a meaningful standalone improvement.
+
+**Unlocks**: M2 can measure entailment of the new encoding and inventory the
+narrowing patterns that would discharge the guards.
+
+**Operator Actions Before Next Milestone**:
+- Run `npm run -s test:unit` and `npm run -s test:integration`; confirm no
+  regression on the non-discriminated-union corpus and that discriminated-union
+  fixtures type-check.
+- Spot-check 2–3 emitted tagged encodings against their TS source to confirm the
+  discriminant detection is structural (not name-based) and the guards are
+  correct.
+
+**Established Precedents** (milestone-scoped): none beyond the workstream-level
+Map encoding + McCarthy/Dafny guards, which this milestone consumes directly.
+
+**Open Questions**:
+- Synthesis home and naming: does the DU domain register through the same synth
+  cell as records/maps, and what is the domain-name derivation (must avoid the
+  field-name-based naming the current `+`-records path uses)? Resolve during
+  M1's gameplan.
+- Disjointness: should the encoding emit an explicit invariant that the
+  discriminant's literal values are pairwise distinct across variants, or rely
+  on congruence alone? Resolve during M1's gameplan.
+
+---
+
+### Milestone 2: du-entailment-narrowing-survey
+
+**Definition of Done**:
+- A read-only survey over the dogfood + constructs corpus: for each
+  discriminated-union `@pant` assertion (and a set of authored probe
+  assertions), classify under `pant --check` (z3) as type-checks / entails /
+  blocked-on-narrowing / blocked-on-a-missing-encoding-invariant.
+- An inventory of the **narrowing patterns** that actually appear: `if (x.kind
+  === lit)`, `switch (x.kind)`, early-return guards on the discriminant, and
+  whether they are intra-function (in scope) or cross-call/assertion-function
+  (out of scope per the local-only decision).
+- A committed survey report (under `tools/ts2pant/docs/`) with: per-pattern
+  counts, the entailment verdict on the M1 encoding (does the guarded encoding
+  entail once a guard is assumed?), and a concrete narrowing design proposal
+  that names the guard-analysis flow-narrowing layer M3 will consume.
+- No translator behavior change — measurement only.
+
+**Why this is a safe pause point**: Nothing changed in emitted output; the
+codebase is exactly as it was after M1 plus a report. The measure→decide
+boundary that justifies splitting narrowing out from the encoding.
+
+**Unlocks**: An evidence-based go/no-go and scope for M3, and confirmation that
+the M1 encoding entails once guards are discharged (or a list of encoding
+invariants to add first).
+
+**Operator Actions Before Next Milestone** (the measure→decide boundary):
+- **Review the survey report and decide whether to proceed to M3.** Proposed
+  gating criterion (confirm during M2's gameplan): proceed iff (a) the M1
+  encoding entails under z3 when a discriminant guard is assumed, and (b) ≥ a
+  threshold of real intra-function narrowing sites exist in the corpus. If the
+  encoding does not entail even with the guard assumed, do NOT start M3 — open an
+  encoding-fix follow-up first.
+- **Confirm the guard-analysis dependency is ready.** M3 consumes the
+  guard-analysis workstream's flow-narrowing layer; verify that milestone has
+  landed (or sequence M3 after it). If it has not, M3 is blocked — do not start.
+- **Abort condition**: if the survey shows the dominant blocker is
+  cross-call/assertion narrowing (out of scope), reduce M3 to the intra-function
+  subset or defer.
+
+**Open Questions**:
+- The exact gating threshold and the precise interface M3 will consume from the
+  guard-analysis layer. Resolve during M2 (the survey produces them).
+
+---
+
+### Milestone 3: du-discriminant-narrowing
+
+**Definition of Done**:
+- **Local, intra-function** narrowing: inside `if (x.kind === lit)` /
+  `switch (x.kind)` / early-return guards on the discriminant, the guard
+  `shape--kind x = lit` is propagated into the branch context so variant-field
+  reads (`shape--r x`) have their guards discharged and the corresponding
+  `@pant` assertions entail under z3.
+- Narrowing is built on the **guard-analysis workstream's flow-narrowing /
+  predicate-following layer** (consumed, not reinvented); cross-call and
+  assertion-function narrowing remain out of scope and refused, matching the
+  any/unknown-opaque workstream's "cross-function-call narrowing not trusted by
+  default" decision.
+- The survey's flagged narrowing assertions now entail; the survey's before/
+  after entailment set guards against regressions.
+
+**Why this is a safe pause point**: Discriminated-union access is now provable in
+the common narrowed patterns; un-narrowed access remains sound-by-guard. The
+headline DU use case (`switch (x.kind)` returning per-variant fields) works
+end-to-end.
+
+**Unlocks**: M4 cutover — once narrowing is proven, the old `+`-records encoding
+has no remaining advantage for discriminated unions and can be retired.
+
+**Operator Actions Before Next Milestone**:
+- Confirm the before/after entailment set from M2 shows no regression and the
+  targeted narrowing assertions now entail.
+
+**Established Precedents** (milestone-scoped):
+- **existing-implementation — guard-analysis flow-narrowing layer** —
+  (the guard-analysis workstream's deliverable; path TBD when that workstream is
+  planned) — M3 consumes its discriminant-guard propagation rather than building
+  a bespoke narrowing mechanism. This is a **cross-workstream dependency**.
+
+**Open Questions**:
+- The precise propagation surface for the discriminant guard through ts2pant's
+  IR/SSA (the any/unknown workstream flagged that flow narrowing "does not always
+  survive" the IR). Resolve during M3's gameplan, informed by the guard-analysis
+  layer's actual shape.
+
+---
+
+### Milestone 4: du-cutover
+
+**Definition of Done**:
+- The `+`-of-records encoding is retired for all discriminated unions; the tagged
+  encoding is the sole path.
+- Nested discriminated unions and discriminated unions inside other synthesized
+  types (records, maps, arrays) are handled or explicitly, soundly refused.
+- Non-discriminated unions and intersections retain a clear, sound refusal (no
+  silent unsound accessor); the unique-field-on-the-`+`-records-path unsoundness
+  noted in Current State is eliminated.
+- Documentation under `tools/ts2pant/docs/` describes the tagged-union encoding
+  and its narrowing.
+
+**Why this is a safe pause point**: Terminal milestone. Discriminated unions have
+a single, sound, narrowing-capable encoding; the legacy path is gone; the
+remaining union shapes are soundly refused. The DU story is complete.
+
+**Unlocks**: Closes the workstream. Any remaining union expressivity (general
+non-discriminated unions) is a separate effort with its own encoding question.
+
+**Operator Actions Before Next Milestone**: none (terminal).
+
+**Open Questions**:
+- Whether non-discriminated unions get any encoding at all, or stay permanently
+  refused. Default: stay refused (no special-casing, no unsound accessor).
+  Revisit only with a separate workstream.
+
+## Dependency Graph
+
+```text
+1 (du-tagged-encoding)            → []
+2 (du-entailment-narrowing-survey) → [1]
+3 (du-discriminant-narrowing)     → [2]  + cross-workstream: guard-analysis flow-narrowing layer
+4 (du-cutover)                    → [3]
+```
+
+**Note**: Strictly sequential. M1–M2 can proceed immediately. M3 is additionally
+**gated on the guard-analysis workstream** delivering a flow-narrowing /
+predicate-following layer (Decisions, below); if that workstream has not landed
+when M2 completes, M3 waits. M4 depends on M3's narrowing being proven.
+
+## Open Questions
+
+| Question | Notes | Resolve By |
+|----------|-------|------------|
+| Does the M1 guarded encoding entail under z3 once a discriminant guard is assumed? | The whole basis for M3. Measured, not assumed. | Milestone 2 (survey) |
+| Gating threshold for proceeding to M3 | Count of real intra-function narrowing sites + encoding-entails verdict. | Milestone 2 |
+| Interface M3 consumes from the guard-analysis flow-narrowing layer | Depends on that workstream being planned. | Milestone 2 / guard-analysis planning |
+| Discriminant disjointness invariant: emit explicitly or rely on congruence? | Affects M1 encoding. | Milestone 1 |
+| Fate of non-discriminated unions | Default: permanently refused, no unsound accessor. | Milestone 4 |
+
+## Decisions Made
+
+These are decisions that did NOT produce a citable precedent — framing,
+constraints, and rejected approaches. Accepted precedents (Map guarded-rule
+encoding, McCarthy/Dafny guards, Kroening & Strichman EUF) live in `Established
+Precedents`.
+
+| Decision | Rationale |
+|----------|-----------|
+| No field-name / discriminant special-casing in the translation layer | Hard project constraint (2026-05-27): the translator must not recognize `.kind`/`_tag`/`type` by name. "Discriminated" is detected structurally (a field whose type is a distinct literal on every member). A name-based shortcut would unblock discriminant reads but leave narrowing unsound — worse than a clean refusal. |
+| Guarded-rule encoding (not a `cond`-dispatch reduction) | A probe showed the current `+`-records encoding can't lower `x.kind` via cond-dispatch (circular: reading the discriminant is the access). The guarded-rule encoding (discriminant rule + per-variant guarded field rules) reads the discriminant directly and makes variant fields partial-on-the-guard — directly analogous to the proven Map encoding. |
+| M3 narrowing is local intra-function only | Matches the any/unknown-opaque workstream's "cross-function-call narrowing not trusted by default" decision. Cross-call / assertion-function narrowing is out of scope; bounded and self-contained. |
+| M3 narrowing depends on (consumes) the guard-analysis workstream's flow-narrowing layer | Chosen over a bespoke DU-only narrowing mechanism: narrowing is shared infrastructure, and ts2pant has none today. This introduces a cross-workstream dependency (M3 gates on guard-analysis), accepted to avoid duplicating flow-narrowing machinery that the guard-analysis roadmap must build anyway. |
+| Encoding migration staged (M1 introduces tagged encoding for discriminated unions; M4 retires `+`-records) | The tagged encoding is a behavior change to currently-emitted output, including the currently-"working" unique-field case. Staging the cutover into M4 bounds regression risk and keeps every milestone a safe pause point. |
+| Standalone workstream (not part of free-call-decl) | Discriminated-union handling is an independent capability; free-call-decl is complete at M2. |

--- a/workstreams/ts2pant-free-call-decl-synthesis.md
+++ b/workstreams/ts2pant-free-call-decl-synthesis.md
@@ -1,5 +1,16 @@
 # Workstream: ts2pant Free-Call-Decl Synthesis
 
+> **STATUS: CLOSED at M2 (2026-05-27).** M1 `free-call-opaque-floor` ✅ (PRs
+> #273–#275), M2 `stdlib-dispatch-coverage` ✅ (PRs #277–#279), M3
+> `entailment-survey` ✅ — verdict **do NOT proceed to M4**. The M4 gate (≥5
+> `@pant` assertions blocked solely on a soundly-modelable stdlib axiom) is met
+> by **0** assertions, the documented abort condition. Every call-involving
+> assertion in the corpus already entails; the M2 dispatch EUF heads are
+> unexercised by any assertion. Survey report:
+> `tools/ts2pant/docs/free-call-decl-entailment-survey.md`. The end-state goal —
+> structurally accepted → declared → type-checks, and provable where there is
+> demand — is fully realized. See M4 below for the targeted re-open trigger.
+
 ## Vision
 
 Close the `free-call-decl` gap: every TypeScript call that ts2pant accepts
@@ -126,7 +137,7 @@ stdlib not yet in the dispatch table** (`String.prototype.replace`,
 
 ## Milestones
 
-### Milestone 1: free-call-opaque-floor
+### Milestone 1: free-call-opaque-floor — ✅ COMPLETE (PRs #273–#275)
 
 **Definition of Done**:
 - Every TS call that does not dispatch to a known builtin and is not otherwise
@@ -179,7 +190,16 @@ standalone improvement.
 
 ---
 
-### Milestone 2: stdlib-dispatch-coverage
+### Milestone 2: stdlib-dispatch-coverage — ✅ COMPLETE (PRs #277–#279)
+
+> Gameplan: `gameplans/ts2pant-stdlib-dispatch-coverage.json`. Note: the survey
+> framing assumed Math/String already dispatched end-to-end; in fact built-in
+> call *emission* was entirely unwired (the table resolved but nothing consumed
+> the `BuiltinSpec`), so M2 also wired emission for the existing JS_MATH/JS_STRING
+> entries via a shared `tryBuildBuiltinCall` helper. Decided during the M2
+> gameplan: **no `JS_SET`** — `Set.has` stays on the higher-fidelity `value in s`
+> membership encoding (and `.length`/`.size` on `#` cardinality) rather than an
+> opaque EUF head.
 
 **Definition of Done**:
 - `BUILTINS` (`builtins.ts`) gains entries for the high-frequency stdlib methods
@@ -216,7 +236,19 @@ here, the floor is simply cleaner and more shareable.
 
 ---
 
-### Milestone 3: entailment-survey
+### Milestone 3: entailment-survey — ✅ COMPLETE (2026-05-27); verdict: stop, do not start M4
+
+> Run read-only, no gameplan (a single `pant --check` measurement pass + report;
+> the work did not decompose into mergeable patches). Report committed at
+> `tools/ts2pant/docs/free-call-decl-entailment-survey.md`. **Findings:** all 13
+> `@pant`-bearing fixtures checked under z3 4.15.4 (`src/` dogfood carries no
+> `@pant`). All 5 call-involving assertions entail — the two guarded-free-call
+> cases via action/guard modeling, and `Map.get`/`Map.has`/`Set.has` via the
+> structured Map (McCarthy select/store) / `in` membership encoding, **not** via
+> any M2 dispatch EUF head. **0** assertions reference a shared js-stdlib EUF rule
+> at all — the dispatched-builtin fixtures (`constMathMax`, `constArrayFromMap`,
+> …) are type-check-only with no assertion. Per-rule blocked-on-sound-axiom count:
+> JS_MATH 0, JS_STRING 0, JS_ARRAY 0, JS_MAP 0. This is the abort condition below.
 
 **Definition of Done**:
 - A read-only survey runs across the dogfood + constructs fixture corpus: for
@@ -255,7 +287,18 @@ builtins it should target.
 
 ---
 
-### Milestone 4: targeted-sound-axioms
+### Milestone 4: targeted-sound-axioms — ❌ NOT STARTED; cancelled by M3 verdict
+
+> The M3 survey met the abort condition (0 assertions blocked solely on a sound
+> stdlib axiom, threshold was ≥5), so M4 does not run. **Targeted re-open
+> trigger (not a milestone):** if a future `@pant` assertion is written that is
+> blocked *solely* on a sound structural property of a dispatched head — e.g.
+> `#(Array.from(m.values())) = <map cardinality>` or `JS_ARRAY::from` length
+> non-negativity — add that single axiom to the owning `samples/js-stdlib/*.pant`
+> module with a soundness justification, guarding before/after with the survey's
+> entailment set. String semantics stay out of scope (the `JS_STRING.pant`
+> refusal). The original M4 design (preserved below) is the reference for how to
+> do that if the trigger fires.
 
 **Definition of Done**:
 - For each shared-module rule the M3 survey selected, add EUF body axioms to its

--- a/workstreams/ts2pant-guard-analysis.md
+++ b/workstreams/ts2pant-guard-analysis.md
@@ -101,9 +101,18 @@ union, `yield* new ErrorClass()`) is unimplemented.
 
 ## Milestones
 
-### Milestone 1: guard-purity-user-calls
+### Milestone 1: guard-purity-user-calls — planned (`gameplans/ts2pant-guard-purity-user-calls.json`)
 
 **Definition of Done**:
+- **Purity-oracle consolidation (sequenced first within M1):** the two purity
+  predicates — checker-free `isPureExpression` (`translate-signature.ts:617`, all
+  calls impure) and checker-aware `expressionHasSideEffects` (`translate-body.ts`)
+  — are merged into a single checker-aware oracle in `purity.ts`; `isPureExpression`
+  is deleted and every guard/condition site routes through the one oracle, so call
+  classification is consistent across stages (known-pure builtin/Effect calls in
+  guard conditions become acceptable). Planning surfaced that the user-function
+  classifier needs the checker, which only the checker-aware predicate has, so the
+  duplication is resolved before the classifier is added.
 - A conservative user-function **purity classifier**: a called function is *pure*
   iff its body has no mutation of non-locals, no IO/throw-as-effect, no calls to
   effectful functions (recursive, visited-set guarded), and is resolvable
@@ -134,9 +143,9 @@ narrowing patterns that remain.
   through (spot-check a few inferred-pure classifications against the callee body).
 
 **Open Questions**:
-- Exact purity predicate boundary (are local `const` bindings / pure loops inside
-  the callee allowed? are recursive-but-pure functions classified pure or bailed?).
-  Resolve during M1's gameplan.
+- *(resolved during M1 gameplan)* Purity predicate boundary: pure local `const`
+  bindings and effect-free loops inside the callee are **allowed**; recursive
+  callees **bail to effectful** (visited-set). See Decisions Made.
 
 ---
 
@@ -276,6 +285,8 @@ in-repo call-following, Kroening & Strichman, TS Compiler API, Effect-TS) live i
 | Decision | Rationale |
 |----------|-----------|
 | User-function purity is **inferred** from the callee body, not annotated | Consistent with the existing conservative call-following; no new `@pure` annotation burden, and sound-by-bail (unknown ⇒ effectful) rather than trusting a possibly-mismarked human annotation. |
+| M1 **absorbs the purity-oracle consolidation** (merge `isPureExpression` + `expressionHasSideEffects` into one checker-aware oracle, delete the checker-free predicate), sequenced first within M1 — not a separate milestone | Decided while planning M1's gameplan. The classifier needs the checker, which only the checker-aware predicate has, so the duplication must be resolved first; consolidation is atomic/autonomous alongside the rest, so it folds into M1 via patch ordering rather than warranting its own milestone. Consolidation is an intended, sound behavior change (only oracle-proven-pure calls newly qualify in guard conditions), not behavior-preserving. |
+| Purity boundary: pure local `const` bindings + effect-free loops in a callee **allowed**; recursive callees **bail to effectful** | Resolves M1's open question. Allowing pure-local structure keeps the classifier useful; bailing on recursion keeps it sound and terminating (visited-set) without attempting a fixpoint. |
 | Both condition-purity and flow-narrowing live in **one workstream** | They are the two facets of "reason about which facts hold where"; flow-narrowing (M3) is the layer the DU workstream was promised to consume, so it belongs on the same roadmap rather than orphaned. |
 | Flow narrowing is **intra-function only** | Matches the any/unknown-opaque workstream's "cross-function-call narrowing not trusted by default" decision. Guard *extraction* still follows calls (already implemented); narrowing does not. |
 | No field-name / discriminant special-casing in narrowing | Inherits the project-wide constraint: discriminant-equality narrowing keys on the structural predicate `<field> === <literal>`, never on `.kind` by name. |

--- a/workstreams/ts2pant-guard-analysis.md
+++ b/workstreams/ts2pant-guard-analysis.md
@@ -1,0 +1,283 @@
+# Workstream: ts2pant Flow-Sensitive Guard & Effect Analysis
+
+## Vision
+
+Make ts2pant reason about *which facts hold where*. Two capabilities: (1) treat
+calls to pure user functions as first-class values/predicates so a condition like
+`if (isValid(x))` lowers to the synthesized EUF rule instead of being rejected as
+effectful; and (2) a flow-narrowing layer that propagates a test's truth into its
+branch (`if (P) { … assume P … }`), so guards, nullish checks, discriminant
+equalities, and type predicates discharge the obligations that depend on them.
+The end state unblocks the largest remaining dogfood class (~66 functions whose
+predicates call helpers) and provides the shared narrowing layer the
+discriminated-union workstream's M3 was promised to consume.
+
+## Current State
+
+Guard *extraction* is largely complete and conservative (the 46-day-old roadmap's
+first two items are done): `isAssertionCall` recognizes `asserts cond` functions
+via `ts.TypePredicateNode.assertsModifier` (`translate-signature.ts:298–371`);
+if-throw / if-else-throw guards are classified by `classifyGuardIf` (~712); and
+**conservative interprocedural call-following** is implemented in `followGuards` /
+`resolveCallTarget` (~380–527) — it substitutes actuals for formals and bails on
+recursion (visited set), dynamic dispatch, and `node_modules`. Extracted guards
+attach to the emitted rule/action as preconditions (`types.ts` `PantRule.guard` /
+`PantAction.guard`; emitted at `emit.ts:154–165`).
+
+Two things are **not** done:
+
+- **User calls in condition/predicate positions are rejected.**
+  `expressionHasSideEffects` (`translate-body.ts:3072`) returns `true` for *any*
+  non-builtin call, so a predicate `if (isValid(x)) …` is refused at
+  `translate-body.ts:2397` ("early-return predicate has side effects") and
+  `ir1-build-body.ts:958` ("impure if-condition in mutating body"). Free-call-decl
+  now synthesizes an EUF rule head for such a call in *value* position, but the
+  purity gate rejects it before lowering in *condition* position. There is no
+  user-function purity classifier — calls default to effectful.
+
+- **Flow narrowing does not exist** — it is explicitly greenfield. Branches are
+  lowered context-free; nothing propagates a test's truth into its branch
+  (`ir1-build.ts:1173` defers literal-union narrowing; `nullish-recognizer.ts`
+  deliberately avoids relying on TS flow-narrowing). Reading a discriminant or a
+  nullish guard produces no assumption usable inside the branch.
+
+Effect-TS *purity* classification exists (`purity.ts` `resolveEffectLibraryExport`
++ a large allowlist), but **error-channel extraction** (`Effect<A,E,R>` error
+union, `yield* new ErrorClass()`) is unimplemented.
+
+## Key Challenges
+
+- **Soundness of user-function purity inference.** Misclassifying an effectful
+  function as pure would let an unsound fact into a guard/condition. The analysis
+  must be conservative-by-bail (unknown ⇒ effectful), reusing the existing
+  call-following conservatism (recursion/dynamic-dispatch/node_modules/IO/mutation
+  ⇒ bail). Inferred, not annotated (see Decisions).
+
+- **Flow narrowing is greenfield and the deepest piece.** Propagating a predicate
+  truth into a branch as an assumption — and threading it through ts2pant's IR/SSA
+  — is new. The any/unknown-opaque workstream already flagged that TS flow
+  narrowing "does not always survive ts2pant's intermediate representations." The
+  layer must be generic enough to serve four consumers (discriminant equality,
+  nullish, user type-predicates, boolean guards) without special-casing any field
+  name. Its exact shape is the reason for a survey milestone before building it.
+
+- **Intra-function only.** Cross-call and assertion-function *narrowing* (as
+  opposed to guard extraction, which already follows calls) stays out of scope,
+  matching the any/unknown-opaque workstream's "cross-function-call narrowing not
+  trusted by default" decision.
+
+- **Two downstream consumers depend on this.** The DU workstream's M3 consumes the
+  flow-narrowing layer; the nullish recognizer and any/unknown handling can consume
+  it too. The layer's interface is a cross-workstream contract.
+
+## Established Precedents
+
+- **paper — Tobin-Hochstadt & Felleisen, "Logical Types for Untyped Languages" (occurrence typing, ICFP 2010)** — https://www2.ccs.neu.edu/racket/pubs/icfp10-thf.pdf
+  The canonical model for the flow-narrowing layer (M3): a predicate in test
+  position refines the facts that hold in each branch. TypeScript's own narrowing
+  is informally occurrence typing; ts2pant's variant refines an *assumption set*
+  whose facts are discharged by z3 rather than a type (cf. "occurrence typing
+  modulo theories", Kent et al. PLDI 2016). Shapes how M3 represents a branch
+  assumption and what predicate forms it recognizes.
+
+- **existing-implementation — in-repo conservative guard call-following** —
+  `tools/ts2pant/src/translate-signature.ts` (`followGuards`, `resolveCallTarget`, `buildSubstitutionMap`, ~380–527)
+  The conservatism template every milestone reuses: resolve a direct call to a
+  block-bodied local function, substitute actuals for formals, recurse with a
+  visited set, and bail (no fact extracted, never a wrong fact) on recursion /
+  dynamic dispatch / `node_modules`. M1's user-function purity inference and M4's
+  Effect extraction follow the same bail discipline.
+
+- **paper — Kroening & Strichman, Decision Procedures Ch. 1–4 (path conditions / EUF)** — https://www.decision-procedures.org/
+  The narrowed predicate becomes an *assumption* (path condition) discharged by the
+  solver when checking the branch's obligations; pure user calls lower to
+  uninterpreted functions whose only built-in axiom is congruence. The basis for
+  why an inferred-pure call and a narrowed guard are sound to assume.
+
+- **documentation — TypeScript Compiler API** — https://github.com/microsoft/TypeScript/wiki/Using-the-Compiler-API
+  `getTypePredicateOfSignature` / `assertsModifier` (already used for assertions;
+  reused in M3 for user `x is T` type-predicate narrowing), `getSymbolAtLocation`
+  and declaration resolution (M1 callee resolution), and control-flow inspection.
+
+## Milestones
+
+### Milestone 1: guard-purity-user-calls
+
+**Definition of Done**:
+- A conservative user-function **purity classifier**: a called function is *pure*
+  iff its body has no mutation of non-locals, no IO/throw-as-effect, no calls to
+  effectful functions (recursive, visited-set guarded), and is resolvable
+  (block-bodied, not `node_modules`, not dynamic dispatch) — reusing the
+  `resolveCallTarget` discipline. Unknown ⇒ effectful (bail).
+- A call to a pure user function in a **condition / early-return predicate /
+  while-predicate / mutating-if-condition** position is no longer rejected by
+  `expressionHasSideEffects`; it lowers to the EUF rule head free-call-decl
+  synthesizes for that call (`is-valid x` etc.), so the predicate becomes a
+  Bool-valued rule application.
+- Effectful calls in those positions still reject with their existing diagnostics
+  (conservative refusal preserved).
+- The dogfood/constructs fixtures blocked solely on "early-return predicate has
+  side effects" / "impure if-condition in mutating body" (where the called
+  predicate is pure) now type-check; their allowlist entries are removed.
+
+**Why this is a safe pause point**: Purely additive to the purity oracle and the
+condition-lowering path; effectful calls still reject, so nothing unsound is
+admitted. Predicates over pure user calls now translate, a meaningful standalone
+dogfood win, with or without any narrowing.
+
+**Unlocks**: M2 can measure the post-purity dogfood residual and inventory the
+narrowing patterns that remain.
+
+**Operator Actions Before Next Milestone**:
+- Run `npm run -s test:unit` / `test:integration`; confirm the targeted
+  free-call-decl-adjacent fixtures now pass and no effectful predicate slipped
+  through (spot-check a few inferred-pure classifications against the callee body).
+
+**Open Questions**:
+- Exact purity predicate boundary (are local `const` bindings / pure loops inside
+  the callee allowed? are recursive-but-pure functions classified pure or bailed?).
+  Resolve during M1's gameplan.
+
+---
+
+### Milestone 2: guard-narrowing-survey
+
+**Definition of Done**:
+- Read-only survey over the dogfood + constructs corpus, run after M1: how many
+  functions M1 unblocked; what remains; and an **inventory of the narrowing
+  patterns** that would discharge remaining obligations — discriminant equality
+  (`x.kind === lit`), nullish (`x != null`), user type-predicates (`x is T`),
+  boolean guards (`if (P) …`) — with counts and intra- vs cross-function split.
+- A committed report (under `tools/ts2pant/docs/`) proposing the M3 flow-narrowing
+  layer's interface and representation (how a branch assumption is carried and
+  discharged), and whether M3 should be one milestone or split by pattern.
+- Names the cross-workstream consumers (DU M3, nullish, any/unknown) and the
+  interface each needs.
+- No translator behavior change — measurement only.
+
+**Why this is a safe pause point**: Nothing changed in emitted output; the
+codebase is exactly as after M1 plus a report. The measure→decide boundary that
+justifies designing the greenfield narrowing layer against evidence rather than
+guessing.
+
+**Unlocks**: An evidence-based M3 design + scope, and a concrete narrowing
+interface the DU workstream can commit to.
+
+**Operator Actions Before Next Milestone** (the measure→decide boundary):
+- **Review the survey and decide M3's scope** — which narrowing patterns to
+  implement and whether M3 splits into per-pattern milestones. Proposed gating: a
+  pattern is in M3 iff it appears across multiple corpus functions OR a downstream
+  workstream (DU M3) hard-depends on it (discriminant equality qualifies on the
+  latter regardless of corpus count).
+- **Confirm the interface** the DU workstream and nullish/any-unknown will consume,
+  so M3 builds the shared layer, not a bespoke one.
+
+**Open Questions**:
+- One milestone vs. split-by-pattern for M3. Resolved by this survey.
+
+---
+
+### Milestone 3: guard-flow-narrowing
+
+**Definition of Done**:
+- A **flow-narrowing layer**: within a function, a test's truth is propagated into
+  its branch as an assumption usable by lowering — covering (at least) boolean
+  guards and the patterns the M2 survey selected (discriminant equality, nullish,
+  user `x is T` type-predicates). The narrowed assumption discharges obligations in
+  the branch (e.g. a discriminant-guarded variant-field rule, a non-null access)
+  and is rendered so z3 can use it as a path condition.
+- **Intra-function only**; cross-call / assertion-function narrowing remains
+  refused (matches the any/unknown-opaque decision).
+- No field-name special-casing — discriminant narrowing keys on the structural
+  predicate (`<field> === <literal>`), not on `.kind`.
+- The layer exposes a stable interface the DU workstream's M3 consumes.
+
+**Why this is a safe pause point**: Narrowing is additive — un-narrowed code keeps
+its current (sound-by-guard) lowering; narrowed branches gain provable facts.
+ts2pant now reasons flow-sensitively within a function.
+
+**Unlocks**: The discriminated-union workstream's M3 (`du-discriminant-narrowing`)
+— a **cross-workstream unlock**; richer nullish and any/unknown handling.
+
+**Operator Actions Before Next Milestone**:
+- Confirm before/after entailment set shows the targeted narrowing obligations now
+  discharge and nothing regressed.
+
+**Established Precedents** (milestone-scoped): the workstream-level occurrence-typing
+and path-condition precedents are consumed here directly.
+
+**Open Questions**:
+- The propagation surface through ts2pant's IR/SSA (the any/unknown workstream
+  flagged narrowing "does not always survive" the IR). Resolve during M3's gameplan
+  using the M2 interface proposal.
+
+---
+
+### Milestone 4: guard-effect-error-channel
+
+**Definition of Done**:
+- Extract the error channel `E` from `Effect<A, E, R>` signatures to enumerate
+  failure modes, and AST-match `yield* new ErrorClass(...)` inside `if` to recover
+  the actual guard condition, feeding both into Pantagruel action preconditions —
+  reusing the existing Effect purity/symbol-resolution infrastructure
+  (`purity.ts:resolveEffectLibraryExport`) and the M1 purity classifier.
+- Conservative: bail (no precondition) on Effect shapes that don't match, never a
+  wrong one.
+
+**Why this is a safe pause point**: Additive precondition source for Effect code;
+non-Effect code unaffected. Terminal milestone — the old roadmap's third item.
+
+**Unlocks**: Richer static failure-mode info for Effect-TS codebases. Closes the
+workstream.
+
+**Operator Actions Before Next Milestone**: none (terminal).
+
+**Established Precedents** (milestone-scoped):
+- **library — Effect-TS** — https://effect.website
+  Source of the `Effect<A, E, R>` type shape and the `yield* new ErrorClass()`
+  error-yield idiom this milestone pattern-matches.
+
+**Open Questions**:
+- Whether branded types / `Schema.positive()` filters are in scope or deferred
+  (name-based pattern matching, lower confidence). Resolve during M4's gameplan.
+
+## Dependency Graph
+
+```text
+1 (guard-purity-user-calls)    → []
+2 (guard-narrowing-survey)     → [1]
+3 (guard-flow-narrowing)       → [2]   ── unlocks DU workstream M3 (cross-workstream)
+4 (guard-effect-error-channel) → [1]   (parallelizable with 2/3; sequenced last)
+```
+
+**Note**: M1 → M2 → M3 is the critical path (the flow-narrowing layer). M4 depends
+only on M1 (Effect precondition extraction is independent of narrowing) and may run
+in parallel, but is positioned last by priority. **M3 is the cross-workstream
+unlock** for the discriminated-union workstream's `du-discriminant-narrowing`
+milestone, which is gated on this layer existing.
+
+## Open Questions
+
+| Question | Notes | Resolve By |
+|----------|-------|------------|
+| Purity predicate boundary for user functions | const bindings / pure loops / recursive-pure inside the callee | Milestone 1 |
+| Which narrowing patterns does M3 implement, and does M3 split? | Driven by the survey + the DU hard-dependency on discriminant equality | Milestone 2 |
+| Flow-narrowing interface the DU / nullish / any-unknown workstreams consume | Cross-workstream contract | Milestone 2 |
+| Propagation surface through IR/SSA | any/unknown flagged narrowing may not survive the IR | Milestone 3 |
+| Effect branded types / Schema filters in scope? | Name-based, lower confidence | Milestone 4 |
+
+## Decisions Made
+
+These are decisions that did NOT produce a citable precedent — framing,
+constraints, and rejected approaches. Accepted precedents (occurrence typing,
+in-repo call-following, Kroening & Strichman, TS Compiler API, Effect-TS) live in
+`Established Precedents`.
+
+| Decision | Rationale |
+|----------|-----------|
+| User-function purity is **inferred** from the callee body, not annotated | Consistent with the existing conservative call-following; no new `@pure` annotation burden, and sound-by-bail (unknown ⇒ effectful) rather than trusting a possibly-mismarked human annotation. |
+| Both condition-purity and flow-narrowing live in **one workstream** | They are the two facets of "reason about which facts hold where"; flow-narrowing (M3) is the layer the DU workstream was promised to consume, so it belongs on the same roadmap rather than orphaned. |
+| Flow narrowing is **intra-function only** | Matches the any/unknown-opaque workstream's "cross-function-call narrowing not trusted by default" decision. Guard *extraction* still follows calls (already implemented); narrowing does not. |
+| No field-name / discriminant special-casing in narrowing | Inherits the project-wide constraint: discriminant-equality narrowing keys on the structural predicate `<field> === <literal>`, never on `.kind` by name. |
+| Effect E-channel extraction is the **final** milestone, not dropped | The user opted to keep it; it is not on either critical path (dogfood lever M1, DU dependency M3), so it is sequenced last and depends only on M1. |
+| Guard *extraction* (asserts, if-throw, call-following) is treated as **already done** | Verified in current code (`translate-signature.ts`); the old roadmap's items 1–2 are implemented, so this workstream does not re-plan them. |


### PR DESCRIPTION
Planning docs only — no code changes.

- **`workstreams/ts2pant-guard-analysis.md`** (new) — Flow-Sensitive Guard & Effect Analysis. Guard *extraction* (asserts, if-throw, conservative call-following) is already implemented; this workstream adds user-call purity (the top dogfood lever, ~66 functions), a greenfield intra-function flow-narrowing layer (the cross-workstream unlock for discriminated-union M3), and Effect-TS error-channel extraction.
- **`workstreams/ts2pant-discriminated-union.md`** (new) — comprehensive tagged-union handling: guarded-rule encoding → entailment/narrowing survey → gated discriminant narrowing → cutover. Its M3 depends on the guard-analysis flow-narrowing layer.
- **`workstreams/ts2pant-free-call-decl-synthesis.md`** (status) — marked CLOSED at M2; the M3 entailment survey verdict was do-not-start-M4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)