### PR TITLE
DU M2 survey + guard-analysis M3a planned

### DIFF
--- a/tools/ts2pant/docs/du-entailment-narrowing-survey.md
+++ b/tools/ts2pant/docs/du-entailment-narrowing-survey.md
@@ -1,0 +1,205 @@
+# Discriminated-Union Entailment & Narrowing Survey (DU M2)
+
+**Workstream:** ts2pant Discriminated-Union Handling — Milestone 2
+(`du-entailment-narrowing-survey`). **Date:** 2026-05-28.
+**Method:** read-only probe over the M1 tagged encoding (`du-tagged-encoding`,
+PRs #290 + #291) plus a corpus inventory of DU-relevant narrowing sites. No
+translator behavior changed.
+
+## Purpose
+
+M1 introduced the guarded tagged-union encoding for structurally-detected
+discriminated unions (`shape--kind s: Shape => String` plus per-variant
+field rules guarded by `shape--kind s = "<literal>"`). The workstream's
+operator-action gate for M3 is twofold:
+
+1. **Does the M1 encoding entail under z3 once a discriminant guard is
+   assumed?** — if not, M3 narrowing is moot until the encoding is fixed.
+2. **Are there enough real intra-function narrowing sites to justify M3?**
+
+This survey answers both, names the interface M3 will consume from the
+guard-analysis workstream's M3a (`du-discriminant-narrowing-layer`), and
+flags one encoding question that M3 will surface.
+
+## (1) Encoding entailment under z3 — the headline
+
+Authored probes against the M1-shaped encoding (`Shape` with two variants:
+`circle`/`square`, shared field `shared`):
+
+| Probe | Result | What it tells us |
+|---|---|---|
+| **Variant-field rule applied in a body whose head asserts the guard** (`f x: Shape, shape--kind x = "circle" => Int` with body `f x = shape--r x`) | ✅ `Entailed` | The guarded rule discharges cleanly when the caller carries the guard. **This is the post-narrowing target shape.** |
+| **Shared-field rule with `or`-guard over all variant literals** (`shape--shared s: Shape, shape--kind s = "circle" or shape--kind s = "square" => String`) | ✅ `Entailed` | Multi-variant guards compose. |
+| **Body equation with an undischarged guard** (`f x: Shape => Int` with body `f x = shape--r x`, no guard on the head) | ✅ `Entailed` (equation level) | McCarthy-style partial-function semantics: the equation is universally satisfiable; the guard is a *partiality* concern, not an equational obligation. The encoding is sound — un-narrowed variant-field reads do not produce a wrong fact, they just fail to discharge any obligation that requires the guard to actually hold. |
+| **Negated disjointness** (`some s: Shape | shape--kind s = "circle" and shape--kind s = "square"`) | ✅ z3 reports `contradictory` | **Disjointness is free** from function-value semantics: `shape--kind` returns a single value, so two literals can't both hold. **No explicit disjointness invariant needs to be emitted.** |
+| **Totality** (`all s: Shape | shape--kind s = "circle" or shape--kind s = "square"`, with `--check`) | ⚠️ Reported only as `jointly satisfiable`, not entailed | z3 will admit a model where the discriminant takes an unknown literal value (e.g., `"triangle"`). **Totality is NOT free** under EUF — an explicit invariant would be required to prove exhaustive `cond` dispatch over all variants. See §5. |
+
+**Verdict for question (1): yes — the M1 encoding entails when the guard is
+discharged.** The probe shape (`f x: Shape, shape--kind x = "circle" => Int`
+with body `f x = shape--r x`) is exactly the post-narrowing target M3 will
+synthesize: the discriminant-equality fact lives in the assumption environment
+on entering the narrowed branch, the variant-field rule's precondition is
+discharged from that environment, and z3 closes the obligation.
+
+## (2) Corpus inventory
+
+### Where M1's encoding lives today
+
+| Layer | DU types encoded | Status |
+|---|---|---|
+| **Fixtures** (`tests/fixtures/constructs/`) | `Shape` (2 variants, shared field) | All 3 reader functions translate + type-check via `constructs.test.mts.snapshot`; the `ambiguous-owner` non-DU stays on the existing refusal path. |
+| **Dogfood** (`tests/integration/dogfood.test.mts.snapshot`) | `DiscriminantLiteral` (3 string-kind variants over `"string"/"number"/"boolean"`), `FieldOwnerResolution` (3 string-kind variants `"resolved"/"none"/"ambiguous"`), `KeyLiteralRec` | Encoded in the snapshot; the `DiscriminantLiteral.value` field carries a heterogeneous variant type (`String + Int + Bool`) under an `or`-guard, which is the headline narrowing case for `switch (lit.kind)` walkers. |
+| **Self-translation (not yet dogfooded)** | `IR1Expr`, `IR1Stmt`, `IR1Binding`, `OpaqueExpr`, … (~16 type defs in `ir1.ts` alone) | These would all be encoded by M1's structural detector. Their narrowing consumers (below) are the dense pattern. |
+
+### Narrowing-pattern inventory (DU-specific subset)
+
+Refining the workstream-wide counts from
+[guard-narrowing-survey.md](./guard-narrowing-survey.md) to the DU-relevant
+subset (excluding `ts.SyntaxKind` enum compares, which are TS-internal and not
+structural DUs):
+
+| Pattern | Workstream-wide count | DU-relevant subset | Notes |
+|---|---|---|---|
+| `switch (x.kind)` | 58 | **~37** | Switches whose `case` labels are bare string literals (IR1Expr/IR1Stmt/binding walkers, etc.). Remainder (~21) are over `ts.SyntaxKind` and excluded. |
+| `if (x.kind === "<lit>")` | 169 | **160** | Counted `.kind === "<bare-string>"` directly; 72 additional `.kind === ts.SyntaxKind.X` excluded. |
+| Discriminant in early-return guard | (in 169 above) | (subset) | Same lowering target as the `if`. |
+
+**Reading:** discriminant narrowing is the densest real pattern in ts2pant's
+own source (≥197 sites combined), heavily dominated by walkers over the
+project's own IR1 union types. The fixture corpus is thin (1 DU type) — the
+real consumer is self-translation once these walker functions are dogfooded.
+
+## (3) Where un-narrowed obligations actually block
+
+Three concrete examples from the dogfood corpus and fixtures show what M3 must
+discharge:
+
+1. **`literalExpr` in `translate-types.ts:567`** —
+   `switch (lit.kind) { case "string": return ast.litString(lit.value); ... }`
+   Inside the `"string"` arm, TS narrows `lit.value: string`, but the M1
+   encoding gives `lit.value: String + Int + Bool` (the shared-field
+   `or`-guard). The variant-specific argument-type obligation on
+   `ast.litString` cannot discharge without narrowing.
+2. **`FieldOwnerResolution` consumers in `ir1-build.ts:1584`/`:1587`** —
+   `if (r.kind === "resolved") { ... r.owner ... }` — `r.owner` is only
+   defined on the `resolved` variant; the M1 rule
+   `field-owner-resolution--owner r: FieldOwnerResolution, field-owner-resolution--kind r = "resolved" => String`
+   needs the `kind === "resolved"` fact to discharge.
+3. **The Shape fixture's `readVariantField`** — translates today but the
+   body equation `read-variant-field x = shape--r x` is entailed at the
+   equation level only; any downstream property that depends on `shape--r`'s
+   guard being satisfied would not discharge without narrowing. The fixture
+   is intentionally minimal and demonstrates the encoding is sound, not that
+   narrowing is unnecessary.
+
+## (4) M3 design — the interface from guard-analysis M3a
+
+The guard-analysis workstream's M2 survey already resolved the design
+([guard-narrowing-survey.md §M3 design proposal](./guard-narrowing-survey.md)):
+a **function-scoped assumption environment** that pushes a fact on entering
+a narrowed branch and pops on exit. M3a will deliver the *discriminant fact*
+keyed structurally as `<property-access> === <literal>`.
+
+DU M3 consumes that layer with this contract:
+
+- **Fact shape M3a emits, M3 reads.** A discriminant fact has the form
+  `<receiver>.<property-name> === <literal>` where `<literal>` is a string,
+  number, or boolean literal. M3a keys this structurally — never on `.kind`
+  by name — so the DU narrowing path inherits the project's no-field-name-
+  special-casing constraint for free.
+- **Where DU lowering plugs in.** When lowering emits a variant-field rule
+  application whose head precondition is `<domain>--<discriminant> s = "<lit>"`,
+  it queries the assumption environment for a fact whose receiver matches the
+  rule's receiver argument and whose property matches the encoded
+  discriminant (resolved via the existing `DiscriminatedUnionSynthEntry`
+  metadata — `discriminant` field). If the fact's literal matches the
+  precondition's literal, the precondition is marked discharged; if absent
+  or mismatched, it remains undischarged (sound-by-guard).
+- **Switch lowering.** `switch (x.kind) { case "circle": ... }` lowers to a
+  `cond`-dispatch; the `"circle"` arm pushes `x.kind === "circle"` into the
+  environment for the arm's body. Default/`true =>` arm pushes the
+  *negation* of all matched literals — relevant to (5) below.
+- **Intra-function only.** Cross-call discharge (a helper that returns
+  `lit.kind === "string"` and is called as a predicate) is out of scope
+  for M3, matching both the DU workstream and the guard-analysis
+  workstream's standing decisions.
+
+No DU-specific narrowing infrastructure is needed; M3 is a consumer, not a
+builder.
+
+## (5) Open encoding question for M3 — totality
+
+The M1 encoding emits no totality invariant. Practical impact:
+
+- `if (x.kind === "circle") { ... } else { ... x.s ... }` — the `else`
+  branch's reader `x.s` needs the guard `x.kind === "square"` to discharge.
+  Under EUF without a totality invariant, the assumption-environment fact
+  for the `else` is `~(x.kind === "circle")`, which does **not** entail
+  `x.kind === "square"` — z3 can model `x.kind = "triangle"`.
+- A `cond` dispatch over all known variants (`cond x.kind === "circle" =>
+  ..., x.kind === "square" => ..., true => ...`) succeeds with a fallback
+  arm but has no exhaustiveness proof without totality.
+
+**Two viable M3 designs to weigh** (decide during M3's gameplan):
+
+1. **Emit a totality invariant** at DU encoding time:
+   `all s: Shape | shape--kind s = "circle" or shape--kind s = "square".`
+   Cheap, sound (the TS union type guarantees it), and gives the `else`
+   branch full discharge for free. Adds one universal per DU domain to
+   every emitted document.
+2. **Push the negated literal as the else-branch fact** in M3a and let
+   downstream obligations live with non-exhaustive dispatch. Simpler
+   encoding, but the `else`-branch discharge case stays unprovable until
+   a totality invariant is added later.
+
+**Recommendation: option 1 — emit the totality invariant.** It is sound
+(TS's union type guarantees the cover), cheap (one universal), and removes
+a class of `else`-branch obligations from M3's surface. The disjointness
+half is already free from function semantics; the totality half should be
+parallel. **Resolve during M3 gameplan.**
+
+## Verdict
+
+**Proceed to M3.** Both gating criteria pass:
+
+- ✅ The M1 encoding entails when the discriminant guard is discharged
+  (probe 1; the post-narrowing target shape compiles cleanly under z3).
+- ✅ Real intra-function narrowing sites exist in quantity: ~37 DU-relevant
+  switches + 160 `.kind === "<literal>"` ifs, dominated by ts2pant's own
+  IR walkers and concentrated in the dogfood corpus once
+  `literalExpr`/`FieldOwnerResolution`-shaped functions are dogfooded.
+
+**M3 scope confirmation:** local intra-function narrowing only; consumes the
+guard-analysis M3a `<property-access> === <literal>` fact unchanged;
+narrowing the `else` branch hinges on the totality-invariant decision in
+M3's gameplan. The any/unknown-opaque workstream's "cross-function-call
+narrowing not trusted by default" constraint stands.
+
+**Dependency status:** guard-analysis M3a is **not yet planned** as of this
+report — DU M3 cannot start until it lands or is gameplanned with a stable
+fact-key contract. M2 has produced everything it can; the next move on the
+DU critical path is to schedule guard-analysis M3a (`du-discriminant-
+narrowing-layer`).
+
+## Caveats
+
+- **Fixture corpus is thin (1 DU).** The encoding-entailment probes are
+  authored directly against the M1-shape; the fixture acts as a sanity
+  check that the pipeline emits that shape, not as a corpus measurement.
+  Confidence is high because the encoding is mechanically synthesized from
+  detection, not per-fixture-tuned.
+- **Heterogeneous shared-field type** (`String + Int + Bool` for
+  `DiscriminantLiteral.value`) — sound today, but `ast.litString(lit.value)`
+  on the narrowed `value: String` is the obligation M3 must discharge. The
+  argument-type rule will need to see the variant-narrowed type, not just
+  the discriminant guard. This is M3 territory (the fact propagates; the
+  type-refinement happens at the type-checker layer, not the encoding).
+- **Multi-discriminant tie-break** (sorted-field-name pick, per the
+  workstream's M1 decision) means a union with multiple qualifying fields
+  encodes only one of them as *the* discriminant — non-chosen qualifying
+  fields become per-variant guarded rules under the chosen discriminant's
+  guard. M3 narrows on the chosen discriminant's predicate; secondary
+  qualifying fields would not narrow (acceptable — the workstream's
+  decision is deterministic by design).
+- **Nested DUs / DUs inside other synth shapes** are M4 cutover scope and
+  not measured here.

--- a/workstreams/ts2pant-discriminated-union.md
+++ b/workstreams/ts2pant-discriminated-union.md
@@ -162,7 +162,19 @@ Map encoding + McCarthy/Dafny guards, which this milestone consumes directly.
 
 ---
 
-### Milestone 2: du-entailment-narrowing-survey
+### Milestone 2: du-entailment-narrowing-survey — ✅ COMPLETE (2026-05-28)
+
+> Run read-only, no gameplan. Report: `tools/ts2pant/docs/du-entailment-narrowing-survey.md`.
+> **Findings:** (1) M1 encoding entails under z3 when the discriminant guard is
+> discharged (the post-narrowing target shape compiles cleanly); disjointness is
+> free from function-value semantics, totality is NOT free (M3 must decide whether
+> to emit a totality invariant — recommendation: emit it). (2) DU-relevant
+> narrowing inventory: ~37 `switch (x.kind)` over structural DUs + 160
+> `.kind === "<literal>"` ifs (excluding `ts.SyntaxKind` enum compares), dominated
+> by ts2pant's own IR1 walkers. (3) M3 consumes the guard-analysis M3a
+> `<property-access> === <literal>` fact unchanged — no DU-specific narrowing
+> infrastructure needed. **Verdict:** proceed to M3, gated on guard-analysis M3a
+> landing; emit-totality decision resolved in M3 gameplan.
 
 **Definition of Done**:
 - A read-only survey over the dogfood + constructs corpus: for each
@@ -210,6 +222,18 @@ invariants to add first).
 
 ### Milestone 3: du-discriminant-narrowing
 
+> **Update (2026-05-28):** the guard-analysis M3a gameplan
+> (`gameplans/ts2pant-du-discriminant-narrowing-layer.json`) ships the
+> assumption-environment infrastructure AND the variant-field-rule discharge
+> wiring AND a narrowing-aware fixture whose `@pant` annotations entail under
+> z3. DU M3's scope correspondingly narrows to (a) the totality-invariant
+> decision from the M2 survey §5 (whether to emit `all s: Shape | shape--kind
+> s = "circle" or shape--kind s = "square"` per DU domain), and (b) DU-corpus-
+> wide `@pant` entailment validation across the existing discriminated-union
+> fixtures + dogfood (`DiscriminantLiteral`, `FieldOwnerResolution`, etc.).
+> The "narrowing mechanism" half is landed by M3a — DU M3 is the validation +
+> totality-decision milestone, not a new mechanism.
+
 **Definition of Done**:
 - **Local, intra-function** narrowing: inside `if (x.kind === lit)` /
   `switch (x.kind)` / early-return guards on the discriminant, the guard
@@ -237,10 +261,14 @@ has no remaining advantage for discriminated unions and can be retired.
   targeted narrowing assertions now entail.
 
 **Established Precedents** (milestone-scoped):
-- **existing-implementation — guard-analysis flow-narrowing layer** —
-  (the guard-analysis workstream's deliverable; path TBD when that workstream is
-  planned) — M3 consumes its discriminant-guard propagation rather than building
-  a bespoke narrowing mechanism. This is a **cross-workstream dependency**.
+- **existing-implementation — guard-analysis M3a env + discharge wiring** —
+  `gameplans/ts2pant-du-discriminant-narrowing-layer.json` (the gameplan;
+  may not survive past patch landing — once the patches land, the durable
+  references are `tools/ts2pant/src/assumption-env.ts`,
+  `tools/ts2pant/src/narrowing-recognizer.ts`, and the env-threading sites in
+  `ir1-build.ts` / `ir1-build-body.ts`). M3 consumes the env's discharge
+  result rather than building a bespoke narrowing mechanism. This was the
+  **cross-workstream dependency**; M3a delivers it.
 
 **Open Questions**:
 - The precise propagation surface for the discriminant guard through ts2pant's

--- a/workstreams/ts2pant-guard-analysis.md
+++ b/workstreams/ts2pant-guard-analysis.md
@@ -206,7 +206,17 @@ interface the DU workstream can commit to.
 > consults it to discharge guards; pop on exit), intra-function only, no field-name
 > special-casing, facts rendered as z3 path conditions.
 
-### Milestone 3a: du-discriminant-narrowing-layer
+### Milestone 3a: du-discriminant-narrowing-layer — planned (`gameplans/ts2pant-du-discriminant-narrowing-layer.json`)
+
+> **Planning decision (2026-05-28):** M3a absorbs the variant-field-rule discharge
+> wiring (Patch 5 in the gameplan) rather than deferring it to DU M3. Reason: the
+> workstream's M3a DoD line "lowering uses to discharge a discriminant-guarded
+> variant-field rule" was ambiguous between "the lowering site is wired to query
+> with no observable change" and "the lowering site emits differently"; the
+> resolution is "wired to query + one new narrowing-aware fixture whose `@pant`
+> annotations entail under z3". The cond-arm test already carries the path
+> condition z3 needs, so existing fixture snapshots stay byte-identical; the
+> BEHAVIOR delta is contained to the new fixture. See gameplan `explicitOpinions`.
 
 **Definition of Done**:
 - The function-scoped assumption-environment infrastructure, plus **discriminant**
@@ -218,12 +228,21 @@ interface the DU workstream can commit to.
   `<property> === <literal>` shape).
 - Exposes the stable `<property> === <literal>` discriminant fact the DU
   workstream's `du-discriminant-narrowing` consumes.
+- **Discharge wiring included:** at every variant-field-rule emission site in
+  `ir1-build.ts`, the env is queried with a Fact constructed from the rule's
+  guard; the emitted IR1 member node records `narrowingDischarged: boolean`.
+  Emitted Pantagruel text for existing fixtures is byte-identical.
+- A new construct fixture `expressions-discriminant-narrowing.ts` translates and
+  its `@pant` annotations entail under `pant --check` z3 — end-to-end proof that
+  discriminated-union narrowing now discharges.
 
 **Why this is a safe pause point**: Narrowing is additive — un-narrowed code keeps
 its sound-by-guard lowering. The DU dependency is delivered.
 
 **Unlocks**: The discriminated-union workstream's M3 (`du-discriminant-narrowing`) —
-the **cross-workstream unlock**.
+the **cross-workstream unlock**. With the discharge wiring absorbed into M3a, DU M3's
+scope narrows to (a) the totality-invariant decision from the DU M2 survey §5 and
+(b) DU-corpus-wide @pant entailment validation.
 
 **Operator Actions Before Next Milestone**:
 - Confirm the before/after entailment set: discriminant-narrowed obligations now
@@ -233,9 +252,11 @@ the **cross-workstream unlock**.
 and path-condition precedents are consumed here directly.
 
 **Open Questions**:
-- The propagation surface through ts2pant's IR/SSA (the any/unknown workstream
-  flagged narrowing "does not always survive" the IR). Resolve during M3a's gameplan
-  using the M2 report's interface proposal.
+- ~~The propagation surface through ts2pant's IR/SSA~~ RESOLVED (M3a gameplan):
+  env lives in `L1BuildContext`, threaded through `ir1-build.ts` +
+  `ir1-build-body.ts` at all conditional-arm boundaries; queried at the variant-
+  field-rule emission site (`qualifyFieldAccess`-adjacent). Narrowing survives the
+  IR because the env is populated at IR1 *build* time before any normalization.
 
 ---
 
