### PR TITLE
[ts2pant-du-cutover] Patch 1: Refusal-reason constants + skipped test stubs

### DIFF
--- a/tools/ts2pant/src/translate-types.ts
+++ b/tools/ts2pant/src/translate-types.ts
@@ -41,6 +41,10 @@ export const UNSUPPORTED_ANONYMOUS_RECORD = "__unsupported_anon_record__";
 export const UNSUPPORTED_UNKNOWN = "__unsupported_unknown__";
 export const UNSUPPORTED_UNKNOWN_REASON =
   "TS unknown is not expressible in Pantagruel; declare a specific type";
+export const UNSUPPORTED_NON_DISCRIMINATED_UNION_FIELD_ACCESS_REASON =
+  "field access on a non-discriminated union is not expressible in Pantagruel";
+export const UNSUPPORTED_DISCRIMINATED_UNION_REGISTRATION_REASON =
+  "discriminated union could not be registered for tagged Pantagruel encoding";
 
 /**
  * True if `pantType` is the `unknown` rejection sentinel. Composite

--- a/tools/ts2pant/tests/du-cutover.test.mts
+++ b/tools/ts2pant/tests/du-cutover.test.mts
@@ -1,0 +1,15 @@
+import { describe, it } from "node:test";
+
+describe("du-cutover", () => {
+  it.skip("non-discriminated union field access is refused", () => {
+    // PENDING: Patch 2.
+  });
+
+  it.skip("intersection field access remains sound (resolves a single owner)", () => {
+    // PENDING: Patch 2.
+  });
+
+  it.skip("detected DU that fails tagged registration is refused (no + fallthrough)", () => {
+    // PENDING: Patch 4.
+  });
+});


### PR DESCRIPTION
## Patch 1: Refusal-reason constants + skipped test stubs

- Define and export the new UNSUPPORTED_* reason string constants next to the existing sentinels in translate-types.ts; do not reference them from any live code path in this patch.
- Create tools/ts2pant/tests/du-cutover.test.mts with three skipped stubs (non-discriminated union field-access refusal, intersection field-access soundness, DU registration-failure refusal), each annotated with the implementing patch number.
- Confirm `npm run -s test:unit` and `npm run -s test:integration` produce no snapshot diffs (the only addition is skipped tests and unused constants).

## Changes
- Define and export the new UNSUPPORTED_* reason string constants next to the existing sentinels in translate-types.ts; do not reference them from any live code path in this patch.
- Create tools/ts2pant/tests/du-cutover.test.mts with three skipped stubs (non-discriminated union field-access refusal, intersection field-access soundness, DU registration-failure refusal), each annotated with the implementing patch number.
- Confirm `npm run -s test:unit` and `npm run -s test:integration` produce no snapshot diffs (the only addition is skipped tests and unused constants).

## Files to Modify
- tools/ts2pant/src/translate-types.ts (modify): Add UNSUPPORTED_* reason constants for the two new refusal cases (non-discriminated union field access; discriminated-union registration failure), alongside the existing UNSUPPORTED_UNKNOWN / UNSUPPORTED_ANONYMOUS_RECORD sentinels. Constants only — not yet referenced by any live path, so emitted output is byte-identical.
- tools/ts2pant/tests/du-cutover.test.mts (create): New test file with skipped (it.skip / test with skip) stubs documenting the Patch 2 and Patch 4 unit expectations: non-discriminated union field access is refused, intersection field access still resolves, and a registration-failing DU is refused. Each stub names the implementing patch in a comment (PENDING: Patch N). Skipped tests do not affect snapshots.

## Gameplan Specification

```
module DU_CUTOVER.

> ══════════════════════════════
> THE GUARANTEE
> ═══════════════════════════════
> After M4 the tagged guarded-rule encoding is the SOLE path for every
> discriminated union: a DU is tagged when it registers and refused
> otherwise, never `+`-encoded, including when nested as a variant field
> or embedded in a record/map/array (one shape-keyed domain shared with
> the same DU elsewhere). Field access on a non-discriminated union is
> refused (no unique-field accessor applied to the whole union), while
> intersection field access stays sound. The `A + B` sum encoding survives
> only as a value type for non-discriminated unions, and optionality
> (`T | null` -> `[T]`) is unchanged.

Ty.
is-union t: Ty => Bool.
is-intersection t: Ty => Bool.
is-discriminated t: Ty => Bool.
nests-discriminated t: Ty => Bool.
registers t: Ty => Bool.
field-access t: Ty => Bool.
narrowed-read t: Ty => Bool.
tagged t: Ty => Bool.
sum-encoded t: Ty => Bool.
refused-access t: Ty => Bool.
resolves t: Ty => Bool.
refused t: Ty => Bool.
entails t: Ty => Bool.

---

> Every discriminated union that registers is tagged and never sum-encoded;
> one that fails registration is refused, also never sum-encoded.
all t: Ty | (is-discriminated t and registers t) -> (tagged t and ~(sum-encoded t)).
all t: Ty | (is-discriminated t and ~(registers t)) -> (refused t and ~(sum-encoded t)).

> A discriminated union nested in a container or as a variant field still tags.
all t: Ty | nests-discriminated t -> (tagged t and ~(sum-encoded t)).

> A narrowed read of a (possibly nested) discriminated union entails.
all t: Ty | (is-discriminated t and narrowed-read t) -> entails t.

> Field access on a non-discriminated union is refused, never resolved;
> the bare sum value encoding still applies to non-discriminated unions.
all t: Ty | (is-union t and ~(is-discriminated t) and field-access t) -> (refused-access t and ~(resolves t)).
all t: Ty | (is-union t and ~(is-discriminated t)) -> sum-encoded t.

> Intersection field access remains sound (resolves a single owner).
all t: Ty | (is-intersection t and field-access t) -> resolves t.
```

## Patch Specification

```
module DU_CUTOVER_PATCH_1.

> Patch 1 introduces refusal-reason constants and skipped test stubs.
> No emitted output changes; the constants are not yet referenced by any
> live code path.

Reason.
nondiscriminated-field-reason => Reason.
du-registration-reason => Reason.
defined r: Reason => Bool.
gates-behavior r: Reason => Bool.

---

> The new reasons exist but gate no behavior yet (dormant constants).
all r: Reason | defined r.
all r: Reason | ~(gates-behavior r).
```


## Implementation Notes

- The new constants are intentionally exported but otherwise unreferenced so existing extraction, dogfood, and snapshot behavior stays byte-stable. I kept them next to `UNSUPPORTED_UNKNOWN_REASON` because the later refusal surfaces will likely need public reason text rather than only private sentinels.
- The skipped test file uses `node:test` `it.skip`, matching the existing harness, and contains no imports from translator internals. That keeps Patch 1 as a pure expectation marker without pulling the new constants into translated dogfood output.
- Spec/Evidence Mapping: dormant reasons are defined in `tools/ts2pant/src/translate-types.ts`; no behavior gate references them in this patch. Future acceptance stubs are in `tools/ts2pant/tests/du-cutover.test.mts`. Required context consulted: `translate-types.ts`, constructs/dogfood harness files, and `package.json`. Evidence: `npm run -s test:unit` and `npm run -s test:integration` both passed with no snapshot updates.