### PR TITLE
[ts2pant-du-cutover] Patch 4: Refuse registration-failing discriminated unions instead of + fallthrough

### DIFF
--- a/tools/ts2pant/src/translate-types.ts
+++ b/tools/ts2pant/src/translate-types.ts
@@ -62,6 +62,26 @@ export function isUnsupportedUnknown(pantType: string): boolean {
   return pantType === UNSUPPORTED_UNKNOWN;
 }
 
+export function isUnsupportedDiscriminatedUnionRegistration(
+  pantType: string,
+): boolean {
+  return pantType === UNSUPPORTED_DISCRIMINATED_UNION_REGISTRATION_REASON;
+}
+
+function isUnsupportedMappedType(pantType: string): boolean {
+  return (
+    isUnsupportedUnknown(pantType) ||
+    isUnsupportedDiscriminatedUnionRegistration(pantType)
+  );
+}
+
+function unsupportedMappedTypeReason(pantType: string): string {
+  if (isUnsupportedUnknown(pantType)) {
+    return UNSUPPORTED_UNKNOWN_REASON;
+  }
+  return pantType;
+}
+
 /**
  * TypeScript type flags for `null` / `undefined` / `void`. Pantagruel
  * retired `Nothing` from the user-facing type surface — there is no
@@ -1924,6 +1944,7 @@ export function mapTsType(
         if (domain !== null) {
           return domain;
         }
+        return UNSUPPORTED_DISCRIMINATED_UNION_REGISTRATION_REASON;
       }
     }
     // List-lift encoding for optionality: strip null/undefined/void before
@@ -2165,10 +2186,15 @@ export function translateTypes(
           // references it.
           const kType = mapTsType(typeArgs[0]!, checker, strategy, synthCell);
           const vType = mapTsType(typeArgs[1]!, checker, strategy, synthCell);
-          if (isUnsupportedUnknown(kType) || isUnsupportedUnknown(vType)) {
+          if (
+            isUnsupportedMappedType(kType) ||
+            isUnsupportedMappedType(vType)
+          ) {
             decls.push({
               kind: "unsupported",
-              reason: `${iface.name}.${prop.name}: ${UNSUPPORTED_UNKNOWN_REASON}`,
+              reason: `${iface.name}.${prop.name}: ${unsupportedMappedTypeReason(
+                isUnsupportedMappedType(kType) ? kType : vType,
+              )}`,
             });
             continue;
           }
@@ -2201,10 +2227,12 @@ export function translateTypes(
         }
       }
       const fieldType = mapTsType(prop.type, checker, strategy, synthCell);
-      if (isUnsupportedUnknown(fieldType)) {
+      if (isUnsupportedMappedType(fieldType)) {
         decls.push({
           kind: "unsupported",
-          reason: `${iface.name}.${prop.name}: ${UNSUPPORTED_UNKNOWN_REASON}`,
+          reason: `${iface.name}.${prop.name}: ${unsupportedMappedTypeReason(
+            fieldType,
+          )}`,
         });
         continue;
       }
@@ -2219,10 +2247,12 @@ export function translateTypes(
 
   for (const alias of extracted.aliases) {
     const aliasType = mapTsType(alias.type, checker, strategy, synthCell);
-    if (isUnsupportedUnknown(aliasType)) {
+    if (isUnsupportedMappedType(aliasType)) {
       decls.push({
         kind: "unsupported",
-        reason: `alias ${alias.name}: ${UNSUPPORTED_UNKNOWN_REASON}`,
+        reason: `alias ${alias.name}: ${unsupportedMappedTypeReason(
+          aliasType,
+        )}`,
       });
       continue;
     }

--- a/tools/ts2pant/tests/du-cutover.test.mts
+++ b/tools/ts2pant/tests/du-cutover.test.mts
@@ -1,6 +1,16 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { createSourceFileFromSource } from "../src/extract.js";
+import {
+  createSourceFileFromSource,
+  extractAllTypes,
+  getChecker,
+} from "../src/extract.js";
+import {
+  IntStrategy,
+  mapTsType,
+  newSynthCell,
+  UNSUPPORTED_DISCRIMINATED_UNION_REGISTRATION_REASON,
+} from "../src/translate-types.js";
 import { buildDocumentFromSourceFile, emitAndCheck } from "./helpers.mjs";
 
 describe("du-cutover", () => {
@@ -45,7 +55,27 @@ describe("du-cutover", () => {
     assert.doesNotMatch(output, /UNSUPPORTED/u);
   });
 
-  it.skip("detected DU that fails tagged registration is refused (no + fallthrough)", () => {
-    // PENDING: Patch 4.
+  it("detected DU that fails tagged registration is refused (no + fallthrough)", () => {
+    const sourceFile = createSourceFileFromSource(`
+      type MixedDiscriminant =
+        | { kind: "left"; value: number }
+        | { kind: 1; value: number };
+    `);
+    const checker = getChecker(sourceFile);
+    const alias = extractAllTypes(sourceFile).aliases[0];
+    assert.ok(alias);
+
+    const mapped = mapTsType(
+      alias.type,
+      checker,
+      IntStrategy,
+      newSynthCell(),
+    );
+
+    assert.equal(
+      mapped,
+      UNSUPPORTED_DISCRIMINATED_UNION_REGISTRATION_REASON,
+    );
+    assert.doesNotMatch(mapped, / \+ /u);
   });
 });


### PR DESCRIPTION
## Patch 4: Refuse registration-failing discriminated unions instead of + fallthrough

- Add the early refusal return in the detected-DU branch on registration failure (domain === null), using the Patch 1 reason constant.
- Verify non-discriminated unions and optionality are untouched (detection === null still reaches `unique.join(" + ")` / `[...]`).
- Implement the Patch 1 registration-failure stub; add a fixture only if needed to exercise the path.
- Regenerate any affected snapshots; confirm test:unit and test:integration pass.

## Changes
- Add the early refusal return in the detected-DU branch on registration failure (domain === null), using the Patch 1 reason constant.
- Verify non-discriminated unions and optionality are untouched (detection === null still reaches `unique.join(" + ")` / `[...]`).
- Implement the Patch 1 registration-failure stub; add a fixture only if needed to exercise the path.
- Regenerate any affected snapshots; confirm test:unit and test:integration pass.

## Files to Modify
- tools/ts2pant/src/translate-types.ts (modify): In mapTsType's union branch, when detectDiscriminatedUnion returns a detection but cellRegisterDiscriminatedUnion returns null, return the UNSUPPORTED_* registration-failure reason (Patch 1 constant) instead of continuing to the `+`-records block. Leave the non-discriminated path (detection === null) and the nullish list-lift exactly as-is.
- tools/ts2pant/tests/du-cutover.test.mts (modify): Un-skip and implement the registration-failure refusal stub: a detected DU whose synthesis fails maps to the refusal sentinel, not an `A + B` string.
- tools/ts2pant/tests/constructs.test.mts.snapshot (modify): Regenerate if any fixture exercises a registration-failing DU (diff is the refusal replacing a `+` encoding).

## Gameplan Specification

```
module DU_CUTOVER.

> ══════════════════════════════
> THE GUARANTEE
> ═══════════════════════════════
> After M4 the tagged guarded-rule encoding is the SOLE path for every
> discriminated union: a DU is tagged when it registers and refused
> otherwise, never `+`-encoded, including when nested as a variant field
> or embedded in a record/map/array (one shape-keyed domain shared with
> the same DU elsewhere). Field access on a non-discriminated union is
> refused (no unique-field accessor applied to the whole union), while
> intersection field access stays sound. The `A + B` sum encoding survives
> only as a value type for non-discriminated unions, and optionality
> (`T | null` -> `[T]`) is unchanged.

Ty.
is-union t: Ty => Bool.
is-intersection t: Ty => Bool.
is-discriminated t: Ty => Bool.
nests-discriminated t: Ty => Bool.
registers t: Ty => Bool.
field-access t: Ty => Bool.
narrowed-read t: Ty => Bool.
tagged t: Ty => Bool.
sum-encoded t: Ty => Bool.
refused-access t: Ty => Bool.
resolves t: Ty => Bool.
refused t: Ty => Bool.
entails t: Ty => Bool.

---

> Every discriminated union that registers is tagged and never sum-encoded;
> one that fails registration is refused, also never sum-encoded.
all t: Ty | (is-discriminated t and registers t) -> (tagged t and ~(sum-encoded t)).
all t: Ty | (is-discriminated t and ~(registers t)) -> (refused t and ~(sum-encoded t)).

> A discriminated union nested in a container or as a variant field still tags.
all t: Ty | nests-discriminated t -> (tagged t and ~(sum-encoded t)).

> A narrowed read of a (possibly nested) discriminated union entails.
all t: Ty | (is-discriminated t and narrowed-read t) -> entails t.

> Field access on a non-discriminated union is refused, never resolved;
> the bare sum value encoding still applies to non-discriminated unions.
all t: Ty | (is-union t and ~(is-discriminated t) and field-access t) -> (refused-access t and ~(resolves t)).
all t: Ty | (is-union t and ~(is-discriminated t)) -> sum-encoded t.

> Intersection field access remains sound (resolves a single owner).
all t: Ty | (is-intersection t and field-access t) -> resolves t.
```

## Patch Specification

```
module DU_CUTOVER_PATCH_4.

> Patch 4 makes a detected discriminated union that fails tagged
> registration refuse, instead of falling through to `+`-records. The
> tagged encoding is the sole discriminated-union path; non-discriminated
> unions keep the `A + B` value encoding and optionality keeps `[T]`.

Ty.
is-union t: Ty => Bool.
is-discriminated t: Ty => Bool.
registers t: Ty => Bool.
tagged t: Ty => Bool.
refused t: Ty => Bool.
sum-encoded t: Ty => Bool.

---

> A discriminated union is tagged when it registers, refused otherwise —
> never `+`-encoded.
all t: Ty | (is-discriminated t and registers t) -> tagged t.
all t: Ty | (is-discriminated t and ~(registers t)) -> (refused t and ~(sum-encoded t)).

> A non-discriminated union still uses the sum value encoding.
all t: Ty | (is-union t and ~(is-discriminated t)) -> sum-encoded t.
```


## Implementation Notes

- The registration-failure reason is treated as a mapped-type refusal sentinel alongside `UNSUPPORTED_UNKNOWN` inside `translate-types.ts`, so interface fields and aliases emit an `unsupported` declaration instead of leaking the reason string as a Pantagruel type.
- The test uses a detected DU with mixed discriminant literal Pant types (`"left"` vs `1`) because `detectDiscriminatedUnion` accepts it structurally, while `cellRegisterDiscriminatedUnion` correctly rejects it when the discriminant return type would be inconsistent.
- No snapshot updates were needed; the new coverage lives in `du-cutover.test.mts` and existing non-DU union/optionality snapshot coverage remained unchanged.

Spec/Evidence Mapping:
- Failed detected DU is refused and not sum-encoded: `mapTsType` returns `UNSUPPORTED_DISCRIMINATED_UNION_REGISTRATION_REASON` immediately after `cellRegisterDiscriminatedUnion(...) === null`; covered by `du-cutover.test.mts`.
- Non-discriminated unions and optionality still use the existing fallthrough: the `detection === null` path still reaches the `unique.join(" + ")` / list-lift block; covered by existing `translate-types.test.mts` cases and the full `npm run test:unit`.
- Required context consulted: `translate-types.ts` union mapping and owner-resolution seam, plus the Patch 1 `du-cutover` stub.
- Verification run: `npm run test:unit`, `npm run test:integration`, `npm run lint`, and `just ts2pant-typecheck`.