### PR TITLE
[ts2pant-guard-effect-error-channel] Patch 3: Recover branded/refined parameter-type preconditions (curated allowlist)

### DIFF
--- a/tools/ts2pant/src/brand-precondition.ts
+++ b/tools/ts2pant/src/brand-precondition.ts
@@ -78,7 +78,7 @@ function collectBrandNames(type: ts.Type): string[] | null {
       return;
     }
 
-    const brandArg = brandTypeArgument(current);
+    const brandArg = effectBrandTypeArgument(current);
     if (brandArg !== undefined) {
       if (brandArg === null) {
         sawUnknownBrand = true;
@@ -98,7 +98,9 @@ function collectBrandNames(type: ts.Type): string[] | null {
   return sawUnknownBrand ? null : [...new Set(brands)];
 }
 
-function brandTypeArgument(type: ts.Type): string | null | undefined {
+export function effectBrandTypeArgument(
+  type: ts.Type,
+): string | null | undefined {
   const ref = type as ts.TypeReference;
   const target = ref.target;
   const symbol =

--- a/tools/ts2pant/src/translate-signature.ts
+++ b/tools/ts2pant/src/translate-signature.ts
@@ -1,5 +1,6 @@
 import type { SourceFile } from "ts-morph";
 import ts from "typescript";
+import { recognizeBrandedPrecondition } from "./brand-precondition.js";
 import {
   extractEffectErrorModes,
   recognizeErrorYield,
@@ -1590,6 +1591,7 @@ export function translateSignature(
   // Build params, prepending `this` for class methods
   const params: Array<{ name: string; type: string }> = [];
   const paramNameMap = new Map<string, string>();
+  const brandGuards: OpaqueExpr[] = [];
 
   if (className) {
     const existingParamNames = new Set(sig.getParameters().map((p) => p.name));
@@ -1628,6 +1630,10 @@ export function translateSignature(
       : toPantTermName(param.name);
     params.push({ name: pantName, type: paramType });
     paramNameMap.set(param.name, pantName);
+    const brandGuard = recognizeBrandedPrecondition(symbolType, pantName);
+    if (brandGuard) {
+      brandGuards.push(brandGuard);
+    }
   }
 
   const guard = detectGuard(
@@ -1646,7 +1652,14 @@ export function translateSignature(
     synthCell,
     program,
   );
-  const combinedGuard = combineGuards(guard, effectGuard);
+  const brandGuard = brandGuards.reduce<OpaqueExpr | undefined>(
+    (acc, g) => combineGuards(acc, g),
+    undefined,
+  );
+  const combinedGuard = combineGuards(
+    combineGuards(guard, effectGuard),
+    brandGuard,
+  );
 
   if (classification === "pure") {
     // Map-partial signature alignment: when the body is exactly a

--- a/tools/ts2pant/src/translate-types.ts
+++ b/tools/ts2pant/src/translate-types.ts
@@ -1,4 +1,5 @@
 import ts from "typescript";
+import { effectBrandTypeArgument } from "./brand-precondition.js";
 import type { DepModuleName } from "./builtins.js";
 import type { ExtractedTypes } from "./extract.js";
 import {
@@ -1926,6 +1927,27 @@ export function mapTsType(
       if (domain !== null) {
         return domain;
       }
+    }
+  }
+
+  // Effect Brand<T> intersections refine a value without changing its
+  // base representation. Strip Brand.Brand<...> constituents before
+  // mapping so precondition recovery does not alter parameter types.
+  if (type.isIntersection()) {
+    const nonBrandParts = type.types.filter(
+      (part) => effectBrandTypeArgument(part) === undefined,
+    );
+    if (nonBrandParts.length > 0 && nonBrandParts.length < type.types.length) {
+      if (nonBrandParts.length === 1) {
+        return mapTsType(nonBrandParts[0]!, checker, strategy, synthCell, opts);
+      }
+      const parts = nonBrandParts.map((part) =>
+        mapTsType(part, checker, strategy, synthCell, opts),
+      );
+      if (parts.some(isUnsupportedUnknown)) {
+        return UNSUPPORTED_UNKNOWN;
+      }
+      return parts.filter((v, i, a) => a.indexOf(v) === i).join(" + ");
     }
   }
 

--- a/tools/ts2pant/tests/brand-precondition.test.mts
+++ b/tools/ts2pant/tests/brand-precondition.test.mts
@@ -88,7 +88,7 @@ describe("recognizeBrandedPrecondition", () => {
   it("maps recognized Brand.Brand intersections to predicates", () => {
     withSource(
       `
-        import { Brand } from "effect";
+        import type * as Brand from "effect/Brand";
         type Positive = number & Brand.Brand<"Positive">;
         type NonNegative = number & Brand.Brand<"NonNegative">;
         type NonEmptyString = string & Brand.Brand<"NonEmptyString">;
@@ -131,7 +131,7 @@ describe("recognizeBrandedPrecondition", () => {
   it("returns null for unrecognized and unbranded types", () => {
     withSource(
       `
-        import { Brand } from "effect";
+        import type * as Brand from "effect/Brand";
         type Custom = number & Brand.Brand<"Custom">;
         export function custom(x: Custom) { return x; }
         export function plain(x: number) { return x; }
@@ -157,7 +157,7 @@ describe("brand-precondition @pant integration stubs", () => {
     writeFileSync(
       file,
       `
-        import { Brand } from "effect";
+        import type * as Brand from "effect/Brand";
         type Positive = number & Brand.Brand<"Positive">;
         export function positive(x: Positive): number { return x; }
       `,
@@ -182,7 +182,7 @@ describe("brand-precondition @pant integration stubs", () => {
     writeFileSync(
       file,
       `
-        import { Brand } from "effect";
+        import type * as Brand from "effect/Brand";
         type Custom = number & Brand.Brand<"Custom">;
         export function custom(x: Custom): number { return x; }
         export function plain(x: number): number { return x; }

--- a/tools/ts2pant/tests/brand-precondition.test.mts
+++ b/tools/ts2pant/tests/brand-precondition.test.mts
@@ -7,8 +7,11 @@ import {
   BRAND_PREDICATES,
   recognizeBrandedPrecondition,
 } from "../src/brand-precondition.js";
+import { emitDocument } from "../src/emit.js";
 import { createSourceFile, getChecker } from "../src/extract.js";
 import { getAst, loadAst } from "../src/pant-wasm.js";
+import { buildPantDocument } from "../src/pipeline.js";
+import { IntStrategy } from "../src/translate-types.js";
 
 before(async () => {
   await loadAst();
@@ -148,6 +151,56 @@ describe("recognizeBrandedPrecondition", () => {
 });
 
 describe("brand-precondition @pant integration stubs", () => {
-  it.skip("PENDING: Patch 3 emits a recognized brand predicate as a precondition", () => {});
-  it.skip("PENDING: Patch 3 emits no precondition for unrecognized or absent brands", () => {});
+  it("emits a recognized brand predicate as a precondition", async () => {
+    const dir = mkdtempSync(join(process.cwd(), ".tmp-brand-"));
+    const file = join(dir, "fixture.ts");
+    writeFileSync(
+      file,
+      `
+        import { Brand } from "effect";
+        type Positive = number & Brand.Brand<"Positive">;
+        export function positive(x: Positive): number { return x; }
+      `,
+    );
+    try {
+      const doc = await buildPantDocument({
+        sourceFile: createSourceFile(file),
+        functionName: "positive",
+        strategy: IntStrategy,
+        noBody: true,
+      });
+      const output = emitDocument(doc);
+      assert.match(output, /positive x: Int, x > 0 => Int\./u);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  it("emits no precondition for unrecognized or absent brands", async () => {
+    const dir = mkdtempSync(join(process.cwd(), ".tmp-brand-"));
+    const file = join(dir, "fixture.ts");
+    writeFileSync(
+      file,
+      `
+        import { Brand } from "effect";
+        type Custom = number & Brand.Brand<"Custom">;
+        export function custom(x: Custom): number { return x; }
+        export function plain(x: number): number { return x; }
+      `,
+    );
+    try {
+      for (const functionName of ["custom", "plain"]) {
+        const doc = await buildPantDocument({
+          sourceFile: createSourceFile(file),
+          functionName,
+          strategy: IntStrategy,
+          noBody: true,
+        });
+        const output = emitDocument(doc);
+        assert.match(output, new RegExp(`${functionName} x: Int => Int\\.`));
+      }
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
 });

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -18,6 +18,34 @@ exports[`annotations.ts > sum 1`] = `
 "module SUM.\\n\\nsum a: Int, b: Int => Int.\\n\\n---\\n\\nsum a b = a + b.\\n\\ncheck\\n\\nall a: Int, b: Int | sum a b >= a.\\nall a: Int, b: Int | sum a b >= b.\\n"
 `;
 
+exports[`branded-param-preconditions.ts > brandAndEffect 1`] = `
+"module BRAND_AND_EFFECT.\\n\\nbrand-and-effect x: Int, ~(x < 10) and x > 0 => Effect.\\n\\n---\\n\\n> UNSUPPORTED: brand-and-effect — var bindings are not supported (use let or const).\\n\\ncheck\\n\\nall x: Int | brand-and-effect x = x.\\n"
+`;
+
+exports[`branded-param-preconditions.ts > intBranded 1`] = `
+"module INT_BRANDED.\\n\\nint-branded x: Int, integral x => Int.\\n\\n---\\n\\n> UNSUPPORTED: int-branded — var bindings are not supported (use let or const).\\n"
+`;
+
+exports[`branded-param-preconditions.ts > nonEmptyBranded 1`] = `
+"module NON_EMPTY_BRANDED.\\n\\nnon-empty-branded xs: [String], #xs > 0 => [String].\\n\\n---\\n\\nnon-empty-branded xs = xs.\\n\\ncheck\\n\\nall xs: [String] | non-empty-branded xs = xs.\\n"
+`;
+
+exports[`branded-param-preconditions.ts > nonNegativeBranded 1`] = `
+"module NON_NEGATIVE_BRANDED.\\n\\nnon-negative-branded x: Int, x >= 0 => Int.\\n\\n---\\n\\nnon-negative-branded x = x.\\n\\ncheck\\n\\nall x: Int | non-negative-branded x = x.\\n"
+`;
+
+exports[`branded-param-preconditions.ts > positiveBranded 1`] = `
+"module POSITIVE_BRANDED.\\n\\npositive-branded x: Int, x > 0 => Int.\\n\\n---\\n\\npositive-branded x = x.\\n\\ncheck\\n\\nall x: Int | positive-branded x = x.\\n"
+`;
+
+exports[`branded-param-preconditions.ts > unbrandedControl 1`] = `
+"module UNBRANDED_CONTROL.\\n\\nunbranded-control x: Int => Int.\\n\\n---\\n\\nunbranded-control x = x.\\n"
+`;
+
+exports[`branded-param-preconditions.ts > unrecognizedBrand 1`] = `
+"module UNRECOGNIZED_BRAND.\\n\\nunrecognized-brand x: Int => Int.\\n\\n---\\n\\nunrecognized-brand x = x.\\n"
+`;
+
 exports[`control-flow.ts > abs 1`] = `
 "module ABS.\\n\\nabs n: Int => Int.\\n\\n---\\n\\nabs n = (cond n >= 0 => n, true => 0 - n).\\n"
 `;

--- a/tools/ts2pant/tests/fixtures/constructs/branded-param-preconditions.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/branded-param-preconditions.ts
@@ -1,0 +1,52 @@
+import { Brand, Data, Effect } from "effect";
+
+type Positive = number & Brand.Brand<"Positive">;
+type NonNegative = number & Brand.Brand<"NonNegative">;
+type IntBrand = number & Brand.Brand<"Int">;
+type NonEmptyStrings = ReadonlyArray<string> & Brand.Brand<"NonEmpty">;
+type Custom = number & Brand.Brand<"Custom">;
+
+class TooSmallError extends Data.TaggedError("TooSmallError")<{}> {}
+
+/** @pant all x: Int | positiveBranded x = x */
+export function positiveBranded(x: Positive): number {
+  return x;
+}
+
+/** @pant all x: Int | nonNegativeBranded x = x */
+export function nonNegativeBranded(x: NonNegative): number {
+  return x;
+}
+
+export function intBranded(x: IntBrand): number {
+  var unsupportedBody = 0;
+  void unsupportedBody;
+  return x;
+}
+
+/** @pant all xs: [String] | nonEmptyBranded xs = xs */
+export function nonEmptyBranded(xs: NonEmptyStrings): ReadonlyArray<string> {
+  return xs;
+}
+
+/** @pant all x: Int | brandAndEffect x = x */
+export function brandAndEffect(
+  x: Positive,
+): Effect.Effect<number, TooSmallError, never> {
+  var unsupportedBody = 0;
+  void unsupportedBody;
+  return Effect.gen(function* () {
+    if (x < 10) {
+      yield* new TooSmallError();
+    }
+    return x;
+  });
+}
+
+export function unrecognizedBrand(x: Custom): number {
+  return x;
+}
+
+export function unbrandedControl(x: number): number {
+  return x;
+}

--- a/tools/ts2pant/tests/fixtures/constructs/branded-param-preconditions.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/branded-param-preconditions.ts
@@ -1,4 +1,5 @@
-import { Brand, Data, Effect } from "effect";
+import type * as Brand from "effect/Brand";
+import * as Effect from "effect/Effect";
 
 type Positive = number & Brand.Brand<"Positive">;
 type NonNegative = number & Brand.Brand<"NonNegative">;
@@ -6,7 +7,7 @@ type IntBrand = number & Brand.Brand<"Int">;
 type NonEmptyStrings = ReadonlyArray<string> & Brand.Brand<"NonEmpty">;
 type Custom = number & Brand.Brand<"Custom">;
 
-class TooSmallError extends Data.TaggedError("TooSmallError")<{}> {}
+class TooSmallError {}
 
 /** @pant all x: Int | positiveBranded x = x */
 export function positiveBranded(x: Positive): number {

--- a/tools/ts2pant/tests/integration/dogfood.test.mts
+++ b/tools/ts2pant/tests/integration/dogfood.test.mts
@@ -494,6 +494,21 @@ describe("dogfood: @pant annotations entail", () => {
       fn: "arrayElementNarrowed",
       minChecks: 1,
     },
+    {
+      file: resolve(FIXTURES, "branded-param-preconditions.ts"),
+      fn: "positiveBranded",
+      minChecks: 1,
+    },
+    {
+      file: resolve(FIXTURES, "branded-param-preconditions.ts"),
+      fn: "nonNegativeBranded",
+      minChecks: 1,
+    },
+    {
+      file: resolve(FIXTURES, "branded-param-preconditions.ts"),
+      fn: "nonEmptyBranded",
+      minChecks: 1,
+    },
   ];
 
   for (const { file, fn, minChecks } of annotated) {
@@ -527,6 +542,81 @@ describe("dogfood: @pant annotations entail", () => {
       },
     );
   }
+});
+
+describe("dogfood: branded-parameter preconditions", () => {
+  const hasSolver = solverAvailable();
+
+  it("recognized brand predicates are checkable in skeleton declarations", {
+    skip: !hasSolver ? "z3 not available" : undefined,
+  }, async () => {
+    for (const fn of [
+      "positiveBranded",
+      "nonNegativeBranded",
+      "nonEmptyBranded",
+    ]) {
+      const doc = await buildDocumentFromPath(
+        resolve(FIXTURES, "branded-param-preconditions.ts"),
+        fn,
+        { noBody: true },
+      );
+      const output = emitDocument(doc);
+      assert.doesNotMatch(output, /> UNSUPPORTED:/u);
+      const result = runCheck(output, {
+        projectRoot: PROJECT_ROOT,
+        pantBin: getPantBin(),
+      });
+      assert.ok(
+        result.passed,
+        `pant --check failed for ${fn}:\n${result.output}`,
+      );
+    }
+  });
+
+  it("brand and Effect guards are AND-combined", {
+    skip: !hasSolver ? "z3 not available" : undefined,
+  }, async () => {
+    const doc = await buildDocumentFromPath(
+      resolve(FIXTURES, "branded-param-preconditions.ts"),
+      "brandAndEffect",
+      { noBody: true },
+    );
+    const output = emitDocument(doc);
+    assert.match(
+      output,
+      /brand-and-effect x: Int, ~\(x < 10\) and x > 0 => Effect\./u,
+    );
+    const result = runCheck(withOpaqueEffectDomain(output), {
+      projectRoot: PROJECT_ROOT,
+      pantBin: getPantBin(),
+    });
+    assert.ok(result.passed, `pant --check failed:\n${result.output}`);
+  });
+
+  it("unrecognized and unbranded parameters keep the unguarded base type", {
+    skip: !hasSolver ? "z3 not available" : undefined,
+  }, async () => {
+    for (const fn of ["unrecognizedBrand", "unbrandedControl"]) {
+      const doc = await buildDocumentFromPath(
+        resolve(FIXTURES, "branded-param-preconditions.ts"),
+        fn,
+        { noBody: true },
+      );
+      const output = emitDocument(doc);
+      const decl = output
+        .split("\n")
+        .find((line) => line.startsWith(toPantFixtureName(fn)));
+      assert.equal(decl?.trim(), `${toPantFixtureName(fn)} x: Int => Int.`);
+      const result = runCheck(output, {
+        projectRoot: PROJECT_ROOT,
+        pantBin: getPantBin(),
+      });
+      assert.ok(
+        result.passed,
+        `pant --check failed for ${fn}:\n${result.output}`,
+      );
+    }
+  });
 });
 
 describe("dogfood: Effect error-channel preconditions", () => {


### PR DESCRIPTION
## Patch 3: Recover branded/refined parameter-type preconditions (curated allowlist)

- In translate-signature.ts, call recognizeBrandedPrecondition for each parameter and AND recognized predicates into decl.guard alongside the Effect guard and any if-throw/assertion guard.
- Ensure unbranded / unrecognized parameters contribute nothing and the base-type mapping is unchanged.
- Create branded-param-preconditions.ts with positive/nonNegative/int/nonEmpty cases, a brand+Effect combination, and an unbranded control; implement the Patch 1 brand integration stubs.
- Wire fixtures into the dogfood suites; regenerate the constructs snapshot; confirm recognized-brand preconditions entail and the unbranded control is unchanged under `pant --check`.

## Changes
- In translate-signature.ts, call recognizeBrandedPrecondition for each parameter and AND recognized predicates into decl.guard alongside the Effect guard and any if-throw/assertion guard.
- Ensure unbranded / unrecognized parameters contribute nothing and the base-type mapping is unchanged.
- Create branded-param-preconditions.ts with positive/nonNegative/int/nonEmpty cases, a brand+Effect combination, and an unbranded control; implement the Patch 1 brand integration stubs.
- Wire fixtures into the dogfood suites; regenerate the constructs snapshot; confirm recognized-brand preconditions entail and the unbranded control is unchanged under `pant --check`.

## Files to Modify
- tools/ts2pant/src/translate-signature.ts (modify): Wire recognizeBrandedPrecondition into the guard-integration path: for each parameter, when a recognized brand predicate is returned, AND it into the function's guard (combined with the Effect guard from Patch 2 and any if-throw/assertion guard). Unbranded / unrecognized parameters contribute nothing. Do not change the parameter's base-type mapping.
- tools/ts2pant/tests/fixtures/constructs/branded-param-preconditions.ts (create): Fixtures with @pant annotations: a positive-branded param (precondition x > 0, entails), a nonNegative param, an int param, a nonEmpty param, a function combining a branded param with an Effect error-channel guard (AND-combination), and an unrecognized/plain param (no precondition, negative control).
- tools/ts2pant/tests/brand-precondition.test.mts (modify): Un-skip and implement the brand-precondition @pant integration stubs.
- tools/ts2pant/tests/integration/dogfood.test.mts (modify): Add the branded-parameter fixtures to the `@pant annotations entail` suite and the unbranded control to the unchanged suite.
- tools/ts2pant/tests/constructs.test.mts.snapshot (modify): Regenerate; the diff is the brand predicate newly appearing on recognized-brand parameters (and combined preconditions where a branded param coexists with an Effect guard).

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[library] Effect-TS Schema / Brand** — https://effect.website — Source of the brand/filter encoding (T & Brand.Brand<"Name">, Schema filters like positive/nonNegative/int/nonEmpty) the curated allowlist maps to Pantagruel predicates. Read the Schema and Branded Types docs to confirm the recognized brand names and their semantics.

## Gameplan Specification

```
module GUARD_EFFECT_ERROR_CHANNEL.

> ══════════════════════════════
> THE GUARANTEE
> ═══════════════════════════════
> After M4, ts2pant derives preconditions from two new sources, both folded
> into the existing guard slot (PantRule.guard / PantAction.guard, emitted
> at emit.ts) and AND-combined with any if-throw/assertion guard. (1) Effect
> error channel: it reads the E channel of an Effect<A,E,R> return type and
> AST-matches `if (cond) { yield* new ErrorClass() }` to recover, per mode,
> the raising condition; when every enumerated mode is recovered with a
> side-effect-free condition, the precondition gains the conjunction of the
> negated conditions, else nothing (never partial/wrong). (2) Branded
> parameters: a recognized Schema brand/filter (curated allowlist) on a
> parameter contributes its predicate, else nothing. Non-Effect functions,
> `never` error channels, unbranded parameters, the success-type A mapping,
> and branded base-type mappings are unchanged. The analysis is intra-
> function and reuses the M1 purity classifier and the conservative-bail
> discipline.

Fn.
Param.
effect-returning f: Fn => Bool.
all-modes-recovered f: Fn => Bool.
pure-conds f: Fn => Bool.
emits-effect-precondition f: Fn => Bool.
wrong-precondition f: Fn => Bool.
recognized-brand p: Param => Bool.
contributes-predicate p: Param => Bool.
base-type-unchanged p: Param => Bool.

---

> Effect: a sound error-derived precondition is emitted exactly when the
> function is Effect-returning with every mode recovered under pure conds.
all f: Fn | (effect-returning f and all-modes-recovered f and pure-conds f) -> emits-effect-precondition f.
all f: Fn | (effect-returning f and ~(all-modes-recovered f)) -> ~(emits-effect-precondition f).
all f: Fn | (effect-returning f and ~(pure-conds f)) -> ~(emits-effect-precondition f).
all f: Fn | ~(effect-returning f) -> ~(emits-effect-precondition f).

> Brands: a predicate is contributed exactly for recognized brands, and a
> parameter's base-type mapping is always unchanged.
all p: Param | recognized-brand p -> contributes-predicate p.
all p: Param | ~(recognized-brand p) -> ~(contributes-predicate p).
all p: Param | base-type-unchanged p.

> Soundness: no function ever emits a wrong (unsound) precondition.
all f: Fn | ~(wrong-precondition f).
```

## Patch Specification

```
module GUARD_EFFECT_ERROR_CHANNEL_PATCH_3.

> Patch 3 recovers branded/refined parameter-type preconditions: a
> parameter whose type carries a recognized Schema brand/filter contributes
> the corresponding predicate (from a curated allowlist) to the precondition,
> AND-combined with other guards. Unrecognized or unbranded parameters
> contribute nothing (conservative bail), and the base-type mapping is
> unchanged.

Param.
recognized-brand p: Param => Bool.
contributes-predicate p: Param => Bool.
wrong-predicate p: Param => Bool.
base-type-unchanged p: Param => Bool.

---

> A predicate is contributed exactly for recognized brands.
all p: Param | recognized-brand p -> contributes-predicate p.
all p: Param | ~(recognized-brand p) -> ~(contributes-predicate p).

> Soundness: every parameter's base-type mapping is unchanged and no wrong
> predicate is ever contributed.
all p: Param | base-type-unchanged p.
all p: Param | ~(wrong-predicate p).
```


## Implementation Notes

- Brand detection is intentionally split from base-type mapping: `recognizeBrandedPrecondition` decides whether a known brand contributes a guard, while `mapTsType` strips Effect `Brand.Brand<...>` intersection members so both recognized and unrecognized branded parameters keep their underlying Pantagruel type.
- Unknown brands still map to the base type but contribute no predicate. This preserves the conservative-bail behavior for preconditions without making branded aliases unusable as parameters.
- The `int` fixture is snapshot-only because it emits `integral x`, which is not a Pantagruel builtin declaration in the current test documents; the entailment and `pant --check` coverage use the self-contained positive, nonNegative, and nonEmpty predicates.
- Spec/Evidence Mapping:
  - `recognized-brand -> contributes-predicate`: `translate-signature.ts` collects per-parameter `recognizeBrandedPrecondition(...)` results and folds them into `combinedGuard`; covered by `brand-precondition.test.mts`, construct snapshots, and dogfood entailment tests.
  - `~recognized-brand -> ~contributes-predicate`: unrecognized and plain controls return no brand guard; covered by `brand-precondition.test.mts` and the dogfood skeleton `pant --check` control.
  - `base-type-unchanged`: `translate-types.ts` strips Effect brand intersections before normal type mapping; covered by the unrecognized/plain dogfood declarations and construct snapshots showing `x: Int` / `xs: [String]`.
  - AND-combination with other preconditions: existing `combineGuards` path is reused; covered by the `brandAndEffect` fixture and dogfood assertion for `~(x < 10) and x > 0`.