### PR TITLE
Guard-analysis M2: narrowing survey + split M3 into M3a/M3b

### DIFF
--- a/tools/ts2pant/docs/guard-narrowing-survey.md
+++ b/tools/ts2pant/docs/guard-narrowing-survey.md
@@ -1,0 +1,106 @@
+# Guard Narrowing Survey (Workstream M2)
+
+**Workstream:** ts2pant Flow-Sensitive Guard & Effect Analysis — Milestone 2
+(`guard-narrowing-survey`). **Date:** 2026-05-27. **Method:** read-only probe over
+ts2pant `src/` (653 functions) + `tests/fixtures` after M1 (`guard-purity-user-calls`)
+merged. No translator behavior changed.
+
+## Purpose
+
+M1 gave ts2pant a single checker-aware purity oracle and admitted calls to pure
+user functions in condition/predicate positions. M3 (`guard-flow-narrowing`) is the
+greenfield layer that propagates a test's truth into its branch — and it is the
+cross-workstream dependency for the discriminated-union workstream's M3. This
+survey measures (1) M1's actual dogfood impact, (2) which narrowing patterns the
+corpus actually uses, to scope and design M3.
+
+## (1) M1 dogfood impact — smaller than the raw count suggested, and that's correct
+
+The body-lowering diagnostic counted ~58 functions blocked on "early-return
+predicate has side effects" / "impure if-condition in mutating body". After M1 the
+counts are 52 + 10. The headline is **not** the absolute delta (the src corpus also
+grew ~23 functions, and a measurement artifact — ~280 functions throw "Maximum call
+stack size exceeded" during whole-file re-translation — adds noise). The headline is
+**what remains and why**:
+
+> The residual predicate-rejections are dominated by predicates that call the
+> **TypeScript compiler API** (`checker.getX(...)`, `ts.isX(...)`), which lives in
+> `node_modules` and the M1 classifier **correctly bails on** (→ effectful).
+> Examples: `isStringLikeType`, `getBuiltinNamespace`, `isNamedCallableDeclaration`,
+> `declarationName`.
+
+So M1 delivered exactly its addressable set — predicates over **local pure helpers**
+(demonstrated by the `expressions-pure-call-predicate` fixtures it cleared) — and the
+remainder are checker-API calls that are inherently unmodellable and *should* stay
+rejected. **Implication for the workstream:** ts2pant's own source is a weaker
+dogfood target for the purity lever than the raw ~66 figure implied, because it is
+TS-compiler-API-heavy. This does not diminish M1 (the lever is real for user code);
+it recalibrates expectations for self-translation specifically.
+
+## (2) Narrowing-pattern inventory (src + fixtures)
+
+| Pattern | Count | Notes |
+|---|---|---|
+| **Discriminant `switch`** (`switch (x.kind)`) | **58** | `switch prop.kind` / `decl.kind` / `expr.kind` / `e.kind` — ts2pant's own IR walkers over `IR1Expr`/`IRExpr` discriminated unions. **This is the DU-workstream M3 dependency, and it is heavily used.** |
+| **`=== literal` on a property** | 169 | Mix of true discriminant narrowing (`.kind === "..."`) and ordinary value compares (`.length === 0`, `.status === 2`). The `.kind === lit` subset is DU-relevant. |
+| **Nullish** (`x !== null`, `=== undefined`) | 165 | Guards a subsequent non-null access. Large, self-contained lever. |
+| **Boolean / call guards** (`if (f(x))`) | 368 | Includes user predicates **and** TS type-guards (`ts.isX(n)`). |
+| **Type predicates** (`x is T`) | (under-measured) | The probe's per-file checker could not resolve signatures, so type-predicate calls fell into the boolean-guard bucket. Qualitatively `ts.isX(...)` type guards are *pervasive* in ts2pant's own code — the primary way it discriminates AST node kinds. |
+
+### Reading the inventory
+
+- **Discriminant narrowing is the clear M3 priority.** It is both the DU M3
+  hard-dependency *and* the densest real pattern (58 switches + the `.kind === lit`
+  ifs). For the DU workstream it narrows *user* discriminated unions; for
+  self-translation it narrows ts2pant's own IR unions.
+- **Nullish narrowing (165)** is the next lever — guarding non-null field/access
+  inside `if (x != null)`.
+- **Type-predicate narrowing (`ts.isX`)** is pervasive but refines *TypeScript
+  compiler types* (complex `ts.Node` unions), so its self-translation payoff is
+  entangled with how ts2pant models those types — higher effort, lower near-term
+  certainty than discriminant/nullish.
+
+## M3 design proposal
+
+A **function-scoped assumption environment**: when lowering enters a branch whose
+test is a recognized narrowing predicate, push the predicate's fact into an
+environment that lowering consults to discharge guards; pop on exit. Facts:
+
+- `discriminant`: `<expr> = <literal>` (from `x.kind === "c"` / matched `switch` arm)
+  → discharges a discriminant-guarded variant-field rule. **The DU workstream's
+  `du-discriminant-narrowing` consumes exactly this fact.**
+- `non-null`: `<expr>` present (from `x != null` / `x !== undefined`) → discharges a
+  nullability obligation.
+- `predicate`: `<predicate-application>` true (from a boolean/type-guard test) → the
+  base case.
+
+Intra-function only (workstream decision); no field-name special-casing — the
+discriminant fact keys on the structural `<property-access> === <literal>` shape, not
+on `.kind`. Facts render as z3 path-condition assumptions (occurrence typing modulo
+theories).
+
+## Verdict & recommended M3 scope
+
+Proceed to M3. Applying the workstream's gate (a pattern is in M3 iff it spans
+multiple corpus functions **or** a downstream workstream hard-depends on it):
+
+- **Discriminant narrowing** — IN (both criteria).
+- **Nullish narrowing** — IN (165 sites).
+- **Type-predicate narrowing** — IN by count, but flagged higher-effort (refines
+  TS-compiler types); candidate to sequence last or defer.
+
+**Recommended split (workstream structural change — for the operator to weigh):**
+split M3 into **M3a `du-discriminant-narrowing-layer`** (discriminant + the boolean
+base case — delivers the DU dependency first, smallest surface) and **M3b
+`nullish-and-predicate-narrowing`** (nullish, then type-predicate). This unblocks the
+DU workstream as early as possible rather than gating it behind the larger
+nullish/predicate work.
+
+## Caveats
+
+- The ~280 "Maximum call stack size exceeded" throws during whole-file re-translation
+  are a probe/translator-robustness artifact on large or mutually-recursive functions;
+  they are not narrowing data and warrant a separate robustness look.
+- The type-predicate vs boolean-guard split is unreliable (per-file checker could not
+  resolve call signatures); treat the 368 boolean-guard bucket as containing a large,
+  unquantified share of `ts.isX` type guards.

