### PR TITLE
[ts2pant-opaque-opt-in] Patch 3: Body-level OpaqueValue emission and opacity contagion under policy opaque

### DIFF
--- a/tools/ts2pant/src/ir1-build-body.ts
+++ b/tools/ts2pant/src/ir1-build-body.ts
@@ -57,6 +57,7 @@ import {
 } from "./ir1.js";
 import {
   buildL1MemberAccess,
+  contagiousOpaqueForOperands,
   elementAccessLiteralKey,
   isCollectionMutationCall,
   isL1Unsupported,
@@ -68,6 +69,7 @@ import {
   negateFact,
   recognizeNarrowingPredicate,
 } from "./narrowing-recognizer.js";
+import type { OpaquePolicy } from "./opaque.js";
 import type { OpaqueExpr } from "./pant-ast.js";
 import {
   ambiguousFieldMsg,
@@ -117,6 +119,7 @@ export interface BuildBodyCtx {
   state: SymbolicState;
   supply: UniqueSupply;
   env: AssumptionEnv;
+  policy?: OpaquePolicy | undefined;
   recognitionHook?: (env: AssumptionEnv, location: string) => void;
   /**
    * When set, this build is inside a foreach loop body. Carries the
@@ -805,6 +808,7 @@ export function buildL1SubExpr(
       state: ctx.state,
       supply: ctx.supply,
       env: ctx.env,
+      policy: ctx.policy,
     };
     const card = tryBuildL1Cardinality(stripped, ctxOptions, l1Options);
     if (card !== null) {
@@ -823,6 +827,7 @@ export function buildL1SubExpr(
     state: ctx.state,
     supply: ctx.supply,
     env: ctx.env,
+    policy: ctx.policy,
   });
   if (native !== null) {
     return native;
@@ -1448,7 +1453,12 @@ export function buildL1AssignStmt(
     }
     const rhs: IR1Expr =
       compoundOp !== undefined
-        ? { kind: "binop", op: irOp!, lhs: target, rhs: rhsExpr }
+        ? (contagiousOpaqueForOperands(ctx, [target, rhsExpr], expr) ?? {
+            kind: "binop",
+            op: irOp!,
+            lhs: target,
+            rhs: rhsExpr,
+          })
         : rhsExpr;
     return ir1Assign(target, rhs);
   }

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -64,10 +64,13 @@ import {
   ir1LitString,
   ir1MapRead,
   ir1Member,
+  ir1Opaque,
+  ir1OpaqueOriginId,
   ir1SetRead,
   ir1Unop,
   ir1Var,
   ir1While,
+  type SourceRef,
 } from "./ir1.js";
 import { lowerL1Expr } from "./ir1-lower.js";
 import { substituteIR1ExprSubtree } from "./ir1-substitute.js";
@@ -83,7 +86,11 @@ import {
   recognizeNullishForm,
   unwrapTransparentExpression,
 } from "./nullish-recognizer.js";
-import type { OpaquePolicy } from "./opaque.js";
+import {
+  contagiousOpaque,
+  OPAQUE_DOMAIN,
+  type OpaquePolicy,
+} from "./opaque.js";
 import type { OpaqueExpr } from "./pant-ast.js";
 import { isStaticallyBoolTyped } from "./purity.js";
 import type {
@@ -104,6 +111,7 @@ import {
 import {
   cellRegisterMap,
   cellRegisterName,
+  cellRegisterOpaqueValue,
   type DiscriminantLiteral,
   detectDiscriminatedUnion,
   fieldRuleName,
@@ -120,6 +128,60 @@ import {
   type ExtractedBlockReturn,
   extractBlockReturn,
 } from "./ts-ast-block-return.js";
+
+function sourceRefForNode(node: ts.Node): SourceRef {
+  const sf = node.getSourceFile();
+  const pos = sf.getLineAndCharacterOfPosition(node.getStart(sf, false));
+  return {
+    file: sf.fileName.split(/[\\/]/u).pop() ?? sf.fileName,
+    line: pos.line + 1,
+  };
+}
+
+function registerOpaqueValueForOrigin(
+  ctx: Pick<L1BuildContext, "supply">,
+  origin: SourceRef,
+): void {
+  if (ctx.supply.synthCell !== undefined) {
+    cellRegisterOpaqueValue(ctx.supply.synthCell, ir1OpaqueOriginId(origin));
+  }
+}
+
+function isDynamicTsType(type: ts.Type): boolean {
+  return (type.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0;
+}
+
+function opaqueValueForDynamicExpr(
+  expr: ts.Expression,
+  ctx: L1BuildContext,
+): IR1Expr | null {
+  if (ctx.policy !== "opaque") {
+    return null;
+  }
+  const type = getOperandDeclaredType(expr, ctx.checker);
+  if (!isDynamicTsType(type)) {
+    return null;
+  }
+  const origin = sourceRefForNode(expr);
+  registerOpaqueValueForOrigin(ctx, origin);
+  return ir1Opaque(OPAQUE_DOMAIN, origin);
+}
+
+export function contagiousOpaqueForOperands(
+  ctx: Pick<L1BuildContext, "policy" | "supply">,
+  operands: readonly IR1Expr[],
+  originNode: ts.Node,
+): IR1Expr | null {
+  if (ctx.policy !== "opaque") {
+    return null;
+  }
+  const origin = sourceRefForNode(originNode);
+  const opaque = contagiousOpaque(operands, origin);
+  if (opaque !== null) {
+    registerOpaqueValueForOrigin(ctx, origin);
+  }
+  return opaque;
+}
 
 /**
  * Context threaded through L1 build. Mirrors the parameter set of
@@ -235,6 +297,10 @@ export function tryBuildBuiltinCall(
     }
   }
   ctx.supply.synthCell?.imports.add(spec.mod);
+  const opaque = contagiousOpaqueForOperands(ctx, args, expr);
+  if (opaque !== null) {
+    return opaque;
+  }
   return ir1App(ir1Var(rule), args);
 }
 
@@ -625,6 +691,10 @@ export function tryBuildL1PureSubExpression(
       innerMember?.methodName === "get" &&
       isMapUnionType(ctx.checker.getTypeAtLocation(innerMember.receiver));
     if (isNullableTsType(receiverTsType) && !isMapGetCall) {
+      const opaque = contagiousOpaqueForOperands(ctx, [inner], expr);
+      if (opaque !== null) {
+        return opaque;
+      }
       return ir1App(inner, [ir1LitNat(1)]);
     }
     return inner;
@@ -654,9 +724,17 @@ export function tryBuildL1PureSubExpression(
     return tryBuildL1TemplateExpression(expr, ctx);
   }
   if (ts.isIdentifier(expr)) {
+    const opaque = opaqueValueForDynamicExpr(expr, ctx);
+    if (opaque !== null) {
+      return opaque;
+    }
     return ir1Var(ctx.paramNames.get(expr.text) ?? expr.text);
   }
   if (expr.kind === ts.SyntaxKind.ThisKeyword) {
+    const opaque = opaqueValueForDynamicExpr(expr as ts.Expression, ctx);
+    if (opaque !== null) {
+      return opaque;
+    }
     return ir1Var(ctx.paramNames.get("this") ?? "this");
   }
   if (isL1ConditionalForm(expr, ctx.checker)) {
@@ -696,6 +774,10 @@ export function tryBuildL1PureSubExpression(
     const operand = tryBuildL1PureSubExpression(expr.operand, ctx);
     if (operand === null || isL1Unsupported(operand)) {
       return operand;
+    }
+    const opaque = contagiousOpaqueForOperands(ctx, [operand], expr);
+    if (opaque !== null) {
+      return opaque;
     }
     return ir1Unop(op, operand);
   }
@@ -739,6 +821,14 @@ export function tryBuildL1PureSubExpression(
       const present = isNullableTsType(rightTsType)
         ? left
         : ir1App(left, [ir1LitNat(1)]);
+      const opaque = contagiousOpaqueForOperands(
+        ctx,
+        [left, right, present],
+        expr,
+      );
+      if (opaque !== null) {
+        return opaque;
+      }
       return ir1Cond([[ir1IsNullish(left), right]], present);
     }
     let op = binaryOperatorToL1(expr.operatorToken.kind);
@@ -767,6 +857,10 @@ export function tryBuildL1PureSubExpression(
     const right = tryBuildL1PureSubExpression(expr.right, ctx);
     if (right === null || isL1Unsupported(right)) {
       return right;
+    }
+    const opaque = contagiousOpaqueForOperands(ctx, [left, right], expr);
+    if (opaque !== null) {
+      return opaque;
     }
     return ir1Binop(op, left, right);
   }
@@ -840,6 +934,10 @@ export function tryBuildL1PureSubExpression(
               );
             }
           }
+          const opaque = contagiousOpaqueForOperands(ctx, [elem, source], expr);
+          if (opaque !== null) {
+            return opaque;
+          }
           return ir1Binop("in", elem, source);
         }
       }
@@ -882,6 +980,14 @@ export function tryBuildL1PureSubExpression(
             }
           }
           const callee = methodName === "has" ? keyPredName : ruleName;
+          const opaque = contagiousOpaqueForOperands(
+            ctx,
+            [receiver.receiver, key],
+            expr,
+          );
+          if (opaque !== null) {
+            return opaque;
+          }
           return ir1App(ir1Var(callee), [receiver.receiver, key]);
         }
         // For union receivers (`Map<K, V> | ReadonlyMap<K, V>`), pick
@@ -962,6 +1068,10 @@ export function tryBuildL1PureSubExpression(
         }
         const callee =
           methodName === "has" ? info.names.keyPred : info.names.rule;
+        const opaque = contagiousOpaqueForOperands(ctx, [receiver, key], expr);
+        if (opaque !== null) {
+          return opaque;
+        }
         return ir1App(ir1Var(callee), [receiver, key]);
       }
     }
@@ -998,6 +1108,10 @@ export function tryBuildL1PureSubExpression(
         return builtArg;
       }
       args.push(builtArg);
+    }
+    const opaque = contagiousOpaqueForOperands(ctx, [callee, ...args], expr);
+    if (opaque !== null) {
+      return opaque;
     }
     return ir1App(callee, args);
   }
@@ -1047,6 +1161,10 @@ function buildL1Stringification(
     isNullableTsType(declaredTsType) && !isNullableTsType(tsType)
       ? ir1App(inner, [ir1LitNat(1)])
       : inner;
+  const opaque = contagiousOpaqueForOperands(ctx, [value], expr);
+  if (opaque !== null) {
+    return opaque;
+  }
   const pantType = mapTsType(
     tsType,
     ctx.checker,
@@ -1080,7 +1198,13 @@ function buildL1Stringification(
   }
   ctx.supply.synthCell.imports.add("TS_PRELUDE");
   const ruleName = pantType === "Int" ? "int-to-string" : "real-to-string";
-  return ir1App(ir1Var(ruleName), [value]);
+  {
+    const opaque = contagiousOpaqueForOperands(ctx, [value], expr);
+    if (opaque !== null) {
+      return opaque;
+    }
+    return ir1App(ir1Var(ruleName), [value]);
+  }
 }
 
 function tryBuildL1TemplateExpression(
@@ -1113,7 +1237,10 @@ function tryBuildL1TemplateExpression(
   }
   // Left-fold `+` chain. With Pant's `(String, String) → String` overload
   // landed (PR #170), each `add` lowers to `(str.++ a b)` in SMT.
-  return parts.reduce((acc, p) => ir1Binop("add", acc, p));
+  return parts.reduce((acc, p) => {
+    const opaque = contagiousOpaqueForOperands(ctx, [acc, p], expr);
+    return opaque ?? ir1Binop("add", acc, p);
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -1206,19 +1333,33 @@ export function tryBuildL1Cardinality(
   if (isMemberSurfaceForm(receiverNode)) {
     const innerCard = tryBuildL1Cardinality(receiverNode, ctx, options);
     if (innerCard !== null) {
+      const opaque = contagiousOpaqueForOperands(ctx, [innerCard], stripped);
+      if (opaque !== null) {
+        return opaque;
+      }
       return ir1Unop("card", innerCard);
     }
     const inner = buildL1MemberAccess(receiverNode, ctx, options);
     if (isL1Unsupported(inner)) {
       return null;
     }
-    return ir1Unop("card", inner);
+    {
+      const opaque = contagiousOpaqueForOperands(ctx, [inner], stripped);
+      if (opaque !== null) {
+        return opaque;
+      }
+      return ir1Unop("card", inner);
+    }
   }
   const nativeReceiver = tryBuildL1PureSubExpression(
     receiverNode as ts.Expression,
     ctx,
   );
   if (nativeReceiver !== null && !isL1Unsupported(nativeReceiver)) {
+    const opaque = contagiousOpaqueForOperands(ctx, [nativeReceiver], stripped);
+    if (opaque !== null) {
+      return opaque;
+    }
     return ir1Unop("card", nativeReceiver);
   }
   return null;
@@ -1394,6 +1535,18 @@ export function buildL1MemberAccess(
       unsupported: "buildL1MemberAccess: unsupported access shape",
     };
   }
+  const receiverDynamicOpaque =
+    ctx.policy === "opaque" && ts.isExpression(receiverNode)
+      ? opaqueValueForDynamicExpr(receiverNode, ctx)
+      : null;
+  if (receiverDynamicOpaque !== null) {
+    const opaque = contagiousOpaqueForOperands(
+      ctx,
+      [receiverDynamicOpaque],
+      stripped,
+    );
+    return opaque ?? receiverDynamicOpaque;
+  }
   const receiverType = receiverTypeForFieldAccess(
     receiverNode as ts.Expression,
     fieldName,
@@ -1454,6 +1607,11 @@ export function buildL1MemberAccess(
         unsupported: `unsupported property-access receiver: ${(receiverNode as ts.Expression).getText()}`,
       };
     }
+  }
+
+  const opaque = contagiousOpaqueForOperands(ctx, [receiverL1], stripped);
+  if (opaque !== null) {
+    return opaque;
   }
 
   // Symbolic-state lookup at the outer Member level: when a prior
@@ -2344,6 +2502,14 @@ export function buildL1ConditionalFromArms(
     if (isL1Unsupported(otherwise)) {
       return otherwise;
     }
+    const opaque = contagiousOpaqueForOperands(
+      ctx,
+      [...builtArms.flat(), otherwise],
+      terminal,
+    );
+    if (opaque !== null) {
+      return opaque;
+    }
     return ir1Cond(
       builtArms as [readonly [IR1Expr, IR1Expr], ...typeof builtArms],
       otherwise,
@@ -2362,6 +2528,14 @@ export function buildL1ConditionalFromArms(
     if (builtArms.length === 0) {
       return { unsupported: "no conditional shape to build" };
     }
+    const opaque = contagiousOpaqueForOperands(
+      ctx,
+      [...builtArms.flat(), terminalL1.otherwise],
+      terminal,
+    );
+    if (opaque !== null) {
+      return opaque;
+    }
     return ir1Cond(
       builtArms as [readonly [IR1Expr, IR1Expr], ...typeof builtArms],
       terminalL1.otherwise,
@@ -2372,6 +2546,14 @@ export function buildL1ConditionalFromArms(
   // Treat the L1 result as the otherwise.
   if (builtArms.length === 0) {
     return terminalL1;
+  }
+  const opaque = contagiousOpaqueForOperands(
+    ctx,
+    [...builtArms.flat(), terminalL1],
+    terminal,
+  );
+  if (opaque !== null) {
+    return opaque;
   }
   return ir1Cond(
     builtArms as [readonly [IR1Expr, IR1Expr], ...typeof builtArms],
@@ -2436,6 +2618,16 @@ function buildFromTernary(
   if (arms.length === 0) {
     // Cannot happen — we entered the loop because expr is a ternary.
     return { unsupported: "ternary with no arms (unreachable)" };
+  }
+  {
+    const opaque = contagiousOpaqueForOperands(
+      ctx,
+      [...arms.flat(), otherwise],
+      expr,
+    );
+    if (opaque !== null) {
+      return opaque;
+    }
   }
   return ir1Cond(
     arms as [readonly [IR1Expr, IR1Expr], ...typeof arms],
@@ -2544,6 +2736,14 @@ function buildFromIfStatement(
         unsupported: "if-statement walk produced no arms (unreachable)",
       };
     }
+    const opaque = contagiousOpaqueForOperands(
+      ctx,
+      [...arms.flat(), elseValue],
+      stmt,
+    );
+    if (opaque !== null) {
+      return opaque;
+    }
     return ir1Cond(
       arms as [readonly [IR1Expr, IR1Expr], ...typeof arms],
       elseValue,
@@ -2646,6 +2846,16 @@ function buildFromSwitchStatement(
   if (arms.length === 0) {
     // Switch with only a default: collapse to just the default value.
     return otherwise;
+  }
+  {
+    const opaque = contagiousOpaqueForOperands(
+      ctx,
+      [...arms.flat(), otherwise],
+      stmt,
+    );
+    if (opaque !== null) {
+      return opaque;
+    }
   }
   return ir1Cond(
     arms as [readonly [IR1Expr, IR1Expr], ...typeof arms],
@@ -2857,9 +3067,13 @@ function buildFromShortCircuit(
     return right;
   }
   if (expr.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken) {
-    return ir1Binop("and", left, right);
+    const opaque = contagiousOpaqueForOperands(ctx, [left, right], expr);
+    return opaque ?? ir1Binop("and", left, right);
   }
-  return ir1Binop("or", left, right);
+  {
+    const opaque = contagiousOpaqueForOperands(ctx, [left, right], expr);
+    return opaque ?? ir1Binop("or", left, right);
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -1316,6 +1316,8 @@ function translatePureBody(
     paramNames,
     supply,
     env,
+    undefined,
+    policy,
   );
   if ("error" in prelude) {
     return [
@@ -1490,6 +1492,7 @@ function translatePureBody(
           state: makeSymbolicState(),
           supply,
           env,
+          policy,
         });
         if (!isUnsupported(terminalL1)) {
           terminalOpaque = lowerL1ToOpaque(terminalL1);
@@ -1516,6 +1519,7 @@ function translatePureBody(
               undefined,
               supply,
               env,
+              policy,
             );
             if (isBodyUnsupported(legacy) || "effect" in legacy) {
               const reason = isBodyUnsupported(legacy)
@@ -1547,15 +1551,32 @@ function translatePureBody(
     }
     rhs = bodyOpaque;
   } else if (ts.isExpression(extracted.returnExpr)) {
-    const ir = buildIR(
-      extracted.returnExpr,
-      checker,
-      strategy,
-      prelude.scopedParams,
-      supply,
-    );
+    const l1Opaque =
+      policy === "opaque"
+        ? buildL1SubExpr(extracted.returnExpr, {
+            checker,
+            strategy,
+            paramNames: prelude.scopedParams,
+            state: makeSymbolicState(),
+            supply,
+            env,
+            policy,
+          })
+        : null;
+    const ir =
+      l1Opaque === null || isUnsupported(l1Opaque)
+        ? buildIR(
+            extracted.returnExpr,
+            checker,
+            strategy,
+            prelude.scopedParams,
+            supply,
+          )
+        : null;
     let bodyOpaque: OpaqueExpr;
-    if (isBuildUnsupported(ir)) {
+    if (l1Opaque !== null && !isUnsupported(l1Opaque)) {
+      bodyOpaque = lowerL1ToOpaque(l1Opaque);
+    } else if (ir !== null && isBuildUnsupported(ir)) {
       // Native pure-IR construction did not cover this surface form.
       // Fall back to `translateBodyExpr` for the OpaqueExpr; the IR
       // pipeline remains the primary path and only specific shapes
@@ -1573,6 +1594,7 @@ function translatePureBody(
         undefined,
         supply,
         env,
+        policy,
       );
       if (isBodyUnsupported(legacy) || "effect" in legacy) {
         const reason = isBodyUnsupported(legacy)
@@ -1588,8 +1610,15 @@ function translatePureBody(
         ];
       }
       bodyOpaque = bodyExpr(legacy);
-    } else {
+    } else if (ir !== null) {
       bodyOpaque = lowerExpr(ir);
+    } else {
+      return [
+        {
+          kind: "unsupported",
+          reason: `${functionName} — unsupported pure return terminal`,
+        },
+      ];
     }
     rhs = bodyOpaque;
   } else {
@@ -2445,6 +2474,7 @@ function lowerPreludeBindings(
   supply: UniqueSupply,
   env: AssumptionEnv,
   state?: SymbolicState,
+  policy?: OpaquePolicy,
 ): LoweredPreludeBindings | { error: string } {
   // Phase 1: TDZ validation — reject forward/self references on TS AST.
   // For μ-search bindings, validate both the init and the predicate; the
@@ -2650,6 +2680,7 @@ function lowerPreludeBindings(
           state: state ?? makeSymbolicState(),
           supply,
           env,
+          policy,
         });
         if (isUnsupported(built)) {
           return { tag: "error", error: built.unsupported };
@@ -3412,6 +3443,24 @@ export function translateBodyExpr(
         return { unsupported: recognized.unsupported };
       }
       return { expr: lowerL1ToOpaque(recognized) };
+    }
+  }
+
+  if (policy === "opaque" && ts.isExpression(expr)) {
+    const l1 = tryBuildL1PureSubExpression(expr, {
+      checker,
+      strategy,
+      paramNames,
+      state,
+      supply,
+      env,
+      policy,
+    });
+    if (l1 !== null) {
+      if (isL1Unsupported(l1)) {
+        return { unsupported: l1.unsupported };
+      }
+      return { expr: lowerL1ToOpaque(l1) };
     }
   }
 
@@ -5051,6 +5100,8 @@ function lowerSupportedSsaMutatingStatements(
     ctx.paramNames,
     ctx.state,
     ctx.supply,
+    ctx.env,
+    ctx.policy,
   );
   if (isBodyUnsupported(gResult)) {
     return ir1SsaBodyLowerUnsupported(gResult.unsupported);
@@ -5203,6 +5254,7 @@ function lowerSupportedSsaMutatingBlock(
     declarations: readonly PantDeclaration[];
     localRuleDecls: PropResult[];
     env: AssumptionEnv;
+    policy?: OpaquePolicy | undefined;
     recognitionHook?: (env: AssumptionEnv, location: string) => void;
   },
 ): IR1SsaBodyLowerResult {
@@ -5216,6 +5268,7 @@ function lowerSupportedSsaMutatingBlock(
     ctx.supply,
     ctx.env,
     ctx.localRuleDecls,
+    ctx.policy,
     ctx.recognitionHook,
   );
 
@@ -5290,6 +5343,7 @@ function buildSupportedSsaMutatingBody(
   supply: UniqueSupply,
   env: AssumptionEnv,
   localRuleDecls?: PropResult[],
+  policy?: OpaquePolicy,
   recognitionHook?: (env: AssumptionEnv, location: string) => void,
 ): IR1Stmt | { unsupported: string } {
   const stmts: IR1Stmt[] = [];
@@ -5375,6 +5429,7 @@ function buildSupportedSsaMutatingBody(
             supply,
             env,
             state,
+            policy,
           );
           if ("error" in lowered) {
             return { unsupported: lowered.error };
@@ -5422,6 +5477,7 @@ function buildSupportedSsaMutatingBody(
           supply,
           env,
           state,
+          policy,
         );
         if ("error" in lowered) {
           return { unsupported: lowered.error };
@@ -5437,6 +5493,7 @@ function buildSupportedSsaMutatingBody(
       state,
       supply,
       env,
+      policy,
       ...(localRuleDecls === undefined ? {} : { localRuleDecls }),
       ...(recognitionHook === undefined ? {} : { recognitionHook }),
     });
@@ -5464,6 +5521,7 @@ function buildSupportedSsaStatement(
     supply: UniqueSupply;
     env: AssumptionEnv;
     localRuleDecls?: PropResult[];
+    policy?: OpaquePolicy | undefined;
     recognitionHook?: (env: AssumptionEnv, location: string) => void;
   },
 ): IR1Stmt | { unsupported: string } {
@@ -5495,6 +5553,7 @@ function buildSupportedSsaStatement(
       ctx.supply,
       ctx.env,
       ctx.localRuleDecls,
+      ctx.policy,
       ctx.recognitionHook,
     );
     return body;
@@ -5587,6 +5646,7 @@ function buildL1BareWhileMutation(
         ctx.supply,
         ctx.env,
         ctx.localRuleDecls,
+        ctx.policy,
       )
     : buildSupportedSsaStatement(stmt.statement, ctx);
   if (isUnsupported(bodyStmt)) {
@@ -5605,6 +5665,7 @@ function buildL1ForCounterMutation(
     supply: UniqueSupply;
     env: AssumptionEnv;
     localRuleDecls?: PropResult[];
+    policy?: OpaquePolicy | undefined;
   },
 ): IR1Stmt | { unsupported: string } {
   const init = buildL1ForCounterInit(stmt.initializer);
@@ -5639,6 +5700,7 @@ function buildL1ForCounterMutation(
     state: ctx.state,
     supply: ctx.supply,
     env: ctx.env,
+    policy: ctx.policy,
   });
   if (isL1StmtUnsupported(step)) {
     return { unsupported: step.unsupported };
@@ -5654,6 +5716,7 @@ function buildL1ForCounterMutation(
         ctx.supply,
         ctx.env,
         ctx.localRuleDecls,
+        ctx.policy,
       )
     : buildSupportedSsaStatement(stmt.statement, ctx);
   if (isUnsupported(bodyStmt)) {
@@ -5715,6 +5778,7 @@ function buildL1LetWhileFixedPointMutation(
     ctx.supply,
     ctx.env,
     ctx.localRuleDecls,
+    ctx.policy,
   );
   if (isUnsupported(bodyStmt)) {
     return bodyStmt;
@@ -5817,6 +5881,7 @@ function buildL1LetWhileMutation(
     ctx.supply,
     ctx.env,
     ctx.localRuleDecls,
+    ctx.policy,
   );
   if (isUnsupported(bodyStmt)) {
     return null;

--- a/tools/ts2pant/tests/fixtures/opaque/bodies.ts
+++ b/tools/ts2pant/tests/fixtures/opaque/bodies.ts
@@ -1,0 +1,55 @@
+declare function consumeAny(value: any): any;
+
+interface Box {
+  total: number;
+}
+
+/**
+ * @pant true.
+ */
+export function readUnknown(value: unknown): unknown {
+  return value;
+}
+
+/**
+ * @pant true.
+ */
+export function arithmeticContagion(value: any): any {
+  return value + 1;
+}
+
+/**
+ * @pant true.
+ */
+export function logicalContagion(value: any): any {
+  return !value;
+}
+
+/**
+ * @pant true.
+ */
+export function callContagion(value: any): any {
+  return consumeAny(value);
+}
+
+/**
+ * @pant true.
+ */
+export function memberContagion(value: any): any {
+  return value.answer;
+}
+
+/**
+ * @pant true.
+ */
+export function conditionalContagion(flag: boolean, value: any): any {
+  return flag ? value : 0;
+}
+
+/**
+ * @pant true.
+ */
+export function mutatingReturnContagion(box: Box, value: any): any {
+  box.total = 1;
+  return value + box.total;
+}

--- a/tools/ts2pant/tests/opaque-opt-in.test.mts
+++ b/tools/ts2pant/tests/opaque-opt-in.test.mts
@@ -55,7 +55,26 @@ describe("opaque opt-in policy", () => {
     }
   });
 
-  it.skip("body operation with an opaque operand propagates opacity (contagion; PENDING: Patch 3)", () => {
-    // @pant all x: Opaque | true.
+  it("body operation with an opaque operand propagates opacity (contagion; @pant checks)", async (t) => {
+    const sourceFile = createSourceFile(
+      resolve(OPAQUE_FIXTURE_DIR, "bodies.ts"),
+    );
+    const targets = [
+      "readUnknown",
+      "arithmeticContagion",
+      "logicalContagion",
+      "callContagion",
+      "memberContagion",
+      "conditionalContagion",
+      "mutatingReturnContagion",
+    ];
+
+    for (const target of targets) {
+      const doc = await buildDocumentFromSourceFile(sourceFile, target, {
+        policy: "opaque",
+      });
+      const output = await emitAndCheck(doc);
+      t.assert.snapshot(output);
+    }
   });
 });

--- a/tools/ts2pant/tests/opaque-opt-in.test.mts.snapshot
+++ b/tools/ts2pant/tests/opaque-opt-in.test.mts.snapshot
@@ -1,3 +1,31 @@
+exports[`opaque opt-in policy > body operation with an opaque operand propagates opacity (contagion; @pant checks) 1`] = `
+"module READ_UNKNOWN.\\n\\nOpaque.\\nread-unknown value: Opaque => Opaque.\\nopaque_value_12_0062_006f_0064_0069_0065_0073_002e_0074_0073_003a_0031_0031  => Opaque.\\n\\n---\\n\\nread-unknown value = opaque_value_12_0062_006f_0064_0069_0065_0073_002e_0074_0073_003a_0031_0031.\\n\\ncheck\\n\\ntrue.\\n"
+`;
+
+exports[`opaque opt-in policy > body operation with an opaque operand propagates opacity (contagion; @pant checks) 2`] = `
+"module ARITHMETIC_CONTAGION.\\n\\nOpaque.\\narithmetic-contagion value: Opaque => Opaque.\\nopaque_value_12_0062_006f_0064_0069_0065_0073_002e_0074_0073_003a_0031_0038  => Opaque.\\n\\n---\\n\\narithmetic-contagion value = opaque_value_12_0062_006f_0064_0069_0065_0073_002e_0074_0073_003a_0031_0038.\\n\\ncheck\\n\\ntrue.\\n"
+`;
+
+exports[`opaque opt-in policy > body operation with an opaque operand propagates opacity (contagion; @pant checks) 3`] = `
+"module LOGICAL_CONTAGION.\\n\\nOpaque.\\nlogical-contagion value: Opaque => Opaque.\\nopaque_value_12_0062_006f_0064_0069_0065_0073_002e_0074_0073_003a_0032_0035  => Opaque.\\n\\n---\\n\\nlogical-contagion value = opaque_value_12_0062_006f_0064_0069_0065_0073_002e_0074_0073_003a_0032_0035.\\n\\ncheck\\n\\ntrue.\\n"
+`;
+
+exports[`opaque opt-in policy > body operation with an opaque operand propagates opacity (contagion; @pant checks) 4`] = `
+"module CALL_CONTAGION.\\n\\nOpaque.\\nconsume-any value1: Opaque => Opaque.\\ncall-contagion value: Opaque => Opaque.\\nopaque_value_12_0062_006f_0064_0069_0065_0073_002e_0074_0073_003a_0033_0032  => Opaque.\\n\\n---\\n\\ncall-contagion value = opaque_value_12_0062_006f_0064_0069_0065_0073_002e_0074_0073_003a_0033_0032.\\n\\ncheck\\n\\ntrue.\\n"
+`;
+
+exports[`opaque opt-in policy > body operation with an opaque operand propagates opacity (contagion; @pant checks) 5`] = `
+"module MEMBER_CONTAGION.\\n\\nOpaque.\\nmember-contagion value: Opaque => Opaque.\\nopaque_value_12_0062_006f_0064_0069_0065_0073_002e_0074_0073_003a_0033_0039  => Opaque.\\n\\n---\\n\\nmember-contagion value = opaque_value_12_0062_006f_0064_0069_0065_0073_002e_0074_0073_003a_0033_0039.\\n\\ncheck\\n\\ntrue.\\n"
+`;
+
+exports[`opaque opt-in policy > body operation with an opaque operand propagates opacity (contagion; @pant checks) 6`] = `
+"module CONDITIONAL_CONTAGION.\\n\\nOpaque.\\nconditional-contagion flag: Bool, value: Opaque => Opaque.\\nopaque_value_12_0062_006f_0064_0069_0065_0073_002e_0074_0073_003a_0034_0036  => Opaque.\\n\\n---\\n\\nconditional-contagion flag value = opaque_value_12_0062_006f_0064_0069_0065_0073_002e_0074_0073_003a_0034_0036.\\n\\ncheck\\n\\ntrue.\\n"
+`;
+
+exports[`opaque opt-in policy > body operation with an opaque operand propagates opacity (contagion; @pant checks) 7`] = `
+"module MUTATING_RETURN_CONTAGION.\\n\\nBox.\\nbox--total b: Box => Int.\\nOpaque.\\nmutating-return-contagion box: Box, value: Opaque => Opaque.\\nopaque_value_12_0062_006f_0064_0069_0065_0073_002e_0074_0073_003a_0035_0034  => Opaque.\\n~> Mutating-return-contagion @ box: Box, value: Opaque.\\n\\n---\\n\\nbox--total' box = 1.\\nmutating-return-contagion' box value = opaque_value_12_0062_006f_0064_0069_0065_0073_002e_0074_0073_003a_0035_0034.\\n\\ncheck\\n\\ntrue.\\n"
+`;
+
 exports[`opaque opt-in policy > signature composite opacity is precision-preserving under policy opaque (@pant checks) 1`] = `
 "module SCALAR_UNKNOWN.\\n\\nOpaque.\\nscalar-unknown value: Opaque => Opaque.\\n\\n---\\n\\ntrue.\\n"
 `;


### PR DESCRIPTION
## Patch 3: Body-level OpaqueValue emission and opacity contagion under policy opaque

- Lower a reference to an any/unknown-typed value to ir1Opaque under policy opaque.
- Instrument the binop/unop/app/member/cond builders (ir1-build.ts and the mutating-body sites in ir1-build-body.ts) to call contagiousOpaque, so any opaque operand yields an opaque result.
- Ensure contagion never treats an opaque operand as a concrete sort and never fires under reject.
- Create tests/fixtures/opaque/bodies.ts; implement the Patch 1 body-contagion stub.
- Regenerate the opaque-suite snapshot; confirm opaque bodies check under pant and the reject corpus is byte-identical.

## Changes
- Lower a reference to an any/unknown-typed value to ir1Opaque under policy opaque.
- Instrument the binop/unop/app/member/cond builders (ir1-build.ts and the mutating-body sites in ir1-build-body.ts) to call contagiousOpaque, so any opaque operand yields an opaque result.
- Ensure contagion never treats an opaque operand as a concrete sort and never fires under reject.
- Create tests/fixtures/opaque/bodies.ts; implement the Patch 1 body-contagion stub.
- Regenerate the opaque-suite snapshot; confirm opaque bodies check under pant and the reject corpus is byte-identical.

## Files to Modify
- tools/ts2pant/src/ir1-build.ts (modify): Under policy "opaque", lower a reference to an any/unknown-typed value to ir1Opaque(OPAQUE_DOMAIN, origin), and at the L1 builders (binop, unop, application, member/property access, cond) call contagiousOpaque on the operands so any opaque operand yields an opaque result. Under reject these sites are unchanged.
- tools/ts2pant/src/ir1-build-body.ts (modify): Apply the same contagion at the mutating-body expression sites that construct L1 expressions from operands, so opacity propagates uniformly in statement bodies. Under reject unchanged.
- tools/ts2pant/tests/fixtures/opaque/bodies.ts (create): Opt-in opaque fixtures (bodies): functions that read an unknown/any parameter and use it in an arithmetic/logical operation, a call, and a member access — each with @pant annotations showing the opaque result, demonstrating contagion produces verifiable Pant.
- tools/ts2pant/tests/opaque-opt-in.test.mts (modify): Un-skip and implement the body-contagion stub: build opaque/bodies.ts with policy:"opaque", snapshot, and check under pant.
- tools/ts2pant/tests/opaque-opt-in.test.mts.snapshot (modify): Regenerate; the new snapshots are the opaque-suite bodies (existing reject corpus untouched).

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[pattern] Uninterpreted sort encoding for dynamic value spaces (Rosette, Z3 community JS/Python encodings)** — Contagion is the operational counterpart of the projection-free Opaque sort: because Opaque has no interpreted operations, any operation consuming it must yield Opaque, never silently producing a concrete value — exactly the soundness posture of the uninterpreted-sort encoding.

## Gameplan Specification

```
module OPAQUE_OPT_IN.

> ══════════════════════════════
> THE GUARANTEE
> ═══════════════════════════════
> After M2, mapTsType takes a `policy: "reject" | "opaque"` (default reject,
> threaded run-wide). Under reject, behavior is exactly as before. Under
> opaque, any/unknown positions lower to the Opaque sort precision-
> preservingly in both signatures (composites keep concrete siblings: Int *
> Opaque, [Opaque], K->Opaque maps, [Opaque] for unknown|null) and bodies
> (a reference to a dynamic value emits an OpaqueValue), and any operation
> with an opaque operand yields an opaque result (contagion). Contagion is
> sound — an Opaque is never treated as a concrete value — and use-site
> precision recovery is deferred to M4. The opt-in is exercised by a
> dedicated opaque fixture suite; the existing corpus stays on reject and is
> byte-identical.

Policy.
Pos.
Expr.
reject => Policy.
opaque => Policy.
default-policy => Policy.
is-dynamic p: Pos => Bool.
opaque-policy-pos p: Pos => Bool.
lowers-to-opaque p: Pos => Bool.
rejected p: Pos => Bool.
concrete-siblings-preserved p: Pos => Bool.
opaque-policy-expr e: Expr => Bool.
has-opaque-operand e: Expr => Bool.
is-opaque-result e: Expr => Bool.
treats-opaque-as-concrete e: Expr => Bool.

---

> Default policy is reject; reject preserves today's behavior.
default-policy = reject.

> Signatures: a dynamic position lowers to Opaque under opaque, is rejected
> under reject, and opacity is precision-preserving.
all p: Pos | (is-dynamic p and opaque-policy-pos p) -> (lowers-to-opaque p and ~(rejected p) and concrete-siblings-preserved p).
all p: Pos | (is-dynamic p and ~(opaque-policy-pos p)) -> rejected p.

> Bodies: an operation with an opaque operand is opaque, and contagion is
> sound.
all e: Expr | (opaque-policy-expr e and has-opaque-operand e) -> is-opaque-result e.
all e: Expr | ~(treats-opaque-as-concrete e).
```

## Patch Specification

```
module OPAQUE_OPT_IN_PATCH_3.

> Patch 3: under policy opaque, a reference to an any/unknown-typed value
> emits an OpaqueValue, and any operation with an opaque operand yields an
> opaque result (contagion). Under reject, body lowering is unchanged.

Expr.
opaque-policy e: Expr => Bool.
has-opaque-operand e: Expr => Bool.
is-opaque-result e: Expr => Bool.
treats-opaque-as-concrete e: Expr => Bool.

---

> Under opaque policy, an operation with an opaque operand is itself opaque.
all e: Expr | (opaque-policy e and has-opaque-operand e) -> is-opaque-result e.

> Soundness: contagion never treats an opaque operand as a concrete value.
all e: Expr | ~(treats-opaque-as-concrete e).
```


## Implementation Notes

- Centralized the body-side opaque behavior in the L1 builder: dynamic leaf emission registers an `Opaque` value with the shared synth cell, and `contagiousOpaqueForOperands` gates contagion on `policy === "opaque"` before any concrete L1 operation is constructed. That keeps reject-mode paths structurally unchanged and avoids lowering an opaque operand through a concrete Pant operator.
- The pure-body path now prefers L1 lowering only when opaque policy is active, before falling back to the existing pure IR builder. This is intentional: the existing pure IR path has no policy channel, while L1 already carries the run-wide policy and the new contagion helper.
- Mutating-body support is mostly policy plumbing: the SSA/mutating builders now carry `policy` into `buildL1SubExpr`, and the tail-return/early-exit expression path routes through opaque-aware L1 lowering under opaque policy. The new `mutatingReturnContagion` fixture covers this path.
- Opaque value origins use a stable fixture-local `basename:line` source id rather than an absolute path, so snapshots do not encode a developer-specific worktree path.

Spec/Evidence Mapping:
- Dynamic body reference emits `OpaqueValue`: `tryBuildL1PureSubExpression` identifier/`this` dynamic detection via `opaqueValueForDynamicExpr`; covered by `readUnknown` in `tests/fixtures/opaque/bodies.ts` and the opaque opt-in snapshot.
- Contagion for binop/unop/app/member/cond: `contagiousOpaqueForOperands` calls in `ir1-build.ts`; covered by `arithmeticContagion`, `logicalContagion`, `callContagion`, `memberContagion`, and `conditionalContagion`.
- Mutating-body contagion: `BuildBodyCtx.policy` threading plus compound-expression contagion in `ir1-build-body.ts` and mutating tail-return coverage in `translate-body.ts`; covered by `mutatingReturnContagion`.
- Reject behavior unchanged: contagion helper returns `null` unless `policy === "opaque"`; `npm run test:unit` and `npm run test:integration` passed after the patch, with the existing reject corpus snapshots unchanged.