### PR TITLE
[ts2pant-guard-effect-error-channel] Patch 2: Recover Effect error-mode guards into the precondition (completeness-bail)

### DIFF
--- a/tools/ts2pant/src/translate-signature.ts
+++ b/tools/ts2pant/src/translate-signature.ts
@@ -1,11 +1,11 @@
 import type { SourceFile } from "ts-morph";
 import ts from "typescript";
-import { lowerExpr } from "./ir-emit.js";
 import {
   extractEffectErrorModes,
-  recoverErrorModeGuard,
   recognizeErrorYield,
+  recoverErrorModeGuard,
 } from "./effect-error-channel.js";
+import { lowerExpr } from "./ir-emit.js";
 import {
   type BuildL1MemberAccessOptions,
   buildL1MemberAccess,

--- a/tools/ts2pant/src/translate-signature.ts
+++ b/tools/ts2pant/src/translate-signature.ts
@@ -2,6 +2,11 @@ import type { SourceFile } from "ts-morph";
 import ts from "typescript";
 import { lowerExpr } from "./ir-emit.js";
 import {
+  extractEffectErrorModes,
+  recoverErrorModeGuard,
+  recognizeErrorYield,
+} from "./effect-error-channel.js";
+import {
   type BuildL1MemberAccessOptions,
   buildL1MemberAccess,
   createL1AssumptionEnv,
@@ -19,7 +24,11 @@ import {
 } from "./nullish-recognizer.js";
 import type { OpaqueBinop, OpaqueExpr } from "./pant-ast.js";
 import { getAst } from "./pant-wasm.js";
-import { isEffectFree, isStaticallyBoolTyped } from "./purity.js";
+import {
+  isEffectFree,
+  isStaticallyBoolTyped,
+  resolveEffectLibraryExport,
+} from "./purity.js";
 import {
   cellIsUsed,
   cellRegisterName,
@@ -972,6 +981,129 @@ export function detectGuard(
   return guards.reduce((acc, g) => ast.binop(ast.opAnd(), acc, g));
 }
 
+function detectEffectErrorChannelGuard(
+  node: ts.FunctionDeclaration | ts.MethodDeclaration,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  paramNames: ReadonlyMap<string, string>,
+  synthCell?: SynthCell,
+  program?: ts.Program,
+): OpaqueExpr | undefined {
+  if (!node.body) {
+    return undefined;
+  }
+
+  const sig = checker.getSignatureFromDeclaration(node);
+  if (!sig) {
+    return undefined;
+  }
+  const modes = extractEffectErrorModes(sig.getReturnType(), checker);
+  if (!modes) {
+    return undefined;
+  }
+
+  const genBody = findReturnedEffectGenBody(node.body, checker);
+  if (!genBody) {
+    return undefined;
+  }
+
+  const ast = getAst();
+  const recovered = new Map<string, OpaqueExpr>();
+
+  for (const stmt of genBody.statements) {
+    if (!ts.isIfStatement(stmt)) {
+      if (nodeContainsErrorYield(stmt)) {
+        return undefined;
+      }
+      continue;
+    }
+
+    if (nodeContainsErrorYield(stmt)) {
+      const modeGuard = recoverErrorModeGuard(stmt, modes, checker);
+      if (!modeGuard || recovered.has(modeGuard.mode.name)) {
+        return undefined;
+      }
+      const translated = tryTranslateGuardExpr(
+        modeGuard.condition,
+        checker,
+        strategy,
+        paramNames,
+        synthCell,
+        program,
+      );
+      if (translated === null) {
+        return undefined;
+      }
+      recovered.set(modeGuard.mode.name, ast.unop(ast.opNot(), translated));
+    }
+  }
+
+  if (modes.some((mode) => !recovered.has(mode.name))) {
+    return undefined;
+  }
+
+  return modes
+    .map((mode) => recovered.get(mode.name)!)
+    .reduce((acc, g) => ast.binop(ast.opAnd(), acc, g));
+}
+
+function findReturnedEffectGenBody(
+  body: ts.Block,
+  checker: ts.TypeChecker,
+): ts.Block | null {
+  for (const stmt of body.statements) {
+    if (!ts.isReturnStatement(stmt) || !stmt.expression) {
+      continue;
+    }
+    const expr = unwrapTransparentExpression(stmt.expression);
+    if (!ts.isCallExpression(expr)) {
+      continue;
+    }
+    const effectExport = resolveEffectLibraryExport(expr.expression, checker);
+    if (effectExport?.module !== "Effect" || effectExport.name !== "gen") {
+      continue;
+    }
+    const generator = expr.arguments[0];
+    if (!generator || !ts.isFunctionExpression(generator)) {
+      return null;
+    }
+    if (!generator.asteriskToken) {
+      return null;
+    }
+    return generator.body;
+  }
+  return null;
+}
+
+function nodeContainsErrorYield(node: ts.Node): boolean {
+  let found = false;
+  function visit(current: ts.Node): void {
+    if (found) {
+      return;
+    }
+    if (recognizeErrorYield(current)) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(current, visit);
+  }
+  visit(node);
+  return found;
+}
+
+function combineGuards(
+  first: OpaqueExpr | undefined,
+  second: OpaqueExpr | undefined,
+): OpaqueExpr | undefined {
+  if (!first) {
+    return second;
+  }
+  if (!second) {
+    return first;
+  }
+  return getAst().binop(getAst().opAnd(), first, second);
+}
+
 function blockThrows(node: ts.Statement, _checker: ts.TypeChecker): boolean {
   if (ts.isThrowStatement(node)) {
     return true;
@@ -1506,6 +1638,15 @@ export function translateSignature(
     synthCell,
     program,
   );
+  const effectGuard = detectEffectErrorChannelGuard(
+    node,
+    checker,
+    strategy,
+    paramNameMap,
+    synthCell,
+    program,
+  );
+  const combinedGuard = combineGuards(guard, effectGuard);
 
   if (classification === "pure") {
     // Map-partial signature alignment: when the body is exactly a
@@ -1539,8 +1680,8 @@ export function translateSignature(
       params,
       returnType,
     };
-    if (guard) {
-      decl.guard = guard;
+    if (combinedGuard) {
+      decl.guard = combinedGuard;
     }
     return { declaration: decl, classification, paramNameMap, synthCell };
   } else {
@@ -1549,8 +1690,8 @@ export function translateSignature(
       label: capitalize(baseName),
       params,
     };
-    if (guard) {
-      decl.guard = guard;
+    if (combinedGuard) {
+      decl.guard = combinedGuard;
     }
     return { declaration: decl, classification, paramNameMap, synthCell };
   }

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -30,6 +30,30 @@ exports[`control-flow.ts > max 1`] = `
 "module MAX.\\n\\nmax a: Int, b: Int => Int.\\n\\n---\\n\\nmax a b = (cond a >= b => a, true => b).\\n"
 `;
 
+exports[`effect-gen-error-guards.ts > combinedWithThrow 1`] = `
+"module COMBINED_WITH_THROW.\\n\\ncombined-with-throw x: Int, x <= 1000 and ~(x < 0) => Effect.\\n\\n---\\n\\n> UNSUPPORTED: combined-with-throw — var bindings are not supported (use let or const).\\n\\ncheck\\n\\nall x: Int | combined-with-throw x = x.\\n"
+`;
+
+exports[`effect-gen-error-guards.ts > impureCond 1`] = `
+"module IMPURE_COND.\\n\\nis-blocked  => Bool.\\nimpure-cond x: Int => Effect.\\n\\n---\\n\\n> UNSUPPORTED: impure-cond — var bindings are not supported (use let or const).\\n"
+`;
+
+exports[`effect-gen-error-guards.ts > multiError 1`] = `
+"module MULTI_ERROR.\\n\\nmulti-error x: Int, ~(x < 0) and ~(x > 100) => Effect.\\n\\n---\\n\\n> UNSUPPORTED: multi-error — var bindings are not supported (use let or const).\\n\\ncheck\\n\\nall x: Int | multi-error x = x.\\n"
+`;
+
+exports[`effect-gen-error-guards.ts > partialRecovery 1`] = `
+"module PARTIAL_RECOVERY.\\n\\npartial-recovery x: Int => Effect.\\n\\n---\\n\\n> UNSUPPORTED: partial-recovery — var bindings are not supported (use let or const).\\n"
+`;
+
+exports[`effect-gen-error-guards.ts > singleError 1`] = `
+"module SINGLE_ERROR.\\n\\nsingle-error x: Int, ~(x < 0) => Effect.\\n\\n---\\n\\n> UNSUPPORTED: single-error — var bindings are not supported (use let or const).\\n\\ncheck\\n\\nall x: Int | single-error x = x.\\n"
+`;
+
+exports[`effect-gen-error-guards.ts > unmatchedShape 1`] = `
+"module UNMATCHED_SHAPE.\\n\\nunmatched-shape x: Int => Effect.\\n\\n---\\n\\n> UNSUPPORTED: unmatched-shape — var bindings are not supported (use let or const).\\n"
+`;
+
 exports[`expressions-arithmetic.ts > add 1`] = `
 "module ADD.\\n\\nadd a: Int, b: Int => Int.\\n\\n---\\n\\nadd a b = a + b.\\n"
 `;

--- a/tools/ts2pant/tests/effect-error-channel.test.mts
+++ b/tools/ts2pant/tests/effect-error-channel.test.mts
@@ -9,8 +9,11 @@ import {
   recognizeErrorYield,
   recoverErrorModeGuard,
 } from "../src/effect-error-channel.js";
+import { emitDocument } from "../src/emit.js";
 import { createSourceFile, getChecker } from "../src/extract.js";
 import { loadAst } from "../src/pant-wasm.js";
+import { buildPantDocument } from "../src/pipeline.js";
+import { IntStrategy } from "../src/translate-types.js";
 
 before(async () => {
   await loadAst();
@@ -91,6 +94,10 @@ function findIf(sourceFile: ts.SourceFile, index = 0): ts.IfStatement {
     throw new Error(`No if statement at index ${index}`);
   }
   return stmt;
+}
+
+function toPantName(name: string): string {
+  return name.replace(/[A-Z]/gu, (c) => `-${c.toLowerCase()}`);
 }
 
 describe("extractEffectErrorModes", () => {
@@ -251,6 +258,99 @@ describe("recoverErrorModeGuard", () => {
 });
 
 describe("effect-error-channel @pant integration stubs", () => {
-  it.skip("PENDING: Patch 2 emits a negated-conjunction precondition when all modes are recovered", () => {});
-  it.skip("PENDING: Patch 2 emits no precondition for incomplete, impure, or unmatched recovery", () => {});
+  it("emits a negated-conjunction precondition when all modes are recovered", async () => {
+    const dir = mkdtempSync(join(process.cwd(), ".tmp-effect-error-"));
+    const file = join(dir, "fixture.ts");
+    writeFileSync(
+      file,
+      `
+        import { Data, Effect } from "effect";
+        class FooError extends Data.TaggedError("FooError")<{}> {}
+        class BarError extends Data.TaggedError("BarError")<{}> {}
+        export function recovered(x: number): Effect.Effect<number, FooError | BarError, never> {
+          return Effect.gen(function* () {
+            if (x < 0) { yield* new FooError(); }
+            if (x > 10) { yield* new BarError(); }
+            return x;
+          });
+        }
+      `,
+    );
+    try {
+      const doc = await buildPantDocument({
+        sourceFile: createSourceFile(file),
+        functionName: "recovered",
+        strategy: IntStrategy,
+        noBody: true,
+      });
+      const output = emitDocument(doc);
+      assert.match(output, /recovered x: Int, ~\(x < 0\) and ~\(x > 10\) =>/u);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  it("emits no precondition for incomplete, impure, or unmatched recovery", async () => {
+    const dir = mkdtempSync(join(process.cwd(), ".tmp-effect-error-"));
+    const file = join(dir, "fixture.ts");
+    writeFileSync(
+      file,
+      `
+        import { Data, Effect } from "effect";
+        class FooError extends Data.TaggedError("FooError")<{}> {}
+        class BarError extends Data.TaggedError("BarError")<{}> {}
+        declare function blocked(): boolean;
+        export function partial(x: number): Effect.Effect<number, FooError | BarError, never> {
+          return Effect.gen(function* () {
+            if (x < 0) { yield* new FooError(); }
+            return x;
+          });
+        }
+        export function impure(x: number): Effect.Effect<number, FooError, never> {
+          return Effect.gen(function* () {
+            if (blocked()) { yield* new FooError(); }
+            return x;
+          });
+        }
+        export function unmatched(x: number): Effect.Effect<number, FooError, never> {
+          return Effect.gen(function* () {
+            if (x < 0) { yield* new BarError(); }
+            return x;
+          });
+        }
+        export function unmatchedShape(x: number): Effect.Effect<number, FooError, never> {
+          return Effect.gen(function* () {
+            yield* new FooError();
+            return x;
+          });
+        }
+      `,
+    );
+    try {
+      for (const functionName of [
+        "partial",
+        "impure",
+        "unmatched",
+        "unmatchedShape",
+      ]) {
+        const pantName = toPantName(functionName);
+        const doc = await buildPantDocument({
+          sourceFile: createSourceFile(file),
+          functionName,
+          strategy: IntStrategy,
+          noBody: true,
+        });
+        const declaration = emitDocument(doc)
+          .split("\n")
+          .find((line) => line.startsWith(`${pantName} `));
+        assert.ok(declaration, `missing declaration for ${functionName}`);
+        assert.equal(
+          declaration.split("=>", 1)[0]!.trim(),
+          `${pantName} x: Int`,
+        );
+      }
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
 });

--- a/tools/ts2pant/tests/fixtures/constructs/effect-gen-error-guards.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/effect-gen-error-guards.ts
@@ -1,0 +1,95 @@
+import { Data, Effect } from "effect";
+
+class NegError extends Data.TaggedError("NegError")<{}> {}
+class TooLargeError extends Data.TaggedError("TooLargeError")<{}> {}
+class MissingError extends Data.TaggedError("MissingError")<{}> {}
+class ImpureError extends Data.TaggedError("ImpureError")<{}> {}
+
+declare function isBlocked(): boolean;
+
+/** @pant all x: Int | singleError x = x */
+export function singleError(
+  x: number,
+): Effect.Effect<number, NegError, never> {
+  var unsupportedBody = 0;
+  void unsupportedBody;
+  return Effect.gen(function* () {
+    if (x < 0) {
+      yield* new NegError();
+    }
+    return x;
+  });
+}
+
+/** @pant all x: Int | multiError x = x */
+export function multiError(
+  x: number,
+): Effect.Effect<number, NegError | TooLargeError, never> {
+  var unsupportedBody = 0;
+  void unsupportedBody;
+  return Effect.gen(function* () {
+    if (x < 0) {
+      yield* new NegError();
+    }
+    if (x > 100) {
+      yield* new TooLargeError();
+    }
+    return x;
+  });
+}
+
+export function partialRecovery(
+  x: number,
+): Effect.Effect<number, NegError | MissingError, never> {
+  var unsupportedBody = 0;
+  void unsupportedBody;
+  return Effect.gen(function* () {
+    if (x < 0) {
+      yield* new NegError();
+    }
+    return x;
+  });
+}
+
+export function impureCond(
+  x: number,
+): Effect.Effect<number, ImpureError, never> {
+  var unsupportedBody = 0;
+  void unsupportedBody;
+  return Effect.gen(function* () {
+    if (isBlocked()) {
+      yield* new ImpureError();
+    }
+    return x;
+  });
+}
+
+export function unmatchedShape(
+  x: number,
+): Effect.Effect<number, NegError, never> {
+  var unsupportedBody = 0;
+  void unsupportedBody;
+  return Effect.gen(function* () {
+    yield* new NegError();
+    return x;
+  });
+}
+
+/** @pant all x: Int | combinedWithThrow x = x */
+export function combinedWithThrow(
+  x: number,
+): Effect.Effect<number, NegError, never> {
+  if (x <= 1000) {
+    // existing if/else-throw guard source
+  } else {
+    throw new Error("too large");
+  }
+  var unsupportedBody = 0;
+  void unsupportedBody;
+  return Effect.gen(function* () {
+    if (x < 0) {
+      yield* new NegError();
+    }
+    return x;
+  });
+}

--- a/tools/ts2pant/tests/integration/dogfood.test.mts
+++ b/tools/ts2pant/tests/integration/dogfood.test.mts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { describe, it } from "node:test";
-import { runCheck } from "../../src/emit.js";
+import { emitDocument, runCheck } from "../../src/emit.js";
 import {
   assertPantTypeChecks,
   buildDocument as buildDocumentFromPath,
@@ -528,6 +528,65 @@ describe("dogfood: @pant annotations entail", () => {
     );
   }
 });
+
+describe("dogfood: Effect error-channel preconditions", () => {
+  const hasSolver = solverAvailable();
+
+  it(
+    "fully recovered Effect-generator preconditions are checkable",
+    { skip: !hasSolver ? "z3 not available" : undefined },
+    async () => {
+      for (const fn of ["singleError", "multiError", "combinedWithThrow"]) {
+        const doc = await buildDocumentFromPath(
+          resolve(FIXTURES, "effect-gen-error-guards.ts"),
+          fn,
+          { noBody: true },
+        );
+        const output = emitDocument(doc);
+        assert.doesNotMatch(output, /> UNSUPPORTED:/u);
+        const result = runCheck(withOpaqueEffectDomain(output), {
+          projectRoot: PROJECT_ROOT,
+          pantBin: getPantBin(),
+        });
+        assert.ok(
+          result.passed,
+          `pant --check failed for ${fn}:\n${result.output}`,
+        );
+      }
+    },
+  );
+
+  it(
+    "partial and impure Effect-generator recovery bail without a guard",
+    { skip: !hasSolver ? "z3 not available" : undefined },
+    async () => {
+      for (const fn of ["partialRecovery", "impureCond", "unmatchedShape"]) {
+        const doc = await buildDocumentFromPath(
+          resolve(FIXTURES, "effect-gen-error-guards.ts"),
+          fn,
+          { noBody: true },
+        );
+        const output = emitDocument(doc);
+        const decl = output
+          .split("\n")
+          .find((line) => line.startsWith(toPantFixtureName(fn)));
+        assert.ok(decl, `missing declaration for ${fn}`);
+        assert.equal(
+          decl.split("=>", 1)[0]!.trim(),
+          `${toPantFixtureName(fn)} x: Int`,
+        );
+      }
+    },
+  );
+});
+
+function toPantFixtureName(name: string): string {
+  return name.replace(/[A-Z]/gu, (c) => `-${c.toLowerCase()}`);
+}
+
+function withOpaqueEffectDomain(output: string): string {
+  return output.replace(/\n\n/u, "\n\nEffect.\n");
+}
 
 describe("dogfood: DU definedness", () => {
   const hasSolver = solverAvailable();


### PR DESCRIPTION
## Patch 2: Recover Effect error-mode guards into the precondition (completeness-bail)

- In translate-signature.ts, detect Effect-generator functions and collect per-error-mode guards via recoverErrorModeGuard against the enumerated modes from extractEffectErrorModes.
- Apply the completeness-bail gate: synthesize the negated-conjunction precondition only when every enumerated error mode is recovered with a pure cond; otherwise contribute no Effect-derived guard.
- AND-combine the Effect guard with any existing if-throw/assertion guard using the same mechanism detectGuard already uses; ensure no double-counting.
- Create effect-gen-error-guards.ts with single-mode, multi-mode, partial-recovery (bail), impure-cond (bail), and combined-with-if-throw cases; implement the Patch 1 error-channel integration stubs.
- Wire fixtures into the dogfood suites; regenerate constructs and dogfood snapshots; confirm fully-recovered preconditions entail and bail cases are unchanged under `pant --check`.

## Changes
- In translate-signature.ts, detect Effect-generator functions and collect per-error-mode guards via recoverErrorModeGuard against the enumerated modes from extractEffectErrorModes.
- Apply the completeness-bail gate: synthesize the negated-conjunction precondition only when every enumerated error mode is recovered with a pure cond; otherwise contribute no Effect-derived guard.
- AND-combine the Effect guard with any existing if-throw/assertion guard using the same mechanism detectGuard already uses; ensure no double-counting.
- Create effect-gen-error-guards.ts with single-mode, multi-mode, partial-recovery (bail), impure-cond (bail), and combined-with-if-throw cases; implement the Patch 1 error-channel integration stubs.
- Wire fixtures into the dogfood suites; regenerate constructs and dogfood snapshots; confirm fully-recovered preconditions entail and bail cases are unchanged under `pant --check`.

## Files to Modify
- tools/ts2pant/src/translate-signature.ts (modify): Wire the Effect error-channel guard source into the guard-integration path. For a function whose return type extractEffectErrorModes recognizes and whose body is an Effect generator, scan its statements with recoverErrorModeGuard; if and only if every enumerated error mode is recovered with a pure cond, AND the conjunction of negated conds into the function's guard (combined with any existing if-throw/assertion guard). Otherwise contribute nothing (conservative bail). Do not change the success-type mapping.
- tools/ts2pant/tests/fixtures/constructs/effect-gen-error-guards.ts (create): Fixtures with @pant annotations: a single-error-mode generator (`if (x < 0) yield* new NegError()` -> precondition x >= 0, entails); a multi-mode generator over a union E with all modes recovered (conjunction, entails); a partial-recovery generator (one E member has no yield -> bail, negative control); an impure-cond generator (bail); and a generator that also has a pre-existing if-throw guard (AND-combination).
- tools/ts2pant/tests/effect-error-channel.test.mts (modify): Un-skip and implement the precondition-emitted and conservative-bail @pant integration stubs.
- tools/ts2pant/tests/integration/dogfood.test.mts (modify): Add the fully-recovered Effect-generator fixtures to the `@pant annotations entail` suite and the bail cases to the not-entailed / unchanged suite.
- tools/ts2pant/tests/constructs.test.mts.snapshot (modify): Regenerate via `npm run test:update-snapshots`; the diff is the precondition newly appearing on the fully-recovered Effect-generator fixtures and any dogfood corpus Effect generators with fully-recovered modes.
- tools/ts2pant/tests/integration/dogfood.test.mts.snapshot (modify): Regenerate if dogfood corpus Effect generators have fully-recovered error modes (preconditions newly emitted).

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[library] Effect-TS** — https://effect.website — The generator-body shape this patch scans (Effect.gen(function* () { ... yield* new ErrorClass() ... })) and the semantics that the success value A is produced only when no error mode is raised — the basis for the negated-conjunction precondition.

## Gameplan Specification

```
module GUARD_EFFECT_ERROR_CHANNEL.

> ══════════════════════════════
> THE GUARANTEE
> ═══════════════════════════════
> After M4, ts2pant derives preconditions from two new sources, both folded
> into the existing guard slot (PantRule.guard / PantAction.guard, emitted
> at emit.ts) and AND-combined with any if-throw/assertion guard. (1) Effect
> error channel: it reads the E channel of an Effect<A,E,R> return type and
> AST-matches `if (cond) { yield* new ErrorClass() }` to recover, per mode,
> the raising condition; when every enumerated mode is recovered with a
> side-effect-free condition, the precondition gains the conjunction of the
> negated conditions, else nothing (never partial/wrong). (2) Branded
> parameters: a recognized Schema brand/filter (curated allowlist) on a
> parameter contributes its predicate, else nothing. Non-Effect functions,
> `never` error channels, unbranded parameters, the success-type A mapping,
> and branded base-type mappings are unchanged. The analysis is intra-
> function and reuses the M1 purity classifier and the conservative-bail
> discipline.

Fn.
Param.
effect-returning f: Fn => Bool.
all-modes-recovered f: Fn => Bool.
pure-conds f: Fn => Bool.
emits-effect-precondition f: Fn => Bool.
wrong-precondition f: Fn => Bool.
recognized-brand p: Param => Bool.
contributes-predicate p: Param => Bool.
base-type-unchanged p: Param => Bool.

---

> Effect: a sound error-derived precondition is emitted exactly when the
> function is Effect-returning with every mode recovered under pure conds.
all f: Fn | (effect-returning f and all-modes-recovered f and pure-conds f) -> emits-effect-precondition f.
all f: Fn | (effect-returning f and ~(all-modes-recovered f)) -> ~(emits-effect-precondition f).
all f: Fn | (effect-returning f and ~(pure-conds f)) -> ~(emits-effect-precondition f).
all f: Fn | ~(effect-returning f) -> ~(emits-effect-precondition f).

> Brands: a predicate is contributed exactly for recognized brands, and a
> parameter's base-type mapping is always unchanged.
all p: Param | recognized-brand p -> contributes-predicate p.
all p: Param | ~(recognized-brand p) -> ~(contributes-predicate p).
all p: Param | base-type-unchanged p.

> Soundness: no function ever emits a wrong (unsound) precondition.
all f: Fn | ~(wrong-precondition f).
```

## Patch Specification

```
module GUARD_EFFECT_ERROR_CHANNEL_PATCH_2.

> Patch 2 recovers Effect error-mode guards into the precondition: for an
> Effect-returning generator, each declared error mode matched by an
> `if (cond) yield* new ErrorClass()` with a pure cond contributes `~cond`.
> The precondition is emitted only when every error mode is recovered;
> otherwise no Effect-derived precondition is emitted (conservative bail),
> and it is never wrong.

Fn.
effect-returning f: Fn => Bool.
all-modes-recovered f: Fn => Bool.
emits-effect-precondition f: Fn => Bool.
wrong-precondition f: Fn => Bool.

---

> An Effect-derived precondition is emitted exactly when the function is
> Effect-returning and every error mode is recovered.
all f: Fn | (effect-returning f and all-modes-recovered f) -> emits-effect-precondition f.
all f: Fn | (effect-returning f and ~(all-modes-recovered f)) -> ~(emits-effect-precondition f).

> Soundness: no function ever emits a wrong (unsound) precondition.
all f: Fn | ~(wrong-precondition f).
```


## Implementation Notes

- The Effect-derived guard is signature-only and deliberately leaves `Effect<A,E,R>` return mapping untouched. The dogfood `pant --check` assertions use no-body documents plus a local `Effect.` domain shim in the test so they verify the emitted guard shape/checkability without expanding the return-type scope.
- Recovery scans the returned `Effect.gen(function* ...)` body for top-level `if` statements containing `yield* new ErrorClass(...)`. Any yielded error outside the exact recoverable `if` shape, duplicate recovery for the same mode, unmatched constructor, unsupported guard expression, or impure condition bails the entire Effect-derived guard.
- Existing leading if-throw/assertion guard extraction is unchanged; the new Effect guard is combined afterwards with the same Pant AST `and` node, so the body scanner does not double-count nested generator guards.
- Fixture bodies intentionally include `var` statements so construct snapshots can capture signature/precondition behavior while the current body translator still rejects `Effect.gen` bodies cleanly. This avoids implying Patch 2 added Effect body translation.
- Spec/Evidence Mapping:
  - “Emit only when all modes recovered”: `detectEffectErrorChannelGuard` in `tools/ts2pant/src/translate-signature.ts`; covered by `singleError`, `multiError`, and `combinedWithThrow` snapshots plus `effect-error-channel.test.mts`.
  - “Bail on incomplete/impure/unmatched recovery”: same helper’s all-mode, purity, duplicate, and unmatched-yield gates; covered by `partialRecovery`, `impureCond`, `unmatchedShape`, and unit integration cases.
  - “AND-combine with existing guard”: `combineGuards` in `translate-signature.ts`; covered by `combinedWithThrow`.
  - Required context consulted: existing purity oracle/Effect symbol resolution in `purity.ts`, guard extraction/translation in `translate-signature.ts`, and construct/dogfood test harnesses.
  - Verification: `npm --prefix tools/ts2pant run build`, `npm --prefix tools/ts2pant run test:update-snapshots`, `npm --prefix tools/ts2pant test`, and `git diff --check`.