### PR TITLE
[ts2pant-du-discriminant-narrowing-layer] Patch 5: Variant-field-rule discharge wiring + narrowing fixture + @pant entailment

### DIFF
--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -101,8 +101,8 @@ import {
 import {
   cellRegisterMap,
   cellRegisterName,
-  detectDiscriminatedUnion,
   type DiscriminantLiteral,
+  detectDiscriminatedUnion,
   fieldRuleName,
   isMapType,
   isSetType,
@@ -1517,7 +1517,9 @@ function queryDiscriminatedUnionFieldDischarge(
     if (fieldRuleName(entry.domain, fieldName) !== qualifiedName) {
       continue;
     }
-    const field = entry.fields.find((candidate) => candidate.name === fieldName);
+    const field = entry.fields.find(
+      (candidate) => candidate.name === fieldName,
+    );
     if (!field) {
       continue;
     }

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -1523,7 +1523,7 @@ function queryDiscriminatedUnionFieldDischarge(
     if (!field) {
       continue;
     }
-    const receiver = receiverNode.getText();
+    const receiver = unwrapTransparentExpression(receiverNode).getText();
     return field.variantKeys.some((variantKey) => {
       const variant = entry.variants.find(
         (candidate) => candidate.key === variantKey,

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -40,6 +40,7 @@ import {
   exitFrame,
   type Fact,
   pushFact,
+  queryFact,
 } from "./assumption-env.js";
 import { lookupBuiltinByCall } from "./builtins.js";
 import { lowerExpr } from "./ir-emit.js";
@@ -100,6 +101,9 @@ import {
 import {
   cellRegisterMap,
   cellRegisterName,
+  detectDiscriminatedUnion,
+  type DiscriminantLiteral,
+  fieldRuleName,
   isMapType,
   isSetType,
   isUnsupportedUnknown,
@@ -1377,7 +1381,11 @@ export function buildL1MemberAccess(
       unsupported: "buildL1MemberAccess: unsupported access shape",
     };
   }
-  const receiverType = ctx.checker.getTypeAtLocation(receiverNode);
+  const receiverType = receiverTypeForFieldAccess(
+    receiverNode as ts.Expression,
+    fieldName,
+    ctx,
+  );
   const qualifiedStrict = qualifyFieldAccess(
     receiverType,
     fieldName,
@@ -1458,7 +1466,78 @@ export function buildL1MemberAccess(
     }
   }
 
-  return ir1Member(receiverL1, qualified);
+  return ir1Member(
+    receiverL1,
+    qualified,
+    queryDiscriminatedUnionFieldDischarge(
+      ctx,
+      receiverNode as ts.Expression,
+      fieldName,
+      qualified,
+    ),
+  );
+}
+
+function discriminantLiteralToFactLiteral(
+  literal: DiscriminantLiteral,
+): string {
+  return String(literal.value);
+}
+
+function receiverTypeForFieldAccess(
+  receiverNode: ts.Expression,
+  fieldName: string,
+  ctx: L1BuildContext,
+): ts.Type {
+  const declared = getOperandDeclaredType(receiverNode, ctx.checker);
+  const detected = detectDiscriminatedUnion(declared, ctx.checker);
+  if (
+    detected &&
+    (fieldName === detected.discriminant ||
+      detected.variants.some((variant) =>
+        variant.fields.some((field) => field.name === fieldName),
+      ))
+  ) {
+    return declared;
+  }
+  return ctx.checker.getTypeAtLocation(receiverNode);
+}
+
+function queryDiscriminatedUnionFieldDischarge(
+  ctx: L1BuildContext,
+  receiverNode: ts.Expression,
+  fieldName: string,
+  qualifiedName: string,
+): boolean | undefined {
+  const synth = ctx.supply.synthCell?.discriminatedUnionSynth;
+  if (!synth) {
+    return undefined;
+  }
+  for (const entry of synth.byShape.values()) {
+    if (fieldRuleName(entry.domain, fieldName) !== qualifiedName) {
+      continue;
+    }
+    const field = entry.fields.find((candidate) => candidate.name === fieldName);
+    if (!field) {
+      continue;
+    }
+    const receiver = receiverNode.getText();
+    return field.variantKeys.some((variantKey) => {
+      const variant = entry.variants.find(
+        (candidate) => candidate.key === variantKey,
+      );
+      if (!variant) {
+        return false;
+      }
+      return queryFact(ctx.env, {
+        kind: "discriminant",
+        receiver,
+        property: entry.discriminant,
+        literal: discriminantLiteralToFactLiteral(variant.literal),
+      });
+    });
+  }
+  return undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -1850,7 +1929,11 @@ function buildL1MemberOrVarForLift(
     if (receiverL1 === null) {
       return null;
     }
-    const receiverType = ctx.checker.getTypeAtLocation(receiverForType);
+    const receiverType = receiverTypeForFieldAccess(
+      receiverForType,
+      stripped.name.text,
+      ctx,
+    );
     const qualified = qualifyFieldAccess(
       receiverType,
       stripped.name.text,
@@ -1861,7 +1944,16 @@ function buildL1MemberOrVarForLift(
     if (qualified === null) {
       return null;
     }
-    return ir1Member(receiverL1, qualified);
+    return ir1Member(
+      receiverL1,
+      qualified,
+      queryDiscriminatedUnionFieldDischarge(
+        ctx,
+        receiverForType,
+        stripped.name.text,
+        qualified,
+      ),
+    );
   }
   if (
     ts.isElementAccessExpression(stripped) &&
@@ -1877,7 +1969,11 @@ function buildL1MemberOrVarForLift(
     if (receiverL1 === null) {
       return null;
     }
-    const receiverType = ctx.checker.getTypeAtLocation(receiverForType);
+    const receiverType = receiverTypeForFieldAccess(
+      receiverForType,
+      fieldName,
+      ctx,
+    );
     const qualified = qualifyFieldAccess(
       receiverType,
       fieldName,
@@ -1888,7 +1984,16 @@ function buildL1MemberOrVarForLift(
     if (qualified === null) {
       return null;
     }
-    return ir1Member(receiverL1, qualified);
+    return ir1Member(
+      receiverL1,
+      qualified,
+      queryDiscriminatedUnionFieldDischarge(
+        ctx,
+        receiverForType,
+        fieldName,
+        qualified,
+      ),
+    );
   }
   return null;
 }

--- a/tools/ts2pant/src/ir1.ts
+++ b/tools/ts2pant/src/ir1.ts
@@ -99,7 +99,12 @@ export type IR1Expr =
    * Property access. Canonicalized form for `obj.f` and `obj["f"]`.
    * Lowering qualifies `name` to a rule (today's `qualifyFieldAccess`).
    */
-  | { kind: "member"; receiver: IR1Expr; name: string }
+  | {
+      kind: "member";
+      receiver: IR1Expr;
+      name: string;
+      narrowingDischarged?: boolean;
+    }
   /**
    * Multi-armed value-position conditional. Canonical form for if-with-
    * returns, ternary chains, switch w/o fall-through, &&/|| when Bool-
@@ -1252,10 +1257,15 @@ export const ir1App = (callee: IR1Expr, args: IR1Expr[]): IR1Expr => ({
   args,
 });
 
-export const ir1Member = (receiver: IR1Expr, name: string): IR1Expr => ({
+export const ir1Member = (
+  receiver: IR1Expr,
+  name: string,
+  narrowingDischarged?: boolean,
+): IR1Expr => ({
   kind: "member",
   receiver,
   name,
+  ...(narrowingDischarged === undefined ? {} : { narrowingDischarged }),
 });
 
 /**

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -262,6 +262,18 @@ exports[`expressions-const-side-effectful.ts > constSetHas 1`] = `
 "module CONST_SET_HAS.\\n\\nconst-set-has s: [String], value: String => Bool.\\nx  => Bool.\\n\\n---\\n\\nx = (value in s).\\nconst-set-has s value = x.\\n"
 `;
 
+exports[`expressions-discriminant-narrowing.ts > circleOnly 1`] = `
+"module CIRCLE_ONLY.\\n\\nShape.\\nshape--kind s: Shape => String.\\nshape--r s: Shape, shape--kind s = \\"circle\\" => Int.\\nshape--s s: Shape, shape--kind s = \\"square\\" => Int.\\nshape--shared s: Shape, shape--kind s = \\"circle\\" or shape--kind s = \\"square\\" => String.\\ncircle-only s1: Shape => Int.\\n\\n---\\n\\ncircle-only s1 = (cond shape--kind s1 ~= \\"circle\\" => 0, true => shape--r s1).\\n\\ncheck\\n\\ncircle-only s1 = (cond shape--kind s1 = \\"circle\\" => shape--r s1, true => 0).\\n"
+`;
+
+exports[`expressions-discriminant-narrowing.ts > dispatchOnKind 1`] = `
+"module DISPATCH_ON_KIND.\\n\\nShape.\\nshape--kind s: Shape => String.\\nshape--r s: Shape, shape--kind s = \\"circle\\" => Int.\\nshape--s s: Shape, shape--kind s = \\"square\\" => Int.\\nshape--shared s: Shape, shape--kind s = \\"circle\\" or shape--kind s = \\"square\\" => String.\\ndispatch-on-kind s1: Shape => Int.\\n\\n---\\n\\ndispatch-on-kind s1 = (cond shape--kind s1 = \\"circle\\" => shape--r s1, shape--kind s1 = \\"square\\" => shape--s s1, true => 0).\\n\\ncheck\\n\\ndispatch-on-kind s1 = (cond shape--kind s1 = \\"circle\\" => shape--r s1, shape--kind s1 = \\"square\\" => shape--s s1, true => 0).\\n"
+`;
+
+exports[`expressions-discriminant-narrowing.ts > getRadius 1`] = `
+"module GET_RADIUS.\\n\\nShape.\\nshape--kind s: Shape => String.\\nshape--r s: Shape, shape--kind s = \\"circle\\" => Int.\\nshape--s s: Shape, shape--kind s = \\"square\\" => Int.\\nshape--shared s: Shape, shape--kind s = \\"circle\\" or shape--kind s = \\"square\\" => String.\\nget-radius s1: Shape => Int.\\n\\n---\\n\\nget-radius s1 = (cond shape--kind s1 = \\"circle\\" => shape--r s1, true => 0).\\n\\ncheck\\n\\nget-radius s1 = (cond shape--kind s1 = \\"circle\\" => shape--r s1, true => 0).\\n"
+`;
+
 exports[`expressions-discriminated-union.ts > ambiguousOwner 1`] = `
 "module AMBIGUOUS_OWNER.\\n\\nLeftOwnerRec.\\nleft-owner-rec--left r: LeftOwnerRec => Int.\\nleft-owner-rec--owner r: LeftOwnerRec => String.\\nOwnerRightRec.\\nowner-right-rec--owner r1: OwnerRightRec => String.\\nowner-right-rec--right r1: OwnerRightRec => Int.\\nambiguous-owner x: LeftOwnerRec + OwnerRightRec => String.\\n\\n---\\n\\n> UNSUPPORTED: property access .owner: ambiguous owner — union/intersection members declare this field on multiple distinct types, so no single qualified accessor rule applies.\\n"
 `;

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-discriminant-narrowing.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-discriminant-narrowing.ts
@@ -1,0 +1,33 @@
+type Shape =
+  | { kind: "circle"; r: number; shared: string }
+  | { kind: "square"; s: number; shared: string };
+
+/**
+ * @pant getRadius s = cond shape--kind s = "circle" => shape--r s, true => 0.
+ */
+export function getRadius(s: Shape): number {
+  if (s.kind === "circle") return s.r;
+  return 0;
+}
+
+/**
+ * @pant dispatchOnKind s = cond shape--kind s = "circle" => shape--r s, shape--kind s = "square" => shape--s s, true => 0.
+ */
+export function dispatchOnKind(s: Shape): number {
+  switch (s.kind) {
+    case "circle":
+      return s.r;
+    case "square":
+      return s.s;
+    default:
+      return 0;
+  }
+}
+
+/**
+ * @pant circleOnly s = cond shape--kind s = "circle" => shape--r s, true => 0.
+ */
+export function circleOnly(s: Shape): number {
+  if (s.kind !== "circle") return 0;
+  return s.r;
+}

--- a/tools/ts2pant/tests/integration/dogfood.test.mts
+++ b/tools/ts2pant/tests/integration/dogfood.test.mts
@@ -27,6 +27,7 @@ function solverAvailable(): boolean {
 // feature to build.
 
 const SRC = resolve(import.meta.dirname, "../../src");
+const FIXTURES = resolve(import.meta.dirname, "../fixtures/constructs");
 const PANT_TIMEOUT_MS = Number(
   process.env.TS2PANT_DOGFOOD_TIMEOUT_MS ?? 30_000,
 );
@@ -407,6 +408,21 @@ describe("dogfood: @pant annotations entail", () => {
     { file: "translate-types.ts", fn: "prefixedDigitStem", minChecks: 1 },
     { file: "translate-types.ts", fn: "tupleDepModuleName", minChecks: 1 },
     { file: "translate-types.ts", fn: "emptyTupleSynth", minChecks: 1 },
+    {
+      file: resolve(FIXTURES, "expressions-discriminant-narrowing.ts"),
+      fn: "getRadius",
+      minChecks: 1,
+    },
+    {
+      file: resolve(FIXTURES, "expressions-discriminant-narrowing.ts"),
+      fn: "dispatchOnKind",
+      minChecks: 1,
+    },
+    {
+      file: resolve(FIXTURES, "expressions-discriminant-narrowing.ts"),
+      fn: "circleOnly",
+      minChecks: 1,
+    },
   ];
 
   for (const { file, fn, minChecks } of annotated) {

--- a/tools/ts2pant/tests/ir1-ssa-invariants.test.mts
+++ b/tools/ts2pant/tests/ir1-ssa-invariants.test.mts
@@ -43,6 +43,7 @@ import {
   ir1Var,
   ir1While,
 } from "../src/ir1.js";
+import { createL1AssumptionEnv } from "../src/ir1-build.js";
 import {
   type BuildBodyCtx,
   buildL1AssignStmt,
@@ -140,6 +141,7 @@ function buildFixtureSupportedSsaBody(
     },
     supply: { n: 0 } as BuildBodyCtx["supply"],
     applyConst: (expr) => expr,
+    env: createL1AssumptionEnv(),
   };
 
   const stmts: IR1Stmt[] = [];

--- a/tools/ts2pant/tests/narrowing-integration.test.mts
+++ b/tools/ts2pant/tests/narrowing-integration.test.mts
@@ -226,6 +226,28 @@ describe("narrowing integration", () => {
     assert.equal(variantRead.narrowingDischarged, true);
   });
 
+  it("variant field discharge normalizes transparent receiver wrappers", () => {
+    const { fn, ctx } = setupFunction(`
+      type Shape =
+        | { kind: "circle"; r: number; shared: string }
+        | { kind: "square"; s: number; shared: string };
+      function f(s: Shape): number {
+        if (s.kind === "circle") return (s as Shape).r;
+        else return 0;
+      }
+    `);
+    const result = buildL1Conditional(
+      fn.body!.statements[0] as ts.IfStatement,
+      ctx,
+    );
+    assert.equal("unsupported" in result, false);
+    assert.equal(result.kind, "cond");
+    const variantRead = result.arms[0][1];
+    assert.equal(variantRead.kind, "member");
+    assert.equal(variantRead.name, "shape--r");
+    assert.equal(variantRead.narrowingDischarged, true);
+  });
+
   it("nested mutating if pushes both frames", () => {
     const sourceFile = createSourceFileFromSource(
       `

--- a/tools/ts2pant/tests/narrowing-integration.test.mts
+++ b/tools/ts2pant/tests/narrowing-integration.test.mts
@@ -204,6 +204,28 @@ describe("narrowing integration", () => {
     assert.equal(envDepth(env), 1);
   });
 
+  it("variant field reads record discharged narrowing", () => {
+    const { fn, ctx } = setupFunction(`
+      type Shape =
+        | { kind: "circle"; r: number; shared: string }
+        | { kind: "square"; s: number; shared: string };
+      function f(s: Shape): number {
+        if (s.kind === "circle") return s.r;
+        else return 0;
+      }
+    `);
+    const result = buildL1Conditional(
+      fn.body!.statements[0] as ts.IfStatement,
+      ctx,
+    );
+    assert.equal("unsupported" in result, false);
+    assert.equal(result.kind, "cond");
+    const variantRead = result.arms[0][1];
+    assert.equal(variantRead.kind, "member");
+    assert.equal(variantRead.name, "shape--r");
+    assert.equal(variantRead.narrowingDischarged, true);
+  });
+
   it("nested mutating if pushes both frames", () => {
     const sourceFile = createSourceFileFromSource(
       `


### PR DESCRIPTION
## Patch 5: Variant-field-rule discharge wiring + narrowing fixture + @pant entailment

- Identify the variant-field-rule emission site in `ir1-build.ts` (property-access lowering ~1570/1805/1832 — confirm via grep `qualifyFieldAccess`). When the resolved owner is a discriminated-union domain, retrieve the rule's guard literal from the `DiscriminatedUnionSynthEntry` and construct a DiscriminantFact (`receiver: receiver.getText()`, `property: <encoded discriminant>`, `literal: <encoded literal>`).
- Call `queryFact(ctx.env, fact)` and store the result on the emitted IR1 member node as `narrowingDischarged: boolean`. Emit normally regardless of result (sound-by-guard fallback preserved when `narrowingDischarged === false`).
- Create `tools/ts2pant/tests/fixtures/constructs/expressions-discriminant-narrowing.ts` with: (1) `function getRadius(s: Shape): number { if (s.kind === "circle") return s.r; return 0; }` plus `@pant getRadius s = cond shape--kind s = "circle" => shape--r s, true => 0.`; (2) `function dispatchOnKind(s: Shape): number { switch (s.kind) { case "circle": return s.r; case "square": return s.s; } }` plus an analogous @pant annotation; (3) `function circleOnly(s: Shape): number { if (s.kind !== "circle") return 0; return s.r; }` plus its @pant annotation.
- Define `type Shape = { kind: "circle"; r: number; shared: string } | { kind: "square"; s: number; shared: string };` at the top of the new fixture (mirroring `expressions-discriminated-union.ts`).
- In `tools/ts2pant/tests/integration/dogfood.test.mts`, extend the `annotated` array (~line 388) with three entries pointing at the new fixture's functions. Note: the existing suite reads from `SRC` (ts2pant src); confirm the path resolves to the fixture file or add a sibling suite that reads from the fixtures directory.
- Run `npm run -s test:integration` and confirm the three new `@pant annotations are entailed by the body` cases pass; existing fixture entailments do not regress.

## Changes
- Identify the variant-field-rule emission site in `ir1-build.ts` (property-access lowering ~1570/1805/1832 — confirm via grep `qualifyFieldAccess`). When the resolved owner is a discriminated-union domain, retrieve the rule's guard literal from the `DiscriminatedUnionSynthEntry` and construct a DiscriminantFact (`receiver: receiver.getText()`, `property: <encoded discriminant>`, `literal: <encoded literal>`).
- Call `queryFact(ctx.env, fact)` and store the result on the emitted IR1 member node as `narrowingDischarged: boolean`. Emit normally regardless of result (sound-by-guard fallback preserved when `narrowingDischarged === false`).
- Create `tools/ts2pant/tests/fixtures/constructs/expressions-discriminant-narrowing.ts` with: (1) `function getRadius(s: Shape): number { if (s.kind === "circle") return s.r; return 0; }` plus `@pant getRadius s = cond shape--kind s = "circle" => shape--r s, true => 0.`; (2) `function dispatchOnKind(s: Shape): number { switch (s.kind) { case "circle": return s.r; case "square": return s.s; } }` plus an analogous @pant annotation; (3) `function circleOnly(s: Shape): number { if (s.kind !== "circle") return 0; return s.r; }` plus its @pant annotation.
- Define `type Shape = { kind: "circle"; r: number; shared: string } | { kind: "square"; s: number; shared: string };` at the top of the new fixture (mirroring `expressions-discriminated-union.ts`).
- In `tools/ts2pant/tests/integration/dogfood.test.mts`, extend the `annotated` array (~line 388) with three entries pointing at the new fixture's functions. Note: the existing suite reads from `SRC` (ts2pant src); confirm the path resolves to the fixture file or add a sibling suite that reads from the fixtures directory.
- Run `npm run -s test:integration` and confirm the three new `@pant annotations are entailed by the body` cases pass; existing fixture entailments do not regress.

## Files to Modify
- tools/ts2pant/src/ir1-build.ts (modify): At the variant-field-rule emission site (qualifyFieldAccess / property-access lowering, ~1570/1805/1832), query `ctx.env` with a Fact constructed from the rule's guard (receiver text, discriminant property name, literal). Annotate the emitted IR1 member node with `narrowingDischarged: boolean` capturing the query result.
- tools/ts2pant/src/ir1.ts (modify): Extend the IR1 `member` node shape with an optional `narrowingDischarged?: boolean` field (no effect on lowering — pure annotation for downstream consumers and tests).
- tools/ts2pant/tests/fixtures/constructs/expressions-discriminant-narrowing.ts (create): New construct fixture: `getRadius(s: Shape)` (if-return discriminant), `dispatchOnKind(s: Shape)` (switch over kind), `circleOnly(s: Shape)` (early-return guard). Each function carries `@pant` annotations on the variant-field obligation.
- tools/ts2pant/tests/integration/dogfood.test.mts (modify): Extend the `dogfood: @pant annotations entail` suite (~line 386) with the three new functions from the narrowing fixture; assert each entails under `pant --check` z3 with `minChecks: 1`.

## Gameplan Specification

```
module DU_DISCRIMINANT_NARROWING_LAYER.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> ts2pant has a function-scoped assumption environment threaded
> through IR1 build. At every conditional-arm boundary (if-then,
> if-else, switch case, switch default, early-return fall-through),
> the env is balanced (enter-frame followed by exit-frame) and the
> recognized fact for the arm's test is pushed for the arm body.
> No emitted Pantagruel changes. The env is exposed via a snapshot
> API for tests; downstream consumers (DU M3, nullish recognizer,
> type-predicate narrowing) will query the env at their own
> lowering sites in separate gameplans.

AssumptionEnv.
Fact.
depth e: AssumptionEnv => Nat0.
push e: AssumptionEnv, f: Fact => AssumptionEnv.
query e: AssumptionEnv, f: Fact => Bool.
enter-frame e: AssumptionEnv => AssumptionEnv.
exit-frame e: AssumptionEnv => AssumptionEnv.

---

> Push makes a fact queryable.
all e: AssumptionEnv, f: Fact | query (push e f) f.

> Enter-frame and exit-frame are depth-inverse.
all e: AssumptionEnv | depth (exit-frame (enter-frame e)) = depth e.

> The empty env answers false.
all e: AssumptionEnv, f: Fact | depth e = 0 -> ~(query e f).

where

> ══════════════════════════════════════════
> RECOGNITION
> ══════════════════════════════════════════
> Recognition is total over boolean test nodes: every boolean test
> maps to a fact (discriminant or predicate). Non-boolean shapes
> are not recognised.

TsTestNode.
bool-typed t: TsTestNode => Bool.
recognized t: TsTestNode => Bool.
fact-of t: TsTestNode, recognized t => Fact.

---

all t: TsTestNode | bool-typed t -> recognized t.
all t: TsTestNode | ~(bool-typed t) -> ~(recognized t).

where

> ══════════════════════════════════════════
> POPULATION DISCIPLINE
> ══════════════════════════════════════════
> At every conditional-arm boundary, the env is entered, the arm's
> fact is pushed, the arm body builds with the fact visible, then
> the frame is exited. After the full function build, the env's
> depth equals its starting depth (balanced).

IfStatement.
SwitchCase.
EarlyReturn.

test-fact n: IfStatement => Fact.
case-fact c: SwitchCase => Fact.
return-fact r: EarlyReturn => Fact.

env-inside-then n: IfStatement => AssumptionEnv.
env-before-build n: IfStatement => AssumptionEnv.
env-after-build n: IfStatement => AssumptionEnv.

---

> Inside the then-arm of an if, the test's fact is queryable.
all n: IfStatement | query (env-inside-then n) (test-fact n).

> After building the if, the env returns to its pre-build depth.
all n: IfStatement | depth (env-after-build n) = depth (env-before-build n).

where

> ══════════════════════════════════════════
> DISCHARGE WIRING
> ══════════════════════════════════════════
> Every variant-field-rule emission site queries the env and records
> the result on the IR1 member node. The emitted Pantagruel text for
> existing fixtures is unchanged; the new narrowing-aware fixtures'
> @pant annotations entail under z3 because the variant-field
> obligations now have the path condition in scope.

VariantFieldRead.
guard-fact r: VariantFieldRead => Fact.
emit-env r: VariantFieldRead => AssumptionEnv.
narrowing-discharged r: VariantFieldRead => Bool.

NarrowedFixture.
entails f: NarrowedFixture => Bool.

---

> narrowing-discharged matches the env query.
all r: VariantFieldRead |
  narrowing-discharged r <-> query (emit-env r) (guard-fact r).

> The narrowing-aware fixtures' @pant obligations entail.
all f: NarrowedFixture | entails f.

```

## Patch Specification

```
module DU_DISCRIMINANT_NARROWING_LAYER_PATCH_5.

> Patch 5 wires the discharge query at variant-field-rule emission
> and adds narrowing-aware fixtures whose @pant annotations entail.
> The emitted Pantagruel text for existing fixtures is unchanged;
> the behavior change is the entailment outcome of the new fixtures.

AssumptionEnv.
Fact.
query e: AssumptionEnv, f: Fact => Bool.

VariantFieldRead.
guard-fact r: VariantFieldRead => Fact.
emit-env r: VariantFieldRead => AssumptionEnv.
narrowing-discharged r: VariantFieldRead => Bool.

NarrowedFixture.
entails f: NarrowedFixture => Bool.

---

> narrowing-discharged is true iff the env discharges the guard fact.
all r: VariantFieldRead |
  narrowing-discharged r <-> query (emit-env r) (guard-fact r).

> The narrowing-aware fixtures' @pant obligations entail under z3.
all f: NarrowedFixture | entails f.

```


## Implementation Notes

- Non-obvious implementation detail: TypeScript flow narrows `s` to the concrete variant record inside `if (s.kind === "circle")`, which previously made `s.r` qualify as an anonymous-record accessor instead of the DU accessor. Patch 5 fixes that at the property-access boundary by preferring the receiver's declared type only when that declared type is a discriminated union that owns the accessed field; other property access keeps the existing `getTypeAtLocation` behavior.
- The env query is keyed to Patch 2/Patch 4's existing `Fact` shape: `property` is the structural source discriminant (`kind`), while the emitted/qualified rule name remains `shape--kind` / `shape--r`. This keeps discharge aligned with facts already pushed at arm boundaries without changing emitted Pantagruel.
- Minor fixture deviation: `dispatchOnKind` includes an explicit `default: return 0;` because the current L1 switch lowering still requires a default arm. The `@pant` annotation uses the same `true => 0` fallback, so the fixture still exercises switch-case narrowing and DU field discharge without expanding switch exhaustiveness in this patch.
- Spec/Evidence Mapping:
  - `narrowing-discharged <-> query emit-env guard-fact`: implemented in `queryDiscriminatedUnionFieldDischarge` and stored via `ir1Member(..., narrowingDischarged)`; covered by `narrowing-integration.test.mts` asserting `shape--r` has `narrowingDischarged === true`.
  - Narrowed fixtures entail: covered by `dogfood.test.mts` entries for `getRadius`, `dispatchOnKind`, and `circleOnly`, plus construct snapshots for the new fixture.
  - Existing Pantagruel output stability: `npm run -s test:unit` and `npm run -s test:integration` passed after updating only the new fixture snapshots.
- Verification: `npm run -s test:unit`, `npm run -s test:integration`, and `npx tsc --noEmit` passed. `npm run -s build` was attempted but failed before TypeScript in the OCaml/WASM prebuild because the shared opam switch reports a corrupted `ppxlib.cmi`.