### PR TITLE
[ts2pant-opaque-opt-in] Patch 1: Generalize opaqueFallback to the policy parameter; thread it; add contagion helpers

### DIFF
--- a/tools/ts2pant/src/extract.ts
+++ b/tools/ts2pant/src/extract.ts
@@ -1098,7 +1098,7 @@ function translateReferencedCallable(
       strategy,
       synthCell,
       undefined,
-      { typeMapping: { opaqueFallback: true } },
+      { typeMapping: { policy: "opaque" } },
     );
     if (sig.declaration.kind !== "rule") {
       return null;
@@ -1121,7 +1121,7 @@ function translateReferencedCallable(
     const paramDecl = param.valueDeclaration ?? decl;
     const paramType = checker.getTypeOfSymbolAtLocation(param, paramDecl);
     const pantType = mapTsType(paramType, checker, strategy, synthCell, {
-      opaqueFallback: true,
+      policy: "opaque",
     });
     const pantName = synthCell
       ? cellRegisterName(synthCell, toPantTermName(param.name))
@@ -1129,7 +1129,7 @@ function translateReferencedCallable(
     return { name: pantName, type: pantType };
   });
   const pantReturnType = mapTsType(returnType, checker, strategy, synthCell, {
-    opaqueFallback: true,
+    policy: "opaque",
   });
   return {
     kind: "rule",

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -119,6 +119,7 @@ import {
   type ExtractedBlockReturn,
   extractBlockReturn,
 } from "./ts-ast-block-return.js";
+import type { OpaquePolicy } from "./opaque.js";
 
 /**
  * Context threaded through L1 build. Mirrors the parameter set of
@@ -131,6 +132,7 @@ export interface L1BuildContext {
   state: SymbolicState | undefined;
   supply: UniqueSupply;
   env: AssumptionEnv;
+  policy?: OpaquePolicy | undefined;
   recognitionHook?: (env: AssumptionEnv, location: string) => void;
 }
 
@@ -226,6 +228,7 @@ export function tryBuildBuiltinCall(
       ctx.checker,
       ctx.strategy,
       ctx.supply.synthCell,
+      { policy: ctx.policy },
     );
     if (sourceType === "[String * Int]") {
       rule = "JS_ARRAY::from-entries";
@@ -515,6 +518,7 @@ function resolveStageASetReadType(
     ctx.checker,
     ctx.strategy,
     ctx.supply.synthCell,
+    { policy: ctx.policy },
   );
   const setType = ctx.checker.getTypeAtLocation(unwrapped);
   const setTypeArgs = ctx.checker.getTypeArguments(setType as ts.TypeReference);
@@ -526,6 +530,7 @@ function resolveStageASetReadType(
     ctx.checker,
     ctx.strategy,
     ctx.supply.synthCell,
+    { policy: ctx.policy },
   );
   if (isUnsupportedUnknown(ownerType) || isUnsupportedUnknown(elemType)) {
     return null;
@@ -564,12 +569,14 @@ function resolveStageAMapReadType(
     ctx.checker,
     ctx.strategy,
     ctx.supply.synthCell,
+    { policy: ctx.policy },
   );
   const keyType = mapTsType(
     typeArgs[0]!,
     ctx.checker,
     ctx.strategy,
     ctx.supply.synthCell,
+    { policy: ctx.policy },
   );
   if (isUnsupportedUnknown(ownerType) || isUnsupportedUnknown(keyType)) {
     return null;
@@ -903,12 +910,14 @@ export function tryBuildL1PureSubExpression(
           ctx.checker,
           ctx.strategy,
           ctx.supply.synthCell,
+          { policy: ctx.policy },
         );
         const vType = mapTsType(
           typeArgs[1]!,
           ctx.checker,
           ctx.strategy,
           ctx.supply.synthCell,
+          { policy: ctx.policy },
         );
         // mapTsType returns the unsupported-unknown sentinel for
         // unresolvable TS types (e.g., raw `unknown`). Bail before
@@ -1043,6 +1052,7 @@ function buildL1Stringification(
     ctx.checker,
     ctx.strategy,
     ctx.supply.synthCell,
+    { policy: ctx.policy },
   );
   if (!STRINGIFIABLE_PRIMITIVES.has(pantType)) {
     return {

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -83,6 +83,7 @@ import {
   recognizeNullishForm,
   unwrapTransparentExpression,
 } from "./nullish-recognizer.js";
+import type { OpaquePolicy } from "./opaque.js";
 import type { OpaqueExpr } from "./pant-ast.js";
 import { isStaticallyBoolTyped } from "./purity.js";
 import type {
@@ -119,7 +120,6 @@ import {
   type ExtractedBlockReturn,
   extractBlockReturn,
 } from "./ts-ast-block-return.js";
-import type { OpaquePolicy } from "./opaque.js";
 
 /**
  * Context threaded through L1 build. Mirrors the parameter set of

--- a/tools/ts2pant/src/opaque.ts
+++ b/tools/ts2pant/src/opaque.ts
@@ -1,4 +1,10 @@
+import { type IR1Expr, type SourceRef, ir1Opaque } from "./ir1.js";
+
 export const OPAQUE_DOMAIN = "Opaque";
+
+export type OpaquePolicy = "reject" | "opaque";
+
+export const DEFAULT_OPAQUE_POLICY: OpaquePolicy = "reject";
 
 /**
  * Return the Pant-safe nullary rule name for one opaque value identity.
@@ -14,4 +20,15 @@ export function opaqueValueRuleName(id: string): string {
   return codeUnits.length === 0
     ? "opaque_value_0"
     : `opaque_value_${id.length}_${codeUnits.join("_")}`;
+}
+
+export function isOpaqueExpr(expr: IR1Expr): boolean {
+  return expr.kind === "opaque";
+}
+
+export function contagiousOpaque(
+  operands: readonly IR1Expr[],
+  origin: SourceRef,
+): IR1Expr | null {
+  return operands.some(isOpaqueExpr) ? ir1Opaque(OPAQUE_DOMAIN, origin) : null;
 }

--- a/tools/ts2pant/src/opaque.ts
+++ b/tools/ts2pant/src/opaque.ts
@@ -1,4 +1,4 @@
-import { type IR1Expr, type SourceRef, ir1Opaque } from "./ir1.js";
+import { type IR1Expr, ir1Opaque, type SourceRef } from "./ir1.js";
 
 export const OPAQUE_DOMAIN = "Opaque";
 

--- a/tools/ts2pant/src/pipeline.ts
+++ b/tools/ts2pant/src/pipeline.ts
@@ -8,6 +8,7 @@ import {
   extractReferencedTypes,
   getChecker,
 } from "./extract.js";
+import { DEFAULT_OPAQUE_POLICY, type OpaquePolicy } from "./opaque.js";
 import { loadAst, loadParser, rewriteAnnotation } from "./pant-wasm.js";
 import { translateBody } from "./translate-body.js";
 import { findFunction, translateSignature } from "./translate-signature.js";
@@ -29,6 +30,7 @@ export interface PipelineOptions {
   functionName: string;
   strategy: NumericStrategy;
   noBody?: boolean;
+  policy?: OpaquePolicy | undefined;
 }
 
 function mutatingReturnValueDeclarations(
@@ -38,6 +40,7 @@ function mutatingReturnValueDeclarations(
   strategy: NumericStrategy,
   synthCell: ReturnType<typeof newSynthCell>,
   sigDecl: PantDeclaration,
+  policy: OpaquePolicy,
 ): PantDeclaration[] {
   if (sigDecl.kind !== "action") {
     return [];
@@ -57,7 +60,9 @@ function mutatingReturnValueDeclarations(
   const baseName = toPantTermName(
     functionName.includes(".") ? functionName.split(".", 2)[1]! : functionName,
   );
-  const returnType = mapTsType(tsReturnType, checker, strategy, synthCell);
+  const returnType = mapTsType(tsReturnType, checker, strategy, synthCell, {
+    policy,
+  });
   if (isUnsupportedUnknown(returnType)) {
     return [
       {
@@ -113,7 +118,13 @@ function filterRuleCollisions(
 export async function buildPantDocument(
   opts: PipelineOptions,
 ): Promise<PantDocument> {
-  const { sourceFile, functionName, strategy, noBody } = opts;
+  const {
+    sourceFile,
+    functionName,
+    strategy,
+    noBody,
+    policy = DEFAULT_OPAQUE_POLICY,
+  } = opts;
 
   // Ensure wasm AST module is loaded before any translation
   await loadAst();
@@ -147,6 +158,7 @@ export async function buildPantDocument(
     strategy,
     synthCell,
     overrides,
+    { typeMapping: { policy } },
   );
   const returnValueDecls = mutatingReturnValueDeclarations(
     sourceFile,
@@ -155,6 +167,7 @@ export async function buildPantDocument(
     strategy,
     synthCell,
     sigDecl,
+    policy,
   );
   const returnValueRuleUnavailable = returnValueDecls.some(
     (decl) => decl.kind === "unsupported",
@@ -163,7 +176,9 @@ export async function buildPantDocument(
   // Extract and translate types (type-derived param names adapt to registry).
   // Pass the synthesizer so nested Maps inside interface-field V register too.
   const extracted = extractReferencedTypes(sourceFile, functionName);
-  const typeDecls = translateTypes(extracted, checker, strategy, synthCell);
+  const typeDecls = translateTypes(extracted, checker, strategy, synthCell, {
+    policy,
+  });
   // After both sig and types have registered their Maps, emit the synth
   // decls (one domain + membership predicate + guarded value rule per
   // unique (K, V)). Splice before sigDecl so the sig's references resolve.
@@ -277,6 +292,7 @@ export async function buildPantDocument(
       declarations,
       synthCell,
       paramNameMap,
+      policy,
     });
     doc = { ...doc, propositions: [...doc.propositions, ...bodyProps] };
 

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -25,7 +25,6 @@ import {
   ir1Var,
   ir1While,
 } from "./ir1.js";
-import type { OpaquePolicy } from "./opaque.js";
 import {
   buildL1Conditional,
   buildL1IncrementStep,
@@ -73,6 +72,7 @@ import {
   type NullishTranslate,
   recognizeNullishForm,
 } from "./nullish-recognizer.js";
+import type { OpaquePolicy } from "./opaque.js";
 import type {
   OpaqueCombiner,
   OpaqueExpr,

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -25,6 +25,7 @@ import {
   ir1Var,
   ir1While,
 } from "./ir1.js";
+import type { OpaquePolicy } from "./opaque.js";
 import {
   buildL1Conditional,
   buildL1IncrementStep,
@@ -1082,6 +1083,7 @@ export interface TranslateBodyOptions {
   paramNameMap?: ReadonlyMap<string, string> | undefined;
   assumptionEnv?: AssumptionEnv | undefined;
   recognitionHook?: (env: AssumptionEnv, location: string) => void;
+  policy?: OpaquePolicy | undefined;
 }
 
 /**
@@ -1101,6 +1103,7 @@ export function translateBody(opts: TranslateBodyOptions): PropResult[] {
     paramNameMap,
     assumptionEnv,
     recognitionHook,
+    policy,
   } = opts;
   const checker = sourceFile.getProject().getTypeChecker().compilerObject;
   const program = sourceFile.getProject().getProgram().compilerObject;
@@ -1154,7 +1157,9 @@ export function translateBody(opts: TranslateBodyOptions): PropResult[] {
       // Pass the synthesizer so Map parameters resolve to their synthesized
       // domain names (idempotent; the signature pass already registered
       // them, so this is a lookup rather than a fresh registration).
-      const typeName = mapTsType(paramType, checker, strategy, synthCell);
+      const typeName = mapTsType(paramType, checker, strategy, synthCell, {
+        policy,
+      });
       // Body-level Forall quantifiers carry param Pant types in their
       // binding heads (`all x: <typeName> | ...`); letting the unknown
       // sentinel reach `paramList` would emit it inside emitted
@@ -1212,6 +1217,7 @@ export function translateBody(opts: TranslateBodyOptions): PropResult[] {
       program,
       assumptionEnv,
       recognitionHook,
+      policy,
     );
   } else {
     return translateMutatingBody(
@@ -1225,6 +1231,7 @@ export function translateBody(opts: TranslateBodyOptions): PropResult[] {
       program,
       assumptionEnv,
       recognitionHook,
+      policy,
     );
   }
 }
@@ -1240,6 +1247,7 @@ function translatePureBody(
   program?: ts.Program,
   suppliedEnv?: AssumptionEnv,
   recognitionHook?: (env: AssumptionEnv, location: string) => void,
+  policy?: OpaquePolicy,
 ): PropResult[] {
   const ast = getAst();
 
@@ -1407,6 +1415,7 @@ function translatePureBody(
       state: undefined as SymbolicState | undefined,
       supply,
       env,
+      policy,
       ...(recognitionHook === undefined ? {} : { recognitionHook }),
     };
     let bodyOpaque: OpaqueExpr;
@@ -3297,6 +3306,7 @@ export function translateBodyExpr(
   state: SymbolicState | undefined,
   supply: UniqueSupply,
   env: AssumptionEnv = createL1AssumptionEnv(),
+  policy?: OpaquePolicy,
 ): BodyResult {
   const ast = getAst();
 
@@ -3387,6 +3397,7 @@ export function translateBodyExpr(
       state,
       supply,
       env,
+      policy,
     };
     const translate: NullishTranslate = (sub) => {
       const subL1 = tryBuildL1PureSubExpression(sub, l1Ctx);
@@ -3417,7 +3428,7 @@ export function translateBodyExpr(
   ) {
     const l1 = buildL1Conditional(
       expr as ts.Expression | ts.IfStatement | ts.SwitchStatement,
-      { checker, strategy, paramNames, state, supply, env },
+      { checker, strategy, paramNames, state, supply, env, policy },
     );
     if (isL1Unsupported(l1)) {
       return { unsupported: l1.unsupported };
@@ -3490,6 +3501,7 @@ export function translateBodyExpr(
       state,
       supply,
       env,
+      policy,
     };
     const card = tryBuildL1Cardinality(expr, l1Ctx);
     if (card !== null) {
@@ -3522,6 +3534,7 @@ export function translateBodyExpr(
       state,
       supply,
       env,
+      policy,
     };
     const member = buildL1MemberAccess(expr, l1Ctx);
     if ("unsupported" in member) {
@@ -4893,6 +4906,7 @@ function translateMutatingBody(
   program?: ts.Program,
   suppliedEnv?: AssumptionEnv,
   recognitionHook?: (env: AssumptionEnv, location: string) => void,
+  policy?: OpaquePolicy,
 ): PropResult[] {
   if (!node.body) {
     return [];
@@ -4912,6 +4926,7 @@ function translateMutatingBody(
       declarations,
       localRuleDecls,
       env,
+      policy,
       ...(recognitionHook === undefined ? {} : { recognitionHook }),
     }),
     declarations,
@@ -4935,6 +4950,7 @@ function lowerSupportedSsaMutatingStatements(
     declarations: readonly PantDeclaration[];
     localRuleDecls: PropResult[];
     env: AssumptionEnv;
+    policy?: OpaquePolicy | undefined;
     recognitionHook?: (env: AssumptionEnv, location: string) => void;
   },
 ): IR1SsaBodyLowerResult {
@@ -4955,6 +4971,7 @@ function lowerSupportedSsaMutatingStatements(
       ctx.state,
       ctx.supply,
       ctx.env,
+      ctx.policy,
     );
     if (isBodyUnsupported(returnExpr)) {
       return ir1SsaBodyLowerUnsupported(returnExpr.unsupported);

--- a/tools/ts2pant/src/translate-types.ts
+++ b/tools/ts2pant/src/translate-types.ts
@@ -8,8 +8,8 @@ import {
 } from "./name-registry.js";
 import {
   OPAQUE_DOMAIN,
-  opaqueValueRuleName,
   type OpaquePolicy,
+  opaqueValueRuleName,
 } from "./opaque.js";
 import type { OpaqueExpr } from "./pant-ast.js";
 import { getAst } from "./pant-wasm.js";

--- a/tools/ts2pant/src/translate-types.ts
+++ b/tools/ts2pant/src/translate-types.ts
@@ -6,7 +6,11 @@ import {
   type NameRegistry,
   registerName,
 } from "./name-registry.js";
-import { OPAQUE_DOMAIN, opaqueValueRuleName } from "./opaque.js";
+import {
+  OPAQUE_DOMAIN,
+  opaqueValueRuleName,
+  type OpaquePolicy,
+} from "./opaque.js";
 import type { OpaqueExpr } from "./pant-ast.js";
 import { getAst } from "./pant-wasm.js";
 import type { PantDeclaration, PropResult } from "./types.js";
@@ -1794,7 +1798,7 @@ export const IntStrategy: NumericStrategy = {
 };
 
 export interface MapTsTypeOptions {
-  readonly opaqueFallback?: boolean;
+  readonly policy?: OpaquePolicy | undefined;
 }
 
 export const RealStrategy: NumericStrategy = {
@@ -1829,7 +1833,7 @@ export function mapTsType(
   // move is to refuse and steer the user toward a declared type. Mapping
   // to a generic placeholder would silently let type errors through.
   if (flags & ts.TypeFlags.Any || flags & ts.TypeFlags.Unknown) {
-    if (opts?.opaqueFallback) {
+    if (opts?.policy === "opaque") {
       if (!synthCell) {
         return UNSUPPORTED_UNKNOWN;
       }
@@ -2157,6 +2161,7 @@ export function translateTypes(
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
   synthCell?: SynthCell,
+  opts?: MapTsTypeOptions,
 ): PantDeclaration[] {
   const decls: PantDeclaration[] = [];
 
@@ -2184,8 +2189,20 @@ export function translateTypes(
           // nested Map inside V (e.g., `inner: Map<K, Map<K', V'>>`)
           // registers its own synthesized domain and the Stage A rule's V
           // references it.
-          const kType = mapTsType(typeArgs[0]!, checker, strategy, synthCell);
-          const vType = mapTsType(typeArgs[1]!, checker, strategy, synthCell);
+          const kType = mapTsType(
+            typeArgs[0]!,
+            checker,
+            strategy,
+            synthCell,
+            opts,
+          );
+          const vType = mapTsType(
+            typeArgs[1]!,
+            checker,
+            strategy,
+            synthCell,
+            opts,
+          );
           if (
             isUnsupportedMappedType(kType) ||
             isUnsupportedMappedType(vType)
@@ -2226,7 +2243,13 @@ export function translateTypes(
           continue;
         }
       }
-      const fieldType = mapTsType(prop.type, checker, strategy, synthCell);
+      const fieldType = mapTsType(
+        prop.type,
+        checker,
+        strategy,
+        synthCell,
+        opts,
+      );
       if (isUnsupportedMappedType(fieldType)) {
         decls.push({
           kind: "unsupported",
@@ -2246,7 +2269,7 @@ export function translateTypes(
   }
 
   for (const alias of extracted.aliases) {
-    const aliasType = mapTsType(alias.type, checker, strategy, synthCell);
+    const aliasType = mapTsType(alias.type, checker, strategy, synthCell, opts);
     if (isUnsupportedMappedType(aliasType)) {
       decls.push({
         kind: "unsupported",

--- a/tools/ts2pant/tests/helpers.mts
+++ b/tools/ts2pant/tests/helpers.mts
@@ -9,6 +9,7 @@ import {
 import { createSourceFile, type SourceFile } from "../src/extract.js";
 import { assertWasmTypeChecks } from "../src/pant-wasm.js";
 import { buildPantDocument } from "../src/pipeline.js";
+import type { OpaquePolicy } from "../src/opaque.js";
 import { IntStrategy } from "../src/translate-types.js";
 import type { PantDocument } from "../src/types.js";
 
@@ -73,7 +74,7 @@ export function assertPantTypeChecks(output: string, timeoutMs = 30_000): void {
 export async function buildDocument(
   fileName: string,
   functionName: string,
-  opts: { noBody?: boolean } = {},
+  opts: { noBody?: boolean; policy?: OpaquePolicy } = {},
 ): Promise<PantDocument> {
   return buildDocumentFromSourceFile(
     createSourceFile(fileName),
@@ -85,13 +86,14 @@ export async function buildDocument(
 export async function buildDocumentFromSourceFile(
   sourceFile: SourceFile,
   functionName: string,
-  opts: { noBody?: boolean } = {},
+  opts: { noBody?: boolean; policy?: OpaquePolicy } = {},
 ): Promise<PantDocument> {
   return buildPantDocument({
     sourceFile,
     functionName,
     strategy: IntStrategy,
     noBody: opts.noBody,
+    policy: opts.policy,
   });
 }
 

--- a/tools/ts2pant/tests/opaque-opt-in.test.mts
+++ b/tools/ts2pant/tests/opaque-opt-in.test.mts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { ir1Binop, ir1LitNat, ir1Opaque, ir1Var } from "../src/ir1.js";
+import { OPAQUE_DOMAIN, contagiousOpaque, isOpaqueExpr } from "../src/opaque.js";
+
+describe("opaque opt-in policy", () => {
+  const origin = { file: "tests/opaque-opt-in.ts", line: 1 };
+
+  it("isOpaqueExpr identifies the OpaqueValue L1 form", () => {
+    assert.equal(isOpaqueExpr(ir1Opaque(OPAQUE_DOMAIN, origin)), true);
+    assert.equal(isOpaqueExpr(ir1Var("x")), false);
+    assert.equal(isOpaqueExpr(ir1LitNat(1)), false);
+  });
+
+  it("contagiousOpaque returns an opaque result iff an operand is opaque", () => {
+    const concrete = ir1Binop("add", ir1LitNat(1), ir1LitNat(2));
+    const opaque = ir1Opaque(OPAQUE_DOMAIN, origin);
+    const resultOrigin = { file: "tests/opaque-opt-in.ts", line: 2 };
+
+    assert.equal(contagiousOpaque([ir1LitNat(1), concrete], resultOrigin), null);
+    assert.deepEqual(contagiousOpaque([ir1LitNat(1), opaque], resultOrigin), {
+      kind: "opaque",
+      sort: OPAQUE_DOMAIN,
+      origin: resultOrigin,
+    });
+  });
+
+  it.skip("signature composite opacity is precision-preserving under policy opaque (@pant checks; PENDING: Patch 2)", () => {
+    // @pant all x: [Int * Opaque] | true.
+  });
+
+  it.skip("body operation with an opaque operand propagates opacity (contagion; PENDING: Patch 3)", () => {
+    // @pant all x: Opaque | true.
+  });
+});

--- a/tools/ts2pant/tests/translate-types.test.mts
+++ b/tools/ts2pant/tests/translate-types.test.mts
@@ -399,7 +399,7 @@ describe("emitDiscriminatedUnionSynthDecls", () => {
 });
 
 describe("mapTsType", () => {
-  it("opaque fallback maps `any` to the shared Opaque sort", async () => {
+  it("opaque policy maps `any` to the shared Opaque sort", async () => {
     await loadAst();
     const cell = newSynthCell();
     const source = `interface Foo { val: any; }`;
@@ -409,7 +409,7 @@ describe("mapTsType", () => {
 
     assert.equal(
       mapTsType(prop.type, checker, IntStrategy, cell, {
-        opaqueFallback: true,
+        policy: "opaque",
       }),
       OPAQUE_DOMAIN,
     );
@@ -419,7 +419,7 @@ describe("mapTsType", () => {
     assert.deepEqual(emitSynthDeclsOnly(cell), []);
   });
 
-  it("opaque fallback maps `unknown` to the shared Opaque sort", async () => {
+  it("opaque policy maps `unknown` to the shared Opaque sort", async () => {
     await loadAst();
     const cell = newSynthCell();
     const source = `interface Foo { val: unknown; }`;
@@ -429,7 +429,7 @@ describe("mapTsType", () => {
 
     assert.equal(
       mapTsType(prop.type, checker, IntStrategy, cell, {
-        opaqueFallback: true,
+        policy: "opaque",
       }),
       OPAQUE_DOMAIN,
     );
@@ -438,7 +438,7 @@ describe("mapTsType", () => {
     ]);
   });
 
-  it("opaque fallback leaves concrete types unchanged", async () => {
+  it("opaque policy leaves concrete types unchanged", async () => {
     await loadAst();
     const cell = newSynthCell();
     const source = `interface Foo { val: number; }`;
@@ -448,14 +448,14 @@ describe("mapTsType", () => {
 
     assert.equal(
       mapTsType(prop.type, checker, IntStrategy, cell, {
-        opaqueFallback: true,
+        policy: "opaque",
       }),
       "Int",
     );
     assert.deepEqual(emitSynthDeclsOnly(cell), []);
   });
 
-  it("opaque fallback disabled keeps `any` and `unknown` unsupported", () => {
+  it("reject policy keeps `any` and `unknown` unsupported", () => {
     const source = `interface Foo { anyVal: any; unknownVal: unknown; }`;
     const sourceFile = createSourceFileFromSource(source);
     const checker = getChecker(sourceFile);
@@ -472,7 +472,7 @@ describe("mapTsType", () => {
     );
   });
 
-  it("opaque fallback without a synth cell keeps `any` unsupported", () => {
+  it("opaque policy without a synth cell keeps `any` unsupported", () => {
     const source = `interface Foo { val: any; }`;
     const sourceFile = createSourceFileFromSource(source);
     const checker = getChecker(sourceFile);
@@ -480,13 +480,13 @@ describe("mapTsType", () => {
 
     assert.equal(
       mapTsType(prop.type, checker, IntStrategy, undefined, {
-        opaqueFallback: true,
+        policy: "opaque",
       }),
       UNSUPPORTED_UNKNOWN,
     );
   });
 
-  it("opaque fallback domain emission dedupes with opaque value emission", async () => {
+  it("opaque policy domain emission dedupes with opaque value emission", async () => {
     await loadAst();
     const cell = newSynthCell();
     const source = `interface Foo { val: any; }`;
@@ -496,7 +496,7 @@ describe("mapTsType", () => {
 
     assert.equal(
       mapTsType(prop.type, checker, IntStrategy, cell, {
-        opaqueFallback: true,
+        policy: "opaque",
       }),
       OPAQUE_DOMAIN,
     );
@@ -523,7 +523,7 @@ describe("mapTsType", () => {
     ]);
   });
 
-  it("opaque fallback propagates through nested composite positions", async () => {
+  it("opaque policy propagates through nested composite positions", async () => {
     await loadAst();
     const cell = newSynthCell();
     const source = `interface Foo { val: Map<string, any[]>; }`;
@@ -533,7 +533,7 @@ describe("mapTsType", () => {
 
     assert.equal(
       mapTsType(prop.type, checker, IntStrategy, cell, {
-        opaqueFallback: true,
+        policy: "opaque",
       }),
       "StringToListOpaqueMap",
     );


### PR DESCRIPTION
## Patch 1: Generalize opaqueFallback to the policy parameter; thread it; add contagion helpers

- Rename MapTsTypeOptions.opaqueFallback to policy: "reject" | "opaque"; update the any/unknown branch and every internal reference; default behavior is reject.
- Update the extract.ts free-call-synthesis call site to policy:"opaque" so its behavior is preserved.
- Add policy to PipelineOptions and thread it (default reject) through buildPantDocument -> translateSignature.typeMapping and into L1BuildContext.
- Add isOpaqueExpr and contagiousOpaque pure helpers in opaque.ts; do not wire them into the body builders yet.
- Create opaque-opt-in.test.mts: implement the helper unit tests; add skipped @pant integration stubs annotated with their implementing patch.
- Confirm `npm run -s test:unit` and `npm run -s test:integration` produce no snapshot diffs (rename is behavior-preserving; new helpers unused; stubs skipped) and free-call-synthesis.test.mts stays green.

## Changes
- Rename MapTsTypeOptions.opaqueFallback to policy: "reject" | "opaque"; update the any/unknown branch and every internal reference; default behavior is reject.
- Update the extract.ts free-call-synthesis call site to policy:"opaque" so its behavior is preserved.
- Add policy to PipelineOptions and thread it (default reject) through buildPantDocument -> translateSignature.typeMapping and into L1BuildContext.
- Add isOpaqueExpr and contagiousOpaque pure helpers in opaque.ts; do not wire them into the body builders yet.
- Create opaque-opt-in.test.mts: implement the helper unit tests; add skipped @pant integration stubs annotated with their implementing patch.
- Confirm `npm run -s test:unit` and `npm run -s test:integration` produce no snapshot diffs (rename is behavior-preserving; new helpers unused; stubs skipped) and free-call-synthesis.test.mts stays green.

## Files to Modify
- tools/ts2pant/src/translate-types.ts (modify): Replace MapTsTypeOptions.opaqueFallback?: boolean with policy?: "reject" | "opaque"; update the any/unknown branch to gate on policy === "opaque" (same Opaque-domain registration + OPAQUE_DOMAIN return). Behavior is preserved: callers that passed opaqueFallback:true now pass policy:"opaque"; absent policy defaults to reject.
- tools/ts2pant/src/extract.ts (modify): Update the free-call-synthesis call site (1101) from `{ typeMapping: { opaqueFallback: true } }` to `{ typeMapping: { policy: "opaque" } }`, preserving the existing any->Opaque rule-synthesis behavior.
- tools/ts2pant/src/pipeline.ts (modify): Add `policy?: "reject" | "opaque"` to PipelineOptions (default "reject") and thread it through buildPantDocument into translateSignature's typeMapping and into the L1BuildContext, so a single run-wide switch reaches all mapTsType callers and the body builders. Defaulting to reject keeps output byte-identical.
- tools/ts2pant/src/translate-signature.ts (modify): Ensure TranslateSignatureOptions.typeMapping.policy is forwarded to every mapTsType call in the signature path (return type, params, defaults), defaulting to reject.
- tools/ts2pant/src/opaque.ts (modify): Add pure helpers isOpaqueExpr(expr) and contagiousOpaque(operands, origin) (returns an ir1Opaque result when any operand is opaque, else null). Not yet called from the body builders.
- tools/ts2pant/tests/opaque-opt-in.test.mts (create): Unit tests (implemented) for isOpaqueExpr and contagiousOpaque. Plus skipped @pant integration stubs for the signature-composite-opacity test (PENDING: Patch 2) and the body-contagion test (PENDING: Patch 3).

## Gameplan Specification

```
module OPAQUE_OPT_IN.

> ══════════════════════════════
> THE GUARANTEE
> ═══════════════════════════════
> After M2, mapTsType takes a `policy: "reject" | "opaque"` (default reject,
> threaded run-wide). Under reject, behavior is exactly as before. Under
> opaque, any/unknown positions lower to the Opaque sort precision-
> preservingly in both signatures (composites keep concrete siblings: Int *
> Opaque, [Opaque], K->Opaque maps, [Opaque] for unknown|null) and bodies
> (a reference to a dynamic value emits an OpaqueValue), and any operation
> with an opaque operand yields an opaque result (contagion). Contagion is
> sound — an Opaque is never treated as a concrete value — and use-site
> precision recovery is deferred to M4. The opt-in is exercised by a
> dedicated opaque fixture suite; the existing corpus stays on reject and is
> byte-identical.

Policy.
Pos.
Expr.
reject => Policy.
opaque => Policy.
default-policy => Policy.
is-dynamic p: Pos => Bool.
opaque-policy-pos p: Pos => Bool.
lowers-to-opaque p: Pos => Bool.
rejected p: Pos => Bool.
concrete-siblings-preserved p: Pos => Bool.
opaque-policy-expr e: Expr => Bool.
has-opaque-operand e: Expr => Bool.
is-opaque-result e: Expr => Bool.
treats-opaque-as-concrete e: Expr => Bool.

---

> Default policy is reject; reject preserves today's behavior.
default-policy = reject.

> Signatures: a dynamic position lowers to Opaque under opaque, is rejected
> under reject, and opacity is precision-preserving.
all p: Pos | (is-dynamic p and opaque-policy-pos p) -> (lowers-to-opaque p and ~(rejected p) and concrete-siblings-preserved p).
all p: Pos | (is-dynamic p and ~(opaque-policy-pos p)) -> rejected p.

> Bodies: an operation with an opaque operand is opaque, and contagion is
> sound.
all e: Expr | (opaque-policy-expr e and has-opaque-operand e) -> is-opaque-result e.
all e: Expr | ~(treats-opaque-as-concrete e).
```

## Patch Specification

```
module OPAQUE_OPT_IN_PATCH_1.

> Patch 1 generalizes the opaqueFallback boolean to a policy parameter
> (default reject), threads it run-wide, and adds pure contagion helpers.
> Behavior-preserving: default reject reproduces today's output and the
> free-call path keeps its opaque behavior under the new spelling.

Policy.
reject => Policy.
opaque => Policy.
default-policy => Policy.
byte-identical-under p: Policy => Bool.

---

> The default policy is reject, and translation under reject is unchanged.
default-policy = reject.
all p: Policy | p = reject -> byte-identical-under p.
```


## Implementation Notes

- I centralized the policy vocabulary in `opaque.ts` (`OpaquePolicy`, `DEFAULT_OPAQUE_POLICY`) so `pipeline`, `mapTsType`, and body/L1 contexts use one shared type instead of repeating the string union.
- I threaded `policy` through `translateTypes` as well as `translateSignature`; this is slightly broader than the minimum wording in the patch body, but it matches the run-wide switch intent and keeps interface fields/type aliases aligned with signatures under future opaque fixtures.
- Body lowering only receives the policy today; it does not emit `OpaqueValue` or call `contagiousOpaque`. Existing body behavior under the default/reject path is unchanged.
- `exactOptionalPropertyTypes` required optional policy fields/options to explicitly allow `undefined` where we pass through destructured options.

Spec/Evidence Mapping:
- `default-policy = reject`: `DEFAULT_OPAQUE_POLICY` in `opaque.ts`, used by `buildPantDocument`; absent `MapTsTypeOptions.policy` still falls through to the existing unsupported-unknown path in `translate-types.ts`.
- Free-call opaque behavior preserved: `extract.ts` now passes `{ policy: "opaque" }` at the previous opaque fallback call sites; covered by the existing unit suite including `free-call-synthesis.test.mts`.
- Run-wide threading: `pipeline.ts` passes policy into signature/type/body translation, and `ir1-build.ts` carries it on `L1BuildContext` for mapTsType calls used by L1 helpers.
- Helper-only contagion surface: `opaque.ts` adds `isOpaqueExpr` and `contagiousOpaque`; `opaque-opt-in.test.mts` verifies both, with Patch 2/Patch 3 integration stubs skipped.
- Verification run: `npx tsc --noEmit`, `npm run -s test:unit`, and `npm run -s test:integration` all pass with no snapshot updates.