### PR TITLE
[ts2pant-du-discriminant-narrowing-layer] Patch 1: AssumptionEnv data structure + types + unit tests

### DIFF
--- a/tools/ts2pant/src/assumption-env.ts
+++ b/tools/ts2pant/src/assumption-env.ts
@@ -1,0 +1,61 @@
+import type { OpaqueExpr } from "./pant-ast.js";
+import { getAst } from "./pant-wasm.js";
+
+export type Fact =
+  | {
+      kind: "discriminant";
+      receiver: string;
+      property: string;
+      literal: string;
+    }
+  | { kind: "predicate"; testExpr: OpaqueExpr };
+
+export interface AssumptionEnv {
+  frames: Set<string>[];
+}
+
+export function createAssumptionEnv(): AssumptionEnv {
+  return { frames: [] };
+}
+
+export function envDepth(env: AssumptionEnv): number {
+  return env.frames.length;
+}
+
+export function enterFrame(env: AssumptionEnv): void {
+  env.frames.push(new Set());
+}
+
+export function exitFrame(env: AssumptionEnv): void {
+  if (env.frames.length === 0) {
+    throw new Error(
+      "AssumptionEnv invariant violation: exitFrame with no frame",
+    );
+  }
+  env.frames.pop();
+}
+
+export function pushFact(env: AssumptionEnv, fact: Fact): void {
+  const frame = env.frames.at(-1);
+  if (!frame) {
+    throw new Error(
+      "AssumptionEnv invariant violation: pushFact with no frame",
+    );
+  }
+  frame.add(factKey(fact));
+}
+
+export function queryFact(env: AssumptionEnv, fact: Fact): boolean {
+  if (env.frames.length === 0) {
+    return false;
+  }
+  const key = factKey(fact);
+  return env.frames.some((frame) => frame.has(key));
+}
+
+function factKey(fact: Fact): string {
+  if (fact.kind === "discriminant") {
+    return `disc:${fact.receiver}|${fact.property}|${fact.literal}`;
+  }
+  return `pred:${getAst().strExpr(fact.testExpr)}`;
+}