--- a/workstreams/ts2pant-discriminated-union.md
+++ b/workstreams/ts2pant-discriminated-union.md
@@ -188,7 +188,8 @@ invariants to add first).
   encoding does not entail even with the guard assumed, do NOT start M3 — open an
   encoding-fix follow-up first.
 - **Confirm the guard-analysis dependency is ready.** M3 consumes the
-  guard-analysis workstream's flow-narrowing layer; verify that milestone has
+  guard-analysis workstream's **M3a `du-discriminant-narrowing-layer`** (the
+  discriminant-narrowing fact `<property> === <literal>`); verify that milestone has
   landed (or sequence M3 after it). If it has not, M3 is blocked — do not start.
 - **Abort condition**: if the survey shows the dominant blocker is
   cross-call/assertion narrowing (out of scope), reduce M3 to the intra-function
@@ -279,9 +280,9 @@ non-discriminated unions) is a separate effort with its own encoding question.
 ```
 
 **Note**: Strictly sequential. M1–M2 can proceed immediately. M3 is additionally
-**gated on the guard-analysis workstream** delivering a flow-narrowing /
-predicate-following layer (Decisions, below); if that workstream has not landed
-when M2 completes, M3 waits. M4 depends on M3's narrowing being proven.
+**gated on the guard-analysis workstream's M3a `du-discriminant-narrowing-layer`**
+(the discriminant-narrowing fact); if that milestone has not landed when M2
+completes, M3 waits. M4 depends on M3's narrowing being proven.
 
 ## Open Questions
 

--- a/workstreams/ts2pant-guard-analysis.md
+++ b/workstreams/ts2pant-guard-analysis.md
@@ -149,7 +149,19 @@ narrowing patterns that remain.
 
 ---
 
-### Milestone 2: guard-narrowing-survey
+### Milestone 2: guard-narrowing-survey — ✅ COMPLETE (2026-05-27)
+
+> Run read-only, no gameplan. Report: `tools/ts2pant/docs/guard-narrowing-survey.md`.
+> **Findings:** (1) M1's self-translation lift is limited — residual predicate
+> rejections are dominated by predicates calling the TS compiler API (node_modules →
+> the classifier correctly bails); the ~66 figure overcounted the addressable set for
+> ts2pant's *own* code (the purity lever remains real for user code). (2) Narrowing
+> inventory: discriminant `switch (x.kind)` = 58 (the DU dependency, heavily used in
+> IR walkers), `=== literal` ifs = 169, nullish = 165, boolean/call guards = 368
+> (type-predicate `ts.isX` pervasive but under-measured). **Verdict:** proceed to M3,
+> **split into M3a + M3b** (see below), with the assumption-environment design in the
+> report. Caveat: ~280 functions throw stack-overflow during whole-file
+> re-translation — a separate robustness concern, not narrowing data.
 
 **Definition of Done**:
 - Read-only survey over the dogfood + constructs corpus, run after M1: how many
@@ -182,43 +194,73 @@ interface the DU workstream can commit to.
   so M3 builds the shared layer, not a bespoke one.
 
 **Open Questions**:
-- One milestone vs. split-by-pattern for M3. Resolved by this survey.
+- *(resolved by this survey)* One milestone vs. split-by-pattern for M3 → **split**
+  into M3a + M3b (below), so the DU dependency ships first.
 
 ---
 
-### Milestone 3: guard-flow-narrowing
+> **M3 was split by the M2 survey** into M3a (discriminant + boolean base case —
+> delivers the DU dependency first, smallest surface) and M3b (nullish, then
+> type-predicate). Both implement the same function-scoped assumption-environment
+> layer (push a fact into an environment on entering a narrowed branch; lowering
+> consults it to discharge guards; pop on exit), intra-function only, no field-name
+> special-casing, facts rendered as z3 path conditions.
+
+### Milestone 3a: du-discriminant-narrowing-layer
 
 **Definition of Done**:
-- A **flow-narrowing layer**: within a function, a test's truth is propagated into
-  its branch as an assumption usable by lowering — covering (at least) boolean
-  guards and the patterns the M2 survey selected (discriminant equality, nullish,
-  user `x is T` type-predicates). The narrowed assumption discharges obligations in
-  the branch (e.g. a discriminant-guarded variant-field rule, a non-null access)
-  and is rendered so z3 can use it as a path condition.
-- **Intra-function only**; cross-call / assertion-function narrowing remains
-  refused (matches the any/unknown-opaque decision).
-- No field-name special-casing — discriminant narrowing keys on the structural
-  predicate (`<field> === <literal>`), not on `.kind`.
-- The layer exposes a stable interface the DU workstream's M3 consumes.
+- The function-scoped assumption-environment infrastructure, plus **discriminant**
+  narrowing: `if (x.kind === lit)` / matched `switch (x.kind)` arms / early-return
+  discriminant guards push a `<property-access> = <literal>` fact that lowering uses
+  to discharge a discriminant-guarded variant-field rule. The boolean base case
+  (`if (P) …` pushes "P holds") is included as the substrate.
+- Intra-function only; no field-name special-casing (keys on the structural
+  `<property> === <literal>` shape).
+- Exposes the stable `<property> === <literal>` discriminant fact the DU
+  workstream's `du-discriminant-narrowing` consumes.
 
 **Why this is a safe pause point**: Narrowing is additive — un-narrowed code keeps
-its current (sound-by-guard) lowering; narrowed branches gain provable facts.
-ts2pant now reasons flow-sensitively within a function.
+its sound-by-guard lowering. The DU dependency is delivered.
 
-**Unlocks**: The discriminated-union workstream's M3 (`du-discriminant-narrowing`)
-— a **cross-workstream unlock**; richer nullish and any/unknown handling.
+**Unlocks**: The discriminated-union workstream's M3 (`du-discriminant-narrowing`) —
+the **cross-workstream unlock**.
 
 **Operator Actions Before Next Milestone**:
-- Confirm before/after entailment set shows the targeted narrowing obligations now
-  discharge and nothing regressed.
+- Confirm the before/after entailment set: discriminant-narrowed obligations now
+  discharge; nothing regressed.
 
 **Established Precedents** (milestone-scoped): the workstream-level occurrence-typing
 and path-condition precedents are consumed here directly.
 
 **Open Questions**:
 - The propagation surface through ts2pant's IR/SSA (the any/unknown workstream
-  flagged narrowing "does not always survive" the IR). Resolve during M3's gameplan
-  using the M2 interface proposal.
+  flagged narrowing "does not always survive" the IR). Resolve during M3a's gameplan
+  using the M2 report's interface proposal.
+
+---
+
+### Milestone 3b: nullish-and-predicate-narrowing
+
+**Definition of Done**:
+- Extends the M3a assumption environment with **nullish** narrowing (`x != null` /
+  `x !== undefined` → non-null fact discharging a nullability obligation) and
+  **user type-predicate** narrowing (`x is T`). Type-predicate narrowing refines
+  TS-compiler types and is the higher-effort tail — sequence it last within M3b or
+  defer if it proves to need the any/unknown-opaque encoding.
+- Same constraints as M3a (intra-function, no special-casing, z3 path conditions).
+
+**Why this is a safe pause point**: Additive on top of M3a; the discriminant
+dependency already shipped, so pausing here leaves DU unblocked and nullish covered.
+
+**Unlocks**: Provable non-null access and predicate-guarded branches across the
+corpus (165 nullish sites + the type-guard tail).
+
+**Operator Actions Before Next Milestone**:
+- Confirm no regression in the M3a discriminant entailment set.
+
+**Open Questions**:
+- Whether `x is T` type-predicate narrowing needs the any/unknown-opaque encoding to
+  represent the refined type. Resolve during M3b's gameplan.
 
 ---
 
@@ -253,26 +295,30 @@ workstream.
 ## Dependency Graph
 
 ```text
