### PR TITLE
[ts2pant-du-discriminant-narrowing] Patch 2: Assumption-env in-scope fact accessor + definedness-obligation renderer

### DIFF
--- a/tools/ts2pant/src/assumption-env.ts
+++ b/tools/ts2pant/src/assumption-env.ts
@@ -7,6 +7,7 @@ export type Fact =
       receiver: string;
       property: string;
       literal: string;
+      negated: boolean;
     }
   | { kind: "predicate"; testExpr: OpaqueExpr };
 
@@ -74,7 +75,10 @@ export function discriminantFactsInScope(
       ) {
         continue;
       }
-      const inScope = decodeDiscriminantLiteral(fact.literal);
+      const inScope: InScopeDiscriminantFact = {
+        literal: fact.literal,
+        negated: fact.negated,
+      };
       const key = `${inScope.negated ? "!" : "="}:${JSON.stringify(
         inScope.literal,
       )}`;
@@ -93,15 +97,8 @@ function factKey(fact: Fact): string {
       fact.receiver,
       fact.property,
       fact.literal,
+      fact.negated,
     ])}`;
   }
   return `pred:${JSON.stringify(getAst().strExpr(fact.testExpr))}`;
-}
-
-function decodeDiscriminantLiteral(literal: string): InScopeDiscriminantFact {
-  const negated = /^!\((.*)\)$/u.exec(literal);
-  if (negated !== null) {
-    return { literal: negated[1]!, negated: true };
-  }
-  return { literal, negated: false };
 }

--- a/tools/ts2pant/src/assumption-env.ts
+++ b/tools/ts2pant/src/assumption-env.ts
@@ -11,7 +11,12 @@ export type Fact =
   | { kind: "predicate"; testExpr: OpaqueExpr };
 
 export interface AssumptionEnv {
-  frames: Set<string>[];
+  frames: Map<string, Fact>[];
+}
+
+export interface InScopeDiscriminantFact {
+  literal: string;
+  negated: boolean;
 }
 
 export function createAssumptionEnv(): AssumptionEnv {
@@ -23,7 +28,7 @@ export function envDepth(env: AssumptionEnv): number {
 }
 
 export function enterFrame(env: AssumptionEnv): void {
-  env.frames.push(new Set());
+  env.frames.push(new Map());
 }
 
 export function exitFrame(env: AssumptionEnv): void {
@@ -42,7 +47,7 @@ export function pushFact(env: AssumptionEnv, fact: Fact): void {
       "AssumptionEnv invariant violation: pushFact with no frame",
     );
   }
-  frame.add(factKey(fact));
+  frame.set(factKey(fact), fact);
 }
 
 export function queryFact(env: AssumptionEnv, fact: Fact): boolean {
@@ -51,6 +56,35 @@ export function queryFact(env: AssumptionEnv, fact: Fact): boolean {
   }
   const key = factKey(fact);
   return env.frames.some((frame) => frame.has(key));
+}
+
+export function discriminantFactsInScope(
+  env: AssumptionEnv,
+  receiver: string,
+  property: string,
+): InScopeDiscriminantFact[] {
+  const out: InScopeDiscriminantFact[] = [];
+  const seen = new Set<string>();
+  for (const frame of env.frames) {
+    for (const fact of frame.values()) {
+      if (
+        fact.kind !== "discriminant" ||
+        fact.receiver !== receiver ||
+        fact.property !== property
+      ) {
+        continue;
+      }
+      const inScope = decodeDiscriminantLiteral(fact.literal);
+      const key = `${inScope.negated ? "!" : "="}:${JSON.stringify(
+        inScope.literal,
+      )}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        out.push(inScope);
+      }
+    }
+  }
+  return out;
 }
 
 function factKey(fact: Fact): string {
@@ -62,4 +96,12 @@ function factKey(fact: Fact): string {
     ])}`;
   }
   return `pred:${JSON.stringify(getAst().strExpr(fact.testExpr))}`;
+}
+
+function decodeDiscriminantLiteral(literal: string): InScopeDiscriminantFact {
+  const negated = /^!\((.*)\)$/u.exec(literal);
+  if (negated !== null) {
+    return { literal: negated[1]!, negated: true };
+  }
+  return { literal, negated: false };
 }

--- a/tools/ts2pant/src/definedness-obligation.ts
+++ b/tools/ts2pant/src/definedness-obligation.ts
@@ -1,0 +1,61 @@
+import type { InScopeDiscriminantFact } from "./assumption-env.js";
+import type { OpaqueExpr } from "./pant-ast.js";
+import { getAst } from "./pant-wasm.js";
+
+export interface DefinednessObligationInput {
+  receiver: OpaqueExpr;
+  discRule: string;
+  requiredLiteral: string;
+  inScope: readonly InScopeDiscriminantFact[];
+}
+
+export interface DefinednessObligation {
+  text: string;
+}
+
+export function renderDefinednessObligation(
+  input: DefinednessObligationInput,
+): DefinednessObligation {
+  const ast = getAst();
+  const consequent = discriminantEquality(
+    input.discRule,
+    input.receiver,
+    input.requiredLiteral,
+  );
+  const antecedents = input.inScope.map((fact) => {
+    const equality = discriminantEquality(
+      input.discRule,
+      input.receiver,
+      fact.literal,
+    );
+    return fact.negated ? ast.unop(ast.opNot(), equality) : equality;
+  });
+  const antecedent = conjoin(antecedents);
+  const result =
+    antecedent === null
+      ? consequent
+      : ast.binop(ast.opImpl(), antecedent, consequent);
+  return { text: ast.strExpr(result) };
+}
+
+function discriminantEquality(
+  discRule: string,
+  receiver: OpaqueExpr,
+  literal: string,
+): OpaqueExpr {
+  const ast = getAst();
+  return ast.binop(
+    ast.opEq(),
+    ast.app(ast.var(discRule), [receiver]),
+    ast.litString(literal),
+  );
+}
+
+function conjoin(exprs: readonly OpaqueExpr[]): OpaqueExpr | null {
+  const ast = getAst();
+  let out: OpaqueExpr | null = null;
+  for (const expr of exprs) {
+    out = out === null ? expr : ast.binop(ast.opAnd(), out, expr);
+  }
+  return out;
+}

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -1536,6 +1536,7 @@ function queryDiscriminatedUnionFieldDischarge(
         receiver,
         property: entry.discriminant,
         literal: discriminantLiteralToFactLiteral(variant.literal),
+        negated: false,
       });
     });
   }

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -140,7 +140,7 @@ export function createL1AssumptionEnv(): AssumptionEnv {
 }
 
 export function snapshotAssumptionEnv(ctx: L1BuildContext): AssumptionEnv {
-  return { frames: ctx.env.frames.map((frame) => new Set(frame)) };
+  return { frames: ctx.env.frames.map((frame) => new Map(frame)) };
 }
 
 export const isL1Unsupported = (

--- a/tools/ts2pant/src/narrowing-recognizer.ts
+++ b/tools/ts2pant/src/narrowing-recognizer.ts
@@ -66,6 +66,7 @@ function discriminantFactFromParts(
     receiver: parts.receiver,
     property: parts.property,
     literal: value,
+    negated: false,
   };
 }
 
@@ -136,10 +137,9 @@ export function recognizeNarrowingFromSwitchCase(
 
 export function negateFact(fact: Fact): Fact {
   if (fact.kind === "discriminant") {
-    const negated = /^!\((.*)\)$/u.exec(fact.literal);
     return {
       ...fact,
-      literal: negated === null ? `!(${fact.literal})` : negated[1]!,
+      negated: !fact.negated,
     };
   }
   const ast = getAst();

--- a/tools/ts2pant/tests/assumption-env.test.mts
+++ b/tools/ts2pant/tests/assumption-env.test.mts
@@ -16,6 +16,7 @@ const circleFact: Fact = {
   receiver: "s",
   property: "kind",
   literal: "circle",
+  negated: false,
 };
 
 const squareFact: Fact = {
@@ -23,6 +24,7 @@ const squareFact: Fact = {
   receiver: "s",
   property: "kind",
   literal: "square",
+  negated: false,
 };
 
 const predicateFact: Fact = {
@@ -35,6 +37,7 @@ const separatorFact: Fact = {
   receiver: "a|b",
   property: "c",
   literal: "d",
+  negated: false,
 };
 
 const separatorCollisionFact: Fact = {
@@ -42,6 +45,7 @@ const separatorCollisionFact: Fact = {
   receiver: "a",
   property: "b|c",
   literal: "d",
+  negated: false,
 };
 
 describe("AssumptionEnv", () => {

--- a/tools/ts2pant/tests/definedness-obligation.test.mts
+++ b/tools/ts2pant/tests/definedness-obligation.test.mts
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import { before, describe, it } from "node:test";
+import {
+  createAssumptionEnv,
+  discriminantFactsInScope,
+  enterFrame,
+  pushFact,
+  type Fact,
+} from "../src/assumption-env.js";
+import { renderDefinednessObligation } from "../src/definedness-obligation.js";
+import { getAst, loadAst } from "../src/pant-wasm.js";
+
+const circleFact: Fact = {
+  kind: "discriminant",
+  receiver: "s",
+  property: "kind",
+  literal: "circle",
+};
+
+const squareFact: Fact = {
+  kind: "discriminant",
+  receiver: "s",
+  property: "kind",
+  literal: "square",
+};
+
+before(async () => {
+  await loadAst();
+});
+
+describe("definedness", () => {
+  it("finds positive in-scope discriminant fact", () => {
+    const env = createAssumptionEnv();
+    enterFrame(env);
+    enterFrame(env);
+    pushFact(env, circleFact);
+
+    assert.deepEqual(discriminantFactsInScope(env, "s", "kind"), [
+      { literal: "circle", negated: false },
+    ]);
+  });
+
+  it("finds negated in-scope fact and flags it", () => {
+    const env = createAssumptionEnv();
+    enterFrame(env);
+    pushFact(env, { ...circleFact, literal: "!(circle)" });
+
+    assert.deepEqual(discriminantFactsInScope(env, "s", "kind"), [
+      { literal: "circle", negated: true },
+    ]);
+  });
+
+  it("unknown receiver yields no in-scope facts", () => {
+    const env = createAssumptionEnv();
+    enterFrame(env);
+    pushFact(env, circleFact);
+
+    assert.deepEqual(discriminantFactsInScope(env, "other", "kind"), []);
+  });
+
+  it("renders obligation over the total discriminant rule", () => {
+    const ast = getAst();
+    const obligation = renderDefinednessObligation({
+      receiver: ast.var("s"),
+      discRule: "shape--kind",
+      requiredLiteral: "circle",
+      inScope: [{ literal: "circle", negated: false }],
+    });
+
+    assert.equal(
+      obligation.text,
+      'shape--kind s = "circle" -> shape--kind s = "circle"',
+    );
+    assert.doesNotMatch(obligation.text, /shape--r/u);
+  });
+
+  it("negated fact renders as negation antecedent", () => {
+    const ast = getAst();
+    const obligation = renderDefinednessObligation({
+      receiver: ast.var("s"),
+      discRule: "shape--kind",
+      requiredLiteral: "square",
+      inScope: [{ literal: "circle", negated: true }],
+    });
+
+    assert.equal(
+      obligation.text,
+      '~(shape--kind s = "circle") -> shape--kind s = "square"',
+    );
+    assert.doesNotMatch(obligation.text, /shape--r/u);
+  });
+
+  it("empty in-scope yields bare consequent", () => {
+    const ast = getAst();
+    const obligation = renderDefinednessObligation({
+      receiver: ast.var("s"),
+      discRule: "shape--kind",
+      requiredLiteral: "circle",
+      inScope: [],
+    });
+
+    assert.equal(obligation.text, 'shape--kind s = "circle"');
+    assert.doesNotMatch(obligation.text, /shape--r/u);
+  });
+
+  it("deduplicates positive and negated facts independently", () => {
+    const env = createAssumptionEnv();
+    enterFrame(env);
+    pushFact(env, circleFact);
+    pushFact(env, circleFact);
+    enterFrame(env);
+    pushFact(env, { ...circleFact, literal: "!(circle)" });
+    pushFact(env, squareFact);
+
+    assert.deepEqual(discriminantFactsInScope(env, "s", "kind"), [
+      { literal: "circle", negated: false },
+      { literal: "circle", negated: true },
+      { literal: "square", negated: false },
+    ]);
+  });
+});

--- a/tools/ts2pant/tests/definedness-obligation.test.mts
+++ b/tools/ts2pant/tests/definedness-obligation.test.mts
@@ -15,6 +15,7 @@ const circleFact: Fact = {
   receiver: "s",
   property: "kind",
   literal: "circle",
+  negated: false,
 };
 
 const squareFact: Fact = {
@@ -22,6 +23,7 @@ const squareFact: Fact = {
   receiver: "s",
   property: "kind",
   literal: "square",
+  negated: false,
 };
 
 before(async () => {
@@ -43,10 +45,26 @@ describe("definedness", () => {
   it("finds negated in-scope fact and flags it", () => {
     const env = createAssumptionEnv();
     enterFrame(env);
-    pushFact(env, { ...circleFact, literal: "!(circle)" });
+    pushFact(env, { ...circleFact, negated: true });
 
     assert.deepEqual(discriminantFactsInScope(env, "s", "kind"), [
       { literal: "circle", negated: true },
+    ]);
+  });
+
+  it("preserves literals shaped like the old negation sentinel", () => {
+    const env = createAssumptionEnv();
+    enterFrame(env);
+    pushFact(env, {
+      kind: "discriminant",
+      receiver: "s",
+      property: "kind",
+      literal: "!(circle)",
+      negated: false,
+    });
+
+    assert.deepEqual(discriminantFactsInScope(env, "s", "kind"), [
+      { literal: "!(circle)", negated: false },
     ]);
   });
 
@@ -109,7 +127,7 @@ describe("definedness", () => {
     pushFact(env, circleFact);
     pushFact(env, circleFact);
     enterFrame(env);
-    pushFact(env, { ...circleFact, literal: "!(circle)" });
+    pushFact(env, { ...circleFact, negated: true });
     pushFact(env, squareFact);
 
     assert.deepEqual(discriminantFactsInScope(env, "s", "kind"), [

--- a/tools/ts2pant/tests/narrowing-integration.test.mts
+++ b/tools/ts2pant/tests/narrowing-integration.test.mts
@@ -63,7 +63,7 @@ function setupFunction(source: string): {
 }
 
 function cloneEnv(env: AssumptionEnv): AssumptionEnv {
-  return { frames: env.frames.map((frame) => new Set(frame)) };
+  return { frames: env.frames.map((frame) => new Map(frame)) };
 }
 
 function envAt(

--- a/tools/ts2pant/tests/narrowing-integration.test.mts
+++ b/tools/ts2pant/tests/narrowing-integration.test.mts
@@ -85,7 +85,8 @@ function assertDiscriminant(
     kind: "discriminant",
     receiver: "s",
     property,
-    literal: negated ? `!(${literal})` : literal,
+    literal,
+    negated,
   };
   assert.ok(
     queryFact(env, expected),

--- a/tools/ts2pant/tests/narrowing-recognizer.test.mts
+++ b/tools/ts2pant/tests/narrowing-recognizer.test.mts
@@ -55,10 +55,16 @@ function recognizeExpr(expr: string): Fact | null {
 
 function assertDiscriminant(
   actual: Fact | null,
-  expected: { receiver: string; property: string; literal: string },
+  expected: {
+    receiver: string;
+    property: string;
+    literal: string;
+    negated?: boolean;
+  },
 ): void {
   assert.deepEqual(actual, {
     kind: "discriminant",
+    negated: false,
     ...expected,
   });
 }
@@ -150,7 +156,8 @@ describe("narrowing-recognizer", () => {
     assertDiscriminant(recognizeExpr('s.kind !== "circle"'), {
       receiver: "s",
       property: "kind",
-      literal: "!(circle)",
+      literal: "circle",
+      negated: true,
     });
   });
 
@@ -158,7 +165,8 @@ describe("narrowing-recognizer", () => {
     assertDiscriminant(recognizeExpr('s.kind != "circle"'), {
       receiver: "s",
       property: "kind",
-      literal: "!(circle)",
+      literal: "circle",
+      negated: true,
     });
   });
 


### PR DESCRIPTION
## Patch 2: Assumption-env in-scope fact accessor + definedness-obligation renderer

- Change `AssumptionEnv.frames` from `Set<string>[]` to `Map<string, Fact>[]` (key = existing `factKey`); update `pushFact`/`queryFact` accordingly (query stays O(1) via `frame.has(key)`).
- Add `discriminantFactsInScope(env, receiver, property)`: scan all frames, collect every `Fact` of kind 'discriminant' matching `receiver` and `property`; map a `!(lit)`-sentinel literal to `{ literal: lit, negated: true }`, else `{ literal, negated: false }`. Return the list (dedup by literal+negated).
- Implement `renderDefinednessObligation({ receiver, discRule, requiredLiteral, inScope })`: consequent = `ast.binop(ast.opEq(), ast.app(ast.var(discRule), [receiver]), ast.litString(requiredLiteral))`; for each in-scope fact build `ast.binop(ast.opEq(), ast.app(ast.var(discRule), [receiver]), ast.litString(fact.literal))` wrapped in `ast.unop(ast.opNot(), …)` when `negated`; conjoin them as the antecedent; result = antecedent.length ? `ast.binop(ast.opImpl(), antecedent, consequent)` : `consequent`; return `{ text: getAst().strExpr(result) }`.
- Unit tests: `discriminantFactsInScope` finds a positive fact across frames; finds a negated fact and reports `negated: true`; returns `[]` for an unknown receiver. Renderer: positive in-scope fact → `shape--kind s = "circle" -> shape--kind s = "circle"`; negated → `~(shape--kind s = "circle") -> shape--kind s = "square"`; empty in-scope → bare `shape--kind s = "circle"`; assert the text never contains a variant-field rule name.

## Changes
- Change `AssumptionEnv.frames` from `Set<string>[]` to `Map<string, Fact>[]` (key = existing `factKey`); update `pushFact`/`queryFact` accordingly (query stays O(1) via `frame.has(key)`).
- Add `discriminantFactsInScope(env, receiver, property)`: scan all frames, collect every `Fact` of kind 'discriminant' matching `receiver` and `property`; map a `!(lit)`-sentinel literal to `{ literal: lit, negated: true }`, else `{ literal, negated: false }`. Return the list (dedup by literal+negated).
- Implement `renderDefinednessObligation({ receiver, discRule, requiredLiteral, inScope })`: consequent = `ast.binop(ast.opEq(), ast.app(ast.var(discRule), [receiver]), ast.litString(requiredLiteral))`; for each in-scope fact build `ast.binop(ast.opEq(), ast.app(ast.var(discRule), [receiver]), ast.litString(fact.literal))` wrapped in `ast.unop(ast.opNot(), …)` when `negated`; conjoin them as the antecedent; result = antecedent.length ? `ast.binop(ast.opImpl(), antecedent, consequent)` : `consequent`; return `{ text: getAst().strExpr(result) }`.
- Unit tests: `discriminantFactsInScope` finds a positive fact across frames; finds a negated fact and reports `negated: true`; returns `[]` for an unknown receiver. Renderer: positive in-scope fact → `shape--kind s = "circle" -> shape--kind s = "circle"`; negated → `~(shape--kind s = "circle") -> shape--kind s = "square"`; empty in-scope → bare `shape--kind s = "circle"`; assert the text never contains a variant-field rule name.

## Files to Modify
- tools/ts2pant/src/assumption-env.ts (modify): Make frame facts recoverable (key→Fact store) and add `discriminantFactsInScope`.
- tools/ts2pant/src/definedness-obligation.ts (create): Pure renderer producing the definedness check text over the total discriminant rule.
- tools/ts2pant/tests/definedness-obligation.test.mts (create): Unit tests for the accessor + renderer.

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[paper] Filliâtre & Paskevich, Why3 — Where Programs Meet Provers (weakest-precondition definedness VCs)** — https://link.springer.com/chapter/10.1007/978-3-642-37036-6_8 — The obligation `path-condition -> discriminant = literal` is exactly Why3's separate definedness verification condition for a partial-function application, here phrased over the total discriminant so the solver sees a non-vacuous goal. Informs the antecedent/consequent shape the renderer builds.

## Gameplan Specification

```
module DU_DISCRIMINANT_NARROWING.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> Variant-field access in a discriminated union is verified safe by
> synthesized definedness check goals phrased over the TOTAL discriminant
> rule (not the partial variant-field rule, which pant injects as a
> vacuity-inducing antecedent). For each variant-field read, ts2pant emits
> a check goal `<in-scope path condition> -> dom--disc s = "<lit>"`. A read
> narrowed by the correct discriminant entails; an un-narrowed or wrong read
> does not. Each DU domain emits a totality body proposition so the
> negation-based (else/default) goals discharge.

