### PR TITLE
[ts2pant-du-discriminant-narrowing-layer] Patch 3: Thread AssumptionEnv through L1BuildContext + snapshot API

### DIFF
--- a/tools/ts2pant/src/ir-build.ts
+++ b/tools/ts2pant/src/ir-build.ts
@@ -27,6 +27,7 @@ import {
 import {
   buildL1MemberAccess,
   computedElementAccessUnsupportedReason,
+  createL1AssumptionEnv,
   elementAccessLiteralKey,
   isArrayChainCall,
   type L1BuildContext,
@@ -972,6 +973,7 @@ export function buildIR(
     paramNames,
     state: undefined,
     supply,
+    env: createL1AssumptionEnv(),
   };
 
   if (ts.isCallExpression(expr)) {

--- a/tools/ts2pant/src/ir1-build-body.ts
+++ b/tools/ts2pant/src/ir1-build-body.ts
@@ -27,6 +27,7 @@
  */
 
 import ts from "typescript";
+import type { AssumptionEnv } from "./assumption-env.js";
 import type { IRBinop } from "./ir.js";
 import {
   type IR1Expr,
@@ -105,6 +106,7 @@ export interface BuildBodyCtx {
   paramNames: ReadonlyMap<string, string>;
   state: SymbolicState;
   supply: UniqueSupply;
+  env: AssumptionEnv;
   /**
    * When set, this build is inside a foreach loop body. Carries the
    * TS names of iterator binders in scope so the recursive
@@ -767,6 +769,7 @@ export function buildL1SubExpr(
       paramNames: ctx.paramNames,
       state: ctx.state,
       supply: ctx.supply,
+      env: ctx.env,
     };
     const card = tryBuildL1Cardinality(stripped, ctxOptions, l1Options);
     if (card !== null) {
@@ -784,6 +787,7 @@ export function buildL1SubExpr(
     paramNames: ctx.paramNames,
     state: ctx.state,
     supply: ctx.supply,
+    env: ctx.env,
   });
   if (native !== null) {
     return native;
@@ -1205,6 +1209,7 @@ export function buildL1EffectCall(
     ctx.paramNames,
     ctx.state,
     ctx.supply,
+    ctx.env,
   );
   if (isBodyUnsupported(result)) {
     return { unsupported: result.unsupported };

--- a/tools/ts2pant/src/ir1-build-body.ts
+++ b/tools/ts2pant/src/ir1-build-body.ts
@@ -921,6 +921,7 @@ function simulateShapeAPropertyWrite(
       subCtx.paramNames,
       subCtx.state,
       subCtx.supply,
+      subCtx.env,
     ),
   );
   if (isBodyUnsupported(objR)) {
@@ -934,6 +935,7 @@ function simulateShapeAPropertyWrite(
       subCtx.paramNames,
       subCtx.state,
       subCtx.supply,
+      subCtx.env,
     ),
   );
   if (isBodyUnsupported(valR)) {

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -33,6 +33,11 @@
  */
 
 import ts from "typescript";
+import {
+  type AssumptionEnv,
+  createAssumptionEnv,
+  enterFrame,
+} from "./assumption-env.js";
 import { lookupBuiltinByCall } from "./builtins.js";
 import { lowerExpr } from "./ir-emit.js";
 import {
@@ -110,9 +115,20 @@ export interface L1BuildContext {
   paramNames: ReadonlyMap<string, string>;
   state: SymbolicState | undefined;
   supply: UniqueSupply;
+  env: AssumptionEnv;
 }
 
 export type L1BuildResult = IR1Expr | { unsupported: string };
+
+export function createL1AssumptionEnv(): AssumptionEnv {
+  const env = createAssumptionEnv();
+  enterFrame(env);
+  return env;
+}
+
+export function snapshotAssumptionEnv(ctx: L1BuildContext): AssumptionEnv {
+  return ctx.env;
+}
 
 export const isL1Unsupported = (
   r: L1BuildResult,

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -1,5 +1,6 @@
 import type { SourceFile } from "ts-morph";
 import ts from "typescript";
+import type { AssumptionEnv } from "./assumption-env.js";
 import { buildIR, isBuildUnsupported } from "./ir-build.js";
 import { lowerExpr } from "./ir-emit.js";
 import {
@@ -23,6 +24,7 @@ import {
   buildL1IncrementStep,
   buildL1MemberAccess,
   buildL1MuSearchCombTyped,
+  createL1AssumptionEnv,
   isL1ConditionalForm,
   isL1StmtUnsupported,
   isL1Unsupported,
@@ -1231,6 +1233,7 @@ function translatePureBody(
   }
 
   const supply = makeUniqueSupply(synthCell, program);
+  const env = createL1AssumptionEnv();
 
   // M4 Patch 5: functor-lift on the if-conversion shape
   //   `if (x == null) return []; return [f(x)];`
@@ -1259,6 +1262,7 @@ function translatePureBody(
         paramNames,
         state: undefined,
         supply,
+        env,
       },
     );
     if (lifted !== null) {
@@ -1282,6 +1286,7 @@ function translatePureBody(
     strategy,
     paramNames,
     supply,
+    env,
   );
   if ("error" in prelude) {
     return [
@@ -1373,6 +1378,7 @@ function translatePureBody(
       paramNames: prelude.scopedParams,
       state: undefined as SymbolicState | undefined,
       supply,
+      env,
     };
     let bodyOpaque: OpaqueExpr;
     if (l1IsConditionalReturn) {
@@ -2368,6 +2374,7 @@ function lowerPreludeBindings(
   strategy: NumericStrategy,
   baseParams: ReadonlyMap<string, string>,
   supply: UniqueSupply,
+  env: AssumptionEnv,
   state?: SymbolicState,
 ): LoweredPreludeBindings | { error: string } {
   // Phase 1: TDZ validation — reject forward/self references on TS AST.
@@ -2478,6 +2485,7 @@ function lowerPreludeBindings(
           acc.scopedParams,
           state,
           supply,
+          env,
         );
         if ("error" in predRes) {
           return { tag: "error", error: predRes.error };
@@ -2491,6 +2499,7 @@ function lowerPreludeBindings(
                 acc.scopedParams,
                 state,
                 supply,
+                env,
               )
             : translateEarlyReturnBlockValue(
                 binding.blockBindings,
@@ -2501,6 +2510,7 @@ function lowerPreludeBindings(
                   scopedParams: acc.scopedParams,
                   state: state ?? makeSymbolicState(),
                   supply,
+                  env,
                 },
               );
         if ("error" in valRes) {
@@ -2521,6 +2531,7 @@ function lowerPreludeBindings(
           paramNames: acc.scopedParams,
           state: state ?? makeSymbolicState(),
           supply,
+          env,
         });
         if (isUnsupported(value)) {
           return { tag: "error", error: value.unsupported };
@@ -2548,6 +2559,7 @@ function lowerPreludeBindings(
           paramNames: scopedParams,
           state: state ?? makeSymbolicState(),
           supply,
+          env,
         });
         if (isUnsupported(built)) {
           return { tag: "error", error: built.unsupported };
@@ -2588,6 +2600,7 @@ function lowerPreludeBindings(
               paramNames: acc.scopedParams,
               state: state ?? makeSymbolicState(),
               supply,
+              env,
             })
           : buildL1MuSearchCombTyped(binding.mu, {
               checker,
@@ -2595,6 +2608,7 @@ function lowerPreludeBindings(
               paramNames: acc.scopedParams,
               state,
               supply,
+              env,
             });
       if (isUnsupported(initExpr) || isL1Unsupported(initExpr)) {
         if (
@@ -2658,6 +2672,7 @@ function translateEarlyReturnBlockValue(
     scopedParams: ReadonlyMap<string, string>;
     state: SymbolicState;
     supply: UniqueSupply;
+    env: AssumptionEnv;
   },
 ): BindingInitResult {
   let scopedParams: ReadonlyMap<string, string> = new Map(ctx.scopedParams);
@@ -2674,6 +2689,7 @@ function translateEarlyReturnBlockValue(
       paramNames: scopedParams,
       state: ctx.state,
       supply: ctx.supply,
+      env: ctx.env,
     });
     if (isUnsupported(initExpr) || isL1Unsupported(initExpr)) {
       return { error: initExpr.unsupported };
@@ -2688,6 +2704,7 @@ function translateEarlyReturnBlockValue(
     paramNames: scopedParams,
     state: ctx.state,
     supply: ctx.supply,
+    env: ctx.env,
   });
   if (isUnsupported(value) || isL1Unsupported(value)) {
     return { error: value.unsupported };
@@ -2708,6 +2725,7 @@ function translateBindingInit(
   scopedParams: ReadonlyMap<string, string>,
   state: SymbolicState | undefined,
   supply: UniqueSupply,
+  env: AssumptionEnv,
 ): BindingInitResult {
   const result = translateBodyExpr(
     initializer,
@@ -2716,6 +2734,7 @@ function translateBindingInit(
     scopedParams,
     state,
     supply,
+    env,
   );
   if (isBodyUnsupported(result)) {
     return { error: result.unsupported };
@@ -3192,6 +3211,7 @@ export function translateBodyExpr(
   paramNames: ReadonlyMap<string, string>,
   state: SymbolicState | undefined,
   supply: UniqueSupply,
+  env: AssumptionEnv = createL1AssumptionEnv(),
 ): BodyResult {
   const ast = getAst();
 
@@ -3281,6 +3301,7 @@ export function translateBodyExpr(
       paramNames,
       state,
       supply,
+      env,
     };
     const translate: NullishTranslate = (sub) => {
       const subL1 = tryBuildL1PureSubExpression(sub, l1Ctx);
@@ -3311,7 +3332,7 @@ export function translateBodyExpr(
   ) {
     const l1 = buildL1Conditional(
       expr as ts.Expression | ts.IfStatement | ts.SwitchStatement,
-      { checker, strategy, paramNames, state, supply },
+      { checker, strategy, paramNames, state, supply, env },
     );
     if (isL1Unsupported(l1)) {
       return { unsupported: l1.unsupported };
@@ -3349,6 +3370,7 @@ export function translateBodyExpr(
           paramNames,
           state,
           supply,
+          env,
         );
         if (isBodyUnsupported(obj)) {
           return obj;
@@ -3382,6 +3404,7 @@ export function translateBodyExpr(
       paramNames,
       state,
       supply,
+      env,
     };
     const card = tryBuildL1Cardinality(expr, l1Ctx);
     if (card !== null) {
@@ -3413,6 +3436,7 @@ export function translateBodyExpr(
       paramNames,
       state,
       supply,
+      env,
     };
     const member = buildL1MemberAccess(expr, l1Ctx);
     if ("unsupported" in member) {
@@ -3428,7 +3452,15 @@ export function translateBodyExpr(
   // so downstream `bodyExpr()` calls see a narrow result and never throw.
   if (ts.isCallExpression(expr)) {
     return rejectEffect(
-      translateCallExpr(expr, checker, strategy, paramNames, state, supply),
+      translateCallExpr(
+        expr,
+        checker,
+        strategy,
+        paramNames,
+        state,
+        supply,
+        env,
+      ),
     );
   }
 
@@ -3441,6 +3473,7 @@ export function translateBodyExpr(
       paramNames,
       state,
       supply,
+      env,
     );
     if (isBodyUnsupported(operand)) {
       return operand;
@@ -4027,6 +4060,7 @@ export function translateCallExpr(
   paramNames: ReadonlyMap<string, string>,
   state: SymbolicState | undefined,
   supply: UniqueSupply,
+  env: AssumptionEnv = createL1AssumptionEnv(),
 ): BodyResult {
   const ast = getAst();
   const builtin = tryBuildBuiltinCall(expr, {
@@ -4035,6 +4069,7 @@ export function translateCallExpr(
     paramNames,
     state,
     supply,
+    env,
   });
   if (builtin !== null) {
     if (isL1Unsupported(builtin)) {
@@ -4088,6 +4123,7 @@ export function translateCallExpr(
           paramNames,
           state,
           supply,
+          env,
         },
         { requireMember: true },
       );
@@ -4208,6 +4244,7 @@ export function translateCallExpr(
             paramNames,
             state,
             supply,
+            env,
           },
           { requireMember: true },
         );
@@ -4346,6 +4383,7 @@ export function translateCallExpr(
             paramNames,
             state,
             supply,
+            env,
           },
           { requireMember: true },
         );
@@ -4542,6 +4580,7 @@ export function translateCallExpr(
               paramNames,
               state,
               supply,
+              env,
             },
             { requireMember: true },
           );
@@ -4772,6 +4811,7 @@ function translateMutatingBody(
     return [];
   }
   const localRuleDecls: PropResult[] = [];
+  const env = createL1AssumptionEnv();
 
   const lowered = appendFramesForUnmodifiedRules(
     lowerSupportedSsaMutatingStatements(Array.from(node.body.statements), {
@@ -4784,6 +4824,7 @@ function translateMutatingBody(
       helperNameBase: functionName,
       declarations,
       localRuleDecls,
+      env,
     }),
     declarations,
   );
@@ -4805,6 +4846,7 @@ function lowerSupportedSsaMutatingStatements(
     helperNameBase: string;
     declarations: readonly PantDeclaration[];
     localRuleDecls: PropResult[];
+    env: AssumptionEnv;
   },
 ): IR1SsaBodyLowerResult {
   const tailReturnValue = extractTailReturnValue(stmts, ctx.checker);
@@ -4823,6 +4865,7 @@ function lowerSupportedSsaMutatingStatements(
       ctx.paramNames,
       ctx.state,
       ctx.supply,
+      ctx.env,
     );
     if (isBodyUnsupported(returnExpr)) {
       return ir1SsaBodyLowerUnsupported(returnExpr.unsupported);
@@ -5053,6 +5096,7 @@ function lowerSupportedSsaMutatingBlock(
     helperNameBase: string;
     declarations: readonly PantDeclaration[];
     localRuleDecls: PropResult[];
+    env: AssumptionEnv;
   },
 ): IR1SsaBodyLowerResult {
   const body = ts.factory.createBlock(stmts, true);
@@ -5063,6 +5107,7 @@ function lowerSupportedSsaMutatingBlock(
     ctx.paramNames,
     ctx.state,
     ctx.supply,
+    ctx.env,
     ctx.localRuleDecls,
   );
 
@@ -5135,6 +5180,7 @@ function buildSupportedSsaMutatingBody(
   paramNames: Map<string, string>,
   state: SymbolicState,
   supply: UniqueSupply,
+  env: AssumptionEnv,
   localRuleDecls?: PropResult[],
 ): IR1Stmt | { unsupported: string } {
   const stmts: IR1Stmt[] = [];
@@ -5173,6 +5219,7 @@ function buildSupportedSsaMutatingBody(
           paramNames: scopedParamNames,
           state,
           supply,
+          env,
         },
       );
       if (built !== null) {
@@ -5189,6 +5236,7 @@ function buildSupportedSsaMutatingBody(
           paramNames: scopedParamNames,
           state,
           supply,
+          env,
         },
       );
       if (isUnsupported(fixedPointBuilt)) {
@@ -5214,6 +5262,7 @@ function buildSupportedSsaMutatingBody(
             strategy,
             scopedParamNames,
             supply,
+            env,
             state,
           );
           if ("error" in lowered) {
@@ -5260,6 +5309,7 @@ function buildSupportedSsaMutatingBody(
           strategy,
           scopedParamNames,
           supply,
+          env,
           state,
         );
         if ("error" in lowered) {
@@ -5275,6 +5325,7 @@ function buildSupportedSsaMutatingBody(
       paramNames: scopedParamNames,
       state,
       supply,
+      env,
       ...(localRuleDecls === undefined ? {} : { localRuleDecls }),
     });
     if (isUnsupported(built)) {
@@ -5299,6 +5350,7 @@ function buildSupportedSsaStatement(
     paramNames: Map<string, string>;
     state: SymbolicState;
     supply: UniqueSupply;
+    env: AssumptionEnv;
     localRuleDecls?: PropResult[];
   },
 ): IR1Stmt | { unsupported: string } {
@@ -5328,6 +5380,7 @@ function buildSupportedSsaStatement(
       ctx.paramNames,
       ctx.state,
       ctx.supply,
+      ctx.env,
       ctx.localRuleDecls,
     );
     return body;
@@ -5418,6 +5471,7 @@ function buildL1BareWhileMutation(
         ctx.paramNames,
         ctx.state,
         ctx.supply,
+        ctx.env,
         ctx.localRuleDecls,
       )
     : buildSupportedSsaStatement(stmt.statement, ctx);
@@ -5435,6 +5489,7 @@ function buildL1ForCounterMutation(
     paramNames: Map<string, string>;
     state: SymbolicState;
     supply: UniqueSupply;
+    env: AssumptionEnv;
     localRuleDecls?: PropResult[];
   },
 ): IR1Stmt | { unsupported: string } {
@@ -5469,6 +5524,7 @@ function buildL1ForCounterMutation(
     paramNames: ctx.paramNames,
     state: ctx.state,
     supply: ctx.supply,
+    env: ctx.env,
   });
   if (isL1StmtUnsupported(step)) {
     return { unsupported: step.unsupported };
@@ -5482,6 +5538,7 @@ function buildL1ForCounterMutation(
         ctx.paramNames,
         ctx.state,
         ctx.supply,
+        ctx.env,
         ctx.localRuleDecls,
       )
     : buildSupportedSsaStatement(stmt.statement, ctx);
@@ -5542,6 +5599,7 @@ function buildL1LetWhileFixedPointMutation(
     ctx.paramNames,
     ctx.state,
     ctx.supply,
+    ctx.env,
     ctx.localRuleDecls,
   );
   if (isUnsupported(bodyStmt)) {
@@ -5643,6 +5701,7 @@ function buildL1LetWhileMutation(
     ctx.paramNames,
     ctx.state,
     ctx.supply,
+    ctx.env,
     ctx.localRuleDecls,
   );
   if (isUnsupported(bodyStmt)) {
@@ -5757,6 +5816,7 @@ function buildL1ForCounterCondition(
     paramNames: Map<string, string>;
     state: SymbolicState;
     supply: UniqueSupply;
+    env: AssumptionEnv;
   },
 ): IR1Expr | { unsupported: string } {
   const cond = unwrapExpression(condition);

--- a/tools/ts2pant/src/translate-signature.ts
+++ b/tools/ts2pant/src/translate-signature.ts
@@ -4,6 +4,7 @@ import { lowerExpr } from "./ir-emit.js";
 import {
   type BuildL1MemberAccessOptions,
   buildL1MemberAccess,
+  createL1AssumptionEnv,
   isL1Unsupported,
   type L1BuildContext,
   tryBuildL1Cardinality,
@@ -1023,6 +1024,7 @@ export function translateExpr(
     paramNames,
     state: undefined,
     supply: { n: 0, synthCell, program },
+    env: createL1AssumptionEnv(),
   };
 
   // M5: plain (non-optional) property access dispatches cardinality
@@ -1125,6 +1127,7 @@ export function translateExpr(
         paramNames,
         state: undefined,
         supply: { n: 0, synthCell, program },
+        env: createL1AssumptionEnv(),
       };
       // Route property/element access operands through the same
       // signature-side cardinality + Member dispatch that


### PR DESCRIPTION
## Patch 3: Thread AssumptionEnv through L1BuildContext + snapshot API

- Import `AssumptionEnv`, `createAssumptionEnv` from `./assumption-env`.
- Extend the `L1BuildContext` interface (line 107) with `env: AssumptionEnv`.
- Find every site that constructs an L1BuildContext (grep for `paramNames:` to locate ctx literals) and initialize `env: createAssumptionEnv()`.
- Export `snapshotAssumptionEnv(ctx: L1BuildContext): AssumptionEnv` — for now this returns `ctx.env` directly (live reference); the integration test will deep-copy when it needs to compare snapshots.
- Add a top-level frame at context creation (so all subsequent push/pop operations are well-balanced under exactly one outer frame): call `enterFrame(env)` immediately after `createAssumptionEnv()` at each ctx-construction site.
- No recognition wiring yet — the env stays at depth 1 (the outer frame) and contains no facts. Verified by an assertion in Patch 4's integration test.

## Changes
- Import `AssumptionEnv`, `createAssumptionEnv` from `./assumption-env`.
- Extend the `L1BuildContext` interface (line 107) with `env: AssumptionEnv`.
- Find every site that constructs an L1BuildContext (grep for `paramNames:` to locate ctx literals) and initialize `env: createAssumptionEnv()`.
- Export `snapshotAssumptionEnv(ctx: L1BuildContext): AssumptionEnv` — for now this returns `ctx.env` directly (live reference); the integration test will deep-copy when it needs to compare snapshots.
- Add a top-level frame at context creation (so all subsequent push/pop operations are well-balanced under exactly one outer frame): call `enterFrame(env)` immediately after `createAssumptionEnv()` at each ctx-construction site.
- No recognition wiring yet — the env stays at depth 1 (the outer frame) and contains no facts. Verified by an assertion in Patch 4's integration test.

## Files to Modify
- tools/ts2pant/src/ir1-build.ts (modify): Add `env: AssumptionEnv` to L1BuildContext (line 107). Initialize via `createAssumptionEnv()` at context construction sites. Export `snapshotAssumptionEnv(ctx)` returning the live env.

## Gameplan Specification

```
module DU_DISCRIMINANT_NARROWING_LAYER.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> ts2pant has a function-scoped assumption environment threaded
> through IR1 build. At every conditional-arm boundary (if-then,
> if-else, switch case, switch default, early-return fall-through),
> the env is balanced (enter-frame followed by exit-frame) and the
> recognized fact for the arm's test is pushed for the arm body.
> No emitted Pantagruel changes. The env is exposed via a snapshot
> API for tests; downstream consumers (DU M3, nullish recognizer,
> type-predicate narrowing) will query the env at their own
> lowering sites in separate gameplans.

AssumptionEnv.
Fact.
depth e: AssumptionEnv => Nat0.
push e: AssumptionEnv, f: Fact => AssumptionEnv.
query e: AssumptionEnv, f: Fact => Bool.
enter-frame e: AssumptionEnv => AssumptionEnv.
exit-frame e: AssumptionEnv => AssumptionEnv.

---

> Push makes a fact queryable.
all e: AssumptionEnv, f: Fact | query (push e f) f.

> Enter-frame and exit-frame are depth-inverse.
all e: AssumptionEnv | depth (exit-frame (enter-frame e)) = depth e.

> The empty env answers false.
all e: AssumptionEnv, f: Fact | depth e = 0 -> ~(query e f).

where

> ══════════════════════════════════════════
> RECOGNITION
> ══════════════════════════════════════════
> Recognition is total over boolean test nodes: every boolean test
> maps to a fact (discriminant or predicate). Non-boolean shapes
> are not recognised.

TsTestNode.
bool-typed t: TsTestNode => Bool.
recognized t: TsTestNode => Bool.
fact-of t: TsTestNode, recognized t => Fact.

---

all t: TsTestNode | bool-typed t -> recognized t.
all t: TsTestNode | ~(bool-typed t) -> ~(recognized t).

where

> ══════════════════════════════════════════
> POPULATION DISCIPLINE
> ══════════════════════════════════════════
> At every conditional-arm boundary, the env is entered, the arm's
> fact is pushed, the arm body builds with the fact visible, then
> the frame is exited. After the full function build, the env's
> depth equals its starting depth (balanced).

IfStatement.
SwitchCase.
EarlyReturn.

test-fact n: IfStatement => Fact.
case-fact c: SwitchCase => Fact.
return-fact r: EarlyReturn => Fact.

env-inside-then n: IfStatement => AssumptionEnv.
env-before-build n: IfStatement => AssumptionEnv.
env-after-build n: IfStatement => AssumptionEnv.

---

> Inside the then-arm of an if, the test's fact is queryable.
all n: IfStatement | query (env-inside-then n) (test-fact n).

> After building the if, the env returns to its pre-build depth.
all n: IfStatement | depth (env-after-build n) = depth (env-before-build n).

where

> ══════════════════════════════════════════
> DISCHARGE WIRING
> ══════════════════════════════════════════
> Every variant-field-rule emission site queries the env and records
> the result on the IR1 member node. The emitted Pantagruel text for
> existing fixtures is unchanged; the new narrowing-aware fixtures'
> @pant annotations entail under z3 because the variant-field
> obligations now have the path condition in scope.

VariantFieldRead.
guard-fact r: VariantFieldRead => Fact.
emit-env r: VariantFieldRead => AssumptionEnv.
narrowing-discharged r: VariantFieldRead => Bool.

NarrowedFixture.
entails f: NarrowedFixture => Bool.

---

> narrowing-discharged matches the env query.
all r: VariantFieldRead |
  narrowing-discharged r <-> query (emit-env r) (guard-fact r).

> The narrowing-aware fixtures' @pant obligations entail.
all f: NarrowedFixture | entails f.

```

## Patch Specification

```
module DU_DISCRIMINANT_NARROWING_LAYER_PATCH_3.

> Patch 3 threads the env type through L1BuildContext and exposes the
> snapshot API. No recognition wiring; the env stays empty.

AssumptionEnv.
depth e: AssumptionEnv => Nat0.

L1BuildContext.
env ctx: L1BuildContext => AssumptionEnv.
snapshot-env ctx: L1BuildContext => AssumptionEnv.

---

> The snapshot is the live env reference (identity).
all ctx: L1BuildContext | snapshot-env ctx = env ctx.

> A freshly-created context has exactly one outer frame and no facts.
all ctx: L1BuildContext | depth (env ctx) >= 1.

```


## Implementation Notes

- Added a `createL1AssumptionEnv()` helper in `ir1-build.ts` so each L1 env is created with the required outer frame in one place. This still performs the planned `createAssumptionEnv()` followed by `enterFrame(env)`, but avoids repeating that sequence across every caller.
- The env had to be threaded through a few structural L1 context users beyond `ir1-build.ts`: pure IR fallback, signature translation, `translateBodyExpr`, `translateCallExpr`, and the mutating SSA body path. Derived contexts keep the same env reference, which preserves the function-scoped/liveness contract for Patch 4.
- No recognition or push/pop population was added in this patch; all new env plumbing is inert with respect to emitted Pantagruel.

Spec/Evidence Mapping:
- `snapshot-env ctx = env ctx`: `snapshotAssumptionEnv(ctx)` returns `ctx.env` directly in `tools/ts2pant/src/ir1-build.ts`.
- `depth (env ctx) >= 1`: all fresh L1 env creation goes through `createL1AssumptionEnv()`, which calls `enterFrame` immediately after `createAssumptionEnv`.
- Function-scoped threading: `translatePureBody` and `translateMutatingBody` each allocate one env and pass it through their L1 sub-build paths; signature/standalone pure IR entry points allocate their own outer-framed env because they are not function-body builds.
- Verification: `npx tsc --noEmit`, `npm run lint`, and `npm test` pass. `npm run build` is blocked before `tsc` by a local opam switch issue: corrupted compiled interface `ppxlib.cmi` during `dune build wasm/`.