@@ -317,7 +338,7 @@ priority.
 | ~~Purity predicate boundary for user functions~~ | RESOLVED (M1): pure local const/loops allowed; recursive callees bail to effectful | Milestone 1 ✅ |
 | ~~Which narrowing patterns does M3 implement, and does M3 split?~~ | RESOLVED (M2 survey): split into M3a (discriminant + boolean base) + M3b (nullish, type-predicate) | Milestone 2 ✅ |
 | ~~Flow-narrowing interface consumed by DU / nullish / any-unknown~~ | RESOLVED (M2): function-scoped assumption environment; DU consumes the `<property> === <literal>` discriminant fact | Milestone 2 ✅ |
-| Propagation surface through IR/SSA | any/unknown flagged narrowing may not survive the IR | Milestone 3a |
+| ~~Propagation surface through IR/SSA~~ | RESOLVED (M3a gameplan): env lives in `L1BuildContext`, threaded through `ir1-build.ts` + `ir1-build-body.ts`; populated at IR1 *build* time before normalization, queried at the variant-field-rule emission site | Milestone 3a ✅ |
 | Does `x is T` type-predicate narrowing need the any/unknown-opaque encoding? | Refines TS-compiler types | Milestone 3b |
 | Effect branded types / Schema filters in scope? | Name-based, lower confidence | Milestone 4 |
 
