### PR TITLE
Ground finite-domain quantifiers into quantifier-free expansions

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -18,6 +18,7 @@ let check_bound = ref 3
 let solver_cmd = ref "z3"
 let solver_timeout = ref 30.0
 let check_steps = ref 5
+let no_ground_quantifiers = ref false
 let dump_smt_dir = ref ""
 let module_path = ref "."
 let files = ref []
@@ -56,6 +57,10 @@ let specs =
     ( "--dump-smt",
       Arg.Set_string dump_smt_dir,
       "DIR  Write generated SMT-LIB2 queries to DIR" );
+    ( "--no-ground-quantifiers",
+      Arg.Set no_ground_quantifiers,
+      " Emit native forall/exists instead of grounding finite-domain \
+       quantifiers" );
     ( "--version",
       Arg.Unit
         (fun () ->
@@ -93,6 +98,8 @@ let run_smt_check env doc =
     let config =
       Pantagruel.Smt.make_config ~bound:!check_bound ~steps:!check_steps
         ~domain_bounds ~inject_guards:true
+        ~ground_quantifiers:(not !no_ground_quantifiers)
+        ()
     in
     let queries = Pantagruel.Smt.generate_queries config env doc in
     if !dump_smt_dir <> "" then begin

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -167,7 +167,13 @@ let check_doc doc =
         List.iter
           (fun w -> prerr_endline (Pantagruel.Error.format_type_warning w))
           warnings;
-        if !do_check then run_smt_check env doc
+        if !do_check then
+          (* Identity-lower list-typed aliases used only as opaque identities,
+             so the SMT encoding avoids arrays-indexed-by-arrays. *)
+          let env, doc =
+            Pantagruel.Module.lower_identity_aliases registry env doc
+          in
+          run_smt_check env doc
         else if !do_normalize <> "" then begin
           let root = !do_normalize in
           let all_names =

--- a/fuzz/fuzz_smt.ml
+++ b/fuzz/fuzz_smt.ml
@@ -28,6 +28,7 @@ let translate_and_check (doc : Ast.document) =
           let domain_bounds = Smt.compute_domain_bounds 3 env in
           let config =
             Smt.make_config ~bound:3 ~steps:1 ~domain_bounds ~inject_guards:true
+              ()
           in
           let queries = Smt.generate_queries config env doc in
           List.iter

--- a/lib/lower_aliases.ml
+++ b/lib/lower_aliases.ml
@@ -1,0 +1,45 @@
+(** Identity-lowering of list-typed aliases.
+
+    A type alias [T = [D]] is normally expanded to the SMT sort [Array D Bool].
+    When the spec never destructures a value of type [T] as a list, [T] is used
+    purely as an opaque identity, and lowering it to a domain sort (a) is
+    faithful to that usage and (b) keeps the SMT encoding out of the
+    arrays-indexed-by-arrays regime, which the solver cannot decide (a
+    list-of-[T] would otherwise become [Array (Array D Bool) Bool]).
+
+    Detection is delegated to the type checker rather than a bespoke syntactic
+    analysis: tentatively rewriting [T] to a domain and re-checking the document
+    is a sound oracle — any list operation on a now-opaque [T] (membership,
+    cardinality, comprehension source) becomes a type error. See
+    [Module.lower_identity_aliases] for the oracle loop. *)
+
+open Ast
+
+(** Names of aliases whose definition is a list type ([T = [D]]) — the
+    candidates for identity lowering. *)
+let list_alias_candidates (doc : document) : string list =
+  List.concat_map
+    (fun (ch : chapter) ->
+      List.filter_map
+        (fun (d : declaration located) ->
+          match[@warning "-4"] d.value with
+          | DeclAlias (Upper name, TList _) -> Some name
+          | _ -> None)
+        ch.head)
+    doc.chapters
+
+(** Rewrite each [DeclAlias (T, _)] with [T] in [names] to [DeclDomain T],
+    leaving everything else untouched. *)
+let rewrite_to_domains (doc : document) (names : string list) : document =
+  let lower (d : declaration located) =
+    match[@warning "-4"] d.value with
+    | DeclAlias (Upper name, _) when List.mem name names ->
+        { d with value = DeclDomain (Upper name) }
+    | _ -> d
+  in
+  let chapters =
+    List.map
+      (fun (ch : chapter) -> { ch with head = List.map lower ch.head })
+      doc.chapters
+  in
+  { doc with chapters }

--- a/lib/module.ml
+++ b/lib/module.ml
@@ -224,3 +224,39 @@ let check_with_imports registry (doc : Ast.document) =
   match Check.check_document full_env doc with
   | Ok warnings -> Ok (full_env, warnings)
   | Error e -> Error (ParseError ("<main>", Error.format_type_error e))
+
+(** Identity-lower list-typed aliases that are never destructured as lists,
+    returning the lowered [(env, doc)]. Uses [check_with_imports] as a soundness
+    oracle: an alias is lowered to a domain only if the rewritten document still
+    type-checks (a list operation on a now-opaque alias is a type error). The
+    maximal safe subset of candidates is lowered. When nothing is lowerable the
+    original [(env, doc)] is returned unchanged, so the common case adds no work
+    beyond a single candidate scan. *)
+let lower_identity_aliases registry (env : Env.t) (doc : Ast.document) :
+    Env.t * Ast.document =
+  match Lower_aliases.list_alias_candidates doc with
+  | [] -> (env, doc)
+  | candidates -> (
+      let type_checks names =
+        match
+          check_with_imports registry
+            (Lower_aliases.rewrite_to_domains doc names)
+        with
+        | Ok _ -> true
+        | Error _ -> false
+      in
+      (* Fast path: try lowering all candidates at once; otherwise greedily keep
+         the maximal safe subset. *)
+      let safe =
+        if type_checks candidates then candidates
+        else
+          List.fold_left
+            (fun acc c -> if type_checks (c :: acc) then c :: acc else acc)
+            [] candidates
+      in
+      if safe = [] then (env, doc)
+      else
+        let doc' = Lower_aliases.rewrite_to_domains doc safe in
+        match check_with_imports registry doc' with
+        | Ok (env', _warnings) -> (env', doc')
+        | Error _ -> (env, doc))

--- a/lib/smt.ml
+++ b/lib/smt.ml
@@ -965,6 +965,173 @@ and translate_quantifier config env quant params guards body =
      on guard expressions (e.g., GIn list exprs) can resolve them. *)
   let param_bindings = resolve_param_bindings env params in
   let env = Env.with_vars param_bindings env in
+  (* Try grounding finite-domain binders into a quantifier-free expansion; fall
+     back to native forall/exists emission when nothing is groundable, the
+     instance count exceeds the cap, or grounding is disabled. *)
+  match
+    if config.ground_quantifiers then
+      try_ground_quantifier config env quant params guards body
+    else None
+  with
+  | Some grounded -> grounded
+  | None -> emit_native_quantifier config env quant params guards body
+
+(** Infer the element type of a membership's right-hand side: [Some elem_ty] for
+    a list, or [Some (TyDomain _)] for iterating a domain directly. Falls back
+    to unpriming the expression (for invariant-preservation queries where the
+    primed name isn't in the type environment). Shared by the native [GIn] arm
+    and the grounding groundability check so primed lists resolve consistently.
+*)
+and infer_membership_elem_ty env list_expr =
+  let infer e =
+    match[@warning "-4"] Check.infer_type { Check.env; loc = dummy_loc } e with
+    | Ok (TyList elem_ty) -> Some elem_ty
+    | Ok (TyDomain _ as ty) -> Some ty
+    | _ -> None
+  in
+  match infer list_expr with
+  | Some _ as r -> r
+  | None -> infer (unprime_expr list_expr)
+
+(** Attempt to ground a quantifier over finite-domain binders. Returns
+    [Some smt] when at least one binder ranges over a finite [TyDomain] (bound >
+    0) and the cartesian-product instance count is within [ground_instance_cap];
+    otherwise [None] to fall through to native emission. Groundable binders are
+    eliminated by substituting each domain-element constant; ungroundable
+    binders (e.g. over Nat/Int) are kept and re-emitted natively by the
+    recursive call. A grounded [GIn] membership survives as a per-instance
+    condition. *)
+and try_ground_quantifier config env quant params guards body =
+  let elems_for_domain d =
+    let b = bound_for config d in
+    if b > 0 then Some (domain_elements d b) else None
+  in
+  let param_domain (p : param) =
+    match[@warning "-4"] Collect.resolve_type env p.param_type dummy_loc with
+    | Ok (TyDomain d) -> (
+        match elems_for_domain d with
+        | Some elems -> Some (d, elems)
+        | None -> None)
+    | _ -> None
+  in
+  (* Partition head params into groundable [(name, domain, elems, no-membership)]
+     and residual params (kept as native binders). *)
+  let head_ground, head_residual =
+    List.partition_map
+      (fun (p : param) ->
+        match param_domain p with
+        | Some (d, elems) ->
+            Either.Left (Ast.lower_name p.param_name, d, elems, None)
+        | None -> Either.Right p)
+      params
+  in
+  (* Same for guard binders. A grounded [GIn] carries its list expression as
+     [Some list_expr] so the membership can be re-emitted as a per-instance
+     condition; [GExpr] guards are always residual conditions. *)
+  let guard_ground, guard_residual =
+    List.fold_right
+      (fun g (gacc, racc) ->
+        match g with
+        | GParam p -> (
+            match param_domain p with
+            | Some (d, elems) ->
+                ((Ast.lower_name p.param_name, d, elems, None) :: gacc, racc)
+            | None -> (gacc, g :: racc))
+        | GIn (Lower name, list_expr) -> (
+            match[@warning "-4"] infer_membership_elem_ty env list_expr with
+            | Some (TyDomain d) -> (
+                match elems_for_domain d with
+                | Some elems -> ((name, d, elems, Some list_expr) :: gacc, racc)
+                | None -> (gacc, g :: racc))
+            | _ -> (gacc, g :: racc))
+        | GExpr _ -> (gacc, g :: racc))
+      guards ([], [])
+  in
+  let grounds = head_ground @ guard_ground in
+  match grounds with
+  | [] -> None
+  | _ ->
+      let product_size =
+        List.fold_left
+          (fun acc (_, _, elems, _) -> acc * List.length elems)
+          1 grounds
+      in
+      if product_size > ground_instance_cap then begin
+        Printf.eprintf
+          "warning: ground-quantifiers: %d instances exceed cap %d for a \
+           quantifier; emitting native quantifier instead\n\
+           %!"
+          product_size ground_instance_cap;
+        None
+      end
+      else begin
+        (* Bind every grounded element constant to its domain type so that type
+           inference on the substituted body/guards (e.g. inferring the element
+           type of [items Thing_0]) still resolves — the synthetic constants are
+           not otherwise present in the type environment. *)
+        let elem_type_bindings =
+          List.concat_map
+            (fun (_, d, elems, _) -> List.map (fun e -> (e, TyDomain d)) elems)
+            grounds
+        in
+        let env = Env.with_vars elem_type_bindings env in
+        (* Cartesian product of the per-binder element choices. *)
+        let rec cartesian = function
+          | [] -> [ [] ]
+          | xs :: rest ->
+              let tails = cartesian rest in
+              List.concat_map (fun x -> List.map (fun t -> x :: t) tails) xs
+        in
+        let choices =
+          List.map
+            (fun (n, _, elems, m) -> List.map (fun e -> (n, e, m)) elems)
+            grounds
+        in
+        let subst_guard subst = function
+          | GParam _ as g -> g
+          | GIn (n, xs) -> GIn (n, Smt_expr.substitute_vars subst xs)
+          | GExpr e -> GExpr (Smt_expr.substitute_vars subst e)
+        in
+        let instances =
+          List.map
+            (fun assignment ->
+              let subst =
+                List.map (fun (n, e, _) -> (n, EVar (Lower e))) assignment
+              in
+              (* Grounded GIn memberships become per-instance conditions so the
+                 antecedent/conjunct semantics are preserved. *)
+              let membership_guards =
+                List.filter_map
+                  (fun (_, e, m) ->
+                    match m with
+                    | Some list_expr ->
+                        Some
+                          (GExpr
+                             (EBinop
+                                ( OpIn,
+                                  EVar (Lower e),
+                                  Smt_expr.substitute_vars subst list_expr )))
+                    | None -> None)
+                  assignment
+              in
+              let residual_guards =
+                List.map (subst_guard subst) guard_residual @ membership_guards
+              in
+              let body' = Smt_expr.substitute_vars subst body in
+              translate_quantifier config env quant head_residual
+                residual_guards body')
+            (cartesian choices)
+        in
+        let connective = if quant = "forall" then "and" else "or" in
+        match instances with
+        | [ single ] -> Some single
+        | _ ->
+            Some
+              (Printf.sprintf "(%s %s)" connective
+                 (String.concat " " instances))
+      end
+
+and emit_native_quantifier config env quant params guards body =
   (* Collect bindings, guard conditions, and type constraints for Nat/Nat0 *)
   let nat_constraint_of_param env (p : param) =
     match Collect.resolve_type env p.param_type dummy_loc with
@@ -1034,23 +1201,10 @@ and translate_quantifier config env quant params guards body =
               conds,
               env )
         | GIn (Lower name, list_expr) ->
-            (* Bind name as element type; resolve from list expression type *)
-            let infer_elem_ty e =
-              match[@warning "-4"]
-                Check.infer_type { Check.env; loc = dummy_loc } e
-              with
-              | Ok (TyList elem_ty) -> Some elem_ty
-              | Ok (TyDomain _ as ty) -> Some ty
-              | _ -> None
-            in
-            (* When the expression has been primed (for invariant preservation
-               checks), the primed name won't be in the type environment.
-               Fall back to unpriming before inference. *)
-            let elem_ty_opt =
-              match infer_elem_ty list_expr with
-              | Some _ as r -> r
-              | None -> infer_elem_ty (unprime_expr list_expr)
-            in
+            (* Bind name as element type; resolve from list expression type.
+               Shared with the grounding groundability check via
+               [infer_membership_elem_ty] (handles the primed-list fallback). *)
+            let elem_ty_opt = infer_membership_elem_ty env list_expr in
             let elem_sort =
               match elem_ty_opt with
               | Some elem_ty -> sort_of_ty elem_ty
@@ -1101,16 +1255,19 @@ and translate_quantifier config env quant params guards body =
     param_type_conditions @ List.rev guard_conditions @ app_guard_strs
   in
   let binding_str = String.concat " " all_bindings in
-  match (quant, conditions) with
-  | "forall", _ :: _ ->
-      Printf.sprintf "(%s (%s) (=> (and %s) %s))" quant binding_str
-        (String.concat " " conditions)
+  let cond_str = String.concat " " conditions in
+  match (all_bindings, quant, conditions) with
+  (* Zero-binder base case (e.g. after fully grounding a quantifier): emit the
+     conditioned body directly, with no degenerate empty binder list. *)
+  | [], "forall", _ :: _ -> Printf.sprintf "(=> (and %s) %s)" cond_str body_str
+  | [], "exists", _ :: _ -> Printf.sprintf "(and %s %s)" cond_str body_str
+  | [], _, _ -> body_str
+  | _, "forall", _ :: _ ->
+      Printf.sprintf "(%s (%s) (=> (and %s) %s))" quant binding_str cond_str
         body_str
-  | "exists", _ :: _ ->
-      Printf.sprintf "(%s (%s) (and %s %s))" quant binding_str
-        (String.concat " " conditions)
-        body_str
-  | _ -> Printf.sprintf "(%s (%s) %s)" quant binding_str body_str
+  | _, "exists", _ :: _ ->
+      Printf.sprintf "(%s (%s) (and %s %s))" quant binding_str cond_str body_str
+  | _, _, _ -> Printf.sprintf "(%s (%s) %s)" quant binding_str body_str
 
 and translate_cond config env = function[@warning "-4"]
   | [] -> assert false

--- a/lib/smt_types.ml
+++ b/lib/smt_types.ml
@@ -7,6 +7,14 @@ type config = {
   steps : int;
   domain_bounds : int Env.StringMap.t;
   inject_guards : bool;
+  ground_quantifiers : bool;
+      (** When true, quantifiers whose binders range over finite domain sorts
+          are expanded ("grounded") into quantifier-free conjunctions /
+          disjunctions over the enumerated domain elements, instead of being
+          emitted as native SMT [forall]/[exists]. This trades a larger formula
+          for a quantifier-free one, which the solver decides far more reliably
+          (no dependence on quantifier-instantiation heuristics) for both sat-
+          and unsat-seeking checks. *)
   quant_bound : string list;
       (** Accumulated quantifier-bound variable names from enclosing scopes.
           Used by [collect_body_guards] so that guard injection does not
@@ -17,8 +25,22 @@ type config = {
     nullary constant counts). [quant_bound] is internal traversal state — use
     [make_config] to construct. *)
 
-let make_config ~bound ~steps ~domain_bounds ~inject_guards =
-  { bound; steps; domain_bounds; inject_guards; quant_bound = [] }
+(** Maximum number of grounded instances a single quantifier node may expand to.
+    Above this, the node falls back to a native [forall]/[exists] (with a
+    visible SMT comment) rather than expanding, bounding formula blow-up from
+    high-arity / high-bound quantifiers. *)
+let ground_instance_cap = 256
+
+let make_config ~bound ~steps ~domain_bounds ~inject_guards
+    ?(ground_quantifiers = true) () =
+  {
+    bound;
+    steps;
+    domain_bounds;
+    inject_guards;
+    ground_quantifiers;
+    quant_bound = [];
+  }
 
 (** Fresh uninterpreted constants for non-exhaustive cond else-branches. When a
     cond's last arm guard is not [true], we emit a fresh constant of the

--- a/lib_parser/dune
+++ b/lib_parser/dune
@@ -42,4 +42,6 @@
 
 (copy_files ../lib/error.ml)
 
+(copy_files ../lib/lower_aliases.ml)
+
 (copy_files ../lib/module.ml)

--- a/test/dune
+++ b/test/dune
@@ -27,7 +27,8 @@
   test_module
   test_smt_invariants
   test_smt_property
-  test_smt_substitution)
+  test_smt_substitution
+  test_lower_aliases)
  (modules :standard \ test_util smt_check)
  (libraries pantagruel test_util smt_check alcotest qcheck-alcotest)
  (deps

--- a/test/test_e2e.ml
+++ b/test/test_e2e.ml
@@ -133,6 +133,7 @@ let test_sample_smt name () =
           let domain_bounds = Smt.compute_domain_bounds 3 env in
           let config =
             Smt.make_config ~bound:3 ~steps:1 ~domain_bounds ~inject_guards:true
+              ()
           in
           let queries = Smt.generate_queries config env doc in
           ignore queries)

--- a/test/test_lower_aliases.ml
+++ b/test/test_lower_aliases.ml
@@ -1,0 +1,102 @@
+(** Identity-lowering of list-typed aliases. *)
+
+open Alcotest
+open Pantagruel
+
+let parse_and_collect = Test_util.parse_and_collect
+
+let kind_of name env =
+  match Env.lookup_type name env with Some e -> Some e.Env.kind | None -> None
+
+let is_domain k =
+  match[@warning "-4"] k with Some Env.KDomain -> true | _ -> false
+
+let is_alias k =
+  match[@warning "-4"] k with Some (Env.KAlias _) -> true | _ -> false
+
+(* Only list aliases ([T = [D]]) are candidates; a product alias is not. *)
+let test_candidates () =
+  let doc =
+    Test_util.parse
+      "module M.\n\
+       Insight.\n\
+       P = [Insight].\n\
+       Pair = Insight * Insight.\n\
+       f p: P => Bool.\n\
+       ---\n\
+       all p: P | f p.\n"
+  in
+  check (list string) "only the list alias" [ "P" ]
+    (Lower_aliases.list_alias_candidates doc)
+
+let test_rewrite () =
+  let doc =
+    Test_util.parse
+      "module M.\n\
+       Insight.\n\
+       P = [Insight].\n\
+       f p: P => Bool.\n\
+       ---\n\
+       all p: P | f p.\n"
+  in
+  let doc' = Lower_aliases.rewrite_to_domains doc [ "P" ] in
+  let has_domain_p =
+    List.exists
+      (fun (ch : Ast.chapter) ->
+        List.exists
+          (fun (d : Ast.declaration Ast.located) ->
+            match[@warning "-4"] d.value with
+            | Ast.DeclDomain (Ast.Upper "P") -> true
+            | _ -> false)
+          ch.head)
+      doc'.chapters
+  in
+  check bool "P rewritten to a domain declaration" true has_domain_p
+
+(* An alias used only as an opaque identity is lowered to a domain. *)
+let test_lower_opaque () =
+  let env, doc =
+    parse_and_collect
+      "module M.\n\
+       Insight.\n\
+       P = [Insight].\n\
+       f p: P => Bool.\n\
+       ---\n\
+       all p: P | f p.\n"
+  in
+  check bool "P starts as an alias" true (is_alias (kind_of "P" env));
+  let env', _doc' =
+    Module.lower_identity_aliases (Module.create_registry ()) env doc
+  in
+  check bool "P lowered to a domain" true (is_domain (kind_of "P" env'))
+
+(* An alias destructured as a list ([i in p]) must NOT be lowered: the rewritten
+   document fails to type-check, so the oracle keeps the alias. *)
+let test_no_lower_destructured () =
+  let env, doc =
+    parse_and_collect
+      "module M.\n\
+       Insight.\n\
+       P = [Insight].\n\
+       g p: P, i: Insight => Bool.\n\
+       ---\n\
+       all p: P | all i: Insight | i in p -> g p i.\n"
+  in
+  let env', _doc' =
+    Module.lower_identity_aliases (Module.create_registry ()) env doc
+  in
+  check bool "destructured alias is not lowered" true
+    (is_alias (kind_of "P" env'))
+
+let () =
+  run "LowerAliases"
+    [
+      ( "lower_aliases",
+        [
+          test_case "candidates are list aliases" `Quick test_candidates;
+          test_case "rewrite to domains" `Quick test_rewrite;
+          test_case "opaque alias is lowered" `Quick test_lower_opaque;
+          test_case "destructured alias is not lowered" `Quick
+            test_no_lower_destructured;
+        ] );
+    ]

--- a/test/test_smt.ml
+++ b/test/test_smt.ml
@@ -9,7 +9,14 @@ let parse_and_collect = Test_util.parse_and_collect
 
 let config =
   Smt.make_config ~bound:3 ~steps:5 ~domain_bounds:Env.StringMap.empty
-    ~inject_guards:true
+    ~inject_guards:true ()
+
+(* Native-quantifier config: disables grounding so tests can assert on the
+   forall/exists emission machinery (alpha-renaming, binder guard substitution)
+   directly, rather than its grounded expansion. *)
+let config_native =
+  Smt.make_config ~bound:3 ~steps:5 ~domain_bounds:Env.StringMap.empty
+    ~inject_guards:true ~ground_quantifiers:false ()
 
 let test_lit_bool () =
   let env = Env.empty "" in
@@ -984,6 +991,7 @@ let test_bound_for () =
   let bounds = Env.StringMap.singleton "Color" 5 in
   let config =
     Smt.make_config ~bound:3 ~steps:5 ~domain_bounds:bounds ~inject_guards:true
+      ()
   in
   check int "Color uses override" 5 (Smt.bound_for config "Color");
   check int "Account uses default" 3 (Smt.bound_for config "Account")
@@ -993,6 +1001,7 @@ let test_card_domain_with_bounds () =
   let bounds = Env.StringMap.singleton "Color" 5 in
   let cfg =
     Smt.make_config ~bound:3 ~steps:5 ~domain_bounds:bounds ~inject_guards:true
+      ()
   in
   check string "#Domain with per-domain bound" "5"
     (Smt.translate_expr cfg env (Ast.EUnop (OpCard, EDomain (Upper "Color"))))
@@ -1150,7 +1159,7 @@ let test_translate_in_zero_bound () =
      Now produces "false" (nothing in empty domain). *)
   let zero_config =
     Smt.make_config ~bound:0 ~steps:0 ~domain_bounds:Env.StringMap.empty
-      ~inject_guards:true
+      ~inject_guards:true ()
   in
   let env = Env.empty "" |> Env.add_domain "D" Ast.dummy_loc ~chapter:0 in
   let result =
@@ -1211,7 +1220,7 @@ let test_domain_closure_bound_one () =
   in
   let one_config =
     Smt.make_config ~bound:1 ~steps:0 ~domain_bounds:Env.StringMap.empty
-      ~inject_guards:true
+      ~inject_guards:true ()
   in
   let queries = Smt.generate_queries one_config env doc in
   let inv =
@@ -1688,7 +1697,7 @@ let test_aggregate_add_empty () =
   (* + over empty domain (bound=0) should return identity "0" *)
   let zero_config =
     Smt.make_config ~bound:0 ~steps:5 ~domain_bounds:Env.StringMap.empty
-      ~inject_guards:true
+      ~inject_guards:true ()
   in
   let env =
     Env.empty ""
@@ -1759,7 +1768,7 @@ let test_aggregate_add_real_empty () =
   (* + over empty Real domain should return "0.0" *)
   let zero_config =
     Smt.make_config ~bound:0 ~steps:5 ~domain_bounds:Env.StringMap.empty
-      ~inject_guards:true
+      ~inject_guards:true ()
   in
   let env =
     Env.empty ""
@@ -2140,7 +2149,7 @@ let test_closure_axiom_generation () =
   in
   let small_config =
     Smt.make_config ~bound:2 ~steps:0 ~domain_bounds:Env.StringMap.empty
-      ~inject_guards:true
+      ~inject_guards:true ()
   in
   let queries = Smt.generate_queries small_config env doc in
   let inv =
@@ -2328,7 +2337,9 @@ let test_guard_substitution () =
       (EBinop
          (OpGe, EApp (EVar (Lower "score"), [ EVar (Lower "x") ]), ELitNat 0))
   in
-  let result = Smt.translate_expr config env expr in
+  (* Use the native config: this test asserts on the binder-bound guard
+     substitution in native forall emission. *)
+  let result = Smt.translate_expr config_native env expr in
   (* Guard should be substituted: (active x), not (active u) *)
   check bool "has (active x)" true (contains result "(active x)");
   check bool "no (active u)" false (contains result "(active u)")
@@ -2830,7 +2841,7 @@ let test_aggregate_empty_domain () =
   let env = make_aggregate_env () in
   let zero_config =
     Smt.make_config ~bound:0 ~steps:0 ~domain_bounds:Env.StringMap.empty
-      ~inject_guards:true
+      ~inject_guards:true ()
   in
   let expr =
     Ast.make_each
@@ -2845,7 +2856,7 @@ let test_aggregate_empty_domain_mul () =
   let env = make_aggregate_env () in
   let zero_config =
     Smt.make_config ~bound:0 ~steps:0 ~domain_bounds:Env.StringMap.empty
-      ~inject_guards:true
+      ~inject_guards:true ()
   in
   let expr =
     Ast.make_each
@@ -2860,7 +2871,7 @@ let test_aggregate_empty_domain_and () =
   let env = make_aggregate_env () in
   let zero_config =
     Smt.make_config ~bound:0 ~steps:0 ~domain_bounds:Env.StringMap.empty
-      ~inject_guards:true
+      ~inject_guards:true ()
   in
   let expr =
     Ast.make_each
@@ -2875,7 +2886,7 @@ let test_aggregate_empty_domain_or () =
   let env = make_aggregate_env () in
   let zero_config =
     Smt.make_config ~bound:0 ~steps:0 ~domain_bounds:Env.StringMap.empty
-      ~inject_guards:true
+      ~inject_guards:true ()
   in
   let expr =
     Ast.make_each
@@ -2891,7 +2902,7 @@ let test_aggregate_empty_domain_min () =
   let env = make_aggregate_env () in
   let zero_config =
     Smt.make_config ~bound:0 ~steps:0 ~domain_bounds:Env.StringMap.empty
-      ~inject_guards:true
+      ~inject_guards:true ()
   in
   let expr =
     Ast.make_each
@@ -2907,7 +2918,7 @@ let test_aggregate_empty_domain_max () =
   let env = make_aggregate_env () in
   let zero_config =
     Smt.make_config ~bound:0 ~steps:0 ~domain_bounds:Env.StringMap.empty
-      ~inject_guards:true
+      ~inject_guards:true ()
   in
   let expr =
     Ast.make_each
@@ -2932,7 +2943,7 @@ let test_aggregate_integration () =
   in
   let small_config =
     Smt.make_config ~bound:2 ~steps:0 ~domain_bounds:Env.StringMap.empty
-      ~inject_guards:true
+      ~inject_guards:true ()
   in
   let queries = Smt.generate_queries small_config env doc in
   let inv =
@@ -3012,8 +3023,10 @@ let test_entailment_action_query () =
     (contains q.smt2 "(= (balance_prime a)");
   check bool "has action precondition assumption" true
     (contains q.smt2 "(>= (balance a) amount)");
+  (* The invariant [all a: Account | balance a >= 0] is grounded over the
+     Account elements, so the assumption appears per-element. *)
   check bool "has invariant assumption" true
-    (contains q.smt2 "(>= (balance a) 0)")
+    (contains q.smt2 "(>= (balance Account_0) 0)")
 
 let test_entailment_uses_chapter_local_invariants () =
   (* Two invariant chapters, each with a check. The check in the second chapter
@@ -3104,6 +3117,160 @@ let entailment_tests =
       test_entailment_multiple_goals;
   ]
 
+(* --- Quantifier grounding tests --- *)
+
+(* Env with a domain [D] and a unary predicate [p : D => Bool]. *)
+let ground_env () =
+  Env.empty ""
+  |> Env.add_domain "D" Ast.dummy_loc ~chapter:0
+  |> Env.add_rule "p"
+       (Types.TyFunc ([ Types.TyDomain "D" ], Some Types.TyBool))
+       Ast.dummy_loc ~chapter:0
+
+(* Config grounding domain D over two elements (D_0, D_1). *)
+let config_g2 =
+  Smt.make_config ~bound:2 ~steps:0 ~domain_bounds:Env.StringMap.empty
+    ~inject_guards:true ()
+
+let test_ground_forall_domain () =
+  let env = ground_env () in
+  let expr =
+    Ast.make_forall
+      [ { param_name = Lower "x"; param_type = TName (Upper "D") } ]
+      []
+      (EApp (EVar (Lower "p"), [ EVar (Lower "x") ]))
+  in
+  let result = Smt.translate_expr config_g2 env expr in
+  check bool "no native forall" false (contains result "forall");
+  check bool "conjunction" true (contains result "(and ");
+  check bool "instance D_0" true (contains result "(p D_0)");
+  check bool "instance D_1" true (contains result "(p D_1)")
+
+let test_ground_exists_domain () =
+  let env = ground_env () in
+  let expr =
+    Ast.make_exists
+      [ { param_name = Lower "x"; param_type = TName (Upper "D") } ]
+      []
+      (EApp (EVar (Lower "p"), [ EVar (Lower "x") ]))
+  in
+  let result = Smt.translate_expr config_g2 env expr in
+  check bool "no native exists" false (contains result "exists");
+  check bool "disjunction" true (contains result "(or ");
+  check bool "instance D_0" true (contains result "(p D_0)");
+  check bool "instance D_1" true (contains result "(p D_1)")
+
+let test_ground_gin_membership () =
+  (* all x in items : the membership becomes a per-instance antecedent. *)
+  let env =
+    ground_env ()
+    |> Env.add_rule "items"
+         (Types.TyFunc ([], Some (Types.TyList (Types.TyDomain "D"))))
+         Ast.dummy_loc ~chapter:0
+  in
+  let expr =
+    Ast.make_forall []
+      [ GIn (Lower "x", EVar (Lower "items")) ]
+      (EApp (EVar (Lower "p"), [ EVar (Lower "x") ]))
+  in
+  let result = Smt.translate_expr config_g2 env expr in
+  check bool "no native forall" false (contains result "forall");
+  check bool "membership antecedent for D_0" true
+    (contains result "(=> (and (select items D_0)) (p D_0))");
+  check bool "membership antecedent for D_1" true
+    (contains result "(=> (and (select items D_1)) (p D_1))")
+
+let test_ground_partial_nat () =
+  (* all x: D | all n: Nat | q x n : outer D grounded, inner Nat stays native. *)
+  let env =
+    ground_env ()
+    |> Env.add_rule "q"
+         (Types.TyFunc ([ Types.TyDomain "D"; Types.TyNat ], Some Types.TyBool))
+         Ast.dummy_loc ~chapter:0
+  in
+  let inner =
+    Ast.make_forall
+      [ { param_name = Lower "n"; param_type = TName (Upper "Nat") } ]
+      []
+      (EApp (EVar (Lower "q"), [ EVar (Lower "x"); EVar (Lower "n") ]))
+  in
+  let expr =
+    Ast.make_forall
+      [ { param_name = Lower "x"; param_type = TName (Upper "D") } ]
+      [] inner
+  in
+  let result = Smt.translate_expr config_g2 env expr in
+  check bool "outer conjunction" true (contains result "(and ");
+  check bool "inner native forall over Int" true
+    (contains result "(forall ((n Int))");
+  check bool "grounded outer arg D_0" true (contains result "(q D_0 n)");
+  check bool "grounded outer arg D_1" true (contains result "(q D_1 n)")
+
+let test_ground_disabled_is_native () =
+  (* config_native reproduces the native forall emission. *)
+  let env = ground_env () in
+  let expr =
+    Ast.make_forall
+      [ { param_name = Lower "x"; param_type = TName (Upper "D") } ]
+      []
+      (EApp (EVar (Lower "p"), [ EVar (Lower "x") ]))
+  in
+  let result = Smt.translate_expr config_native env expr in
+  check bool "native forall binder" true (contains result "(forall ((x D))");
+  check bool "no grounded instance" false (contains result "(p D_0)")
+
+let test_ground_cap_fallback () =
+  (* Five binders at bound 4 = 1024 > cap 256 -> native fallback. *)
+  let env =
+    Env.empty ""
+    |> Env.add_domain "D" Ast.dummy_loc ~chapter:0
+    |> Env.add_rule "r5"
+         (Types.TyFunc
+            ( [
+                Types.TyDomain "D";
+                Types.TyDomain "D";
+                Types.TyDomain "D";
+                Types.TyDomain "D";
+                Types.TyDomain "D";
+              ],
+              Some Types.TyBool ))
+         Ast.dummy_loc ~chapter:0
+  in
+  let mkp n = Ast.{ param_name = Lower n; param_type = TName (Upper "D") } in
+  let expr =
+    Ast.make_forall
+      [ mkp "a"; mkp "b"; mkp "c"; mkp "d"; mkp "e" ]
+      []
+      (EApp
+         ( EVar (Lower "r5"),
+           List.map
+             (fun n -> Ast.EVar (Ast.Lower n))
+             [ "a"; "b"; "c"; "d"; "e" ] ))
+  in
+  let config_g4 =
+    Smt.make_config ~bound:4 ~steps:0 ~domain_bounds:Env.StringMap.empty
+      ~inject_guards:true ()
+  in
+  let result = Smt.translate_expr config_g4 env expr in
+  check bool "fell back to native forall" true
+    (contains result "(forall ((a D)")
+
+let grounding_tests =
+  [
+    test_case "forall over domain grounds to conjunction" `Quick
+      test_ground_forall_domain;
+    test_case "exists over domain grounds to disjunction" `Quick
+      test_ground_exists_domain;
+    test_case "GIn membership becomes per-instance antecedent" `Quick
+      test_ground_gin_membership;
+    test_case "partial grounding leaves Nat binder native" `Quick
+      test_ground_partial_nat;
+    test_case "grounding disabled emits native quantifier" `Quick
+      test_ground_disabled_is_native;
+    test_case "over-cap quantifier falls back to native" `Quick
+      test_ground_cap_fallback;
+  ]
+
 let () =
   run "SMT"
     [
@@ -3122,4 +3289,5 @@ let () =
       ("bug_finding", bug_finding_tests);
       ("aggregates", aggregate_tests);
       ("entailment", entailment_tests);
+      ("grounding", grounding_tests);
     ]

--- a/test/test_smt_invariants.ml
+++ b/test/test_smt_invariants.ml
@@ -206,14 +206,20 @@ let test_regression_fixture fixture expect_kinds () =
     coincides with a head-rule-param's name, the action body's free reference
     must resolve to the declared constant, not a wrapping
     [(forall ((<name> ...)) ...)]. *)
-let test_no_shadowing_forall fixture shadowed_name () =
+let test_no_shadowing_forall ?(native = false) fixture shadowed_name () =
   match regression_dir with
   | None -> failf "regression directory not found"
   | Some dir ->
       let path = Filename.concat dir fixture in
       if not (Sys.file_exists path) then failf "missing fixture: %s" path;
       let queries =
-        match translate_path path with
+        (* This asserts native forall emission does not shadow an action-param
+           constant; translate with grounding off so the forall binder is
+           actually present to check (grounding would expand it away). *)
+        match
+          Test_util.translate_to_queries ~ground_quantifiers:(not native)
+            (Test_util.parse_pant_file path)
+        with
         | Ok qs -> qs
         | Error msg -> failf "%s — translation failed: %s" fixture msg
       in
@@ -249,14 +255,20 @@ let test_no_shadowing_forall fixture shadowed_name () =
     as a substring. Used to lock in structural post-fix shapes — e.g. the
     alpha-renamed binder suffix that [test_regression_fixture] (which only
     checks structural-failure kinds) would miss. *)
-let test_smt_contains fixture needle () =
+let test_smt_contains ?(native = false) fixture needle () =
   match regression_dir with
   | None -> failf "regression directory not found"
   | Some dir ->
       let path = Filename.concat dir fixture in
       if not (Sys.file_exists path) then failf "missing fixture: %s" path;
       let queries =
-        match translate_path path with
+        (* Binder-renaming assertions target the native forall/exists emission;
+           translate with grounding off so the renamed binder survives in the
+           output instead of being expanded away. *)
+        match
+          Test_util.translate_to_queries ~ground_quantifiers:(not native)
+            (Test_util.parse_pant_file path)
+        with
         | Ok qs -> qs
         | Error msg -> failf "%s — translation failed: %s" fixture msg
       in
@@ -304,26 +316,27 @@ let regression_cases () =
     test_case "bug_action_param_shadows_rule.pant — translates cleanly" `Quick
       (test_regression_fixture "bug_action_param_shadows_rule.pant" []);
     test_case "bug_action_param_shadows_rule.pant — no shadow forall" `Quick
-      (test_no_shadowing_forall "bug_action_param_shadows_rule.pant" "a1");
+      (test_no_shadowing_forall ~native:true
+         "bug_action_param_shadows_rule.pant" "a1");
     test_case "bug_rule_param_collision.pant — clean post-fix" `Quick
       (test_regression_fixture "bug_rule_param_collision.pant" []);
     test_case "bug_rule_param_collision.pant — quantifier binder renamed" `Quick
-      (test_smt_contains "bug_rule_param_collision.pant" "name_q");
+      (test_smt_contains ~native:true "bug_rule_param_collision.pant" "name_q");
     test_case "bug_nested_binder_collision.pant — clean post-fix" `Quick
       (test_regression_fixture "bug_nested_binder_collision.pant" []);
     test_case
       "bug_nested_binder_collision.pant — inner rename skips outer binder"
       `Quick
-      (test_smt_contains "bug_nested_binder_collision.pant" "x_q1");
+      (test_smt_contains ~native:true "bug_nested_binder_collision.pant" "x_q1");
     test_case "bug_rename_app_head.pant — clean post-fix" `Quick
       (test_regression_fixture "bug_rename_app_head.pant"
          [ "fallback_emission" ]);
     test_case "bug_rename_app_head.pant — renamed binder used in head position"
       `Quick
-      (test_smt_contains "bug_rename_app_head.pant" "(xs_q 1)");
+      (test_smt_contains ~native:true "bug_rename_app_head.pant" "(xs_q 1)");
     test_case "bug_rename_app_head.pant — binder does not shadow declared xs"
       `Quick
-      (test_no_shadowing_forall "bug_rename_app_head.pant" "xs");
+      (test_no_shadowing_forall ~native:true "bug_rename_app_head.pant" "xs");
   ]
 
 let () =

--- a/test/test_util.ml
+++ b/test/test_util.ml
@@ -55,8 +55,8 @@ let parse_pant_file path =
     fails. Test-specific baseline: bound 3, steps 1 (CLI default is steps 5),
     guards injected. Used by every Layer-1, Layer-2, and fuzz test that needs
     the full translator output. *)
-let translate_to_queries (doc : Ast.document) : (Smt.query list, string) result
-    =
+let translate_to_queries ?(ground_quantifiers = true) (doc : Ast.document) :
+    (Smt.query list, string) result =
   let mod_name = Option.fold ~none:"" ~some:Ast.upper_name doc.module_name in
   match Collect.collect_all ~base_env:(Env.empty mod_name) doc with
   | Error e -> Error (Collect.show_collect_error e)
@@ -67,6 +67,7 @@ let translate_to_queries (doc : Ast.document) : (Smt.query list, string) result
           let domain_bounds = Smt.compute_domain_bounds 3 env in
           let config =
             Smt.make_config ~bound:3 ~steps:1 ~domain_bounds ~inject_guards:true
+              ~ground_quantifiers ()
           in
           Ok (Smt.generate_queries config env doc))
 


### PR DESCRIPTION
Two complementary changes that together make finite-domain SMT checks fast and reliable — and make the original `data-governance.pant` check in ~0.3s instead of returning `unknown`.

## 1. Quantifier grounding

When a spec quantifies over a finite domain sort, pant emitted a native SMT `forall`/`exists` and leaned on Z3's quantifier-instantiation heuristics (E-matching/MBQI) — slow/flaky for opaque-domain specs (30–90s, sometimes timing out).

This adds a **grounding pass**: when every binder of a quantifier node ranges over a finite `TyDomain` (bound > 0), it expands the quantifier over the enumerated element constants into a quantifier-free `(and …)`/`(or …)`. Z3's DPLL(T) core decides that reliably and fast — for **both** sat-seeking (consistency) and unsat-seeking (entailment) checks, unlike a solver-flag hack which only helps the sat side. Generalizes the move already used for closure axioms (`smt_preamble.ml`).

Design (`lib/smt.ml`): `translate_quantifier` → `try_ground_quantifier` → `emit_native_quantifier`. Substitutes element constants via capture-avoiding `Smt_expr.substitute_vars` and recurses; zero-binder base case in the tail; grounded element constants bound to their domain type so type inference still resolves; `GIn` memberships become per-instance antecedents; ungroundable binders (Nat/Int) stay native (partial grounding); per-node cap (256) with an `eprintf` fallback. Gated by default-on `ground_quantifiers` + `--no-ground-quantifiers`.

## 2. Identity-lowering of list-typed aliases

A bare alias `T = [D]` expands to `Array D Bool`, so `[T]` becomes `Array (Array D Bool) Bool` — **arrays indexed by arrays**, which the solver's array theory can't decide (this is *why* `data-governance.pant` with `Page = [Insight]` returned `unknown`). Grounding can't help — an array-aliased binder isn't a finite `TyDomain`.

When a spec never destructures a value of type `T` as a list, `T` is a pure opaque identity. This pass **lowers such aliases to domain sorts**, so `[T]` becomes `Array T Bool` (scalar-indexed) — decidable, and then ground-able.

Detection is delegated to the type checker, not a bespoke analysis: tentatively rewrite `T = [D]` → `DeclDomain T` and re-check — any list op on a now-opaque `T` is a type error, so a passing re-check *proves* `T` is opaque-only. `Module.lower_identity_aliases` lowers the maximal safe subset (fast path all-at-once, else greedy), falling back when nothing is lowerable.

(The fully-general alternative — preserving alias identity in `ty` and expanding at `sort_of_ty` — would touch ~40 `ty` match sites across the type checker and every backend; this document-rewrite-with-type-check-oracle is the localized version.)

## Smoke test — original `data-governance.pant`, unedited

| Config | Verdict | Time |
|---|---|---|
| grounding + lowering (default) | `OK` | ~0.3s |
| `--no-ground-quantifiers` (lowering only) | timeout | 30s |

Both pieces are needed: lowering makes `Page` a scalar domain (decidable); grounding makes the resulting quantifiers fast.

## Tests

- New `grounding` group: forall→conjunction, exists→disjunction, GIn antecedent, partial-Nat, disabled-is-native, over-cap fallback.
- New `LowerAliases` suite: candidate detection, rewrite, lowered-when-opaque, and the key negative case (a destructured alias is **not** lowered).
- Native-machinery tests (alpha-renaming, shadow avoidance, guard substitution) pinned to `~ground_quantifiers:false` rather than weakened.
- **Equivalence audit**: every `samples/smt-examples` spec yields an identical verdict grounded vs `--no-ground-quantifiers`.
- Full suite green.

## Note

Independent of PR #298 (which fixes how an `unknown` verdict is *reported*). Branched off `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)