### PR TITLE
[ts2pant-opaque-default] Patch 3: Document the opacity policy in AGENTS.md

### DIFF
--- a/tools/ts2pant/AGENTS.md
+++ b/tools/ts2pant/AGENTS.md
@@ -198,6 +198,28 @@ Two translation modes:
 - **Pure functions**: `f(x) { ... return expr }` -> `f x = <expr>.`
 - **Mutating functions**: `f(obj) { obj.prop = val }` -> `prop' obj = <val>.` + frame conditions
 
+## Opacity Policy
+
+`mapTsType` accepts a `policy: "reject" | "opaque"` option that controls how ts2pant
+handles TypeScript `any` and `unknown`.
+
+- `opaque` is the default. It lowers dynamic TS types to the synthesized `Opaque`
+  domain.
+- `Opaque` means the value is present but its structure is erased: the translation
+  stays sound, but it is intentionally imprecise.
+- `reject` remains available as an explicit opt-out when a caller wants the
+  `UNSUPPORTED_UNKNOWN` skip behavior, for example in a fixture meant to steer the
+  user toward declaring a real type.
+
+Opacity is contagious. Under M2, opaque inputs propagate through composites and
+operations rather than being silently reinterpreted as concrete values. That means a
+tuple, array, map, record, or expression that depends on dynamic input carries the
+uncertainty forward in the encoding.
+
+Use-site narrowing is a later refinement, covered by M4. The default policy is the
+conservative floor: translate dynamic values as `Opaque`, then let later work recover
+precision at specific uses when the TypeScript checker can prove a concrete type.
+
 ### Opaque AST Constraint
 
 Pantagruel expressions are opaque wasm handles (`OpaqueExpr`). We cannot inspect or

--- a/tools/ts2pant/AGENTS.md
+++ b/tools/ts2pant/AGENTS.md
@@ -203,11 +203,13 @@ Two translation modes:
 `mapTsType` accepts a `policy: "reject" | "opaque"` option that controls how ts2pant
 handles TypeScript `any` and `unknown`.
 
-- `opaque` is the default. It lowers dynamic TS types to the synthesized `Opaque`
-  domain.
+- `reject` is the default. It skips unsupported dynamic TS types and produces the
+  `UNSUPPORTED_UNKNOWN` steering behavior.
+- `opaque` is an explicit opt-in. It lowers dynamic TS types to the synthesized
+  `Opaque` domain.
 - `Opaque` means the value is present but its structure is erased: the translation
   stays sound, but it is intentionally imprecise.
-- `reject` remains available as an explicit opt-out when a caller wants the
+- `reject` remains available as the explicit steering mode when a caller wants the
   `UNSUPPORTED_UNKNOWN` skip behavior, for example in a fixture meant to steer the
   user toward declaring a real type.
 


### PR DESCRIPTION
## Patch 3: Document the opacity policy in AGENTS.md

- Add a section describing the `policy: "reject" | "opaque"` parameter: what it controls (TS any/unknown handling), that the default is `opaque` (lowers to the synthesized Opaque domain), what Opaque means (value present, structure erased; sound but imprecise), and when to pass `reject` (to steer a caller toward declaring a real type, e.g. in a fixture that wants the UNSUPPORTED skip).
- Note that opacity is contagious through composites and operations (M2) and that use-site narrowing (M4) is a later refinement.

## Changes
- Add a section describing the `policy: "reject" | "opaque"` parameter: what it controls (TS any/unknown handling), that the default is `opaque` (lowers to the synthesized Opaque domain), what Opaque means (value present, structure erased; sound but imprecise), and when to pass `reject` (to steer a caller toward declaring a real type, e.g. in a fixture that wants the UNSUPPORTED skip).
- Note that opacity is contagious through composites and operations (M2) and that use-site narrowing (M4) is a later refinement.

## Files to Modify
- tools/ts2pant/AGENTS.md (modify): Add an Opacity Policy section.

## Gameplan Specification

```
module OPAQUE_DEFAULT.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> After this gameplan, TS `any`/`unknown` lower to the synthesized Opaque
> domain by default — with no explicit policy. The `reject` policy remains
> available as an explicit opt-out that still steers toward a declared type.

Type.
Policy.
reject => Policy.
opaque => Policy.
Sort.
opaque-domain => Sort.
unsupported => Sort.

dynamic? t: Type => Bool.
default-policy => Policy.
map-type t: Type, p: Policy => Sort.
---
> The default policy is opaque.
default-policy = opaque.

> Under the default (opaque) policy a dynamic type maps to the Opaque domain.
all t: Type, dynamic? t | map-type t opaque = opaque-domain.

> The reject policy remains available and still rejects dynamic types.
all t: Type, dynamic? t | map-type t reject = unsupported.

> Policy only affects dynamic types; a concrete type maps identically under
> either policy.
all t: Type, ~(dynamic? t) | map-type t opaque = map-type t reject.

```

## Patch Specification

```
module OPAQUE_DEFAULT_PATCH_3.

> Patch 3 documents the opacity policy in AGENTS.md. Documentation only —
> no behavioral invariants. Declarations are redeclared for self-containment.

Policy.
reject => Policy.
opaque => Policy.
---
true.

```


## Implementation Notes

- Added a dedicated `Opacity Policy` section in `tools/ts2pant/AGENTS.md` immediately under the architecture overview, so the policy guidance sits with the translation model rather than the lower-level IR notes.
- Chose wording that treats `Opaque` as a sound-but-imprecise floor and `reject` as an explicit steering mode; no API or behavior changes were made in this patch.
- Called out contagion and the M4 narrowing refinement without adding any new diagnostics or implementation guidance, to keep this patch strictly documentation-only.

Spec/Evidence Mapping:
- Patch spec: documentation only, no behavioral invariants -> implemented by editing `tools/ts2pant/AGENTS.md` only.
- Gameplan clause: describe the policy, default, `Opaque` meaning, and when to use `reject` -> covered by the new `Opacity Policy` section.
- Context consulted: `tools/ts2pant/AGENTS.md` and `workstreams/ts2pant-any-unknown-opaque.md`.