-1 (guard-purity-user-calls)    → []
-2 (guard-narrowing-survey)     → [1]
-3 (guard-flow-narrowing)       → [2]   ── unlocks DU workstream M3 (cross-workstream)
-4 (guard-effect-error-channel) → [1]   (parallelizable with 2/3; sequenced last)
+1  (guard-purity-user-calls)        → []        ✅ DONE
+2  (guard-narrowing-survey)         → [1]       ✅ DONE
+3a (du-discriminant-narrowing-layer) → [2]      ── unlocks DU workstream M3 (cross-workstream)
+3b (nullish-and-predicate-narrowing) → [3a]
+4  (guard-effect-error-channel)     → [1]       (parallelizable; sequenced last)
 ```
 
-**Note**: M1 → M2 → M3 is the critical path (the flow-narrowing layer). M4 depends
-only on M1 (Effect precondition extraction is independent of narrowing) and may run
-in parallel, but is positioned last by priority. **M3 is the cross-workstream
-unlock** for the discriminated-union workstream's `du-discriminant-narrowing`
-milestone, which is gated on this layer existing.
+**Note**: M1 → M2 → M3a is the critical path. M3 was split by the M2 survey: **M3a**
+delivers the discriminant-narrowing fact the discriminated-union workstream's
+`du-discriminant-narrowing` is gated on (the cross-workstream unlock, shipped as
+early as possible); **M3b** adds nullish + type-predicate narrowing on the same
+assumption-environment infrastructure. M4 depends only on M1 (Effect precondition
+extraction is independent of narrowing) and may run in parallel, positioned last by
+priority.
 
 ## Open Questions
 
 | Question | Notes | Resolve By |
 |----------|-------|------------|
-| Purity predicate boundary for user functions | const bindings / pure loops / recursive-pure inside the callee | Milestone 1 |
-| Which narrowing patterns does M3 implement, and does M3 split? | Driven by the survey + the DU hard-dependency on discriminant equality | Milestone 2 |
-| Flow-narrowing interface the DU / nullish / any-unknown workstreams consume | Cross-workstream contract | Milestone 2 |
-| Propagation surface through IR/SSA | any/unknown flagged narrowing may not survive the IR | Milestone 3 |
+| ~~Purity predicate boundary for user functions~~ | RESOLVED (M1): pure local const/loops allowed; recursive callees bail to effectful | Milestone 1 ✅ |
+| ~~Which narrowing patterns does M3 implement, and does M3 split?~~ | RESOLVED (M2 survey): split into M3a (discriminant + boolean base) + M3b (nullish, type-predicate) | Milestone 2 ✅ |
+| ~~Flow-narrowing interface consumed by DU / nullish / any-unknown~~ | RESOLVED (M2): function-scoped assumption environment; DU consumes the `<property> === <literal>` discriminant fact | Milestone 2 ✅ |
+| Propagation surface through IR/SSA | any/unknown flagged narrowing may not survive the IR | Milestone 3a |
+| Does `x is T` type-predicate narrowing need the any/unknown-opaque encoding? | Refines TS-compiler types | Milestone 3b |
 | Effect branded types / Schema filters in scope? | Name-based, lower confidence | Milestone 4 |
 
 ## Decisions Made
@@ -287,6 +333,9 @@ in-repo call-following, Kroening & Strichman, TS Compiler API, Effect-TS) live i
 | User-function purity is **inferred** from the callee body, not annotated | Consistent with the existing conservative call-following; no new `@pure` annotation burden, and sound-by-bail (unknown ⇒ effectful) rather than trusting a possibly-mismarked human annotation. |
 | M1 **absorbs the purity-oracle consolidation** (merge `isPureExpression` + `expressionHasSideEffects` into one checker-aware oracle, delete the checker-free predicate), sequenced first within M1 — not a separate milestone | Decided while planning M1's gameplan. The classifier needs the checker, which only the checker-aware predicate has, so the duplication must be resolved first; consolidation is atomic/autonomous alongside the rest, so it folds into M1 via patch ordering rather than warranting its own milestone. Consolidation is an intended, sound behavior change (only oracle-proven-pure calls newly qualify in guard conditions), not behavior-preserving. |
 | Purity boundary: pure local `const` bindings + effect-free loops in a callee **allowed**; recursive callees **bail to effectful** | Resolves M1's open question. Allowing pure-local structure keeps the classifier useful; bailing on recursion keeps it sound and terminating (visited-set) without attempting a fixpoint. |
+| **M3 split into M3a (discriminant) + M3b (nullish + type-predicate)** | M2 survey decision. Discriminant narrowing is both the DU hard-dependency and the densest real pattern (58 `switch (x.kind)` + `.kind === lit` ifs); splitting ships the DU unlock first on the smallest surface, with nullish (165 sites) and the higher-effort type-predicate tail following on the same assumption-environment infra. |
+| M3 design: **function-scoped assumption environment** (discriminant / non-null / predicate facts as z3 path conditions) | M2 survey. A branch test pushes a fact; lowering consults it to discharge guards; pop on exit. The DU workstream consumes the `<property> === <literal>` fact. Occurrence typing modulo theories. |
+| ts2pant self-translation is **bottlenecked by TS-compiler-API calls**, not addressable by the purity lever | M2 finding. Residual predicate rejections mostly call `checker.getX` / `ts.isX` (node_modules → conservatively effectful); the ~66 dogfood figure overcounted the addressable set for ts2pant's own code. The purity lever remains real for user code; self-translation ceiling is lower than the raw count implied. |
 | Both condition-purity and flow-narrowing live in **one workstream** | They are the two facets of "reason about which facts hold where"; flow-narrowing (M3) is the layer the DU workstream was promised to consume, so it belongs on the same roadmap rather than orphaned. |
 | Flow narrowing is **intra-function only** | Matches the any/unknown-opaque workstream's "cross-function-call narrowing not trusted by default" decision. Guard *extraction* still follows calls (already implemented); narrowing does not. |
 | No field-name / discriminant special-casing in narrowing | Inherits the project-wide constraint: discriminant-equality narrowing keys on the structural predicate `<field> === <literal>`, never on `.kind` by name. |


### PR DESCRIPTION
Read-only survey milestone (no code changes) + workstream reconciliation.

- **`tools/ts2pant/docs/guard-narrowing-survey.md`** (new) — M2 of the guard-analysis workstream. Findings: M1's self-translation lift is bottlenecked by TS-compiler-API predicates (`checker.getX` / `ts.isX`, correctly bailed as effectful), so the ~66 dogfood figure overcounted the addressable set for ts2pant's own code. Narrowing inventory: discriminant `switch (x.kind)` = 58 (the DU dependency, heavily used), nullish = 165, boolean/call guards = 368.
- **`workstreams/ts2pant-guard-analysis.md`** — M2 marked done; M3 split into **M3a** (`du-discriminant-narrowing-layer`, the DU unlock, shipped first) and **M3b** (nullish + type-predicate); decisions recorded; resolved open questions closed.
- **`workstreams/ts2pant-discriminated-union.md`** — the M3 dependency now names guard-analysis **M3a** specifically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)