### PR TITLE
[ts2pant-du-cutover] Patch 5: Document the tagged-union encoding and refusal taxonomy

### DIFF
--- a/tools/ts2pant/docs/du-tagged-union-encoding.md
+++ b/tools/ts2pant/docs/du-tagged-union-encoding.md
@@ -1,0 +1,134 @@
+# Tagged Discriminated-Union Encoding
+
+This document describes the terminal-state `ts2pant` encoding for TypeScript
+discriminated unions after the `du-cutover` milestone. It builds on the M2
+entailment survey in
+[du-entailment-narrowing-survey.md](./du-entailment-narrowing-survey.md) and
+the milestone decisions in
+[workstreams/ts2pant-discriminated-union.md](../../../workstreams/ts2pant-discriminated-union.md).
+
+## Scope
+
+A TypeScript union is a discriminated union only by structure. The translator
+does not special-case field names such as `kind`, `type`, or `_tag`.
+
+A union qualifies when:
+
+- it has at least two non-nullish members;
+- every member has at least one common field; and
+- at least one common field has a distinct literal type on every member.
+
+When more than one field qualifies, detection picks the first qualifying field
+by sorted field name. The selected field is the discriminant. Any other
+qualifying field is encoded as an ordinary guarded variant field under the
+chosen discriminant.
+
+Unions that contain `null`, `undefined`, or `void` do not qualify as
+discriminated unions. Optionality stays on the existing list-lift path:
+`T | null` maps to `[T]`, and `A | B | null` maps to `[A + B]`.
+
+## Encoding
+
+Each successfully registered discriminated-union shape maps to one synthesized
+Pantagruel domain. Registration is shape-keyed, so the same TypeScript DU shape
+uses one shared domain whether it appears as a top-level alias, a variant field,
+an anonymous-record field, a `Map` value, or an array/tuple element.
+
+For:
+
+```ts
+type Shape =
+  | { kind: "circle"; r: number; shared: string }
+  | { kind: "square"; s: number; shared: string };
+```
+
+the emitted shape is:
+
+```pant
+Shape.
+shape--kind s: Shape => String.
+shape--r s: Shape, shape--kind s = "circle" => Int.
+shape--s s: Shape, shape--kind s = "square" => Int.
+shape--shared s: Shape, shape--kind s = "circle" or shape--kind s = "square" => String.
+
+all s: Shape | shape--kind s = "circle" or shape--kind s = "square".
+```
+
+The discriminant rule is total on the synthesized domain. Variant-only fields
+are guarded by exactly the variants that declare them. Shared fields are also
+guarded, with an `or` over every declaring variant. Field rule names follow the
+same owner/field convention as record synthesis: `<domain>--<field>`.
+
+The totality assertion is emitted once per DU domain. The M2 survey showed that
+disjointness is already available from function-value semantics, but totality is
+not free under EUF. The explicit invariant lets exhaustive narrowing and
+fallback arms reason from the known TypeScript variant cover.
+
+## Narrowing
+
+Variant-field reads are sound without narrowing because guarded Pantagruel
+rules are partial on their preconditions. The translator may emit
+`shape--r x`, but the field rule carries the guard
+`shape--kind x = "circle"`.
+
+Narrowing is local and intra-function. The recognizer records facts from tests
+such as:
+
+- `x.kind === "circle"`;
+- `"circle" === x.kind`;
+- `x.kind !== "circle"`; and
+- `switch (x.kind) { case "circle": ... }`.
+
+The assumption environment stores those facts by receiver text, property name,
+literal, and negation. When a guarded variant-field rule is applied, the
+translator checks whether the matching discriminant fact is in scope. If it is,
+the precondition is discharged and the generated `@pant` obligation entails
+under z3. This is the target shape measured in the M2 survey: the guarded
+encoding entails once the discriminant equality is available.
+
+The narrowing layer is intentionally not cross-call. A helper predicate that
+returns `x.kind === "circle"` does not currently transfer the discriminant fact
+to the caller.
+
+## Nested Discriminated Unions
+
+Nested DUs use the same recursive synthesis path as other synthesized shapes.
+When `mapTsType` is called with a synth cell, it recursively maps:
+
+- array, tuple, iterator, and set elements;
+- `Map<K, V>` keys and values;
+- anonymous-record fields; and
+- discriminated-union variant fields.
+
+If a nested type is itself a discriminated union, it is registered through the
+same `cellRegisterDiscriminatedUnion` path as a top-level DU. Because
+registration is keyed by structural shape, the nested occurrence and any other
+occurrence share one synthesized domain. A nested narrowed read therefore has
+the same entailment story as a top-level narrowed read.
+
+## Refusal Taxonomy
+
+The cutover makes the tagged guarded-rule encoding the sole path for detected
+discriminated unions:
+
+- If detection succeeds and tagged registration succeeds, the union maps to the
+  synthesized DU domain and is never `+`-encoded.
+- If detection succeeds but tagged registration fails, the union is refused with
+  `discriminated union could not be registered for tagged Pantagruel encoding`.
+  It does not fall back to the legacy `+`-of-records encoding.
+- If a non-discriminated union is used only as a value type, the existing
+  `A + B` encoding remains available.
+- If code accesses a field on a non-discriminated union, the access is refused
+  with
+  `field access on a non-discriminated union is not expressible in Pantagruel`.
+  This removes the old unique-field unsoundness where a field declared by one
+  member could be resolved to that member's accessor and applied to the whole
+  union value.
+- Intersection field access is unchanged. Intersections have AND semantics, so
+  a field declared by one member is genuinely present on the intersection
+  value; resolving that member's accessor remains sound.
+- Optionality is unchanged: `T | null` still maps to `[T]`.
+
+The remaining `A + B` support is therefore a value encoding for
+non-discriminated unions, not a discriminated-union fallback and not a license
+to access member-specific fields through a union receiver.


