### PR TITLE
[ts2pant-guard-effect-error-channel] Patch 4: Document the Effect error-channel and branded-parameter precondition extraction

### DIFF
--- a/tools/ts2pant/docs/effect-error-channel.md
+++ b/tools/ts2pant/docs/effect-error-channel.md
@@ -1,0 +1,145 @@
+# Effect Error-Channel And Brand Preconditions
+
+**Workstream:** ts2pant Flow-Sensitive Guard & Effect Analysis - Milestone 4
+(`guard-effect-error-channel`).
+
+This note documents the two M4 precondition sources added to ts2pant:
+Effect error-channel recovery and branded/refined parameter recovery. Both follow
+the workstream's conservative-bail rule: emit a sound precondition only when the
+translator has enough static evidence, otherwise emit nothing.
+
+See the M4 definition of done in
+[`workstreams/ts2pant-guard-analysis.md`](../../../workstreams/ts2pant-guard-analysis.md#milestone-4-guard-effect-error-channel).
+The Effect side is based on Effect's `Effect<A, E, R>` shape and generator
+composition model in the Effect docs:
+[`Effect.ts`](https://effect-ts.github.io/effect/effect/Effect.ts.html). The brand
+side follows Effect's branded/refined type model and Schema filter naming:
+[`Brand.ts`](https://effect-ts.github.io/effect/effect/Brand.ts.html) and
+[`Schema.ts`](https://effect-ts.github.io/effect/effect/Schema.ts.html).
+
+## Output Channel
+
+These analyses do not create a new Pantagruel emission path. They feed the same
+guard slot already used by if-throw guards, assertion guards, and followed guard
+helpers:
+
+- `PantRule.guard` for pure functions.
+- `PantAction.guard` for actions.
+
+When more than one source contributes a precondition, ts2pant AND-combines the
+predicates. For example, an existing assertion guard, an Effect error-channel guard,
+and a brand guard become one declaration guard:
+
+```pant
+f x: Int, assertion-guard x and effect-guard x and brand-guard x => Int.
+```
+
+## Effect Error-Channel Recovery
+
+Effect's public type is `Effect<A, E, R>`: `A` is the success value, `E` is the
+typed error channel, and `R` is the required environment. M4 only reads `E` for
+precondition synthesis.
+
+For an Effect-returning function, ts2pant:
+
+1. Resolves that the return type is Effect's `Effect`.
+2. Extracts the second type argument, `E`.
+3. Enumerates the non-nullish members of `E` when it is a union.
+4. Ignores the function when `E` is `never`, nullish-only, non-Effect, or not
+   statically nameable.
+5. Looks inside the returned `Effect.gen(function* () { ... })` body for guarded
+   error yields of the form:
+
+```ts
+if (cond) {
+  yield* new FooError()
+}
+```
+
+For each enumerated error mode, the constructor name must match one recovered
+`yield* new ErrorClass(...)`. If `FooError` is raised when `cond` holds, then the
+success precondition includes `~cond`: callers get the success value only when that
+failure condition is false.
+
+For a return type with two modes:
+
+```ts
+Effect.Effect<number, FooError | BarError, never>
+```
+
+and a generator body that raises `FooError` under `x < 0` and `BarError` under
+`x > 10`, ts2pant emits a precondition equivalent to:
+
+```pant
+~(x < 0) and ~(x > 10)
+```
+
+## Completeness Bail
+
+The error-channel analysis is all-or-nothing per function. It emits the
+Effect-derived precondition only when every enumerated `E` member is recovered and
+every recovered condition is side-effect-free according to the M1 purity classifier.
+
+ts2pant emits no Effect-derived precondition when:
+
+- The return type is not Effect's `Effect<A, E, R>`.
+- The `E` channel is `never`.
+- An `E` member cannot be enumerated or named.
+- A mode in `E` has no matching guarded `yield* new ErrorClass(...)`.
+- The generator contains an unmatched error yield shape.
+- A matching condition is effectful or cannot be translated as a Pantagruel guard.
+- The same mode is recovered more than once.
+
+This is a soundness rule. A partial conjunction would be a too-weak caller
+precondition: it could claim the function succeeds in states where an unrecovered
+error mode still fails.
+
+## Branded Parameter Preconditions
+
+M4 also recovers preconditions from recognized Effect brand/refinement information
+on parameter types. Effect brands refine an underlying TypeScript type with an
+extra type tag; Effect's `Brand.refined` API associates those brands with
+validation predicates.
+
+ts2pant keeps the parameter's base type mapping unchanged and contributes only an
+additional declaration guard when the brand is in the curated allowlist:
+
+| Brand/filter name | Pantagruel predicate |
+| --- | --- |
+| `positive`, `Positive` | `x > 0` |
+| `negative`, `Negative` | `x < 0` |
+| `nonNegative`, `NonNegative` | `x >= 0` |
+| `nonPositive`, `NonPositive` | `x <= 0` |
+| `int`, `Int`, `integer`, `Integer` | `integral x` |
+| `nonEmpty`, `NonEmpty`, `NonEmptyString` | `#x > 0` |
+
+Multiple recognized brands on the same parameter are AND-combined. For example:
+
+```ts
+type PositiveInt = number & Brand.Brand<"Positive"> & Brand.Brand<"Int">
+```
+
+contributes:
+
+```pant
+x > 0 and integral x
+```
+
+If a parameter carries an unrecognized brand, ts2pant emits no brand predicate for
+that parameter rather than emitting only the recognized subset. Unbranded
+parameters also contribute nothing.
+
+## Out Of Scope
+
+M4 is scoped to precondition synthesis only. It intentionally does not:
+
+- Decompose or remap the Effect success type `A`.
+- Change the branded parameter's base-type mapping.
+- Infer arbitrary user-defined brand predicates by reading constructor bodies.
+- Infer semantics for custom or nominal brand names outside the allowlist.
+- Perform cross-function Effect generator analysis.
+- Treat incomplete recovery as a weaker precondition.
+
+The resulting behavior is additive: non-Effect functions, infallible Effect
+functions, unbranded parameters, unknown brands, and unsupported Effect generator
+shapes keep their prior emitted Pantagruel shape.


### PR DESCRIPTION
## Patch 4: Document the Effect error-channel and branded-parameter precondition extraction

- Write tools/ts2pant/docs/effect-error-channel.md covering both precondition sources, the completeness-bail rule, the brand allowlist, AND-combination, and the out-of-scope cases, citing the workstream doc and Effect-TS.
- No code or snapshot changes.

## Changes
- Write tools/ts2pant/docs/effect-error-channel.md covering both precondition sources, the completeness-bail rule, the brand allowlist, AND-combination, and the out-of-scope cases, citing the workstream doc and Effect-TS.
- No code or snapshot changes.

## Files to Modify
- tools/ts2pant/docs/effect-error-channel.md (create): Documentation: how Effect<A,E,R> error modes are enumerated, the `if (cond) { yield* new ErrorClass() }` recovery pattern, the completeness-bail soundness rule; the branded-parameter precondition source (the curated brand allowlist, recognized brands, and the conservative bail on unknowns); AND-combination with if-throw/assertion guards; and the out-of-scope cases (success-type A mapping unchanged; branded base-type mapping unchanged; intra-function only). Cross-reference the workstream doc and the Effect-TS docs.

## Gameplan Specification

```
module GUARD_EFFECT_ERROR_CHANNEL.

> ══════════════════════════════
> THE GUARANTEE
> ═══════════════════════════════
> After M4, ts2pant derives preconditions from two new sources, both folded
> into the existing guard slot (PantRule.guard / PantAction.guard, emitted
> at emit.ts) and AND-combined with any if-throw/assertion guard. (1) Effect
> error channel: it reads the E channel of an Effect<A,E,R> return type and
> AST-matches `if (cond) { yield* new ErrorClass() }` to recover, per mode,
> the raising condition; when every enumerated mode is recovered with a
> side-effect-free condition, the precondition gains the conjunction of the
> negated conditions, else nothing (never partial/wrong). (2) Branded
> parameters: a recognized Schema brand/filter (curated allowlist) on a
> parameter contributes its predicate, else nothing. Non-Effect functions,
> `never` error channels, unbranded parameters, the success-type A mapping,
> and branded base-type mappings are unchanged. The analysis is intra-
> function and reuses the M1 purity classifier and the conservative-bail
> discipline.

Fn.
Param.
effect-returning f: Fn => Bool.
all-modes-recovered f: Fn => Bool.
pure-conds f: Fn => Bool.
emits-effect-precondition f: Fn => Bool.
wrong-precondition f: Fn => Bool.
recognized-brand p: Param => Bool.
contributes-predicate p: Param => Bool.
base-type-unchanged p: Param => Bool.

---

> Effect: a sound error-derived precondition is emitted exactly when the
> function is Effect-returning with every mode recovered under pure conds.
all f: Fn | (effect-returning f and all-modes-recovered f and pure-conds f) -> emits-effect-precondition f.
all f: Fn | (effect-returning f and ~(all-modes-recovered f)) -> ~(emits-effect-precondition f).
all f: Fn | (effect-returning f and ~(pure-conds f)) -> ~(emits-effect-precondition f).
all f: Fn | ~(effect-returning f) -> ~(emits-effect-precondition f).

> Brands: a predicate is contributed exactly for recognized brands, and a
> parameter's base-type mapping is always unchanged.
all p: Param | recognized-brand p -> contributes-predicate p.
all p: Param | ~(recognized-brand p) -> ~(contributes-predicate p).
all p: Param | base-type-unchanged p.

> Soundness: no function ever emits a wrong (unsound) precondition.
all f: Fn | ~(wrong-precondition f).
```

## Patch Specification

```
module GUARD_EFFECT_ERROR_CHANNEL_PATCH_4.

> Patch 4 adds documentation only; no emitted output or behavior changes.
> Redeclared for self-containment.

Doc.
describes-error-channel d: Doc => Bool.
describes-brands d: Doc => Bool.
describes-bail-rule d: Doc => Bool.

---

> The doc describes the error-channel recovery, the branded-parameter
> source, and the completeness/allowlist bail rules.
all d: Doc | (describes-error-channel d and describes-brands d and describes-bail-rule d).
```


## Implementation Notes

- Documentation is intentionally descriptive rather than normative about future behavior: it points reviewers to the M4 workstream as the authority and mirrors the behavior already wired by patches 2 and 3.
- The Effect docs links use the generated API pages for `Effect`, `Brand`, and `Schema`; this keeps the doc tied to the concrete type/API surfaces relevant to `Effect<A, E, R>` and branded/refined parameters.
- Non-obvious detail: the doc calls out that an unrecognized brand suppresses the predicate for that parameter instead of emitting only a recognized subset, matching the conservative no-partial-precondition rule.

Spec/Evidence Mapping:
- `describes-error-channel`: covered in `tools/ts2pant/docs/effect-error-channel.md` under "Effect Error-Channel Recovery"; checked against `workstreams/ts2pant-guard-analysis.md` M4 and the dependency patch helpers/tests.
- `describes-brands`: covered under "Branded Parameter Preconditions", including the current allowlist from `brand-precondition.ts`.
- `describes-bail-rule`: covered under "Completeness Bail" and the unrecognized-brand paragraph; `git diff --check` passed for the documentation-only patch.