### PR TITLE
[ts2pant-opaque-narrowing] Patch 3: Document use-site opaque narrowing

### DIFF
--- a/tools/ts2pant/AGENTS.md
+++ b/tools/ts2pant/AGENTS.md
@@ -221,6 +221,8 @@ uncertainty forward in the encoding.
 Use-site narrowing is a later refinement, covered by M4. The default policy is the
 conservative floor: translate dynamic values as `Opaque`, then let later work recover
 precision at specific uses when the TypeScript checker can prove a concrete type.
+See [`docs/opaque-narrowing.md`](docs/opaque-narrowing.md) for the use-site
+precision-recovery rule and its cross-function boundary.
 
 ### Opaque AST Constraint
 

--- a/tools/ts2pant/docs/opaque-narrowing.md
+++ b/tools/ts2pant/docs/opaque-narrowing.md
@@ -1,0 +1,66 @@
+# Opaque Narrowing
+
+**Workstream:** ts2pant `any` / `unknown` handling via `Opaque` sort - Milestone 4
+(`ts2pant-opaque-narrowing`).
+
+This note documents the use-site narrowing rule for `any` and `unknown` values.
+It is the M4 complement to [guard-narrowing.md](./guard-narrowing.md): guard
+narrowing is about definedness facts, while this note is about choosing a more
+precise sort for a dynamic value when the TypeScript checker has already
+flow-narrowed it.
+
+The governing workstream decisions live in
+[workstreams/ts2pant-any-unknown-opaque.md](../../../workstreams/ts2pant-any-unknown-opaque.md):
+narrowing is consulted at the use site with `checker.getTypeAtLocation`, the
+recovered type must be something `mapTsType` already knows how to lower, and the
+boundary remains conservative at function signatures.
+
+## Use-Site Narrowing
+
+M4 keeps the opaque floor, but it lets ts2pant recover precision where the
+TypeScript compiler has already done the work. At a dynamic use site, lowering
+consults `checker.getTypeAtLocation(useNode)` instead of relying only on the
+declared type.
+
+When the declared type is dynamic (`any` or `unknown`) and the use-site type is
+concrete enough for the current `mapTsType` coverage, the occurrence lowers to a
+synthesized constant of that concrete sort rather than to `Opaque`. The
+occurrence remains a fresh synthesized value; only its sort changes.
+
+If the narrowed type is still dynamic, or if it lands in a shape that the current
+type mapping does not support, ts2pant keeps the existing opaque lowering. The
+behavior is additive: un-narrowed or unmappable reads stay byte-identical to the
+opaque baseline.
+
+The narrowing is intentionally local to the use site. Two reads of the same
+dynamic variable can lower differently if TypeScript has narrowed them
+differently at those occurrences.
+
+## Signature Boundary
+
+M4 does not trust caller-side narrowing across a function boundary. A parameter
+declared `any` or `unknown` keeps `Opaque` at the signature sort, even if the
+caller had previously narrowed the argument. That is the conservative
+cross-function boundary for this milestone.
+
+The result is a simple split:
+
+- use-site narrowing can recover a concrete sort when the checker already knows
+  one;
+- the function signature still records the declared dynamic type as opaque;
+- cross-function narrowing is not inferred by following caller flow.
+
+This preserves the workstream's soundness boundary while recovering the
+common intra-function precision wins from `typeof`, `Array.isArray`,
+`instanceof`, and related checker-driven refinements.
+
+## Validation Expectations
+
+The fixture contract for this layer is precision recovery, not broad rewriting.
+Representative uses that flow-narrow to supported concrete sorts should lower to
+those sorts, while un-narrowed or unsupported uses should stay opaque. A
+parameter whose declared type is `any` or `unknown` should still appear as
+`Opaque` in the signature.
+
+Existing opaque output should remain stable outside the recognized narrowing
+sites, preserving the additive posture established by the M2/M3 opaque work.


### PR DESCRIPTION
## Patch 3: Document use-site opaque narrowing