DuDomain.
Document.
VariantRead.
DiscRule.

total d: DiscRule => Bool.
discriminant-rule dom: DuDomain => DiscRule.
emitted-totality d: Document, dom: DuDomain => Bool.
has-domain d: Document, dom: DuDomain => Bool.

---

> The discriminant rule is total (unguarded); the variant-field rules are not.
all dom: DuDomain | total (discriminant-rule dom).

> Every DU domain carries a totality body proposition.
all d: Document, dom: DuDomain | has-domain d dom -> emitted-totality d dom.

where

> ══════════════════════════════════════════
> DEFINEDNESS GOALS
> ══════════════════════════════════════════
> Every variant-field read contributes a check goal over the total
> discriminant rule; the goal entails exactly when the in-scope path
> condition (from the M3a assumption env) implies the required tag.

reads d: Document, r: VariantRead => Bool.
in-checks d: Document, r: VariantRead => Bool.
over-total-rule r: VariantRead => Bool.
path-implies-tag r: VariantRead => Bool.
goal-entails r: VariantRead => Bool.

---

> Every read contributes a goal, phrased over a total rule (never vacuous).
all d: Document, r: VariantRead | reads d r -> in-checks d r.
all r: VariantRead | over-total-rule r.

> A goal entails exactly when narrowing put the tag in scope.
all r: VariantRead | goal-entails r <-> path-implies-tag r.

