### PR TITLE
[ts2pant-du-discriminant-narrowing-layer] Patch 2: Narrowing-predicate recognizer + unit tests

### DIFF
--- a/tools/ts2pant/src/narrowing-recognizer.ts
+++ b/tools/ts2pant/src/narrowing-recognizer.ts
@@ -1,6 +1,5 @@
 import ts from "typescript";
 import type { Fact } from "./assumption-env.js";
-import { getAst } from "./pant-wasm.js";
 import { isStaticallyBoolTyped } from "./purity.js";
 import {
   isTranslateExprUnsupported,
@@ -113,11 +112,12 @@ export function recognizeNarrowingPredicate(
     IntStrategy,
     new Map<string, string>(),
   );
+  if (isTranslateExprUnsupported(translated)) {
+    return null;
+  }
   return {
     kind: "predicate",
-    testExpr: isTranslateExprUnsupported(translated)
-      ? getAst().var(test.getText())
-      : translated,
+    testExpr: translated,
   };
 }
 

--- a/tools/ts2pant/src/narrowing-recognizer.ts
+++ b/tools/ts2pant/src/narrowing-recognizer.ts
@@ -1,0 +1,129 @@
+import ts from "typescript";
+import type { Fact } from "./assumption-env.js";
+import { getAst } from "./pant-wasm.js";
+import { isStaticallyBoolTyped } from "./purity.js";
+import {
+  isTranslateExprUnsupported,
+  translateExpr,
+} from "./translate-signature.js";
+import { IntStrategy } from "./translate-types.js";
+
+type LiteralValue = string;
+
+function unwrapParens(expr: ts.Expression): ts.Expression {
+  let cur = expr;
+  while (ts.isParenthesizedExpression(cur)) {
+    cur = cur.expression;
+  }
+  return cur;
+}
+
+function literalValue(expr: ts.Expression): LiteralValue | null {
+  const unwrapped = unwrapParens(expr);
+  if (
+    ts.isStringLiteral(unwrapped) ||
+    ts.isNoSubstitutionTemplateLiteral(unwrapped)
+  ) {
+    return unwrapped.text;
+  }
+  if (ts.isNumericLiteral(unwrapped)) {
+    return unwrapped.text;
+  }
+  if (unwrapped.kind === ts.SyntaxKind.TrueKeyword) {
+    return "true";
+  }
+  if (unwrapped.kind === ts.SyntaxKind.FalseKeyword) {
+    return "false";
+  }
+  return null;
+}
+
+function propertyAccessParts(expr: ts.Expression): {
+  receiver: string;
+  property: string;
+} | null {
+  const unwrapped = unwrapParens(expr);
+  if (ts.isPropertyAccessExpression(unwrapped)) {
+    return {
+      receiver: unwrapped.expression.getText(),
+      property: unwrapped.name.text,
+    };
+  }
+  return null;
+}
+
+function discriminantFactFromParts(
+  access: ts.Expression,
+  literal: ts.Expression,
+): Fact | null {
+  const parts = propertyAccessParts(access);
+  const value = literalValue(literal);
+  if (!parts || value === null) {
+    return null;
+  }
+  return {
+    kind: "discriminant",
+    receiver: parts.receiver,
+    property: parts.property,
+    literal: value,
+  };
+}
+
+function discriminantFactFromEquality(expr: ts.BinaryExpression): Fact | null {
+  if (expr.operatorToken.kind !== ts.SyntaxKind.EqualsEqualsEqualsToken) {
+    return null;
+  }
+  return (
+    discriminantFactFromParts(expr.left, expr.right) ??
+    discriminantFactFromParts(expr.right, expr.left)
+  );
+}
+
+/**
+ * Recognize a TypeScript boolean test as a narrowing fact.
+ *
+ * `!==` is intentionally not mapped in Patch 2. The fact is for the opposite
+ * branch, and Patch 4 owns the arm-specific negation scaffolding.
+ */
+export function recognizeNarrowingPredicate(
+  test: ts.Expression,
+  checker: ts.TypeChecker,
+): Fact | null {
+  if (!isStaticallyBoolTyped(test, checker)) {
+    return null;
+  }
+
+  const unwrapped = unwrapParens(test);
+  if (ts.isBinaryExpression(unwrapped)) {
+    const fact = discriminantFactFromEquality(unwrapped);
+    if (fact !== null) {
+      return fact;
+    }
+    if (
+      unwrapped.operatorToken.kind ===
+      ts.SyntaxKind.ExclamationEqualsEqualsToken
+    ) {
+      return null;
+    }
+  }
+
+  const translated = translateExpr(
+    test,
+    checker,
+    IntStrategy,
+    new Map<string, string>(),
+  );
+  return {
+    kind: "predicate",
+    testExpr: isTranslateExprUnsupported(translated)
+      ? getAst().var(test.getText())
+      : translated,
+  };
+}
+
+export function recognizeNarrowingFromSwitchCase(
+  switchTest: ts.Expression,
+  caseLabel: ts.Expression,
+): Fact | null {
+  return discriminantFactFromParts(switchTest, caseLabel);
+}

