### PR TITLE
[ts2pant-nullish-and-predicate-narrowing] Patch 3: User type-predicate narrowing (tractable subset, sound bail)

### DIFF
--- a/tools/ts2pant/src/assumption-env.ts
+++ b/tools/ts2pant/src/assumption-env.ts
@@ -1,6 +1,12 @@
 import type { OpaqueExpr } from "./pant-ast.js";
 import { getAst } from "./pant-wasm.js";
 
+export interface TypePredicateFactInfo {
+  receiver: string;
+  negated: boolean;
+  tractable: boolean;
+}
+
 export type Fact =
   | {
       kind: "discriminant";
@@ -10,7 +16,11 @@ export type Fact =
       negated: boolean;
     }
   | { kind: "non-null"; receiver: string; negated: boolean }
-  | { kind: "predicate"; testExpr: OpaqueExpr };
+  | {
+      kind: "predicate";
+      testExpr: OpaqueExpr;
+      typePredicate?: TypePredicateFactInfo;
+    };
 
 export interface AssumptionEnv {
   frames: Map<string, Fact>[];
@@ -24,6 +34,13 @@ export interface InScopeDiscriminantFact {
 export interface InScopeNonNullFact {
   receiver: string;
   negated: boolean;
+}
+
+export interface InScopeTypePredicateFact {
+  testExpr: OpaqueExpr;
+  receiver: string;
+  negated: boolean;
+  tractable: boolean;
 }
 
 export function createAssumptionEnv(): AssumptionEnv {
@@ -124,6 +141,37 @@ export function nonNullFactInScope(
   return out;
 }
 
+export function typePredicateFactsInScope(
+  env: AssumptionEnv,
+  receiver: string,
+): InScopeTypePredicateFact[] {
+  const out: InScopeTypePredicateFact[] = [];
+  const seen = new Set<string>();
+  for (const frame of env.frames) {
+    for (const fact of frame.values()) {
+      if (
+        fact.kind !== "predicate" ||
+        fact.typePredicate === undefined ||
+        fact.typePredicate.receiver !== receiver
+      ) {
+        continue;
+      }
+      const inScope: InScopeTypePredicateFact = {
+        testExpr: fact.testExpr,
+        receiver: fact.typePredicate.receiver,
+        negated: fact.typePredicate.negated,
+        tractable: fact.typePredicate.tractable,
+      };
+      const key = `${inScope.negated ? "!" : "="}:${inScope.tractable ? "t" : "b"}:${getAst().strExpr(inScope.testExpr)}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        out.push(inScope);
+      }
+    }
+  }
+  return out;
+}
+
 function factKey(fact: Fact): string {
   if (fact.kind === "discriminant") {
     return `disc:${JSON.stringify([
@@ -136,5 +184,10 @@ function factKey(fact: Fact): string {
   if (fact.kind === "non-null") {
     return `nonnull:${JSON.stringify([fact.receiver, fact.negated])}`;
   }
-  return `pred:${JSON.stringify(getAst().strExpr(fact.testExpr))}`;
+  return `pred:${JSON.stringify([
+    getAst().strExpr(fact.testExpr),
+    fact.typePredicate?.receiver,
+    fact.typePredicate?.negated,
+    fact.typePredicate?.tractable,
+  ])}`;
 }

--- a/tools/ts2pant/src/definedness-obligation.ts
+++ b/tools/ts2pant/src/definedness-obligation.ts
@@ -1,6 +1,7 @@
 import type {
   InScopeDiscriminantFact,
   InScopeNonNullFact,
+  InScopeTypePredicateFact,
 } from "./assumption-env.js";
 import type { OpaqueExpr } from "./pant-ast.js";
 import { getAst } from "./pant-wasm.js";
@@ -20,6 +21,10 @@ export interface DefinednessObligation {
 export interface NullishObligationInput {
   receiver: OpaqueExpr;
   inScope: readonly InScopeNonNullFact[];
+}
+
+export interface TypePredicateObligationInput {
+  inScope: readonly InScopeTypePredicateFact[];
 }
 
 export function renderDefinednessObligation(
@@ -77,6 +82,21 @@ export function renderNullishObligation(
       ? consequent
       : ast.binop(ast.opImpl(), antecedent, consequent);
   return { text: ast.strExpr(result) };
+}
+
+export function renderTypePredicateObligation(
+  input: TypePredicateObligationInput,
+): DefinednessObligation {
+  const ast = getAst();
+  if (input.inScope.some((fact) => !fact.negated && fact.tractable)) {
+    return { text: ast.strExpr(ast.litBool(true)) };
+  }
+  const antecedent = conjoin(
+    input.inScope.map((fact) =>
+      fact.negated ? ast.unop(ast.opNot(), fact.testExpr) : fact.testExpr,
+    ),
+  );
+  return { text: ast.strExpr(antecedent ?? ast.litBool(false)) };
 }
 
 function discriminantEquality(

--- a/tools/ts2pant/src/ir1-build-body.ts
+++ b/tools/ts2pant/src/ir1-build-body.ts
@@ -69,6 +69,7 @@ import {
   negateFact,
   recognizeNarrowingPredicate,
   recognizeNullishNarrowing,
+  recognizeTypePredicateNarrowing,
 } from "./narrowing-recognizer.js";
 import type { OpaquePolicy } from "./opaque.js";
 import type { OpaqueExpr } from "./pant-ast.js";
@@ -184,6 +185,7 @@ function recognizeBranchFact(
 ): Fact | null {
   return (
     recognizeNullishNarrowing(test, checker) ??
+    recognizeTypePredicateNarrowing(test, checker) ??
     recognizeNarrowingPredicate(test, checker)
   );
 }

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -43,11 +43,13 @@ import {
   nonNullFactInScope,
   pushFact,
   queryFact,
+  typePredicateFactsInScope,
 } from "./assumption-env.js";
 import { lookupBuiltinByCall } from "./builtins.js";
 import {
   renderDefinednessObligation,
   renderNullishObligation,
+  renderTypePredicateObligation,
 } from "./definedness-obligation.js";
 import { lowerExpr } from "./ir-emit.js";
 import {
@@ -83,6 +85,7 @@ import {
   recognizeNarrowingFromSwitchCase,
   recognizeNarrowingPredicate,
   recognizeNullishNarrowing,
+  recognizeTypePredicateNarrowing,
 } from "./narrowing-recognizer.js";
 import {
   getOperandDeclaredType,
@@ -226,6 +229,7 @@ function recognizeBranchFact(
 ): Fact | null {
   return (
     recognizeNullishNarrowing(test, checker) ??
+    recognizeTypePredicateNarrowing(test, checker) ??
     recognizeNarrowingPredicate(test, checker)
   );
 }
@@ -257,14 +261,21 @@ function narrowNullableIdentifierRead(
     ...fact,
     receiver: ctx.paramNames.get(fact.receiver) ?? fact.receiver,
   }));
-  if (!inScope.some((fact) => !fact.negated)) {
+  if (inScope.some((fact) => !fact.negated)) {
+    ctx.supply.synthCell?.definednessObligations.push(
+      renderNullishObligation({
+        receiver: lowerExpr(lowerL1Expr(value)),
+        inScope,
+      }),
+    );
+    return ir1App(value, [ir1LitNat(1)]);
+  }
+  const predicateInScope = typePredicateFactsInScope(env, expr.text);
+  if (!predicateInScope.some((fact) => !fact.negated && fact.tractable)) {
     return value;
   }
   ctx.supply.synthCell?.definednessObligations.push(
-    renderNullishObligation({
-      receiver: lowerExpr(lowerL1Expr(value)),
-      inScope,
-    }),
+    renderTypePredicateObligation({ inScope: predicateInScope }),
   );
   return ir1App(value, [ir1LitNat(1)]);
 }
@@ -1703,16 +1714,18 @@ export function buildL1MemberAccess(
     }
   }
 
+  const discriminantDischarge = queryDiscriminatedUnionFieldDischarge(
+    ctx,
+    receiverNode as ts.Expression,
+    receiverL1,
+    fieldName,
+    qualified,
+  );
   return ir1Member(
     receiverL1,
     qualified,
-    queryDiscriminatedUnionFieldDischarge(
-      ctx,
-      receiverNode as ts.Expression,
-      receiverL1,
-      fieldName,
-      qualified,
-    ),
+    discriminantDischarge ??
+      queryTypePredicateFieldDischarge(ctx, receiverNode as ts.Expression),
   );
 }
 
@@ -1801,6 +1814,31 @@ function queryDiscriminatedUnionFieldDischarge(
     );
   }
   return undefined;
+}
+
+function queryTypePredicateFieldDischarge(
+  ctx: L1BuildContext,
+  receiverNode: ts.Expression,
+): boolean | undefined {
+  const env = (ctx as { env?: L1BuildContext["env"] }).env;
+  if (env === undefined) {
+    return undefined;
+  }
+  const receiver = unwrapTransparentExpression(receiverNode);
+  if (!ts.isIdentifier(receiver)) {
+    return undefined;
+  }
+  if (isNullableTsType(getOperandDeclaredType(receiver, ctx.checker))) {
+    return undefined;
+  }
+  const inScope = typePredicateFactsInScope(env, receiver.text);
+  if (!inScope.some((fact) => !fact.negated && fact.tractable)) {
+    return undefined;
+  }
+  ctx.supply.synthCell?.definednessObligations.push(
+    renderTypePredicateObligation({ inScope }),
+  );
+  return true;
 }
 
 // ---------------------------------------------------------------------------

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -293,17 +293,15 @@ function rebindTypePredicateFacts(
     return [...facts];
   }
   const ast = getAst();
+  const substitutions = [...ctx.paramNames.entries()]
+    .filter(([sourceName, pantName]) => sourceName !== pantName)
+    .reverse();
   return facts.map((fact) => {
-    let testExpr = fact.testExpr;
-    for (const [sourceName, pantName] of ctx.paramNames) {
-      if (sourceName !== pantName) {
-        testExpr = ast.substituteBinder(
-          testExpr,
-          sourceName,
-          ast.var(pantName),
-        );
-      }
-    }
+    const testExpr = substitutions.reduce(
+      (acc, [sourceName, pantName]) =>
+        ast.substituteBinder(acc, sourceName, ast.var(pantName)),
+      fact.testExpr,
+    );
     return {
       ...fact,
       receiver: ctx.paramNames.get(fact.receiver) ?? fact.receiver,

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -40,6 +40,7 @@ import {
   enterFrame,
   exitFrame,
   type Fact,
+  type InScopeTypePredicateFact,
   nonNullFactInScope,
   pushFact,
   queryFact,
@@ -100,6 +101,7 @@ import {
   type OpaquePolicy,
 } from "./opaque.js";
 import type { OpaqueExpr } from "./pant-ast.js";
+import { getAst } from "./pant-wasm.js";
 import { isStaticallyBoolTyped } from "./purity.js";
 import type {
   MuSearch,
@@ -270,7 +272,10 @@ function narrowNullableIdentifierRead(
     );
     return ir1App(value, [ir1LitNat(1)]);
   }
-  const predicateInScope = typePredicateFactsInScope(env, expr.text);
+  const predicateInScope = rebindTypePredicateFacts(
+    ctx,
+    typePredicateFactsInScope(env, expr.text),
+  );
   if (!predicateInScope.some((fact) => !fact.negated && fact.tractable)) {
     return value;
   }
@@ -278,6 +283,33 @@ function narrowNullableIdentifierRead(
     renderTypePredicateObligation({ inScope: predicateInScope }),
   );
   return ir1App(value, [ir1LitNat(1)]);
+}
+
+function rebindTypePredicateFacts(
+  ctx: L1BuildContext,
+  facts: readonly InScopeTypePredicateFact[],
+): InScopeTypePredicateFact[] {
+  if (facts.length === 0 || ctx.paramNames.size === 0) {
+    return [...facts];
+  }
+  const ast = getAst();
+  return facts.map((fact) => {
+    let testExpr = fact.testExpr;
+    for (const [sourceName, pantName] of ctx.paramNames) {
+      if (sourceName !== pantName) {
+        testExpr = ast.substituteBinder(
+          testExpr,
+          sourceName,
+          ast.var(pantName),
+        );
+      }
+    }
+    return {
+      ...fact,
+      receiver: ctx.paramNames.get(fact.receiver) ?? fact.receiver,
+      testExpr,
+    };
+  });
 }
 
 function isSingletonExtraction(expr: IR1Expr): boolean {
@@ -1831,7 +1863,10 @@ function queryTypePredicateFieldDischarge(
   if (isNullableTsType(getOperandDeclaredType(receiver, ctx.checker))) {
     return undefined;
   }
-  const inScope = typePredicateFactsInScope(env, receiver.text);
+  const inScope = rebindTypePredicateFacts(
+    ctx,
+    typePredicateFactsInScope(env, receiver.text),
+  );
   if (!inScope.some((fact) => !fact.negated && fact.tractable)) {
     return undefined;
   }

--- a/tools/ts2pant/src/narrowing-recognizer.ts
+++ b/tools/ts2pant/src/narrowing-recognizer.ts
@@ -8,7 +8,12 @@ import {
   isTranslateExprUnsupported,
   translateExpr,
 } from "./translate-signature.js";
-import { IntStrategy } from "./translate-types.js";
+import {
+  detectDiscriminatedUnion,
+  IntStrategy,
+  isUnsupportedUnknown,
+  mapTsType,
+} from "./translate-types.js";
 
 type LiteralValue = string;
 
@@ -147,7 +152,19 @@ export function recognizeTypePredicateNarrowing(
     return null;
   }
   const signature = checker.getResolvedSignature(unwrapped);
-  if (!signature || !checker.getTypePredicateOfSignature(signature)) {
+  const predicate = signature
+    ? checker.getTypePredicateOfSignature(signature)
+    : undefined;
+  if (
+    !signature ||
+    !predicate ||
+    predicate.kind !== ts.TypePredicateKind.Identifier ||
+    predicate.type === undefined
+  ) {
+    return null;
+  }
+  const argument = unwrapped.arguments[predicate.parameterIndex];
+  if (argument === undefined || !ts.isIdentifier(unwrapParens(argument))) {
     return null;
   }
   const translated = translateExpr(
@@ -162,7 +179,23 @@ export function recognizeTypePredicateNarrowing(
   return {
     kind: "predicate",
     testExpr: translated,
+    typePredicate: {
+      receiver: unwrapParens(argument).getText(),
+      negated: false,
+      tractable: isTractableTypePredicateTarget(predicate.type, checker),
+    },
   };
+}
+
+function isTractableTypePredicateTarget(
+  type: ts.Type,
+  checker: ts.TypeChecker,
+): boolean {
+  if (detectDiscriminatedUnion(type, checker) !== null) {
+    return false;
+  }
+  const mapped = mapTsType(type, checker, IntStrategy, undefined);
+  return !isUnsupportedUnknown(mapped);
 }
 
 /** Recognize a TypeScript boolean test as a narrowing fact. */
@@ -221,5 +254,13 @@ export function negateFact(fact: Fact): Fact {
   return {
     kind: "predicate",
     testExpr: ast.unop(ast.opNot(), fact.testExpr),
+    ...(fact.typePredicate === undefined
+      ? {}
+      : {
+          typePredicate: {
+            ...fact.typePredicate,
+            negated: !fact.typePredicate.negated,
+          },
+        }),
   };
 }

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -67,6 +67,7 @@ import {
   negateFact,
   recognizeNarrowingPredicate,
   recognizeNullishNarrowing,
+  recognizeTypePredicateNarrowing,
 } from "./narrowing-recognizer.js";
 import {
   getOperandDeclaredType,
@@ -128,6 +129,7 @@ function recognizeBranchFact(
 ): Fact | null {
   return (
     recognizeNullishNarrowing(test, checker) ??
+    recognizeTypePredicateNarrowing(test, checker) ??
     recognizeNarrowingPredicate(test, checker)
   );
 }
@@ -2617,7 +2619,9 @@ function lowerPreludeBindings(
               ? [...supply.synthCell.definednessObligations]
               : null;
             const l1Value =
-              currentFact?.kind === "non-null"
+              currentFact?.kind === "non-null" ||
+              (currentFact?.kind === "predicate" &&
+                currentFact.typePredicate !== undefined)
                 ? buildL1SubExpr(binding.valueExpr, {
                     checker,
                     strategy,

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -814,6 +814,14 @@ exports[`expressions-optional-default.ts > usesOptionalDirectly 1`] = `
 "module USES_OPTIONAL_DIRECTLY.\\n\\nuses-optional-directly value: [Int] => Int.\\n\\n---\\n\\nuses-optional-directly value = (cond #value = 0 => 0 + (cond #value = 0 => 1, true => value 1), true => value 1).\\n"
 `;
 
+exports[`expressions-predicate-narrowing.ts > predicateCircleRadius 1`] = `
+"module PREDICATE_CIRCLE_RADIUS.\\n\\nShape.\\nshape--kind s: Shape => String.\\nshape--r s: Shape, shape--kind s = \\"circle\\" => Int.\\nshape--s s: Shape, shape--kind s = \\"square\\" => Int.\\nis-circle s2: Shape => Bool.\\npredicate-circle-radius s1: Shape => Int.\\n\\n---\\n\\nall s: Shape | shape--kind s = \\"circle\\" or shape--kind s = \\"square\\".\\npredicate-circle-radius s1 = (cond is-circle s1 => shape--r s1, true => 0).\\n\\ncheck\\n\\nshape--kind s1 = \\"circle\\".\\nshape--kind s1 = \\"circle\\".\\n"
+`;
+
+exports[`expressions-predicate-narrowing.ts > predicateValue 1`] = `
+"module PREDICATE_VALUE.\\n\\nis-number x1: [Int] => Bool.\\npredicate-value x: [Int], fallback: Int => Int.\\n\\n---\\n\\npredicate-value x fallback = (cond is-number x => x 1, true => fallback).\\n\\ncheck\\n\\ntrue.\\npredicate-value x fallback = (cond is-number x => x 1, true => fallback).\\n"
+`;
+
 exports[`expressions-property-element-access.ts > effectiveBalanceByLiteral 1`] = `
 "module EFFECTIVE_BALANCE_BY_LITERAL.\\n\\nUser.\\nuser--name u: User => String.\\nAccount.\\naccount--balance a1: Account => Int.\\naccount--owner a1: Account => User.\\naccount--active a1: Account => Bool.\\neffective-balance-by-literal a: Account => Int.\\n\\n---\\n\\neffective-balance-by-literal a = (cond account--active a => account--balance a, true => 0).\\n"
 `;

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-predicate-narrowing.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-predicate-narrowing.ts
@@ -1,0 +1,25 @@
+function isNumber(x: number | null): x is number {
+  return true;
+}
+
+/**
+ * @pant predicate-value x fallback = cond is-number x => x 1, true => fallback.
+ */
+export function predicateValue(x: number | null, fallback: number): number {
+  if (isNumber(x)) return x;
+  return fallback;
+}
+
+type Shape = { kind: "circle"; r: number } | { kind: "square"; s: number };
+
+function isCircle(s: Shape): s is Extract<Shape, { kind: "circle" }> {
+  return false;
+}
+
+/**
+ * @pant shape--kind s = "circle".
+ */
+export function predicateCircleRadius(s: Shape): number {
+  if (isCircle(s)) return s.r;
+  return 0;
+}

--- a/tools/ts2pant/tests/helpers.mts
+++ b/tools/ts2pant/tests/helpers.mts
@@ -2,14 +2,14 @@ import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import {
+  type CheckOptions,
   emitDocument,
   runCheck as runCheckWithOptions,
-  type CheckOptions,
 } from "../src/emit.js";
 import { createSourceFile, type SourceFile } from "../src/extract.js";
+import type { OpaquePolicy } from "../src/opaque.js";
 import { assertWasmTypeChecks } from "../src/pant-wasm.js";
 import { buildPantDocument } from "../src/pipeline.js";
-import type { OpaquePolicy } from "../src/opaque.js";
 import { IntStrategy } from "../src/translate-types.js";
 import type { PantDocument } from "../src/types.js";
 
@@ -52,6 +52,15 @@ export function getPantBin(): string {
   }
   cachedPantBin = binPath;
   return binPath;
+}
+
+export function solverAvailable(): boolean {
+  try {
+    execFileSync("z3", ["-version"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export function assertPantTypeChecks(output: string, timeoutMs = 30_000): void {

--- a/tools/ts2pant/tests/integration/dogfood.test.mts
+++ b/tools/ts2pant/tests/integration/dogfood.test.mts
@@ -534,6 +534,11 @@ describe("dogfood: @pant annotations entail", () => {
       fn: "earlyReturnComplement",
       minChecks: 1,
     },
+    {
+      file: resolve(FIXTURES, "expressions-predicate-narrowing.ts"),
+      fn: "predicateValue",
+      minChecks: 2,
+    },
   ];
 
   for (const { file, fn, minChecks } of annotated) {
@@ -790,6 +795,36 @@ describe("dogfood: nullish definedness", () => {
           /UNKNOWN: Entailed:/u.test(result.output),
         result.output,
       );
+    },
+  );
+});
+
+describe("dogfood: predicate definedness", () => {
+  const hasSolver = solverAvailable();
+
+  it(
+    "intractable type-predicate read is not discharged",
+    { skip: !hasSolver ? "z3 not available" : undefined },
+    async () => {
+      const doc = await buildDocumentFromPath(
+        resolve(FIXTURES, "expressions-predicate-narrowing.ts"),
+        "predicateCircleRadius",
+      );
+      const output = await emitAndCheck(doc);
+      const result = runCheck(output, {
+        projectRoot: PROJECT_ROOT,
+        pantBin: getPantBin(),
+      });
+      const entailments = result.checks.filter((c) =>
+        c.message.startsWith("OK: Entailed:") ||
+        c.message.startsWith("FAIL: Not entailed:"),
+      );
+      assert.ok(
+        entailments.length >= 1,
+        `expected at least one entailment result, got ${entailments.length}`,
+      );
+      assert.equal(result.passed, false, result.output);
+      assert.ok(entailments.some((c) => !c.passed), result.output);
     },
   );
 });

--- a/tools/ts2pant/tests/integration/dogfood.test.mts
+++ b/tools/ts2pant/tests/integration/dogfood.test.mts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { describe, it } from "node:test";
 import { emitDocument, runCheck } from "../../src/emit.js";
@@ -9,16 +8,8 @@ import {
   emitAndCheck,
   getPantBin,
   PROJECT_ROOT,
+  solverAvailable,
 } from "../helpers.mjs";
-
-function solverAvailable(): boolean {
-  try {
-    execFileSync("z3", ["-version"], { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
-}
 
 // Dogfood: translate ts2pant's own source files with ts2pant itself.
 // Depth-first — one target module at a time, smallest function first.

--- a/tools/ts2pant/tests/predicate-narrowing.test.mts
+++ b/tools/ts2pant/tests/predicate-narrowing.test.mts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { before, describe, it } from "node:test";
 import ts from "typescript";
@@ -12,18 +11,10 @@ import {
   emitAndCheck,
   getPantBin,
   PROJECT_ROOT,
+  solverAvailable,
 } from "./helpers.mts";
 
 const FIXTURES = resolve(import.meta.dirname, "fixtures/constructs");
-
-function solverAvailable(): boolean {
-  try {
-    execFileSync("z3", ["-version"], { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
-}
 
 before(async () => {
   await loadAst();

--- a/tools/ts2pant/tests/predicate-narrowing.test.mts
+++ b/tools/ts2pant/tests/predicate-narrowing.test.mts
@@ -1,9 +1,29 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
 import { before, describe, it } from "node:test";
 import ts from "typescript";
+import { runCheck } from "../src/emit.js";
 import { createSourceFileFromSource, getChecker } from "../src/extract.js";
 import { recognizeTypePredicateNarrowing } from "../src/narrowing-recognizer.js";
 import { getAst, loadAst } from "../src/pant-wasm.js";
+import {
+  buildDocument,
+  emitAndCheck,
+  getPantBin,
+  PROJECT_ROOT,
+} from "./helpers.mts";
+
+const FIXTURES = resolve(import.meta.dirname, "fixtures/constructs");
+
+function solverAvailable(): boolean {
+  try {
+    execFileSync("z3", ["-version"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 before(async () => {
   await loadAst();
@@ -46,6 +66,10 @@ describe("predicate narrowing helpers", () => {
       fact?.kind === "predicate" ? getAst().strExpr(fact.testExpr) : null,
       "isUser x",
     );
+    assert.deepEqual(
+      fact?.kind === "predicate" ? fact.typePredicate : undefined,
+      { receiver: "x", negated: false, tractable: true },
+    );
   });
 
   it("recognizeTypePredicateNarrowing ignores ordinary boolean calls", () => {
@@ -78,13 +102,43 @@ describe("predicate narrowing helpers", () => {
     );
   });
 
-  it.skip(
-    "tractable x is T refinement is discharged (@pant entails) — PENDING: Patch 3",
-    () => {},
-  );
+  it("tractable x is T refinement is discharged (@pant entails)", {
+    skip: !solverAvailable() ? "z3 not available" : undefined,
+  }, async () => {
+    const doc = await buildDocument(
+      resolve(FIXTURES, "expressions-predicate-narrowing.ts"),
+      "predicateValue",
+    );
+    const output = await emitAndCheck(doc);
+    assert.match(output, /^true\.$/mu);
+    const result = runCheck(output, {
+      projectRoot: PROJECT_ROOT,
+      pantBin: getPantBin(),
+    });
+    assert.equal(result.passed, true, result.output);
+    assert.ok(
+      result.checks.some((c) => c.message.startsWith("OK: Entailed:")),
+      result.output,
+    );
+  });
 
-  it.skip(
-    "cross-call/opaque x is T is soundly not discharged — PENDING: Patch 3",
-    () => {},
-  );
+  it("cross-call/opaque x is T is soundly not discharged", {
+    skip: !solverAvailable() ? "z3 not available" : undefined,
+  }, async () => {
+    const doc = await buildDocument(
+      resolve(FIXTURES, "expressions-predicate-narrowing.ts"),
+      "predicateCircleRadius",
+    );
+    const output = await emitAndCheck(doc);
+    assert.doesNotMatch(output, /^true\.$/mu);
+    const result = runCheck(output, {
+      projectRoot: PROJECT_ROOT,
+      pantBin: getPantBin(),
+    });
+    assert.equal(result.passed, false, result.output);
+    assert.ok(
+      result.checks.some((c) => c.message.startsWith("FAIL: Not entailed:")),
+      result.output,
+    );
+  });
 });


### PR DESCRIPTION
## Patch 3: User type-predicate narrowing (tractable subset, sound bail)

- Call recognizeTypePredicateNarrowing alongside the other recognizers so type-predicate facts are pushed at branch boundaries.
- At the refined-type read, discharge only the tractable subset; bail soundly (no discharge, no false positive) when cross-call narrowing or the opaque encoding would be required.
- Do not introduce any cross-call body-following; keep narrowing intra-function.
- Create expressions-predicate-narrowing.ts with a tractable (entails) and an intractable (does not entail, not falsely discharged) case; implement the Patch 1 predicate integration stubs.
- Wire fixtures into dogfood suites; regenerate snapshots; confirm the tractable read entails and the intractable read does not under `pant --check`.

## Changes
- Call recognizeTypePredicateNarrowing alongside the other recognizers so type-predicate facts are pushed at branch boundaries.
- At the refined-type read, discharge only the tractable subset; bail soundly (no discharge, no false positive) when cross-call narrowing or the opaque encoding would be required.
- Do not introduce any cross-call body-following; keep narrowing intra-function.
- Create expressions-predicate-narrowing.ts with a tractable (entails) and an intractable (does not entail, not falsely discharged) case; implement the Patch 1 predicate integration stubs.
- Wire fixtures into dogfood suites; regenerate snapshots; confirm the tractable read entails and the intractable read does not under `pant --check`.

## Files to Modify
- tools/ts2pant/src/ir1-build.ts (modify): Wire recognizeTypePredicateNarrowing into the fact-recognition site so an `if (isFoo(x))` / early-return guard pushes the type-predicate fact. At the refined-type read site, discharge for the tractable subset (no cross-call body-following, no opaque-type representation needed); otherwise leave the read un-narrowed (sound bail) and never claim a discharge. Honor the intra-function boundary: do not follow into the predicate body.
- tools/ts2pant/tests/fixtures/constructs/expressions-predicate-narrowing.ts (create): Fixtures with @pant annotations: a tractable `isFoo(x)` guard whose refined-type read entails, and an intractable case (predicate refining to a DU variant or a type needing the opaque encoding) whose read is soundly NOT discharged (does not entail) and is not falsely discharged.
- tools/ts2pant/tests/predicate-narrowing.test.mts (modify): Un-skip and implement the tractable-discharge and intractable-sound-bail @pant integration stubs.
- tools/ts2pant/tests/integration/dogfood.test.mts (modify): Add the tractable type-predicate fixture to the `@pant annotations entail` suite and the intractable case to the not-entailed suite.
- tools/ts2pant/tests/constructs.test.mts.snapshot (modify): Regenerate; diff is the tractable type-predicate-narrowed read (discharged) and the intractable read staying un-narrowed.

## Gameplan Specification

```
module NULLISH_PRED_NARROWING.

> ══════════════════════════════
> THE GUARANTEE
> ═══════════════════════════════
> After M3b the assumption environment carries two new intra-function
> narrowing facts on top of M3a's discriminant fact. A nullish guard makes
> a read of the optional value inside it extract the singleton with a
> discharged cardinality obligation (un-narrowed reads unchanged). A user
> type-predicate guard discharges the refined-type read for the tractable
> subset and is soundly left undischarged — never falsely discharged — for
> cases needing cross-call narrowing or the unlanded any/unknown-opaque
> encoding. No field-name special-casing; no cross-call body-following.

Fact.
Expr.
Pred.
non-null-variant f: Fact => Bool.
optional-read e: Expr => Bool.
in-nonnull-guard e: Expr => Bool.
extracts-singleton e: Expr => Bool.
discharged-read e: Expr => Bool.
type-predicate p: Pred => Bool.
tractable p: Pred => Bool.
discharged-pred p: Pred => Bool.
falsely-discharged p: Pred => Bool.
intra-function p: Pred => Bool.

---

> Nullish: an optional read inside a non-null guard extracts the singleton
> and is discharged; outside any guard it is unchanged.
all e: Expr | (optional-read e and in-nonnull-guard e) -> (extracts-singleton e and discharged-read e).
all e: Expr | (optional-read e and ~(in-nonnull-guard e)) -> (~(extracts-singleton e) and ~(discharged-read e)).

> Type-predicate: tractable refinements discharge, intractable ones do not,
> and none is ever falsely discharged; narrowing stays intra-function.
all p: Pred | (type-predicate p and tractable p) -> discharged-pred p.
all p: Pred | (type-predicate p and ~(tractable p)) -> ~(discharged-pred p).
all p: Pred | ~(falsely-discharged p).
all p: Pred | type-predicate p -> intra-function p.
```

## Patch Specification

```
module NULLISH_PRED_NARROWING_PATCH_3.

> Patch 3 adds user type-predicate narrowing for the tractable subset: an
> `x is T` call pushes a fact; a refined-type read is discharged only when
> no cross-call or opaque-type knowledge is required, and is soundly left
> undischarged (never falsely discharged) otherwise.

Pred.
type-predicate p: Pred => Bool.
tractable p: Pred => Bool.
discharged p: Pred => Bool.
falsely-discharged p: Pred => Bool.

---

> A tractable type-predicate refinement is discharged; an intractable one
> (needs cross-call narrowing or the unlanded opaque encoding) is not.
all p: Pred | (type-predicate p and tractable p) -> discharged p.
all p: Pred | (type-predicate p and ~(tractable p)) -> ~(discharged p).

> Soundness: no type-predicate fact is ever falsely discharged.
all p: Pred | ~(falsely-discharged p).
```


## Implementation Notes

- Type-predicate facts are still stored as the existing `predicate` fact kind, with receiver metadata added only when the resolved signature has an `Identifier` type predicate and the guarded argument is a simple identifier. This keeps generic boolean predicate facts unchanged while giving the discharge site enough structure to stay intra-function.
- The tractable positive case is deliberately scoped to optional-value extraction under a predicate such as `x is number` for `x: number | null`. That mirrors the nullish singleton extraction path and avoids inventing a general Pant coercion from a union/sum value into an arbitrary refined object/domain type.
- Intractable DU predicate narrowing is left to the existing DU definedness obligation. For `isCircle(s)` followed by `s.r`, the emitted check remains `shape--kind s = "circle"` rather than being discharged from the predicate call, so the negative fixture proves we did not falsely learn the predicate body.
- The implementation does not inspect user predicate bodies for narrowing facts. It uses TypeScript's resolved signature only to classify the call and target type; pure local predicate bodies in the fixture are present so ts2pant's existing side-effect gate accepts the guard call, not so the narrowing layer can follow the body.

Spec/Evidence Mapping:
- `type-predicate p -> intra-function p`: `recognizeTypePredicateNarrowing` records only the call expression, identifier argument, and signature predicate metadata; branch wiring is in `ir1-build.ts`, `ir1-build-body.ts`, and early-return lowering in `translate-body.ts`. Context: CR-assumption-env, CR-type-predicate-detection, CR-discharge-site. Evidence: `just ts2pant-precommit`.
- `(type-predicate p and tractable p) -> discharged p`: optional predicate-narrowed reads route through L1 and `narrowNullableIdentifierRead`, emit `renderTypePredicateObligation`, and lower to singleton extraction. Evidence: `predicateValue` fixture, `predicate-narrowing.test.mts`, constructs snapshot, and dogfood `@pant annotations entail`.
- `(type-predicate p and ~(tractable p)) -> ~(discharged p)` plus no false discharge: DU variant predicate reads are not converted into discriminant facts and keep their undisched DU obligation. Evidence: `predicateCircleRadius` fixture, `predicate-narrowing.test.mts` negative case, and dogfood `predicate definedness` not-entailed check.