### PR TITLE
[ts2pant-opaque-opt-in] Patch 2: Signature-level composite opacity under policy opaque (precision-preserving)

### DIFF
--- a/tools/ts2pant/src/translate-signature.ts
+++ b/tools/ts2pant/src/translate-signature.ts
@@ -27,6 +27,7 @@ import {
   isUnsupportedUnknown,
   type MapTsTypeOptions,
   mapTsType,
+  mapTsTypeFromTypeNode,
   type NumericStrategy,
   type SynthCell,
   toPantTermName,
@@ -1468,13 +1469,24 @@ export function translateSignature(
 
   for (const param of sig.getParameters()) {
     const symbolType = checker.getTypeOfSymbol(param);
-    const defaultType = mapTsType(
-      symbolType,
-      checker,
-      strategy,
-      synthCell,
-      opts?.typeMapping,
-    );
+    const paramDecl = param.valueDeclaration;
+    const defaultType =
+      paramDecl && ts.isParameter(paramDecl) && paramDecl.type
+        ? mapTsTypeFromTypeNode(
+            paramDecl.type,
+            symbolType,
+            checker,
+            strategy,
+            synthCell,
+            opts?.typeMapping,
+          )
+        : mapTsType(
+            symbolType,
+            checker,
+            strategy,
+            synthCell,
+            opts?.typeMapping,
+          );
     const paramType = overrides?.get(param.name) ?? defaultType;
     if (isUnsupportedUnknown(paramType)) {
       // Don't let the sentinel reach the emitted rule head — route
@@ -1512,16 +1524,27 @@ export function translateSignature(
     // bare `m.get(k)` return, narrow `V | undefined` to `V` so the
     // signature matches the unboxed Pant emission. See
     // `bodyIsBareMapGet` for the rationale.
-    const tsReturnType = bodyIsBareMapGet(node, checker)
+    const bareMapGetReturn = bodyIsBareMapGet(node, checker);
+    const tsReturnType = bareMapGetReturn
       ? checker.getNonNullableType(sig.getReturnType())
       : sig.getReturnType();
-    const returnType = mapTsType(
-      tsReturnType,
-      checker,
-      strategy,
-      synthCell,
-      opts?.typeMapping,
-    );
+    const returnType =
+      !bareMapGetReturn && node.type
+        ? mapTsTypeFromTypeNode(
+            node.type,
+            tsReturnType,
+            checker,
+            strategy,
+            synthCell,
+            opts?.typeMapping,
+          )
+        : mapTsType(
+            tsReturnType,
+            checker,
+            strategy,
+            synthCell,
+            opts?.typeMapping,
+          );
     if (isUnsupportedUnknown(returnType)) {
       return {
         declaration: {

--- a/tools/ts2pant/src/translate-types.ts
+++ b/tools/ts2pant/src/translate-types.ts
@@ -1834,10 +1834,9 @@ export function mapTsType(
   // to a generic placeholder would silently let type errors through.
   if (flags & ts.TypeFlags.Any || flags & ts.TypeFlags.Unknown) {
     if (opts?.policy === "opaque") {
-      if (!synthCell) {
-        return UNSUPPORTED_UNKNOWN;
+      if (synthCell) {
+        cellRegisterOpaqueDomain(synthCell);
       }
-      cellRegisterOpaqueDomain(synthCell);
       return OPAQUE_DOMAIN;
     }
     return UNSUPPORTED_UNKNOWN;
@@ -2009,6 +2008,93 @@ export function mapTsType(
   }
 
   return checker.typeToString(type);
+}
+
+function isDynamicTypeNode(node: ts.TypeNode): boolean {
+  return (
+    node.kind === ts.SyntaxKind.AnyKeyword ||
+    node.kind === ts.SyntaxKind.UnknownKeyword
+  );
+}
+
+function isNullishTypeNode(node: ts.TypeNode): boolean {
+  return (
+    node.kind === ts.SyntaxKind.UndefinedKeyword ||
+    node.kind === ts.SyntaxKind.VoidKeyword ||
+    (ts.isLiteralTypeNode(node) &&
+      node.literal.kind === ts.SyntaxKind.NullKeyword)
+  );
+}
+
+function mapDynamicTypeNode(
+  synthCell: SynthCell | undefined,
+  opts: MapTsTypeOptions | undefined,
+): string {
+  if (opts?.policy === "opaque") {
+    if (synthCell) {
+      cellRegisterOpaqueDomain(synthCell);
+    }
+    return OPAQUE_DOMAIN;
+  }
+  return UNSUPPORTED_UNKNOWN;
+}
+
+function mapTsTypeNodePart(
+  node: ts.TypeNode,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  synthCell?: SynthCell,
+  opts?: MapTsTypeOptions,
+): string {
+  if (isDynamicTypeNode(node)) {
+    return mapDynamicTypeNode(synthCell, opts);
+  }
+  return mapTsType(
+    checker.getTypeFromTypeNode(node),
+    checker,
+    strategy,
+    synthCell,
+    opts,
+  );
+}
+
+/**
+ * Map an explicitly declared TS type node when the syntactic union shape
+ * carries precision the checker erases. In particular, TypeScript reduces
+ * `unknown | null` and `number | unknown` to plain `unknown`; opaque policy
+ * needs to preserve the declared composite positions as `[Opaque]` and
+ * `Int + Opaque` rather than collapsing them to `Opaque`.
+ */
+export function mapTsTypeFromTypeNode(
+  node: ts.TypeNode,
+  fallbackType: ts.Type,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  synthCell?: SynthCell,
+  opts?: MapTsTypeOptions,
+): string {
+  if (!ts.isUnionTypeNode(node) || !node.types.some(isDynamicTypeNode)) {
+    return mapTsType(fallbackType, checker, strategy, synthCell, opts);
+  }
+
+  const hasNullish = node.types.some(isNullishTypeNode);
+  const nonNullTypes = node.types.filter((part) => !isNullishTypeNode(part));
+  if (nonNullTypes.length === 0) {
+    return checker.typeToString(fallbackType);
+  }
+
+  const parts = nonNullTypes.map((part) =>
+    mapTsTypeNodePart(part, checker, strategy, synthCell, opts),
+  );
+  if (parts.some(isUnsupportedUnknown)) {
+    return UNSUPPORTED_UNKNOWN;
+  }
+
+  const unique = parts.filter((v, i, a) => a.indexOf(v) === i);
+  if (hasNullish) {
+    return `[${unique.join(" + ")}]`;
+  }
+  return unique.join(" + ");
 }
 
 function getBuiltinIteratorElementType(

--- a/tools/ts2pant/tests/fixtures/opaque/signatures.ts
+++ b/tools/ts2pant/tests/fixtures/opaque/signatures.ts
@@ -1,0 +1,25 @@
+export declare function scalarUnknown(value: unknown): unknown;
+
+export declare function scalarAny(value: any): any;
+
+export declare function unknownArray(value: unknown[]): unknown[];
+
+export declare function numberUnknownTuple(
+  value: [number, unknown],
+): [number, unknown];
+
+export declare function stringUnknownMap(
+  value: Map<string, unknown>,
+): Map<string, unknown>;
+
+export declare function numberUnknownUnion(
+  value: number | unknown,
+): number | unknown;
+
+export declare function nullableUnknown(
+  value: unknown | null,
+): unknown | null;
+
+export declare function anonymousRecord(
+  value: { known: number; mystery: unknown },
+): { known: number; mystery: unknown };

--- a/tools/ts2pant/tests/opaque-opt-in.test.mts
+++ b/tools/ts2pant/tests/opaque-opt-in.test.mts
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict";
+import { resolve } from "node:path";
 import { describe, it } from "node:test";
 import { ir1Binop, ir1LitNat, ir1Opaque, ir1Var } from "../src/ir1.js";
 import { OPAQUE_DOMAIN, contagiousOpaque, isOpaqueExpr } from "../src/opaque.js";
+import { createSourceFile } from "../src/extract.js";
+import { buildDocumentFromSourceFile, emitAndCheck } from "./helpers.mjs";
+
+const OPAQUE_FIXTURE_DIR = resolve(import.meta.dirname, "fixtures/opaque");
 
 describe("opaque opt-in policy", () => {
   const origin = { file: "tests/opaque-opt-in.ts", line: 1 };
@@ -25,8 +30,29 @@ describe("opaque opt-in policy", () => {
     });
   });
 
-  it.skip("signature composite opacity is precision-preserving under policy opaque (@pant checks; PENDING: Patch 2)", () => {
-    // @pant all x: [Int * Opaque] | true.
+  it("signature composite opacity is precision-preserving under policy opaque (@pant checks)", async (t) => {
+    const sourceFile = createSourceFile(
+      resolve(OPAQUE_FIXTURE_DIR, "signatures.ts"),
+    );
+    const targets = [
+      "scalarUnknown",
+      "scalarAny",
+      "unknownArray",
+      "numberUnknownTuple",
+      "stringUnknownMap",
+      "numberUnknownUnion",
+      "nullableUnknown",
+      "anonymousRecord",
+    ];
+
+    for (const target of targets) {
+      const doc = await buildDocumentFromSourceFile(sourceFile, target, {
+        noBody: true,
+        policy: "opaque",
+      });
+      const output = await emitAndCheck(doc);
+      t.assert.snapshot(output);
+    }
   });
 
   it.skip("body operation with an opaque operand propagates opacity (contagion; PENDING: Patch 3)", () => {

--- a/tools/ts2pant/tests/opaque-opt-in.test.mts.snapshot
+++ b/tools/ts2pant/tests/opaque-opt-in.test.mts.snapshot
@@ -1,0 +1,31 @@
+exports[`opaque opt-in policy > signature composite opacity is precision-preserving under policy opaque (@pant checks) 1`] = `
+"module SCALAR_UNKNOWN.\\n\\nOpaque.\\nscalar-unknown value: Opaque => Opaque.\\n\\n---\\n\\ntrue.\\n"
+`;
+
+exports[`opaque opt-in policy > signature composite opacity is precision-preserving under policy opaque (@pant checks) 2`] = `
+"module SCALAR_ANY.\\n\\nOpaque.\\nscalar-any value: Opaque => Opaque.\\n\\n---\\n\\ntrue.\\n"
+`;
+
+exports[`opaque opt-in policy > signature composite opacity is precision-preserving under policy opaque (@pant checks) 3`] = `
+"module UNKNOWN_ARRAY.\\n\\nOpaque.\\nunknown-array value: [Opaque] => [Opaque].\\n\\n---\\n\\ntrue.\\n"
+`;
+
+exports[`opaque opt-in policy > signature composite opacity is precision-preserving under policy opaque (@pant checks) 4`] = `
+"module NUMBER_UNKNOWN_TUPLE.\\n\\nOpaque.\\nnumber-unknown-tuple value: Int * Opaque => Int * Opaque.\\n\\n---\\n\\ntrue.\\n"
+`;
+
+exports[`opaque opt-in policy > signature composite opacity is precision-preserving under policy opaque (@pant checks) 5`] = `
+"module STRING_UNKNOWN_MAP.\\n\\nOpaque.\\nStringToOpaqueMap.\\nstring-to-opaque-map-key m: StringToOpaqueMap, k: String => Bool.\\nstring-to-opaque-map m: StringToOpaqueMap, k: String, string-to-opaque-map-key m k => Opaque.\\nstring-unknown-map value: StringToOpaqueMap => StringToOpaqueMap.\\n\\n---\\n\\ntrue.\\n"
+`;
+
+exports[`opaque opt-in policy > signature composite opacity is precision-preserving under policy opaque (@pant checks) 6`] = `
+"module NUMBER_UNKNOWN_UNION.\\n\\nOpaque.\\nnumber-unknown-union value: Int + Opaque => Int + Opaque.\\n\\n---\\n\\ntrue.\\n"
+`;
+
+exports[`opaque opt-in policy > signature composite opacity is precision-preserving under policy opaque (@pant checks) 7`] = `
+"module NULLABLE_UNKNOWN.\\n\\nOpaque.\\nnullable-unknown value: [Opaque] => [Opaque].\\n\\n---\\n\\ntrue.\\n"
+`;
+
+exports[`opaque opt-in policy > signature composite opacity is precision-preserving under policy opaque (@pant checks) 8`] = `
+"module ANONYMOUS_RECORD.\\n\\nOpaque.\\nKnownMysteryRec.\\nknown-mystery-rec--known r: KnownMysteryRec => Int.\\nknown-mystery-rec--mystery r: KnownMysteryRec => Opaque.\\nanonymous-record value: KnownMysteryRec => KnownMysteryRec.\\n\\n---\\n\\ntrue.\\n"
+`;

--- a/tools/ts2pant/tests/translate-types.test.mts
+++ b/tools/ts2pant/tests/translate-types.test.mts
@@ -472,7 +472,7 @@ describe("mapTsType", () => {
     );
   });
 
-  it("opaque policy without a synth cell keeps `any` unsupported", () => {
+  it("opaque policy without a synth cell maps `any` to Opaque", () => {
     const source = `interface Foo { val: any; }`;
     const sourceFile = createSourceFileFromSource(source);
     const checker = getChecker(sourceFile);
@@ -482,7 +482,7 @@ describe("mapTsType", () => {
       mapTsType(prop.type, checker, IntStrategy, undefined, {
         policy: "opaque",
       }),
-      UNSUPPORTED_UNKNOWN,
+      OPAQUE_DOMAIN,
     );
   });
 


### PR DESCRIPTION
## Patch 2: Signature-level composite opacity under policy opaque (precision-preserving)

- In each composite branch of mapTsType, under policy "opaque" allow an Opaque sub-result to propagate precision-preservingly instead of rejecting; verify the recursion already yields this and fix any branch (e.g. the !synthCell guard, the union sentinel check) that still poisons.
- Confirm `unknown | null` -> `[Opaque]` and `Map<string, unknown>` -> a String->Opaque synth domain.
- Add the dedicated `policy` option to the test harness (helpers.mts) and create tests/fixtures/opaque/signatures.ts.
- Implement the Patch 1 signature stub; regenerate the opaque-suite snapshot; confirm @pant signatures check under pant and the existing reject corpus is byte-identical.

## Changes
- In each composite branch of mapTsType, under policy "opaque" allow an Opaque sub-result to propagate precision-preservingly instead of rejecting; verify the recursion already yields this and fix any branch (e.g. the !synthCell guard, the union sentinel check) that still poisons.
- Confirm `unknown | null` -> `[Opaque]` and `Map<string, unknown>` -> a String->Opaque synth domain.
- Add the dedicated `policy` option to the test harness (helpers.mts) and create tests/fixtures/opaque/signatures.ts.
- Implement the Patch 1 signature stub; regenerate the opaque-suite snapshot; confirm @pant signatures check under pant and the existing reject corpus is byte-identical.

## Files to Modify
- tools/ts2pant/src/translate-types.ts (modify): Under policy "opaque", complete composite propagation so an Opaque sub-position does not poison the container: tuple -> Int * Opaque, array/set -> [Opaque], Map<K,V> -> the K->Opaque synth domain, union -> A + Opaque, union with nullish -> [Opaque], anonymous record -> the unknown field mapped to Opaque. Keep the `!synthCell` residual rejection. Under reject, all branches behave exactly as today.
- tools/ts2pant/tests/fixtures/opaque/signatures.ts (create): Opt-in opaque fixtures (signatures): functions whose params/returns are unknown, any, unknown[], [number, unknown], Map<string, unknown>, number | unknown, unknown | null, and an anonymous record with an unknown field — each with @pant annotations over the Opaque-typed signature.
- tools/ts2pant/tests/opaque-opt-in.test.mts (modify): Un-skip and implement the signature-composite-opacity stub: build the opaque/signatures.ts fixtures with policy:"opaque" via the dedicated suite, snapshot, and check under pant.
- tools/ts2pant/tests/helpers.mts (modify): Add an optional `policy` to buildDocumentFromSourceFile (threaded to PipelineOptions) so the opaque suite can request policy:"opaque".
- tools/ts2pant/tests/opaque-opt-in.test.mts.snapshot (modify): Regenerate via `npm run test:update-snapshots`; the snapshots are the new opaque-suite signatures only (existing reject corpus untouched).

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[pattern] Uninterpreted sort encoding for dynamic value spaces (Rosette, Z3 community JS/Python encodings)** — The Opaque sort is an uninterpreted sort with no projection/injection functions; composite propagation keeps it projection-free (a tuple position is Opaque, never coerced), so the container encoding (`Int * Opaque`, `[Opaque]`) stays sound by carrying opacity rather than inventing structure.

## Gameplan Specification

```
module OPAQUE_OPT_IN.

> ══════════════════════════════
> THE GUARANTEE
> ═══════════════════════════════
> After M2, mapTsType takes a `policy: "reject" | "opaque"` (default reject,
> threaded run-wide). Under reject, behavior is exactly as before. Under
> opaque, any/unknown positions lower to the Opaque sort precision-
> preservingly in both signatures (composites keep concrete siblings: Int *
> Opaque, [Opaque], K->Opaque maps, [Opaque] for unknown|null) and bodies
> (a reference to a dynamic value emits an OpaqueValue), and any operation
> with an opaque operand yields an opaque result (contagion). Contagion is
> sound — an Opaque is never treated as a concrete value — and use-site
> precision recovery is deferred to M4. The opt-in is exercised by a
> dedicated opaque fixture suite; the existing corpus stays on reject and is
> byte-identical.

Policy.
Pos.
Expr.
reject => Policy.
opaque => Policy.
default-policy => Policy.
is-dynamic p: Pos => Bool.
opaque-policy-pos p: Pos => Bool.
lowers-to-opaque p: Pos => Bool.
rejected p: Pos => Bool.
concrete-siblings-preserved p: Pos => Bool.
opaque-policy-expr e: Expr => Bool.
has-opaque-operand e: Expr => Bool.
is-opaque-result e: Expr => Bool.
treats-opaque-as-concrete e: Expr => Bool.

---

> Default policy is reject; reject preserves today's behavior.
default-policy = reject.

> Signatures: a dynamic position lowers to Opaque under opaque, is rejected
> under reject, and opacity is precision-preserving.
all p: Pos | (is-dynamic p and opaque-policy-pos p) -> (lowers-to-opaque p and ~(rejected p) and concrete-siblings-preserved p).
all p: Pos | (is-dynamic p and ~(opaque-policy-pos p)) -> rejected p.

> Bodies: an operation with an opaque operand is opaque, and contagion is
> sound.
all e: Expr | (opaque-policy-expr e and has-opaque-operand e) -> is-opaque-result e.
all e: Expr | ~(treats-opaque-as-concrete e).
```

## Patch Specification

```
module OPAQUE_OPT_IN_PATCH_2.

> Patch 2: under policy opaque, any/unknown positions lower to the Opaque
> sort precision-preservingly inside composites; under reject they are
> still rejected. Concrete sibling positions stay concrete.

Pos.
opaque-policy p: Pos => Bool.
is-dynamic p: Pos => Bool.
lowers-to-opaque p: Pos => Bool.
rejected p: Pos => Bool.
concrete-siblings-preserved p: Pos => Bool.

---

> A dynamic (any/unknown) position lowers to Opaque under opaque policy and
> is rejected under reject.
all p: Pos | (is-dynamic p and opaque-policy p) -> (lowers-to-opaque p and ~(rejected p)).
all p: Pos | (is-dynamic p and ~(opaque-policy p)) -> rejected p.

> Opacity is precision-preserving: concrete siblings of an opaque position
> are not collapsed.
all p: Pos | (lowers-to-opaque p) -> concrete-siblings-preserved p.
```


## Implementation Notes

- TypeScript collapses `unknown | null` and `number | unknown` to plain `unknown` in the checker type, so the signature path now consults explicit type syntax for dynamic unions before falling back to checker-based `mapTsType`. This is intentionally narrow: non-dynamic unions and the existing bare `Map.get` return narrowing keep the previous checker-type behavior.
- `mapTsType` now returns `Opaque` under `policy: "opaque"` even without a synth cell. When a synth cell is present it still registers the `Opaque` domain for emission; cell-less callers get a faithful type string instead of the old rejection sentinel.
- Patch 1 had already added `policy` to `buildDocumentFromSourceFile`, so this patch did not need to modify `helpers.mts`; the opaque suite uses that existing hook.
- The signature fixture suite builds with `noBody: true` because Patch 2 owns signature lowering only. Body emission and opacity contagion remain covered by the Patch 3 stub.

Spec/Evidence Mapping:
- Dynamic positions lower to Opaque under opaque policy: `mapTsType` dynamic branch and `mapTsTypeFromTypeNode`; proved by `tests/opaque-opt-in.test.mts` snapshots for scalar `any`/`unknown`, `unknown[]`, `[number, unknown]`, `Map<string, unknown>`, `number | unknown`, `unknown | null`, and anonymous-record fields.
- Concrete siblings are preserved: recursive composite mapping plus the signature type-node dynamic-union path; snapshot evidence includes `Int * Opaque`, `StringToOpaqueMap`, `Int + Opaque`, `[Opaque]`, and `KnownMysteryRec.known => Int` alongside `KnownMysteryRec.mystery => Opaque`.
- Reject behavior remains default: existing reject corpus snapshots were unchanged after snapshot regeneration, and `tests/translate-types.test.mts` still covers default rejection for `any`/`unknown`.
- Required context consulted: `translate-types.ts`, `helpers.mts` / `opaque-opt-in.test.mts`, `free-call-synthesis.test.mts`, and `workstreams/ts2pant-any-unknown-opaque.md`.