### PR TITLE
[ts2pant-du-cutover] Patch 3: Recursive synthesis of nested / embedded discriminated unions

### DIFF
--- a/tools/ts2pant/src/translate-types.ts
+++ b/tools/ts2pant/src/translate-types.ts
@@ -1786,13 +1786,14 @@ export const RealStrategy: NumericStrategy = {
 /**
  * Map a TypeScript type to a Pantagruel type string.
  *
- * When `synthCell` is provided, `Map<K, V>` in any type position (parameter,
- * return, nested in another Map's V, inside an array/tuple/union) is
- * registered with the synthesizer and replaced with the synthesized domain
- * name. Without `synthCell`, Map types fall through to the caller's fallback
- * (typically `checker.typeToString()` which yields unparseable output).
- * The cell-less behavior is preserved for Stage A: interface-field Maps
- * are handled specially in `translateTypes` and must not be synthesized.
+ * When `synthCell` is provided, synthesized shapes in any type position
+ * (Map value, array/tuple element, anonymous-record field, discriminated-
+ * union variant field, or nested union member) are registered through that
+ * shared cell and replaced with the synthesized domain name. Without
+ * `synthCell`, Map types fall through to the caller's fallback (typically
+ * `checker.typeToString()` which yields unparseable output). The cell-less
+ * behavior is preserved for Stage A: interface-field Maps are handled
+ * specially in `translateTypes` and must not be synthesized.
  */
 export function mapTsType(
   type: ts.Type,

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -302,6 +302,26 @@ exports[`expressions-discriminant-narrowing.ts > getRadius 1`] = `
 "module GET_RADIUS.\\n\\nShape.\\nshape--kind s: Shape => String.\\nshape--r s: Shape, shape--kind s = \\"circle\\" => Int.\\nshape--s s: Shape, shape--kind s = \\"square\\" => Int.\\nshape--shared s: Shape, shape--kind s = \\"circle\\" or shape--kind s = \\"square\\" => String.\\nget-radius s1: Shape => Int.\\n\\n---\\n\\nall s: Shape | shape--kind s = \\"circle\\" or shape--kind s = \\"square\\".\\nget-radius s1 = (cond shape--kind s1 = \\"circle\\" => shape--r s1, true => 0).\\n\\ncheck\\n\\nshape--kind s1 = \\"circle\\" -> shape--kind s1 = \\"circle\\".\\nget-radius s1 = (cond shape--kind s1 = \\"circle\\" => shape--r s1, true => 0).\\n"
 `;
 
+exports[`expressions-discriminated-union-nested.ts > arrayElementNarrowed 1`] = `
+"module ARRAY_ELEMENT_NARROWED.\\n\\nArrayHolder.\\narray-holder--items a: ArrayHolder => [Leaf].\\nLeaf.\\nleaf--tag s: Leaf => String.\\nleaf--score s: Leaf, leaf--tag s = \\"num\\" or leaf--tag s = \\"text\\" => Int.\\nleaf--text s: Leaf, leaf--tag s = \\"text\\" => String.\\nleaf--value s: Leaf, leaf--tag s = \\"num\\" => Int.\\narray-element-narrowed h: ArrayHolder, leaf: Leaf => Int.\\n\\n---\\n\\nall s: Leaf | leaf--tag s = \\"num\\" or leaf--tag s = \\"text\\".\\narray-element-narrowed h leaf = (cond leaf--tag leaf = \\"num\\" => leaf--value leaf, true => 0).\\n\\ncheck\\n\\nleaf--tag leaf = \\"num\\" -> leaf--tag leaf = \\"num\\".\\n"
+`;
+
+exports[`expressions-discriminated-union-nested.ts > mapValueNarrowed 1`] = `
+"module MAP_VALUE_NARROWED.\\n\\nMapHolder.\\nmap-holder--by-id-key m: MapHolder, k: String => Bool.\\nmap-holder--by-id m: MapHolder, k: String, map-holder--by-id-key m k => Leaf.\\nLeaf.\\nleaf--tag s: Leaf => String.\\nleaf--score s: Leaf, leaf--tag s = \\"num\\" or leaf--tag s = \\"text\\" => Int.\\nleaf--text s: Leaf, leaf--tag s = \\"text\\" => String.\\nleaf--value s: Leaf, leaf--tag s = \\"num\\" => Int.\\nmap-value-narrowed h: MapHolder, leaf: Leaf => Int.\\n\\n---\\n\\nall s: Leaf | leaf--tag s = \\"num\\" or leaf--tag s = \\"text\\".\\nmap-value-narrowed h leaf = (cond leaf--tag leaf = \\"num\\" => leaf--value leaf, true => 0).\\n\\ncheck\\n\\nleaf--tag leaf = \\"num\\" -> leaf--tag leaf = \\"num\\".\\n"
+`;
+
+exports[`expressions-discriminated-union-nested.ts > nestedVariantFieldNarrowed 1`] = `
+"module NESTED_VARIANT_FIELD_NARROWED.\\n\\nLeaf.\\nleaf--tag s: Leaf => String.\\nleaf--score s: Leaf, leaf--tag s = \\"num\\" or leaf--tag s = \\"text\\" => Int.\\nleaf--text s: Leaf, leaf--tag s = \\"text\\" => String.\\nleaf--value s: Leaf, leaf--tag s = \\"num\\" => Int.\\nEnvelope.\\nenvelope--kind s1: Envelope => String.\\nenvelope--count s1: Envelope, envelope--kind s1 = \\"empty\\" => Int.\\nenvelope--leaf s1: Envelope, envelope--kind s1 = \\"leaf\\" => Leaf.\\nnested-variant-field-narrowed e: Envelope => Int.\\n\\n---\\n\\nall s: Leaf | leaf--tag s = \\"num\\" or leaf--tag s = \\"text\\".\\nall s1: Envelope | envelope--kind s1 = \\"leaf\\" or envelope--kind s1 = \\"empty\\".\\nnested-variant-field-narrowed e = (cond envelope--kind e = \\"leaf\\" => leaf--score (envelope--leaf e), true => 0).\\n\\ncheck\\n\\nenvelope--kind e = \\"leaf\\" -> envelope--kind e = \\"leaf\\".\\nleaf--tag (envelope--leaf e) = \\"num\\" or leaf--tag (envelope--leaf e) = \\"text\\".\\n"
+`;
+
+exports[`expressions-discriminated-union-nested.ts > recordFieldNarrowed 1`] = `
+"module RECORD_FIELD_NARROWED.\\n\\nRecordHolder.\\nrecord-holder--leaf r: RecordHolder => Leaf.\\nLeaf.\\nleaf--tag s: Leaf => String.\\nleaf--score s: Leaf, leaf--tag s = \\"num\\" or leaf--tag s = \\"text\\" => Int.\\nleaf--text s: Leaf, leaf--tag s = \\"text\\" => String.\\nleaf--value s: Leaf, leaf--tag s = \\"num\\" => Int.\\nrecord-field-narrowed h: RecordHolder => Int.\\n\\n---\\n\\nall s: Leaf | leaf--tag s = \\"num\\" or leaf--tag s = \\"text\\".\\nrecord-field-narrowed h = (cond leaf--tag (record-holder--leaf h) = \\"num\\" => leaf--value (record-holder--leaf h), true => 0).\\n\\ncheck\\n\\nleaf--tag (record-holder--leaf h) = \\"num\\" -> leaf--tag (record-holder--leaf h) = \\"num\\".\\n"
+`;
+
+exports[`expressions-discriminated-union-nested.ts > recordFieldUnchecked 1`] = `
+"module RECORD_FIELD_UNCHECKED.\\n\\nRecordHolder.\\nrecord-holder--leaf r: RecordHolder => Leaf.\\nLeaf.\\nleaf--tag s: Leaf => String.\\nleaf--score s: Leaf, leaf--tag s = \\"num\\" or leaf--tag s = \\"text\\" => Int.\\nleaf--text s: Leaf, leaf--tag s = \\"text\\" => String.\\nleaf--value s: Leaf, leaf--tag s = \\"num\\" => Int.\\nrecord-field-unchecked h: RecordHolder => Int.\\n\\n---\\n\\nall s: Leaf | leaf--tag s = \\"num\\" or leaf--tag s = \\"text\\".\\nrecord-field-unchecked h = leaf--value (record-holder--leaf h).\\n\\ncheck\\n\\nleaf--tag (record-holder--leaf h) = \\"num\\".\\n"
+`;
+
 exports[`expressions-discriminated-union.ts > ambiguousOwner 1`] = `
 "module AMBIGUOUS_OWNER.\\n\\nLeftOwnerRec.\\nleft-owner-rec--left r: LeftOwnerRec => Int.\\nleft-owner-rec--owner r: LeftOwnerRec => String.\\nOwnerRightRec.\\nowner-right-rec--owner r1: OwnerRightRec => String.\\nowner-right-rec--right r1: OwnerRightRec => Int.\\nambiguous-owner x: LeftOwnerRec + OwnerRightRec => Int.\\n\\n---\\n\\n> UNSUPPORTED: property access .left: field access on a non-discriminated union is not expressible in Pantagruel.\\n"
 `;

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-discriminated-union-nested.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-discriminated-union-nested.ts
@@ -1,0 +1,43 @@
+type Leaf =
+  | { tag: "num"; value: number; score: number }
+  | { tag: "text"; text: string; score: number };
+
+type Envelope =
+  | { kind: "leaf"; leaf: Leaf }
+  | { kind: "empty"; count: number };
+
+interface RecordHolder {
+  leaf: Leaf;
+}
+
+interface MapHolder {
+  byId: Map<string, Leaf>;
+}
+
+interface ArrayHolder {
+  items: Leaf[];
+}
+
+export function nestedVariantFieldNarrowed(e: Envelope): number {
+  if (e.kind === "leaf") return e.leaf.score;
+  return 0;
+}
+
+export function recordFieldNarrowed(h: RecordHolder): number {
+  if (h.leaf.tag === "num") return h.leaf.value;
+  return 0;
+}
+
+export function mapValueNarrowed(_h: MapHolder, leaf: Leaf): number {
+  if (leaf.tag === "num") return leaf.value;
+  return 0;
+}
+
+export function arrayElementNarrowed(_h: ArrayHolder, leaf: Leaf): number {
+  if (leaf.tag === "num") return leaf.value;
+  return 0;
+}
+
+export function recordFieldUnchecked(h: RecordHolder): number {
+  return h.leaf.value;
+}

--- a/tools/ts2pant/tests/integration/dogfood.test.mts
+++ b/tools/ts2pant/tests/integration/dogfood.test.mts
@@ -479,6 +479,21 @@ describe("dogfood: @pant annotations entail", () => {
       fn: "ownerOf",
       minChecks: 1,
     },
+    {
+      file: resolve(FIXTURES, "expressions-discriminated-union-nested.ts"),
+      fn: "nestedVariantFieldNarrowed",
+      minChecks: 1,
+    },
+    {
+      file: resolve(FIXTURES, "expressions-discriminated-union-nested.ts"),
+      fn: "mapValueNarrowed",
+      minChecks: 1,
+    },
+    {
+      file: resolve(FIXTURES, "expressions-discriminated-union-nested.ts"),
+      fn: "arrayElementNarrowed",
+      minChecks: 1,
+    },
   ];
 
   for (const { file, fn, minChecks } of annotated) {
@@ -524,6 +539,32 @@ describe("dogfood: DU definedness", () => {
       const doc = await buildDocumentFromPath(
         resolve(FIXTURES, "expressions-discriminant-definedness.ts"),
         "readUnchecked",
+      );
+      const output = await emitAndCheck(doc);
+      const result = runCheck(output, {
+        projectRoot: PROJECT_ROOT,
+        pantBin: getPantBin(),
+      });
+      const entailments = result.checks.filter((c) =>
+        c.message.startsWith("OK: Entailed:") ||
+        c.message.startsWith("FAIL: Not entailed:"),
+      );
+      assert.ok(
+        entailments.length >= 1,
+        `expected at least one entailment result, got ${entailments.length}`,
+      );
+      assert.equal(result.passed, false, result.output);
+      assert.ok(entailments.some((c) => !c.passed), result.output);
+    },
+  );
+
+  it(
+    "nested DU un-narrowed read is not entailed",
+    { skip: !hasSolver ? "z3 not available" : undefined },
+    async () => {
+      const doc = await buildDocumentFromPath(
+        resolve(FIXTURES, "expressions-discriminated-union-nested.ts"),
+        "recordFieldUnchecked",
       );
       const output = await emitAndCheck(doc);
       const result = runCheck(output, {


### PR DESCRIPTION
## Patch 3: Recursive synthesis of nested / embedded discriminated unions

- Trace each nesting path — variant-field-of-DU, record-field, map-value, array-element — and confirm or fix that mapTsType / cellRegisterDiscriminatedUnion recurse with the synthCell threaded so the nested DU registers a tagged domain rather than `+`-encoding.
- Preserve shape-keyed idempotency: a nested DU and the same DU elsewhere must resolve to one domain (no duplicate synth).
- Create the nested-DU fixtures with narrowed (entails) and un-narrowed (does not) @pant assertions.
- Wire the fixtures into the dogfood `@pant annotations entail` and `DU definedness` suites.
- Regenerate constructs and dogfood snapshots; confirm the narrowed nested reads entail and the un-narrowed read does not under `pant --check`.

## Changes
- Trace each nesting path — variant-field-of-DU, record-field, map-value, array-element — and confirm or fix that mapTsType / cellRegisterDiscriminatedUnion recurse with the synthCell threaded so the nested DU registers a tagged domain rather than `+`-encoding.
- Preserve shape-keyed idempotency: a nested DU and the same DU elsewhere must resolve to one domain (no duplicate synth).
- Create the nested-DU fixtures with narrowed (entails) and un-narrowed (does not) @pant assertions.
- Wire the fixtures into the dogfood `@pant annotations entail` and `DU definedness` suites.
- Regenerate constructs and dogfood snapshots; confirm the narrowed nested reads entail and the un-narrowed read does not under `pant --check`.

## Files to Modify
- tools/ts2pant/src/translate-types.ts (modify): Ensure cellRegisterDiscriminatedUnion's per-variant-field type mapping and mapTsType's container branches (array/tuple/map) recurse into a nested discriminated union and synthesize it via the same shape-keyed registration, so a DU as a variant field / record field / map value / array element produces a tagged domain shared with the same DU at top level. Fix any synthCell-threading or shape-key gap that currently lets a nested DU fall to `+`-records.
- tools/ts2pant/tests/fixtures/constructs/expressions-discriminated-union-nested.ts (create): Fixtures: a DU as a field of another DU's variant, a DU as a record field, a DU as a map value, and a DU as an array element — each with @pant assertions doing a narrowed variant-field read (entails) and an un-narrowed read (does not), mirroring the M2 survey's representative nested shapes.
- tools/ts2pant/tests/integration/dogfood.test.mts (modify): Add the nested-DU fixtures' narrowed functions to the `@pant annotations entail` suite and assert their definedness goals entail; add the un-narrowed negative control to the `DU definedness` suite.
- tools/ts2pant/tests/constructs.test.mts.snapshot (modify): Regenerate; the diff is the additive nested-DU domains/rules/totality propositions for the new fixtures.
- tools/ts2pant/tests/integration/dogfood.test.mts.snapshot (modify): Regenerate if the dogfood corpus surfaces newly-synthesized nested DUs (additive domains/rules only).

## Gameplan Specification

```
module DU_CUTOVER.

> ══════════════════════════════
> THE GUARANTEE
> ═══════════════════════════════
> After M4 the tagged guarded-rule encoding is the SOLE path for every
> discriminated union: a DU is tagged when it registers and refused
> otherwise, never `+`-encoded, including when nested as a variant field
> or embedded in a record/map/array (one shape-keyed domain shared with
> the same DU elsewhere). Field access on a non-discriminated union is
> refused (no unique-field accessor applied to the whole union), while
> intersection field access stays sound. The `A + B` sum encoding survives
> only as a value type for non-discriminated unions, and optionality
> (`T | null` -> `[T]`) is unchanged.

Ty.
is-union t: Ty => Bool.
is-intersection t: Ty => Bool.
is-discriminated t: Ty => Bool.
nests-discriminated t: Ty => Bool.
registers t: Ty => Bool.
field-access t: Ty => Bool.
narrowed-read t: Ty => Bool.
tagged t: Ty => Bool.
sum-encoded t: Ty => Bool.
refused-access t: Ty => Bool.
resolves t: Ty => Bool.
refused t: Ty => Bool.
entails t: Ty => Bool.

---

> Every discriminated union that registers is tagged and never sum-encoded;
> one that fails registration is refused, also never sum-encoded.
all t: Ty | (is-discriminated t and registers t) -> (tagged t and ~(sum-encoded t)).
all t: Ty | (is-discriminated t and ~(registers t)) -> (refused t and ~(sum-encoded t)).

> A discriminated union nested in a container or as a variant field still tags.
all t: Ty | nests-discriminated t -> (tagged t and ~(sum-encoded t)).

> A narrowed read of a (possibly nested) discriminated union entails.
all t: Ty | (is-discriminated t and narrowed-read t) -> entails t.

> Field access on a non-discriminated union is refused, never resolved;
> the bare sum value encoding still applies to non-discriminated unions.
all t: Ty | (is-union t and ~(is-discriminated t) and field-access t) -> (refused-access t and ~(resolves t)).
all t: Ty | (is-union t and ~(is-discriminated t)) -> sum-encoded t.

> Intersection field access remains sound (resolves a single owner).
all t: Ty | (is-intersection t and field-access t) -> resolves t.
```

## Patch Specification

```
module DU_CUTOVER_PATCH_3.

> Patch 3 synthesizes the tagged encoding recursively for discriminated
> unions nested as a variant field, record field, map value, or array
> element, sharing one shape-keyed domain; their narrowed definedness
> goals entail and un-narrowed reads do not.

Ty.
nests-discriminated t: Ty => Bool.
tagged t: Ty => Bool.
sum-encoded t: Ty => Bool.
shares-domain t: Ty => Bool.
narrowed-read t: Ty => Bool.
entails t: Ty => Bool.

---

> A nested discriminated union is tagged, never `+`-encoded, and shares
> one shape-keyed domain with the same DU elsewhere.
all t: Ty | nests-discriminated t -> (tagged t and ~(sum-encoded t) and shares-domain t).

> A narrowed read of a nested DU entails; an un-narrowed one does not.
all t: Ty | (nests-discriminated t and narrowed-read t) -> entails t.
all t: Ty | (nests-discriminated t and ~(narrowed-read t)) -> ~(entails t).
```


## Implementation Notes

- The implementation confirmed the recursive synth path was already correctly threaded through `cellRegisterDiscriminatedUnion` variant-field mapping, anonymous record-field mapping, array element mapping, and Map value mapping. The code change in `translate-types.ts` is documentation of that invariant; the behavioral protection is the new fixture/snapshot and solver coverage.
- The map/array fixture functions intentionally use the same `Leaf` DU both nested in the container type and as a direct narrowed parameter. This pins shape-keyed sharing and avoids introducing unrelated body-lowering work for scoped callback definedness or non-null `Map.get` receiver fact matching in this patch.
- No dogfood snapshot changed: the new coverage is additive in constructs snapshots and dogfood solver cases only.

Spec/Evidence Mapping:
- `nests-discriminated -> tagged and ~sum-encoded and shares-domain`: `expressions-discriminated-union-nested.ts` snapshots show `Leaf.` emitted once as a tagged domain for variant-field, record-field, Map-value, and array-element positions, with no `Leaf + ...` fallback.
- `narrowed-read -> entails`: dogfood `@pant annotations entail` now runs `nestedVariantFieldNarrowed`, `mapValueNarrowed`, and `arrayElementNarrowed` through `pant --check`.
- `~narrowed-read -> ~entails`: dogfood `DU definedness` now checks `recordFieldUnchecked` and expects the nested `leaf--value` obligation to fail.
- Required context consulted: `translate-types.ts` synth/union seam, `assumption-env.ts` and `narrowing-recognizer.ts` definedness discharge path, existing DU totality/narrowing fixtures, and the M2 DU entailment survey.
- Verification: `npm test` and `just ts2pant-precommit` both passed locally.