### PR TITLE
[ts2pant-guard-purity-user-calls] Patch 4: Wire the classifier into the oracle: admit pure user calls in condition positions

### DIFF
--- a/tools/ts2pant/src/extract.ts
+++ b/tools/ts2pant/src/extract.ts
@@ -4,6 +4,7 @@ import ts from "typescript";
 import { lookupBuiltinByCall } from "./builtins.js";
 import type { OpaqueExpr } from "./pant-ast.js";
 import { getAst } from "./pant-wasm.js";
+import { isPureUserCall } from "./purity.js";
 import { classifyFunction, translateSignature } from "./translate-signature.js";
 import {
   cellRegisterName,
@@ -931,10 +932,7 @@ export function extractReferencedFunctions(
   if (!consumerNode?.body) {
     return [];
   }
-  if (classifyFunction(consumerNode, checker) !== "pure") {
-    return [];
-  }
-
+  const consumerIsPure = classifyFunction(consumerNode, checker) === "pure";
   // Collect (declaration, callSiteNames) pairs for free-function calls
   // reached from the consumer's body. Keying by the
   // resolved declaration deduplicates aliased imports — `import {
@@ -952,6 +950,10 @@ export function extractReferencedFunctions(
       !n.arguments.some(ts.isSpreadElement)
     ) {
       if (lookupBuiltinByCall(n, checker, program) !== null) {
+        ts.forEachChild(n, visit);
+        return;
+      }
+      if (!consumerIsPure && !isPureUserCall(n, checker)) {
         ts.forEachChild(n, visit);
         return;
       }

--- a/tools/ts2pant/src/purity.ts
+++ b/tools/ts2pant/src/purity.ts
@@ -417,7 +417,10 @@ export function isKnownPureCall(
   checker: ts.TypeChecker,
 ): boolean {
   try {
-    return isKnownPureCallInner(expr, checker);
+    return (
+      isKnownBuiltinOrLibraryPureCall(expr, checker) ||
+      isPureUserCall(expr, checker)
+    );
   } catch {
     // TypeChecker can throw on malformed/incomplete ASTs.
     // Conservative fallback: treat as effectful.
@@ -425,7 +428,7 @@ export function isKnownPureCall(
   }
 }
 
-function isKnownPureCallInner(
+function isKnownBuiltinOrLibraryPureCall(
   expr: ts.CallExpression,
   checker: ts.TypeChecker,
 ): boolean {
@@ -539,9 +542,8 @@ function isKnownPureCallInner(
 /**
  * Conservatively classify a direct user-function call as pure.
  *
- * Dormant in Patch 3: this is intentionally not consulted by
- * `isKnownPureCall`/`isEffectFree` yet. Patch 4 wires it into the canonical
- * oracle once the behavior change is enabled.
+ * This feeds the canonical checker-aware oracle. Calls stay effectful unless
+ * the callee resolves to a user function whose body is conservatively pure.
  */
 export function isPureUserCall(
   call: ts.CallExpression,
@@ -1025,7 +1027,7 @@ function userExpressionIsPure(
     );
   }
   if (ts.isCallExpression(expr)) {
-    if (isKnownPureCall(expr, checker)) {
+    if (isKnownBuiltinOrLibraryPureCall(expr, checker)) {
       return (
         userExpressionIsPure(expr.expression, checker, visited) &&
         expr.arguments.every((arg) =>

--- a/tools/ts2pant/src/purity.ts
+++ b/tools/ts2pant/src/purity.ts
@@ -550,17 +550,27 @@ export function isPureUserCall(
   checker: ts.TypeChecker,
 ): boolean {
   try {
-    if (call.arguments.some(ts.isSpreadElement)) {
-      return false;
-    }
-    if (!call.arguments.every((arg) => userExpressionIsPure(arg, checker))) {
-      return false;
-    }
-    const decl = resolveUserCallTarget(call, checker);
-    return decl !== null && isPureUserFunction(decl, checker);
+    return isPureUserCallWithVisited(call, checker, new Set());
   } catch {
     return false;
   }
+}
+
+function isPureUserCallWithVisited(
+  call: ts.CallExpression,
+  checker: ts.TypeChecker,
+  visited: Set<ts.Node>,
+): boolean {
+  if (call.arguments.some(ts.isSpreadElement)) {
+    return false;
+  }
+  if (
+    !call.arguments.every((arg) => userExpressionIsPure(arg, checker, visited))
+  ) {
+    return false;
+  }
+  const decl = resolveUserCallTarget(call, checker);
+  return decl !== null && isPureUserFunction(decl, checker, visited);
 }
 
 /**
@@ -1035,18 +1045,7 @@ function userExpressionIsPure(
         )
       );
     }
-    if (expr.arguments.some(ts.isSpreadElement)) {
-      return false;
-    }
-    if (
-      !expr.arguments.every((arg) =>
-        userExpressionIsPure(arg, checker, visited),
-      )
-    ) {
-      return false;
-    }
-    const decl = resolveUserCallTarget(expr, checker);
-    return decl !== null && isPureUserFunction(decl, checker, visited);
+    return isPureUserCallWithVisited(expr, checker, visited);
   }
 
   return false;

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -691,11 +691,11 @@ exports[`expressions-pure-call-predicate.ts > effectfulCallPredicate 1`] = `
 `;
 
 exports[`expressions-pure-call-predicate.ts > pureCallEarlyReturn 1`] = `
-"module PURE_CALL_EARLY_RETURN.\\n\\nis-positive n1: Int => Bool.\\npure-call-early-return n: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: pure-call-early-return — early-return predicate has side effects.\\n"
+"module PURE_CALL_EARLY_RETURN.\\n\\nis-positive n1: Int => Bool.\\npure-call-early-return n: Int => Int.\\n\\n---\\n\\npure-call-early-return n = (cond is-positive n => 1, true => 0).\\n"
 `;
 
 exports[`expressions-pure-call-predicate.ts > pureCallMutatingIf 1`] = `
-"module PURE_CALL_MUTATING_IF.\\n\\nAccount.\\naccount--balance a: Account => Int.\\n~> Pure-call-mutating-if @ account: Account, amount: Int.\\n\\n---\\n\\n> UNSUPPORTED: impure if-condition in mutating body.\\n"
+"module PURE_CALL_MUTATING_IF.\\n\\nAccount.\\naccount--balance a: Account => Int.\\nis-deposit-allowed amount1: Int => Bool.\\n~> Pure-call-mutating-if @ account: Account, amount: Int.\\n\\n---\\n\\naccount--balance' account = (cond is-deposit-allowed amount => account--balance account + amount, true => account--balance account).\\nis-deposit-allowed' amount1 = is-deposit-allowed amount1.\\n"
 `;
 
 exports[`expressions-readonly-set.ts > cardinalityReadonly 1`] = `

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-pure-call-predicate.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-pure-call-predicate.ts
@@ -18,7 +18,6 @@ function recordsObservation(n: number): boolean {
   return observed > 0;
 }
 
-/** PENDING Patch 4: pure helper call in an early-return predicate */
 export function pureCallEarlyReturn(n: number): number {
   if (isPositive(n)) {
     return 1;
@@ -26,7 +25,6 @@ export function pureCallEarlyReturn(n: number): number {
   return 0;
 }
 
-/** PENDING Patch 4: pure helper call in a mutating if-condition */
 export function pureCallMutatingIf(account: Account, amount: number): void {
   if (isDepositAllowed(amount)) {
     account.balance = account.balance + amount;

--- a/tools/ts2pant/tests/integration/e2e.test.mts
+++ b/tools/ts2pant/tests/integration/e2e.test.mts
@@ -3,11 +3,15 @@ import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { describe, it } from "node:test";
 import { extractFunctionAnnotations } from "../../src/annotations.js";
-import { createSourceFile } from "../../src/extract.js";
+import {
+  createSourceFile,
+  createSourceFileFromSource,
+} from "../../src/extract.js";
 import type { PantDocument } from "../../src/types.js";
 import {
   assertPantTypeChecks,
   buildDocument as buildDocumentFromPath,
+  buildDocumentFromSourceFile,
   emitAndCheck,
   runCheck,
 } from "../helpers.mjs";
@@ -152,6 +156,50 @@ describe("full pipeline", () => {
     const output = await emitAndCheck(doc);
 
     assertPantTypeChecks(output);
+  });
+});
+
+describe("pure user calls in predicates", () => {
+  it("early-return predicate emits a synthesized EUF rule head", async () => {
+    const sourceFile = createSourceFileFromSource(`
+      function isPositive(n: number): boolean {
+        return n > 0;
+      }
+      export function f(n: number): number {
+        if (isPositive(n)) return 1;
+        return 0;
+      }
+    `);
+    const output = await emitAndCheck(
+      await buildDocumentFromSourceFile(sourceFile, "f"),
+    );
+
+    assert.match(output, /^is-positive n1: Int => Bool\.$/mu);
+    assert.match(output, /^f n = \(cond is-positive n => 1, true => 0\)\.$/mu);
+  });
+
+  it("mutating if-condition emits a synthesized EUF rule head", async () => {
+    const sourceFile = createSourceFileFromSource(`
+      interface Account { balance: number }
+      function isDepositAllowed(amount: number): boolean {
+        const normalized = Math.max(0, amount);
+        return normalized > 0;
+      }
+      export function deposit(account: Account, amount: number): void {
+        if (isDepositAllowed(amount)) {
+          account.balance = account.balance + amount;
+        }
+      }
+    `);
+    const output = await emitAndCheck(
+      await buildDocumentFromSourceFile(sourceFile, "deposit"),
+    );
+
+    assert.match(output, /^is-deposit-allowed amount1: Int => Bool\.$/mu);
+    assert.match(
+      output,
+      /^account--balance' account = \(cond is-deposit-allowed amount => account--balance account \+ amount, true => account--balance account\)\.$/mu,
+    );
   });
 });
 

--- a/tools/ts2pant/tests/known-typecheck-failures.mts
+++ b/tools/ts2pant/tests/known-typecheck-failures.mts
@@ -55,14 +55,6 @@ export const KNOWN_TYPECHECK_FAILURES = new Map<string, string>([
   ["expressions-boolean.ts > or", "$-binder-leak"],
   ["expressions-let-closure-captured.ts > letForEachCapturedTotal", "closure-captured-reassignment"],
   ["expressions-let-closure-captured.ts > letMapCapturedCount", "closure-captured-reassignment"],
-  [
-    "expressions-pure-call-predicate.ts > pureCallEarlyReturn",
-    "pure-call-predicate",
-  ],
-  [
-    "expressions-pure-call-predicate.ts > pureCallMutatingIf",
-    "pure-call-predicate",
-  ],
   ["expressions-var-rejected.ts > varBinding", "var-rejected"],
   ["expressions-var-rejected.ts > varReassignment", "var-rejected"],
   ["functions-class.ts > Account.getBalance", "requires-external-context"],

--- a/tools/ts2pant/tests/purity.test.mts
+++ b/tools/ts2pant/tests/purity.test.mts
@@ -544,9 +544,6 @@ describe("isPureUserFunction", () => {
     );
   });
 
-  it.skip("PENDING Patch 4: pure user call in early-return predicate lowers to its EUF rule", () => {});
-
-  it.skip("PENDING Patch 4: pure user call in mutating if-condition lowers to its EUF rule", () => {});
 });
 
 // ---------------------------------------------------------------------------
@@ -644,7 +641,7 @@ describe("isKnownPureCall (Effect-TS symbol resolution)", () => {
 
   // --- User function returning Effect ---
 
-  it("user function returning Effect is impure (not a library export)", () => {
-    assert.equal(checkFixturePurity("userEffectReturning"), false);
+  it("pure user function returning Effect is pure by body analysis", () => {
+    assert.equal(checkFixturePurity("userEffectReturning"), true);
   });
 });

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -11,6 +11,7 @@ import {
   UNSUPPORTED_UNKNOWN_REASON,
 } from "../src/translate-types.js";
 import type { PropResult } from "../src/types.js";
+import { buildDocumentFromSourceFile, emitAndCheck } from "./helpers.mjs";
 
 before(async () => {
   await loadAst();
@@ -571,6 +572,51 @@ describe("if-early-return prelude arms", () => {
     }
   });
 
+  it("pure user call in early-return predicate lowers to its EUF rule", async () => {
+    const source = `
+      function isPositive(n: number): boolean {
+        return n > 0;
+      }
+      export function f(n: number): number {
+        if (isPositive(n)) return 1;
+        return 0;
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const output = await emitAndCheck(
+      await buildDocumentFromSourceFile(sourceFile, "f"),
+    );
+
+    assert.match(output, /^is-positive n1: Int => Bool\.$/mu);
+    assert.match(output, /^f n = \(cond is-positive n => 1, true => 0\)\.$/mu);
+  });
+
+  it("effectful user call in early-return predicate still rejects", () => {
+    const source = `
+      let observed = 0;
+      function recordsObservation(n: number): boolean {
+        observed = n;
+        return observed > 0;
+      }
+      export function f(n: number): number {
+        if (recordsObservation(n)) return 1;
+        return 0;
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "f",
+      strategy: IntStrategy,
+    });
+
+    assertUnsupportedReason(
+      props,
+      /early-return predicate has side effects/u,
+      "effectful user predicate",
+    );
+  });
+
   it("pure block-bodied early-return arm lowers to cond with inlined bindings", () => {
     const source = `
       export function f(n: number): number {
@@ -1046,6 +1092,59 @@ describe("translateCallExpr", () => {
 });
 
 describe("conditional mutations (symbolic last-write)", () => {
+  it("pure user call in mutating if-condition lowers to its EUF rule", async () => {
+    const source = `
+      interface Account { balance: number }
+      function isDepositAllowed(amount: number): boolean {
+        const normalized = Math.max(0, amount);
+        return normalized > 0;
+      }
+      export function deposit(account: Account, amount: number): void {
+        if (isDepositAllowed(amount)) {
+          account.balance = account.balance + amount;
+        }
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const output = await emitAndCheck(
+      await buildDocumentFromSourceFile(sourceFile, "deposit"),
+    );
+
+    assert.match(output, /^is-deposit-allowed amount1: Int => Bool\.$/mu);
+    assert.match(
+      output,
+      /^account--balance' account = \(cond is-deposit-allowed amount => account--balance account \+ amount, true => account--balance account\)\.$/mu,
+    );
+  });
+
+  it("effectful user call in mutating if-condition still rejects", () => {
+    const source = `
+      interface Account { balance: number }
+      let observed = 0;
+      function recordsObservation(n: number): boolean {
+        observed = n;
+        return observed > 0;
+      }
+      export function deposit(account: Account, amount: number): void {
+        if (recordsObservation(amount)) {
+          account.balance = account.balance + amount;
+        }
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBody({
+      sourceFile,
+      functionName: "deposit",
+      strategy: IntStrategy,
+    });
+
+    assertUnsupportedReason(
+      props,
+      /impure if-condition in mutating body/u,
+      "effectful mutating if-condition",
+    );
+  });
+
   // `m.set(k, v)` etc. return the receiver/boolean, but the
   // translator categorizes them as effects (statement-only). Without
   // a `rejectEffect` guard at the assignment handler, `bodyExpr(val)`

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -11,7 +11,6 @@ import {
   UNSUPPORTED_UNKNOWN_REASON,
 } from "../src/translate-types.js";
 import type { PropResult } from "../src/types.js";
-import { buildDocumentFromSourceFile, emitAndCheck } from "./helpers.mjs";
 
 before(async () => {
   await loadAst();
@@ -572,7 +571,7 @@ describe("if-early-return prelude arms", () => {
     }
   });
 
-  it("pure user call in early-return predicate lowers to its EUF rule", async () => {
+  it("admits pure user call in early-return predicate", () => {
     const source = `
       function isPositive(n: number): boolean {
         return n > 0;
@@ -583,12 +582,16 @@ describe("if-early-return prelude arms", () => {
       }
     `;
     const sourceFile = createSourceFileFromSource(source);
-    const output = await emitAndCheck(
-      await buildDocumentFromSourceFile(sourceFile, "f"),
-    );
+    const props = translateBody({
+      sourceFile,
+      functionName: "f",
+      strategy: IntStrategy,
+    });
 
-    assert.match(output, /^is-positive n1: Int => Bool\.$/mu);
-    assert.match(output, /^f n = \(cond is-positive n => 1, true => 0\)\.$/mu);
+    assert.equal(
+      getAst().strExpr(finalEquation(props).rhs),
+      "cond is-positive n => 1, true => 0",
+    );
   });
 
   it("effectful user call in early-return predicate still rejects", () => {
@@ -1092,7 +1095,7 @@ describe("translateCallExpr", () => {
 });
 
 describe("conditional mutations (symbolic last-write)", () => {
-  it("pure user call in mutating if-condition lowers to its EUF rule", async () => {
+  it("admits pure user call in mutating if-condition", () => {
     const source = `
       interface Account { balance: number }
       function isDepositAllowed(amount: number): boolean {
@@ -1106,15 +1109,14 @@ describe("conditional mutations (symbolic last-write)", () => {
       }
     `;
     const sourceFile = createSourceFileFromSource(source);
-    const output = await emitAndCheck(
-      await buildDocumentFromSourceFile(sourceFile, "deposit"),
-    );
+    const props = translateBody({
+      sourceFile,
+      functionName: "deposit",
+      strategy: IntStrategy,
+    });
 
-    assert.match(output, /^is-deposit-allowed amount1: Int => Bool\.$/mu);
-    assert.match(
-      output,
-      /^account--balance' account = \(cond is-deposit-allowed amount => account--balance account \+ amount, true => account--balance account\)\.$/mu,
-    );
+    assert.equal(props.some((p) => p.kind === "unsupported"), false);
+    assert.match(equationRhsText(props), /isDepositAllowed amount/u);
   });
 
   it("effectful user call in mutating if-condition still rejects", () => {

--- a/tools/ts2pant/tests/translate-signature.test.mts
+++ b/tools/ts2pant/tests/translate-signature.test.mts
@@ -160,7 +160,7 @@ describe("guard expression structure", () => {
     );
   });
 
-  it("skips guard when if-condition has side effects (call)", () => {
+  it("extracts guard when if-condition calls a pure helper", () => {
     const source = `
       interface Account { balance: number; }
       function audit(): boolean { return true; }
@@ -177,10 +177,10 @@ describe("guard expression structure", () => {
     if (result.declaration.kind !== "action") {
       return;
     }
-    assert.equal(result.declaration.guard, undefined);
+    assert.equal(getAst().strExpr(result.declaration.guard!), "audit");
   });
 
-  it("skips guard when negated if-condition has side effects", () => {
+  it("extracts negated guard when if-condition calls a pure helper", () => {
     const source = `
       interface Account { balance: number; }
       function check(): boolean { return true; }
@@ -196,7 +196,7 @@ describe("guard expression structure", () => {
     if (result.declaration.kind !== "action") {
       return;
     }
-    assert.equal(result.declaration.guard, undefined);
+    assert.equal(getAst().strExpr(result.declaration.guard!), "check");
   });
 
   it("guard detection stops at non-if statements", () => {


### PR DESCRIPTION
## Patch 4: Wire the classifier into the oracle: admit pure user calls in condition positions

- Wire isPureUserCall into the canonical oracle so pure user calls are classified effect-free; confirm the condition then lowers via the existing path to the free-call-decl-synthesized EUF rule head (and the head/import is emitted).
- Verify effectful user calls in those positions still reject (negative fixture).
- Clear the pure-call-predicate allowlist entries, regenerate snapshots, unskip the emission tests.
- Run test:unit + test:integration; confirm the cleared fixtures type-check and no unrelated snapshot churn.

## Changes
- Wire isPureUserCall into the canonical oracle so pure user calls are classified effect-free; confirm the condition then lowers via the existing path to the free-call-decl-synthesized EUF rule head (and the head/import is emitted).
- Verify effectful user calls in those positions still reject (negative fixture).
- Clear the pure-call-predicate allowlist entries, regenerate snapshots, unskip the emission tests.
- Run test:unit + test:integration; confirm the cleared fixtures type-check and no unrelated snapshot churn.

## Files to Modify
- tools/ts2pant/src/purity.ts (modify): Consult isPureUserCall inside the canonical oracle / isKnownPureCall so a call to a pure user function is effect-free. This unblocks the early-return-predicate (translate-body.ts:2397) and mutating-if-condition (ir1-build-body.ts:958) gates, which route through the oracle.
- tools/ts2pant/tests/known-typecheck-failures.mts (modify): Remove the pure-call-predicate entries.
- tools/ts2pant/tests/constructs.test.mts.snapshot (modify): Add snapshots for the pure-call-predicate fixtures (predicate lowered to the EUF rule application).
- tools/ts2pant/tests/translate-body.test.mts (modify): Unskip and implement: a pure user call in an early-return predicate lowers to its synthesized rule; an effectful one still rejects.

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[paper] Kroening & Strichman, Decision Procedures Ch. 4 (Equality with Uninterpreted Functions)** — https://www.decision-procedures.org/ — An admitted pure user call lowers to an uninterpreted-function application (the free-call-decl EUF rule head); soundness rests on congruence alone, which is why treating a pure call as a value in a predicate position introduces no unsound axiom.

## Gameplan Specification

```
module GUARD_PURITY_USER_CALLS.

> Two outcomes. (1) Consolidation: ts2pant has a single checker-aware
> purity oracle — the checker-free isPureExpression is gone, so call
> classification is consistent across signature-extraction and body-
> lowering. (2) User-call purity: a call to a conservatively-pure user
> function is effect-free, so it is admitted in predicate/condition
> positions and lowers to the EUF rule free-call-decl synthesizes.
> Purity is inferred from the callee body; unknown ⇒ effectful (bail).

Expr.
Call.
Fn.
Site.

callee c: Call => Fn.
pure-fn? f: Fn => Bool.
resolvable? f: Fn => Bool.
effect-free? e: Expr => Bool.
legacy-syntactic? s: Site => Bool.
has-side-effects? c: Call => Bool.
admitted? c: Call => Bool.
lowers-to-euf-rule? c: Call => Bool.

---

> Consolidation: no purity-decision site uses the removed checker-free predicate.
all s: Site | ~(legacy-syntactic? s).
> Conservative: a function is deemed pure only if it resolves; unknown
> callees stay effectful.
all f: Fn | pure-fn? f -> resolvable? f.
> A call to a pure user function is side-effect-free, admitted in
> predicate/condition positions, and lowers to its EUF rule.
all c: Call | pure-fn? (callee c) -> ~(has-side-effects? c) and admitted? c and lowers-to-euf-rule? c.
```

## Patch Specification

```
module GUARD_PURITY_USER_CALLS_PATCH_4.

Call.
Fn.
callee c: Call => Fn.
pure-fn? f: Fn => Bool.
has-side-effects? c: Call => Bool.
admitted? c: Call => Bool.
lowers-to-euf-rule? c: Call => Bool.

---

> Wiring the classifier into the oracle: a call to a pure user function
> is side-effect-free, admitted in predicate/condition positions, and
> lowers to its synthesized EUF rule.
all c: Call | pure-fn? (callee c) -> ~(has-side-effects? c) and admitted? c and lowers-to-euf-rule? c.
```


## Implementation Notes

- The public oracle now treats `isKnownPureCall` as builtin/library purity OR conservative user-function purity. Inside the user-function analyzer, recursive call following deliberately uses a builtin/library-only helper before following direct user calls with the shared `visited` set; this avoids re-entering the public oracle with a fresh visited set and missing recursion.
- Mutating consumers were a non-obvious plumbing gap: `extractReferencedFunctions` previously returned early for non-pure consumers, so a newly admitted mutating `if (pureHelper(...))` condition could lower to an undeclared raw callee. The extraction path now keeps the old broad behavior for pure consumers, but for mutating consumers it only synthesizes referenced function heads for calls `isPureUserCall` proves pure. This keeps assert/unsupported fixtures from gaining unrelated helper declarations.
- The Effect-TS “user function returning Effect” oracle test now expects purity when the user function body is conservatively pure. This is a behavior change from “only library exports are pure,” and follows the patch’s user-body-analysis rule rather than return-type-based classification.
- Spec/Evidence Mapping: pure user call implies `~has-side-effects?` via `tools/ts2pant/src/purity.ts` (`isKnownPureCall` delegates to `isPureUserCall`); admitted/lowered in early-return predicates through `translate-body` coverage; admitted/lowered in mutating if-conditions through `ir1-build-body` plus the narrowed `extractReferencedFunctions` declaration synthesis. Evidence: `npm run test:unit`, `npm run test:integration`, updated `expressions-pure-call-predicate.ts` snapshots, and new positive/negative tests in `tools/ts2pant/tests/translate-body.test.mts`.