### PR TITLE
[ts2pant-guard-purity-user-calls] Patch 1: Canonical checker-aware purity oracle + thread checker through guard-extraction helpers

### DIFF
--- a/tools/ts2pant/src/purity.ts
+++ b/tools/ts2pant/src/purity.ts
@@ -536,6 +536,93 @@ function isKnownPureCallInner(
   return false;
 }
 
+/**
+ * Canonical checker-aware effect oracle for TypeScript expressions.
+ *
+ * Returns true only when evaluating `expr` is known not to produce observable
+ * side effects. Unknown calls and unknown syntax stay effectful by default.
+ */
+export function isEffectFree(
+  expr: ts.Expression,
+  checker: ts.TypeChecker,
+): boolean {
+  return !expressionHasSideEffects(expr, checker);
+}
+
+/**
+ * Compatibility spelling for existing body-lowering callers. New purity
+ * decisions should prefer `isEffectFree` so the positive predicate is shared
+ * across signature and body stages.
+ */
+export function expressionHasSideEffects(
+  expr: ts.Expression,
+  checker: ts.TypeChecker,
+): boolean {
+  expr = unwrapEffectExpression(expr);
+
+  if (ts.isDeleteExpression(expr)) {
+    return true;
+  }
+
+  if (ts.isBinaryExpression(expr)) {
+    return (
+      isAssignmentOperator(expr.operatorToken.kind) ||
+      expressionHasSideEffects(expr.left, checker) ||
+      expressionHasSideEffects(expr.right, checker)
+    );
+  }
+
+  if (ts.isCallExpression(expr)) {
+    if (isKnownPureCall(expr, checker)) {
+      // Known-pure callees still require pure receiver/callee and arguments:
+      // e.g. `makeString().trim()` matches the String method allowlist, but
+      // the receiver call itself has unknown effects.
+      return (
+        expressionHasSideEffects(expr.expression, checker) ||
+        expr.arguments.some((arg) => expressionHasSideEffects(arg, checker))
+      );
+    }
+    return true;
+  }
+
+  if (ts.isNewExpression(expr) || ts.isAwaitExpression(expr)) {
+    return true;
+  }
+
+  if (ts.isPrefixUnaryExpression(expr) || ts.isPostfixUnaryExpression(expr)) {
+    const op = expr.operator;
+    return (
+      op === ts.SyntaxKind.PlusPlusToken ||
+      op === ts.SyntaxKind.MinusMinusToken ||
+      expressionHasSideEffects(expr.operand, checker)
+    );
+  }
+
+  return (
+    ts.forEachChild(expr, (child) =>
+      ts.isExpression(child) ? expressionHasSideEffects(child, checker) : false,
+    ) ?? false
+  );
+}
+
+function unwrapEffectExpression(expr: ts.Expression): ts.Expression {
+  while (
+    ts.isParenthesizedExpression(expr) ||
+    ts.isAsExpression(expr) ||
+    ts.isSatisfiesExpression(expr) ||
+    ts.isNonNullExpression(expr)
+  ) {
+    expr = expr.expression;
+  }
+  return expr;
+}
+
+function isAssignmentOperator(kind: ts.SyntaxKind): boolean {
+  return (
+    kind >= ts.SyntaxKind.EqualsToken && kind <= ts.SyntaxKind.CaretEqualsToken
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -67,7 +67,7 @@ import type {
   OpaqueParam,
 } from "./pant-ast.js";
 import { getAst } from "./pant-wasm.js";
-import { isKnownPureCall, isStaticallyBoolTyped } from "./purity.js";
+import { expressionHasSideEffects, isStaticallyBoolTyped } from "./purity.js";
 import { translateRecordReturn } from "./translate-record.js";
 import {
   classifyFunction,
@@ -101,6 +101,8 @@ import {
   extractBlockReturn,
 } from "./ts-ast-block-return.js";
 import type { PantDeclaration, PropResult } from "./types.js";
+
+export { expressionHasSideEffects } from "./purity.js";
 
 // --- Const-binding inlining infrastructure (let-elimination) ---
 
@@ -3170,58 +3172,6 @@ export function unwrapExpression(expr: ts.Expression): ts.Expression {
     expr = expr.expression;
   }
   return expr;
-}
-
-export function expressionHasSideEffects(
-  expr: ts.Expression,
-  checker: ts.TypeChecker,
-): boolean {
-  expr = unwrapExpression(expr);
-
-  if (ts.isDeleteExpression(expr)) {
-    return true;
-  }
-
-  if (ts.isBinaryExpression(expr)) {
-    // Any assignment operator
-    return (
-      (expr.operatorToken.kind >= ts.SyntaxKind.EqualsToken &&
-        expr.operatorToken.kind <= ts.SyntaxKind.CaretEqualsToken) ||
-      expressionHasSideEffects(expr.left, checker) ||
-      expressionHasSideEffects(expr.right, checker)
-    );
-  }
-  if (ts.isCallExpression(expr)) {
-    if (isKnownPureCall(expr, checker)) {
-      // Known-pure callees still require a pure callee expression —
-      // `makeString().trim()` passes the name-based builtin allowlist
-      // but the receiver `makeString()` is itself a user call with
-      // unknown effects. The Tier 1a checks in `isKnownPureCall`
-      // already enforce this for Map/Set/HO-array, but not for
-      // Math/String/Number/PURE_ARRAY entries, so we double-check here.
-      return (
-        expressionHasSideEffects(expr.expression, checker) ||
-        expr.arguments.some((a) => expressionHasSideEffects(a, checker))
-      );
-    }
-    return true;
-  }
-  if (ts.isNewExpression(expr) || ts.isAwaitExpression(expr)) {
-    return true;
-  }
-  if (ts.isPrefixUnaryExpression(expr) || ts.isPostfixUnaryExpression(expr)) {
-    const op = expr.operator;
-    return (
-      op === ts.SyntaxKind.PlusPlusToken ||
-      op === ts.SyntaxKind.MinusMinusToken ||
-      expressionHasSideEffects(expr.operand, checker)
-    );
-  }
-  return (
-    ts.forEachChild(expr, (child) =>
-      ts.isExpression(child) ? expressionHasSideEffects(child, checker) : false,
-    ) ?? false
-  );
 }
 
 /**

--- a/tools/ts2pant/src/translate-signature.ts
+++ b/tools/ts2pant/src/translate-signature.ts
@@ -669,8 +669,13 @@ export function isPureExpression(expr: ts.Expression): boolean {
  * so extracting the condition as a guard won't silently discard
  * meaningful work.  Aligned with isGuardStatement in translate-body.ts.
  */
-function isSafeGuardThenBranch(stmt: ts.Statement): boolean {
-  return guardBranchHasNoSideEffects(stmt) && !guardBranchReturns(stmt);
+function isSafeGuardThenBranch(
+  stmt: ts.Statement,
+  checker: ts.TypeChecker,
+): boolean {
+  return (
+    guardBranchHasNoSideEffects(stmt, checker) && !guardBranchReturns(stmt)
+  );
 }
 
 function guardBranchReturns(node: ts.Statement): boolean {
@@ -680,9 +685,14 @@ function guardBranchReturns(node: ts.Statement): boolean {
   return ts.isReturnStatement(node);
 }
 
-function guardBranchHasNoSideEffects(node: ts.Statement): boolean {
+function guardBranchHasNoSideEffects(
+  node: ts.Statement,
+  _checker: ts.TypeChecker,
+): boolean {
   if (ts.isBlock(node)) {
-    return node.statements.every((s) => guardBranchHasNoSideEffects(s));
+    return node.statements.every((s) =>
+      guardBranchHasNoSideEffects(s, _checker),
+    );
   }
   if (ts.isExpressionStatement(node)) {
     return isPureExpression(node.expression);
@@ -709,7 +719,10 @@ function guardBranchHasNoSideEffects(node: ts.Statement): boolean {
  * The then-branch acceptance must stay aligned with isGuardStatement in
  * translate-body.ts — both accept side-effect-free, non-returning then-blocks.
  */
-function classifyGuardIf(stmt: ts.IfStatement): "positive" | "negative" | null {
+function classifyGuardIf(
+  stmt: ts.IfStatement,
+  checker: ts.TypeChecker,
+): "positive" | "negative" | null {
   if (!isPureExpression(stmt.expression)) {
     return null;
   }
@@ -724,12 +737,12 @@ function classifyGuardIf(stmt: ts.IfStatement): "positive" | "negative" | null {
   }
   if (
     stmt.elseStatement &&
-    isSafeGuardThenBranch(stmt.thenStatement) &&
-    blockThrows(stmt.elseStatement)
+    isSafeGuardThenBranch(stmt.thenStatement, checker) &&
+    blockThrows(stmt.elseStatement, checker)
   ) {
     return "positive";
   }
-  if (!stmt.elseStatement && blockThrows(stmt.thenStatement)) {
+  if (!stmt.elseStatement && blockThrows(stmt.thenStatement, checker)) {
     return "negative";
   }
   return null;
@@ -803,7 +816,7 @@ function scanBodyForGuards(
       break;
     }
 
-    const guardKind = classifyGuardIf(stmt);
+    const guardKind = classifyGuardIf(stmt, checker);
     if (guardKind === "positive") {
       const g = tryTranslateGuardExpr(
         stmt.expression,
@@ -954,7 +967,7 @@ export function isFollowableGuardCall(
     }
     // classifyGuardIf already rejects untranslatable conditions —
     // this is the same check scanBodyForGuards relies on.
-    return classifyGuardIf(stmt) !== null;
+    return classifyGuardIf(stmt, checker) !== null;
   });
   visited.delete(target.body);
   return result;
@@ -998,7 +1011,7 @@ export function detectGuard(
   return guards.reduce((acc, g) => ast.binop(ast.opAnd(), acc, g));
 }
 
-function blockThrows(node: ts.Statement): boolean {
+function blockThrows(node: ts.Statement, _checker: ts.TypeChecker): boolean {
   if (ts.isThrowStatement(node)) {
     return true;
   }

--- a/tools/ts2pant/tests/purity.test.mts
+++ b/tools/ts2pant/tests/purity.test.mts
@@ -7,7 +7,7 @@ import {
   createSourceFileFromSource,
   getChecker,
 } from "../src/extract.js";
-import { isKnownPureCall } from "../src/purity.js";
+import { isEffectFree, isKnownPureCall } from "../src/purity.js";
 
 /**
  * Find the first CallExpression in a source file's function body.
@@ -41,6 +41,32 @@ function checkPurity(source: string): boolean {
     throw new Error("No CallExpression found in source");
   }
   return isKnownPureCall(callExpr, checker);
+}
+
+function findReturnExpression(
+  sourceFile: ts.SourceFile,
+): ts.Expression | undefined {
+  let result: ts.Expression | undefined;
+  function visit(node: ts.Node) {
+    if (result) return;
+    if (ts.isReturnStatement(node) && node.expression) {
+      result = node.expression;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  }
+  ts.forEachChild(sourceFile, visit);
+  return result;
+}
+
+function checkEffectFree(source: string): boolean {
+  const sf = createSourceFileFromSource(source);
+  const checker = getChecker(sf);
+  const expr = findReturnExpression(sf.compilerNode);
+  if (!expr) {
+    throw new Error("No return expression found in source");
+  }
+  return isEffectFree(expr, checker);
 }
 
 describe("isKnownPureCall", () => {
@@ -287,6 +313,60 @@ describe("isKnownPureCall", () => {
       false,
     );
   });
+});
+
+describe("isEffectFree", () => {
+  it("treats known-pure builtin calls as effect-free", () => {
+    assert.equal(
+      checkEffectFree(`
+        function f(a: number, b: number) { return Math.max(a, b); }
+      `),
+      true,
+    );
+  });
+
+  it("treats user calls as effectful", () => {
+    assert.equal(
+      checkEffectFree(`
+        declare function userFn(x: number): number;
+        function f(x: number) { return userFn(x); }
+      `),
+      false,
+    );
+  });
+
+  it("treats mutation as effectful", () => {
+    assert.equal(
+      checkEffectFree(`
+        function f(x: number) { return ++x; }
+      `),
+      false,
+    );
+  });
+
+  it("treats await as effectful", () => {
+    assert.equal(
+      checkEffectFree(`
+        async function f(p: Promise<number>) { return await p; }
+      `),
+      false,
+    );
+  });
+
+  it("treats new expressions as effectful", () => {
+    assert.equal(
+      checkEffectFree(`
+        class Box {}
+        function f() { return new Box(); }
+      `),
+      false,
+    );
+  });
+
+  it.skip(
+    "guard extraction over a builtin-call condition uses the checker-aware oracle",
+    () => {},
+  );
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Patch 1: Canonical checker-aware purity oracle + thread checker through guard-extraction helpers

- Introduce isEffectFree(expr, checker) as the single canonical purity/effect oracle, preserving the current verdicts of both expressionHasSideEffects and (semantically) isPureExpression's syntactic cases.
- Place it where both translate-signature.ts and translate-body.ts can import without a cycle (purity.ts), relocating expressionHasSideEffects's body if necessary and aliasing for existing callers.
- Thread `checker` through the guard-extraction helper chain without changing which predicate they call (still isPureExpression) — pure plumbing.
- Add isEffectFree unit tests; add the skipped consolidation-parity stub.
- Confirm no constructs snapshot changes (no behavior change in this patch).

## Changes
- Introduce isEffectFree(expr, checker) as the single canonical purity/effect oracle, preserving the current verdicts of both expressionHasSideEffects and (semantically) isPureExpression's syntactic cases.
- Place it where both translate-signature.ts and translate-body.ts can import without a cycle (purity.ts), relocating expressionHasSideEffects's body if necessary and aliasing for existing callers.
- Thread `checker` through the guard-extraction helper chain without changing which predicate they call (still isPureExpression) — pure plumbing.
- Add isEffectFree unit tests; add the skipped consolidation-parity stub.
- Confirm no constructs snapshot changes (no behavior change in this patch).

## Files to Modify
- tools/ts2pant/src/purity.ts (modify): Define the single canonical oracle isEffectFree(expr, checker) (built from the existing expressionHasSideEffects implementation + isKnownPureCall); relocate expressionHasSideEffects's logic here if needed to avoid an import cycle, re-exporting/aliasing so existing callers keep working. No call-site semantics change yet.
- tools/ts2pant/src/translate-signature.ts (modify): Thread a `checker` parameter through classifyGuardIf, isSafeGuardThenBranch, guardBranchHasNoSideEffects, scanBodyForGuards, and the isAssertionCall purity check — these still call the checker-free isPureExpression for now (plumbing only). The checker is already available in scanBodyForGuards/detectGuard scope.
- tools/ts2pant/tests/purity.test.mts (modify): Unit tests for isEffectFree (known-pure builtin call effect-free; user call effectful; mutation/await/new effectful). Add a skipped stub asserting guard extraction over a builtin-call condition, PENDING Patch 2.

## Gameplan Specification

```
module GUARD_PURITY_USER_CALLS.

> Two outcomes. (1) Consolidation: ts2pant has a single checker-aware
> purity oracle — the checker-free isPureExpression is gone, so call
> classification is consistent across signature-extraction and body-
> lowering. (2) User-call purity: a call to a conservatively-pure user
> function is effect-free, so it is admitted in predicate/condition
> positions and lowers to the EUF rule free-call-decl synthesizes.
> Purity is inferred from the callee body; unknown ⇒ effectful (bail).

Expr.
Call.
Fn.
Site.

callee c: Call => Fn.
pure-fn? f: Fn => Bool.
resolvable? f: Fn => Bool.
effect-free? e: Expr => Bool.
legacy-syntactic? s: Site => Bool.
has-side-effects? c: Call => Bool.
admitted? c: Call => Bool.
lowers-to-euf-rule? c: Call => Bool.

---

> Consolidation: no purity-decision site uses the removed checker-free predicate.
all s: Site | ~(legacy-syntactic? s).
> Conservative: a function is deemed pure only if it resolves; unknown
> callees stay effectful.
all f: Fn | pure-fn? f -> resolvable? f.
> A call to a pure user function is side-effect-free, admitted in
> predicate/condition positions, and lowers to its EUF rule.
all c: Call | pure-fn? (callee c) -> ~(has-side-effects? c) and admitted? c and lowers-to-euf-rule? c.
```

## Patch Specification

```
module GUARD_PURITY_USER_CALLS_PATCH_1.

> Canonical checker-aware oracle established in purity.ts; checker
> threaded through the guard-extraction helpers that currently call the
> checker-free predicate. Plumbing only — both predicates still in use,
> no behavior change.

Expr.
Site.
effect-free? e: Expr => Bool.
checker-available? s: Site => Bool.

---

> Every guard-extraction site now has the checker in scope (ready to
> route through the oracle in patch 2).
all s: Site | checker-available? s.
```


## Implementation Notes

- Kept `translate-body.ts` as a compatibility re-export for `expressionHasSideEffects` so existing body/IR imports stay stable in this plumbing patch; the canonical implementation now lives in `purity.ts`.
- `isEffectFree` is intentionally a positive wrapper over the relocated side-effect walker, not over the stricter private `expressionIsPure` helper. That preserves the body-lowering verdicts exactly while still centralizing future call classification behind the checker-aware oracle.
- Guard-extraction plumbing threads `checker` through helper signatures now, but underscore-prefixes parameters at helper bodies that cannot consume it until Patch 2. This keeps the patch behavior-neutral and lint-clean.
- Spec/Evidence Mapping: `checker-available? s` is represented by the new checker parameters through `classifyGuardIf`, `isSafeGuardThenBranch`, `guardBranchHasNoSideEffects`, and `blockThrows`, reached from `scanBodyForGuards` / `detectGuard`; verified by `npm test`, `npm run lint`, and `npx tsc --noEmit`. The constructs snapshot suite ran as part of `npm test`, and no constructs snapshot files changed.