### PR TITLE
[ts2pant-guard-effect-error-channel] Patch 1: effect-error-channel.ts + brand-precondition.ts pure helpers — unwired

### DIFF
--- a/tools/ts2pant/src/brand-precondition.ts
+++ b/tools/ts2pant/src/brand-precondition.ts
@@ -1,0 +1,177 @@
+import type ts from "typescript";
+import type { OpaqueExpr } from "./pant-ast.js";
+import { getAst } from "./pant-wasm.js";
+
+type PredicateBuilder = (paramName: string) => OpaqueExpr;
+
+export const BRAND_PREDICATES: ReadonlyMap<string, PredicateBuilder> = new Map([
+  ["positive", (name) => compare(name, ">", 0)],
+  ["Positive", (name) => compare(name, ">", 0)],
+  ["negative", (name) => compare(name, "<", 0)],
+  ["Negative", (name) => compare(name, "<", 0)],
+  ["nonNegative", (name) => compare(name, ">=", 0)],
+  ["NonNegative", (name) => compare(name, ">=", 0)],
+  ["nonPositive", (name) => compare(name, "<=", 0)],
+  ["NonPositive", (name) => compare(name, "<=", 0)],
+  [
+    "int",
+    (name) => getAst().app(getAst().var("integral"), [getAst().var(name)]),
+  ],
+  [
+    "Int",
+    (name) => getAst().app(getAst().var("integral"), [getAst().var(name)]),
+  ],
+  [
+    "integer",
+    (name) => getAst().app(getAst().var("integral"), [getAst().var(name)]),
+  ],
+  [
+    "Integer",
+    (name) => getAst().app(getAst().var("integral"), [getAst().var(name)]),
+  ],
+  ["nonEmpty", (name) => nonEmpty(name)],
+  ["NonEmpty", (name) => nonEmpty(name)],
+  ["NonEmptyString", (name) => nonEmpty(name)],
+]);
+
+/**
+ * Recover a Pantagruel precondition from a recognized Effect Brand/Schema
+ * refinement carried by a parameter type. Unknown brand intersections return
+ * null instead of emitting a partial predicate.
+ */
+export function recognizeBrandedPrecondition(
+  type: ts.Type,
+  pantParamName: string,
+): OpaqueExpr | null {
+  const brands = collectBrandNames(type);
+  if (brands === null || brands.length === 0) {
+    return null;
+  }
+
+  const predicates: OpaqueExpr[] = [];
+  for (const brand of brands) {
+    const build = BRAND_PREDICATES.get(brand);
+    if (!build) {
+      return null;
+    }
+    predicates.push(build(pantParamName));
+  }
+
+  const ast = getAst();
+  return predicates.reduce((acc, pred) => ast.binop(ast.opAnd(), acc, pred));
+}
+
+function collectBrandNames(type: ts.Type): string[] | null {
+  const brands: string[] = [];
+  let sawUnknownBrand = false;
+
+  function visit(current: ts.Type): void {
+    if (current.isUnion()) {
+      sawUnknownBrand = true;
+      return;
+    }
+
+    if (current.isIntersection()) {
+      for (const part of current.types) {
+        visit(part);
+      }
+      return;
+    }
+
+    const brandArg = brandTypeArgument(current);
+    if (brandArg !== undefined) {
+      if (brandArg === null) {
+        sawUnknownBrand = true;
+      } else {
+        brands.push(brandArg);
+      }
+      return;
+    }
+
+    const schemaName = effectSchemaFilterName(current);
+    if (schemaName !== null) {
+      brands.push(schemaName);
+    }
+  }
+
+  visit(type);
+  return sawUnknownBrand ? null : [...new Set(brands)];
+}
+
+function brandTypeArgument(type: ts.Type): string | null | undefined {
+  const ref = type as ts.TypeReference;
+  const target = ref.target;
+  const symbol =
+    target?.aliasSymbol ?? target?.symbol ?? type.aliasSymbol ?? type.symbol;
+  if (symbol?.getName() !== "Brand") {
+    return undefined;
+  }
+
+  if (
+    !symbol
+      .getDeclarations()
+      ?.some((decl) =>
+        /node_modules\/effect\/(?:dist\/dts|src)\/Brand\.(?:d\.ts|ts)$/u.test(
+          decl.getSourceFile().fileName,
+        ),
+      )
+  ) {
+    return undefined;
+  }
+
+  const arg = ref.typeArguments?.[0];
+  if (!arg?.isStringLiteral()) {
+    return null;
+  }
+  return arg.value;
+}
+
+function effectSchemaFilterName(type: ts.Type): string | null {
+  const symbol = type.aliasSymbol ?? type.symbol;
+  const name = symbol?.getName();
+  if (!name || !BRAND_PREDICATES.has(name)) {
+    return null;
+  }
+  const fromEffectSchema =
+    symbol
+      .getDeclarations()
+      ?.some((decl) =>
+        /node_modules\/effect\/(?:dist\/dts|src)\/Schema\.(?:d\.ts|ts)$/u.test(
+          decl.getSourceFile().fileName,
+        ),
+      ) ?? false;
+  return fromEffectSchema ? name : null;
+}
+
+function compare(
+  paramName: string,
+  op: ">" | ">=" | "<" | "<=",
+  literal: number,
+): OpaqueExpr {
+  const ast = getAst();
+  const left = ast.var(paramName);
+  const right = ast.litNat(literal);
+  switch (op) {
+    case ">":
+      return ast.binop(ast.opGt(), left, right);
+    case ">=":
+      return ast.binop(ast.opGe(), left, right);
+    case "<":
+      return ast.binop(ast.opLt(), left, right);
+    case "<=":
+      return ast.binop(ast.opLe(), left, right);
+    default: {
+      const _exhaustive: never = op;
+      throw new Error(`Unhandled brand predicate operator: ${_exhaustive}`);
+    }
+  }
+}
+
+function nonEmpty(paramName: string): OpaqueExpr {
+  const ast = getAst();
+  return ast.binop(
+    ast.opGt(),
+    ast.unop(ast.opCard(), ast.var(paramName)),
+    ast.litNat(0),
+  );
+}

