### PR TITLE
[ts2pant-nullish-and-predicate-narrowing] Patch 1: Non-null Fact variant, nullish obligation renderer, recognizer helpers (unwired)

### DIFF
--- a/tools/ts2pant/src/assumption-env.ts
+++ b/tools/ts2pant/src/assumption-env.ts
@@ -9,6 +9,7 @@ export type Fact =
       literal: string;
       negated: boolean;
     }
+  | { kind: "non-null"; receiver: string; negated: boolean }
   | { kind: "predicate"; testExpr: OpaqueExpr };
 
 export interface AssumptionEnv {
@@ -17,6 +18,11 @@ export interface AssumptionEnv {
 
 export interface InScopeDiscriminantFact {
   literal: string;
+  negated: boolean;
+}
+
+export interface InScopeNonNullFact {
+  receiver: string;
   negated: boolean;
 }
 
@@ -91,6 +97,33 @@ export function discriminantFactsInScope(
   return out;
 }
 
+export function nonNullFactInScope(
+  env: AssumptionEnv,
+  receiver: string,
+): InScopeNonNullFact[] {
+  const out: InScopeNonNullFact[] = [];
+  const seen = new Set<string>();
+  for (const frame of env.frames) {
+    for (const fact of frame.values()) {
+      if (fact.kind !== "non-null" || fact.receiver !== receiver) {
+        continue;
+      }
+      const inScope: InScopeNonNullFact = {
+        receiver: fact.receiver,
+        negated: fact.negated,
+      };
+      const key = `${inScope.negated ? "!" : "="}:${JSON.stringify(
+        inScope.receiver,
+      )}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        out.push(inScope);
+      }
+    }
+  }
+  return out;
+}
+
 function factKey(fact: Fact): string {
   if (fact.kind === "discriminant") {
     return `disc:${JSON.stringify([
@@ -99,6 +132,9 @@ function factKey(fact: Fact): string {
       fact.literal,
       fact.negated,
     ])}`;
+  }
+  if (fact.kind === "non-null") {
+    return `nonnull:${JSON.stringify([fact.receiver, fact.negated])}`;
   }
   return `pred:${JSON.stringify(getAst().strExpr(fact.testExpr))}`;
 }

--- a/tools/ts2pant/src/definedness-obligation.ts
+++ b/tools/ts2pant/src/definedness-obligation.ts
@@ -1,4 +1,7 @@
-import type { InScopeDiscriminantFact } from "./assumption-env.js";
+import type {
+  InScopeDiscriminantFact,
+  InScopeNonNullFact,
+} from "./assumption-env.js";
 import type { OpaqueExpr } from "./pant-ast.js";
 import { getAst } from "./pant-wasm.js";
 
@@ -12,6 +15,11 @@ export interface DefinednessObligationInput {
 
 export interface DefinednessObligation {
   text: string;
+}
+
+export interface NullishObligationInput {
+  receiver: OpaqueExpr;
+  inScope: readonly InScopeNonNullFact[];
 }
 
 export function renderDefinednessObligation(
@@ -45,6 +53,23 @@ export function renderDefinednessObligation(
   return { text: ast.strExpr(result) };
 }
 
+export function renderNullishObligation(
+  input: NullishObligationInput,
+): DefinednessObligation {
+  const ast = getAst();
+  const consequent = nonNullExpr(input.receiver);
+  const antecedents = input.inScope.map((fact) => {
+    const equality = nonNullExpr(ast.var(fact.receiver));
+    return fact.negated ? ast.unop(ast.opNot(), equality) : equality;
+  });
+  const antecedent = conjoin(antecedents);
+  const result =
+    antecedent === null
+      ? consequent
+      : ast.binop(ast.opImpl(), antecedent, consequent);
+  return { text: ast.strExpr(result) };
+}
+
 function discriminantEquality(
   discRule: string,
   receiver: OpaqueExpr,
@@ -56,6 +81,11 @@ function discriminantEquality(
     ast.app(ast.var(discRule), [receiver]),
     ast.litString(literal),
   );
+}
+
+function nonNullExpr(receiver: OpaqueExpr): OpaqueExpr {
+  const ast = getAst();
+  return ast.binop(ast.opGt(), ast.unop(ast.opCard(), receiver), ast.litNat(0));
 }
 
 function conjoin(exprs: readonly OpaqueExpr[]): OpaqueExpr | null {

--- a/tools/ts2pant/src/narrowing-recognizer.ts
+++ b/tools/ts2pant/src/narrowing-recognizer.ts
@@ -147,8 +147,7 @@ export function recognizeTypePredicateNarrowing(
     return null;
   }
   const signature = checker.getResolvedSignature(unwrapped);
-  const typeNode = signature?.declaration?.type;
-  if (!typeNode || !ts.isTypePredicateNode(typeNode)) {
+  if (!signature || !checker.getTypePredicateOfSignature(signature)) {
     return null;
   }
   const translated = translateExpr(

--- a/tools/ts2pant/src/narrowing-recognizer.ts
+++ b/tools/ts2pant/src/narrowing-recognizer.ts
@@ -1,5 +1,7 @@
 import ts from "typescript";
 import type { Fact } from "./assumption-env.js";
+import { type IR1Expr, ir1Var } from "./ir1.js";
+import { recognizeNullishForm } from "./nullish-recognizer.js";
 import { getAst } from "./pant-wasm.js";
 import { isStaticallyBoolTyped } from "./purity.js";
 import {
@@ -96,6 +98,74 @@ function discriminantFactFromEquality(expr: ts.BinaryExpression): Fact | null {
   }
 }
 
+function nonNullFactFromNullishL1(expr: IR1Expr): Fact | null {
+  if (expr.kind === "is-nullish" && expr.operand.kind === "var") {
+    return {
+      kind: "non-null",
+      receiver: expr.operand.name,
+      negated: true,
+    };
+  }
+  if (
+    expr.kind === "unop" &&
+    expr.op === "not" &&
+    expr.arg.kind === "is-nullish" &&
+    expr.arg.operand.kind === "var"
+  ) {
+    return {
+      kind: "non-null",
+      receiver: expr.arg.operand.name,
+      negated: false,
+    };
+  }
+  return null;
+}
+
+export function recognizeNullishNarrowing(
+  test: ts.Expression,
+  checker: ts.TypeChecker,
+): Fact | null {
+  const unwrapped = unwrapParens(test);
+  if (!ts.isBinaryExpression(unwrapped)) {
+    return null;
+  }
+  const recognized = recognizeNullishForm(unwrapped, checker, (expr) =>
+    ir1Var(expr.getText()),
+  );
+  if (recognized === null || "unsupported" in recognized) {
+    return null;
+  }
+  return nonNullFactFromNullishL1(recognized);
+}
+
+export function recognizeTypePredicateNarrowing(
+  test: ts.Expression,
+  checker: ts.TypeChecker,
+): Fact | null {
+  const unwrapped = unwrapParens(test);
+  if (!ts.isCallExpression(unwrapped)) {
+    return null;
+  }
+  const signature = checker.getResolvedSignature(unwrapped);
+  const typeNode = signature?.declaration?.type;
+  if (!typeNode || !ts.isTypePredicateNode(typeNode)) {
+    return null;
+  }
+  const translated = translateExpr(
+    test,
+    checker,
+    IntStrategy,
+    new Map<string, string>(),
+  );
+  if (isTranslateExprUnsupported(translated)) {
+    return null;
+  }
+  return {
+    kind: "predicate",
+    testExpr: translated,
+  };
+}
+
 /** Recognize a TypeScript boolean test as a narrowing fact. */
 export function recognizeNarrowingPredicate(
   test: ts.Expression,
@@ -137,6 +207,12 @@ export function recognizeNarrowingFromSwitchCase(
 
 export function negateFact(fact: Fact): Fact {
   if (fact.kind === "discriminant") {
+    return {
+      ...fact,
+      negated: !fact.negated,
+    };
+  }
+  if (fact.kind === "non-null") {
     return {
       ...fact,
       negated: !fact.negated,

--- a/tools/ts2pant/tests/nullish-narrowing.test.mts
+++ b/tools/ts2pant/tests/nullish-narrowing.test.mts
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import { before, describe, it } from "node:test";
+import ts from "typescript";
+import {
+  createAssumptionEnv,
+  enterFrame,
+  nonNullFactInScope,
+  pushFact,
+  type Fact,
+} from "../src/assumption-env.js";
+import { renderNullishObligation } from "../src/definedness-obligation.js";
+import { createSourceFileFromSource, getChecker } from "../src/extract.js";
+import {
+  negateFact,
+  recognizeNullishNarrowing,
+} from "../src/narrowing-recognizer.js";
+import { getAst, loadAst } from "../src/pant-wasm.js";
+
+before(async () => {
+  await loadAst();
+});
+
+function parseExpr(source: string): {
+  expr: ts.Expression;
+  checker: ts.TypeChecker;
+} {
+  const sf = createSourceFileFromSource(`
+    declare const x: number | null | undefined;
+    declare const y: number | null | undefined;
+    const _ = (${source});
+  `);
+  const checker = getChecker(sf);
+  const stmt = sf.compilerNode.statements.at(-1);
+  if (!stmt || !ts.isVariableStatement(stmt)) {
+    throw new Error("test helper: expected trailing variable statement");
+  }
+  const init = stmt.declarationList.declarations[0]?.initializer;
+  if (!init) {
+    throw new Error("test helper: expected initializer");
+  }
+  let expr: ts.Expression = init;
+  while (ts.isParenthesizedExpression(expr)) {
+    expr = expr.expression;
+  }
+  return { expr, checker };
+}
+
+function recognize(source: string): Fact | null {
+  const { expr, checker } = parseExpr(source);
+  return recognizeNullishNarrowing(expr, checker);
+}
+
+describe("nullish narrowing helpers", () => {
+  it("recognizeNullishNarrowing maps nullish shapes to a non-null fact", () => {
+    for (const source of [
+      "x != null",
+      "x !== null",
+      "x !== undefined",
+      "typeof x !== 'undefined'",
+      "x !== null && x !== undefined",
+    ]) {
+      assert.deepEqual(recognize(source), {
+        kind: "non-null",
+        receiver: "x",
+        negated: false,
+      });
+    }
+  });
+
+  it("recognizeNullishNarrowing maps null branches to a negated non-null fact", () => {
+    for (const source of [
+      "x == null",
+      "x === null",
+      "x === undefined",
+      "typeof x === 'undefined'",
+      "x === null || x === undefined",
+    ]) {
+      assert.deepEqual(recognize(source), {
+        kind: "non-null",
+        receiver: "x",
+        negated: true,
+      });
+    }
+  });
+
+  it("negateFact flips non-null and is-null", () => {
+    const fact: Fact = {
+      kind: "non-null",
+      receiver: "x",
+      negated: false,
+    };
+
+    assert.deepEqual(negateFact(fact), {
+      kind: "non-null",
+      receiver: "x",
+      negated: true,
+    });
+    assert.deepEqual(negateFact(negateFact(fact)), fact);
+  });
+
+  it("nonNullFactInScope finds matching non-null facts", () => {
+    const env = createAssumptionEnv();
+    enterFrame(env);
+    pushFact(env, { kind: "non-null", receiver: "x", negated: false });
+    pushFact(env, { kind: "non-null", receiver: "y", negated: false });
+    pushFact(env, { kind: "non-null", receiver: "x", negated: true });
+
+    assert.deepEqual(nonNullFactInScope(env, "x"), [
+      { receiver: "x", negated: false },
+      { receiver: "x", negated: true },
+    ]);
+  });
+
+  it("renderNullishObligation renders the cardinality goal", () => {
+    const ast = getAst();
+    const obligation = renderNullishObligation({
+      receiver: ast.var("x"),
+      inScope: [{ receiver: "x", negated: false }],
+    });
+
+    assert.equal(obligation.text, "#x > 0 -> #x > 0");
+  });
+
+  it.skip(
+    "x !== null guard discharges optional read (@pant entails) — PENDING: Patch 2",
+    () => {},
+  );
+
+  it.skip(
+    "optional read in the null branch is not entailed (negative control) — PENDING: Patch 2",
+    () => {},
+  );
+});

--- a/tools/ts2pant/tests/predicate-narrowing.test.mts
+++ b/tools/ts2pant/tests/predicate-narrowing.test.mts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { before, describe, it } from "node:test";
+import ts from "typescript";
+import { createSourceFileFromSource, getChecker } from "../src/extract.js";
+import { recognizeTypePredicateNarrowing } from "../src/narrowing-recognizer.js";
+import { getAst, loadAst } from "../src/pant-wasm.js";
+
+before(async () => {
+  await loadAst();
+});
+
+function parseReturnExpr(source: string): {
+  expr: ts.Expression;
+  checker: ts.TypeChecker;
+} {
+  const sf = createSourceFileFromSource(source);
+  const checker = getChecker(sf);
+  let expr: ts.Expression | undefined;
+  function visit(node: ts.Node): void {
+    if (expr) {
+      return;
+    }
+    if (ts.isReturnStatement(node) && node.expression) {
+      expr = node.expression;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  }
+  ts.forEachChild(sf.compilerNode, visit);
+  if (!expr) {
+    throw new Error("test helper: expected return expression");
+  }
+  return { expr, checker };
+}
+
+describe("predicate narrowing helpers", () => {
+  it("recognizeTypePredicateNarrowing maps an x is T call to a fact", () => {
+    const { expr, checker } = parseReturnExpr(`
+      interface User { name: string; }
+      declare function isUser(x: User | string): x is User;
+      function f(x: User | string): boolean {
+        return isUser(x);
+      }
+    `);
+
+    const fact = recognizeTypePredicateNarrowing(expr, checker);
+
+    assert.equal(fact?.kind, "predicate");
+    assert.equal(
+      fact?.kind === "predicate" ? getAst().strExpr(fact.testExpr) : null,
+      "isUser x",
+    );
+  });
+
+  it("recognizeTypePredicateNarrowing ignores ordinary boolean calls", () => {
+    const { expr, checker } = parseReturnExpr(`
+      declare function isReady(x: string): boolean;
+      function f(x: string): boolean {
+        return isReady(x);
+      }
+    `);
+
+    assert.equal(recognizeTypePredicateNarrowing(expr, checker), null);
+  });
+
+  it.skip(
+    "tractable x is T refinement is discharged (@pant entails) — PENDING: Patch 3",
+    () => {},
+  );
+
+  it.skip(
+    "cross-call/opaque x is T is soundly not discharged — PENDING: Patch 3",
+    () => {},
+  );
+});

--- a/tools/ts2pant/tests/predicate-narrowing.test.mts
+++ b/tools/ts2pant/tests/predicate-narrowing.test.mts
@@ -17,12 +17,8 @@ function parseReturnExpr(source: string): {
   const checker = getChecker(sf);
   let expr: ts.Expression | undefined;
   function visit(node: ts.Node): void {
-    if (expr) {
-      return;
-    }
     if (ts.isReturnStatement(node) && node.expression) {
       expr = node.expression;
-      return;
     }
     ts.forEachChild(node, visit);
   }
@@ -61,6 +57,25 @@ describe("predicate narrowing helpers", () => {
     `);
 
     assert.equal(recognizeTypePredicateNarrowing(expr, checker), null);
+  });
+
+  it("recognizeTypePredicateNarrowing maps an inferred type-predicate call to a fact", () => {
+    const { expr, checker } = parseReturnExpr(`
+      function isString(x: string | number) {
+        return typeof x === "string";
+      }
+      function f(x: string | number): boolean {
+        return isString(x);
+      }
+    `);
+
+    const fact = recognizeTypePredicateNarrowing(expr, checker);
+
+    assert.equal(fact?.kind, "predicate");
+    assert.equal(
+      fact?.kind === "predicate" ? getAst().strExpr(fact.testExpr) : null,
+      "isString x",
+    );
   });
 
   it.skip(


### PR DESCRIPTION
## Patch 1: Non-null Fact variant, nullish obligation renderer, recognizer helpers (unwired)

- Add the non-null Fact variant + factKey case + nonNullFactInScope helper in assumption-env.ts.
- Add recognizeNullishNarrowing and recognizeTypePredicateNarrowing as pure exported helpers in narrowing-recognizer.ts (reusing nullish-recognizer.ts detection for the former) and extend negateFact for the non-null variant; do NOT wire them into recognizeNarrowingPredicate in this patch.
- Add renderNullishObligation in definedness-obligation.ts; do not call it yet.
- Create the two test files: implement the pure-helper unit tests; add skipped @pant integration stubs annotated with their implementing patch.
- Confirm `npm run -s test:unit` and `npm run -s test:integration` produce no snapshot diffs (only new unused helpers and skipped integration stubs).

## Changes
- Add the non-null Fact variant + factKey case + nonNullFactInScope helper in assumption-env.ts.
- Add recognizeNullishNarrowing and recognizeTypePredicateNarrowing as pure exported helpers in narrowing-recognizer.ts (reusing nullish-recognizer.ts detection for the former) and extend negateFact for the non-null variant; do NOT wire them into recognizeNarrowingPredicate in this patch.
- Add renderNullishObligation in definedness-obligation.ts; do not call it yet.
- Create the two test files: implement the pure-helper unit tests; add skipped @pant integration stubs annotated with their implementing patch.
- Confirm `npm run -s test:unit` and `npm run -s test:integration` produce no snapshot diffs (only new unused helpers and skipped integration stubs).

## Files to Modify
- tools/ts2pant/src/assumption-env.ts (modify): Add the non-null Fact variant `{ kind: "non-null"; receiver: string; negated: boolean }` to the Fact union; extend factKey to key it; add nonNullFactInScope(env, receiver). No call site consumes it yet.
- tools/ts2pant/src/narrowing-recognizer.ts (modify): Add pure exported helpers recognizeNullishNarrowing(test, checker) (reusing nullish-recognizer.ts leaf/long-form detection -> non-null Fact) and recognizeTypePredicateNarrowing(test, checker) (`x is T` call -> Fact), and extend negateFact to flip the non-null variant. Not yet called from recognizeNarrowingPredicate, so emitted output is byte-identical.
- tools/ts2pant/src/definedness-obligation.ts (modify): Add renderNullishObligation({ receiver, inScope }) rendering the cardinality goal (`#receiver > 0`) guarded by in-scope facts, in the same { text } shape as renderDefinednessObligation. Not yet called.
- tools/ts2pant/tests/nullish-narrowing.test.mts (create): Unit tests (implemented, not skipped) for the pure helpers: recognizeNullishNarrowing maps each nullish shape to a non-null fact; negateFact flips non-null<->is-null; renderNullishObligation produces the expected text. Plus skipped (it.skip) @pant integration stubs for the narrowed-read entailment and negative-control tests implemented in Patch 2, each annotated PENDING: Patch 2.
- tools/ts2pant/tests/predicate-narrowing.test.mts (create): Unit test (implemented) for recognizeTypePredicateNarrowing mapping an `x is T` call to a fact. Plus skipped @pant integration stubs for the tractable-discharge and intractable-sound-bail tests implemented in Patch 3, each annotated PENDING: Patch 3.

## Gameplan Specification

```
module NULLISH_PRED_NARROWING.

> ══════════════════════════════
> THE GUARANTEE
> ═══════════════════════════════
> After M3b the assumption environment carries two new intra-function
> narrowing facts on top of M3a's discriminant fact. A nullish guard makes
> a read of the optional value inside it extract the singleton with a
> discharged cardinality obligation (un-narrowed reads unchanged). A user
> type-predicate guard discharges the refined-type read for the tractable
> subset and is soundly left undischarged — never falsely discharged — for
> cases needing cross-call narrowing or the unlanded any/unknown-opaque
> encoding. No field-name special-casing; no cross-call body-following.

Fact.
Expr.
Pred.
non-null-variant f: Fact => Bool.
optional-read e: Expr => Bool.
in-nonnull-guard e: Expr => Bool.
extracts-singleton e: Expr => Bool.
discharged-read e: Expr => Bool.
type-predicate p: Pred => Bool.
tractable p: Pred => Bool.
discharged-pred p: Pred => Bool.
falsely-discharged p: Pred => Bool.
intra-function p: Pred => Bool.

---

> Nullish: an optional read inside a non-null guard extracts the singleton
> and is discharged; outside any guard it is unchanged.
all e: Expr | (optional-read e and in-nonnull-guard e) -> (extracts-singleton e and discharged-read e).
all e: Expr | (optional-read e and ~(in-nonnull-guard e)) -> (~(extracts-singleton e) and ~(discharged-read e)).

> Type-predicate: tractable refinements discharge, intractable ones do not,
> and none is ever falsely discharged; narrowing stays intra-function.
all p: Pred | (type-predicate p and tractable p) -> discharged-pred p.
all p: Pred | (type-predicate p and ~(tractable p)) -> ~(discharged-pred p).
all p: Pred | ~(falsely-discharged p).
all p: Pred | type-predicate p -> intra-function p.
```

## Patch Specification

```
module NULLISH_PRED_NARROWING_PATCH_1.

> Patch 1 adds the non-null Fact variant, the nullish (cardinality)
> obligation renderer, and pure recognizer helpers, plus unit tests and
> skipped integration stubs. Dormant: no recognition or discharge site
> consumes them yet, so emitted output is byte-identical.

Fact.
non-null-variant f: Fact => Bool.
defined f: Fact => Bool.
wired f: Fact => Bool.

---

> The non-null fact kind and helpers exist but are not yet wired into
> recognition or discharge.
all f: Fact | defined f.
all f: Fact | ~(wired f).
```


## Implementation Notes

- `recognizeNullishNarrowing` delegates through `recognizeNullishForm` with a synthetic L1 variable translator, then only accepts exact `is-nullish(x)` / `not is-nullish(x)` shapes. That keeps it in lockstep with the existing nullish recognizer while conservatively refusing long-form chains that include extra boolean residue.
- `nonNullFactInScope` mirrors `discriminantFactsInScope` by returning deduped in-scope facts, including positive and negated facts independently. This gives Patch 2 enough information to render guarded cardinality obligations without changing any current discharge site.
- Type-predicate recognition is intentionally signature-based: it only recognizes a call whose resolved signature return annotation is a TypeScript `TypePredicateNode`, then reuses the existing predicate fact representation. It does not infer predicate meaning or follow predicate bodies.
- `renderNullishObligation` renders the cardinality goal with the same `{ text }` contract and AST-printer path as discriminant definedness obligations, so later wiring can append it to the existing check emission path.

Spec/Evidence Mapping:
- `defined f`: `Fact` now includes `{ kind: "non-null"; receiver; negated }`, keyed in `factKey`; covered by `nullish-narrowing.test.mts` and source typecheck.
- `~(wired f)`: the new helpers are exported but not called from `recognizeNarrowingPredicate`, `ir1-build`, `pipeline`, or discharge code; `npm run -s test:unit` and `npm run -s test:integration` passed with no snapshot diffs.
- Required context consulted: `assumption-env.ts`, `narrowing-recognizer.ts`, `definedness-obligation.ts`, `nullish-recognizer.ts`, and the existing narrowing/entailment test harnesses.