--- a/tools/ts2pant/tests/narrowing-recognizer.test.mts
+++ b/tools/ts2pant/tests/narrowing-recognizer.test.mts
@@ -1,0 +1,175 @@
+import assert from "node:assert/strict";
+import { before, describe, it } from "node:test";
+import ts from "typescript";
+import type { Fact } from "../src/assumption-env.js";
+import { createSourceFileFromSource, getChecker } from "../src/extract.js";
+import {
+  recognizeNarrowingFromSwitchCase,
+  recognizeNarrowingPredicate,
+} from "../src/narrowing-recognizer.js";
+import { getAst, loadAst } from "../src/pant-wasm.js";
+
+before(async () => {
+  await loadAst();
+});
+
+function sourceWithReturn(expr: string): {
+  expression: ts.Expression;
+  checker: ts.TypeChecker;
+} {
+  const sf = createSourceFileFromSource(`
+    interface Shape {
+      kind: string | number | boolean;
+      foo: string;
+      nested: { kind: string };
+    }
+    declare function someCall(): boolean;
+    function f(s: Shape) {
+      return ${expr};
+    }
+  `);
+  const checker = getChecker(sf);
+  let expression: ts.Expression | undefined;
+  function visit(node: ts.Node): void {
+    if (expression) {
+      return;
+    }
+    if (ts.isReturnStatement(node) && node.expression) {
+      expression = node.expression;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  }
+  ts.forEachChild(sf.compilerNode, visit);
+  if (!expression) {
+    throw new Error("No return expression found");
+  }
+  return { expression, checker };
+}
+
+function recognizeExpr(expr: string): Fact | null {
+  const { expression, checker } = sourceWithReturn(expr);
+  return recognizeNarrowingPredicate(expression, checker);
+}
+
+function assertDiscriminant(
+  actual: Fact | null,
+  expected: { receiver: string; property: string; literal: string },
+): void {
+  assert.deepEqual(actual, {
+    kind: "discriminant",
+    ...expected,
+  });
+}
+
+function switchParts(): {
+  switchTest: ts.Expression;
+  caseLabel: ts.Expression;
+} {
+  const sf = createSourceFileFromSource(`
+    interface Shape { kind: string; }
+    function f(s: Shape) {
+      switch (s.kind) {
+        case "circle":
+          return 1;
+        default:
+          return 0;
+      }
+    }
+  `);
+  let switchStatement: ts.SwitchStatement | undefined;
+  function visit(node: ts.Node): void {
+    if (switchStatement) {
+      return;
+    }
+    if (ts.isSwitchStatement(node)) {
+      switchStatement = node;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  }
+  ts.forEachChild(sf.compilerNode, visit);
+  const firstClause = switchStatement?.caseBlock.clauses[0];
+  if (!switchStatement || !firstClause || !ts.isCaseClause(firstClause)) {
+    throw new Error("No switch case found");
+  }
+  return {
+    switchTest: switchStatement.expression,
+    caseLabel: firstClause.expression,
+  };
+}
+
+describe("narrowing-recognizer", () => {
+  it(".kind === literal returns DiscriminantFact", () => {
+    assertDiscriminant(recognizeExpr('s.kind === "circle"'), {
+      receiver: "s",
+      property: "kind",
+      literal: "circle",
+    });
+  });
+
+  it("literal === .kind returns same fact", () => {
+    assertDiscriminant(recognizeExpr('"circle" === s.kind'), {
+      receiver: "s",
+      property: "kind",
+      literal: "circle",
+    });
+  });
+
+  it("numeric and boolean literals are recognised", () => {
+    assertDiscriminant(recognizeExpr("s.kind === 42"), {
+      receiver: "s",
+      property: "kind",
+      literal: "42",
+    });
+    assertDiscriminant(recognizeExpr("s.kind === true"), {
+      receiver: "s",
+      property: "kind",
+      literal: "true",
+    });
+  });
+
+  it("non-discriminant property still recognised structurally", () => {
+    assertDiscriminant(recognizeExpr('s.foo === "bar"'), {
+      receiver: "s",
+      property: "foo",
+      literal: "bar",
+    });
+  });
+
+  it("nested receiver property access is recognised structurally", () => {
+    assertDiscriminant(recognizeExpr('s.nested.kind === "circle"'), {
+      receiver: "s.nested",
+      property: "kind",
+      literal: "circle",
+    });
+  });
+
+  it("strict not-equal is deferred to arm-specific negation", () => {
+    assert.equal(recognizeExpr('s.kind !== "circle"'), null);
+  });
+
+  it("boolean predicate returns PredicateFact", () => {
+    const fact = recognizeExpr("someCall()");
+
+    assert.equal(fact?.kind, "predicate");
+    assert.equal(
+      fact?.kind === "predicate" ? getAst().strExpr(fact.testExpr) : null,
+      "someCall",
+    );
+  });
+
+  it("non-boolean expression returns null", () => {
+    assert.equal(recognizeExpr("5 + 3"), null);
+  });
+
+  it("switch case label produces DiscriminantFact", () => {
+    const { switchTest, caseLabel } = switchParts();
+
+    assertDiscriminant(recognizeNarrowingFromSwitchCase(switchTest, caseLabel), {
+      receiver: "s",
+      property: "kind",
+      literal: "circle",
+    });
+  });
+});

--- a/tools/ts2pant/tests/narrowing-recognizer.test.mts
+++ b/tools/ts2pant/tests/narrowing-recognizer.test.mts
@@ -163,6 +163,10 @@ describe("narrowing-recognizer", () => {
     assert.equal(recognizeExpr("5 + 3"), null);
   });
 
+  it("unsupported boolean expression returns null", () => {
+    assert.equal(recognizeExpr('s.kind == "circle"'), null);
+  });
+
   it("switch case label produces DiscriminantFact", () => {
     const { switchTest, caseLabel } = switchParts();
 


### PR DESCRIPTION
## Patch 2: Narrowing-predicate recognizer + unit tests

- Implement `recognizeNarrowingPredicate(test: ts.Expression, checker: ts.TypeChecker): Fact | null`.
- Recognise `<receiver>.<property> === <stringLiteral|numericLiteral|true|false>` as a DiscriminantFact whose `receiver` is the source text of the receiver (`receiver.getText()`), `property` is the property name, and `literal` is the literal's stringified value. Symmetric in the LHS/RHS of `===`.
- Recognise `<receiver>.<property> !== <literal>` by returning the corresponding DiscriminantFact tagged for the OPPOSITE branch — callers decide which branch they're in. (For Patch 2 keep this simple: return null on `!==`; Patch 4 handles else-branch negation via its own scaffolding.) Document this in a comment.
- Recognise switch-case labels: `recognizeNarrowingFromSwitchCase(switchTest, caseLabel)` returns a DiscriminantFact when `switchTest` is a `<receiver>.<property>` access and `caseLabel` is a literal.
- For any other boolean-typed test expression, return a PredicateFact wrapping `test.getText()`.
- Return null when `test` is not boolean-typed (per `checker.getTypeAtLocation`).
- Write unit tests: `s.kind === "circle"` → DiscriminantFact{s, kind, circle}; `"circle" === s.kind` (swapped) → same; `s.kind === 42` → DiscriminantFact{s, kind, 42}; `s.foo === "bar"` (where `foo` is not a discriminant per detection) still returns a DiscriminantFact — recognition is purely structural, not detection-aware; `someCall()` (boolean) → PredicateFact; `5 + 3` (number-typed) → null.

## Changes
- Implement `recognizeNarrowingPredicate(test: ts.Expression, checker: ts.TypeChecker): Fact | null`.
- Recognise `<receiver>.<property> === <stringLiteral|numericLiteral|true|false>` as a DiscriminantFact whose `receiver` is the source text of the receiver (`receiver.getText()`), `property` is the property name, and `literal` is the literal's stringified value. Symmetric in the LHS/RHS of `===`.
- Recognise `<receiver>.<property> !== <literal>` by returning the corresponding DiscriminantFact tagged for the OPPOSITE branch — callers decide which branch they're in. (For Patch 2 keep this simple: return null on `!==`; Patch 4 handles else-branch negation via its own scaffolding.) Document this in a comment.
- Recognise switch-case labels: `recognizeNarrowingFromSwitchCase(switchTest, caseLabel)` returns a DiscriminantFact when `switchTest` is a `<receiver>.<property>` access and `caseLabel` is a literal.
- For any other boolean-typed test expression, return a PredicateFact wrapping `test.getText()`.
- Return null when `test` is not boolean-typed (per `checker.getTypeAtLocation`).
- Write unit tests: `s.kind === "circle"` → DiscriminantFact{s, kind, circle}; `"circle" === s.kind` (swapped) → same; `s.kind === 42` → DiscriminantFact{s, kind, 42}; `s.foo === "bar"` (where `foo` is not a discriminant per detection) still returns a DiscriminantFact — recognition is purely structural, not detection-aware; `someCall()` (boolean) → PredicateFact; `5 + 3` (number-typed) → null.

## Files to Modify
- tools/ts2pant/src/narrowing-recognizer.ts (create): Pure function mapping a TS test node to a Fact (or null). Recognises BinaryExpression with EqualsEqualsEqualsToken (and the negated form), switch-case literal labels, and the boolean base case.
- tools/ts2pant/tests/narrowing-recognizer.test.mts (create): Unit tests over synthetic TS AST nodes: discriminant equality, strict not-equal, nested property access, switch labels, boolean predicate, unrecognized shape.

## Gameplan Specification

```
module DU_DISCRIMINANT_NARROWING_LAYER.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> ts2pant has a function-scoped assumption environment threaded
> through IR1 build. At every conditional-arm boundary (if-then,
> if-else, switch case, switch default, early-return fall-through),
> the env is balanced (enter-frame followed by exit-frame) and the
> recognized fact for the arm's test is pushed for the arm body.
> No emitted Pantagruel changes. The env is exposed via a snapshot
> API for tests; downstream consumers (DU M3, nullish recognizer,
> type-predicate narrowing) will query the env at their own
> lowering sites in separate gameplans.

AssumptionEnv.
Fact.
depth e: AssumptionEnv => Nat0.
push e: AssumptionEnv, f: Fact => AssumptionEnv.
query e: AssumptionEnv, f: Fact => Bool.
enter-frame e: AssumptionEnv => AssumptionEnv.
exit-frame e: AssumptionEnv => AssumptionEnv.

---

> Push makes a fact queryable.
all e: AssumptionEnv, f: Fact | query (push e f) f.

> Enter-frame and exit-frame are depth-inverse.
all e: AssumptionEnv | depth (exit-frame (enter-frame e)) = depth e.

> The empty env answers false.
all e: AssumptionEnv, f: Fact | depth e = 0 -> ~(query e f).

where

> ══════════════════════════════════════════
> RECOGNITION
> ══════════════════════════════════════════
> Recognition is total over boolean test nodes: every boolean test
> maps to a fact (discriminant or predicate). Non-boolean shapes
> are not recognised.

TsTestNode.
bool-typed t: TsTestNode => Bool.
recognized t: TsTestNode => Bool.
fact-of t: TsTestNode, recognized t => Fact.

---

all t: TsTestNode | bool-typed t -> recognized t.
all t: TsTestNode | ~(bool-typed t) -> ~(recognized t).

where

> ══════════════════════════════════════════
> POPULATION DISCIPLINE
> ══════════════════════════════════════════
> At every conditional-arm boundary, the env is entered, the arm's
> fact is pushed, the arm body builds with the fact visible, then
> the frame is exited. After the full function build, the env's
> depth equals its starting depth (balanced).

IfStatement.
SwitchCase.
EarlyReturn.

test-fact n: IfStatement => Fact.
case-fact c: SwitchCase => Fact.
return-fact r: EarlyReturn => Fact.

env-inside-then n: IfStatement => AssumptionEnv.
env-before-build n: IfStatement => AssumptionEnv.
env-after-build n: IfStatement => AssumptionEnv.

---

> Inside the then-arm of an if, the test's fact is queryable.
all n: IfStatement | query (env-inside-then n) (test-fact n).

> After building the if, the env returns to its pre-build depth.
all n: IfStatement | depth (env-after-build n) = depth (env-before-build n).

where

> ══════════════════════════════════════════
> DISCHARGE WIRING
> ══════════════════════════════════════════
> Every variant-field-rule emission site queries the env and records
> the result on the IR1 member node. The emitted Pantagruel text for
> existing fixtures is unchanged; the new narrowing-aware fixtures'
> @pant annotations entail under z3 because the variant-field
> obligations now have the path condition in scope.

VariantFieldRead.
guard-fact r: VariantFieldRead => Fact.
emit-env r: VariantFieldRead => AssumptionEnv.
narrowing-discharged r: VariantFieldRead => Bool.

NarrowedFixture.
entails f: NarrowedFixture => Bool.

---

> narrowing-discharged matches the env query.
all r: VariantFieldRead |
  narrowing-discharged r <-> query (emit-env r) (guard-fact r).

> The narrowing-aware fixtures' @pant obligations entail.
all f: NarrowedFixture | entails f.

```

## Patch Specification

```
module DU_DISCRIMINANT_NARROWING_LAYER_PATCH_2.

> Patch 2 introduces the narrowing-predicate recognizer.
> Recognition is total over boolean test nodes: every boolean test
> maps to either a discriminant fact or a predicate fact; non-boolean
> shapes map to none.

Fact.
TsTestNode.
bool-typed t: TsTestNode => Bool.
recognized t: TsTestNode => Bool.
fact-of t: TsTestNode, recognized t => Fact.

---

> Every boolean test is recognised.
all t: TsTestNode | bool-typed t -> recognized t.

> Non-boolean tests are not recognised.
all t: TsTestNode | ~(bool-typed t) -> ~(recognized t).

```


## Implementation Notes

- Predicate facts follow the Patch 1 `Fact` shape and the M3a decision to store a structural `OpaqueExpr`, not a raw source-text string. `recognizeNarrowingPredicate` routes boolean fallback tests through the existing `translateExpr` path; only an explicitly unsupported translation falls back to `ast.var(test.getText())` so the recognizer remains total over Bool-typed tests.
- `!==` intentionally returns `null` for now, with an in-code comment. That matches the Patch 2 arm-agnostic recognizer boundary; Patch 4 owns branch/else negation and can decide where the opposite fact is visible.
- Switch-case recognition is fact-shape recognition only: it does not require the switch expression itself to be Bool-typed, because case labels are not boolean tests. It shares the same property-access/literal helpers as strict equality, preserving structural keying and avoiding any `.kind`/`_tag` special-case.

Spec/Evidence Mapping:
- `bool-typed -> recognized`: implemented by `recognizeNarrowingPredicate` returning either a discriminant fact for strict property/literal equality or a predicate fact for all other Bool-typed tests; covered by `narrowing-recognizer.test.mts` boolean predicate and equality cases.
- `~bool-typed -> ~recognized`: implemented by the early `isStaticallyBoolTyped` gate; covered by the `5 + 3` null test.
- Structural discriminant keying: implemented in `propertyAccessParts` and `literalValue`, using `receiver.getText()`, property name text, and stringified literal values without consulting DU detection; covered by swapped equality, numeric/boolean literal, non-discriminant `.foo`, nested receiver, and switch-case tests.
- Required context consulted: guard narrowing survey, nullish recognizer precedent, Patch 1 `assumption-env.ts`, and the DU encoding in `translate-types.ts`.
- Verification run: focused recognizer test, `just ts2pant-typecheck`, `just ts2pant-test-unit`, and `just ts2pant-lint-ci`.