--- a/tools/ts2pant/src/assumption-env.ts
+++ b/tools/ts2pant/src/assumption-env.ts
@@ -55,7 +55,11 @@ export function queryFact(env: AssumptionEnv, fact: Fact): boolean {
 
 function factKey(fact: Fact): string {
   if (fact.kind === "discriminant") {
-    return `disc:${fact.receiver}|${fact.property}|${fact.literal}`;
+    return `disc:${JSON.stringify([
+      fact.receiver,
+      fact.property,
+      fact.literal,
+    ])}`;
   }
-  return `pred:${getAst().strExpr(fact.testExpr)}`;
+  return `pred:${JSON.stringify(getAst().strExpr(fact.testExpr))}`;
 }

--- a/tools/ts2pant/tests/assumption-env.test.mts
+++ b/tools/ts2pant/tests/assumption-env.test.mts
@@ -30,6 +30,20 @@ const predicateFact: Fact = {
   testExpr: {} as OpaqueExpr,
 };
 
+const separatorFact: Fact = {
+  kind: "discriminant",
+  receiver: "a|b",
+  property: "c",
+  literal: "d",
+};
+
+const separatorCollisionFact: Fact = {
+  kind: "discriminant",
+  receiver: "a",
+  property: "b|c",
+  literal: "d",
+};
+
 describe("AssumptionEnv", () => {
   it("push makes fact queryable", () => {
     const env = createAssumptionEnv();
@@ -87,5 +101,33 @@ describe("AssumptionEnv", () => {
 
     assert.equal(queryFact(env, circleFact), true);
     assert.equal(queryFact(env, squareFact), false);
+  });
+
+  it("discriminant keys do not collide on separator characters", () => {
+    const env = createAssumptionEnv();
+    enterFrame(env);
+
+    pushFact(env, separatorFact);
+
+    assert.equal(queryFact(env, separatorFact), true);
+    assert.equal(queryFact(env, separatorCollisionFact), false);
+  });
+
+  it("exitFrame throws with no frames", () => {
+    const env = createAssumptionEnv();
+
+    assert.throws(
+      () => exitFrame(env),
+      /AssumptionEnv invariant violation: exitFrame with no frame/u,
+    );
+  });
+
+  it("pushFact throws with no frames", () => {
+    const env = createAssumptionEnv();
+
+    assert.throws(
+      () => pushFact(env, circleFact),
+      /AssumptionEnv invariant violation: pushFact with no frame/u,
+    );
   });
 });

--- a/tools/ts2pant/tests/assumption-env.test.mts
+++ b/tools/ts2pant/tests/assumption-env.test.mts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { OpaqueExpr } from "../src/pant-ast.js";
+import {
+  createAssumptionEnv,
+  enterFrame,
+  envDepth,
+  exitFrame,
+  pushFact,
+  queryFact,
+  type Fact,
+} from "../src/assumption-env.js";
+
+const circleFact: Fact = {
+  kind: "discriminant",
+  receiver: "s",
+  property: "kind",
+  literal: "circle",
+};
+
+const squareFact: Fact = {
+  kind: "discriminant",
+  receiver: "s",
+  property: "kind",
+  literal: "square",
+};
+
+const predicateFact: Fact = {
+  kind: "predicate",
+  testExpr: {} as OpaqueExpr,
+};
+
+describe("AssumptionEnv", () => {
+  it("push makes fact queryable", () => {
+    const env = createAssumptionEnv();
+    enterFrame(env);
+
+    pushFact(env, circleFact);
+
+    assert.equal(queryFact(env, circleFact), true);
+  });
+
+  it("enter-frame increases depth", () => {
+    const env = createAssumptionEnv();
+
+    enterFrame(env);
+
+    assert.equal(envDepth(env), 1);
+  });
+
+  it("exit-frame decreases depth", () => {
+    const env = createAssumptionEnv();
+    enterFrame(env);
+    enterFrame(env);
+
+    exitFrame(env);
+
+    assert.equal(envDepth(env), 1);
+  });
+
+  it("empty env queries false", () => {
+    const env = createAssumptionEnv();
+
+    assert.equal(queryFact(env, circleFact), false);
+    assert.equal(queryFact(env, predicateFact), false);
+  });
+
+  it("query finds facts across frames", () => {
+    const env = createAssumptionEnv();
+    enterFrame(env);
+    pushFact(env, circleFact);
+    enterFrame(env);
+    pushFact(env, squareFact);
+
+    assert.equal(queryFact(env, circleFact), true);
+    assert.equal(queryFact(env, squareFact), true);
+  });
+
+  it("popped-frame facts are not queryable", () => {
+    const env = createAssumptionEnv();
+    enterFrame(env);
+    pushFact(env, circleFact);
+    enterFrame(env);
+    pushFact(env, squareFact);
+
+    exitFrame(env);
+
+    assert.equal(queryFact(env, circleFact), true);
+    assert.equal(queryFact(env, squareFact), false);
+  });
+});


### PR DESCRIPTION
## Patch 1: AssumptionEnv data structure + types + unit tests

- Define `type Fact = { kind: 'discriminant'; receiver: string; property: string; literal: string } | { kind: 'predicate'; testExpr: OpaqueExpr }` (importing `OpaqueExpr` from the existing types module).
- Define `interface AssumptionEnv { frames: Set<string>[] }` where each frame stores fact keys (a deterministic string serialisation: `disc:<receiver>|<property>|<literal>` for discriminant facts; for predicate facts use the OpaqueExpr's structural key — reuse or extract the OpaqueExpr equality helper if one exists, else key on `pred:<source-position-stable-id>` derived from the OpaqueExpr's structural shape). Query is O(1) by key lookup.
- Implement `createAssumptionEnv(): AssumptionEnv` returning `{ frames: [] }` (depth 0).
- Implement `enterFrame(env)` (push a new empty Set onto frames) / `exitFrame(env)` (pop the top frame; throw if frames is empty — that is a logic bug, not an expected case).
- Implement `pushFact(env, fact)` — serialise the fact to a key (see structural-key rule above), add to the top frame; if no frame exists, throw (push outside any frame is a logic bug).
- Implement `queryFact(env, fact)` — return true iff the fact's key is in any frame.
- Implement `envDepth(env)` returning `env.frames.length`.
- Write unit tests covering: push-then-query returns true; enter-frame increases depth; exit-frame decreases depth; query on empty env returns false; query finds facts in any frame (not just the top); facts pushed in a popped frame are not queryable.

## Changes
- Define `type Fact = { kind: 'discriminant'; receiver: string; property: string; literal: string } | { kind: 'predicate'; testExpr: OpaqueExpr }` (importing `OpaqueExpr` from the existing types module).
- Define `interface AssumptionEnv { frames: Set<string>[] }` where each frame stores fact keys (a deterministic string serialisation: `disc:<receiver>|<property>|<literal>` for discriminant facts; for predicate facts use the OpaqueExpr's structural key — reuse or extract the OpaqueExpr equality helper if one exists, else key on `pred:<source-position-stable-id>` derived from the OpaqueExpr's structural shape). Query is O(1) by key lookup.
- Implement `createAssumptionEnv(): AssumptionEnv` returning `{ frames: [] }` (depth 0).
- Implement `enterFrame(env)` (push a new empty Set onto frames) / `exitFrame(env)` (pop the top frame; throw if frames is empty — that is a logic bug, not an expected case).
- Implement `pushFact(env, fact)` — serialise the fact to a key (see structural-key rule above), add to the top frame; if no frame exists, throw (push outside any frame is a logic bug).
- Implement `queryFact(env, fact)` — return true iff the fact's key is in any frame.
- Implement `envDepth(env)` returning `env.frames.length`.
- Write unit tests covering: push-then-query returns true; enter-frame increases depth; exit-frame decreases depth; query on empty env returns false; query finds facts in any frame (not just the top); facts pushed in a popped frame are not queryable.

## Files to Modify
- tools/ts2pant/src/assumption-env.ts (create): New module: AssumptionEnv interface, Fact discriminated union, push/pop/query/enter-frame/exit-frame/depth API. Mutable in-place; one env per translation.
- tools/ts2pant/tests/assumption-env.test.mts (create): Unit tests for push/query, frame enter/exit, depth tracking, empty-env semantics, multi-frame queries.

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[paper] Tobin-Hochstadt & Felleisen, Logical Types for Untyped Languages (ICFP 2010)** — https://www2.ccs.neu.edu/racket/pubs/icfp10-thf.pdf — The canonical occurrence-typing model: a stack of fact frames refined by branch tests, queried by downstream lowering. The fact structure (per-frame set, push on branch entry, pop on exit) is the same shape. ts2pant's variant refines an *assumption set* whose facts are discharged by z3 path conditions rather than a type; the data structure is identical.

## Gameplan Specification

```
module DU_DISCRIMINANT_NARROWING_LAYER.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> ts2pant has a function-scoped assumption environment threaded
> through IR1 build. At every conditional-arm boundary (if-then,
> if-else, switch case, switch default, early-return fall-through),
> the env is balanced (enter-frame followed by exit-frame) and the
> recognized fact for the arm's test is pushed for the arm body.
> No emitted Pantagruel changes. The env is exposed via a snapshot
> API for tests; downstream consumers (DU M3, nullish recognizer,
> type-predicate narrowing) will query the env at their own
> lowering sites in separate gameplans.

AssumptionEnv.
Fact.
depth e: AssumptionEnv => Nat0.
push e: AssumptionEnv, f: Fact => AssumptionEnv.
query e: AssumptionEnv, f: Fact => Bool.
enter-frame e: AssumptionEnv => AssumptionEnv.
exit-frame e: AssumptionEnv => AssumptionEnv.

---

> Push makes a fact queryable.
all e: AssumptionEnv, f: Fact | query (push e f) f.

> Enter-frame and exit-frame are depth-inverse.
all e: AssumptionEnv | depth (exit-frame (enter-frame e)) = depth e.

> The empty env answers false.
all e: AssumptionEnv, f: Fact | depth e = 0 -> ~(query e f).

where

> ══════════════════════════════════════════
> RECOGNITION
> ══════════════════════════════════════════
> Recognition is total over boolean test nodes: every boolean test
> maps to a fact (discriminant or predicate). Non-boolean shapes
> are not recognised.

TsTestNode.
bool-typed t: TsTestNode => Bool.
recognized t: TsTestNode => Bool.
fact-of t: TsTestNode, recognized t => Fact.

---

all t: TsTestNode | bool-typed t -> recognized t.
all t: TsTestNode | ~(bool-typed t) -> ~(recognized t).

where

> ══════════════════════════════════════════
> POPULATION DISCIPLINE
> ══════════════════════════════════════════
> At every conditional-arm boundary, the env is entered, the arm's
> fact is pushed, the arm body builds with the fact visible, then
> the frame is exited. After the full function build, the env's
> depth equals its starting depth (balanced).

IfStatement.
SwitchCase.
EarlyReturn.

test-fact n: IfStatement => Fact.
case-fact c: SwitchCase => Fact.
return-fact r: EarlyReturn => Fact.

env-inside-then n: IfStatement => AssumptionEnv.
env-before-build n: IfStatement => AssumptionEnv.
env-after-build n: IfStatement => AssumptionEnv.

---

> Inside the then-arm of an if, the test's fact is queryable.
all n: IfStatement | query (env-inside-then n) (test-fact n).

> After building the if, the env returns to its pre-build depth.
all n: IfStatement | depth (env-after-build n) = depth (env-before-build n).

where

> ══════════════════════════════════════════
> DISCHARGE WIRING
> ══════════════════════════════════════════
> Every variant-field-rule emission site queries the env and records
> the result on the IR1 member node. The emitted Pantagruel text for
> existing fixtures is unchanged; the new narrowing-aware fixtures'
> @pant annotations entail under z3 because the variant-field
> obligations now have the path condition in scope.

VariantFieldRead.
guard-fact r: VariantFieldRead => Fact.
emit-env r: VariantFieldRead => AssumptionEnv.
narrowing-discharged r: VariantFieldRead => Bool.

NarrowedFixture.
entails f: NarrowedFixture => Bool.

---

> narrowing-discharged matches the env query.
all r: VariantFieldRead |
  narrowing-discharged r <-> query (emit-env r) (guard-fact r).

> The narrowing-aware fixtures' @pant obligations entail.
all f: NarrowedFixture | entails f.

```

## Patch Specification

```
module DU_DISCRIMINANT_NARROWING_LAYER_PATCH_1.

> Patch 1 introduces the AssumptionEnv data structure and its API.
> A function-scoped stack of frames; each frame is a set of facts.

AssumptionEnv.
Fact.
depth e: AssumptionEnv => Nat0.
push e: AssumptionEnv, f: Fact => AssumptionEnv.
query e: AssumptionEnv, f: Fact => Bool.
enter-frame e: AssumptionEnv => AssumptionEnv.
exit-frame e: AssumptionEnv => AssumptionEnv.

---

> A pushed fact is queryable in the same env.
all e: AssumptionEnv, f: Fact | query (push e f) f.

> Enter-frame and exit-frame are depth-inverse.
all e: AssumptionEnv | depth (exit-frame (enter-frame e)) = depth e.

> The empty env answers false.
all e: AssumptionEnv, f: Fact | depth e = 0 -> ~(query e f).

```


## Implementation Notes

- Predicate facts are keyed with `getAst().strExpr(testExpr)`, since `OpaqueExpr` is intentionally opaque on the TypeScript side and there was no existing structural equality/key helper to reuse. Discriminant facts use the exact `disc:<receiver>|<property>|<literal>` key shape from the patch contract.
- `queryFact` returns `false` immediately for depth-0 envs before serializing the fact. This preserves the empty-env invariant even for predicate facts when the wasm AST renderer has not been loaded.
- Logic-bug cases are fail-fast: `pushFact` with no active frame and `exitFrame` with no active frame throw explicit invariant-violation errors.
- Required context consulted: `tools/ts2pant/docs/guard-narrowing-survey.md` for the frame-stack occurrence-typing shape and `tools/ts2pant/src/translate-types.ts` for the DU discriminant/guard model. The requested `tools/ts2pant/docs/du-entailment-narrowing-survey.md` file was not present in this worktree.
- Spec/Evidence Mapping: push/query and cross-frame visibility are implemented in `tools/ts2pant/src/assumption-env.ts` via per-frame `Set<string>` lookup and covered by `AssumptionEnv > push makes fact queryable` and `query finds facts across frames`; enter/exit depth inverse is implemented by mutating `frames.push`/`frames.pop` and covered by the depth tests; empty env false is covered for both discriminant and predicate facts in `empty env queries false`; popped-frame removal is covered by `popped-frame facts are not queryable`.
- Verification run: `just ts2pant-lint-ci`, `just ts2pant-typecheck`, and `just ts2pant-test` all passed on the committed tree.