### PR TITLE
[ts2pant-opaque-default] Patch 1: Centralize opacity-policy default resolution and pin reject tests

### DIFF
--- a/tools/ts2pant/src/translate-types.ts
+++ b/tools/ts2pant/src/translate-types.ts
@@ -11,6 +11,7 @@ import {
   registerName,
 } from "./name-registry.js";
 import {
+  DEFAULT_OPAQUE_POLICY,
   OPAQUE_DOMAIN,
   type OpaquePolicy,
   opaqueValueRuleName,
@@ -1808,6 +1809,12 @@ export interface MapTsTypeOptions {
   readonly policy?: OpaquePolicy | undefined;
 }
 
+function effectiveOpacityPolicy(
+  opts: MapTsTypeOptions | undefined,
+): OpaquePolicy {
+  return opts?.policy ?? DEFAULT_OPAQUE_POLICY;
+}
+
 export const RealStrategy: NumericStrategy = {
   mapNumber() {
     return "Real";
@@ -1840,7 +1847,7 @@ export function mapTsType(
   // move is to refuse and steer the user toward a declared type. Mapping
   // to a generic placeholder would silently let type errors through.
   if (flags & ts.TypeFlags.Any || flags & ts.TypeFlags.Unknown) {
-    if (opts?.policy === "opaque") {
+    if (effectiveOpacityPolicy(opts) === "opaque") {
       if (synthCell) {
         cellRegisterOpaqueDomain(synthCell);
       }
@@ -2058,7 +2065,7 @@ function mapDynamicTypeNode(
   synthCell: SynthCell | undefined,
   opts: MapTsTypeOptions | undefined,
 ): string {
-  if (opts?.policy === "opaque") {
+  if (effectiveOpacityPolicy(opts) === "opaque") {
     if (synthCell) {
       cellRegisterOpaqueDomain(synthCell);
     }

--- a/tools/ts2pant/tests/any-rejection.test.mts
+++ b/tools/ts2pant/tests/any-rejection.test.mts
@@ -12,7 +12,16 @@ import {
 
 function unsupportedReason(source: string, functionName: string): string {
   const sourceFile = createSourceFileFromSource(source);
-  const result = translateSignature(sourceFile, functionName, IntStrategy);
+  const result = translateSignature(
+    sourceFile,
+    functionName,
+    IntStrategy,
+    undefined,
+    undefined,
+    {
+      typeMapping: { policy: "reject" },
+    },
+  );
   assert.equal(result.declaration.kind, "unsupported");
   if (result.declaration.kind !== "unsupported") {
     throw new Error("expected unsupported declaration");

--- a/tools/ts2pant/tests/opaque-default.test.mts
+++ b/tools/ts2pant/tests/opaque-default.test.mts
@@ -1,0 +1,64 @@
+// @archlint.module test
+// @archlint.domain ts2pant.opaque
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { createSourceFileFromSource } from "../src/extract.js";
+import { OPAQUE_DOMAIN } from "../src/opaque.js";
+import { translateSignature } from "../src/translate-signature.js";
+import {
+  IntStrategy,
+  UNSUPPORTED_UNKNOWN_REASON,
+} from "../src/translate-types.js";
+import { buildDocumentFromSourceFile } from "./helpers.mjs";
+
+describe("opaque default", () => {
+  // PENDING: Patch 2 flips the default opacity policy to opaque.
+  it.skip("any and unknown lower to the Opaque domain with no explicit policy", async () => {
+    const sourceFile = createSourceFileFromSource(`
+        export function withAny(value: any): any {
+          return value;
+        }
+      `);
+
+    const signature = translateSignature(sourceFile, "withAny", IntStrategy);
+    assert.equal(signature.declaration.kind, "rule");
+    if (signature.declaration.kind !== "rule") {
+      throw new Error("expected rule declaration");
+    }
+    assert.equal(signature.declaration.returnType, OPAQUE_DOMAIN);
+
+    const doc = await buildDocumentFromSourceFile(sourceFile, "withAny");
+    assert.ok(
+      doc.declarations.some(
+        (decl) => decl.kind === "domain" && decl.name === OPAQUE_DOMAIN,
+      ),
+    );
+  });
+
+  // PENDING: Patch 2 flips the default opacity policy to opaque.
+  it.skip("explicit reject policy still emits UNSUPPORTED_UNKNOWN", () => {
+    const sourceFile = createSourceFileFromSource(`
+      export function withUnknown(value: unknown): number {
+        return 0;
+      }
+    `);
+
+    const result = translateSignature(
+      sourceFile,
+      "withUnknown",
+      IntStrategy,
+      undefined,
+      undefined,
+      { typeMapping: { policy: "reject" } },
+    );
+    assert.equal(result.declaration.kind, "unsupported");
+    if (result.declaration.kind !== "unsupported") {
+      throw new Error("expected unsupported declaration");
+    }
+    assert.equal(
+      result.declaration.reason,
+      `with-unknown param 'value': ${UNSUPPORTED_UNKNOWN_REASON}`,
+    );
+  });
+});

--- a/tools/ts2pant/tests/translate-types.test.mts
+++ b/tools/ts2pant/tests/translate-types.test.mts
@@ -49,7 +49,9 @@ function extractAndTranslate(source: string, strategy = IntStrategy) {
   const sourceFile = createSourceFileFromSource(source);
   const extracted = extractAllTypes(sourceFile);
   const checker = getChecker(sourceFile);
-  const decls = translateTypes(extracted, checker, strategy);
+  const decls = translateTypes(extracted, checker, strategy, undefined, {
+    policy: "reject",
+  });
   return { decls, extracted, checker, sourceFile };
 }
 
@@ -881,7 +883,9 @@ describe("mapTsType", () => {
     const prop = extracted.interfaces[0].properties[0];
 
     assert.equal(
-      mapTsType(prop.type, checker, IntStrategy),
+      mapTsType(prop.type, checker, IntStrategy, undefined, {
+        policy: "reject",
+      }),
       UNSUPPORTED_UNKNOWN,
     );
   });
@@ -894,7 +898,9 @@ describe("mapTsType", () => {
     const prop = extracted.interfaces[0].properties[0];
 
     assert.equal(
-      mapTsType(prop.type, checker, IntStrategy),
+      mapTsType(prop.type, checker, IntStrategy, undefined, {
+        policy: "reject",
+      }),
       UNSUPPORTED_UNKNOWN,
     );
   });
@@ -907,7 +913,9 @@ describe("mapTsType", () => {
     const prop = extracted.interfaces[0].properties[0];
 
     assert.equal(
-      mapTsType(prop.type, checker, IntStrategy),
+      mapTsType(prop.type, checker, IntStrategy, undefined, {
+        policy: "reject",
+      }),
       UNSUPPORTED_UNKNOWN,
     );
   });
@@ -920,7 +928,9 @@ describe("mapTsType", () => {
     const prop = extracted.interfaces[0].properties[0];
 
     assert.equal(
-      mapTsType(prop.type, checker, IntStrategy),
+      mapTsType(prop.type, checker, IntStrategy, undefined, {
+        policy: "reject",
+      }),
       UNSUPPORTED_UNKNOWN,
     );
   });
@@ -935,7 +945,9 @@ describe("mapTsType", () => {
     const sfK = createSourceFileFromSource(sourceK);
     const propK = extractAllTypes(sfK).interfaces[0].properties[0];
     assert.equal(
-      mapTsType(propK.type, getChecker(sfK), IntStrategy, cellK),
+      mapTsType(propK.type, getChecker(sfK), IntStrategy, cellK, {
+        policy: "reject",
+      }),
       UNSUPPORTED_UNKNOWN,
     );
     // No partial Map domain leaked into the synth state.
@@ -946,7 +958,9 @@ describe("mapTsType", () => {
     const sfV = createSourceFileFromSource(sourceV);
     const propV = extractAllTypes(sfV).interfaces[0].properties[0];
     assert.equal(
-      mapTsType(propV.type, getChecker(sfV), IntStrategy, cellV),
+      mapTsType(propV.type, getChecker(sfV), IntStrategy, cellV, {
+        policy: "reject",
+      }),
       UNSUPPORTED_UNKNOWN,
     );
     assert.equal(cellV.synth.byKV.size, 0);
@@ -964,7 +978,9 @@ describe("mapTsType", () => {
     // way. Either pre-collapse (the union check fires) or post-collapse
     // (the unknown short-circuit fires) — both surface the sentinel.
     assert.equal(
-      mapTsType(prop.type, checker, IntStrategy),
+      mapTsType(prop.type, checker, IntStrategy, undefined, {
+        policy: "reject",
+      }),
       UNSUPPORTED_UNKNOWN,
     );
   });
@@ -977,7 +993,9 @@ describe("mapTsType", () => {
     const fn = sourceFile.getFunctionOrThrow("f");
     const returnType = fn.getReturnType().compilerType;
     assert.equal(
-      mapTsType(returnType, checker, IntStrategy, cell),
+      mapTsType(returnType, checker, IntStrategy, cell, {
+        policy: "reject",
+      }),
       UNSUPPORTED_UNKNOWN,
     );
     // No partial record domain leaked into the synth state.


### PR DESCRIPTION
## Patch 1: Centralize opacity-policy default resolution and pin reject tests

- Add `function effectiveOpacityPolicy(opts: MapTsTypeOptions | undefined): OpaquePolicy { return opts?.policy ?? DEFAULT_OPAQUE_POLICY; }` in translate-types.ts and import DEFAULT_OPAQUE_POLICY (and OpaquePolicy type if not already) from ./opaque.js.
- Replace `if (opts?.policy === "opaque")` at the mapTsType scalar any/unknown branch (~1843) with a check on `effectiveOpacityPolicy(opts) === "opaque"`; do the same in mapDynamicTypeNode (~2061). No other behavior changes — while DEFAULT_OPAQUE_POLICY is still "reject", an absent policy resolves to reject exactly as before.
- In any-rejection.test.mts, thread `{ typeMapping: { policy: "reject" } }` (or the equivalent translateSignature options shape) into the translateSignature call inside `unsupportedReason` so the test pins reject explicitly.
- In translate-types.test.mts, add `policy: "reject"` to the opts passed to mapTsType/translateTypes in each reject-asserting case (these are no-ops today and keep the reject path covered after the flip).
- Create tests/opaque-default.test.mts importing createSourceFile/createSourceFileFromSource, buildDocumentFromSourceFile or translateSignature, and the Opaque markers; add two tests marked skipped with a `PENDING: Patch 2` comment — see testStubsIntroduced.

## Changes
- Add `function effectiveOpacityPolicy(opts: MapTsTypeOptions | undefined): OpaquePolicy { return opts?.policy ?? DEFAULT_OPAQUE_POLICY; }` in translate-types.ts and import DEFAULT_OPAQUE_POLICY (and OpaquePolicy type if not already) from ./opaque.js.
- Replace `if (opts?.policy === "opaque")` at the mapTsType scalar any/unknown branch (~1843) with a check on `effectiveOpacityPolicy(opts) === "opaque"`; do the same in mapDynamicTypeNode (~2061). No other behavior changes — while DEFAULT_OPAQUE_POLICY is still "reject", an absent policy resolves to reject exactly as before.
- In any-rejection.test.mts, thread `{ typeMapping: { policy: "reject" } }` (or the equivalent translateSignature options shape) into the translateSignature call inside `unsupportedReason` so the test pins reject explicitly.
- In translate-types.test.mts, add `policy: "reject"` to the opts passed to mapTsType/translateTypes in each reject-asserting case (these are no-ops today and keep the reject path covered after the flip).
- Create tests/opaque-default.test.mts importing createSourceFile/createSourceFileFromSource, buildDocumentFromSourceFile or translateSignature, and the Opaque markers; add two tests marked skipped with a `PENDING: Patch 2` comment — see testStubsIntroduced.

## Files to Modify
- tools/ts2pant/src/translate-types.ts (modify): Add an `effectiveOpacityPolicy(opts)` helper returning `opts?.policy ?? DEFAULT_OPAQUE_POLICY`; use it at the mapTsType scalar branch (~1843) and mapDynamicTypeNode (~2061) in place of `opts?.policy === "opaque"`. Import DEFAULT_OPAQUE_POLICY from ./opaque.js.
- tools/ts2pant/tests/any-rejection.test.mts (modify): Pass translateSignature an options object pinning typeMapping.policy = "reject" so the UNSUPPORTED_UNKNOWN assertions stay on the reject path.
- tools/ts2pant/tests/translate-types.test.mts (modify): Add explicit `policy: "reject"` to the opts of every reject-asserting mapTsType/translateTypes case (rejects unknown ~872; composite propagation ~889-987; routes-through-unsupported ~989-1040).
- tools/ts2pant/tests/opaque-default.test.mts (create): New test file with two skipped (pending: Patch 2) tests: default-policy any/unknown -> Opaque domain, and explicit reject -> UNSUPPORTED_UNKNOWN.

## Gameplan Specification

```
module OPAQUE_DEFAULT.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> After this gameplan, TS `any`/`unknown` lower to the synthesized Opaque
> domain by default — with no explicit policy. The `reject` policy remains
> available as an explicit opt-out that still steers toward a declared type.

Type.
Policy.
reject => Policy.
opaque => Policy.
Sort.
opaque-domain => Sort.
unsupported => Sort.

dynamic? t: Type => Bool.
default-policy => Policy.
map-type t: Type, p: Policy => Sort.
---
> The default policy is opaque.
default-policy = opaque.

> Under the default (opaque) policy a dynamic type maps to the Opaque domain.
all t: Type, dynamic? t | map-type t opaque = opaque-domain.

> The reject policy remains available and still rejects dynamic types.
all t: Type, dynamic? t | map-type t reject = unsupported.

> Policy only affects dynamic types; a concrete type maps identically under
> either policy.
all t: Type, ~(dynamic? t) | map-type t opaque = map-type t reject.

```

## Patch Specification

```
module OPAQUE_DEFAULT_PATCH_1.

> Patch 1 centralizes opacity-policy default resolution (an unspecified
> policy now resolves to `default-policy`) and pins reject-asserting tests.
> Behavior is unchanged: `default-policy` is still reject until Patch 2.

Type.
Policy.
reject => Policy.
opaque => Policy.
Sort.
opaque-domain => Sort.
unsupported => Sort.

dynamic? t: Type => Bool.
default-policy => Policy.
map-type t: Type, p: Policy => Sort.
---
> After Patch 1 the resolved default is still reject; the flip is Patch 2.
default-policy = reject.

> A dynamic type under the reject policy maps to the unsupported sentinel.
all t: Type, dynamic? t | map-type t reject = unsupported.

```


## Implementation Notes

- `effectiveOpacityPolicy()` is intentionally local to `translate-types.ts` and only used at the two dynamic-type branch points. Composite propagation paths were left untouched on purpose; they already recurse through `mapTsType` / `mapDynamicTypeNode`, so centralizing resolution there gives one source of truth without widening Patch 1’s surface area.
- I pinned the reject assertions in two ways: direct `mapTsType(...)` / `translateTypes(...)` calls now pass `policy: "reject"`, and `any-rejection.test.mts` pins reject through `translateSignature(..., { typeMapping: { policy: "reject" } })`. That keeps coverage on the explicit opt-out path after Patch 2 flips the constant.
- Minor deviation from the patch prose: `translate-types.test.mts` now routes its local `extractAndTranslate(...)` helper through `policy: "reject"`. That broadens the pin slightly beyond the two `unknown`-routing assertions, but keeps the helper aligned with the reject-only section of this file and avoids hidden default dependence there.
- The new `opaque-default.test.mts` file is deliberately all-skipped scaffolding. It is safe to unskip in Patch 2 without reshaping helpers or imports; one test exercises default-path signature/document behavior, the other keeps the explicit reject behavior anchored.
- Biome still reports unrelated pre-existing findings in `tests/translate-types.test.mts` (for example `noExplicitAny` and several false-positive `noSecrets` hits). I did not touch those because they predate this patch and are outside scope.

- Spec/Evidence Mapping:
  - `default-policy = reject` for Patch 1: implemented by resolving `opts?.policy ?? DEFAULT_OPAQUE_POLICY` while `DEFAULT_OPAQUE_POLICY` remains `"reject"` in `src/opaque.ts`; context consulted: `tools/ts2pant/src/opaque.ts`, `tools/ts2pant/src/translate-types.ts`; evidence: targeted test run covering `tests/any-rejection.test.mts` and reject cases in `tests/translate-types.test.mts`.
  - `all t: Type, dynamic? t | map-type t reject = unsupported`: implemented by the unchanged reject return path in `mapTsType` and `mapDynamicTypeNode`, now reached via `effectiveOpacityPolicy(opts)`; context consulted: `opacity-policy-sites`; evidence: reject assertions in `tests/any-rejection.test.mts` and `tests/translate-types.test.mts` pass with explicit `policy: "reject"`.