### PR TITLE
Fix opaque-contagion crash on synthetic SSA loop-body nodes

### DIFF
--- a/tools/ts2pant/src/ir-build.ts
+++ b/tools/ts2pant/src/ir-build.ts
@@ -45,14 +45,13 @@ import {
   unwrapTransparentExpression,
 } from "./nullish-recognizer.js";
 import { isStaticallyBoolTyped } from "./purity.js";
+import { freshHygienicBinder, type UniqueSupply } from "./supply.js";
 import {
   allocComprehensionBinder,
   ambiguousFieldMsg,
   expressionReferencesNames,
-  freshHygienicBinder,
   isNullableTsType,
   qualifyFieldAccess,
-  type UniqueSupply,
 } from "./translate-body.js";
 import {
   cellRegisterMap,

--- a/tools/ts2pant/src/ir1-build-body.ts
+++ b/tools/ts2pant/src/ir1-build-body.ts
@@ -76,13 +76,13 @@ import {
 } from "./narrowing-recognizer.js";
 import type { OpaquePolicy } from "./opaque.js";
 import type { OpaqueExpr } from "./pant-ast.js";
+import { freshHygienicBinder, type UniqueSupply } from "./supply.js";
 import {
   ambiguousFieldMsg,
   bodyExpr,
   cloneSymbolicState,
   expressionHasSideEffects,
   expressionReferencesNames,
-  freshHygienicBinder,
   getRootIdentifier,
   isBodyUnsupported,
   isGuardStatement,
@@ -92,7 +92,6 @@ import {
   symbolicKey,
   translateBodyExpr,
   translateCallExpr,
-  type UniqueSupply,
   unwrapExpression,
   type WriteEntry,
 } from "./translate-body.js";

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -100,25 +100,26 @@ import {
 } from "./nullish-recognizer.js";
 import {
   contagiousOpaque,
+  isOpaqueExpr,
   OPAQUE_DOMAIN,
   type OpaquePolicy,
 } from "./opaque.js";
 import type { OpaqueExpr } from "./pant-ast.js";
 import { getAst } from "./pant-wasm.js";
 import { isStaticallyBoolTyped } from "./purity.js";
-import type {
-  MuSearch,
-  SymbolicState,
-  UniqueSupply,
-} from "./translate-body.js";
+import {
+  freshHygienicBinder,
+  freshSyntheticOrigin,
+  registerOpaqueAlias,
+  type UniqueSupply,
+} from "./supply.js";
+import type { MuSearch, SymbolicState } from "./translate-body.js";
 import {
   expressionHasSideEffects,
   expressionReferencesNames,
   extractReturnFromBranch,
-  freshHygienicBinder,
   isNullableTsType,
   qualifyFieldAccess,
-  registerOpaqueAlias,
   symbolicKey,
 } from "./translate-body.js";
 import {
@@ -142,9 +143,35 @@ import {
   extractBlockReturn,
 } from "./ts-ast-block-return.js";
 
-function sourceRefForNode(node: ts.Node): SourceRef {
-  const sf = node.getSourceFile();
-  const pos = sf.getLineAndCharacterOfPosition(node.getStart(sf, false));
+// `getSourceFile()` is typed non-optional but walks parent pointers; a
+// factory-synthesized node has none and yields `undefined` at runtime.
+function sourceFileOf(node: ts.Node): ts.SourceFile | undefined {
+  return node.getSourceFile() as ts.SourceFile | undefined;
+}
+
+// Recover the real, source-anchored node behind `node`: either `node` itself
+// or its original (set via `ts.setOriginalNode` at SSA-desugaring sites).
+function realSourceNode(node: ts.Node): ts.Node | undefined {
+  if (sourceFileOf(node) !== undefined) {
+    return node;
+  }
+  const original = ts.getOriginalNode(node);
+  return original !== node && sourceFileOf(original) !== undefined
+    ? original
+    : undefined;
+}
+
+// Total: never throws on synthetic nodes. Real nodes (or those anchored to a
+// real original) get their true file:line; an otherwise unrecoverable
+// synthetic node gets a guaranteed-unique origin from the supply counter so
+// distinct opaque values can never collapse onto one Pant identity.
+function sourceRefForNode(node: ts.Node, supply: UniqueSupply): SourceRef {
+  const real = realSourceNode(node);
+  if (real === undefined) {
+    return freshSyntheticOrigin(supply);
+  }
+  const sf = real.getSourceFile();
+  const pos = sf.getLineAndCharacterOfPosition(real.getStart(sf, false));
   return {
     file: sf.fileName.split(/[\\/]/u).pop() ?? sf.fileName,
     line: pos.line + 1,
@@ -175,7 +202,7 @@ function opaqueValueForDynamicExpr(
   if (!isDynamicTsType(type)) {
     return null;
   }
-  const origin = sourceRefForNode(expr);
+  const origin = sourceRefForNode(expr, ctx.supply);
   registerOpaqueValueForOrigin(ctx, origin);
   return ir1Opaque(OPAQUE_DOMAIN, origin);
 }
@@ -188,7 +215,14 @@ export function contagiousOpaqueForOperands(
   if (ctx.policy !== "opaque") {
     return null;
   }
-  const origin = sourceRefForNode(originNode);
+  // Compute the origin lazily — only once an operand is actually opaque — so
+  // the common non-opaque case never touches `sourceRefForNode` (and so a
+  // synthetic origin counter is consumed only when it genuinely participates
+  // in an opaque identity).
+  if (!operands.some(isOpaqueExpr)) {
+    return null;
+  }
+  const origin = sourceRefForNode(originNode, ctx.supply);
   const opaque = contagiousOpaque(operands, origin);
   if (opaque !== null) {
     registerOpaqueValueForOrigin(ctx, origin);

--- a/tools/ts2pant/src/supply.ts
+++ b/tools/ts2pant/src/supply.ts
@@ -1,0 +1,127 @@
+// @archlint.module core
+// @archlint.domain ts2pant.supply
+
+import type ts from "typescript";
+
+import type { SourceRef } from "./ir1.js";
+import type { OpaqueExpr } from "./pant-ast.js";
+import { getAst } from "./pant-wasm.js";
+import type { SynthCell } from "./translate-types.js";
+
+// Leaf module: the document-wide unique-id supply and the opaque-alias
+// side-channel. Lives below the build pipeline (no dependency on
+// translate-body / ir1-build) so any module can draw fresh ids without
+// importing into an import cycle.
+
+/**
+ * Per-body translation context threaded through every `translateBodyExpr`
+ * call. Carries the hygienic-binder counter and (optionally) the
+ * module-wide `SynthCell` so `.get`/`.has` on non-field Map receivers
+ * can resolve to the synthesized rule names.
+ *
+ * Mutable 2-field record: `n` is reassigned in place by `nextSupply`. This
+ * is within ts2pant's self-translation envelope (cell-field reassignment
+ * translates to primed rules on the cell), unlike the prior closure over a
+ * `let counter = 0`.
+ */
+export interface UniqueSupply {
+  n: number;
+  synthCell?: SynthCell | undefined;
+  program?: ts.Program | undefined;
+  /**
+   * Side-channel registry of fresh hygienic names that bind a
+   * pre-built `OpaqueExpr` value. Populated by the mutating-body
+   * property-write cache inside `buildL1MemberAccess` when a property read
+   * resolves to a previously-recorded write — the build allocates a
+   * fresh `$N` name, registers `($N → OpaqueExpr)` here, and returns
+   * `Var($N)` in L1. This keeps L1 free of OpaqueExpr-bearing nodes
+   * while still surfacing read-after-write semantics.
+   *
+   * Lower sites apply these substitutions via `applyOpaqueAliases`, so the
+   * final Pantagruel text contains the recorded value rather than the `$N`
+   * reference.
+   */
+  opaqueAliases?: Map<string, OpaqueExpr>;
+}
+
+export function makeUniqueSupply(
+  synthCell?: SynthCell,
+  program?: ts.Program,
+): UniqueSupply {
+  return { n: 0, synthCell, program };
+}
+
+/**
+ * Register a fresh hygienic name as an alias for a pre-built
+ * `OpaqueExpr`. The alias is consumed by `applyOpaqueAliases` at
+ * lower-to-opaque sites and substituted out before Pantagruel
+ * emission, so the alias name never reaches the parser.
+ *
+ * The stored value is *eagerly resolved* against any aliases already
+ * in the map: if `value` itself contains references to earlier
+ * aliases, those get substituted out before insertion.
+ * This keeps the alias map flat — no `B → Var(A)` chain pointing at
+ * another alias — so `applyOpaqueAliases` can substitute in a single
+ * pass instead of running to fixpoint.
+ */
+export function registerOpaqueAlias(
+  supply: UniqueSupply,
+  name: string,
+  value: OpaqueExpr,
+): void {
+  if (supply.opaqueAliases === undefined) {
+    supply.opaqueAliases = new Map();
+  }
+  supply.opaqueAliases.set(name, applyOpaqueAliases(value, supply));
+}
+
+/**
+ * Apply every alias in `supply.opaqueAliases` to `expr` via Pant's
+ * capture-avoiding `substituteBinder`. Idempotent for fresh
+ * expressions that contain no alias references; otherwise replaces
+ * each `Var(aliasName)` occurrence with the registered OpaqueExpr.
+ *
+ * Single-pass — alias values are flattened at registration time
+ * (`registerOpaqueAlias` resolves prior aliases before storing), so
+ * the map never carries `B → Var(A)` chains that would require a
+ * fixpoint iteration here.
+ */
+export function applyOpaqueAliases(
+  expr: OpaqueExpr,
+  supply: UniqueSupply | undefined,
+): OpaqueExpr {
+  if (supply?.opaqueAliases === undefined || supply.opaqueAliases.size === 0) {
+    return expr;
+  }
+  const ast = getAst();
+  let r = expr;
+  for (const [name, value] of supply.opaqueAliases) {
+    r = ast.substituteBinder(r, name, value);
+  }
+  return r;
+}
+
+export function nextSupply(supply: UniqueSupply): number {
+  const value = supply.n;
+  supply.n = value + 1;
+  return value;
+}
+
+export function freshHygienicBinder(supply: UniqueSupply): string {
+  return `$${nextSupply(supply)}`;
+}
+
+// Synthetic file name for origins minted when no real source position can be
+// recovered. Combined with a fresh supply counter it yields a unique opaque
+// identity (see `ir1OpaqueOriginId`), never colliding with another value.
+export const SYNTHETIC_ORIGIN_FILE = "<synthetic>";
+
+/**
+ * Mint a guaranteed-unique `SourceRef` for a node with no recoverable source
+ * position (e.g. a factory-synthesized SSA desugaring that carries no
+ * original node). Uniqueness via the supply counter keeps distinct opaque
+ * values from collapsing onto one Pant identity.
+ */
+export function freshSyntheticOrigin(supply: UniqueSupply): SourceRef {
+  return { file: SYNTHETIC_ORIGIN_FILE, line: nextSupply(supply) };
+}

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -90,6 +90,13 @@ import {
   isEffectFree,
   isStaticallyBoolTyped,
 } from "./purity.js";
+import {
+  applyOpaqueAliases,
+  freshHygienicBinder,
+  makeUniqueSupply,
+  nextSupply,
+  type UniqueSupply,
+} from "./supply.js";
 import { translateRecordReturn } from "./translate-record.js";
 import {
   classifyFunction,
@@ -139,102 +146,9 @@ function recognizeBranchFact(
 
 // --- Const-binding inlining infrastructure (let-elimination) ---
 
-/**
- * Per-body translation context threaded through every `translateBodyExpr`
- * call. Carries the hygienic-binder counter and (optionally) the
- * module-wide `SynthCell` so `.get`/`.has` on non-field Map receivers
- * can resolve to the synthesized rule names.
- *
- * Mutable 2-field record: `n` is reassigned in place by `nextSupply`. This
- * is within ts2pant's self-translation envelope (cell-field reassignment
- * translates to primed rules on the cell), unlike the prior closure over a
- * `let counter = 0`.
- */
-export interface UniqueSupply {
-  n: number;
-  synthCell?: SynthCell | undefined;
-  program?: ts.Program | undefined;
-  /**
-   * Side-channel registry of fresh hygienic names that bind a
-   * pre-built `OpaqueExpr` value. Populated by the mutating-body
-   * property-write cache inside `buildL1MemberAccess` when a property read
-   * resolves to a previously-recorded write — the build allocates a
-   * fresh `$N` name, registers `($N → OpaqueExpr)` here, and returns
-   * `Var($N)` in L1. This keeps L1 free of OpaqueExpr-bearing nodes
-   * while still surfacing read-after-write semantics.
-   *
-   * Lower sites apply these substitutions via `applyOpaqueAliases`, so the
-   * final Pantagruel text contains the recorded value rather than the `$N`
-   * reference.
-   */
-  opaqueAliases?: Map<string, OpaqueExpr>;
-}
-function makeUniqueSupply(
-  synthCell?: SynthCell,
-  program?: ts.Program,
-): UniqueSupply {
-  return { n: 0, synthCell, program };
-}
-
-/**
- * Register a fresh hygienic name as an alias for a pre-built
- * `OpaqueExpr`. The alias is consumed by `applyOpaqueAliases` at
- * lower-to-opaque sites and substituted out before Pantagruel
- * emission, so the alias name never reaches the parser.
- *
- * The stored value is *eagerly resolved* against any aliases already
- * in the map: if `value` itself contains references to earlier
- * aliases, those get substituted out before insertion.
- * This keeps the alias map flat — no `B → Var(A)` chain pointing at
- * another alias — so `applyOpaqueAliases` can substitute in a single
- * pass instead of running to fixpoint.
- */
-export function registerOpaqueAlias(
-  supply: UniqueSupply,
-  name: string,
-  value: OpaqueExpr,
-): void {
-  if (supply.opaqueAliases === undefined) {
-    supply.opaqueAliases = new Map();
-  }
-  supply.opaqueAliases.set(name, applyOpaqueAliases(value, supply));
-}
-
-/**
- * Apply every alias in `supply.opaqueAliases` to `expr` via Pant's
- * capture-avoiding `substituteBinder`. Idempotent for fresh
- * expressions that contain no alias references; otherwise replaces
- * each `Var(aliasName)` occurrence with the registered OpaqueExpr.
- *
- * Single-pass — alias values are flattened at registration time
- * (`registerOpaqueAlias` resolves prior aliases before storing), so
- * the map never carries `B → Var(A)` chains that would require a
- * fixpoint iteration here.
- */
-export function applyOpaqueAliases(
-  expr: OpaqueExpr,
-  supply: UniqueSupply | undefined,
-): OpaqueExpr {
-  if (supply?.opaqueAliases === undefined || supply.opaqueAliases.size === 0) {
-    return expr;
-  }
-  const ast = getAst();
-  let r = expr;
-  for (const [name, value] of supply.opaqueAliases) {
-    r = ast.substituteBinder(r, name, value);
-  }
-  return r;
-}
-
-function nextSupply(supply: UniqueSupply): number {
-  const value = supply.n;
-  supply.n = value + 1;
-  return value;
-}
-
-export function freshHygienicBinder(supply: UniqueSupply): string {
-  return `$${nextSupply(supply)}`;
-}
+// The unique-id supply and opaque-alias side-channel live in the leaf
+// `supply.ts` module (below the build pipeline) so consumers can draw fresh
+// ids without importing into the translate-body ↔ ir1-build cycle.
 
 /**
  * Allocate a parser-roundtrippable comprehension binder through
@@ -2196,10 +2110,12 @@ function reassignmentsFromExpressionStatement(
         {
           kind: "reassign",
           tsName: expr.left.text,
-          valueExpr: ts.factory.createBinaryExpression(
-            expr.left,
-            op,
-            expr.right,
+          // Anchor the synthetic binop to its real originating node so
+          // `sourceRefForNode` can recover a source position for it (a bare
+          // factory node has no source file). See ir1-build.ts:sourceRefForNode.
+          valueExpr: ts.setOriginalNode(
+            ts.factory.createBinaryExpression(expr.left, op, expr.right),
+            expr,
           ),
         },
       ];
@@ -2219,12 +2135,16 @@ function reassignmentsFromExpressionStatement(
       {
         kind: "reassign",
         tsName: expr.operand.text,
-        valueExpr: ts.factory.createBinaryExpression(
-          expr.operand,
-          expr.operator === ts.SyntaxKind.PlusPlusToken
-            ? ts.SyntaxKind.PlusToken
-            : ts.SyntaxKind.MinusToken,
-          ts.factory.createNumericLiteral(1),
+        // Anchor the synthetic binop to its real originating node (see above).
+        valueExpr: ts.setOriginalNode(
+          ts.factory.createBinaryExpression(
+            expr.operand,
+            expr.operator === ts.SyntaxKind.PlusPlusToken
+              ? ts.SyntaxKind.PlusToken
+              : ts.SyntaxKind.MinusToken,
+            ts.factory.createNumericLiteral(1),
+          ),
+          expr,
         ),
       },
     ];

--- a/tools/ts2pant/src/translate-record.ts
+++ b/tools/ts2pant/src/translate-record.ts
@@ -5,12 +5,12 @@ import ts from "typescript";
 import { type NameRegistry, registerName } from "./name-registry.js";
 import type { OpaqueExpr } from "./pant-ast.js";
 import { getAst } from "./pant-wasm.js";
+import type { UniqueSupply } from "./supply.js";
 import {
   bodyExpr,
   isBodyEffect,
   isBodyUnsupported,
   translateBodyExpr,
-  type UniqueSupply,
 } from "./translate-body.js";
 import {
   cellRegisterName,

--- a/tools/ts2pant/tests/fixtures/opaque/functions-mutating-loop-opaque.ts
+++ b/tools/ts2pant/tests/fixtures/opaque/functions-mutating-loop-opaque.ts
@@ -1,0 +1,26 @@
+// @archlint.module exempt
+// @archlint.exempt-reason test-support
+
+interface Account {
+  total: number;
+}
+
+/**
+ * Bounded while whose property accumulator is updated with a
+ * dynamically-typed value. `a.total += extra` is lowered by the generic
+ * bare-while mutation path (`buildL1BareWhileMutation` →
+ * `buildL1PropertyAssignment`), which synthesizes an `a.total + extra` binary
+ * expression with no source file. Under policy "opaque", `extra` (typed
+ * `any`) lowers to an OpaqueValue, so that synthetic binop reaches
+ * `sourceRefForNode` with an opaque operand — the case that used to
+ * dereference an undefined source file. `sourceRefForNode` must instead mint a
+ * sound, unique synthetic origin (the totality fallback) so the build
+ * completes without crashing.
+ */
+export function addDynamicWhile(a: Account, n: number, extra: any): void {
+  let i = 0;
+  while (i < n) {
+    a.total += extra;
+    i++;
+  }
+}

--- a/tools/ts2pant/tests/ir-build.test.mts
+++ b/tools/ts2pant/tests/ir-build.test.mts
@@ -9,8 +9,8 @@ import { buildIR, isBuildUnsupported } from "../src/ir-build.js";
 import type { IRExpr } from "../src/ir.js";
 import { createSourceFileFromSource, getChecker } from "../src/extract.js";
 import { loadAst } from "../src/pant-wasm.js";
+import type { UniqueSupply } from "../src/supply.js";
 import { IntStrategy, newSynthCell } from "../src/translate-types.js";
-import type { UniqueSupply } from "../src/translate-body.js";
 
 before(async () => {
   await loadAst();

--- a/tools/ts2pant/tests/ir1-build-call-purity.test.mts
+++ b/tools/ts2pant/tests/ir1-build-call-purity.test.mts
@@ -10,7 +10,7 @@ import {
   tryBuildL1PureSubExpression,
 } from "../src/ir1-build.js";
 import { loadAst } from "../src/pant-wasm.js";
-import type { UniqueSupply } from "../src/translate-body.js";
+import type { UniqueSupply } from "../src/supply.js";
 import {
   cellRegisterName,
   IntStrategy,

--- a/tools/ts2pant/tests/ir1-build-cardinality.test.mts
+++ b/tools/ts2pant/tests/ir1-build-cardinality.test.mts
@@ -29,9 +29,7 @@ import {
 } from "../src/ir1-build.js";
 import type { IR1Expr } from "../src/ir1.js";
 import { loadAst } from "../src/pant-wasm.js";
-import {
-  type UniqueSupply,
-} from "../src/translate-body.js";
+import type { UniqueSupply } from "../src/supply.js";
 import {
   cellRegisterName,
   IntStrategy,

--- a/tools/ts2pant/tests/ir1-build-functor-lift.test.mts
+++ b/tools/ts2pant/tests/ir1-build-functor-lift.test.mts
@@ -29,7 +29,7 @@ import {
 } from "../src/ir1-build.js";
 import type { IR1Expr } from "../src/ir1.js";
 import { getAst, loadAst } from "../src/pant-wasm.js";
-import type { UniqueSupply } from "../src/translate-body.js";
+import type { UniqueSupply } from "../src/supply.js";
 import {
   cellRegisterName,
   IntStrategy,

--- a/tools/ts2pant/tests/ir1-build-increment.test.mts
+++ b/tools/ts2pant/tests/ir1-build-increment.test.mts
@@ -29,10 +29,7 @@ import {
   ir1Var,
 } from "../src/ir1.js";
 import { loadAst } from "../src/pant-wasm.js";
-import {
-  type UniqueSupply,
-  freshHygienicBinder,
-} from "../src/translate-body.js";
+import { freshHygienicBinder, type UniqueSupply } from "../src/supply.js";
 import { IntStrategy } from "../src/translate-types.js";
 import ts from "typescript";
 

--- a/tools/ts2pant/tests/ir1-build-nullish.test.mts
+++ b/tools/ts2pant/tests/ir1-build-nullish.test.mts
@@ -33,7 +33,7 @@ import {
   recognizeNullishForm,
 } from "../src/nullish-recognizer.js";
 import { loadAst } from "../src/pant-wasm.js";
-import type { UniqueSupply } from "../src/translate-body.js";
+import type { UniqueSupply } from "../src/supply.js";
 import { IntStrategy, newSynthCell } from "../src/translate-types.js";
 
 before(async () => {

--- a/tools/ts2pant/tests/ir1-build-parens.test.mts
+++ b/tools/ts2pant/tests/ir1-build-parens.test.mts
@@ -30,9 +30,7 @@ import {
   lowerL1ToOpaque,
 } from "../src/ir1-build.js";
 import { getAst, loadAst } from "../src/pant-wasm.js";
-import {
-  type UniqueSupply,
-} from "../src/translate-body.js";
+import type { UniqueSupply } from "../src/supply.js";
 import {
   cellRegisterName,
   IntStrategy,

--- a/tools/ts2pant/tests/ir1-build-property.test.mts
+++ b/tools/ts2pant/tests/ir1-build-property.test.mts
@@ -25,10 +25,8 @@ import type { IR1Expr } from "../src/ir1.js";
 import { lowerExpr } from "../src/ir-emit.js";
 import { lowerL1Expr } from "../src/ir1-lower.js";
 import { getAst, loadAst } from "../src/pant-wasm.js";
-import {
-  qualifyFieldAccess,
-  type UniqueSupply,
-} from "../src/translate-body.js";
+import type { UniqueSupply } from "../src/supply.js";
+import { qualifyFieldAccess } from "../src/translate-body.js";
 import {
   cellRegisterName,
   IntStrategy,

--- a/tools/ts2pant/tests/ir1-build-state-aware-reads.test.mts
+++ b/tools/ts2pant/tests/ir1-build-state-aware-reads.test.mts
@@ -22,10 +22,10 @@ import {
 } from "../src/ir1-build.js";
 import type { IR1Expr } from "../src/ir1.js";
 import { getAst, loadAst } from "../src/pant-wasm.js";
+import type { UniqueSupply } from "../src/supply.js";
 import {
   makeSymbolicState,
   translateBody,
-  type UniqueSupply,
 } from "../src/translate-body.js";
 import { translateSignature } from "../src/translate-signature.js";
 import {

--- a/tools/ts2pant/tests/narrowing-integration.test.mts
+++ b/tools/ts2pant/tests/narrowing-integration.test.mts
@@ -18,10 +18,10 @@ import {
 } from "../src/ir1-build.js";
 import { buildL1IfMutation } from "../src/ir1-build-body.js";
 import { loadAst } from "../src/pant-wasm.js";
+import type { UniqueSupply } from "../src/supply.js";
 import {
   makeSymbolicState,
   translateBody,
-  type UniqueSupply,
 } from "../src/translate-body.js";
 import { IntStrategy, newSynthCell } from "../src/translate-types.js";
 

--- a/tools/ts2pant/tests/opaque-opt-in.test.mts
+++ b/tools/ts2pant/tests/opaque-opt-in.test.mts
@@ -12,10 +12,15 @@ import {
   isOpaqueExpr,
   opaqueValueRuleName,
 } from "../src/opaque.js";
+import { emitDocument } from "../src/emit.js";
 import { createSourceFile } from "../src/extract.js";
 import { buildDocumentFromSourceFile, emitAndCheck } from "./helpers.mjs";
 
 const OPAQUE_FIXTURE_DIR = resolve(import.meta.dirname, "fixtures/opaque");
+const CONSTRUCTS_FIXTURE_DIR = resolve(
+  import.meta.dirname,
+  "fixtures/constructs",
+);
 
 describe("opaque opt-in policy", () => {
   const origin = { file: "tests/opaque-opt-in.ts", line: 1 };
@@ -122,5 +127,48 @@ describe("opaque opt-in policy", () => {
       const output = await emitAndCheck(doc);
       t.assert.snapshot(output);
     }
+  });
+
+  it("integer mutating-loop bodies build under policy opaque (regression: no synthetic-node crash)", async () => {
+    // Compound-assignment (`+=`) and `++`/`--` desugaring synthesizes
+    // binary-expression nodes with no source file. Under policy "opaque" the
+    // contagion path used to compute an origin for these unconditionally and
+    // crash in `sourceRefForNode`. These fixtures contain no `any`/`unknown`,
+    // so opacity never triggers — they must simply translate without throwing.
+    const cases: ReadonlyArray<readonly [string, string]> = [
+      ["functions-mutating-counter-loop.ts", "sumFirstN"],
+      ["functions-mutating-counter-loop.ts", "sumIfPositiveFirstN"],
+      ["functions-mutating-bounded-while.ts", "sumFirstNWhile"],
+      ["functions-mutating-fixed-point-while.ts", "adjustBalanceTo"],
+    ];
+
+    for (const [file, target] of cases) {
+      const sourceFile = createSourceFile(
+        resolve(CONSTRUCTS_FIXTURE_DIR, file),
+      );
+      await assert.doesNotReject(
+        buildDocumentFromSourceFile(sourceFile, target, { policy: "opaque" }),
+      );
+    }
+  });
+
+  it("opaque operand inside a synthetic loop binop builds without crashing (regression)", async () => {
+    // `a.total += extra` (extra: any) is lowered by the generic bare-while
+    // mutation path, which synthesizes an `a.total + extra` binop with no
+    // source file. Under policy "opaque", `extra` is an OpaqueValue, so the
+    // synthetic node reaches `sourceRefForNode` with an opaque operand — the
+    // case that used to dereference an undefined source file. The build must
+    // not crash, and opacity must propagate (an Opaque domain is emitted).
+    const sourceFile = createSourceFile(
+      resolve(OPAQUE_FIXTURE_DIR, "functions-mutating-loop-opaque.ts"),
+    );
+    const doc = await buildDocumentFromSourceFile(
+      sourceFile,
+      "addDynamicWhile",
+      { policy: "opaque" },
+    );
+    const output = emitDocument(doc);
+
+    assert.match(output, /Opaque/u);
   });
 });

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -7,6 +7,7 @@ import * as fc from "fast-check";
 import ts from "typescript";
 import { createSourceFileFromSource } from "../src/extract.js";
 import { getAst, loadAst } from "../src/pant-wasm.js";
+import * as Supply from "../src/supply.js";
 import * as TB from "../src/translate-body.js";
 import { translateBody } from "../src/translate-body.js";
 import { translateSignature } from "../src/translate-signature.js";
@@ -163,9 +164,12 @@ it("generated body helpers preserve structural translations", () => {
       const stmt = firstStatement(sourceFile);
       const paramNames = new Map([["a", "a"]]);
 
-      TB.registerOpaqueAlias(supply, "alias", ast.litNat(1));
-      assert.equal(ast.strExpr(TB.applyOpaqueAliases(ast.var("alias"), supply)), "1");
-      assert.equal(TB.freshHygienicBinder(supply).startsWith("$"), true);
+      Supply.registerOpaqueAlias(supply, "alias", ast.litNat(1));
+      assert.equal(
+        ast.strExpr(Supply.applyOpaqueAliases(ast.var("alias"), supply)),
+        "1",
+      );
+      assert.equal(Supply.freshHygienicBinder(supply).startsWith("$"), true);
       assert.equal(TB.allocComprehensionBinder(supply, "item").length > 0, true);
       assert.equal(TB.isBodyUnsupported({ unsupported: "x" }), true);
       assert.equal(TB.isBodyEffect({ effect: {} } as never), true);


### PR DESCRIPTION
## Context

While verifying the M2→M3 entry gate for the `any`/`unknown`-opaque workstream, flipping `DEFAULT_OPAQUE_POLICY` from `"reject"` to `"opaque"` crashed **7 previously-passing mutating-loop fixtures** (`sumFirstN`, `sumIfPositiveFirstN`, `sumFirstNWhile`, `sumFirstNDescending`, `adjustBalanceTo`, `fillUpTo`, `drainTo`):

```
TypeError: Cannot read properties of undefined (reading 'getLineAndCharacterOfPosition')
  at sourceRefForNode (src/ir1-build.ts)
  at contagiousOpaqueForOperands (src/ir1-build.ts)
```

This trips the workstream's explicit M2→M3 abort condition ("any new parse failure on a previously-passing fixture — fix under M2 before proceeding to M3"). The observation window did its job: it surfaced a latent interaction between two independently-built features — opaque contagion and general-loop SSA.

### Root cause

`sourceRefForNode` dereferenced `node.getSourceFile()`, which is `undefined` for the factory-synthesized binary expressions that SSA loop-lowering produces (`buildL1BareWhileMutation`). The path was dormant only because `contagiousOpaqueForOperands` early-returns under the default `reject` policy. The origin was also computed *unconditionally* — before checking whether any operand was opaque — so even integer-only loops crashed.

## The fix (`src/ir1-build.ts`)

1. **Lazy origin** — compute the contagion origin only once an operand is actually opaque, so the common non-opaque case never touches `sourceRefForNode` (fixes all 7 observed crashes).
2. **Total `sourceRefForNode`** — fall back to `ts.getOriginalNode`, then to a **guaranteed-unique** synthetic origin from the supply counter. Uniqueness prevents distinct opaque values from collapsing onto one Pant identity (identity is just `file:line`). Handles the genuinely-opaque-operand-on-synthetic-node case (e.g. `a.total += extra` with `extra: any`).
3. **`setOriginalNode`** at the identifier `+=` / `++` desugaring sites (`translate-body.ts`) for better synthetic-node provenance.

## Import-cycle refactor

Per review, extracted the unique-id supply primitives (`UniqueSupply`, `nextSupply`, `freshHygienicBinder`, opaque-alias helpers, new `freshSyntheticOrigin`) into a new **leaf module `src/supply.ts`** that depends only on leaf modules, so the fix draws fresh ids without deepening the `ir1-build ↔ translate-body` cycle. Consumers (and tests) now import these from `supply.js` directly.

**This unblocks M3 (`opaque-default`) but does not perform the flip — the default stays `reject`.**

## Verification

- **Crash gate**: flipping the default to `opaque` now gives **111/111** integration (was 104/111 with 7 crashes); reverted back to `reject`.
- **Negative check**: the new regression test reproduces the original `TypeError` when the totality guard is removed.
- Full suites green: unit **385/385** + **937/940** (3 pre-existing skips), integration **111/111**; `tsc` + biome clean.
- Adds 2 regression tests in `opaque-opt-in.test.mts` (lazy-guard path + totality-fallback path) and a fixture in `tests/fixtures/opaque/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)