--- a/tools/ts2pant/src/effect-error-channel.ts
+++ b/tools/ts2pant/src/effect-error-channel.ts
@@ -1,0 +1,158 @@
+import ts from "typescript";
+import { isEffectFree } from "./purity.js";
+import { isTsNullish } from "./translate-types.js";
+
+export interface EffectErrorMode {
+  name: string;
+  type: ts.Type;
+}
+
+export interface ErrorYield {
+  errorName: string;
+  expression: ts.NewExpression;
+}
+
+export interface ErrorModeGuard {
+  mode: EffectErrorMode;
+  condition: ts.Expression;
+}
+
+/**
+ * Extract the recoverable E-channel modes from an Effect<A, E, R> type.
+ *
+ * Returns null for non-Effect types, a never E-channel, nullish-only unions,
+ * or unnameable error members. Unions are enumerated member-by-member after
+ * stripping nullish members, matching the discriminated-union helper's
+ * conservative union traversal.
+ */
+export function extractEffectErrorModes(
+  returnType: ts.Type,
+  checker: ts.TypeChecker,
+): EffectErrorMode[] | null {
+  const typeArgs = effectTypeArguments(returnType);
+  if (!typeArgs || typeArgs.length < 2) {
+    return null;
+  }
+
+  const errorType = typeArgs[1]!;
+  if (isNeverType(errorType)) {
+    return null;
+  }
+
+  const members = errorType.isUnion()
+    ? errorType.types.filter((member) => !isTsNullish(member))
+    : [errorType];
+  if (members.length === 0 || members.some(isNeverType)) {
+    return null;
+  }
+
+  const modes: EffectErrorMode[] = [];
+  const seen = new Set<string>();
+  for (const member of members) {
+    const name = errorModeName(member, checker);
+    if (!name || seen.has(name)) {
+      return null;
+    }
+    seen.add(name);
+    modes.push({ name, type: member });
+  }
+  return modes.length > 0 ? modes : null;
+}
+
+/**
+ * Recognize the Effect.gen typed-error idiom `yield* new ErrorClass(...)`.
+ */
+export function recognizeErrorYield(node: ts.Node): ErrorYield | null {
+  const expr = ts.isExpressionStatement(node) ? node.expression : node;
+  if (!ts.isYieldExpression(expr) || expr.asteriskToken === undefined) {
+    return null;
+  }
+  if (!expr.expression || !ts.isNewExpression(expr.expression)) {
+    return null;
+  }
+  const errorName = constructorName(expr.expression.expression);
+  return errorName === null ? null : { errorName, expression: expr.expression };
+}
+
+/**
+ * Recover `cond` from `if (cond) { yield* new ErrorClass(...) }`.
+ *
+ * The condition must be side-effect-free and the yielded constructor must
+ * match one of the enumerated E-channel modes; otherwise this helper bails.
+ */
+export function recoverErrorModeGuard(
+  stmt: ts.IfStatement,
+  modes: readonly EffectErrorMode[],
+  checker: ts.TypeChecker,
+): ErrorModeGuard | null {
+  if (stmt.elseStatement || !isEffectFree(stmt.expression, checker)) {
+    return null;
+  }
+
+  const yielded = recognizeErrorYield(singleThenStatement(stmt.thenStatement));
+  if (!yielded) {
+    return null;
+  }
+
+  const mode = modes.find((candidate) => candidate.name === yielded.errorName);
+  return mode ? { mode, condition: stmt.expression } : null;
+}
+
+function effectTypeArguments(type: ts.Type): readonly ts.Type[] | null {
+  const ref = type as ts.TypeReference;
+  const target = ref.target;
+  if (!target || !isEffectTypeTarget(target)) {
+    return null;
+  }
+  return ref.typeArguments ?? [];
+}
+
+function isEffectTypeTarget(target: ts.Type): boolean {
+  const symbol = target.aliasSymbol ?? target.symbol;
+  if (symbol?.getName() !== "Effect") {
+    return false;
+  }
+  return (
+    symbol
+      .getDeclarations()
+      ?.some((decl) =>
+        /node_modules\/effect\/(?:dist\/dts|src)\/Effect\.(?:d\.ts|ts)$/u.test(
+          decl.getSourceFile().fileName,
+        ),
+      ) ?? false
+  );
+}
+
+function isNeverType(type: ts.Type): boolean {
+  return (type.flags & ts.TypeFlags.Never) !== 0;
+}
+
+function errorModeName(type: ts.Type, checker: ts.TypeChecker): string | null {
+  const symbol = type.aliasSymbol ?? type.symbol;
+  const name = symbol?.getName();
+  if (name && name !== "__type") {
+    return name;
+  }
+
+  const rendered = checker
+    .typeToString(type)
+    .replace(/^import\("[^"]+"\)\./u, "");
+  return /^[A-Za-z_$][A-Za-z0-9_$]*$/u.test(rendered) ? rendered : null;
+}
+
+function constructorName(expr: ts.Expression): string | null {
+  if (ts.isIdentifier(expr)) {
+    return expr.text;
+  }
+  if (ts.isPropertyAccessExpression(expr)) {
+    return expr.name.text;
+  }
+  return null;
+}
+
+function singleThenStatement(stmt: ts.Statement): ts.Statement {
+  if (ts.isBlock(stmt) && stmt.statements.length === 1) {
+    return stmt.statements[0]!;
+  }
+  return stmt;
+}

--- a/tools/ts2pant/src/purity.ts
+++ b/tools/ts2pant/src/purity.ts
@@ -1070,7 +1070,7 @@ function userExpressionIsPure(
  *
  * Handles: Effect.succeed(x), E.map(fn) (aliased import), pipe(x, ...) (bare).
  */
-function resolveEffectLibraryExport(
+export function resolveEffectLibraryExport(
   callee: ts.Expression,
   checker: ts.TypeChecker,
 ): { module: string; name: string } | null {

--- a/tools/ts2pant/src/translate-types.ts
+++ b/tools/ts2pant/src/translate-types.ts
@@ -96,7 +96,7 @@ const NULLISH_FLAGS =
   ts.TypeFlags.Null | ts.TypeFlags.Undefined | ts.TypeFlags.Void;
 
 /** True for TypeScript `null` / `undefined` / `void`. */
-function isTsNullish(type: ts.Type): boolean {
+export function isTsNullish(type: ts.Type): boolean {
   return (type.flags & NULLISH_FLAGS) !== 0;
 }
 

--- a/tools/ts2pant/tests/brand-precondition.test.mts
+++ b/tools/ts2pant/tests/brand-precondition.test.mts
@@ -1,0 +1,153 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { before, describe, it } from "node:test";
+import ts from "typescript";
+import {
+  BRAND_PREDICATES,
+  recognizeBrandedPrecondition,
+} from "../src/brand-precondition.js";
+import { createSourceFile, getChecker } from "../src/extract.js";
+import { getAst, loadAst } from "../src/pant-wasm.js";
+
+before(async () => {
+  await loadAst();
+});
+
+function withSource<T>(source: string, use: (ctx: SourceCtx) => T): T {
+  const dir = mkdtempSync(join(process.cwd(), ".tmp-brand-"));
+  const file = join(dir, "fixture.ts");
+  writeFileSync(file, source);
+  try {
+    const sourceFile = createSourceFile(file);
+    return use({
+      sourceFile: sourceFile.compilerNode,
+      checker: getChecker(sourceFile),
+    });
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+}
+
+interface SourceCtx {
+  sourceFile: ts.SourceFile;
+  checker: ts.TypeChecker;
+}
+
+function paramType(ctx: SourceCtx, name: string): ts.Type {
+  let found: ts.ParameterDeclaration | undefined;
+  ts.forEachChild(ctx.sourceFile, function visit(node) {
+    if (
+      ts.isFunctionDeclaration(node) &&
+      node.name?.text === name &&
+      node.parameters[0]
+    ) {
+      found = node.parameters[0];
+      return;
+    }
+    ts.forEachChild(node, visit);
+  });
+  if (!found) {
+    throw new Error(`No first parameter for ${name}`);
+  }
+  return ctx.checker.getTypeAtLocation(found);
+}
+
+describe("BRAND_PREDICATES", () => {
+  it("maps the curated allowlist to Pant predicates", () => {
+    const ast = getAst();
+    const expected = new Map([
+      ["positive", "x > 0"],
+      ["Positive", "x > 0"],
+      ["negative", "x < 0"],
+      ["Negative", "x < 0"],
+      ["nonNegative", "x >= 0"],
+      ["NonNegative", "x >= 0"],
+      ["nonPositive", "x <= 0"],
+      ["NonPositive", "x <= 0"],
+      ["int", "integral x"],
+      ["Int", "integral x"],
+      ["integer", "integral x"],
+      ["Integer", "integral x"],
+      ["nonEmpty", "#x > 0"],
+      ["NonEmpty", "#x > 0"],
+      ["NonEmptyString", "#x > 0"],
+    ]);
+
+    assert.deepEqual([...BRAND_PREDICATES.keys()], [...expected.keys()]);
+    for (const [brand, rendered] of expected) {
+      assert.equal(ast.strExpr(BRAND_PREDICATES.get(brand)!("x")), rendered);
+    }
+  });
+});
+
+describe("recognizeBrandedPrecondition", () => {
+  it("maps recognized Brand.Brand intersections to predicates", () => {
+    withSource(
+      `
+        import { Brand } from "effect";
+        type Positive = number & Brand.Brand<"Positive">;
+        type NonNegative = number & Brand.Brand<"NonNegative">;
+        type NonEmptyString = string & Brand.Brand<"NonEmptyString">;
+        type PositiveInt = number & Brand.Brand<"Positive"> & Brand.Brand<"Int">;
+        export function positive(x: Positive) { return x; }
+        export function nonNegative(x: NonNegative) { return x; }
+        export function nonEmpty(x: NonEmptyString) { return x; }
+        export function positiveInt(x: PositiveInt) { return x; }
+      `,
+      (ctx) => {
+        const ast = getAst();
+        assert.equal(
+          ast.strExpr(
+            recognizeBrandedPrecondition(paramType(ctx, "positive"), "x")!,
+          ),
+          "x > 0",
+        );
+        assert.equal(
+          ast.strExpr(
+            recognizeBrandedPrecondition(paramType(ctx, "nonNegative"), "x")!,
+          ),
+          "x >= 0",
+        );
+        assert.equal(
+          ast.strExpr(
+            recognizeBrandedPrecondition(paramType(ctx, "nonEmpty"), "x")!,
+          ),
+          "#x > 0",
+        );
+        assert.equal(
+          ast.strExpr(
+            recognizeBrandedPrecondition(paramType(ctx, "positiveInt"), "x")!,
+          ),
+          "x > 0 and integral x",
+        );
+      },
+    );
+  });
+
+  it("returns null for unrecognized and unbranded types", () => {
+    withSource(
+      `
+        import { Brand } from "effect";
+        type Custom = number & Brand.Brand<"Custom">;
+        export function custom(x: Custom) { return x; }
+        export function plain(x: number) { return x; }
+      `,
+      (ctx) => {
+        assert.equal(
+          recognizeBrandedPrecondition(paramType(ctx, "custom"), "x"),
+          null,
+        );
+        assert.equal(
+          recognizeBrandedPrecondition(paramType(ctx, "plain"), "x"),
+          null,
+        );
+      },
+    );
+  });
+});
+
+describe("brand-precondition @pant integration stubs", () => {
+  it.skip("PENDING: Patch 3 emits a recognized brand predicate as a precondition", () => {});
+  it.skip("PENDING: Patch 3 emits no precondition for unrecognized or absent brands", () => {});
+});

--- a/tools/ts2pant/tests/effect-error-channel.test.mts
+++ b/tools/ts2pant/tests/effect-error-channel.test.mts
@@ -1,0 +1,256 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { before, describe, it } from "node:test";
+import ts from "typescript";
+import {
+  type EffectErrorMode,
+  extractEffectErrorModes,
+  recognizeErrorYield,
+  recoverErrorModeGuard,
+} from "../src/effect-error-channel.js";
+import { createSourceFile, getChecker } from "../src/extract.js";
+import { loadAst } from "../src/pant-wasm.js";
+
+before(async () => {
+  await loadAst();
+});
+
+function withSource<T>(source: string, use: (ctx: SourceCtx) => T): T {
+  const dir = mkdtempSync(join(process.cwd(), ".tmp-effect-error-"));
+  const file = join(dir, "fixture.ts");
+  writeFileSync(file, source);
+  try {
+    const sourceFile = createSourceFile(file);
+    return use({
+      sourceFile: sourceFile.compilerNode,
+      checker: getChecker(sourceFile),
+    });
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+}
+
+interface SourceCtx {
+  sourceFile: ts.SourceFile;
+  checker: ts.TypeChecker;
+}
+
+function functionReturnType(ctx: SourceCtx, name: string): ts.Type {
+  const fn = findFunction(ctx.sourceFile, name);
+  const signature = ctx.checker.getSignatureFromDeclaration(fn);
+  if (!signature) {
+    throw new Error(`No signature for ${name}`);
+  }
+  return ctx.checker.getReturnTypeOfSignature(signature);
+}
+
+function findFunction(
+  sourceFile: ts.SourceFile,
+  name: string,
+): ts.FunctionDeclaration {
+  let found: ts.FunctionDeclaration | undefined;
+  ts.forEachChild(sourceFile, function visit(node) {
+    if (ts.isFunctionDeclaration(node) && node.name?.text === name) {
+      found = node;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  });
+  if (!found) {
+    throw new Error(`No function named ${name}`);
+  }
+  return found;
+}
+
+function findFirstYield(sourceFile: ts.SourceFile): ts.YieldExpression {
+  let found: ts.YieldExpression | undefined;
+  ts.forEachChild(sourceFile, function visit(node) {
+    if (!found && ts.isYieldExpression(node)) {
+      found = node;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  });
+  if (!found) {
+    throw new Error("No yield expression found");
+  }
+  return found;
+}
+
+function findIf(sourceFile: ts.SourceFile, index = 0): ts.IfStatement {
+  const found: ts.IfStatement[] = [];
+  ts.forEachChild(sourceFile, function visit(node) {
+    if (ts.isIfStatement(node)) {
+      found.push(node);
+    }
+    ts.forEachChild(node, visit);
+  });
+  const stmt = found[index];
+  if (!stmt) {
+    throw new Error(`No if statement at index ${index}`);
+  }
+  return stmt;
+}
+
+describe("extractEffectErrorModes", () => {
+  it("enumerates single and union E-channel modes", () => {
+    withSource(
+      `
+        import { Effect } from "effect";
+        class FooError {}
+        class BarError {}
+        export function single(): Effect.Effect<number, FooError, never> {
+          return Effect.succeed(1) as Effect.Effect<number, FooError, never>;
+        }
+        export function union(): Effect.Effect<number, FooError | BarError, never> {
+          return Effect.succeed(1) as Effect.Effect<number, FooError | BarError, never>;
+        }
+      `,
+      (ctx) => {
+        assert.deepEqual(
+          extractEffectErrorModes(
+            functionReturnType(ctx, "single"),
+            ctx.checker,
+          )?.map((mode) => mode.name),
+          ["FooError"],
+        );
+        assert.deepEqual(
+          extractEffectErrorModes(
+            functionReturnType(ctx, "union"),
+            ctx.checker,
+          )?.map((mode) => mode.name),
+          ["FooError", "BarError"],
+        );
+      },
+    );
+  });
+
+  it("returns null for non-Effect and never E-channel returns", () => {
+    withSource(
+      `
+        import { Effect } from "effect";
+        export function plain(): number { return 1; }
+        export function infallible(): Effect.Effect<number, never, never> {
+          return Effect.succeed(1);
+        }
+      `,
+      (ctx) => {
+        assert.equal(
+          extractEffectErrorModes(
+            functionReturnType(ctx, "plain"),
+            ctx.checker,
+          ),
+          null,
+        );
+        assert.equal(
+          extractEffectErrorModes(
+            functionReturnType(ctx, "infallible"),
+            ctx.checker,
+          ),
+          null,
+        );
+      },
+    );
+  });
+});
+
+describe("recognizeErrorYield", () => {
+  it("matches yield* new ErrorClass()", () => {
+    withSource(
+      `
+        class FooError {}
+        function* gen() {
+          yield* new FooError("bad");
+        }
+      `,
+      (ctx) => {
+        assert.equal(
+          recognizeErrorYield(findFirstYield(ctx.sourceFile))?.errorName,
+          "FooError",
+        );
+      },
+    );
+  });
+
+  it("rejects non-asterisk yields and non-constructor expressions", () => {
+    withSource(
+      `
+        class FooError {}
+        function* gen() {
+          yield new FooError();
+          yield* makeError();
+        }
+      `,
+      (ctx) => {
+        const yields: ts.YieldExpression[] = [];
+        ts.forEachChild(ctx.sourceFile, function visit(node) {
+          if (ts.isYieldExpression(node)) {
+            yields.push(node);
+          }
+          ts.forEachChild(node, visit);
+        });
+        assert.equal(recognizeErrorYield(yields[0]!), null);
+        assert.equal(recognizeErrorYield(yields[1]!), null);
+      },
+    );
+  });
+});
+
+describe("recoverErrorModeGuard", () => {
+  const modes: EffectErrorMode[] = [
+    { name: "FooError", type: undefined as unknown as ts.Type },
+  ];
+
+  it("matches braced and braceless if-yield guards", () => {
+    withSource(
+      `
+        class FooError {}
+        declare function sideEffect(): boolean;
+        function* gen(x: number) {
+          if (x > 0) { yield* new FooError(); }
+          if (x === 0) yield* new FooError();
+          if (sideEffect()) { yield* new FooError(); }
+        }
+      `,
+      (ctx) => {
+        assert.equal(
+          recoverErrorModeGuard(findIf(ctx.sourceFile, 0), modes, ctx.checker)
+            ?.mode.name,
+          "FooError",
+        );
+        assert.equal(
+          recoverErrorModeGuard(findIf(ctx.sourceFile, 1), modes, ctx.checker)
+            ?.mode.name,
+          "FooError",
+        );
+        assert.equal(
+          recoverErrorModeGuard(findIf(ctx.sourceFile, 2), modes, ctx.checker),
+          null,
+        );
+      },
+    );
+  });
+
+  it("rejects unmatched error constructors", () => {
+    withSource(
+      `
+        class BarError {}
+        function* gen(x: number) {
+          if (x > 0) { yield* new BarError(); }
+        }
+      `,
+      (ctx) => {
+        assert.equal(
+          recoverErrorModeGuard(findIf(ctx.sourceFile), modes, ctx.checker),
+          null,
+        );
+      },
+    );
+  });
+});
+
+describe("effect-error-channel @pant integration stubs", () => {
+  it.skip("PENDING: Patch 2 emits a negated-conjunction precondition when all modes are recovered", () => {});
+  it.skip("PENDING: Patch 2 emits no precondition for incomplete, impure, or unmatched recovery", () => {});
+});


### PR DESCRIPTION
## Patch 1: effect-error-channel.ts + brand-precondition.ts pure helpers — unwired

- Create effect-error-channel.ts with EffectErrorMode and the three pure helpers, reusing resolveEffectLibraryExport / isEffectFree (purity.ts) and the union-enumeration helpers (translate-types.ts).
- Create brand-precondition.ts with BRAND_PREDICATES and recognizeBrandedPrecondition, recognizing brands per the Effect Schema/Brand encoding and bailing on unknowns.
- Do NOT import either module from translate-signature.ts in this patch, so emitted output is byte-identical.
- Create the two test files: implement the pure-helper unit tests; add skipped @pant integration stubs annotated with their implementing patch.
- Confirm `npm run -s test:unit` and `npm run -s test:integration` produce no snapshot diffs (only new unused modules and skipped integration stubs).

## Changes
- Create effect-error-channel.ts with EffectErrorMode and the three pure helpers, reusing resolveEffectLibraryExport / isEffectFree (purity.ts) and the union-enumeration helpers (translate-types.ts).
- Create brand-precondition.ts with BRAND_PREDICATES and recognizeBrandedPrecondition, recognizing brands per the Effect Schema/Brand encoding and bailing on unknowns.
- Do NOT import either module from translate-signature.ts in this patch, so emitted output is byte-identical.
- Create the two test files: implement the pure-helper unit tests; add skipped @pant integration stubs annotated with their implementing patch.
- Confirm `npm run -s test:unit` and `npm run -s test:integration` produce no snapshot diffs (only new unused modules and skipped integration stubs).

## Files to Modify
- tools/ts2pant/src/effect-error-channel.ts (create): New module with the EffectErrorMode type and three pure exported helpers: extractEffectErrorModes (recognize Effect<A,E,R>, enumerate E members, null for non-Effect or `never`), recognizeErrorYield (match `yield* new ErrorClass(...)`), recoverErrorModeGuard (match `if (cond) { yield* new ErrorClass(...) }` with isEffectFree(cond) gate, else null). Not imported by translateSignature in this patch.
- tools/ts2pant/src/brand-precondition.ts (create): New module with the BRAND_PREDICATES curated allowlist (brand/filter name -> predicate builder) and recognizeBrandedPrecondition (inspect a parameter type for a recognized brand, return the predicate OpaqueExpr over the Pant param name, else null). Not imported by translateSignature in this patch.
- tools/ts2pant/tests/effect-error-channel.test.mts (create): Unit tests (implemented) for the three error-channel helpers: enumeration over single and union E channels and null cases; yield* matching incl. non-matches; guard recovery incl. impure-cond bail and braceless form. Plus skipped @pant integration stubs for the precondition-emitted and bail tests implemented in Patch 2 (PENDING: Patch 2).
- tools/ts2pant/tests/brand-precondition.test.mts (create): Unit tests (implemented) for recognizeBrandedPrecondition: each allowlisted brand maps to the expected predicate; unrecognized and unbranded types return null. Plus skipped @pant integration stubs for the brand-precondition tests implemented in Patch 3 (PENDING: Patch 3).

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[library] Effect-TS** — https://effect.website — Source of the Effect<A,E,R> type shape (E = error channel), the `yield* new ErrorClass()` / Effect.gen error-yield idiom recognizeErrorYield matches, and the Schema brand/filter encoding (T & Brand.Brand<"Name">) recognizeBrandedPrecondition pattern-matches. Read the Error Management, Effect.gen, and Schema/Brand docs to confirm the AST/type shapes.
- **[documentation] TypeScript Compiler API** — https://github.com/microsoft/TypeScript/wiki/Using-the-Compiler-API — The AST/type inspection the helpers rely on: type-argument access for Effect<A,E,R>, YieldExpression.asteriskToken + NewExpression matching, isUnion()/type.types enumeration of the E channel, and intersection-member inspection for Brand types.

## Gameplan Specification

```
module GUARD_EFFECT_ERROR_CHANNEL.

> ══════════════════════════════
> THE GUARANTEE
> ═══════════════════════════════
> After M4, ts2pant derives preconditions from two new sources, both folded
> into the existing guard slot (PantRule.guard / PantAction.guard, emitted
> at emit.ts) and AND-combined with any if-throw/assertion guard. (1) Effect
> error channel: it reads the E channel of an Effect<A,E,R> return type and
> AST-matches `if (cond) { yield* new ErrorClass() }` to recover, per mode,
> the raising condition; when every enumerated mode is recovered with a
> side-effect-free condition, the precondition gains the conjunction of the
> negated conditions, else nothing (never partial/wrong). (2) Branded
> parameters: a recognized Schema brand/filter (curated allowlist) on a
> parameter contributes its predicate, else nothing. Non-Effect functions,
> `never` error channels, unbranded parameters, the success-type A mapping,
> and branded base-type mappings are unchanged. The analysis is intra-
> function and reuses the M1 purity classifier and the conservative-bail
> discipline.

Fn.
Param.
effect-returning f: Fn => Bool.
all-modes-recovered f: Fn => Bool.
pure-conds f: Fn => Bool.
emits-effect-precondition f: Fn => Bool.
wrong-precondition f: Fn => Bool.
recognized-brand p: Param => Bool.
contributes-predicate p: Param => Bool.
base-type-unchanged p: Param => Bool.

---

> Effect: a sound error-derived precondition is emitted exactly when the
> function is Effect-returning with every mode recovered under pure conds.
all f: Fn | (effect-returning f and all-modes-recovered f and pure-conds f) -> emits-effect-precondition f.
all f: Fn | (effect-returning f and ~(all-modes-recovered f)) -> ~(emits-effect-precondition f).
all f: Fn | (effect-returning f and ~(pure-conds f)) -> ~(emits-effect-precondition f).
all f: Fn | ~(effect-returning f) -> ~(emits-effect-precondition f).

> Brands: a predicate is contributed exactly for recognized brands, and a
> parameter's base-type mapping is always unchanged.
all p: Param | recognized-brand p -> contributes-predicate p.
all p: Param | ~(recognized-brand p) -> ~(contributes-predicate p).
all p: Param | base-type-unchanged p.

> Soundness: no function ever emits a wrong (unsound) precondition.
all f: Fn | ~(wrong-precondition f).
```

## Patch Specification

```
module GUARD_EFFECT_ERROR_CHANNEL_PATCH_1.

> Patch 1 adds the effect-error-channel and brand-precondition pure helpers
> plus unit tests and skipped integration stubs. Dormant: translateSignature
> does not import either module yet, so emitted output is byte-identical.

Helper.
defined h: Helper => Bool.
wired h: Helper => Bool.

---

> The helpers exist but are not yet wired into signature translation.
all h: Helper | defined h.
all h: Helper | ~(wired h).
```


## Implementation Notes

- Effect return-type detection validates the `Effect` interface by declaration origin under the `effect` package, then reads the E type argument directly. `resolveEffectLibraryExport` is now exported for later callee-expression wiring, but the dormant `extractEffectErrorModes` helper uses return-type structure because the existing resolver is intentionally callee-oriented.
- `recoverErrorModeGuard` returns the original TypeScript condition rather than translating it to Pant yet. That keeps Patch 1 pure and lets Patch 2 translate, negate, and AND-combine in the existing signature context where parameter name mapping and synth state already live.
- Brand recovery is intentionally all-or-nothing per parameter type: any unknown `Brand.Brand<...>` in an intersection makes `recognizeBrandedPrecondition` return `null`, while multiple recognized brands are AND-combined. Schema filter names are accepted only when their symbol resolves to `effect/Schema`, avoiding unsound matches on user aliases with the same names.
- Spec/Evidence Mapping: helper existence and dormancy are in `src/effect-error-channel.ts` / `src/brand-precondition.ts`, with no `translate-signature.ts` import (`rg effect-error-channel|brand-precondition tools/ts2pant/src` only finds none outside tests). Effect mode enumeration and `yield* new ErrorClass()` matching are covered by `tests/effect-error-channel.test.mts`; brand allowlist, unknown-brand bail, and unbranded null are covered by `tests/brand-precondition.test.mts`. Static and snapshot evidence: `npx tsc --noEmit`, `npx biome check ...`, `npm run -s test:unit`, and `npm run -s test:integration` all passed.