### PR TITLE
[ts2pant-guard-purity-user-calls] Patch 3: Conservative interprocedural user-function purity classifier (dormant)

### DIFF
--- a/tools/ts2pant/src/purity.ts
+++ b/tools/ts2pant/src/purity.ts
@@ -537,6 +537,70 @@ function isKnownPureCallInner(
 }
 
 /**
+ * Conservatively classify a direct user-function call as pure.
+ *
+ * Dormant in Patch 3: this is intentionally not consulted by
+ * `isKnownPureCall`/`isEffectFree` yet. Patch 4 wires it into the canonical
+ * oracle once the behavior change is enabled.
+ */
+export function isPureUserCall(
+  call: ts.CallExpression,
+  checker: ts.TypeChecker,
+): boolean {
+  try {
+    if (call.arguments.some(ts.isSpreadElement)) {
+      return false;
+    }
+    if (!call.arguments.every((arg) => userExpressionIsPure(arg, checker))) {
+      return false;
+    }
+    const decl = resolveUserCallTarget(call, checker);
+    return decl !== null && isPureUserFunction(decl, checker);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Conservative whole-body, interprocedural purity classifier for user code.
+ *
+ * Unknown syntax, dynamic dispatch, unresolved callees, node_modules targets,
+ * recursion, mutation, throw, await, IO, and higher-order calls all bail to
+ * effectful. Returning true is therefore positive evidence only.
+ */
+export function isPureUserFunction(
+  decl: ts.FunctionLikeDeclaration,
+  checker: ts.TypeChecker,
+  visited: Set<ts.Node> = new Set(),
+): boolean {
+  try {
+    if (declarationIsFromNodeModules(decl)) {
+      return false;
+    }
+    if (
+      !parameterInitializersArePureForUserAnalysis(decl.parameters, checker)
+    ) {
+      return false;
+    }
+
+    const body = getBlockBody(decl);
+    if (!body) {
+      return false;
+    }
+    if (visited.has(body)) {
+      return false;
+    }
+
+    visited.add(body);
+    const result = blockIsPureForUserAnalysis(body, checker, visited);
+    visited.delete(body);
+    return result;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Canonical checker-aware effect oracle for TypeScript expressions.
  *
  * Returns true only when evaluating `expr` is known not to produce observable
@@ -618,9 +682,372 @@ function unwrapEffectExpression(expr: ts.Expression): ts.Expression {
 }
 
 function isAssignmentOperator(kind: ts.SyntaxKind): boolean {
-  return (
-    kind >= ts.SyntaxKind.EqualsToken && kind <= ts.SyntaxKind.CaretEqualsToken
+  return ASSIGNMENT_OPERATORS.has(kind);
+}
+
+const ASSIGNMENT_OPERATORS: ReadonlySet<ts.SyntaxKind> = new Set([
+  ts.SyntaxKind.EqualsToken,
+  ts.SyntaxKind.PlusEqualsToken,
+  ts.SyntaxKind.MinusEqualsToken,
+  ts.SyntaxKind.AsteriskEqualsToken,
+  ts.SyntaxKind.SlashEqualsToken,
+  ts.SyntaxKind.PercentEqualsToken,
+  ts.SyntaxKind.AsteriskAsteriskEqualsToken,
+  ts.SyntaxKind.LessThanLessThanEqualsToken,
+  ts.SyntaxKind.GreaterThanGreaterThanEqualsToken,
+  ts.SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken,
+  ts.SyntaxKind.AmpersandEqualsToken,
+  ts.SyntaxKind.BarEqualsToken,
+  ts.SyntaxKind.CaretEqualsToken,
+  ts.SyntaxKind.BarBarEqualsToken,
+  ts.SyntaxKind.AmpersandAmpersandEqualsToken,
+  ts.SyntaxKind.QuestionQuestionEqualsToken,
+]);
+
+type AnalyzableFunctionLike =
+  | ts.FunctionDeclaration
+  | ts.MethodDeclaration
+  | ts.ConstructorDeclaration
+  | ts.FunctionExpression
+  | ts.ArrowFunction;
+
+function resolveUserCallTarget(
+  call: ts.CallExpression,
+  checker: ts.TypeChecker,
+): AnalyzableFunctionLike | null {
+  // Match guard-following discipline: direct calls only. Property access is
+  // dynamic dispatch and may need `this`, so it bails.
+  if (!ts.isIdentifier(call.expression)) {
+    return null;
+  }
+
+  const calleeSymbol = checker.getSymbolAtLocation(call.expression);
+  const calleeDecl = calleeSymbol?.valueDeclaration;
+  if (calleeDecl && ts.isParameter(calleeDecl)) {
+    return null;
+  }
+
+  let decl = asAnalyzableFunctionLike(
+    checker.getResolvedSignature(call)?.declaration,
   );
+  if (!decl || !getBlockBody(decl)) {
+    const resolved = resolveFunctionLikeFromSymbol(calleeSymbol, checker);
+    if (resolved) {
+      decl = resolved;
+    }
+  }
+
+  if (!decl) {
+    return null;
+  }
+  if (declarationIsFromNodeModules(decl)) {
+    return null;
+  }
+  if (!getBlockBody(decl)) {
+    return null;
+  }
+
+  return decl;
+}
+
+function resolveFunctionLikeFromSymbol(
+  symbol: ts.Symbol | undefined,
+  checker: ts.TypeChecker,
+): AnalyzableFunctionLike | null {
+  if (!symbol) {
+    return null;
+  }
+
+  let resolved = symbol;
+  if (resolved.flags & ts.SymbolFlags.Alias) {
+    resolved = checker.getAliasedSymbol(resolved);
+  }
+
+  const declarations = resolved.getDeclarations() ?? [];
+  for (const decl of declarations) {
+    const functionDecl = asAnalyzableFunctionLike(decl);
+    if (functionDecl && getBlockBody(functionDecl)) {
+      return functionDecl;
+    }
+    if (ts.isVariableDeclaration(decl) && decl.initializer) {
+      const init = decl.initializer;
+      if (
+        (ts.isFunctionExpression(init) || ts.isArrowFunction(init)) &&
+        getBlockBody(init)
+      ) {
+        return init;
+      }
+    }
+  }
+
+  return null;
+}
+
+function asAnalyzableFunctionLike(
+  node: ts.Node | undefined,
+): AnalyzableFunctionLike | null {
+  if (!node) {
+    return null;
+  }
+  if (
+    ts.isFunctionDeclaration(node) ||
+    ts.isMethodDeclaration(node) ||
+    ts.isConstructorDeclaration(node) ||
+    ts.isFunctionExpression(node) ||
+    ts.isArrowFunction(node)
+  ) {
+    return node;
+  }
+  return null;
+}
+
+function getBlockBody(decl: ts.FunctionLikeDeclaration): ts.Block | undefined {
+  if (
+    ts.isFunctionDeclaration(decl) ||
+    ts.isMethodDeclaration(decl) ||
+    ts.isFunctionExpression(decl) ||
+    ts.isConstructorDeclaration(decl)
+  ) {
+    return decl.body;
+  }
+  if (ts.isArrowFunction(decl)) {
+    return ts.isBlock(decl.body) ? decl.body : undefined;
+  }
+  return undefined;
+}
+
+function declarationIsFromNodeModules(decl: ts.Node): boolean {
+  return /(?:^|[/\\])node_modules(?:[/\\]|$)/u.test(
+    decl.getSourceFile().fileName,
+  );
+}
+
+function blockIsPureForUserAnalysis(
+  block: ts.Block,
+  checker: ts.TypeChecker,
+  visited: Set<ts.Node>,
+): boolean {
+  return block.statements.every((stmt) =>
+    statementIsPureForUserAnalysis(stmt, checker, visited),
+  );
+}
+
+function statementIsPureForUserAnalysis(
+  stmt: ts.Statement,
+  checker: ts.TypeChecker,
+  visited: Set<ts.Node>,
+): boolean {
+  if (ts.isBlock(stmt)) {
+    return blockIsPureForUserAnalysis(stmt, checker, visited);
+  }
+  if (ts.isEmptyStatement(stmt) || ts.isFunctionDeclaration(stmt)) {
+    return true;
+  }
+  if (ts.isReturnStatement(stmt)) {
+    return (
+      !stmt.expression ||
+      userExpressionIsPure(stmt.expression, checker, visited)
+    );
+  }
+  if (ts.isExpressionStatement(stmt)) {
+    return userExpressionIsPure(stmt.expression, checker, visited);
+  }
+  if (ts.isVariableStatement(stmt)) {
+    return stmt.declarationList.declarations.every((decl) => {
+      if (!bindingNameIsSimpleLocal(decl.name)) {
+        return false;
+      }
+      return (
+        decl.initializer === undefined ||
+        userExpressionIsPure(decl.initializer, checker, visited)
+      );
+    });
+  }
+  if (ts.isIfStatement(stmt)) {
+    return (
+      userExpressionIsPure(stmt.expression, checker, visited) &&
+      statementIsPureForUserAnalysis(stmt.thenStatement, checker, visited) &&
+      (stmt.elseStatement === undefined ||
+        statementIsPureForUserAnalysis(stmt.elseStatement, checker, visited))
+    );
+  }
+
+  // Loops, switch, try/catch/finally, throw, debugger, imports/exports, and
+  // unknown statements are effectful until proven otherwise by a later patch.
+  return false;
+}
+
+function bindingNameIsSimpleLocal(name: ts.BindingName): boolean {
+  if (ts.isIdentifier(name)) {
+    return true;
+  }
+  return name.elements.every((element) => {
+    if (ts.isOmittedExpression(element)) {
+      return true;
+    }
+    return bindingNameIsSimpleLocal(element.name);
+  });
+}
+
+function parameterInitializersArePureForUserAnalysis(
+  params: ts.NodeArray<ts.ParameterDeclaration>,
+  checker: ts.TypeChecker,
+): boolean {
+  for (const param of params) {
+    if (param.dotDotDotToken) {
+      return false;
+    }
+    if (
+      param.initializer &&
+      !userExpressionIsPure(param.initializer, checker)
+    ) {
+      return false;
+    }
+    if (
+      (ts.isObjectBindingPattern(param.name) ||
+        ts.isArrayBindingPattern(param.name)) &&
+      !bindingPatternInitializersArePureForUserAnalysis(param.name, checker)
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function bindingPatternInitializersArePureForUserAnalysis(
+  pattern: ts.BindingPattern,
+  checker: ts.TypeChecker,
+): boolean {
+  for (const element of pattern.elements) {
+    if (ts.isOmittedExpression(element)) {
+      continue;
+    }
+    if (
+      element.initializer &&
+      !userExpressionIsPure(element.initializer, checker)
+    ) {
+      return false;
+    }
+    if (
+      (ts.isObjectBindingPattern(element.name) ||
+        ts.isArrayBindingPattern(element.name)) &&
+      !bindingPatternInitializersArePureForUserAnalysis(element.name, checker)
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function userExpressionIsPure(
+  expr: ts.Expression,
+  checker: ts.TypeChecker,
+  visited: Set<ts.Node> = new Set(),
+): boolean {
+  expr = unwrapEffectExpression(expr);
+
+  if (
+    ts.isIdentifier(expr) ||
+    ts.isNumericLiteral(expr) ||
+    ts.isStringLiteral(expr) ||
+    ts.isNoSubstitutionTemplateLiteral(expr) ||
+    expr.kind === ts.SyntaxKind.TrueKeyword ||
+    expr.kind === ts.SyntaxKind.FalseKeyword ||
+    expr.kind === ts.SyntaxKind.NullKeyword ||
+    expr.kind === ts.SyntaxKind.UndefinedKeyword ||
+    expr.kind === ts.SyntaxKind.ThisKeyword
+  ) {
+    return true;
+  }
+
+  if (ts.isPropertyAccessExpression(expr)) {
+    return userExpressionIsPure(expr.expression, checker, visited);
+  }
+  if (ts.isElementAccessExpression(expr)) {
+    return (
+      expr.argumentExpression !== undefined &&
+      userExpressionIsPure(expr.expression, checker, visited) &&
+      userExpressionIsPure(expr.argumentExpression, checker, visited)
+    );
+  }
+  if (ts.isArrayLiteralExpression(expr)) {
+    return expr.elements.every((element) => {
+      if (ts.isSpreadElement(element)) {
+        return false;
+      }
+      return userExpressionIsPure(element, checker, visited);
+    });
+  }
+  if (ts.isObjectLiteralExpression(expr)) {
+    return expr.properties.every((prop) => {
+      if (ts.isPropertyAssignment(prop)) {
+        return (
+          (!ts.isComputedPropertyName(prop.name) ||
+            userExpressionIsPure(prop.name.expression, checker, visited)) &&
+          userExpressionIsPure(prop.initializer, checker, visited)
+        );
+      }
+      if (ts.isShorthandPropertyAssignment(prop)) {
+        return true;
+      }
+      if (ts.isSpreadAssignment(prop)) {
+        return false;
+      }
+      return false;
+    });
+  }
+  if (ts.isTemplateExpression(expr)) {
+    return expr.templateSpans.every((span) =>
+      userExpressionIsPure(span.expression, checker, visited),
+    );
+  }
+  if (ts.isPrefixUnaryExpression(expr) || ts.isPostfixUnaryExpression(expr)) {
+    if (
+      expr.operator === ts.SyntaxKind.PlusPlusToken ||
+      expr.operator === ts.SyntaxKind.MinusMinusToken
+    ) {
+      return false;
+    }
+    return userExpressionIsPure(expr.operand, checker, visited);
+  }
+  if (ts.isBinaryExpression(expr)) {
+    return (
+      !isAssignmentOperator(expr.operatorToken.kind) &&
+      userExpressionIsPure(expr.left, checker, visited) &&
+      userExpressionIsPure(expr.right, checker, visited)
+    );
+  }
+  if (ts.isConditionalExpression(expr)) {
+    return (
+      userExpressionIsPure(expr.condition, checker, visited) &&
+      userExpressionIsPure(expr.whenTrue, checker, visited) &&
+      userExpressionIsPure(expr.whenFalse, checker, visited)
+    );
+  }
+  if (ts.isCallExpression(expr)) {
+    if (isKnownPureCall(expr, checker)) {
+      return (
+        userExpressionIsPure(expr.expression, checker, visited) &&
+        expr.arguments.every((arg) =>
+          userExpressionIsPure(arg, checker, visited),
+        )
+      );
+    }
+    if (expr.arguments.some(ts.isSpreadElement)) {
+      return false;
+    }
+    if (
+      !expr.arguments.every((arg) =>
+        userExpressionIsPure(arg, checker, visited),
+      )
+    ) {
+      return false;
+    }
+    const decl = resolveUserCallTarget(expr, checker);
+    return decl !== null && isPureUserFunction(decl, checker, visited);
+  }
+
+  return false;
 }
 
 // ---------------------------------------------------------------------------

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -686,6 +686,18 @@ exports[`expressions-property.ts > getOwnerName 1`] = `
 "module GET_OWNER_NAME.\\n\\nUser.\\nuser--name u: User => String.\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--owner a1: Account => User.\\naccount--active a1: Account => Bool.\\nget-owner-name a: Account => String.\\n\\n---\\n\\nget-owner-name a = user--name (account--owner a).\\n"
 `;
 
+exports[`expressions-pure-call-predicate.ts > effectfulCallPredicate 1`] = `
+"module EFFECTFUL_CALL_PREDICATE.\\n\\nrecords-observation n1: Int => Bool.\\neffectful-call-predicate n: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: effectful-call-predicate — early-return predicate has side effects.\\n"
+`;
+
+exports[`expressions-pure-call-predicate.ts > pureCallEarlyReturn 1`] = `
+"module PURE_CALL_EARLY_RETURN.\\n\\nis-positive n1: Int => Bool.\\npure-call-early-return n: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: pure-call-early-return — early-return predicate has side effects.\\n"
+`;
+
+exports[`expressions-pure-call-predicate.ts > pureCallMutatingIf 1`] = `
+"module PURE_CALL_MUTATING_IF.\\n\\nAccount.\\naccount--balance a: Account => Int.\\n~> Pure-call-mutating-if @ account: Account, amount: Int.\\n\\n---\\n\\n> UNSUPPORTED: impure if-condition in mutating body.\\n"
+`;
+
 exports[`expressions-readonly-set.ts > cardinalityReadonly 1`] = `
 "module CARDINALITY_READONLY.\\n\\ncardinality-readonly xs: [String] => Int.\\n\\n---\\n\\ncardinality-readonly xs = #xs.\\n"
 `;

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-pure-call-predicate.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-pure-call-predicate.ts
@@ -1,0 +1,42 @@
+interface Account {
+  balance: number;
+}
+
+function isPositive(n: number): boolean {
+  return n > 0;
+}
+
+function isDepositAllowed(amount: number): boolean {
+  const normalized = Math.max(0, amount);
+  return normalized > 0;
+}
+
+let observed = 0;
+
+function recordsObservation(n: number): boolean {
+  observed = n;
+  return observed > 0;
+}
+
+/** PENDING Patch 4: pure helper call in an early-return predicate */
+export function pureCallEarlyReturn(n: number): number {
+  if (isPositive(n)) {
+    return 1;
+  }
+  return 0;
+}
+
+/** PENDING Patch 4: pure helper call in a mutating if-condition */
+export function pureCallMutatingIf(account: Account, amount: number): void {
+  if (isDepositAllowed(amount)) {
+    account.balance = account.balance + amount;
+  }
+}
+
+/** effectful helper call must stay rejected */
+export function effectfulCallPredicate(n: number): number {
+  if (recordsObservation(n)) {
+    return 1;
+  }
+  return 0;
+}

--- a/tools/ts2pant/tests/known-typecheck-failures.mts
+++ b/tools/ts2pant/tests/known-typecheck-failures.mts
@@ -55,6 +55,14 @@ export const KNOWN_TYPECHECK_FAILURES = new Map<string, string>([
   ["expressions-boolean.ts > or", "$-binder-leak"],
   ["expressions-let-closure-captured.ts > letForEachCapturedTotal", "closure-captured-reassignment"],
   ["expressions-let-closure-captured.ts > letMapCapturedCount", "closure-captured-reassignment"],
+  [
+    "expressions-pure-call-predicate.ts > pureCallEarlyReturn",
+    "pure-call-predicate",
+  ],
+  [
+    "expressions-pure-call-predicate.ts > pureCallMutatingIf",
+    "pure-call-predicate",
+  ],
   ["expressions-var-rejected.ts > varBinding", "var-rejected"],
   ["expressions-var-rejected.ts > varReassignment", "var-rejected"],
   ["functions-class.ts > Account.getBalance", "requires-external-context"],

--- a/tools/ts2pant/tests/purity.test.mts
+++ b/tools/ts2pant/tests/purity.test.mts
@@ -7,7 +7,12 @@ import {
   createSourceFileFromSource,
   getChecker,
 } from "../src/extract.js";
-import { isEffectFree, isKnownPureCall } from "../src/purity.js";
+import {
+  isEffectFree,
+  isKnownPureCall,
+  isPureUserCall,
+  isPureUserFunction,
+} from "../src/purity.js";
 
 /**
  * Find the first CallExpression in a source file's function body.
@@ -56,6 +61,49 @@ function findReturnExpression(
     ts.forEachChild(node, visit);
   }
   ts.forEachChild(sourceFile, visit);
+  return result;
+}
+
+function findFunctionDeclaration(
+  sourceFile: ts.SourceFile,
+  name: string,
+): ts.FunctionDeclaration {
+  let result: ts.FunctionDeclaration | undefined;
+  function visit(node: ts.Node) {
+    if (result) return;
+    if (ts.isFunctionDeclaration(node) && node.name?.text === name) {
+      result = node;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  }
+  ts.forEachChild(sourceFile, visit);
+  if (!result) {
+    throw new Error(`No function declaration found for ${name}`);
+  }
+  return result;
+}
+
+function findCallInNamedFunction(
+  sourceFile: ts.SourceFile,
+  name: string,
+): ts.CallExpression {
+  const fn = findFunctionDeclaration(sourceFile, name);
+  let result: ts.CallExpression | undefined;
+  function visit(node: ts.Node) {
+    if (result) return;
+    if (ts.isCallExpression(node)) {
+      result = node;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  }
+  if (fn.body) {
+    ts.forEachChild(fn.body, visit);
+  }
+  if (!result) {
+    throw new Error(`No CallExpression found in function ${name}`);
+  }
   return result;
 }
 
@@ -365,6 +413,120 @@ describe("isEffectFree", () => {
 
   it.skip(
     "guard extraction over a builtin-call condition uses the checker-aware oracle",
+    () => {},
+  );
+});
+
+describe("isPureUserFunction", () => {
+  it("classifies a pure helper and its direct call as pure", () => {
+    const sf = createSourceFileFromSource(`
+      function isPositive(n: number): boolean {
+        const limit = Math.max(0, n);
+        return limit > 0;
+      }
+      function f(n: number): boolean {
+        return isPositive(n);
+      }
+    `);
+    const checker = getChecker(sf);
+
+    assert.equal(
+      isPureUserFunction(
+        findFunctionDeclaration(sf.compilerNode, "isPositive"),
+        checker,
+      ),
+      true,
+    );
+    assert.equal(
+      isPureUserCall(findCallInNamedFunction(sf.compilerNode, "f"), checker),
+      true,
+    );
+  });
+
+  it("classifies mutating, throwing, and async helpers as effectful", () => {
+    const sf = createSourceFileFromSource(`
+      let counter = 0;
+      function mutates(n: number): number {
+        counter = n;
+        return n;
+      }
+      function throws(n: number): number {
+        if (n < 0) throw new Error("bad");
+        return n;
+      }
+      async function awaits(p: Promise<number>): Promise<number> {
+        return await p;
+      }
+    `);
+    const checker = getChecker(sf);
+
+    for (const name of ["mutates", "throws", "awaits"]) {
+      assert.equal(
+        isPureUserFunction(
+          findFunctionDeclaration(sf.compilerNode, name),
+          checker,
+        ),
+        false,
+      );
+    }
+  });
+
+  it("bails to effectful on recursive helper calls", () => {
+    const sf = createSourceFileFromSource(`
+      function isEven(n: number): boolean {
+        if (n === 0) return true;
+        return isOdd(n - 1);
+      }
+      function isOdd(n: number): boolean {
+        if (n === 0) return false;
+        return isEven(n - 1);
+      }
+      function f(n: number): boolean {
+        return isEven(n);
+      }
+    `);
+    const checker = getChecker(sf);
+
+    assert.equal(
+      isPureUserFunction(
+        findFunctionDeclaration(sf.compilerNode, "isEven"),
+        checker,
+      ),
+      false,
+    );
+    assert.equal(
+      isPureUserCall(findCallInNamedFunction(sf.compilerNode, "f"), checker),
+      false,
+    );
+  });
+
+  it("bails to effectful for node_modules call targets", () => {
+    const sf = createSourceFileFromSource(
+      `
+        function helper(n: number): boolean {
+          return n > 0;
+        }
+        function f(n: number): boolean {
+          return helper(n);
+        }
+      `,
+      "/project/node_modules/pkg/index.ts",
+    );
+    const checker = getChecker(sf);
+
+    assert.equal(
+      isPureUserCall(findCallInNamedFunction(sf.compilerNode, "f"), checker),
+      false,
+    );
+  });
+
+  it.skip(
+    "PENDING Patch 4: pure user call in early-return predicate lowers to its EUF rule",
+    () => {},
+  );
+
+  it.skip(
+    "PENDING Patch 4: pure user call in mutating if-condition lowers to its EUF rule",
     () => {},
   );
 });


### PR DESCRIPTION
## Patch 3: Conservative interprocedural user-function purity classifier (dormant)

- Implement isPureUserFunction as a conservative whole-body, interprocedural effect analysis with a visited set, reusing resolveCallTarget for callee resolution and its bail conditions.
- Implement isPureUserCall as the call-level wrapper that resolves the callee and classifies it.
- Add direct unit tests for pure / effectful / recursion-bail / node_modules-bail cases.
- Add the fixtures (positive + negative) and allowlist entries; add skipped emission stubs for Patch 4.
- Confirm no behavior change (classifier unused by the oracle in this patch).

## Changes
- Implement isPureUserFunction as a conservative whole-body, interprocedural effect analysis with a visited set, reusing resolveCallTarget for callee resolution and its bail conditions.
- Implement isPureUserCall as the call-level wrapper that resolves the callee and classifies it.
- Add direct unit tests for pure / effectful / recursion-bail / node_modules-bail cases.
- Add the fixtures (positive + negative) and allowlist entries; add skipped emission stubs for Patch 4.
- Confirm no behavior change (classifier unused by the oracle in this patch).

## Files to Modify
- tools/ts2pant/src/purity.ts (modify): Add isPureUserFunction(decl, checker, visited) and isPureUserCall(call, checker): resolve the callee (reusing resolveCallTarget's discipline), analyze its body for effect-freedom (no mutation of non-locals, no property mutation, no throw, no await, no ++/--, no IO), recursively classifying called functions with a visited set, and bail to effectful on recursion / dynamic dispatch / node_modules / unresolvable / higher-order. Not yet consulted by the oracle (dormant).
- tools/ts2pant/tests/purity.test.mts (modify): Direct unit tests: a pure helper classifies pure; an effectful helper (mutates / throws / awaits) classifies effectful; a recursive helper bails to effectful; a node_modules call bails. Add skipped stubs (PENDING Patch 4) for the emission tests.
- tools/ts2pant/tests/fixtures/constructs/expressions-pure-call-predicate.ts (create): Fixtures: pure-helper calls in early-return-predicate and mutating-if-condition positions (positive), plus an effectful-helper-call predicate (negative, must stay rejected).
- tools/ts2pant/tests/known-typecheck-failures.mts (modify): Register the positive pure-call-predicate fixtures under a new tag (pure-call-predicate); the effectful negative stays under its existing tag.

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[documentation] TypeScript Compiler API (getSymbolAtLocation, declaration resolution)** — https://github.com/microsoft/TypeScript/wiki/Using-the-Compiler-API — The classifier resolves a call's callee to its declaration and walks the body; reuse resolveCallTarget's symbol-resolution + default-lib/node_modules detection so the bail conditions match the existing guard call-following.

## Gameplan Specification

```
module GUARD_PURITY_USER_CALLS.

> Two outcomes. (1) Consolidation: ts2pant has a single checker-aware
> purity oracle — the checker-free isPureExpression is gone, so call
> classification is consistent across signature-extraction and body-
> lowering. (2) User-call purity: a call to a conservatively-pure user
> function is effect-free, so it is admitted in predicate/condition
> positions and lowers to the EUF rule free-call-decl synthesizes.
> Purity is inferred from the callee body; unknown ⇒ effectful (bail).

Expr.
Call.
Fn.
Site.

callee c: Call => Fn.
pure-fn? f: Fn => Bool.
resolvable? f: Fn => Bool.
effect-free? e: Expr => Bool.
legacy-syntactic? s: Site => Bool.
has-side-effects? c: Call => Bool.
admitted? c: Call => Bool.
lowers-to-euf-rule? c: Call => Bool.

---

> Consolidation: no purity-decision site uses the removed checker-free predicate.
all s: Site | ~(legacy-syntactic? s).
> Conservative: a function is deemed pure only if it resolves; unknown
> callees stay effectful.
all f: Fn | pure-fn? f -> resolvable? f.
> A call to a pure user function is side-effect-free, admitted in
> predicate/condition positions, and lowers to its EUF rule.
all c: Call | pure-fn? (callee c) -> ~(has-side-effects? c) and admitted? c and lowers-to-euf-rule? c.
```

## Patch Specification

```
module GUARD_PURITY_USER_CALLS_PATCH_3.

Fn.
pure-fn? f: Fn => Bool.
resolvable? f: Fn => Bool.
effect-free-body? f: Fn => Bool.

---

> The classifier deems a function pure only if it resolves and its body
> is effect-free (conservative whole-body, interprocedural; unknown ⇒
> not pure). Dormant until wired in patch 4 — no behavior change.
all f: Fn | pure-fn? f -> resolvable? f and effect-free-body? f.
```


## Implementation Notes

- The classifier is deliberately stricter than the minimum wording in one place: it rejects all assignment expressions, not just non-local writes. That keeps Patch 3 sound-by-bail while dormant; local-mutation recovery can be added later if there is a concrete need.
- `resolveUserCallTarget` mirrors the guard-following resolver’s conservative shape rather than exporting/refactoring the existing private helper in this patch: direct identifier calls only, block-bodied function targets only, `node_modules` rejected, function-typed parameters rejected as higher-order/dynamic calls. This avoids churn in guard extraction before Patch 4.
- Known-pure builtins are still allowed inside user-function bodies through `isKnownPureCall`, but user-call purity is not wired into `isKnownPureCall` or `isEffectFree` yet. The existing `isEffectFree` user-call test remains the no-behavior-change guard.
- Spread literals are treated as effectful in the user classifier even when their operand expression looks pure, because iterator/getter execution would otherwise be an unsound admission.

Spec/Evidence Mapping:
- `pure-fn? f -> resolvable? f`: implemented by `isPureUserFunction` requiring a concrete non-`node_modules` block body and by `isPureUserCall` resolving through `resolveUserCallTarget`; covered by the `node_modules` bail and recursion-bail tests in `purity.test.mts`.
- `pure-fn? f -> effect-free-body? f`: implemented by `blockIsPureForUserAnalysis` / `statementIsPureForUserAnalysis` / `userExpressionIsPure`; covered by pure-helper and mutates/throws/awaits tests.
- Dormant/no behavior change: `isPureUserCall` is exported but not consulted by the oracle; covered by the existing `isEffectFree` test that still treats user calls as effectful, plus `just ts2pant-precommit`.