@@ -341,3 +362,7 @@ in-repo call-following, Kroening & Strichman, TS Compiler API, Effect-TS) live i
 | No field-name / discriminant special-casing in narrowing | Inherits the project-wide constraint: discriminant-equality narrowing keys on the structural predicate `<field> === <literal>`, never on `.kind` by name. |
 | Effect E-channel extraction is the **final** milestone, not dropped | The user opted to keep it; it is not on either critical path (dogfood lever M1, DU dependency M3), so it is sequenced last and depends only on M1. |
 | Guard *extraction* (asserts, if-throw, call-following) is treated as **already done** | Verified in current code (`translate-signature.ts`); the old roadmap's items 1–2 are implemented, so this workstream does not re-plan them. |
+| M3a **absorbs the variant-field-rule discharge wiring** (Patch 5 in the M3a gameplan), not deferred to DU M3 | Decided while planning M3a (2026-05-28). The workstream's M3a DoD line "lowering uses to discharge a discriminant-guarded variant-field rule" was ambiguous; resolution is "wired to query + new narrowing-aware fixture whose `@pant` annotations entail". The cond-arm test already carries the path condition z3 needs, so existing snapshots stay byte-identical; BEHAVIOR delta is one new fixture. DU M3's scope correspondingly narrows. |
+| M3a env is **mutable in place** (`pushFact` / `enterFrame` mutate the AssumptionEnv), one per L1BuildContext | M3a gameplan decision. Matches the per-translation single-threaded ctx pattern; the snapshot API deep-copies when tests need to compare states. Cheapest at the IR1-build threading sites (no allocation per if/switch arm). |
+| M3a `PredicateFact` wraps an `OpaqueExpr`, not a source-text snapshot | M3a gameplan decision. M3b consumers (nullish, type-predicate narrowing) need structural pattern-match; storing source text would force them to re-parse. Upfront cost in M3a's recognizer patch is small. |
+| Switch `default:` arms push the conjunction of negated case literals; if-else arms push the negated test | M3a gameplan decision. Gives consumers a positive fact to query for the default/else case — necessary for DU M3 to prove the else-branch of `if (s.kind === "circle") { … } else { /* s.kind === "square" by exhaustion */ }`. |


