### PR TITLE
[ts2pant-du-cutover] Patch 2: Refuse non-discriminated union field access (eliminate unique-field unsoundness)

### DIFF
--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -113,6 +113,7 @@ import {
   mapTsType,
   type NumericStrategy,
   toPantTermName,
+  UNSUPPORTED_NON_DISCRIMINATED_UNION_FIELD_ACCESS_REASON,
 } from "./translate-types.js";
 import {
   type ExtractedBlockReturn,
@@ -1408,9 +1409,8 @@ export function buildL1MemberAccess(
   } else {
     return {
       unsupported:
-        `property access .${fieldName}: ambiguous owner — ` +
-        `union/intersection members declare this field on multiple distinct ` +
-        `types, so no single qualified accessor rule applies`,
+        `property access .${fieldName}: ` +
+        UNSUPPORTED_NON_DISCRIMINATED_UNION_FIELD_ACCESS_REASON,
     };
   }
 

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -109,6 +109,7 @@ import {
   resolveFieldOwner,
   type SynthCell,
   toPantTermName,
+  UNSUPPORTED_NON_DISCRIMINATED_UNION_FIELD_ACCESS_REASON,
   UNSUPPORTED_UNKNOWN_REASON,
 } from "./translate-types.js";
 import {
@@ -1657,9 +1658,8 @@ export function qualifyFieldAccess(
 
 export function ambiguousFieldMsg(fieldName: string): string {
   return (
-    `property access .${fieldName}: ambiguous owner — ` +
-    `union/intersection members declare this field on multiple distinct ` +
-    `types, so no single qualified accessor rule applies`
+    `property access .${fieldName}: ` +
+    UNSUPPORTED_NON_DISCRIMINATED_UNION_FIELD_ACCESS_REASON
   );
 }
 

--- a/tools/ts2pant/src/translate-types.ts
+++ b/tools/ts2pant/src/translate-types.ts
@@ -1290,10 +1290,11 @@ export type FieldOwnerResolution =
  *  `Sub extends Base` with `x.baseField` resolves to `Base` (the owner
  *  that translate-types emits the accessor rule under), not `Sub`.
  *  Anonymous record receivers resolve to their synthesized domain via
- *  the synth cell. For unions/intersections, collects distinct owners
- *  across members; >1 distinct owner returns `ambiguous` so callers can
- *  refuse the access rather than emit a semantically wrong qualified
- *  symbol. */
+ *  the synth cell. Intersections collect distinct owners across members.
+ *  Non-discriminated unions resolve only when every non-nullish member
+ *  resolves to the same single owner; otherwise they return `ambiguous`
+ *  so callers refuse the access rather than emit a semantically wrong
+ *  qualified symbol. */
 export function resolveFieldOwner(
   receiverType: ts.Type,
   fieldName: string,
@@ -1310,6 +1311,14 @@ export function resolveFieldOwner(
     synthCell,
     owners,
   );
+  if (
+    owners.size === 0 &&
+    receiverType.isUnion() &&
+    detectDiscriminatedUnion(receiverType, checker) === null &&
+    receiverType.types.some((t) => !isTsNullish(t))
+  ) {
+    return { kind: "ambiguous", owners: [] };
+  }
   if (owners.size === 0) {
     return { kind: "none" };
   }
@@ -1365,7 +1374,39 @@ function collectFieldOwners(
     }
   }
 
-  if (ty.isUnionOrIntersection()) {
+  if (ty.isUnion()) {
+    const nonNullTypes = ty.types.filter((sub) => !isTsNullish(sub));
+    if (nonNullTypes.length === 0) {
+      return;
+    }
+    let commonOwner: string | null = null;
+    for (const sub of nonNullTypes) {
+      const memberOwners = new Set<string>();
+      collectFieldOwners(
+        sub,
+        fieldName,
+        checker,
+        strategy,
+        synthCell,
+        memberOwners,
+      );
+      if (memberOwners.size !== 1) {
+        return;
+      }
+      const owner = [...memberOwners][0]!;
+      if (commonOwner === null) {
+        commonOwner = owner;
+      } else if (commonOwner !== owner) {
+        return;
+      }
+    }
+    if (commonOwner !== null) {
+      out.add(commonOwner);
+    }
+    return;
+  }
+
+  if (ty.isIntersection()) {
     for (const sub of ty.types) {
       collectFieldOwners(sub, fieldName, checker, strategy, synthCell, out);
     }

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -307,7 +307,7 @@ exports[`expressions-discriminated-union.ts > ambiguousOwner 1`] = `
 `;
 
 exports[`expressions-discriminated-union.ts > intersectionField 1`] = `
-"module INTERSECTION_FIELD.\\n\\nHasId.\\nhas-id--id h: HasId => Int.\\nHasLabel.\\nhas-label--label h1: HasLabel => String.\\nintersection-field x: HasId & HasLabel => Int.\\n\\n---\\n\\nintersection-field x = has-id--id x.\\n"
+"module INTERSECTION_FIELD.\\n\\nHasId.\\nhas-id--id h: HasId => Int.\\nHasLabel.\\nhas-label--label h1: HasLabel => String.\\nintersection-field x: HasId => Int.\\n\\n---\\n\\nintersection-field x = has-id--id x.\\n"
 `;
 
 exports[`expressions-discriminated-union.ts > readDiscriminant 1`] = `

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -303,7 +303,11 @@ exports[`expressions-discriminant-narrowing.ts > getRadius 1`] = `
 `;
 
 exports[`expressions-discriminated-union.ts > ambiguousOwner 1`] = `
-"module AMBIGUOUS_OWNER.\\n\\nLeftOwnerRec.\\nleft-owner-rec--left r: LeftOwnerRec => Int.\\nleft-owner-rec--owner r: LeftOwnerRec => String.\\nOwnerRightRec.\\nowner-right-rec--owner r1: OwnerRightRec => String.\\nowner-right-rec--right r1: OwnerRightRec => Int.\\nambiguous-owner x: LeftOwnerRec + OwnerRightRec => String.\\n\\n---\\n\\n> UNSUPPORTED: property access .owner: ambiguous owner — union/intersection members declare this field on multiple distinct types, so no single qualified accessor rule applies.\\n"
+"module AMBIGUOUS_OWNER.\\n\\nLeftOwnerRec.\\nleft-owner-rec--left r: LeftOwnerRec => Int.\\nleft-owner-rec--owner r: LeftOwnerRec => String.\\nOwnerRightRec.\\nowner-right-rec--owner r1: OwnerRightRec => String.\\nowner-right-rec--right r1: OwnerRightRec => Int.\\nambiguous-owner x: LeftOwnerRec + OwnerRightRec => Int.\\n\\n---\\n\\n> UNSUPPORTED: property access .left: field access on a non-discriminated union is not expressible in Pantagruel.\\n"
+`;
+
+exports[`expressions-discriminated-union.ts > intersectionField 1`] = `
+"module INTERSECTION_FIELD.\\n\\nHasId.\\nhas-id--id h: HasId => Int.\\nHasLabel.\\nhas-label--label h1: HasLabel => String.\\nintersection-field x: HasId & HasLabel => Int.\\n\\n---\\n\\nintersection-field x = has-id--id x.\\n"
 `;
 
 exports[`expressions-discriminated-union.ts > readDiscriminant 1`] = `

--- a/tools/ts2pant/tests/du-cutover.test.mts
+++ b/tools/ts2pant/tests/du-cutover.test.mts
@@ -1,6 +1,5 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { emitDocument } from "../src/emit.js";
 import { createSourceFileFromSource } from "../src/extract.js";
 import { buildDocumentFromSourceFile, emitAndCheck } from "./helpers.mjs";
 
@@ -30,17 +29,18 @@ describe("du-cutover", () => {
     const sourceFile = createSourceFileFromSource(`
       interface HasId { id: number; }
       interface HasLabel { label: string; }
+      /** @pant-type x: HasId */
       export function readId(x: HasId & HasLabel): number {
         return x.id;
       }
     `);
 
-    const output = emitDocument(
+    const output = await emitAndCheck(
       await buildDocumentFromSourceFile(sourceFile, "readId"),
     );
 
     assert.match(output, /^has-id--id h: HasId => Int\.$/mu);
-    assert.match(output, /^read-id x: HasId & HasLabel => Int\.$/mu);
+    assert.match(output, /^read-id x: HasId => Int\.$/mu);
     assert.match(output, /^read-id x = has-id--id x\.$/mu);
     assert.doesNotMatch(output, /UNSUPPORTED/u);
   });

--- a/tools/ts2pant/tests/du-cutover.test.mts
+++ b/tools/ts2pant/tests/du-cutover.test.mts
@@ -1,12 +1,48 @@
+import assert from "node:assert/strict";
 import { describe, it } from "node:test";
+import { emitDocument } from "../src/emit.js";
+import { createSourceFileFromSource } from "../src/extract.js";
+import { buildDocumentFromSourceFile, emitAndCheck } from "./helpers.mjs";
 
 describe("du-cutover", () => {
-  it.skip("non-discriminated union field access is refused", () => {
-    // PENDING: Patch 2.
+  it("non-discriminated union field access is refused", async () => {
+    const sourceFile = createSourceFileFromSource(`
+      type NonDiscriminated =
+        | { owner: string; left: number }
+        | { owner: string; right: number };
+
+      export function readLeft(x: NonDiscriminated): number {
+        return x.left;
+      }
+    `);
+
+    const output = await emitAndCheck(
+      await buildDocumentFromSourceFile(sourceFile, "readLeft"),
+    );
+
+    assert.match(
+      output,
+      /UNSUPPORTED: property access \.left: field access on a non-discriminated union is not expressible in Pantagruel/u,
+    );
   });
 
-  it.skip("intersection field access remains sound (resolves a single owner)", () => {
-    // PENDING: Patch 2.
+  it("intersection field access remains sound (resolves a single owner)", async () => {
+    const sourceFile = createSourceFileFromSource(`
+      interface HasId { id: number; }
+      interface HasLabel { label: string; }
+      export function readId(x: HasId & HasLabel): number {
+        return x.id;
+      }
+    `);
+
+    const output = emitDocument(
+      await buildDocumentFromSourceFile(sourceFile, "readId"),
+    );
+
+    assert.match(output, /^has-id--id h: HasId => Int\.$/mu);
+    assert.match(output, /^read-id x: HasId & HasLabel => Int\.$/mu);
+    assert.match(output, /^read-id x = has-id--id x\.$/mu);
+    assert.doesNotMatch(output, /UNSUPPORTED/u);
   });
 
   it.skip("detected DU that fails tagged registration is refused (no + fallthrough)", () => {

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-discriminated-union.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-discriminated-union.ts
@@ -35,6 +35,7 @@ export function ambiguousOwner(x: NonDiscriminated): number {
 }
 
 /** Intersections keep AND-semantics field access. */
+/** @pant-type x: HasId */
 export function intersectionField(x: HasId & HasLabel): number {
   return x.id;
 }

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-discriminated-union.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-discriminated-union.ts
@@ -6,6 +6,14 @@ type NonDiscriminated =
   | { owner: string; left: number }
   | { owner: string; right: number };
 
+interface HasId {
+  id: number;
+}
+
+interface HasLabel {
+  label: string;
+}
+
 /** PENDING Patch 2: discriminant access on a DU receiver resolves. */
 export function readDiscriminant(x: Shape): string {
   return x.kind;
@@ -22,6 +30,11 @@ export function readSharedField(x: Shape): string {
 }
 
 /** Non-discriminated unions keep the ambiguous-owner refusal. */
-export function ambiguousOwner(x: NonDiscriminated): string {
-  return x.owner;
+export function ambiguousOwner(x: NonDiscriminated): number {
+  return x.left;
+}
+
+/** Intersections keep AND-semantics field access. */
+export function intersectionField(x: HasId & HasLabel): number {
+  return x.id;
 }

--- a/tools/ts2pant/tests/ir1-build-property.test.mts
+++ b/tools/ts2pant/tests/ir1-build-property.test.mts
@@ -168,7 +168,10 @@ describe("ir1-build-property", () => {
       `expected unsupported, got Member: ${JSON.stringify(result)}`,
     );
     if ("unsupported" in result) {
-      assert.match(result.unsupported, /ambiguous owner/u);
+      assert.match(
+        result.unsupported,
+        /field access on a non-discriminated union is not expressible in Pantagruel/u,
+      );
     }
   });
 

--- a/tools/ts2pant/tests/known-typecheck-failures.mts
+++ b/tools/ts2pant/tests/known-typecheck-failures.mts
@@ -47,9 +47,6 @@
  *   - "annotation-types"  the user's `@pant` annotation is itself
  *                         ill-typed against the emitted signature
  *                         (e.g. comparing a Bool result to an Int).
- *   - "intersection-type" Pantagruel has no intersection type encoding;
- *                         the fixture pins field-access owner resolution
- *                         only and intentionally skips standalone checking.
  */
 export const KNOWN_TYPECHECK_FAILURES = new Map<string, string>([
   ["control-flow.ts > max", "$-binder-leak"],
@@ -57,10 +54,6 @@ export const KNOWN_TYPECHECK_FAILURES = new Map<string, string>([
   ["expressions-boolean.ts > and", "$-binder-leak"],
   ["expressions-boolean.ts > or", "$-binder-leak"],
   ["expressions-discriminated-union.ts > ambiguousOwner", "ambiguous-owner"],
-  [
-    "expressions-discriminated-union.ts > intersectionField",
-    "intersection-type",
-  ],
   [
     "expressions-let-closure-captured.ts > letForEachCapturedTotal",
     "closure-captured-reassignment",

--- a/tools/ts2pant/tests/known-typecheck-failures.mts
+++ b/tools/ts2pant/tests/known-typecheck-failures.mts
@@ -47,6 +47,9 @@
  *   - "annotation-types"  the user's `@pant` annotation is itself
  *                         ill-typed against the emitted signature
  *                         (e.g. comparing a Bool result to an Int).
+ *   - "intersection-type" Pantagruel has no intersection type encoding;
+ *                         the fixture pins field-access owner resolution
+ *                         only and intentionally skips standalone checking.
  */
 export const KNOWN_TYPECHECK_FAILURES = new Map<string, string>([
   ["control-flow.ts > max", "$-binder-leak"],
@@ -54,6 +57,10 @@ export const KNOWN_TYPECHECK_FAILURES = new Map<string, string>([
   ["expressions-boolean.ts > and", "$-binder-leak"],
   ["expressions-boolean.ts > or", "$-binder-leak"],
   ["expressions-discriminated-union.ts > ambiguousOwner", "ambiguous-owner"],
+  [
+    "expressions-discriminated-union.ts > intersectionField",
+    "intersection-type",
+  ],
   [
     "expressions-let-closure-captured.ts > letForEachCapturedTotal",
     "closure-captured-reassignment",

--- a/tools/ts2pant/tests/translate-types.test.mts
+++ b/tools/ts2pant/tests/translate-types.test.mts
@@ -351,7 +351,7 @@ describe("emitDiscriminatedUnionSynthDecls", () => {
     );
   });
 
-  it("keeps non-discriminated union field access ambiguous", () => {
+  it("refuses non-discriminated union field access unless every member has the same owner", () => {
     const { alias, checker } = extractFirstAlias(`
       type NonDiscriminated =
         | { owner: string; left: number }
@@ -365,7 +365,34 @@ describe("emitDiscriminatedUnionSynthDecls", () => {
       resolveFieldOwner(alias.type, "owner", checker, IntStrategy, cell),
       {
         kind: "ambiguous",
-        owners: mapped.split(" + "),
+        owners: [],
+      },
+    );
+    assert.deepEqual(
+      resolveFieldOwner(alias.type, "left", checker, IntStrategy, cell),
+      {
+        kind: "ambiguous",
+        owners: [],
+      },
+    );
+  });
+
+  it("keeps intersection field access resolved by the declaring owner", () => {
+    const sourceFile = createSourceFileFromSource(`
+      interface HasId { id: number; }
+      interface HasLabel { label: string; }
+      type Both = HasId & HasLabel;
+    `);
+    const extracted = extractAllTypes(sourceFile);
+    const checker = getChecker(sourceFile);
+    const alias = extracted.aliases.find((entry) => entry.name === "Both");
+    assert.ok(alias);
+
+    assert.deepEqual(
+      resolveFieldOwner(alias.type, "id", checker, IntStrategy, newSynthCell()),
+      {
+        kind: "resolved",
+        owner: "HasId",
       },
     );
   });


### PR DESCRIPTION
## Patch 2: Refuse non-discriminated union field access (eliminate unique-field unsoundness)

- Split the isUnionOrIntersection branch in collectFieldOwners so a non-discriminated union and an intersection are handled distinctly.
- For a non-discriminated union (isUnion and detectDiscriminatedUnion === null), only add an owner when the field resolves to the same single owner on every member; otherwise add none, so resolveFieldOwner yields a non-resolved verdict and the access is refused through the existing qualifyFieldAccess/ir1-build channels.
- Leave intersection handling (genuine AND-semantics presence) recursing as today, resolving its single sound owner.
- Implement the Patch 1 stubs for non-discriminated-union refusal and intersection soundness.
- Adjust the non-discriminated control fixture to access a unique-to-one-member field, then regenerate constructs snapshots; confirm test:unit and test:integration pass.

## Changes
- Split the isUnionOrIntersection branch in collectFieldOwners so a non-discriminated union and an intersection are handled distinctly.
- For a non-discriminated union (isUnion and detectDiscriminatedUnion === null), only add an owner when the field resolves to the same single owner on every member; otherwise add none, so resolveFieldOwner yields a non-resolved verdict and the access is refused through the existing qualifyFieldAccess/ir1-build channels.
- Leave intersection handling (genuine AND-semantics presence) recursing as today, resolving its single sound owner.
- Implement the Patch 1 stubs for non-discriminated-union refusal and intersection soundness.
- Adjust the non-discriminated control fixture to access a unique-to-one-member field, then regenerate constructs snapshots; confirm test:unit and test:integration pass.

## Files to Modify
- tools/ts2pant/src/translate-types.ts (modify): In collectFieldOwners, separate the union case from the intersection case (currently merged at the isUnionOrIntersection branch). For a non-discriminated union receiver, a field is only resolvable when it is common to every member resolving to a single consistent owner; otherwise collect no owner so resolveFieldOwner returns `none`/`ambiguous` rather than `resolved`. Intersection recursion is unchanged.
- tools/ts2pant/tests/du-cutover.test.mts (modify): Un-skip and implement the non-discriminated-union-field-access-refused and intersection-field-access-sound stubs.
- tools/ts2pant/tests/fixtures/constructs/expressions-discriminated-union.ts (modify): Ensure the existing non-discriminated control exercises a unique-to-one-member field access so the refusal is captured; add an intersection-field-access case if not already covered.
- tools/ts2pant/tests/constructs.test.mts.snapshot (modify): Regenerate via `npm run test:update-snapshots`; the diff is the non-discriminated union field access now emitting the refusal instead of a unique-field accessor.

## Gameplan Specification

```
module DU_CUTOVER.

> ══════════════════════════════
> THE GUARANTEE
> ═══════════════════════════════
> After M4 the tagged guarded-rule encoding is the SOLE path for every
> discriminated union: a DU is tagged when it registers and refused
> otherwise, never `+`-encoded, including when nested as a variant field
> or embedded in a record/map/array (one shape-keyed domain shared with
> the same DU elsewhere). Field access on a non-discriminated union is
> refused (no unique-field accessor applied to the whole union), while
> intersection field access stays sound. The `A + B` sum encoding survives
> only as a value type for non-discriminated unions, and optionality
> (`T | null` -> `[T]`) is unchanged.

Ty.
is-union t: Ty => Bool.
is-intersection t: Ty => Bool.
is-discriminated t: Ty => Bool.
nests-discriminated t: Ty => Bool.
registers t: Ty => Bool.
field-access t: Ty => Bool.
narrowed-read t: Ty => Bool.
tagged t: Ty => Bool.
sum-encoded t: Ty => Bool.
refused-access t: Ty => Bool.
resolves t: Ty => Bool.
refused t: Ty => Bool.
entails t: Ty => Bool.

---

> Every discriminated union that registers is tagged and never sum-encoded;
> one that fails registration is refused, also never sum-encoded.
all t: Ty | (is-discriminated t and registers t) -> (tagged t and ~(sum-encoded t)).
all t: Ty | (is-discriminated t and ~(registers t)) -> (refused t and ~(sum-encoded t)).

> A discriminated union nested in a container or as a variant field still tags.
all t: Ty | nests-discriminated t -> (tagged t and ~(sum-encoded t)).

> A narrowed read of a (possibly nested) discriminated union entails.
all t: Ty | (is-discriminated t and narrowed-read t) -> entails t.

> Field access on a non-discriminated union is refused, never resolved;
> the bare sum value encoding still applies to non-discriminated unions.
all t: Ty | (is-union t and ~(is-discriminated t) and field-access t) -> (refused-access t and ~(resolves t)).
all t: Ty | (is-union t and ~(is-discriminated t)) -> sum-encoded t.

> Intersection field access remains sound (resolves a single owner).
all t: Ty | (is-intersection t and field-access t) -> resolves t.
```

## Patch Specification

```
module DU_CUTOVER_PATCH_2.

> Patch 2 eliminates the unique-field unsoundness: field access on a
> non-discriminated union is refused; intersection field access (genuine
> AND-semantics presence) still resolves to a single sound owner.

Ty.
is-union t: Ty => Bool.
is-intersection t: Ty => Bool.
is-discriminated t: Ty => Bool.
field-access t: Ty => Bool.
refused t: Ty => Bool.
resolves t: Ty => Bool.

---

> Field access on a non-discriminated union is refused, never resolved.
all t: Ty | (is-union t and ~(is-discriminated t) and field-access t) -> (refused t and ~(resolves t)).

> Intersection field access remains sound (resolves a single owner).
all t: Ty | (is-intersection t and field-access t) -> resolves t.
```


## Implementation Notes

- Non-discriminated union refusal is represented as an `ambiguous` field-owner verdict with an empty owner list. That preserves the existing `qualifyFieldAccess` / `buildL1MemberAccess` unsupported flow while avoiding the old `none` fallback to a bare field name.
- The union collector ignores nullish members for owner agreement, matching the existing optionality list-lift behavior and leaving `T | null` handling unchanged.
- Intersection coverage intentionally asserts emitted owner resolution instead of requiring standalone Pantagruel typechecking for `A & B`; intersection type encoding is pre-existing status quo and outside this patch.

Spec/Evidence Mapping:
- Non-discriminated union field access refused: `resolveFieldOwner` and `collectFieldOwners` in `tools/ts2pant/src/translate-types.ts`; refusal text in `translate-body.ts` and `ir1-build.ts`; proven by `du-cutover.test.mts`, `translate-types.test.mts`, `ir1-build-property.test.mts`, and the regenerated constructs snapshot.
- Intersection field access remains sound: `collectFieldOwners` keeps separate intersection recursion; proven by `du-cutover.test.mts`, `translate-types.test.mts`, and the new `intersectionField` construct snapshot.
- Required context consulted: `translate-types.ts` DU/field-owner seam, `translate-body.ts` and `ir1-build.ts` refusal sites, and the constructs/unit/integration test harness.