### PR DESCRIPTION
## Patch 5: Document the tagged-union encoding and refusal taxonomy

- Write tools/ts2pant/docs/du-tagged-union-encoding.md covering detection, encoding, narrowing, nesting, and the refusal taxonomy, citing du-entailment-narrowing-survey.md and the workstream doc.
- No code or snapshot changes.

## Changes
- Write tools/ts2pant/docs/du-tagged-union-encoding.md covering detection, encoding, narrowing, nesting, and the refusal taxonomy, citing du-entailment-narrowing-survey.md and the workstream doc.
- No code or snapshot changes.

## Files to Modify
- tools/ts2pant/docs/du-tagged-union-encoding.md (create): Terminal-state documentation: structural discriminant detection (no field-name special-casing), the discriminant rule + per-variant guarded field rules + totality invariant, definedness goals and local intra-function narrowing, nested-DU recursive synthesis, and the refusal taxonomy (non-discriminated union field access refused; registration-failure refused; preserved `A + B` value encoding and `T | null` → `[T]` optionality; intersection field access sound). Cross-reference the M2 survey and the workstream doc.

## Gameplan Specification

```
module DU_CUTOVER.

> ══════════════════════════════
> THE GUARANTEE
> ═══════════════════════════════
> After M4 the tagged guarded-rule encoding is the SOLE path for every
> discriminated union: a DU is tagged when it registers and refused
> otherwise, never `+`-encoded, including when nested as a variant field
> or embedded in a record/map/array (one shape-keyed domain shared with
> the same DU elsewhere). Field access on a non-discriminated union is
> refused (no unique-field accessor applied to the whole union), while
> intersection field access stays sound. The `A + B` sum encoding survives
> only as a value type for non-discriminated unions, and optionality
> (`T | null` -> `[T]`) is unchanged.

Ty.
is-union t: Ty => Bool.
is-intersection t: Ty => Bool.
is-discriminated t: Ty => Bool.
nests-discriminated t: Ty => Bool.
registers t: Ty => Bool.
field-access t: Ty => Bool.
narrowed-read t: Ty => Bool.
tagged t: Ty => Bool.
sum-encoded t: Ty => Bool.
refused-access t: Ty => Bool.
resolves t: Ty => Bool.
refused t: Ty => Bool.
entails t: Ty => Bool.

---

> Every discriminated union that registers is tagged and never sum-encoded;
> one that fails registration is refused, also never sum-encoded.
all t: Ty | (is-discriminated t and registers t) -> (tagged t and ~(sum-encoded t)).
all t: Ty | (is-discriminated t and ~(registers t)) -> (refused t and ~(sum-encoded t)).

> A discriminated union nested in a container or as a variant field still tags.
all t: Ty | nests-discriminated t -> (tagged t and ~(sum-encoded t)).

> A narrowed read of a (possibly nested) discriminated union entails.
all t: Ty | (is-discriminated t and narrowed-read t) -> entails t.

> Field access on a non-discriminated union is refused, never resolved;
> the bare sum value encoding still applies to non-discriminated unions.
all t: Ty | (is-union t and ~(is-discriminated t) and field-access t) -> (refused-access t and ~(resolves t)).
all t: Ty | (is-union t and ~(is-discriminated t)) -> sum-encoded t.

> Intersection field access remains sound (resolves a single owner).
all t: Ty | (is-intersection t and field-access t) -> resolves t.
```

## Patch Specification

```
module DU_CUTOVER_PATCH_5.

> Patch 5 adds documentation only; no emitted output or behavior changes.
> Redeclared for self-containment.

Doc.
describes-encoding d: Doc => Bool.
describes-narrowing d: Doc => Bool.
describes-refusal d: Doc => Bool.

---

> The doc describes the encoding, its narrowing, and the refusal taxonomy.
all d: Doc | (describes-encoding d and describes-narrowing d and describes-refusal d).
```


## Implementation Notes

- Document is intentionally terminal-state oriented: it describes the behavior after patches 2-4 rather than rehashing the staged migration history, so reviewers can use it as the durable reference for the final DU encoding.
- The non-obvious point captured in the doc is that `A + B` is still valid for non-discriminated union values; only discriminated-union fallback and non-discriminated union field access are ruled out. Optionality stays on the separate list-lift path.
- No deviations from the plan: this patch is docs-only, with no code, fixture, or snapshot edits.

Spec/Evidence Mapping:
- `describes-encoding`: covered by the detection and encoding sections, based on `translate-types.ts` (`detectDiscriminatedUnion`, `cellRegisterDiscriminatedUnion`, `emitDiscriminatedUnionSynthDecls`, `buildDiscriminatedUnionTotalityAssertion`) and checked against `du-totality.test.mts`.
- `describes-narrowing`: covered by the narrowing section, based on `assumption-env.ts`, `narrowing-recognizer.ts`, and the predecessor analysis in `du-entailment-narrowing-survey.md`.
- `describes-refusal`: covered by the refusal taxonomy, based on Patch 4's public refusal reasons in `translate-types.ts` and the M4 decisions in `workstreams/ts2pant-discriminated-union.md`.
- Verification run: `just ts2pant-precommit` passed, including Biome, TypeScript `--noEmit`, WASM build, unit tests, and integration tests.