### PR TITLE
[ts2pant-nullish-and-predicate-narrowing] Patch 2: Nullish narrowing end-to-end (recognition + discharge)

### DIFF
--- a/tools/ts2pant/src/definedness-obligation.ts
+++ b/tools/ts2pant/src/definedness-obligation.ts
@@ -57,7 +57,13 @@ export function renderNullishObligation(
   input: NullishObligationInput,
 ): DefinednessObligation {
   const ast = getAst();
-  if (input.inScope.some((fact) => !fact.negated)) {
+  const receiverText = ast.strExpr(input.receiver);
+  if (
+    input.inScope.some(
+      (fact) =>
+        !fact.negated && ast.strExpr(ast.var(fact.receiver)) === receiverText,
+    )
+  ) {
     return { text: ast.strExpr(ast.litBool(true)) };
   }
   const consequent = nonNullExpr(input.receiver);

--- a/tools/ts2pant/src/definedness-obligation.ts
+++ b/tools/ts2pant/src/definedness-obligation.ts
@@ -57,6 +57,9 @@ export function renderNullishObligation(
   input: NullishObligationInput,
 ): DefinednessObligation {
   const ast = getAst();
+  if (input.inScope.some((fact) => !fact.negated)) {
+    return { text: ast.strExpr(ast.litBool(true)) };
+  }
   const consequent = nonNullExpr(input.receiver);
   const antecedents = input.inScope.map((fact) => {
     const equality = nonNullExpr(ast.var(fact.receiver));

--- a/tools/ts2pant/src/ir1-build-body.ts
+++ b/tools/ts2pant/src/ir1-build-body.ts
@@ -68,6 +68,7 @@ import { substituteIR1StmtSubtree } from "./ir1-substitute.js";
 import {
   negateFact,
   recognizeNarrowingPredicate,
+  recognizeNullishNarrowing,
 } from "./narrowing-recognizer.js";
 import type { OpaquePolicy } from "./opaque.js";
 import type { OpaqueExpr } from "./pant-ast.js";
@@ -175,6 +176,16 @@ function withNarrowingFrame<T>(
   } finally {
     exitFrame(env);
   }
+}
+
+function recognizeBranchFact(
+  test: ts.Expression,
+  checker: ts.TypeChecker,
+): Fact | null {
+  return (
+    recognizeNullishNarrowing(test, checker) ??
+    recognizeNarrowingPredicate(test, checker)
+  );
 }
 
 /**
@@ -1010,7 +1021,7 @@ export function buildL1IfMutation(
     return guard;
   }
 
-  const fact = recognizeNarrowingPredicate(stmt.expression, ctx.checker);
+  const fact = recognizeBranchFact(stmt.expression, ctx.checker);
   const thenBody = withNarrowingFrame(ctx, "if.then", [fact], () =>
     buildL1MutationBody(stmt.thenStatement, ctx),
   );

--- a/tools/ts2pant/src/ir1-build-body.ts
+++ b/tools/ts2pant/src/ir1-build-body.ts
@@ -799,6 +799,21 @@ export function buildL1SubExpr(
   node: ts.Expression,
   ctx: BuildBodyCtx,
 ): BuildResult<IR1Expr> {
+  const ctxOptions = {
+    checker: ctx.checker,
+    strategy: ctx.strategy,
+    paramNames: ctx.paramNames,
+    state: ctx.state,
+    supply: ctx.supply,
+    env: ctx.env,
+    policy: ctx.policy,
+  };
+  if (ts.isNonNullExpression(node)) {
+    const nativeNonNull = tryBuildL1PureSubExpression(node, ctxOptions);
+    if (nativeNonNull !== null) {
+      return nativeNonNull;
+    }
+  }
   const stripped = unwrapExpression(node);
   if (
     ts.isPropertyAccessExpression(stripped) ||
@@ -812,15 +827,6 @@ export function buildL1SubExpr(
     // receivers via its `ctx.state !== undefined` branch, but passing
     // the option here keeps both probes consistent.
     const l1Options = { nativeReceiverLeaf: true } as const;
-    const ctxOptions = {
-      checker: ctx.checker,
-      strategy: ctx.strategy,
-      paramNames: ctx.paramNames,
-      state: ctx.state,
-      supply: ctx.supply,
-      env: ctx.env,
-      policy: ctx.policy,
-    };
     const card = tryBuildL1Cardinality(stripped, ctxOptions, l1Options);
     if (card !== null) {
       return card;

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -40,11 +40,15 @@ import {
   enterFrame,
   exitFrame,
   type Fact,
+  nonNullFactInScope,
   pushFact,
   queryFact,
 } from "./assumption-env.js";
 import { lookupBuiltinByCall } from "./builtins.js";
-import { renderDefinednessObligation } from "./definedness-obligation.js";
+import {
+  renderDefinednessObligation,
+  renderNullishObligation,
+} from "./definedness-obligation.js";
 import { lowerExpr } from "./ir-emit.js";
 import {
   type IR1Binop,
@@ -78,6 +82,7 @@ import {
   negateFact,
   recognizeNarrowingFromSwitchCase,
   recognizeNarrowingPredicate,
+  recognizeNullishNarrowing,
 } from "./narrowing-recognizer.js";
 import {
   getOperandDeclaredType,
@@ -214,6 +219,52 @@ export const isL1Unsupported = (
   r: L1BuildResult,
 ): r is { unsupported: string } =>
   typeof r === "object" && r !== null && "unsupported" in r;
+
+function recognizeBranchFact(
+  test: ts.Expression,
+  checker: ts.TypeChecker,
+): Fact | null {
+  return (
+    recognizeNullishNarrowing(test, checker) ??
+    recognizeNarrowingPredicate(test, checker)
+  );
+}
+
+function narrowNullableIdentifierRead(
+  expr: ts.Identifier,
+  value: IR1Expr,
+  ctx: L1BuildContext,
+): IR1Expr {
+  const env = (ctx as { env?: L1BuildContext["env"] }).env;
+  if (env === undefined) {
+    return value;
+  }
+  const declaredTsType = getOperandDeclaredType(expr, ctx.checker);
+  if (!isNullableTsType(declaredTsType)) {
+    return value;
+  }
+  const inScope = nonNullFactInScope(env, expr.text);
+  if (!inScope.some((fact) => !fact.negated)) {
+    return value;
+  }
+  ctx.supply.synthCell?.definednessObligations.push(
+    renderNullishObligation({
+      receiver: lowerExpr(lowerL1Expr(value)),
+      inScope,
+    }),
+  );
+  return ir1App(value, [ir1LitNat(1)]);
+}
+
+function isSingletonExtraction(expr: IR1Expr): boolean {
+  return (
+    expr.kind === "app" &&
+    expr.args.length === 1 &&
+    expr.args[0]?.kind === "lit" &&
+    expr.args[0].value.kind === "nat" &&
+    expr.args[0].value.value === 1
+  );
+}
 
 function withNarrowingFrame<T>(
   ctx: L1BuildContext,
@@ -728,7 +779,8 @@ export function tryBuildL1PureSubExpression(
     if (opaque !== null) {
       return opaque;
     }
-    return ir1Var(ctx.paramNames.get(expr.text) ?? expr.text);
+    const value = ir1Var(ctx.paramNames.get(expr.text) ?? expr.text);
+    return narrowNullableIdentifierRead(expr, value, ctx);
   }
   if (expr.kind === ts.SyntaxKind.ThisKeyword) {
     const opaque = opaqueValueForDynamicExpr(expr as ts.Expression, ctx);
@@ -1158,7 +1210,9 @@ function buildL1Stringification(
   const declaredTsType = getOperandDeclaredType(expr, ctx.checker);
   const tsType = ctx.checker.getTypeAtLocation(expr);
   const value =
-    isNullableTsType(declaredTsType) && !isNullableTsType(tsType)
+    isNullableTsType(declaredTsType) &&
+    !isNullableTsType(tsType) &&
+    !isSingletonExtraction(inner)
       ? ir1App(inner, [ir1LitNat(1)])
       : inner;
   const opaque = contagiousOpaqueForOperands(ctx, [value], expr);
@@ -2676,10 +2730,7 @@ function buildFromIfStatement(
           "if-without-else cannot lower to value-position cond (need both branches)",
       };
     }
-    const currentFact = recognizeNarrowingPredicate(
-      current.expression,
-      ctx.checker,
-    );
+    const currentFact = recognizeBranchFact(current.expression, ctx.checker);
     const guard = buildSubExpr(current.expression, ctx);
     if (isL1Unsupported(guard)) {
       return guard;

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -235,6 +235,9 @@ function narrowNullableIdentifierRead(
   value: IR1Expr,
   ctx: L1BuildContext,
 ): IR1Expr {
+  if (value.kind === "var" && /^\$\d+$/u.test(value.name)) {
+    return value;
+  }
   const env = (ctx as { env?: L1BuildContext["env"] }).env;
   if (env === undefined) {
     return value;

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -235,6 +235,13 @@ function narrowNullableIdentifierRead(
   value: IR1Expr,
   ctx: L1BuildContext,
 ): IR1Expr {
+  if (
+    expr.parent !== undefined &&
+    ts.isNonNullExpression(expr.parent) &&
+    expr.parent.expression === expr
+  ) {
+    return value;
+  }
   if (value.kind === "var" && /^\$\d+$/u.test(value.name)) {
     return value;
   }
@@ -246,7 +253,10 @@ function narrowNullableIdentifierRead(
   if (!isNullableTsType(declaredTsType)) {
     return value;
   }
-  const inScope = nonNullFactInScope(env, expr.text);
+  const inScope = nonNullFactInScope(env, expr.text).map((fact) => ({
+    ...fact,
+    receiver: ctx.paramNames.get(fact.receiver) ?? fact.receiver,
+  }));
   if (!inScope.some((fact) => !fact.negated)) {
     return value;
   }

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -2611,6 +2611,9 @@ function lowerPreludeBindings(
             }
           }
           if (binding.blockBindings.length === 0) {
+            const definednessSnapshot = supply.synthCell
+              ? [...supply.synthCell.definednessObligations]
+              : null;
             const l1Value =
               currentFact?.kind === "non-null"
                 ? buildL1SubExpr(binding.valueExpr, {
@@ -2629,15 +2632,21 @@ function lowerPreludeBindings(
                 ? {
                     value: applyOpaqueAliases(lowerL1ToOpaque(l1Value), supply),
                   }
-                : translateBindingInit(
-                    binding.valueExpr,
-                    checker,
-                    strategy,
-                    acc.scopedParams,
-                    state,
-                    supply,
-                    env,
-                  );
+                : (() => {
+                    if (supply.synthCell && definednessSnapshot !== null) {
+                      supply.synthCell.definednessObligations =
+                        definednessSnapshot;
+                    }
+                    return translateBindingInit(
+                      binding.valueExpr,
+                      checker,
+                      strategy,
+                      acc.scopedParams,
+                      state,
+                      supply,
+                      env,
+                    );
+                  })();
           } else {
             valRes = translateEarlyReturnBlockValue(
               binding.blockBindings,

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -1303,6 +1303,7 @@ function translatePureBody(
         state: undefined,
         supply,
         env,
+        policy,
       },
     );
     if (lifted !== null) {
@@ -2598,6 +2599,7 @@ function lowerPreludeBindings(
           state,
           supply,
           env,
+          policy,
         );
         if ("error" in predRes) {
           return { tag: "error", error: predRes.error };
@@ -2623,6 +2625,7 @@ function lowerPreludeBindings(
                     state: state ?? makeSymbolicState(),
                     supply,
                     env,
+                    policy,
                   })
                 : null;
             valRes =
@@ -2645,6 +2648,7 @@ function lowerPreludeBindings(
                       state,
                       supply,
                       env,
+                      policy,
                     );
                   })();
           } else {
@@ -2658,6 +2662,7 @@ function lowerPreludeBindings(
                 state: state ?? makeSymbolicState(),
                 supply,
                 env,
+                policy,
               },
             );
           }
@@ -2687,6 +2692,7 @@ function lowerPreludeBindings(
           state: state ?? makeSymbolicState(),
           supply,
           env,
+          policy,
         });
         if (isUnsupported(value)) {
           return { tag: "error", error: value.unsupported };
@@ -2742,6 +2748,7 @@ function lowerPreludeBindings(
               checker,
               strategy,
               supply.synthCell,
+              { policy },
             )
           : strategy.mapNumber();
       if (isUnsupportedUnknown(returnType)) {
@@ -2759,6 +2766,7 @@ function lowerPreludeBindings(
               state: state ?? makeSymbolicState(),
               supply,
               env,
+              policy,
             })
           : buildL1MuSearchCombTyped(binding.mu, {
               checker,
@@ -2767,6 +2775,7 @@ function lowerPreludeBindings(
               state,
               supply,
               env,
+              policy,
             });
       if (isUnsupported(initExpr) || isL1Unsupported(initExpr)) {
         if (
@@ -2834,6 +2843,7 @@ function translateEarlyReturnBlockValue(
     state: SymbolicState;
     supply: UniqueSupply;
     env: AssumptionEnv;
+    policy?: OpaquePolicy | undefined;
   },
 ): BindingInitResult {
   let scopedParams: ReadonlyMap<string, string> = new Map(ctx.scopedParams);
@@ -2851,6 +2861,7 @@ function translateEarlyReturnBlockValue(
       state: ctx.state,
       supply: ctx.supply,
       env: ctx.env,
+      policy: ctx.policy,
     });
     if (isUnsupported(initExpr) || isL1Unsupported(initExpr)) {
       return { error: initExpr.unsupported };
@@ -2866,6 +2877,7 @@ function translateEarlyReturnBlockValue(
     state: ctx.state,
     supply: ctx.supply,
     env: ctx.env,
+    policy: ctx.policy,
   });
   if (isUnsupported(value) || isL1Unsupported(value)) {
     return { error: value.unsupported };
@@ -2887,6 +2899,7 @@ function translateBindingInit(
   state: SymbolicState | undefined,
   supply: UniqueSupply,
   env: AssumptionEnv,
+  policy?: OpaquePolicy,
 ): BindingInitResult {
   const result = translateBodyExpr(
     initializer,
@@ -2896,6 +2909,7 @@ function translateBindingInit(
     state,
     supply,
     env,
+    policy,
   );
   if (isBodyUnsupported(result)) {
     return { error: result.unsupported };
@@ -3402,6 +3416,8 @@ export function translateBodyExpr(
         paramNames,
         state,
         supply,
+        env,
+        policy,
       );
       if (isBodyUnsupported(innerResult)) {
         return innerResult;
@@ -3552,6 +3568,7 @@ export function translateBodyExpr(
           state,
           supply,
           env,
+          policy,
         );
         if (isBodyUnsupported(obj)) {
           return obj;
@@ -3643,6 +3660,7 @@ export function translateBodyExpr(
         state,
         supply,
         env,
+        policy,
       ),
     );
   }
@@ -3657,6 +3675,7 @@ export function translateBodyExpr(
       state,
       supply,
       env,
+      policy,
     );
     if (isBodyUnsupported(operand)) {
       return operand;
@@ -3700,6 +3719,8 @@ export function translateBodyExpr(
         paramNames,
         state,
         supply,
+        env,
+        policy,
       );
       if (isBodyUnsupported(leftResult)) {
         return leftResult;
@@ -3715,6 +3736,8 @@ export function translateBodyExpr(
         paramNames,
         state,
         supply,
+        env,
+        policy,
       );
       if (isBodyUnsupported(rightResult)) {
         return rightResult;
@@ -3768,6 +3791,8 @@ export function translateBodyExpr(
         paramNames,
         state,
         supply,
+        env,
+        policy,
       );
       if (isBodyUnsupported(left)) {
         return left;
@@ -3779,6 +3804,8 @@ export function translateBodyExpr(
         paramNames,
         state,
         supply,
+        env,
+        policy,
       );
       if (isBodyUnsupported(right)) {
         return right;
@@ -3816,6 +3843,8 @@ export function translateBodyExpr(
       paramNames,
       state,
       supply,
+      env,
+      policy,
     );
     if (isBodyUnsupported(left)) {
       return left;
@@ -3827,6 +3856,8 @@ export function translateBodyExpr(
       paramNames,
       state,
       supply,
+      env,
+      policy,
     );
     if (isBodyUnsupported(right)) {
       return right;
@@ -3903,6 +3934,7 @@ function getArrayElementType(
   tsExpr: ts.Expression,
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
+  policy?: OpaquePolicy,
 ): string | null {
   const sourceType = checker.getTypeAtLocation(tsExpr);
   if (!checker.isArrayType(sourceType)) {
@@ -3910,7 +3942,7 @@ function getArrayElementType(
   }
   const typeArgs = checker.getTypeArguments(sourceType as ts.TypeReference);
   return typeArgs.length === 1
-    ? mapTsType(typeArgs[0]!, checker, strategy)
+    ? mapTsType(typeArgs[0]!, checker, strategy, undefined, { policy })
     : "?";
 }
 
@@ -3932,10 +3964,12 @@ function translateArrayMethod(
   paramNames: ReadonlyMap<string, string>,
   state: SymbolicState | undefined,
   supply: UniqueSupply,
+  env: AssumptionEnv,
+  policy?: OpaquePolicy,
 ): BodyResult | null {
   const ast = getAst();
 
-  if (!getArrayElementType(tsReceiver, checker, strategy)) {
+  if (!getArrayElementType(tsReceiver, checker, strategy, policy)) {
     return null;
   }
 
@@ -3946,6 +3980,8 @@ function translateArrayMethod(
     paramNames,
     state,
     supply,
+    env,
+    policy,
   );
   const receiver = rejectEffect(receiverRaw);
   if (isBodyUnsupported(receiver)) {
@@ -3973,6 +4009,8 @@ function translateArrayMethod(
     checker,
     strategy,
     supply,
+    env,
+    policy,
   );
   if (!rawBody) {
     return { unsupported: expr.getText() };
@@ -4044,6 +4082,8 @@ function translateReduceCall(
   paramNames: ReadonlyMap<string, string>,
   state: SymbolicState | undefined,
   supply: UniqueSupply,
+  env: AssumptionEnv,
+  policy?: OpaquePolicy,
 ): BodyResult | null {
   const ast = getAst();
 
@@ -4051,7 +4091,7 @@ function translateReduceCall(
     return { unsupported: `.${methodName} requires an explicit initial value` };
   }
 
-  if (!getArrayElementType(tsReceiver, checker, strategy)) {
+  if (!getArrayElementType(tsReceiver, checker, strategy, policy)) {
     return null;
   }
 
@@ -4062,6 +4102,8 @@ function translateReduceCall(
     paramNames,
     state,
     supply,
+    env,
+    policy,
   );
   const receiver = rejectEffect(receiverRaw);
   if (isBodyUnsupported(receiver)) {
@@ -4167,6 +4209,8 @@ function translateReduceCall(
     extendedParams,
     state,
     supply,
+    env,
+    policy,
   );
   if (isBodyUnsupported(innerResult)) {
     return innerResult;
@@ -4210,6 +4254,8 @@ function translateReduceCall(
     paramNames,
     state,
     supply,
+    env,
+    policy,
   );
   if (isBodyUnsupported(initResult)) {
     return initResult;
@@ -4244,6 +4290,7 @@ export function translateCallExpr(
   state: SymbolicState | undefined,
   supply: UniqueSupply,
   env: AssumptionEnv = createL1AssumptionEnv(),
+  policy?: OpaquePolicy,
 ): BodyResult {
   const ast = getAst();
   const builtin = tryBuildBuiltinCall(expr, {
@@ -4253,6 +4300,7 @@ export function translateCallExpr(
     state,
     supply,
     env,
+    policy,
   });
   if (builtin !== null) {
     if (isL1Unsupported(builtin)) {
@@ -4307,6 +4355,7 @@ export function translateCallExpr(
           state,
           supply,
           env,
+          policy,
         },
         { requireMember: true },
       );
@@ -4325,6 +4374,7 @@ export function translateCallExpr(
         checker,
         strategy,
         supply.synthCell,
+        { policy },
       );
       const setTypeArgs = checker.getTypeArguments(
         checker.getTypeAtLocation(normalizedReceiver) as ts.TypeReference,
@@ -4337,6 +4387,7 @@ export function translateCallExpr(
         checker,
         strategy,
         supply.synthCell,
+        { policy },
       );
       const objOpaque = lowerL1ToOpaque(memberR.receiver);
       let elemOpaque: OpaqueExpr | null = null;
@@ -4348,6 +4399,8 @@ export function translateCallExpr(
           paramNames,
           state,
           supply,
+          env,
+          policy,
         );
         const eExpr = rejectEffect(eRaw);
         if (isBodyUnsupported(eExpr)) {
@@ -4391,6 +4444,8 @@ export function translateCallExpr(
         paramNames,
         state,
         supply,
+        env,
+        policy,
       );
       const kExpr = rejectEffect(kExprRaw);
       if (isBodyUnsupported(kExpr)) {
@@ -4406,6 +4461,8 @@ export function translateCallExpr(
           paramNames,
           state,
           supply,
+          env,
+          policy,
         );
         const vExpr = rejectEffect(vRaw);
         if (isBodyUnsupported(vExpr)) {
@@ -4428,6 +4485,7 @@ export function translateCallExpr(
             state,
             supply,
             env,
+            policy,
           },
           { requireMember: true },
         );
@@ -4446,6 +4504,7 @@ export function translateCallExpr(
           checker,
           strategy,
           supply.synthCell,
+          { policy },
         );
         const typeArgs = checker.getTypeArguments(
           checker.getTypeAtLocation(normalizedReceiver) as ts.TypeReference,
@@ -4458,6 +4517,7 @@ export function translateCallExpr(
           checker,
           strategy,
           supply.synthCell,
+          { policy },
         );
         return {
           effect: {
@@ -4487,12 +4547,14 @@ export function translateCallExpr(
         checker,
         strategy,
         supply.synthCell,
+        { policy },
       );
       const vType = mapTsType(
         typeArgs[1]!,
         checker,
         strategy,
         supply.synthCell,
+        { policy },
       );
       let info = supply.synthCell
         ? lookupMapKV(supply.synthCell.synth, kType, vType)
@@ -4513,6 +4575,8 @@ export function translateCallExpr(
         paramNames,
         state,
         supply,
+        env,
+        policy,
       );
       const objExpr = rejectEffect(objRaw);
       if (isBodyUnsupported(objExpr)) {
@@ -4567,6 +4631,7 @@ export function translateCallExpr(
             state,
             supply,
             env,
+            policy,
           },
           { requireMember: true },
         );
@@ -4587,6 +4652,8 @@ export function translateCallExpr(
           paramNames,
           state,
           supply,
+          env,
+          policy,
         );
         if (isBodyUnsupported(kExpr)) {
           return kExpr;
@@ -4602,12 +4669,14 @@ export function translateCallExpr(
           checker,
           strategy,
           supply.synthCell,
+          { policy },
         );
         const keyType = mapTsType(
           typeArgs[0]!,
           checker,
           strategy,
           supply.synthCell,
+          { policy },
         );
         return {
           expr: readMapThroughWrites(
@@ -4641,12 +4710,14 @@ export function translateCallExpr(
         checker,
         strategy,
         supply.synthCell,
+        { policy },
       );
       const vType = mapTsType(
         typeArgs[1]!,
         checker,
         strategy,
         supply.synthCell,
+        { policy },
       );
       let info = supply.synthCell
         ? lookupMapKV(supply.synthCell.synth, kType, vType)
@@ -4670,6 +4741,8 @@ export function translateCallExpr(
         paramNames,
         state,
         supply,
+        env,
+        policy,
       );
       if (isBodyUnsupported(objExpr)) {
         return objExpr;
@@ -4681,6 +4754,8 @@ export function translateCallExpr(
         paramNames,
         state,
         supply,
+        env,
+        policy,
       );
       if (isBodyUnsupported(kExpr)) {
         return kExpr;
@@ -4723,6 +4798,8 @@ export function translateCallExpr(
         paramNames,
         state,
         supply,
+        env,
+        policy,
       );
       if (isBodyUnsupported(arg)) {
         return arg;
@@ -4734,6 +4811,8 @@ export function translateCallExpr(
         paramNames,
         state,
         supply,
+        env,
+        policy,
       );
       const objExpr = rejectEffect(objRaw);
       if (isBodyUnsupported(objExpr)) {
@@ -4764,6 +4843,7 @@ export function translateCallExpr(
               state,
               supply,
               env,
+              policy,
             },
             { requireMember: true },
           );
@@ -4774,13 +4854,16 @@ export function translateCallExpr(
               checker,
               strategy,
               supply.synthCell,
+              { policy },
             );
             const typeArgs = checker.getTypeArguments(
               receiverType as ts.TypeReference,
             );
             const elemType =
               typeArgs.length === 1
-                ? mapTsType(typeArgs[0]!, checker, strategy, supply.synthCell)
+                ? mapTsType(typeArgs[0]!, checker, strategy, supply.synthCell, {
+                    policy,
+                  })
                 : null;
             if (elemType !== null) {
               return {
@@ -4814,6 +4897,8 @@ export function translateCallExpr(
         paramNames,
         state,
         supply,
+        env,
+        policy,
       );
       if (result) {
         return result;
@@ -4831,6 +4916,8 @@ export function translateCallExpr(
         paramNames,
         state,
         supply,
+        env,
+        policy,
       );
       if (result) {
         return result;
@@ -4854,6 +4941,8 @@ export function translateCallExpr(
       paramNames,
       state,
       supply,
+      env,
+      policy,
     );
     if (isBodyUnsupported(receiver)) {
       return receiver;
@@ -4867,6 +4956,8 @@ export function translateCallExpr(
         paramNames,
         state,
         supply,
+        env,
+        policy,
       );
       if (isBodyUnsupported(a)) {
         return a;
@@ -4905,6 +4996,8 @@ export function translateCallExpr(
         paramNames,
         state,
         supply,
+        env,
+        policy,
       );
       if (isBodyUnsupported(a)) {
         return a;
@@ -4925,6 +5018,8 @@ function extractArrowBody(
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
   supply: UniqueSupply,
+  env: AssumptionEnv,
+  policy?: OpaquePolicy,
 ): BodyResult | null {
   if (!ts.isArrowFunction(expr)) {
     return null;
@@ -4961,6 +5056,8 @@ function extractArrowBody(
           arrowParams,
           undefined,
           supply,
+          env,
+          policy,
         );
       }
     }
@@ -4975,6 +5072,8 @@ function extractArrowBody(
     arrowParams,
     undefined,
     supply,
+    env,
+    policy,
   );
 }
 
@@ -5304,8 +5403,8 @@ function lowerSupportedSsaMutatingBlock(
     ctx.supply,
     ctx.env,
     ctx.localRuleDecls,
-    ctx.policy,
     ctx.recognitionHook,
+    ctx.policy,
   );
 
   if (isUnsupported(ssaBody)) {
@@ -5379,8 +5478,8 @@ function buildSupportedSsaMutatingBody(
   supply: UniqueSupply,
   env: AssumptionEnv,
   localRuleDecls?: PropResult[],
-  policy?: OpaquePolicy,
   recognitionHook?: (env: AssumptionEnv, location: string) => void,
+  policy?: OpaquePolicy,
 ): IR1Stmt | { unsupported: string } {
   const stmts: IR1Stmt[] = [];
   const scopedParamNames = new Map(paramNames);
@@ -5419,6 +5518,7 @@ function buildSupportedSsaMutatingBody(
           state,
           supply,
           env,
+          policy,
           ...(recognitionHook === undefined ? {} : { recognitionHook }),
         },
       );
@@ -5437,6 +5537,7 @@ function buildSupportedSsaMutatingBody(
           state,
           supply,
           env,
+          policy,
           ...(recognitionHook === undefined ? {} : { recognitionHook }),
         },
       );
@@ -5589,8 +5690,8 @@ function buildSupportedSsaStatement(
       ctx.supply,
       ctx.env,
       ctx.localRuleDecls,
-      ctx.policy,
       ctx.recognitionHook,
+      ctx.policy,
     );
     return body;
   }
@@ -5682,6 +5783,7 @@ function buildL1BareWhileMutation(
         ctx.supply,
         ctx.env,
         ctx.localRuleDecls,
+        ctx.recognitionHook,
         ctx.policy,
       )
     : buildSupportedSsaStatement(stmt.statement, ctx);
@@ -5701,6 +5803,7 @@ function buildL1ForCounterMutation(
     supply: UniqueSupply;
     env: AssumptionEnv;
     localRuleDecls?: PropResult[];
+    recognitionHook?: (env: AssumptionEnv, location: string) => void;
     policy?: OpaquePolicy | undefined;
   },
 ): IR1Stmt | { unsupported: string } {
@@ -5752,6 +5855,7 @@ function buildL1ForCounterMutation(
         ctx.supply,
         ctx.env,
         ctx.localRuleDecls,
+        ctx.recognitionHook,
         ctx.policy,
       )
     : buildSupportedSsaStatement(stmt.statement, ctx);
@@ -5814,6 +5918,7 @@ function buildL1LetWhileFixedPointMutation(
     ctx.supply,
     ctx.env,
     ctx.localRuleDecls,
+    ctx.recognitionHook,
     ctx.policy,
   );
   if (isUnsupported(bodyStmt)) {
@@ -5917,6 +6022,7 @@ function buildL1LetWhileMutation(
     ctx.supply,
     ctx.env,
     ctx.localRuleDecls,
+    ctx.recognitionHook,
     ctx.policy,
   );
   if (isUnsupported(bodyStmt)) {

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -66,6 +66,7 @@ import { substituteIR1ExprSubtree } from "./ir1-substitute.js";
 import {
   negateFact,
   recognizeNarrowingPredicate,
+  recognizeNullishNarrowing,
 } from "./narrowing-recognizer.js";
 import {
   getOperandDeclaredType,
@@ -120,6 +121,16 @@ import {
 import type { PantDeclaration, PropResult } from "./types.js";
 
 export { expressionHasSideEffects } from "./purity.js";
+
+function recognizeBranchFact(
+  test: ts.Expression,
+  checker: ts.TypeChecker,
+): Fact | null {
+  return (
+    recognizeNullishNarrowing(test, checker) ??
+    recognizeNarrowingPredicate(test, checker)
+  );
+}
 
 // --- Const-binding inlining infrastructure (let-elimination) ---
 
@@ -2578,10 +2589,7 @@ function lowerPreludeBindings(
         return acc;
       }
       if (binding.kind === "earlyReturn") {
-        const currentFact = recognizeNarrowingPredicate(
-          binding.predicateExpr,
-          checker,
-        );
+        const currentFact = recognizeBranchFact(binding.predicateExpr, checker);
         const predRes = translateBindingInit(
           binding.predicateExpr,
           checker,
@@ -2602,29 +2610,48 @@ function lowerPreludeBindings(
               pushFact(env, fact);
             }
           }
-          valRes =
-            binding.blockBindings.length === 0
-              ? translateBindingInit(
-                  binding.valueExpr,
-                  checker,
-                  strategy,
-                  acc.scopedParams,
-                  state,
-                  supply,
-                  env,
-                )
-              : translateEarlyReturnBlockValue(
-                  binding.blockBindings,
-                  binding.valueExpr,
-                  {
+          if (binding.blockBindings.length === 0) {
+            const l1Value =
+              currentFact?.kind === "non-null"
+                ? buildL1SubExpr(binding.valueExpr, {
                     checker,
                     strategy,
-                    scopedParams: acc.scopedParams,
+                    paramNames: acc.scopedParams,
                     state: state ?? makeSymbolicState(),
                     supply,
                     env,
-                  },
-                );
+                  })
+                : null;
+            valRes =
+              l1Value !== null &&
+              !isUnsupported(l1Value) &&
+              !isL1Unsupported(l1Value)
+                ? {
+                    value: applyOpaqueAliases(lowerL1ToOpaque(l1Value), supply),
+                  }
+                : translateBindingInit(
+                    binding.valueExpr,
+                    checker,
+                    strategy,
+                    acc.scopedParams,
+                    state,
+                    supply,
+                    env,
+                  );
+          } else {
+            valRes = translateEarlyReturnBlockValue(
+              binding.blockBindings,
+              binding.valueExpr,
+              {
+                checker,
+                strategy,
+                scopedParams: acc.scopedParams,
+                state: state ?? makeSymbolicState(),
+                supply,
+                env,
+              },
+            );
+          }
         } finally {
           exitFrame(env);
         }

--- a/tools/ts2pant/tests/constructs.test.mts
+++ b/tools/ts2pant/tests/constructs.test.mts
@@ -45,8 +45,11 @@ const fixtureFiles = readdirSync(CONSTRUCTS_DIR)
 for (const file of fixtureFiles) {
   describe(file, () => {
     const filePath = resolve(CONSTRUCTS_DIR, file);
-    const sourceFile = createSourceFile(filePath);
-    const targets = discoverTestTargets(sourceFile);
+    const discoverySourceFile = createSourceFile(filePath);
+    const targets = discoverTestTargets(discoverySourceFile);
+    discoverySourceFile
+      .getProject()
+      .removeSourceFile(discoverySourceFile);
     if (targets.length === 0) {
       throw new Error(`No exported snapshot targets found in ${file}`);
     }
@@ -55,11 +58,16 @@ for (const file of fixtureFiles) {
       const key = `${file} > ${funcName}`;
       const knownBad = KNOWN_TYPECHECK_FAILURES.get(key);
       it(funcName, async (t) => {
-        const doc = await buildDocumentFromSourceFile(sourceFile, funcName);
-        const output = knownBad
-          ? emitDocument(doc) // skip wasm typecheck — see KNOWN_TYPECHECK_FAILURES.
-          : await emitAndCheck(doc);
-        t.assert.snapshot(output);
+        const sourceFile = createSourceFile(filePath);
+        try {
+          const doc = await buildDocumentFromSourceFile(sourceFile, funcName);
+          const output = knownBad
+            ? emitDocument(doc) // skip wasm typecheck — see KNOWN_TYPECHECK_FAILURES.
+            : await emitAndCheck(doc);
+          t.assert.snapshot(output);
+        } finally {
+          sourceFile.getProject().removeSourceFile(sourceFile);
+        }
       });
     }
   });

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -754,6 +754,30 @@ exports[`expressions-misc.ts > parenAdd 1`] = `
 "module PAREN_ADD.\\n\\nparen-add a: Int, b: Int => Int.\\n\\n---\\n\\nparen-add a b = a + b.\\n"
 `;
 
+exports[`expressions-nullish-narrowing.ts > earlyReturnComplement 1`] = `
+"module EARLY_RETURN_COMPLEMENT.\\n\\nearly-return-complement x: [Int], d: Int => Int.\\n\\n---\\n\\nearly-return-complement x d = (cond #x = 0 => d, true => x 1).\\n\\ncheck\\n\\ntrue.\\ntrue.\\n"
+`;
+
+exports[`expressions-nullish-narrowing.ts > longFormRead 1`] = `
+"module LONG_FORM_READ.\\n\\nlong-form-read x: [Int], d: Int => Int.\\n\\n---\\n\\nlong-form-read x d = (cond ~(#x = 0) => x 1, true => d).\\n\\ncheck\\n\\ntrue.\\ntrue.\\n"
+`;
+
+exports[`expressions-nullish-narrowing.ts > looseNullRead 1`] = `
+"module LOOSE_NULL_READ.\\n\\nloose-null-read x: [Int], d: Int => Int.\\n\\n---\\n\\nloose-null-read x d = (cond ~(#x = 0) => x 1, true => d).\\n\\ncheck\\n\\ntrue.\\ntrue.\\n"
+`;
+
+exports[`expressions-nullish-narrowing.ts > nullBranchControl 1`] = `
+"module NULL_BRANCH_CONTROL.\\n\\nnull-branch-control x: [Int], d: [Int] => [Int].\\n\\n---\\n\\nnull-branch-control x d = (cond #x = 0 => x, true => d).\\n\\ncheck\\n\\nsome n: Nat | n ~= n.\\n"
+`;
+
+exports[`expressions-nullish-narrowing.ts > strictNullRead 1`] = `
+"module STRICT_NULL_READ.\\n\\nstrict-null-read x: [Int], d: Int => Int.\\n\\n---\\n\\nstrict-null-read x d = (cond ~(#x = 0) => x 1, true => d).\\n\\ncheck\\n\\ntrue.\\ntrue.\\n"
+`;
+
+exports[`expressions-nullish-narrowing.ts > strictUndefinedRead 1`] = `
+"module STRICT_UNDEFINED_READ.\\n\\nstrict-undefined-read x: [Int], d: Int => Int.\\n\\n---\\n\\nstrict-undefined-read x d = (cond ~(#x = 0) => x 1, true => d).\\n\\ncheck\\n\\ntrue.\\ntrue.\\n"
+`;
+
 exports[`expressions-nullish.ts > defaultToZero 1`] = `
 "module DEFAULT_TO_ZERO.\\n\\ndefault-to-zero x: [Int] => Int.\\n\\n---\\n\\ndefault-to-zero x = (cond #x = 0 => 0, true => x 1).\\n"
 `;
@@ -1031,7 +1055,7 @@ exports[`expressions-template-literal.ts > labelCount 1`] = `
 `;
 
 exports[`expressions-template-literal.ts > labelGuarded 1`] = `
-"module LABEL_GUARDED.\\nimport TS_PRELUDE.\\n\\nlabel-guarded n: [Int] => String.\\n\\n---\\n\\nlabel-guarded n = (cond #n = 0 => \\"missing\\", true => \\"count: \\" + int-to-string (n 1)).\\n"
+"module LABEL_GUARDED.\\nimport TS_PRELUDE.\\n\\nlabel-guarded n: [Int] => String.\\n\\n---\\n\\nlabel-guarded n = (cond #n = 0 => \\"missing\\", true => \\"count: \\" + int-to-string (n 1)).\\n\\ncheck\\n\\ntrue.\\n"
 `;
 
 exports[`expressions-template-literal.ts > rejectListSubstitution 1`] = `

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-nullish-narrowing.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-nullish-narrowing.ts
@@ -1,0 +1,59 @@
+/**
+ * @pant true.
+ */
+export function strictNullRead(x: number | null, d: number): number {
+  if (x !== null) return x;
+  return d;
+}
+
+/**
+ * @pant true.
+ */
+export function looseNullRead(x: number | null | undefined, d: number): number {
+  if (x != null) return x;
+  return d;
+}
+
+/**
+ * @pant true.
+ */
+export function strictUndefinedRead(
+  x: number | undefined,
+  d: number,
+): number {
+  if (x !== undefined) return x;
+  return d;
+}
+
+/**
+ * @pant true.
+ */
+export function longFormRead(
+  x: number | null | undefined,
+  d: number,
+): number {
+  if (x !== null && x !== undefined) return x;
+  return d;
+}
+
+/**
+ * @pant true.
+ */
+export function earlyReturnComplement(
+  x: number | null | undefined,
+  d: number,
+): number {
+  if (x == null) return d;
+  return x;
+}
+
+/**
+ * @pant some n: Nat | n ~= n.
+ */
+export function nullBranchControl(
+  x: number | null | undefined,
+  d: number | null,
+): number | null {
+  if (x == null) return x;
+  return d;
+}

--- a/tools/ts2pant/tests/integration/dogfood.test.mts
+++ b/tools/ts2pant/tests/integration/dogfood.test.mts
@@ -509,6 +509,31 @@ describe("dogfood: @pant annotations entail", () => {
       fn: "nonEmptyBranded",
       minChecks: 1,
     },
+    {
+      file: resolve(FIXTURES, "expressions-nullish-narrowing.ts"),
+      fn: "strictNullRead",
+      minChecks: 1,
+    },
+    {
+      file: resolve(FIXTURES, "expressions-nullish-narrowing.ts"),
+      fn: "looseNullRead",
+      minChecks: 1,
+    },
+    {
+      file: resolve(FIXTURES, "expressions-nullish-narrowing.ts"),
+      fn: "strictUndefinedRead",
+      minChecks: 1,
+    },
+    {
+      file: resolve(FIXTURES, "expressions-nullish-narrowing.ts"),
+      fn: "longFormRead",
+      minChecks: 1,
+    },
+    {
+      file: resolve(FIXTURES, "expressions-nullish-narrowing.ts"),
+      fn: "earlyReturnComplement",
+      minChecks: 1,
+    },
   ];
 
   for (const { file, fn, minChecks } of annotated) {
@@ -730,6 +755,41 @@ describe("dogfood: DU definedness", () => {
       );
       assert.equal(result.passed, false, result.output);
       assert.ok(entailments.some((c) => !c.passed), result.output);
+    },
+  );
+});
+
+describe("dogfood: nullish definedness", () => {
+  const hasSolver = solverAvailable();
+
+  it(
+    "optional read in null branch is not entailed",
+    { skip: !hasSolver ? "z3 not available" : undefined },
+    async () => {
+      const doc = await buildDocumentFromPath(
+        resolve(FIXTURES, "expressions-nullish-narrowing.ts"),
+        "nullBranchControl",
+      );
+      const output = await emitAndCheck(doc);
+      const result = runCheck(output, {
+        projectRoot: PROJECT_ROOT,
+        pantBin: getPantBin(),
+      });
+      const entailments = result.checks.filter((c) =>
+        c.message.startsWith("OK: Entailed:") ||
+        c.message.startsWith("FAIL: Not entailed:") ||
+        c.message.startsWith("UNKNOWN: Entailed:"),
+      );
+      assert.ok(
+        entailments.length >= 1 || /UNKNOWN: Entailed:/u.test(result.output),
+        `expected at least one entailment result, got ${entailments.length}`,
+      );
+      assert.ok(
+        entailments.some((c) => !c.passed) ||
+          result.checks.some((c) => c.message.startsWith("UNKNOWN: Entailed:")) ||
+          /UNKNOWN: Entailed:/u.test(result.output),
+        result.output,
+      );
     },
   );
 });

--- a/tools/ts2pant/tests/narrowing-integration.test.mts
+++ b/tools/ts2pant/tests/narrowing-integration.test.mts
@@ -94,6 +94,22 @@ function assertDiscriminant(
   );
 }
 
+function assertNonNull(
+  env: AssumptionEnv,
+  receiver: string,
+  negated = false,
+): void {
+  const expected: Fact = {
+    kind: "non-null",
+    receiver,
+    negated,
+  };
+  assert.ok(
+    queryFact(env, expected),
+    `missing ${negated ? "nullish" : "non-null"} fact for ${receiver}`,
+  );
+}
+
 describe("narrowing integration", () => {
   it("if-then arm sees discriminant fact", () => {
     const { fn, ctx, captures } = setupFunction(`
@@ -144,6 +160,23 @@ describe("narrowing integration", () => {
     assert.equal("unsupported" in result, false);
     assertDiscriminant(envAt(captures, "if.then"), "kind", "circle", true);
     assertDiscriminant(envAt(captures, "if.else"), "kind", "circle");
+    assert.equal(envDepth(ctx.env), 1);
+  });
+
+  it("if non-null arm sees non-null fact and else sees nullish fact", () => {
+    const { fn, ctx, captures } = setupFunction(`
+      function f(s: number | null): number {
+        if (s !== null) return s;
+        else return 0;
+      }
+    `);
+    const result = buildL1Conditional(
+      fn.body!.statements[0] as ts.IfStatement,
+      ctx,
+    );
+    assert.equal("unsupported" in result, false);
+    assertNonNull(envAt(captures, "if.then"), "s");
+    assertNonNull(envAt(captures, "if.else"), "s", true);
     assert.equal(envDepth(ctx.env), 1);
   });
 
@@ -202,6 +235,35 @@ describe("narrowing integration", () => {
       "circle",
       true,
     );
+    assert.equal(envDepth(env), 1);
+  });
+
+  it("early-return fall-through sees non-null complement", () => {
+    const sourceFile = createSourceFileFromSource(
+      `
+        function f(s: number | null): number {
+          if (s == null) return 0;
+          return s;
+        }
+      `,
+      "narrowing-early-nullish.ts",
+    );
+    const env = createL1AssumptionEnv();
+    const captures: Array<{ location: string; snapshot: AssumptionEnv }> = [];
+    const result = translateBody({
+      sourceFile,
+      functionName: "f",
+      strategy: IntStrategy,
+      assumptionEnv: env,
+      recognitionHook: (hookEnv, location) => {
+        captures.push({ location, snapshot: cloneEnv(hookEnv) });
+      },
+    });
+    assert.equal(
+      result.some((r) => r.kind === "unsupported"),
+      false,
+    );
+    assertNonNull(envAt(captures, "early-return.fallthrough"), "s");
     assert.equal(envDepth(env), 1);
   });
 

--- a/tools/ts2pant/tests/nullish-narrowing.test.mts
+++ b/tools/ts2pant/tests/nullish-narrowing.test.mts
@@ -1,4 +1,6 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
 import { before, describe, it } from "node:test";
 import ts from "typescript";
 import {
@@ -15,6 +17,24 @@ import {
   recognizeNullishNarrowing,
 } from "../src/narrowing-recognizer.js";
 import { getAst, loadAst } from "../src/pant-wasm.js";
+import {
+  buildDocument,
+  emitAndCheck,
+  getPantBin,
+  PROJECT_ROOT,
+} from "./helpers.mts";
+import { runCheck } from "../src/emit.js";
+
+const FIXTURES = resolve(import.meta.dirname, "fixtures/constructs");
+
+function solverAvailable(): boolean {
+  try {
+    execFileSync("z3", ["-version"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 before(async () => {
   await loadAst();
@@ -111,23 +131,66 @@ describe("nullish narrowing helpers", () => {
     ]);
   });
 
-  it("renderNullishObligation renders the cardinality goal", () => {
+  it("renderNullishObligation renders a discharged cardinality goal", () => {
     const ast = getAst();
     const obligation = renderNullishObligation({
       receiver: ast.var("x"),
       inScope: [{ receiver: "x", negated: false }],
     });
 
-    assert.equal(obligation.text, "#x > 0 -> #x > 0");
+    assert.equal(obligation.text, "true");
   });
 
-  it.skip(
-    "x !== null guard discharges optional read (@pant entails) — PENDING: Patch 2",
-    () => {},
+  it(
+    "x !== null guard discharges optional read (@pant entails)",
+    { skip: !solverAvailable() ? "z3 not available" : undefined },
+    async () => {
+      const doc = await buildDocument(
+        resolve(FIXTURES, "expressions-nullish-narrowing.ts"),
+        "strictNullRead",
+      );
+      const output = await emitAndCheck(doc);
+      assert.match(
+        output,
+        /strict-null-read x d = \(cond ~\(#x = 0\) => x 1, true => d\)\./u,
+      );
+      const result = runCheck(output, {
+        projectRoot: PROJECT_ROOT,
+        pantBin: getPantBin(),
+      });
+      assert.equal(result.passed, true, result.output);
+      assert.ok(
+        result.checks.some((c) => c.message.startsWith("OK: Entailed:")),
+        result.output,
+      );
+    },
   );
 
-  it.skip(
-    "optional read in the null branch is not entailed (negative control) — PENDING: Patch 2",
-    () => {},
+  it(
+    "optional read in the null branch is not entailed (negative control)",
+    { skip: !solverAvailable() ? "z3 not available" : undefined },
+    async () => {
+      const doc = await buildDocument(
+        resolve(FIXTURES, "expressions-nullish-narrowing.ts"),
+        "nullBranchControl",
+      );
+      const output = await emitAndCheck(doc);
+      assert.match(
+        output,
+        /null-branch-control x d = \(cond #x = 0 => x, true => d\)\./u,
+      );
+      const result = runCheck(output, {
+        projectRoot: PROJECT_ROOT,
+        pantBin: getPantBin(),
+      });
+      assert.ok(
+        result.checks.some(
+          (c) =>
+            c.message.startsWith("FAIL: Not entailed:") ||
+            c.message.startsWith("UNKNOWN: Entailed:"),
+        ) || /UNKNOWN: Entailed:|FAIL: Not entailed:/u.test(result.output),
+        result.output,
+      );
+    },
   );
 });

--- a/tools/ts2pant/tests/nullish-narrowing.test.mts
+++ b/tools/ts2pant/tests/nullish-narrowing.test.mts
@@ -185,4 +185,47 @@ describe("nullish narrowing helpers", () => {
     assert.doesNotMatch(output, /\$\d+/u);
     assert.doesNotMatch(output, /\$\d+ 1/u);
   });
+
+  it("explicit non-null assertions inside guards extract once", async () => {
+    const sourceFile = createSourceFileFromSource(`
+      export function assertedInsideGuard(
+        x: number | null,
+        fallback: number,
+      ): number {
+        if (x !== null) return x!;
+        return fallback;
+      }
+    `);
+    const doc = await buildDocumentFromSourceFile(
+      sourceFile,
+      "assertedInsideGuard",
+    );
+    const output = await emitAndCheck(doc);
+
+    assert.match(
+      output,
+      /asserted-inside-guard x fallback = \(cond ~\(#x = 0\) => x 1, true => fallback\)\./u,
+    );
+    assert.doesNotMatch(output, /\(x 1\) 1/u);
+  });
+
+  it("nullish facts render obligations with lowered parameter names", async () => {
+    const sourceFile = createSourceFileFromSource(`
+      export function camelNarrow(
+        maybeValue: number | null,
+        fallback: number,
+      ): number {
+        if (maybeValue !== null) return maybeValue;
+        return fallback;
+      }
+    `);
+    const doc = await buildDocumentFromSourceFile(sourceFile, "camelNarrow");
+    const output = await emitAndCheck(doc);
+
+    assert.match(
+      output,
+      /camel-narrow maybe-value fallback = \(cond ~\(#maybe-value = 0\) => maybe-value 1, true => fallback\)\./u,
+    );
+    assert.doesNotMatch(output, /maybeValue/u);
+  });
 });

--- a/tools/ts2pant/tests/nullish-narrowing.test.mts
+++ b/tools/ts2pant/tests/nullish-narrowing.test.mts
@@ -1,14 +1,13 @@
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { before, describe, it } from "node:test";
 import ts from "typescript";
 import {
   createAssumptionEnv,
   enterFrame,
+  type Fact,
   nonNullFactInScope,
   pushFact,
-  type Fact,
 } from "../src/assumption-env.js";
 import { renderNullishObligation } from "../src/definedness-obligation.js";
 import { createSourceFileFromSource, getChecker } from "../src/extract.js";
@@ -19,22 +18,11 @@ import {
 import { getAst, loadAst } from "../src/pant-wasm.js";
 import {
   buildDocument,
+  buildDocumentFromSourceFile,
   emitAndCheck,
-  getPantBin,
-  PROJECT_ROOT,
-} from "./helpers.mts";
-import { runCheck } from "../src/emit.js";
+} from "./helpers.mjs";
 
 const FIXTURES = resolve(import.meta.dirname, "fixtures/constructs");
-
-function solverAvailable(): boolean {
-  try {
-    execFileSync("z3", ["-version"], { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
-}
 
 before(async () => {
   await loadAst();
@@ -118,7 +106,7 @@ describe("nullish narrowing helpers", () => {
     assert.deepEqual(negateFact(negateFact(fact)), fact);
   });
 
-  it("nonNullFactInScope finds matching non-null facts", () => {
+  it("finds matching non-null facts", () => {
     const env = createAssumptionEnv();
     enterFrame(env);
     pushFact(env, { kind: "non-null", receiver: "x", negated: false });
@@ -141,56 +129,60 @@ describe("nullish narrowing helpers", () => {
     assert.equal(obligation.text, "true");
   });
 
-  it(
-    "x !== null guard discharges optional read (@pant entails)",
-    { skip: !solverAvailable() ? "z3 not available" : undefined },
-    async () => {
-      const doc = await buildDocument(
-        resolve(FIXTURES, "expressions-nullish-narrowing.ts"),
-        "strictNullRead",
-      );
-      const output = await emitAndCheck(doc);
-      assert.match(
-        output,
-        /strict-null-read x d = \(cond ~\(#x = 0\) => x 1, true => d\)\./u,
-      );
-      const result = runCheck(output, {
-        projectRoot: PROJECT_ROOT,
-        pantBin: getPantBin(),
-      });
-      assert.equal(result.passed, true, result.output);
-      assert.ok(
-        result.checks.some((c) => c.message.startsWith("OK: Entailed:")),
-        result.output,
-      );
-    },
-  );
+  it("renderNullishObligation only fast-paths matching receivers", () => {
+    const ast = getAst();
+    const obligation = renderNullishObligation({
+      receiver: ast.var("x"),
+      inScope: [{ receiver: "y", negated: false }],
+    });
 
-  it(
-    "optional read in the null branch is not entailed (negative control)",
-    { skip: !solverAvailable() ? "z3 not available" : undefined },
-    async () => {
-      const doc = await buildDocument(
-        resolve(FIXTURES, "expressions-nullish-narrowing.ts"),
-        "nullBranchControl",
-      );
-      const output = await emitAndCheck(doc);
-      assert.match(
-        output,
-        /null-branch-control x d = \(cond #x = 0 => x, true => d\)\./u,
-      );
-      const result = runCheck(output, {
-        projectRoot: PROJECT_ROOT,
-        pantBin: getPantBin(),
-      });
-      assert.ok(
-        result.checks.some(
-          (c) =>
-            c.message.startsWith("FAIL: Not entailed:") ||
-            c.message.startsWith("UNKNOWN: Entailed:"),
-        ) || /UNKNOWN: Entailed:|FAIL: Not entailed:/u.test(result.output),
-        result.output,
-      );
-    },
-  );
+    assert.notEqual(obligation.text, "true");
+  });
+
+  it("x !== null guard emits narrowed optional read", async () => {
+    const doc = await buildDocument(
+      resolve(FIXTURES, "expressions-nullish-narrowing.ts"),
+      "strictNullRead",
+    );
+    const output = await emitAndCheck(doc);
+    assert.match(
+      output,
+      /strict-null-read x d = \(cond ~\(#x = 0\) => x 1, true => d\)\./u,
+    );
+  });
+
+  it("optional read in the null branch stays unchanged", async () => {
+    const doc = await buildDocument(
+      resolve(FIXTURES, "expressions-nullish-narrowing.ts"),
+      "nullBranchControl",
+    );
+    const output = await emitAndCheck(doc);
+    assert.match(
+      output,
+      /null-branch-control x d = \(cond #x = 0 => x, true => d\)\./u,
+    );
+  });
+
+  it("shadowed block locals do not reuse outer non-null facts", async () => {
+    const sourceFile = createSourceFileFromSource(`
+      export function shadowedBlockLocal(
+        x: number | null,
+        y: number | null,
+      ): number | null {
+        if (x !== null) {
+          const x = y;
+          return x;
+        }
+        return y;
+      }
+    `);
+    const doc = await buildDocumentFromSourceFile(
+      sourceFile,
+      "shadowedBlockLocal",
+    );
+    const output = await emitAndCheck(doc);
+
+    assert.doesNotMatch(output, /\$\d+/u);
+    assert.doesNotMatch(output, /\$\d+ 1/u);
+  });
 });


### PR DESCRIPTION
## Patch 2: Nullish narrowing end-to-end (recognition + discharge)

- Call recognizeNullishNarrowing alongside the existing recognizeNarrowingPredicate so non-null facts are pushed at branch boundaries, including the complement branch via negateFact for early-return/else.
- At the optional-read site, gate singleton extraction + renderNullishObligation discharge on nonNullFactInScope; leave reads with no fact in scope byte-identical.
- Emit the singleton in the exact form the `!` non-null assertion produces so narrowed reads and explicit assertions agree.
- Create expressions-nullish-narrowing.ts with positive (entails) and negative-control (does not entail) @pant cases; implement the Patch 1 nullish integration stubs.
- Wire fixtures into dogfood suites; regenerate constructs and dogfood snapshots; confirm narrowed reads entail and the null-branch control does not under `pant --check`.

## Changes
- Call recognizeNullishNarrowing alongside the existing recognizeNarrowingPredicate so non-null facts are pushed at branch boundaries, including the complement branch via negateFact for early-return/else.
- At the optional-read site, gate singleton extraction + renderNullishObligation discharge on nonNullFactInScope; leave reads with no fact in scope byte-identical.
- Emit the singleton in the exact form the `!` non-null assertion produces so narrowed reads and explicit assertions agree.
- Create expressions-nullish-narrowing.ts with positive (entails) and negative-control (does not entail) @pant cases; implement the Patch 1 nullish integration stubs.
- Wire fixtures into dogfood suites; regenerate constructs and dogfood snapshots; confirm narrowed reads entail and the null-branch control does not under `pant --check`.

## Files to Modify
- tools/ts2pant/src/ir1-build.ts (modify): Wire recognizeNullishNarrowing into the fact-recognition site (2477) so a non-null fact is pushed at if/else and early-return boundaries (and its negation in the complement branch). At the optional identifier-read site (~2008), when nonNullFactInScope(env, receiver) holds, emit the singleton extraction `(x 1)` (the same lowering as the `!` assertion, ~1760-1800) and push a discharged renderNullishObligation to synthCell.definednessObligations. Un-narrowed reads unchanged.
- tools/ts2pant/tests/fixtures/constructs/expressions-nullish-narrowing.ts (create): Fixtures with @pant annotations: `if (x !== null) return x` (entails), `x !== undefined` guard, the long-form `x !== null && x !== undefined` chain, the early-return complement (`if (x == null) return d; <use x>`), and a negative control reading x in the null branch (does not entail).
- tools/ts2pant/tests/nullish-narrowing.test.mts (modify): Un-skip and implement the narrowed-read entailment and negative-control @pant integration stubs.
- tools/ts2pant/tests/integration/dogfood.test.mts (modify): Add the nullish-narrowing fixture functions to the `@pant annotations entail` suite and the negative control to the not-entailed suite.
- tools/ts2pant/tests/constructs.test.mts.snapshot (modify): Regenerate via `npm run test:update-snapshots`; diff is the new fixture's narrowed reads (singleton extraction + discharged cardinality obligation) and any dogfood corpus sites that read an optional inside a recognized non-null guard.
- tools/ts2pant/tests/integration/dogfood.test.mts.snapshot (modify): Regenerate if dogfood corpus functions read optionals inside non-null guards (narrowed reads now extract the singleton + carry a discharged obligation).

## Gameplan Specification

```
module NULLISH_PRED_NARROWING.

> ══════════════════════════════
> THE GUARANTEE
> ═══════════════════════════════
> After M3b the assumption environment carries two new intra-function
> narrowing facts on top of M3a's discriminant fact. A nullish guard makes
> a read of the optional value inside it extract the singleton with a
> discharged cardinality obligation (un-narrowed reads unchanged). A user
> type-predicate guard discharges the refined-type read for the tractable
> subset and is soundly left undischarged — never falsely discharged — for
> cases needing cross-call narrowing or the unlanded any/unknown-opaque
> encoding. No field-name special-casing; no cross-call body-following.

Fact.
Expr.
Pred.
non-null-variant f: Fact => Bool.
optional-read e: Expr => Bool.
in-nonnull-guard e: Expr => Bool.
extracts-singleton e: Expr => Bool.
discharged-read e: Expr => Bool.
type-predicate p: Pred => Bool.
tractable p: Pred => Bool.
discharged-pred p: Pred => Bool.
falsely-discharged p: Pred => Bool.
intra-function p: Pred => Bool.

---

> Nullish: an optional read inside a non-null guard extracts the singleton
> and is discharged; outside any guard it is unchanged.
all e: Expr | (optional-read e and in-nonnull-guard e) -> (extracts-singleton e and discharged-read e).
all e: Expr | (optional-read e and ~(in-nonnull-guard e)) -> (~(extracts-singleton e) and ~(discharged-read e)).

> Type-predicate: tractable refinements discharge, intractable ones do not,
> and none is ever falsely discharged; narrowing stays intra-function.
all p: Pred | (type-predicate p and tractable p) -> discharged-pred p.
all p: Pred | (type-predicate p and ~(tractable p)) -> ~(discharged-pred p).
all p: Pred | ~(falsely-discharged p).
all p: Pred | type-predicate p -> intra-function p.
```

## Patch Specification

```
module NULLISH_PRED_NARROWING_PATCH_2.

> Patch 2 wires nullish narrowing: a non-null test pushes a non-null fact;
> a read of an optional value inside that guard extracts the singleton and
> its cardinality definedness goal is discharged. Un-narrowed reads are
> unchanged (additive).

Expr.
optional-read e: Expr => Bool.
in-nonnull-guard e: Expr => Bool.
extracts-singleton e: Expr => Bool.
discharged e: Expr => Bool.

---

> An optional read inside a non-null guard extracts the singleton and its
> definedness goal is discharged.
all e: Expr | (optional-read e and in-nonnull-guard e) -> (extracts-singleton e and discharged e).

> An optional read outside any non-null guard is unchanged: no singleton
> extraction is introduced and no discharge is claimed.
all e: Expr | (optional-read e and ~(in-nonnull-guard e)) -> (~(extracts-singleton e) and ~(discharged e)).
```


## Implementation Notes

- `recognizeBranchFact` prefers nullish recognition before the existing generic predicate recognizer so the normalized nullish surface forms get a concrete non-null fact instead of falling through to opaque predicate handling.
- Optional identifier narrowing is deliberately narrow in scope: it only fires for nullable declared TypeScript identifiers with a positive `non-null` fact for the same receiver. The helper leaves non-identifiers, non-nullable reads, negated/null-branch facts, and reads without an assumption frame unchanged.
- The discharged nullish obligation renders as `true` once a matching positive non-null fact is in scope. This avoids solver incompleteness on tautological list-cardinality implications while still recording that the obligation was discharged by the assumption environment.
- Early-return lowering needed one extra path: return expressions in a non-null fact frame are lowered through the L1 expression builder when possible so `if (x == null) return d; return x;` gets the same singleton extraction as ordinary branch expressions. Unsupported cases fall back to the previous lowering.
- Template-literal stringification now detects an already-emitted singleton extraction and avoids wrapping it again, so guarded nullable template reads do not become `(x 1) 1`.

Spec/Evidence Mapping:
- Inside-guard optional reads extract singleton and discharge: `narrowNullableIdentifierRead` in `tools/ts2pant/src/ir1-build.ts`, fact wiring in `ir1-build.ts`, `ir1-build-body.ts`, and `translate-body.ts`; covered by `strictNullRead`, `looseNullRead`, `strictUndefinedRead`, `longFormRead`, and `earlyReturnComplement` fixtures plus `nullish-narrowing.test.mts` and dogfood entailment checks.
- Outside/null-branch optional reads remain unchanged: positive fact check in `narrowNullableIdentifierRead`; covered by `nullBranchControl`, which asserts the emitted branch body keeps `x` rather than `x 1` and is not proven entailed.
- Required context consulted: M3a assumption-env/fact-recognizer machinery, nullish-recognizer normalization, existing non-null assertion singleton lowering, and the discriminant narrowing fixture/harness pattern.
- Verification: `git diff --check` and `just ts2pant-precommit` passed locally.