### PR TITLE
[ts2pant-du-discriminant-narrowing-layer] Patch 4: Wire recognition at IR1-build arm boundaries + integration tests

### DIFF
--- a/tools/ts2pant/src/ir1-build-body.ts
+++ b/tools/ts2pant/src/ir1-build-body.ts
@@ -27,7 +27,13 @@
  */
 
 import ts from "typescript";
-import type { AssumptionEnv } from "./assumption-env.js";
+import {
+  type AssumptionEnv,
+  enterFrame,
+  exitFrame,
+  type Fact,
+  pushFact,
+} from "./assumption-env.js";
 import type { IRBinop } from "./ir.js";
 import {
   type IR1Expr,
@@ -58,6 +64,10 @@ import {
   tryBuildL1PureSubExpression,
 } from "./ir1-build.js";
 import { substituteIR1StmtSubtree } from "./ir1-substitute.js";
+import {
+  negateFact,
+  recognizeNarrowingPredicate,
+} from "./narrowing-recognizer.js";
 import type { OpaqueExpr } from "./pant-ast.js";
 import {
   ambiguousFieldMsg,
@@ -107,6 +117,7 @@ export interface BuildBodyCtx {
   state: SymbolicState;
   supply: UniqueSupply;
   env: AssumptionEnv;
+  recognitionHook?: (env: AssumptionEnv, location: string) => void;
   /**
    * When set, this build is inside a foreach loop body. Carries the
    * TS names of iterator binders in scope so the recursive
@@ -137,6 +148,30 @@ export function isUnsupported<T>(
     x !== null &&
     "unsupported" in (x as Record<string, unknown>)
   );
+}
+
+function withNarrowingFrame<T>(
+  ctx: BuildBodyCtx,
+  location: string,
+  facts: readonly (Fact | null)[],
+  build: () => T,
+): T {
+  const env = (ctx as { env?: BuildBodyCtx["env"] }).env;
+  if (env === undefined) {
+    return build();
+  }
+  enterFrame(env);
+  try {
+    for (const fact of facts) {
+      if (fact !== null) {
+        pushFact(env, fact);
+      }
+    }
+    ctx.recognitionHook?.(env, location);
+    return build();
+  } finally {
+    exitFrame(env);
+  }
 }
 
 /**
@@ -970,14 +1005,22 @@ export function buildL1IfMutation(
     return guard;
   }
 
-  const thenBody = buildL1MutationBody(stmt.thenStatement, ctx);
+  const fact = recognizeNarrowingPredicate(stmt.expression, ctx.checker);
+  const thenBody = withNarrowingFrame(ctx, "if.then", [fact], () =>
+    buildL1MutationBody(stmt.thenStatement, ctx),
+  );
   if (isUnsupported(thenBody)) {
     return thenBody;
   }
 
   let elseBody: IR1Stmt | null = null;
   if (stmt.elseStatement) {
-    const e = buildL1MutationBody(stmt.elseStatement, ctx);
+    const e = withNarrowingFrame(
+      ctx,
+      "if.else",
+      [fact === null ? null : negateFact(fact)],
+      () => buildL1MutationBody(stmt.elseStatement!, ctx),
+    );
     if (isUnsupported(e)) {
       return e;
     }

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -37,6 +37,9 @@ import {
   type AssumptionEnv,
   createAssumptionEnv,
   enterFrame,
+  exitFrame,
+  type Fact,
+  pushFact,
 } from "./assumption-env.js";
 import { lookupBuiltinByCall } from "./builtins.js";
 import { lowerExpr } from "./ir-emit.js";
@@ -65,6 +68,11 @@ import {
 } from "./ir1.js";
 import { lowerL1Expr } from "./ir1-lower.js";
 import { substituteIR1ExprSubtree } from "./ir1-substitute.js";
+import {
+  negateFact,
+  recognizeNarrowingFromSwitchCase,
+  recognizeNarrowingPredicate,
+} from "./narrowing-recognizer.js";
 import {
   getOperandDeclaredType,
   type NullishTranslate,
@@ -116,6 +124,7 @@ export interface L1BuildContext {
   state: SymbolicState | undefined;
   supply: UniqueSupply;
   env: AssumptionEnv;
+  recognitionHook?: (env: AssumptionEnv, location: string) => void;
 }
 
 export type L1BuildResult = IR1Expr | { unsupported: string };
@@ -127,13 +136,37 @@ export function createL1AssumptionEnv(): AssumptionEnv {
 }
 
 export function snapshotAssumptionEnv(ctx: L1BuildContext): AssumptionEnv {
-  return ctx.env;
+  return { frames: ctx.env.frames.map((frame) => new Set(frame)) };
 }
 
 export const isL1Unsupported = (
   r: L1BuildResult,
 ): r is { unsupported: string } =>
   typeof r === "object" && r !== null && "unsupported" in r;
+
+function withNarrowingFrame<T>(
+  ctx: L1BuildContext,
+  location: string,
+  facts: readonly (Fact | null)[],
+  build: () => T,
+): T {
+  const env = (ctx as { env?: L1BuildContext["env"] }).env;
+  if (env === undefined) {
+    return build();
+  }
+  enterFrame(env);
+  try {
+    for (const fact of facts) {
+      if (fact !== null) {
+        pushFact(env, fact);
+      }
+    }
+    ctx.recognitionHook?.(env, location);
+    return build();
+  } finally {
+    exitFrame(env);
+  }
+}
 
 export function tryBuildBuiltinCall(
   expr: ts.CallExpression,
@@ -2294,6 +2327,7 @@ function buildFromIfStatement(
 
   const arms: Array<readonly [IR1Expr, IR1Expr]> = [];
   let current: ts.IfStatement = stmt;
+  const elsePathFacts: Fact[] = [];
   while (true) {
     if (!current.elseStatement) {
       return {
@@ -2301,6 +2335,10 @@ function buildFromIfStatement(
           "if-without-else cannot lower to value-position cond (need both branches)",
       };
     }
+    const currentFact = recognizeNarrowingPredicate(
+      current.expression,
+      ctx.checker,
+    );
     const guard = buildSubExpr(current.expression, ctx);
     if (isL1Unsupported(guard)) {
       return guard;
@@ -2314,14 +2352,23 @@ function buildFromIfStatement(
         unsupported: "if-then branch must contain a single return-with-value",
       };
     }
-    const thenValue = buildSubExpr(thenExpr, ctx);
+    const thenValue = withNarrowingFrame(
+      ctx,
+      "if.then",
+      [...elsePathFacts, currentFact],
+      () => buildSubExpr(thenExpr, ctx),
+    );
     if (isL1Unsupported(thenValue)) {
       return thenValue;
     }
     arms.push([guard, thenValue] as const);
 
     // Else: another IfStatement (chain) or a terminal block-with-return.
+    const elseFact = currentFact === null ? null : negateFact(currentFact);
     if (ts.isIfStatement(current.elseStatement)) {
+      if (elseFact !== null) {
+        elsePathFacts.push(elseFact);
+      }
       current = current.elseStatement;
       continue;
     }
@@ -2334,7 +2381,12 @@ function buildFromIfStatement(
         unsupported: "if-else branch must contain a single return-with-value",
       };
     }
-    const elseValue = buildSubExpr(elseExpr, ctx);
+    const elseValue = withNarrowingFrame(
+      ctx,
+      "if.else",
+      [...elsePathFacts, elseFact],
+      () => buildSubExpr(elseExpr, ctx),
+    );
     if (isL1Unsupported(elseValue)) {
       return elseValue;
     }
@@ -2396,13 +2448,23 @@ function buildFromSwitchStatement(
   // M1 only supports return-cases; break/throw cases are rejected
   // (no coherent value-position lowering).
   const arms: Array<readonly [IR1Expr, IR1Expr]> = [];
+  const caseFacts: Fact[] = [];
   for (let i = 0; i < defaultIdx; i++) {
     const clause = clauses[i] as ts.CaseClause;
     const labelL1 = buildCaseLabel(clause.expression, ctx);
     if (isL1Unsupported(labelL1)) {
       return labelL1;
     }
-    const value = lowerCaseReturnValue(clause, ctx);
+    const caseFact = recognizeNarrowingFromSwitchCase(
+      stmt.expression,
+      clause.expression,
+    );
+    if (caseFact !== null) {
+      caseFacts.push(caseFact);
+    }
+    const value = withNarrowingFrame(ctx, "switch.case", [caseFact], () =>
+      lowerCaseReturnValue(clause, ctx),
+    );
     if (value === null) {
       return {
         unsupported:
@@ -2417,7 +2479,12 @@ function buildFromSwitchStatement(
 
   // Default clause.
   const defaultClause = clauses[defaultIdx] as ts.DefaultClause;
-  const otherwise = lowerCaseReturnValue(defaultClause, ctx);
+  const otherwise = withNarrowingFrame(
+    ctx,
+    "switch.default",
+    caseFacts.map(negateFact),
+    () => lowerCaseReturnValue(defaultClause, ctx),
+  );
   if (otherwise === null) {
     return {
       unsupported: "switch default must end with `return EXPR`",

--- a/tools/ts2pant/src/narrowing-recognizer.ts
+++ b/tools/ts2pant/src/narrowing-recognizer.ts
@@ -69,22 +69,33 @@ function discriminantFactFromParts(
   };
 }
 
-function discriminantFactFromEquality(expr: ts.BinaryExpression): Fact | null {
-  if (expr.operatorToken.kind !== ts.SyntaxKind.EqualsEqualsEqualsToken) {
-    return null;
-  }
+function discriminantFactFromEqualityOperands(
+  expr: ts.BinaryExpression,
+): Fact | null {
   return (
     discriminantFactFromParts(expr.left, expr.right) ??
     discriminantFactFromParts(expr.right, expr.left)
   );
 }
 
-/**
- * Recognize a TypeScript boolean test as a narrowing fact.
- *
- * `!==` is intentionally not mapped in Patch 2. The fact is for the opposite
- * branch, and Patch 4 owns the arm-specific negation scaffolding.
- */
+function discriminantFactFromEquality(expr: ts.BinaryExpression): Fact | null {
+  switch (expr.operatorToken.kind) {
+    case ts.SyntaxKind.EqualsEqualsEqualsToken:
+      return discriminantFactFromEqualityOperands(expr);
+    case ts.SyntaxKind.ExclamationEqualsEqualsToken: {
+      const fact = discriminantFactFromEqualityOperands(expr);
+      return fact === null ? null : negateFact(fact);
+    }
+    case ts.SyntaxKind.ExclamationEqualsToken: {
+      const fact = discriminantFactFromEqualityOperands(expr);
+      return fact === null ? null : negateFact(fact);
+    }
+    default:
+      return null;
+  }
+}
+
+/** Recognize a TypeScript boolean test as a narrowing fact. */
 export function recognizeNarrowingPredicate(
   test: ts.Expression,
   checker: ts.TypeChecker,
@@ -98,12 +109,6 @@ export function recognizeNarrowingPredicate(
     const fact = discriminantFactFromEquality(unwrapped);
     if (fact !== null) {
       return fact;
-    }
-    if (
-      unwrapped.operatorToken.kind ===
-      ts.SyntaxKind.ExclamationEqualsEqualsToken
-    ) {
-      return null;
     }
   }
 
@@ -131,9 +136,10 @@ export function recognizeNarrowingFromSwitchCase(
 
 export function negateFact(fact: Fact): Fact {
   if (fact.kind === "discriminant") {
+    const negated = /^!\((.*)\)$/u.exec(fact.literal);
     return {
       ...fact,
-      literal: `!(${fact.literal})`,
+      literal: negated === null ? `!(${fact.literal})` : negated[1]!,
     };
   }
   const ast = getAst();

--- a/tools/ts2pant/src/narrowing-recognizer.ts
+++ b/tools/ts2pant/src/narrowing-recognizer.ts
@@ -1,5 +1,6 @@
 import ts from "typescript";
 import type { Fact } from "./assumption-env.js";
+import { getAst } from "./pant-wasm.js";
 import { isStaticallyBoolTyped } from "./purity.js";
 import {
   isTranslateExprUnsupported,
@@ -126,4 +127,18 @@ export function recognizeNarrowingFromSwitchCase(
   caseLabel: ts.Expression,
 ): Fact | null {
   return discriminantFactFromParts(switchTest, caseLabel);
+}
+
+export function negateFact(fact: Fact): Fact {
+  if (fact.kind === "discriminant") {
+    return {
+      ...fact,
+      literal: `!(${fact.literal})`,
+    };
+  }
+  const ast = getAst();
+  return {
+    kind: "predicate",
+    testExpr: ast.unop(ast.opNot(), fact.testExpr),
+  };
 }

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -1,6 +1,12 @@
 import type { SourceFile } from "ts-morph";
 import ts from "typescript";
-import type { AssumptionEnv } from "./assumption-env.js";
+import {
+  type AssumptionEnv,
+  enterFrame,
+  exitFrame,
+  type Fact,
+  pushFact,
+} from "./assumption-env.js";
 import { buildIR, isBuildUnsupported } from "./ir-build.js";
 import { lowerExpr } from "./ir-emit.js";
 import {
@@ -57,6 +63,10 @@ import {
   type ScalarSsaEarlyExitPropertyInput,
 } from "./ir1-ssa-scalars.js";
 import { substituteIR1ExprSubtree } from "./ir1-substitute.js";
+import {
+  negateFact,
+  recognizeNarrowingPredicate,
+} from "./narrowing-recognizer.js";
 import {
   getOperandDeclaredType,
   type NullishTranslate,
@@ -1069,6 +1079,8 @@ export interface TranslateBodyOptions {
    * signature and body-emitted applications.
    */
   paramNameMap?: ReadonlyMap<string, string> | undefined;
+  assumptionEnv?: AssumptionEnv | undefined;
+  recognitionHook?: (env: AssumptionEnv, location: string) => void;
 }
 
 /**
@@ -1086,6 +1098,8 @@ export function translateBody(opts: TranslateBodyOptions): PropResult[] {
     declarations,
     synthCell,
     paramNameMap,
+    assumptionEnv,
+    recognitionHook,
   } = opts;
   const checker = sourceFile.getProject().getTypeChecker().compilerObject;
   const program = sourceFile.getProject().getProgram().compilerObject;
@@ -1195,6 +1209,8 @@ export function translateBody(opts: TranslateBodyOptions): PropResult[] {
       paramNames,
       synthCell,
       program,
+      assumptionEnv,
+      recognitionHook,
     );
   } else {
     return translateMutatingBody(
@@ -1206,6 +1222,8 @@ export function translateBody(opts: TranslateBodyOptions): PropResult[] {
       declarations ?? [],
       synthCell,
       program,
+      assumptionEnv,
+      recognitionHook,
     );
   }
 }
@@ -1219,6 +1237,8 @@ function translatePureBody(
   paramNames: ReadonlyMap<string, string>,
   synthCell?: SynthCell,
   program?: ts.Program,
+  suppliedEnv?: AssumptionEnv,
+  recognitionHook?: (env: AssumptionEnv, location: string) => void,
 ): PropResult[] {
   const ast = getAst();
 
@@ -1233,7 +1253,7 @@ function translatePureBody(
   }
 
   const supply = makeUniqueSupply(synthCell, program);
-  const env = createL1AssumptionEnv();
+  const env = suppliedEnv ?? createL1AssumptionEnv();
 
   // M4 Patch 5: functor-lift on the if-conversion shape
   //   `if (x == null) return []; return [f(x)];`
@@ -1372,6 +1392,13 @@ function translatePureBody(
     (ts.isExpression(extracted.returnExpr) &&
       isL1ConditionalForm(extracted.returnExpr, checker));
   if (prelude.arms.length > 0 || l1IsConditionalReturn) {
+    if (prelude.fallthroughFacts.length > 0) {
+      enterFrame(env);
+      for (const fact of prelude.fallthroughFacts) {
+        pushFact(env, fact);
+      }
+      recognitionHook?.(env, "early-return.fallthrough");
+    }
     const l1Ctx = {
       checker,
       strategy,
@@ -1379,103 +1406,113 @@ function translatePureBody(
       state: undefined as SymbolicState | undefined,
       supply,
       env,
+      ...(recognitionHook === undefined ? {} : { recognitionHook }),
     };
     let bodyOpaque: OpaqueExpr;
-    if (l1IsConditionalReturn) {
-      // Build the conditional terminal as L1 first, then merge prelude
-      // early-return arms at the OpaqueExpr layer. When the L1 terminal is
-      // itself a cond we
-      // splice its arms in to keep the output flat (matching the
-      // legacy single-cond shape).
-      const terminalL1 = buildL1Conditional(extracted.returnExpr, l1Ctx);
-      if (isL1Unsupported(terminalL1)) {
-        return [
-          {
-            kind: "unsupported",
-            reason: `${functionName} — ${terminalL1.unsupported}`,
-          },
-        ];
-      }
-      if (terminalL1.kind === "cond") {
-        const armsOpaque: Array<[OpaqueExpr, OpaqueExpr]> = [
-          ...prelude.arms.map(([g, v]) => [g, v] as [OpaqueExpr, OpaqueExpr]),
-          ...terminalL1.arms.map(
-            ([g, v]) =>
-              [lowerL1ToOpaque(g), lowerL1ToOpaque(v)] as [
-                OpaqueExpr,
-                OpaqueExpr,
-              ],
-          ),
-          [ast.litBool(true), lowerL1ToOpaque(terminalL1.otherwise)] as [
-            OpaqueExpr,
-            OpaqueExpr,
-          ],
-        ];
-        bodyOpaque = ast.cond(armsOpaque);
-      } else {
-        const terminalOpaque = lowerL1ToOpaque(terminalL1);
-        if (prelude.arms.length === 0) {
-          bodyOpaque = terminalOpaque;
-        } else {
-          bodyOpaque = ast.cond([
-            ...prelude.arms.map(([g, v]) => [g, v] as [OpaqueExpr, OpaqueExpr]),
-            [ast.litBool(true), terminalOpaque] as [OpaqueExpr, OpaqueExpr],
-          ]);
+    try {
+      if (l1IsConditionalReturn) {
+        // Build the conditional terminal as L1 first, then merge prelude
+        // early-return arms at the OpaqueExpr layer. When the L1 terminal is
+        // itself a cond we
+        // splice its arms in to keep the output flat (matching the
+        // legacy single-cond shape).
+        const terminalL1 = buildL1Conditional(extracted.returnExpr, l1Ctx);
+        if (isL1Unsupported(terminalL1)) {
+          return [
+            {
+              kind: "unsupported",
+              reason: `${functionName} — ${terminalL1.unsupported}`,
+            },
+          ];
         }
-      }
-    } else {
-      // Arms-only path: terminal is a plain expression that we route
-      // through `buildIR` (the canonical pure path) and merge with the
-      // prelude arms at the OpaqueExpr layer. Mirror the plain-return
-      // path's legacy fallback so adding a prelude arm doesn't regress
-      // a function whose terminal expression only translates through
-      // `translateBodyExpr` (`%`, `**`, raw array literals, etc.).
-      if (!ts.isExpression(extracted.returnExpr)) {
-        return [
-          {
-            kind: "unsupported",
-            reason: `${functionName} — unsupported pure return terminal`,
-          },
-        ];
-      }
-      const ir = buildIR(
-        extracted.returnExpr,
-        checker,
-        strategy,
-        prelude.scopedParams,
-        supply,
-      );
-      let terminalOpaque: OpaqueExpr;
-      if (isBuildUnsupported(ir)) {
-        const legacy = translateBodyExpr(
+        if (terminalL1.kind === "cond") {
+          const armsOpaque: Array<[OpaqueExpr, OpaqueExpr]> = [
+            ...prelude.arms.map(([g, v]) => [g, v] as [OpaqueExpr, OpaqueExpr]),
+            ...terminalL1.arms.map(
+              ([g, v]) =>
+                [lowerL1ToOpaque(g), lowerL1ToOpaque(v)] as [
+                  OpaqueExpr,
+                  OpaqueExpr,
+                ],
+            ),
+            [ast.litBool(true), lowerL1ToOpaque(terminalL1.otherwise)] as [
+              OpaqueExpr,
+              OpaqueExpr,
+            ],
+          ];
+          bodyOpaque = ast.cond(armsOpaque);
+        } else {
+          const terminalOpaque = lowerL1ToOpaque(terminalL1);
+          if (prelude.arms.length === 0) {
+            bodyOpaque = terminalOpaque;
+          } else {
+            bodyOpaque = ast.cond([
+              ...prelude.arms.map(
+                ([g, v]) => [g, v] as [OpaqueExpr, OpaqueExpr],
+              ),
+              [ast.litBool(true), terminalOpaque] as [OpaqueExpr, OpaqueExpr],
+            ]);
+          }
+        }
+      } else {
+        // Arms-only path: terminal is a plain expression that we route
+        // through `buildIR` (the canonical pure path) and merge with the
+        // prelude arms at the OpaqueExpr layer. Mirror the plain-return
+        // path's legacy fallback so adding a prelude arm doesn't regress
+        // a function whose terminal expression only translates through
+        // `translateBodyExpr` (`%`, `**`, raw array literals, etc.).
+        if (!ts.isExpression(extracted.returnExpr)) {
+          return [
+            {
+              kind: "unsupported",
+              reason: `${functionName} — unsupported pure return terminal`,
+            },
+          ];
+        }
+        const ir = buildIR(
           extracted.returnExpr,
           checker,
           strategy,
           prelude.scopedParams,
-          undefined,
           supply,
         );
-        if (isBodyUnsupported(legacy) || "effect" in legacy) {
-          const reason = isBodyUnsupported(legacy)
-            ? legacy.unsupported
-            : `${functionName} — collection mutation in pure return position`;
-          return [
-            {
-              kind: "unsupported",
-              reason: ir.unsupported.startsWith("unsupported pure expression")
-                ? reason
-                : ir.unsupported,
-            },
-          ];
+        let terminalOpaque: OpaqueExpr;
+        if (isBuildUnsupported(ir)) {
+          const legacy = translateBodyExpr(
+            extracted.returnExpr,
+            checker,
+            strategy,
+            prelude.scopedParams,
+            undefined,
+            supply,
+            env,
+          );
+          if (isBodyUnsupported(legacy) || "effect" in legacy) {
+            const reason = isBodyUnsupported(legacy)
+              ? legacy.unsupported
+              : `${functionName} — collection mutation in pure return position`;
+            return [
+              {
+                kind: "unsupported",
+                reason: ir.unsupported.startsWith("unsupported pure expression")
+                  ? reason
+                  : ir.unsupported,
+              },
+            ];
+          }
+          terminalOpaque = bodyExpr(legacy);
+        } else {
+          terminalOpaque = lowerExpr(ir);
         }
-        terminalOpaque = bodyExpr(legacy);
-      } else {
-        terminalOpaque = lowerExpr(ir);
+        bodyOpaque = ast.cond([
+          ...prelude.arms.map(([g, v]) => [g, v] as [OpaqueExpr, OpaqueExpr]),
+          [ast.litBool(true), terminalOpaque] as [OpaqueExpr, OpaqueExpr],
+        ]);
       }
-      bodyOpaque = ast.cond([
-        ...prelude.arms.map(([g, v]) => [g, v] as [OpaqueExpr, OpaqueExpr]),
-        [ast.litBool(true), terminalOpaque] as [OpaqueExpr, OpaqueExpr],
-      ]);
+    } finally {
+      if (prelude.fallthroughFacts.length > 0) {
+        exitFrame(env);
+      }
     }
     rhs = bodyOpaque;
   } else if (ts.isExpression(extracted.returnExpr)) {
@@ -1504,6 +1541,7 @@ function translatePureBody(
         prelude.scopedParams,
         undefined,
         supply,
+        env,
       );
       if (isBodyUnsupported(legacy) || "effect" in legacy) {
         const reason = isBodyUnsupported(legacy)
@@ -2366,6 +2404,7 @@ interface LoweredPreludeBindings {
   ruleDecls: PropResult[];
   scopedParams: ReadonlyMap<string, string>;
   arms: ReadonlyArray<readonly [OpaqueExpr, OpaqueExpr]>;
+  fallthroughFacts: Fact[];
 }
 
 function lowerPreludeBindings(
@@ -2469,6 +2508,7 @@ function lowerPreludeBindings(
         letStmts: IR1Stmt[];
         ruleDecls: PropResult[];
         arms: ReadonlyArray<readonly [OpaqueExpr, OpaqueExpr]>;
+        fallthroughFacts: Fact[];
       }
     | { tag: "error"; error: string };
 
@@ -2522,6 +2562,10 @@ function lowerPreludeBindings(
           letStmts: acc.letStmts,
           ruleDecls: acc.ruleDecls,
           arms: [...acc.arms, [predRes.value, valRes.value] as const],
+          fallthroughFacts: [
+            ...acc.fallthroughFacts,
+            ...earlyReturnFallthroughFacts(binding.predicateExpr, checker),
+          ],
         };
       }
       if (binding.kind === "reassign") {
@@ -2549,6 +2593,7 @@ function lowerPreludeBindings(
           letStmts: [...acc.letStmts, ir1Assign(ir1Var(localName), value)],
           ruleDecls: acc.ruleDecls,
           arms: acc.arms,
+          fallthroughFacts: acc.fallthroughFacts,
         };
       }
       if (binding.kind === "stmt") {
@@ -2570,6 +2615,7 @@ function lowerPreludeBindings(
           letStmts: [...acc.letStmts, built],
           ruleDecls: acc.ruleDecls,
           arms: acc.arms,
+          fallthroughFacts: acc.fallthroughFacts,
         };
       }
       const localName = allocLocalBindingName(
@@ -2639,6 +2685,7 @@ function lowerPreludeBindings(
         ],
         letStmts: [...acc.letStmts, ir1Let(localName, initExpr)],
         arms: acc.arms,
+        fallthroughFacts: acc.fallthroughFacts,
       };
     },
     {
@@ -2647,6 +2694,7 @@ function lowerPreludeBindings(
       letStmts: [],
       ruleDecls: [],
       arms: [],
+      fallthroughFacts: [],
     },
   );
 
@@ -2658,7 +2706,16 @@ function lowerPreludeBindings(
     ruleDecls: folded.ruleDecls,
     scopedParams: folded.scopedParams,
     arms: folded.arms,
+    fallthroughFacts: folded.fallthroughFacts,
   };
+}
+
+function earlyReturnFallthroughFacts(
+  predicateExpr: ts.Expression,
+  checker: ts.TypeChecker,
+): Fact[] {
+  const fact = recognizeNarrowingPredicate(predicateExpr, checker);
+  return fact === null ? [] : [negateFact(fact)];
 }
 
 type BindingInitResult = { value: OpaqueExpr } | { error: string };
@@ -4806,12 +4863,14 @@ function translateMutatingBody(
   declarations: PantDeclaration[],
   synthCell?: SynthCell,
   program?: ts.Program,
+  suppliedEnv?: AssumptionEnv,
+  recognitionHook?: (env: AssumptionEnv, location: string) => void,
 ): PropResult[] {
   if (!node.body) {
     return [];
   }
   const localRuleDecls: PropResult[] = [];
-  const env = createL1AssumptionEnv();
+  const env = suppliedEnv ?? createL1AssumptionEnv();
 
   const lowered = appendFramesForUnmodifiedRules(
     lowerSupportedSsaMutatingStatements(Array.from(node.body.statements), {
@@ -4825,6 +4884,7 @@ function translateMutatingBody(
       declarations,
       localRuleDecls,
       env,
+      ...(recognitionHook === undefined ? {} : { recognitionHook }),
     }),
     declarations,
   );
@@ -4847,6 +4907,7 @@ function lowerSupportedSsaMutatingStatements(
     declarations: readonly PantDeclaration[];
     localRuleDecls: PropResult[];
     env: AssumptionEnv;
+    recognitionHook?: (env: AssumptionEnv, location: string) => void;
   },
 ): IR1SsaBodyLowerResult {
   const tailReturnValue = extractTailReturnValue(stmts, ctx.checker);
@@ -5097,6 +5158,7 @@ function lowerSupportedSsaMutatingBlock(
     declarations: readonly PantDeclaration[];
     localRuleDecls: PropResult[];
     env: AssumptionEnv;
+    recognitionHook?: (env: AssumptionEnv, location: string) => void;
   },
 ): IR1SsaBodyLowerResult {
   const body = ts.factory.createBlock(stmts, true);
@@ -5109,6 +5171,7 @@ function lowerSupportedSsaMutatingBlock(
     ctx.supply,
     ctx.env,
     ctx.localRuleDecls,
+    ctx.recognitionHook,
   );
 
   if (isUnsupported(ssaBody)) {
@@ -5182,6 +5245,7 @@ function buildSupportedSsaMutatingBody(
   supply: UniqueSupply,
   env: AssumptionEnv,
   localRuleDecls?: PropResult[],
+  recognitionHook?: (env: AssumptionEnv, location: string) => void,
 ): IR1Stmt | { unsupported: string } {
   const stmts: IR1Stmt[] = [];
   const scopedParamNames = new Map(paramNames);
@@ -5220,6 +5284,7 @@ function buildSupportedSsaMutatingBody(
           state,
           supply,
           env,
+          ...(recognitionHook === undefined ? {} : { recognitionHook }),
         },
       );
       if (built !== null) {
@@ -5237,6 +5302,7 @@ function buildSupportedSsaMutatingBody(
           state,
           supply,
           env,
+          ...(recognitionHook === undefined ? {} : { recognitionHook }),
         },
       );
       if (isUnsupported(fixedPointBuilt)) {
@@ -5327,6 +5393,7 @@ function buildSupportedSsaMutatingBody(
       supply,
       env,
       ...(localRuleDecls === undefined ? {} : { localRuleDecls }),
+      ...(recognitionHook === undefined ? {} : { recognitionHook }),
     });
     if (isUnsupported(built)) {
       return built;
@@ -5352,6 +5419,7 @@ function buildSupportedSsaStatement(
     supply: UniqueSupply;
     env: AssumptionEnv;
     localRuleDecls?: PropResult[];
+    recognitionHook?: (env: AssumptionEnv, location: string) => void;
   },
 ): IR1Stmt | { unsupported: string } {
   if (
@@ -5382,6 +5450,7 @@ function buildSupportedSsaStatement(
       ctx.supply,
       ctx.env,
       ctx.localRuleDecls,
+      ctx.recognitionHook,
     );
     return body;
   }

--- a/tools/ts2pant/tests/narrowing-integration.test.mts
+++ b/tools/ts2pant/tests/narrowing-integration.test.mts
@@ -128,6 +128,24 @@ describe("narrowing integration", () => {
     assert.equal(envDepth(ctx.env), 1);
   });
 
+  it("if not-equal arm sees negated fact and else sees positive fact", () => {
+    const { fn, ctx, captures } = setupFunction(`
+      interface Shape { kind: "circle" | "square"; }
+      function f(s: Shape): number {
+        if (s.kind !== "circle") return 1;
+        else return 2;
+      }
+    `);
+    const result = buildL1Conditional(
+      fn.body!.statements[0] as ts.IfStatement,
+      ctx,
+    );
+    assert.equal("unsupported" in result, false);
+    assertDiscriminant(envAt(captures, "if.then"), "kind", "circle", true);
+    assertDiscriminant(envAt(captures, "if.else"), "kind", "circle");
+    assert.equal(envDepth(ctx.env), 1);
+  });
+
   it("switch case and default arms see case facts", () => {
     const { fn, ctx, captures } = setupFunction(`
       interface Shape { kind: "circle" | "square"; }
@@ -225,6 +243,45 @@ describe("narrowing integration", () => {
     assert.equal(envDepth(inner.snapshot), 3);
     assertDiscriminant(inner.snapshot, "kind", "circle");
     assertDiscriminant(inner.snapshot, "color", "red");
+    assert.equal(envDepth(env), 1);
+  });
+
+  it("mutating if not-equal arm sees negated fact and else sees positive fact", () => {
+    const sourceFile = createSourceFileFromSource(
+      `
+        interface Shape { kind: "circle" | "square"; value: number; }
+        function f(s: Shape): void {
+          if (s.kind !== "circle") {
+            s.value = 1;
+          } else {
+            s.value = 2;
+          }
+        }
+      `,
+      "narrowing-mutating-not-equal.ts",
+    );
+    const checker = getChecker(sourceFile);
+    const fn = sourceFile.compilerNode.statements.find(
+      (stmt): stmt is ts.FunctionDeclaration =>
+        ts.isFunctionDeclaration(stmt) && stmt.body !== undefined,
+    );
+    assert.ok(fn?.body);
+    const env = createL1AssumptionEnv();
+    const captures: Array<{ location: string; snapshot: AssumptionEnv }> = [];
+    const result = buildL1IfMutation(fn.body.statements[0] as ts.IfStatement, {
+      checker,
+      strategy: IntStrategy,
+      paramNames: new Map([["s", "s"]]),
+      state: makeSymbolicState(),
+      supply: { n: 0, synthCell: newSynthCell() },
+      env,
+      recognitionHook: (hookEnv, location) => {
+        captures.push({ location, snapshot: cloneEnv(hookEnv) });
+      },
+    });
+    assert.equal("unsupported" in result, false);
+    assertDiscriminant(envAt(captures, "if.then"), "kind", "circle", true);
+    assertDiscriminant(envAt(captures, "if.else"), "kind", "circle");
     assert.equal(envDepth(env), 1);
   });
 });

--- a/tools/ts2pant/tests/narrowing-integration.test.mts
+++ b/tools/ts2pant/tests/narrowing-integration.test.mts
@@ -1,0 +1,230 @@
+import assert from "node:assert/strict";
+import { before, describe, it } from "node:test";
+import ts from "typescript";
+import {
+  type AssumptionEnv,
+  envDepth,
+  type Fact,
+  queryFact,
+} from "../src/assumption-env.js";
+import { createSourceFileFromSource, getChecker } from "../src/extract.js";
+import {
+  buildL1Conditional,
+  createL1AssumptionEnv,
+  type L1BuildContext,
+} from "../src/ir1-build.js";
+import { buildL1IfMutation } from "../src/ir1-build-body.js";
+import { loadAst } from "../src/pant-wasm.js";
+import {
+  makeSymbolicState,
+  translateBody,
+  type UniqueSupply,
+} from "../src/translate-body.js";
+import { IntStrategy, newSynthCell } from "../src/translate-types.js";
+
+before(async () => {
+  await loadAst();
+});
+
+function setupFunction(source: string): {
+  fn: ts.FunctionDeclaration;
+  checker: ts.TypeChecker;
+  ctx: L1BuildContext;
+  captures: Array<{ location: string; snapshot: AssumptionEnv }>;
+} {
+  const sourceFile = createSourceFileFromSource(source, "narrowing.ts");
+  const checker = getChecker(sourceFile);
+  const fn = sourceFile.compilerNode.statements.find(
+    (stmt): stmt is ts.FunctionDeclaration =>
+      ts.isFunctionDeclaration(stmt) && stmt.body !== undefined,
+  );
+  if (!fn?.body) {
+    throw new Error("setup: expected a function body");
+  }
+  const captures: Array<{ location: string; snapshot: AssumptionEnv }> = [];
+  const env = createL1AssumptionEnv();
+  const supply: UniqueSupply = { n: 0, synthCell: newSynthCell() };
+  return {
+    fn,
+    checker,
+    captures,
+    ctx: {
+      checker,
+      strategy: IntStrategy,
+      paramNames: new Map([["s", "s"]]),
+      state: undefined,
+      supply,
+      env,
+      recognitionHook: (hookEnv, location) => {
+        captures.push({ location, snapshot: cloneEnv(hookEnv) });
+      },
+    },
+  };
+}
+
+function cloneEnv(env: AssumptionEnv): AssumptionEnv {
+  return { frames: env.frames.map((frame) => new Set(frame)) };
+}
+
+function envAt(
+  captures: Array<{ location: string; snapshot: AssumptionEnv }>,
+  location: string,
+): AssumptionEnv {
+  const capture = captures.find((c) => c.location === location);
+  assert.ok(capture, `missing capture for ${location}`);
+  return capture.snapshot;
+}
+
+function assertDiscriminant(
+  env: AssumptionEnv,
+  property: string,
+  literal: string,
+  negated = false,
+): void {
+  const expected: Fact = {
+    kind: "discriminant",
+    receiver: "s",
+    property,
+    literal: negated ? `!(${literal})` : literal,
+  };
+  assert.ok(
+    queryFact(env, expected),
+    `missing ${negated ? "negated " : ""}${property} === ${literal}`,
+  );
+}
+
+describe("narrowing integration", () => {
+  it("if-then arm sees discriminant fact", () => {
+    const { fn, ctx, captures } = setupFunction(`
+      interface Shape { kind: "circle" | "square"; }
+      function f(s: Shape): number {
+        if (s.kind === "circle") return 1;
+        else return 2;
+      }
+    `);
+    const result = buildL1Conditional(
+      fn.body!.statements[0] as ts.IfStatement,
+      ctx,
+    );
+    assert.equal("unsupported" in result, false);
+    assertDiscriminant(envAt(captures, "if.then"), "kind", "circle");
+    assert.equal(envDepth(ctx.env), 1);
+  });
+
+  it("if-else arm sees negated fact", () => {
+    const { fn, ctx, captures } = setupFunction(`
+      interface Shape { kind: "circle" | "square"; }
+      function f(s: Shape): number {
+        if (s.kind === "circle") return 1;
+        else return 2;
+      }
+    `);
+    const result = buildL1Conditional(
+      fn.body!.statements[0] as ts.IfStatement,
+      ctx,
+    );
+    assert.equal("unsupported" in result, false);
+    assertDiscriminant(envAt(captures, "if.else"), "kind", "circle", true);
+    assert.equal(envDepth(ctx.env), 1);
+  });
+
+  it("switch case and default arms see case facts", () => {
+    const { fn, ctx, captures } = setupFunction(`
+      interface Shape { kind: "circle" | "square"; }
+      function f(s: Shape): number {
+        switch (s.kind) {
+          case "circle": return 1;
+          case "square": return 2;
+          default: return 3;
+        }
+      }
+    `);
+    const result = buildL1Conditional(
+      fn.body!.statements[0] as ts.SwitchStatement,
+      ctx,
+    );
+    assert.equal("unsupported" in result, false);
+    assertDiscriminant(envAt(captures, "switch.case"), "kind", "circle");
+    const defaults = envAt(captures, "switch.default");
+    assertDiscriminant(defaults, "kind", "circle", true);
+    assertDiscriminant(defaults, "kind", "square", true);
+    assert.equal(envDepth(ctx.env), 1);
+  });
+
+  it("early-return fall-through sees negated fact", () => {
+    const sourceFile = createSourceFileFromSource(
+      `
+        interface Shape { kind: "circle" | "square"; }
+        function f(s: Shape): number {
+          if (s.kind === "circle") return 1;
+          return 2;
+        }
+      `,
+      "narrowing-early.ts",
+    );
+    const env = createL1AssumptionEnv();
+    const captures: Array<{ location: string; snapshot: AssumptionEnv }> = [];
+    const result = translateBody({
+      sourceFile,
+      functionName: "f",
+      strategy: IntStrategy,
+      assumptionEnv: env,
+      recognitionHook: (hookEnv, location) => {
+        captures.push({ location, snapshot: cloneEnv(hookEnv) });
+      },
+    });
+    assert.equal(
+      result.some((r) => r.kind === "unsupported"),
+      false,
+    );
+    assertDiscriminant(
+      envAt(captures, "early-return.fallthrough"),
+      "kind",
+      "circle",
+      true,
+    );
+    assert.equal(envDepth(env), 1);
+  });
+
+  it("nested mutating if pushes both frames", () => {
+    const sourceFile = createSourceFileFromSource(
+      `
+        interface Shape { kind: "circle" | "square"; color: "red" | "blue"; value: number; }
+        function f(s: Shape): void {
+          if (s.kind === "circle") {
+            if (s.color === "red") {
+              s.value = 1;
+            }
+          }
+        }
+      `,
+      "narrowing-mutating.ts",
+    );
+    const checker = getChecker(sourceFile);
+    const fn = sourceFile.compilerNode.statements.find(
+      (stmt): stmt is ts.FunctionDeclaration =>
+        ts.isFunctionDeclaration(stmt) && stmt.body !== undefined,
+    );
+    assert.ok(fn?.body);
+    const env = createL1AssumptionEnv();
+    const captures: Array<{ location: string; snapshot: AssumptionEnv }> = [];
+    const result = buildL1IfMutation(fn.body.statements[0] as ts.IfStatement, {
+      checker,
+      strategy: IntStrategy,
+      paramNames: new Map([["s", "s"]]),
+      state: makeSymbolicState(),
+      supply: { n: 0, synthCell: newSynthCell() },
+      env,
+      recognitionHook: (hookEnv, location) => {
+        captures.push({ location, snapshot: cloneEnv(hookEnv) });
+      },
+    });
+    assert.equal("unsupported" in result, false);
+    const inner = captures.filter((c) => c.location === "if.then")[1];
+    assert.ok(inner);
+    assert.equal(envDepth(inner.snapshot), 3);
+    assertDiscriminant(inner.snapshot, "kind", "circle");
+    assertDiscriminant(inner.snapshot, "color", "red");
+    assert.equal(envDepth(env), 1);
+  });
+});

--- a/tools/ts2pant/tests/narrowing-recognizer.test.mts
+++ b/tools/ts2pant/tests/narrowing-recognizer.test.mts
@@ -4,6 +4,7 @@ import ts from "typescript";
 import type { Fact } from "../src/assumption-env.js";
 import { createSourceFileFromSource, getChecker } from "../src/extract.js";
 import {
+  negateFact,
   recognizeNarrowingFromSwitchCase,
   recognizeNarrowingPredicate,
 } from "../src/narrowing-recognizer.js";
@@ -145,8 +146,30 @@ describe("narrowing-recognizer", () => {
     });
   });
 
-  it("strict not-equal is deferred to arm-specific negation", () => {
-    assert.equal(recognizeExpr('s.kind !== "circle"'), null);
+  it("strict not-equal returns a negated DiscriminantFact", () => {
+    assertDiscriminant(recognizeExpr('s.kind !== "circle"'), {
+      receiver: "s",
+      property: "kind",
+      literal: "!(circle)",
+    });
+  });
+
+  it("loose not-equal returns a negated DiscriminantFact", () => {
+    assertDiscriminant(recognizeExpr('s.kind != "circle"'), {
+      receiver: "s",
+      property: "kind",
+      literal: "!(circle)",
+    });
+  });
+
+  it("negating a negated discriminant fact restores the positive fact", () => {
+    const fact = recognizeExpr('s.kind !== "circle"');
+
+    assertDiscriminant(fact === null ? null : negateFact(fact), {
+      receiver: "s",
+      property: "kind",
+      literal: "circle",
+    });
   });
 
   it("boolean predicate returns PredicateFact", () => {


### PR DESCRIPTION
## Patch 4: Wire recognition at IR1-build arm boundaries + integration tests

- In `buildFromIfStatement` (locate via grep in ir1-build.ts): on entering the then-branch, call `enterFrame(ctx.env)`, then `recognizeNarrowingPredicate(ifStmt.expression, ctx.checker)` and push if non-null. Build the then-body. Call `exitFrame(ctx.env)`. Do the same for the else-branch with the negated fact (helper `negateFact` — for a DiscriminantFact returns a structurally-flipped sentinel that the env stores; for a PredicateFact wraps the text with `!(...)`).
- In `buildFromSwitchStatement`: for each case clause, `enterFrame`, build the case-test as a DiscriminantFact (using the switch test + case label via `recognizeNarrowingFromSwitchCase`), push, build the case body, `exitFrame`. For the `default:` clause, push the negations of all sibling case literals against the same receiver/property.
- In the early-return rewrite (locate the cond-from-early-return construction): after the early-return arm, the fall-through reflects the negated test — push the negated fact for the rest-of-function build, and pop when the function build exits.
- Mirror in `ir1-build-body.ts` for the mutating-SSA path.
- Add `negateFact(fact: Fact): Fact` to `narrowing-recognizer.ts` (small helper colocated with recognition).
- Integration test setup: create a small TS program via the project's test-helper (look for `buildL1FromSource` or similar in `tests/helpers.mts`); add a `recognitionHook?: (env: AssumptionEnv, location: string) => void` to L1BuildContext (test-only — passed only by tests) that fires at each arm body's entry; the hook captures `snapshotAssumptionEnv(ctx)` for assertion. Alternative: insert a sentinel `@narrowing-probe` JSDoc that the test pipeline recognises and triggers a snapshot capture — pick the cleaner approach during implementation.
- Test cases: `function f(s: Shape) { if (s.kind === "circle") { /* probe 1 */ } }` — probe 1 sees DiscriminantFact{s, kind, circle}; `switch (s.kind) { case "circle": /* probe 2 */; default: /* probe 3 */ }` — probe 2 sees DiscriminantFact{s, kind, circle}, probe 3 sees both negations; `if (s.kind === "circle") return s.r; /* probe 4 */` — probe 4 sees the negated fact.
- Confirm: NO existing snapshot test changes (M3a is INFRA-only); `npm run -s test:unit` and `npm run -s test:integration` pass; `npm run -s typecheck` clean.

## Changes
- In `buildFromIfStatement` (locate via grep in ir1-build.ts): on entering the then-branch, call `enterFrame(ctx.env)`, then `recognizeNarrowingPredicate(ifStmt.expression, ctx.checker)` and push if non-null. Build the then-body. Call `exitFrame(ctx.env)`. Do the same for the else-branch with the negated fact (helper `negateFact` — for a DiscriminantFact returns a structurally-flipped sentinel that the env stores; for a PredicateFact wraps the text with `!(...)`).
- In `buildFromSwitchStatement`: for each case clause, `enterFrame`, build the case-test as a DiscriminantFact (using the switch test + case label via `recognizeNarrowingFromSwitchCase`), push, build the case body, `exitFrame`. For the `default:` clause, push the negations of all sibling case literals against the same receiver/property.
- In the early-return rewrite (locate the cond-from-early-return construction): after the early-return arm, the fall-through reflects the negated test — push the negated fact for the rest-of-function build, and pop when the function build exits.
- Mirror in `ir1-build-body.ts` for the mutating-SSA path.
- Add `negateFact(fact: Fact): Fact` to `narrowing-recognizer.ts` (small helper colocated with recognition).
- Integration test setup: create a small TS program via the project's test-helper (look for `buildL1FromSource` or similar in `tests/helpers.mts`); add a `recognitionHook?: (env: AssumptionEnv, location: string) => void` to L1BuildContext (test-only — passed only by tests) that fires at each arm body's entry; the hook captures `snapshotAssumptionEnv(ctx)` for assertion. Alternative: insert a sentinel `@narrowing-probe` JSDoc that the test pipeline recognises and triggers a snapshot capture — pick the cleaner approach during implementation.
- Test cases: `function f(s: Shape) { if (s.kind === "circle") { /* probe 1 */ } }` — probe 1 sees DiscriminantFact{s, kind, circle}; `switch (s.kind) { case "circle": /* probe 2 */; default: /* probe 3 */ }` — probe 2 sees DiscriminantFact{s, kind, circle}, probe 3 sees both negations; `if (s.kind === "circle") return s.r; /* probe 4 */` — probe 4 sees the negated fact.
- Confirm: NO existing snapshot test changes (M3a is INFRA-only); `npm run -s test:unit` and `npm run -s test:integration` pass; `npm run -s typecheck` clean.

## Files to Modify
- tools/ts2pant/src/ir1-build.ts (modify): At every conditional-arm construction site in buildL1Conditional / buildFromIfStatement / buildFromSwitchStatement / the early-return rewrite: call enterFrame, push the recognized fact (if any) for the arm's test, build the arm body with the env populated, then exitFrame.
- tools/ts2pant/src/ir1-build-body.ts (modify): Mirror the same enter-frame / push / exit-frame discipline at the mutating-SSA path's branch-arm construction sites, sharing the L1BuildContext's env.
- tools/ts2pant/tests/narrowing-integration.test.mts (create): Integration test: build IR1 from synthetic TS sources exercising if-then, if-else, switch (with cases AND default), and early-return shapes; assert via snapshotAssumptionEnv that the expected facts appear at expected points (using a probe inserted into the arm body via an injected hook OR by overriding a recognition callback).

## Gameplan Specification

```
module DU_DISCRIMINANT_NARROWING_LAYER.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> ts2pant has a function-scoped assumption environment threaded
> through IR1 build. At every conditional-arm boundary (if-then,
> if-else, switch case, switch default, early-return fall-through),
> the env is balanced (enter-frame followed by exit-frame) and the
> recognized fact for the arm's test is pushed for the arm body.
> No emitted Pantagruel changes. The env is exposed via a snapshot
> API for tests; downstream consumers (DU M3, nullish recognizer,
> type-predicate narrowing) will query the env at their own
> lowering sites in separate gameplans.

AssumptionEnv.
Fact.
depth e: AssumptionEnv => Nat0.
push e: AssumptionEnv, f: Fact => AssumptionEnv.
query e: AssumptionEnv, f: Fact => Bool.
enter-frame e: AssumptionEnv => AssumptionEnv.
exit-frame e: AssumptionEnv => AssumptionEnv.

---

> Push makes a fact queryable.
all e: AssumptionEnv, f: Fact | query (push e f) f.

> Enter-frame and exit-frame are depth-inverse.
all e: AssumptionEnv | depth (exit-frame (enter-frame e)) = depth e.

> The empty env answers false.
all e: AssumptionEnv, f: Fact | depth e = 0 -> ~(query e f).

where

> ══════════════════════════════════════════
> RECOGNITION
> ══════════════════════════════════════════
> Recognition is total over boolean test nodes: every boolean test
> maps to a fact (discriminant or predicate). Non-boolean shapes
> are not recognised.

TsTestNode.
bool-typed t: TsTestNode => Bool.
recognized t: TsTestNode => Bool.
fact-of t: TsTestNode, recognized t => Fact.

---

all t: TsTestNode | bool-typed t -> recognized t.
all t: TsTestNode | ~(bool-typed t) -> ~(recognized t).

where

> ══════════════════════════════════════════
> POPULATION DISCIPLINE
> ══════════════════════════════════════════
> At every conditional-arm boundary, the env is entered, the arm's
> fact is pushed, the arm body builds with the fact visible, then
> the frame is exited. After the full function build, the env's
> depth equals its starting depth (balanced).

IfStatement.
SwitchCase.
EarlyReturn.

test-fact n: IfStatement => Fact.
case-fact c: SwitchCase => Fact.
return-fact r: EarlyReturn => Fact.

env-inside-then n: IfStatement => AssumptionEnv.
env-before-build n: IfStatement => AssumptionEnv.
env-after-build n: IfStatement => AssumptionEnv.

---

> Inside the then-arm of an if, the test's fact is queryable.
all n: IfStatement | query (env-inside-then n) (test-fact n).

> After building the if, the env returns to its pre-build depth.
all n: IfStatement | depth (env-after-build n) = depth (env-before-build n).

where

> ══════════════════════════════════════════
> DISCHARGE WIRING
> ══════════════════════════════════════════
> Every variant-field-rule emission site queries the env and records
> the result on the IR1 member node. The emitted Pantagruel text for
> existing fixtures is unchanged; the new narrowing-aware fixtures'
> @pant annotations entail under z3 because the variant-field
> obligations now have the path condition in scope.

VariantFieldRead.
guard-fact r: VariantFieldRead => Fact.
emit-env r: VariantFieldRead => AssumptionEnv.
narrowing-discharged r: VariantFieldRead => Bool.

NarrowedFixture.
entails f: NarrowedFixture => Bool.

---

> narrowing-discharged matches the env query.
all r: VariantFieldRead |
  narrowing-discharged r <-> query (emit-env r) (guard-fact r).

> The narrowing-aware fixtures' @pant obligations entail.
all f: NarrowedFixture | entails f.

```

## Patch Specification

```
module DU_DISCRIMINANT_NARROWING_LAYER_PATCH_4.

> Patch 4 wires recognition at IR1-build arm boundaries.
> Every conditional-arm boundary in if / switch / early-return
> pushes the recognized fact for the arm body and pops on exit.

AssumptionEnv.
Fact.
depth e: AssumptionEnv => Nat0.
query e: AssumptionEnv, f: Fact => Bool.

IfStatement.
SwitchCase.
EarlyReturn.

test-fact n: IfStatement => Fact.
case-fact c: SwitchCase => Fact.
return-fact r: EarlyReturn => Fact.

env-inside-then n: IfStatement => AssumptionEnv.
env-after-build n: IfStatement => AssumptionEnv.
env-before-build n: IfStatement => AssumptionEnv.

---

> Inside the then-arm of an if, the test's fact is queryable.
all n: IfStatement | query (env-inside-then n) (test-fact n).

> After building the if, the env returns to its pre-build depth.
all n: IfStatement | depth (env-after-build n) = depth (env-before-build n).

```


## Implementation Notes

- The narrowing frame helper is centralized in both IR1 builders and wraps arm construction in `try/finally`, so balance is maintained even when a branch body returns an unsupported result or throws during build.
- `recognitionHook` is intentionally coarse-grained (`if.then`, `if.else`, `switch.case`, `switch.default`, `early-return.fallthrough`) and test-only. It observes the live env after facts are pushed, while tests clone the frame sets immediately to avoid later pops mutating assertions.
- The switch `default:` implementation only negates sibling case facts that the recognizer can express structurally. If a case label is not recognized, it contributes no default fact rather than inventing a text-based fallback.
- Early-return fall-through facts are populated in `translate-body.ts`, where the early-return prelude is rewritten and the rest-of-function body is built. That is the only place with the right lifetime for “after this return arm” facts.
- A small defensive compatibility guard remains in the pure and mutating `withNarrowingFrame` helpers: direct unit fixtures that bypass normal translation and omit `env` still build without narrowing population. Normal translation paths always supply the function-scoped env.

Spec/Evidence Mapping:
- If/switch arm population and balance: `withNarrowingFrame` plus `buildFromIfStatement` / `buildFromSwitchStatement` in `ir1-build.ts`; mirrored by `buildL1IfMutation` in `ir1-build-body.ts`; covered by `tests/narrowing-integration.test.mts` and `npm run -s test:unit`.
- Early-return fall-through population: `lowerPreludeBindings` / `translatePureBody` in `translate-body.ts`; covered by the early-return narrowing integration case and existing early-return fixture suites.
- Recognized fact visibility: `queryFact` assertions in `tests/narrowing-integration.test.mts` cover then, else-negation, switch case, switch default negations, early-return fall-through, and nested mutating frames.
- Required context consulted: the two narrowing survey docs for the function-scoped env contract, `ir1-build.ts` / `ir1-build-body.ts` for arm-boundary lowering sites, and the ts2pant helper/test harness for integration coverage.
- Static/runtime checks run: `npx tsc --noEmit`, `npm run -s lint`, `npm run -s test:unit`, and `npm run -s test:integration` all pass. `npm run -s typecheck` is not available in this package; `npx tsc --noEmit` was used as the equivalent check.