### PR TITLE
[ts2pant-du-discriminant-narrowing] Patch 1: DU totality-invariant builder + emit channel (assertions returned, not yet threaded)

### DIFF
--- a/tools/ts2pant/src/pipeline.ts
+++ b/tools/ts2pant/src/pipeline.ts
@@ -167,7 +167,7 @@ export async function buildPantDocument(
   // After both sig and types have registered their Maps, emit the synth
   // decls (one domain + membership predicate + guarded value rule per
   // unique (K, V)). Splice before sigDecl so the sig's references resolve.
-  const synthDecls = cellEmitSynth(synthCell);
+  const { decls: synthDecls } = cellEmitSynth(synthCell);
 
   // Module-level `const NAME = <literal>` declarations map onto 0-arity
   // rules + body equations. Done after `translateSignature` so the
@@ -225,7 +225,7 @@ export async function buildPantDocument(
   // initial signature/type drain above. Drain once more before building
   // the declaration list so those rule heads have their domains in the
   // same document even if body translation does not register anything new.
-  const refFnSynthDecls = cellEmitSynth(synthCell);
+  const { decls: refFnSynthDecls } = cellEmitSynth(synthCell);
   const collisionSafeFnDecls = filterRuleCollisions(fnDecls, [
     ...typeDecls,
     ...synthDecls,
@@ -280,7 +280,7 @@ export async function buildPantDocument(
     // (e.g., `build().get(k)!` where `build`'s return type wasn't surfaced
     // through the signature or referenced types). cellEmitSynth is
     // incremental, so this returns only entries new since the pre-body emit.
-    const extraSynthDecls = cellEmitSynth(synthCell);
+    const { decls: extraSynthDecls } = cellEmitSynth(synthCell);
     if (extraSynthDecls.length > 0) {
       doc = {
         ...doc,

--- a/tools/ts2pant/src/translate-types.ts
+++ b/tools/ts2pant/src/translate-types.ts
@@ -700,20 +700,31 @@ export function buildDiscriminatedUnionTotalityAssertion(
   entry: DiscriminatedUnionSynthEntry,
   ast = getAst(),
 ): PropResult {
-  const body = disjunction(
-    entry.variants.map((variant) =>
+  const comparisons: OpaqueExpr[] = [];
+  for (const variant of entry.variants) {
+    const lit = literalExpr(variant.literal);
+    if (!lit) {
+      return {
+        kind: "unsupported",
+        reason: `unsupported discriminant literal in ${entry.domain}`,
+      };
+    }
+    comparisons.push(
       ast.binop(
         ast.opEq(),
         ast.app(ast.var(fieldRuleName(entry.domain, entry.discriminant)), [
           ast.var(entry.binder),
         ]),
-        literalExpr(variant.literal)!,
+        lit,
       ),
-    ),
-    ast,
-  );
+    );
+  }
+  const body = disjunction(comparisons, ast);
   if (!body) {
-    throw new Error(`discriminated union ${entry.domain} has no variants`);
+    return {
+      kind: "unsupported",
+      reason: `discriminated union ${entry.domain} has no variants`,
+    };
   }
   return {
     kind: "assertion",

--- a/tools/ts2pant/src/translate-types.ts
+++ b/tools/ts2pant/src/translate-types.ts
@@ -9,7 +9,7 @@ import {
 import { OPAQUE_DOMAIN, opaqueValueRuleName } from "./opaque.js";
 import type { OpaqueExpr } from "./pant-ast.js";
 import { getAst } from "./pant-wasm.js";
-import type { PantDeclaration } from "./types.js";
+import type { PantDeclaration, PropResult } from "./types.js";
 
 /**
  * Sentinel returned by `mapTsType` when an anonymous-record type is
@@ -687,14 +687,39 @@ export function detectDiscriminatedUnion(
   return null;
 }
 
-function disjunction(exprs: OpaqueExpr[]): OpaqueExpr | null {
+function disjunction(exprs: OpaqueExpr[], ast = getAst()): OpaqueExpr | null {
   if (exprs.length === 0) {
     return null;
   }
-  const ast = getAst();
   return exprs
     .slice(1)
     .reduce((acc, expr) => ast.binop(ast.opOr(), acc, expr), exprs[0]!);
+}
+
+export function buildDiscriminatedUnionTotalityAssertion(
+  entry: DiscriminatedUnionSynthEntry,
+  ast = getAst(),
+): PropResult {
+  const body = disjunction(
+    entry.variants.map((variant) =>
+      ast.binop(
+        ast.opEq(),
+        ast.app(ast.var(fieldRuleName(entry.domain, entry.discriminant)), [
+          ast.var(entry.binder),
+        ]),
+        literalExpr(variant.literal)!,
+      ),
+    ),
+    ast,
+  );
+  if (!body) {
+    throw new Error(`discriminated union ${entry.domain} has no variants`);
+  }
+  return {
+    kind: "assertion",
+    quantifiers: [ast.param(entry.binder, ast.tName(entry.domain))],
+    body,
+  };
 }
 
 function discriminatedUnionShapeKey(
@@ -816,10 +841,12 @@ export function emitDiscriminatedUnionSynthDecls(
   registry: NameRegistry,
 ): {
   decls: PantDeclaration[];
+  assertions: PropResult[];
   synth: DiscriminatedUnionSynth;
   registry: NameRegistry;
 } {
   const decls: PantDeclaration[] = [];
+  const assertions: PropResult[] = [];
   const ast = getAst();
   const newEmitted = new Set(synth.emitted);
   for (const [key, entry] of synth.byShape) {
@@ -827,6 +854,7 @@ export function emitDiscriminatedUnionSynthDecls(
       continue;
     }
     newEmitted.add(key);
+    assertions.push(buildDiscriminatedUnionTotalityAssertion(entry, ast));
     const discRule = fieldRuleName(entry.domain, entry.discriminant);
     const guardByVariant = new Map<string, OpaqueExpr>();
     for (const variant of entry.variants) {
@@ -869,6 +897,7 @@ export function emitDiscriminatedUnionSynthDecls(
   }
   return {
     decls,
+    assertions,
     synth: { byShape: synth.byShape, emitted: newEmitted },
     registry,
   };
@@ -1524,7 +1553,10 @@ export function cellIsUsed(cell: SynthCell, name: string): boolean {
  *  Tuple-constructor synth is *not* drained here — tuple constructors
  *  emit to a separate per-source-file dep module via
  *  `emitTupleCtorModule`, not into the consumer document's head. */
-export function cellEmitSynth(cell: SynthCell): PantDeclaration[] {
+export function cellEmitSynth(cell: SynthCell): {
+  decls: PantDeclaration[];
+  assertions: PropResult[];
+} {
   const opaqueR = emitOpaqueSynthDecls(cell.opaqueSynth, cell.registry);
   cell.opaqueSynth = opaqueR.synth;
   cell.registry = opaqueR.registry;
@@ -1540,7 +1572,10 @@ export function cellEmitSynth(cell: SynthCell): PantDeclaration[] {
   const recR = emitRecordSynthDecls(cell.recordSynth, cell.registry);
   cell.recordSynth = recR.synth;
   cell.registry = recR.registry;
-  return [...opaqueR.decls, ...mapR.decls, ...duR.decls, ...recR.decls];
+  return {
+    decls: [...opaqueR.decls, ...mapR.decls, ...duR.decls, ...recR.decls],
+    assertions: duR.assertions,
+  };
 }
 
 /**

--- a/tools/ts2pant/tests/du-totality.test.mts
+++ b/tools/ts2pant/tests/du-totality.test.mts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  createSourceFileFromSource,
+  extractAllTypes,
+  getChecker,
+} from "../src/extract.js";
+import { getAst, loadAst } from "../src/pant-wasm.js";
+import {
+  buildDiscriminatedUnionTotalityAssertion,
+  cellEmitSynth,
+  cellRegisterDiscriminatedUnion,
+  type DiscriminatedUnionSynthEntry,
+  detectDiscriminatedUnion,
+  IntStrategy,
+  newSynthCell,
+} from "../src/translate-types.js";
+
+function extractFirstAlias(source: string) {
+  const sourceFile = createSourceFileFromSource(source);
+  const extracted = extractAllTypes(sourceFile);
+  const checker = getChecker(sourceFile);
+  const alias = extracted.aliases[0];
+  assert.ok(alias);
+  return { alias, checker };
+}
+
+describe("du-totality", () => {
+  it("builder emits disjunction over all variant literals", async () => {
+    await loadAst();
+    const ast = getAst();
+    const entry: DiscriminatedUnionSynthEntry = {
+      domain: "Shape",
+      binder: "s",
+      discriminant: "kind",
+      discriminantType: "String",
+      variants: [
+        { key: "string:circle", literal: { kind: "string", value: "circle" } },
+        { key: "string:square", literal: { kind: "string", value: "square" } },
+      ],
+      fields: [],
+    };
+
+    const assertion = buildDiscriminatedUnionTotalityAssertion(entry, ast);
+    if (assertion.kind !== "assertion") {
+      throw new Error("expected assertion");
+    }
+    assert.equal(
+      ast.strExpr(ast.forall(assertion.quantifiers, [], assertion.body)),
+      'all s: Shape | shape--kind s = "circle" or shape--kind s = "square"',
+    );
+  });
+
+  it("cellEmitSynth returns one assertion per newly-emitted DU domain", async () => {
+    await loadAst();
+    const { alias, checker } = extractFirstAlias(`
+      type Shape =
+        | { kind: "circle"; r: number }
+        | { kind: "square"; s: number };
+    `);
+    const detected = detectDiscriminatedUnion(alias.type, checker);
+    assert.ok(detected);
+    const cell = newSynthCell();
+
+    assert.equal(
+      cellRegisterDiscriminatedUnion(
+        cell,
+        detected,
+        checker,
+        IntStrategy,
+        "Shape",
+      ),
+      "Shape",
+    );
+
+    const first = cellEmitSynth(cell);
+    assert.equal(first.assertions.length, 1);
+    assert.equal(first.assertions[0]!.kind, "assertion");
+    assert.equal(cellEmitSynth(cell).assertions.length, 0);
+  });
+});

--- a/tools/ts2pant/tests/du-totality.test.mts
+++ b/tools/ts2pant/tests/du-totality.test.mts
@@ -51,6 +51,40 @@ describe("du-totality", () => {
     );
   });
 
+  it("builder returns unsupported for empty variant lists", async () => {
+    await loadAst();
+    const assertion = buildDiscriminatedUnionTotalityAssertion({
+      domain: "Shape",
+      binder: "s",
+      discriminant: "kind",
+      discriminantType: "String",
+      variants: [],
+      fields: [],
+    });
+
+    assert.deepEqual(assertion, {
+      kind: "unsupported",
+      reason: "discriminated union Shape has no variants",
+    });
+  });
+
+  it("builder returns unsupported for unrenderable discriminant literals", async () => {
+    await loadAst();
+    const assertion = buildDiscriminatedUnionTotalityAssertion({
+      domain: "Shape",
+      binder: "s",
+      discriminant: "kind",
+      discriminantType: "Nat0",
+      variants: [{ key: "number:-1", literal: { kind: "number", value: -1 } }],
+      fields: [],
+    });
+
+    assert.deepEqual(assertion, {
+      kind: "unsupported",
+      reason: "unsupported discriminant literal in Shape",
+    });
+  });
+
   it("cellEmitSynth returns one assertion per newly-emitted DU domain", async () => {
     await loadAst();
     const { alias, checker } = extractFirstAlias(`

--- a/tools/ts2pant/tests/translate-types.test.mts
+++ b/tools/ts2pant/tests/translate-types.test.mts
@@ -53,6 +53,10 @@ function extractFirstAlias(source: string) {
   return { alias, checker, sourceFile };
 }
 
+function emitSynthDeclsOnly(cell: ReturnType<typeof newSynthCell>) {
+  return cellEmitSynth(cell).decls;
+}
+
 describe("numeric strategy", () => {
   it("IntStrategy maps number to Int", () => {
     const { decls } = extractAndTranslate(
@@ -294,7 +298,7 @@ describe("emitDiscriminatedUnionSynthDecls", () => {
     const output = emitDocument({
       moduleName: "TEST",
       imports: [],
-      declarations: cellEmitSynth(cell),
+      declarations: emitSynthDeclsOnly(cell),
       propositions: [],
       checks: [],
       bundleModules: new Map(),
@@ -336,7 +340,7 @@ describe("emitDiscriminatedUnionSynthDecls", () => {
       ],
     );
 
-    const decls = cellEmitSynth(cell);
+    const decls = emitSynthDeclsOnly(cell);
     assert.ok(
       decls.some(
         (decl) =>
@@ -382,10 +386,10 @@ describe("mapTsType", () => {
       }),
       OPAQUE_DOMAIN,
     );
-    assert.deepEqual(cellEmitSynth(cell), [
+    assert.deepEqual(emitSynthDeclsOnly(cell), [
       { kind: "domain", name: OPAQUE_DOMAIN },
     ]);
-    assert.deepEqual(cellEmitSynth(cell), []);
+    assert.deepEqual(emitSynthDeclsOnly(cell), []);
   });
 
   it("opaque fallback maps `unknown` to the shared Opaque sort", async () => {
@@ -402,7 +406,7 @@ describe("mapTsType", () => {
       }),
       OPAQUE_DOMAIN,
     );
-    assert.deepEqual(cellEmitSynth(cell), [
+    assert.deepEqual(emitSynthDeclsOnly(cell), [
       { kind: "domain", name: OPAQUE_DOMAIN },
     ]);
   });
@@ -421,7 +425,7 @@ describe("mapTsType", () => {
       }),
       "Int",
     );
-    assert.deepEqual(cellEmitSynth(cell), []);
+    assert.deepEqual(emitSynthDeclsOnly(cell), []);
   });
 
   it("opaque fallback disabled keeps `any` and `unknown` unsupported", () => {
@@ -471,7 +475,7 @@ describe("mapTsType", () => {
     );
     cellRegisterOpaqueValue(cell, "foo.ts:1");
 
-    assert.deepEqual(cellEmitSynth(cell), [
+    assert.deepEqual(emitSynthDeclsOnly(cell), [
       { kind: "domain", name: OPAQUE_DOMAIN },
       {
         kind: "rule",
@@ -482,7 +486,7 @@ describe("mapTsType", () => {
     ]);
 
     cellRegisterOpaqueValue(cell, "foo.ts:2");
-    assert.deepEqual(cellEmitSynth(cell), [
+    assert.deepEqual(emitSynthDeclsOnly(cell), [
       {
         kind: "rule",
         name: opaqueValueRuleName("foo.ts:2"),
@@ -507,7 +511,7 @@ describe("mapTsType", () => {
       "StringToListOpaqueMap",
     );
 
-    const decls = cellEmitSynth(cell);
+    const decls = emitSynthDeclsOnly(cell);
     assert.equal(decls.length, 4);
     assert.deepEqual(decls[0], { kind: "domain", name: OPAQUE_DOMAIN });
     assert.deepEqual(decls[1], {
@@ -535,7 +539,7 @@ describe("mapTsType", () => {
     assert.equal(decls[3].returnType, "[Opaque]");
 
     cellRegisterOpaqueValue(cell, "foo.ts:2");
-    assert.deepEqual(cellEmitSynth(cell), [
+    assert.deepEqual(emitSynthDeclsOnly(cell), [
       {
         kind: "rule",
         name: opaqueValueRuleName("foo.ts:2"),
@@ -774,7 +778,7 @@ describe("cellRegisterOpaqueValue / cellEmitSynth", () => {
   it("emits nothing while no opaque id is registered", async () => {
     await loadAst();
     const cell = newSynthCell();
-    assert.deepEqual(cellEmitSynth(cell), []);
+    assert.deepEqual(emitSynthDeclsOnly(cell), []);
   });
 
   it("emits the Opaque domain and one nullary constant per id on use", async () => {
@@ -788,7 +792,7 @@ describe("cellRegisterOpaqueValue / cellEmitSynth", () => {
     assert.equal(firstAgain.rule, first.rule);
     assert.equal(cellLookupOpaqueValue(cell, "foo.ts:2"), second);
 
-    assert.deepEqual(cellEmitSynth(cell), [
+    assert.deepEqual(emitSynthDeclsOnly(cell), [
       { kind: "domain", name: OPAQUE_DOMAIN },
       {
         kind: "rule",
@@ -803,10 +807,10 @@ describe("cellRegisterOpaqueValue / cellEmitSynth", () => {
         returnType: OPAQUE_DOMAIN,
       },
     ]);
-    assert.deepEqual(cellEmitSynth(cell), []);
+    assert.deepEqual(emitSynthDeclsOnly(cell), []);
 
     cellRegisterOpaqueValue(cell, "foo.ts:3");
-    assert.deepEqual(cellEmitSynth(cell), [
+    assert.deepEqual(emitSynthDeclsOnly(cell), [
       {
         kind: "rule",
         name: opaqueValueRuleName("foo.ts:3"),


### PR DESCRIPTION
## Patch 1: DU totality-invariant builder + emit channel (assertions returned, not yet threaded)

- Implement `buildDiscriminatedUnionTotalityAssertion(entry, ast)`: quantifier `[{ name: entry.binder, type: entry.domain }]`, body = `disjunction(entry.variants.map(v => ast.binop(ast.opEq(), ast.app(ast.var(fieldRuleName(entry.domain, entry.discriminant)), [ast.var(entry.binder)]), literalExpr(v.literal))))`. Return `{ kind: 'assertion', quantifiers, body }`.
- In `emitDiscriminatedUnionSynthDecls`, for each DU entry emitted this drain (same loop guarded by `newEmitted.has(key)`), build its totality assertion and accumulate into an `assertions: PropResult[]`; add `assertions` to the returned object.
- Change `cellEmitSynth` to aggregate `duR.assertions` and return `{ decls: [...opaqueR.decls, ...mapR.decls, ...duR.decls, ...recR.decls], assertions: duR.assertions }`.
- Update pipeline.ts callers (170/228/283) to `const { decls: synthDecls } = cellEmitSynth(...)` etc.; do not thread `assertions` yet.
- Unit tests: builder over a 2-variant union yields `all s: Shape | shape--kind s = "circle" or shape--kind s = "square"` (compare via `strExpr`); `cellEmitSynth` returns exactly one assertion after registering one DU shape, and none on a second (idempotent) drain.

## Changes
- Implement `buildDiscriminatedUnionTotalityAssertion(entry, ast)`: quantifier `[{ name: entry.binder, type: entry.domain }]`, body = `disjunction(entry.variants.map(v => ast.binop(ast.opEq(), ast.app(ast.var(fieldRuleName(entry.domain, entry.discriminant)), [ast.var(entry.binder)]), literalExpr(v.literal))))`. Return `{ kind: 'assertion', quantifiers, body }`.
- In `emitDiscriminatedUnionSynthDecls`, for each DU entry emitted this drain (same loop guarded by `newEmitted.has(key)`), build its totality assertion and accumulate into an `assertions: PropResult[]`; add `assertions` to the returned object.
- Change `cellEmitSynth` to aggregate `duR.assertions` and return `{ decls: [...opaqueR.decls, ...mapR.decls, ...duR.decls, ...recR.decls], assertions: duR.assertions }`.
- Update pipeline.ts callers (170/228/283) to `const { decls: synthDecls } = cellEmitSynth(...)` etc.; do not thread `assertions` yet.
- Unit tests: builder over a 2-variant union yields `all s: Shape | shape--kind s = "circle" or shape--kind s = "square"` (compare via `strExpr`); `cellEmitSynth` returns exactly one assertion after registering one DU shape, and none on a second (idempotent) drain.

## Files to Modify
- tools/ts2pant/src/translate-types.ts (modify): Add `buildDiscriminatedUnionTotalityAssertion`; extend `emitDiscriminatedUnionSynthDecls` to also return `assertions: PropResult[]` (one per newly-emitted DU domain, gated by the same `emitted` set); extend `cellEmitSynth` return to `{ decls, assertions }`.
- tools/ts2pant/src/pipeline.ts (modify): Update the 3 `cellEmitSynth` call sites to destructure `{ decls }`; ignore `assertions` for now (no output change).
- tools/ts2pant/tests/du-totality.test.mts (create): Unit tests for the totality builder + emit channel.

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[algorithm] McCarthy theory of arrays + Dafny-style precondition guards** — https://doi.org/10.1145/321033.321034 — The totality invariant is the closed-world cover for the discriminant viewed as a selector: the union of variant-literal equalities, the dual of the disjointness that function-value semantics already give for free. Shapes the disjunction the builder emits.

## Gameplan Specification

```
module DU_DISCRIMINANT_NARROWING.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> Variant-field access in a discriminated union is verified safe by
> synthesized definedness check goals phrased over the TOTAL discriminant
> rule (not the partial variant-field rule, which pant injects as a
> vacuity-inducing antecedent). For each variant-field read, ts2pant emits
> a check goal `<in-scope path condition> -> dom--disc s = "<lit>"`. A read
> narrowed by the correct discriminant entails; an un-narrowed or wrong read
> does not. Each DU domain emits a totality body proposition so the
> negation-based (else/default) goals discharge.

DuDomain.
Document.
VariantRead.
DiscRule.

total d: DiscRule => Bool.
discriminant-rule dom: DuDomain => DiscRule.
emitted-totality d: Document, dom: DuDomain => Bool.
has-domain d: Document, dom: DuDomain => Bool.

---

> The discriminant rule is total (unguarded); the variant-field rules are not.
all dom: DuDomain | total (discriminant-rule dom).

> Every DU domain carries a totality body proposition.
all d: Document, dom: DuDomain | has-domain d dom -> emitted-totality d dom.

where

> ══════════════════════════════════════════
> DEFINEDNESS GOALS
> ══════════════════════════════════════════
> Every variant-field read contributes a check goal over the total
> discriminant rule; the goal entails exactly when the in-scope path
> condition (from the M3a assumption env) implies the required tag.

reads d: Document, r: VariantRead => Bool.
in-checks d: Document, r: VariantRead => Bool.
over-total-rule r: VariantRead => Bool.
path-implies-tag r: VariantRead => Bool.
goal-entails r: VariantRead => Bool.

---

> Every read contributes a goal, phrased over a total rule (never vacuous).
all d: Document, r: VariantRead | reads d r -> in-checks d r.
all r: VariantRead | over-total-rule r.

> A goal entails exactly when narrowing put the tag in scope.
all r: VariantRead | goal-entails r <-> path-implies-tag r.

```

## Patch Specification

```
module DU_DISCRIMINANT_NARROWING_PATCH_1.

> Patch 1 adds the DU totality-invariant builder and an emit channel
> that surfaces assertions alongside declarations. No assertion reaches
> the document yet (callers ignore them).

DuEntry.
Variant.
Assertion.
totality-of e: DuEntry => Assertion.
variant-of e: DuEntry => Variant.
covers a: Assertion, v: Variant => Bool.

---

> The built totality assertion covers the entry's variants.
all e: DuEntry | covers (totality-of e) (variant-of e).

```


## Implementation Notes

- `PropResult.quantifiers` are wasm `OpaqueParam` handles, not plain `{ name, type }` objects. The builder therefore returns `quantifiers: [ast.param(entry.binder, ast.tName(entry.domain))]`; the rendered assertion still matches the planned `all s: Shape | ...` shape.
- `cellEmitSynth` now exposes only DU assertions in the new `assertions` channel. Opaque, Map, and Record synths remain declaration-only, so this keeps the return shape narrow for Patch 1 and avoids inventing empty assertion channels for unrelated synths.
- The assertion is generated at the same incremental drain point as the DU declarations, immediately after the emitted-set gate is crossed. That makes assertion emission idempotent under the existing synth drain semantics.
- `disjunction` now accepts an optional `ast` instance so the totality builder can consistently use the caller-provided wasm AST module when constructing and rendering expressions.

Spec/Evidence Mapping:
- Patch spec `totality-of e` covers each `variant-of e`: `buildDiscriminatedUnionTotalityAssertion` in `tools/ts2pant/src/translate-types.ts` maps every `entry.variants` literal into a discriminant equality and folds them with `or`; covered by `du-totality > builder emits disjunction over all variant literals`.
- Patch requirement that assertions are surfaced but not threaded: `emitDiscriminatedUnionSynthDecls` and `cellEmitSynth` return `assertions`, while `pipeline.ts` destructures only `decls`; verified by unchanged integration snapshots/checks under `npm test -- --runInBand` and `just ts2pant-precommit`.
- Idempotent drain requirement: `emitDiscriminatedUnionSynthDecls` pushes an assertion only after passing `newEmitted.has(key)`; covered by `du-totality > cellEmitSynth returns one assertion per newly-emitted DU domain`.
- Required context consulted: `REFERENCE.md`, `tools/ts2pant/docs/du-entailment-narrowing-survey.md`, `workstreams/ts2pant-discriminated-union.md`, and the existing DU encoding in `tools/ts2pant/src/translate-types.ts`.