### PR DESCRIPTION
## Summary

- **DU M2 entailment & narrowing survey** (`tools/ts2pant/docs/du-entailment-narrowing-survey.md`): probes confirm the M1 tagged encoding entails under z3 when the discriminant guard is discharged; disjointness is free (function-value semantics), totality is not (M3 must decide whether to emit a totality invariant per DU domain). DU-relevant narrowing inventory: ~37 `switch (x.kind)` + 160 `.kind === "<lit>"` ifs (excluding `ts.SyntaxKind` enum compares).
- **DU workstream**: M2 marked complete; M3 scope narrowed (the variant-field-rule discharge wiring moves to guard-analysis M3a, leaving DU M3 as totality-invariant decision + corpus-wide `@pant` entailment validation).
- **Guard-analysis workstream**: M3a marked planned with the gameplan reference; DoD now lists the discharge wiring + new fixture; IR/SSA propagation-surface open question resolved (env lives in `L1BuildContext`, populated at IR1 build time). Four M3a-gameplan decisions captured in `Decisions Made`.

The M3a gameplan JSON itself is intentionally not included in this PR.

## Test plan

- [ ] No code changes; nothing to run.
- [ ] Confirm the workstream M2 reference resolves: `tools/ts2pant/docs/du-entailment-narrowing-survey.md` is present.
- [ ] Confirm the DU workstream M3 update note is consistent with the guard-analysis M3a DoD changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)