- Write docs/opaque-narrowing.md: at a use site, ts2pant consults checker.getTypeAtLocation; a narrowed concrete type that mapTsType supports lowers to that sort instead of Opaque; un-narrowed/unsupported uses stay Opaque; narrowing is use-site-local and a parameter keeps Opaque at the signature (cross-function narrowing not trusted). Keep the framing consistent with guard-narrowing.md.
- Add a short cross-reference from AGENTS.md's opacity-policy section to the new note.

## Changes
- Write docs/opaque-narrowing.md: at a use site, ts2pant consults checker.getTypeAtLocation; a narrowed concrete type that mapTsType supports lowers to that sort instead of Opaque; un-narrowed/unsupported uses stay Opaque; narrowing is use-site-local and a parameter keeps Opaque at the signature (cross-function narrowing not trusted). Keep the framing consistent with guard-narrowing.md.
- Add a short cross-reference from AGENTS.md's opacity-policy section to the new note.

## Files to Modify
- tools/ts2pant/docs/opaque-narrowing.md (create): New note describing the use-site narrowing model, the mapTsType-coverage scope, and the cross-function-not-trusted boundary.
- tools/ts2pant/AGENTS.md (modify): Extend the opacity-policy section with the narrowing behavior and a pointer to the new note.

## Gameplan Specification

```
module OPAQUE_NARROWING.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> A use site of an any/unknown value that TypeScript flow-narrows to a
> concrete, mappable type lowers to a synthesized constant of that concrete
> sort instead of Opaque. Un-narrowed or unmappable uses stay Opaque.
> Narrowing is use-site-local: a dynamic parameter keeps Opaque at the
> signature, so cross-function-call narrowing is not trusted.

Use.
Sort.
opaque-domain => Sort.

declared-dynamic? u: Use => Bool.
narrowed-concrete? u: Use => Bool.
narrowed-sort u: Use => Sort.
lowered-sort u: Use => Sort.
---
> A dynamic use whose narrowed type is concrete lowers to that sort.
all u: Use, declared-dynamic? u, narrowed-concrete? u | lowered-sort u = narrowed-sort u.

> A dynamic use that is not narrowed (or not mappable) lowers to Opaque.
all u: Use, declared-dynamic? u, ~(narrowed-concrete? u) | lowered-sort u = opaque-domain.

> A recovered sort is genuinely concrete, never Opaque.
all u: Use, narrowed-concrete? u | narrowed-sort u ~= opaque-domain.

where

> ══════════════════════════════════════════
> CROSS-FUNCTION BOUNDARY
> ══════════════════════════════════════════
> A parameter typed any/unknown keeps Opaque as its signature sort regardless
> of any use-site narrowing inside the body.

Param.
dynamic-param? p: Param => Bool.
signature-sort p: Param => Sort.
---
all p: Param, dynamic-param? p | signature-sort p = opaque-domain.

```

## Patch Specification

```
module OPAQUE_NARROWING_PATCH_3.

> Patch 3 documents use-site opaque narrowing. Documentation only — no
> behavioral invariants. Declarations redeclared for self-containment.

Use.
Sort.
opaque-domain => Sort.
---
true.

```


## Implementation Notes

- Added `tools/ts2pant/docs/opaque-narrowing.md` as a new M4 note in the same style as `guard-narrowing.md`, so reviewers can read the use-site narrowing rule next to the existing flow-sensitive guard story.
- The new note deliberately frames narrowing as a use-site decision driven by `checker.getTypeAtLocation`, and keeps the signature boundary conservative: dynamic parameters still surface as `Opaque` at declaration time. That boundary is the main thing a downstream patch should preserve.
- `tools/ts2pant/AGENTS.md` now points readers from the opacity-policy section to the new note. I kept the change to a single short cross-reference rather than expanding the policy text, so the policy summary stays compact.
- No code paths, invariants, or tests changed in this patch. The only observable effect is documentation coverage for the M4 narrowing behavior.

Spec/Evidence Mapping:
- Documentation of the use-site narrowing rule and cross-function boundary -> `tools/ts2pant/docs/opaque-narrowing.md`
- Cross-reference from opacity-policy guidance -> `tools/ts2pant/AGENTS.md`
- Behavioral clauses in the gameplan spec -> no code evidence in this patch; intentionally docs-only