### PR TITLE
Surface real reason-unknown instead of garbled unsat-core error

### DIFF
--- a/lib/smt.ml
+++ b/lib/smt.ml
@@ -1402,6 +1402,15 @@ let build_value_terms config env (params : param list) =
   in
   param_terms @ func_terms
 
+(** Append a (check-sat) command followed by a (get-info :reason-unknown) query.
+    The latter is harmless when the result is sat/unsat (Z3 returns an empty
+    reason) but gives a meaningful diagnostic — e.g. "(incomplete (theory
+    array))" — when the result is unknown, instead of leaving the parser to
+    scrape a reason out of unrelated trailing commands. *)
+let append_check_sat buf =
+  Buffer.add_string buf "(check-sat)\n";
+  Buffer.add_string buf "(get-info :reason-unknown)\n"
+
 (** Append (get-value ...) command to buffer if value_terms is non-empty *)
 let append_get_value buf value_terms =
   match value_terms with
@@ -1518,7 +1527,7 @@ let generate_contradiction_query config env action =
         (translate_proposition post_config env p.value))
     action.a_propositions;
   let value_terms = build_value_terms config env action.a_params in
-  Buffer.add_string buf "(check-sat)\n";
+  append_check_sat buf;
   Buffer.add_string buf "(get-unsat-core)\n";
   append_get_value buf value_terms;
   {
@@ -1572,7 +1581,7 @@ let generate_invariant_query config env ~all_invariants ~index
   let inv_primed = translate_proposition config env primed_inv.value in
   Buffer.add_string buf (Printf.sprintf "(assert (not %s))\n" inv_primed);
   let value_terms = build_value_terms config env action.a_params in
-  Buffer.add_string buf "(check-sat)\n";
+  append_check_sat buf;
   append_get_value buf value_terms;
   {
     name = Printf.sprintf "invariant:%s:%d" action.a_label index;
@@ -1625,7 +1634,7 @@ let generate_precondition_query config env invariant_props action =
         (Printf.sprintf "Precondition: %s" (Pretty.str_expr e))
         (translate_precondition config env e))
     precond_exprs;
-  Buffer.add_string buf "(check-sat)\n";
+  append_check_sat buf;
   Buffer.add_string buf "(get-unsat-core)\n";
   {
     name = Printf.sprintf "precondition:%s" action.a_label;
@@ -1691,7 +1700,7 @@ let generate_invariant_consistency_query config env invariant_props =
         (translate_proposition config env inv.value))
     invariant_props;
   let value_terms = build_invariant_value_terms config env in
-  Buffer.add_string buf "(check-sat)\n";
+  append_check_sat buf;
   Buffer.add_string buf "(get-unsat-core)\n";
   append_get_value buf value_terms;
   {
@@ -1729,7 +1738,7 @@ let generate_init_consistency_query config env init_props =
         (translate_proposition config env prop.value))
     init_props;
   let value_terms = build_invariant_value_terms config env in
-  Buffer.add_string buf "(check-sat)\n";
+  append_check_sat buf;
   Buffer.add_string buf "(get-unsat-core)\n";
   append_get_value buf value_terms;
   {
@@ -1766,7 +1775,7 @@ let generate_init_invariant_query config env init_props ~index
   let inv_smt = translate_proposition config env inv.value in
   Buffer.add_string buf (Printf.sprintf "(assert (not %s))\n" inv_smt);
   let value_terms = build_invariant_value_terms config env in
-  Buffer.add_string buf "(check-sat)\n";
+  append_check_sat buf;
   append_get_value buf value_terms;
   {
     name = Printf.sprintf "init-invariant:%d" index;
@@ -2029,7 +2038,7 @@ let generate_bmc_query config env init_props actions ~inv_index
   Buffer.add_string buf
     (Printf.sprintf "(assert (or %s))\n" (String.concat " " negated_steps));
   let value_terms = build_bmc_value_terms config env steps in
-  Buffer.add_string buf "(check-sat)\n";
+  append_check_sat buf;
   append_get_value buf value_terms;
   {
     name = Printf.sprintf "bmc-invariant:%d" inv_index;
@@ -2168,7 +2177,7 @@ let generate_bmc_deadlock_query config env init_props invariant_props actions
   (* Assert all actions disabled at step k *)
   Buffer.add_string buf (generate_all_actions_disabled config env actions steps);
   let value_terms = build_bmc_value_terms config env steps in
-  Buffer.add_string buf "(check-sat)\n";
+  append_check_sat buf;
   append_get_value buf value_terms;
   {
     name = "bmc-deadlock";
@@ -2348,7 +2357,7 @@ let generate_exhaustiveness_query config env ~all_invariants:_ ~index cond =
   Buffer.add_string buf "\n; --- Exhaustiveness (negated) ---\n";
   Buffer.add_string buf (Printf.sprintf "(assert (not %s))\n" smt_exhaustive);
   let value_terms = build_cond_value_terms config env cond in
-  Buffer.add_string buf "(check-sat)\n";
+  append_check_sat buf;
   append_get_value buf value_terms;
   {
     name = Printf.sprintf "cond-exhaustiveness:%d" index;
@@ -2381,7 +2390,7 @@ let generate_invariant_entailment_query config env invariant_props ~index
   let goal_smt = translate_proposition config env goal.value in
   Buffer.add_string buf (Printf.sprintf "(assert (not %s))\n" goal_smt);
   let value_terms = build_invariant_value_terms config env in
-  Buffer.add_string buf "(check-sat)\n";
+  append_check_sat buf;
   append_get_value buf value_terms;
   {
     name = Printf.sprintf "entailment:invariant:%d" index;
@@ -2432,7 +2441,7 @@ let generate_action_entailment_query config env ~all_invariants ~index
   let goal_smt = translate_proposition config env goal.value in
   Buffer.add_string buf (Printf.sprintf "(assert (not %s))\n" goal_smt);
   let value_terms = build_value_terms config env action.a_params in
-  Buffer.add_string buf "(check-sat)\n";
+  append_check_sat buf;
   append_get_value buf value_terms;
   {
     name = Printf.sprintf "entailment:%s:%d" action.a_label index;

--- a/lib/solver.ml
+++ b/lib/solver.ml
@@ -363,6 +363,16 @@ let read_with_timeout fd timeout =
   in
   loop ()
 
+(** Extract the reason-unknown string from a (get-info :reason-unknown) response
+    sexp: (:reason-unknown "..."). Returns None if not such a sexp or if the
+    reason is empty. *)
+let extract_reason_unknown (sexp : Sexp.t) =
+  match sexp with
+  | List [ Atom ":reason-unknown"; Atom reason ] when String.trim reason <> ""
+    ->
+      Some (String.trim reason)
+  | List _ | Atom _ -> None
+
 (** Parse raw solver output into a [solver_result]. *)
 let parse_solver_output output =
   if String.length output = 0 then SolverError "No output from solver"
@@ -374,6 +384,10 @@ let parse_solver_output output =
           List.find_map
             (fun (s : Sexp.t) ->
               match s with
+              (* skip (error ...) from e.g. (get-unsat-core) on a sat result,
+                 and the (:reason-unknown "") info response *)
+              | List (Atom "error" :: _) | List (Atom ":reason-unknown" :: _) ->
+                  None
               | List _ -> Some (parse_get_value_sexp s)
               | Atom _ -> None)
             rest
@@ -385,7 +399,10 @@ let parse_solver_output output =
           List.find_map
             (fun (s : Sexp.t) ->
               match s with
-              | List (Atom "error" :: _) -> None
+              (* skip (error ...) and the (:reason-unknown "") info response
+                 that now precedes the core in the output *)
+              | List (Atom "error" :: _) | List (Atom ":reason-unknown" :: _) ->
+                  None
               | List _ -> Some (parse_unsat_core_sexp s)
               | Atom _ -> None)
             rest
@@ -393,8 +410,12 @@ let parse_solver_output output =
         in
         Unsat core
     | Atom "unknown" :: rest ->
-        let reason = String.concat " " (List.map sexp_to_string rest) in
-        Unknown (if reason = "" then "unknown" else reason)
+        (* Prefer Z3's own (get-info :reason-unknown) diagnostic. Trailing
+           commands like (get-unsat-core) error on a non-unsat result and
+           (get-value ...) dumps a candidate model — neither belongs in the
+           reason, so we don't scrape the whole tail. *)
+        let reason = List.find_map extract_reason_unknown rest in
+        Unknown (Option.value reason ~default:"unknown")
     | List (Atom "error" :: _) :: _ -> SolverError output
     | List _ :: _ | Atom _ :: _ | [] ->
         SolverError (Printf.sprintf "Unexpected solver output: %s" output)


### PR DESCRIPTION
## Problem

Model-checking a spec where Z3 returns `unknown` produced a confusing message:

```
UNKNOWN: Invariants are jointly satisfiable (reason: (error"line 91 column 15: unsat core is not available") (((sources Event_0)(store ...giant model dump...)))
```

The `unsat core is not available` string is **not** a spec error — it's pant garbling its own diagnostics. Two compounding issues:

1. **Every consistency query unconditionally emits `(get-unsat-core)` after `(check-sat)`.** That command is only legal after an `unsat` result. On `unknown` (or `sat`) Z3 prints `(error "...unsat core is not available")`.
2. **The solver parser, on an `unknown` verdict, concatenated *all* trailing s-expressions into the reason** — that error plus the entire candidate-model dump from `(get-value ...)` — burying Z3's actual reason (`(incomplete (theory array))`).

## Fix

- Add `append_check_sat`, which emits `(check-sat)` then `(get-info :reason-unknown)`. The info query returns `""` on sat/unsat (harmless) and the real reason on unknown. All 11 `check-sat` sites route through it.
- Parse the `:reason-unknown` info in the parser's `unknown` branch instead of scraping the whole command tail.
- Harden the `sat` and `unsat` branches to skip `(error ...)` and the new `:reason-unknown` sexps when locating the get-value / unsat-core response (the `sat` branch had a latent bug where it could parse an `error` sexp as a model).

## Result

```
UNKNOWN: Invariants are jointly satisfiable (reason: (incomplete (theory array)))
```

## Testing

- Full suite passes (164 SMT + 32 Solver tests, incl. the existing `parse_solver_output / unknown` case).
- Verified end-to-end: sat → `OK`, contradiction → `FAIL` with the conflicting-constraint core intact, and the originally-reported spec → the clean `UNKNOWN … (incomplete (theory array))`.

Note: this fixes the *reporting*. The verdict on that spec is still genuinely `unknown` — Z3's array decision procedure is incomplete for its quantified `Array … Bool` page encoding plus the uninterpreted closure. Making that spec decidable is separate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)