```

## Patch Specification

```
module DU_DISCRIMINANT_NARROWING_PATCH_2.

> Patch 2 adds recovery of in-scope discriminant facts from the
> assumption env and a renderer that builds a definedness obligation
> over the TOTAL discriminant rule (immune to guard-as-antecedent
> vacuity).

Receiver.
Property.
Obligation.
DiscRule.
total d: DiscRule => Bool.
rendered-over o: Obligation => DiscRule.
obligation-of r: Receiver, p: Property, lit: String => Obligation.
discriminant-rule p: Property => DiscRule.

---

> The discriminant rule is total (unguarded).
all p: Property | total (discriminant-rule p).

> Every rendered obligation is phrased over a total rule.
all r: Receiver, p: Property, lit: String |
  total (rendered-over (obligation-of r p lit)).

```


## Implementation Notes

- `AssumptionEnv` keeps the existing serialized `factKey` as the `Map` key, so `queryFact` remains the same O(1) frame lookup shape while the original `Fact` is recoverable for path-condition rendering. Snapshot helpers now clone maps instead of sets for the same reason.
- `discriminantFactsInScope` intentionally returns facts in frame insertion order and dedupes by `(literal, negated)`. Positive and negated facts for the same literal remain distinct because they render different antecedents.
- `renderDefinednessObligation` takes the receiver as an `OpaqueExpr`, not a string, so the later read-site integration can pass the already-lowered receiver expression without reparsing or text reconstruction. The in-scope fact lookup remains string-keyed to match the existing recognizer contract.
- No behavioral pipeline wiring is included in this patch; the new renderer is pure infrastructure for Patch 4. The only non-test call-site adjustments are map-clone updates required by the changed env representation.

Spec/Evidence Mapping:
- Recover in-scope discriminant facts: `tools/ts2pant/src/assumption-env.ts::discriminantFactsInScope`; informed by `tools/ts2pant/src/narrowing-recognizer.ts` sentinel negation format; covered by `definedness-obligation.test.mts` positive, negated, unknown receiver, and dedupe cases.
- Render obligations over the total discriminant rule: `tools/ts2pant/src/definedness-obligation.ts::renderDefinednessObligation`; informed by `REFERENCE.md` and the DU entailment survey guard-as-antecedent findings; covered by renderer tests asserting the expected implication text and absence of a variant-field rule name.
- Regression/static checks run: `npm run -s build`, `npm test`, `npm run -s lint`, and `git diff --check`.