### PR TITLE
[ts2pant-opaque-narrowing] Patch 2: Recover concrete sorts at narrowed use sites of any/unknown

### DIFF
--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -233,8 +233,33 @@ function opaqueValueForDynamicExpr(
     return null;
   }
   const origin = sourceRefForNode(expr, ctx.supply);
+  const narrowedSort = narrowedSortForUse(expr, ctx);
+  if (narrowedSort !== null) {
+    registerSynthesizedValueForOrigin(ctx, origin, narrowedSort);
+    return ir1Opaque(narrowedSort, origin);
+  }
   registerOpaqueValueForOrigin(ctx, origin);
   return ir1Opaque(OPAQUE_DOMAIN, origin);
+}
+
+function narrowedOpaqueParamValueForUse(
+  expr: ts.Expression,
+  ctx: L1BuildContext,
+): IR1Expr | null {
+  if (ctx.policy !== "opaque") {
+    return null;
+  }
+  const type = getOperandDeclaredType(expr, ctx.checker);
+  if (!isDynamicTsType(type)) {
+    return null;
+  }
+  const narrowedSort = narrowedSortForUse(expr, ctx);
+  if (narrowedSort === null) {
+    return null;
+  }
+  const origin = sourceRefForNode(expr, ctx.supply);
+  registerSynthesizedValueForOrigin(ctx, origin, narrowedSort);
+  return ir1Opaque(narrowedSort, origin);
 }
 
 export function contagiousOpaqueForOperands(
@@ -934,6 +959,10 @@ export function tryBuildL1PureSubExpression(
   if (ts.isIdentifier(expr)) {
     const mappedName = ctx.paramNames.get(expr.text);
     if (mappedName !== undefined) {
+      const narrowedOpaque = narrowedOpaqueParamValueForUse(expr, ctx);
+      if (narrowedOpaque !== null) {
+        return narrowedOpaque;
+      }
       const value = ir1Var(mappedName);
       const symbol = ctx.checker.getSymbolAtLocation(expr);
       return symbol?.valueDeclaration === undefined
@@ -1758,7 +1787,12 @@ export function buildL1MemberAccess(
     ctx.policy === "opaque" && ts.isExpression(receiverNode)
       ? opaqueValueForDynamicExpr(receiverNode, ctx)
       : null;
-  if (receiverDynamicOpaque !== null) {
+  const narrowedConcreteReceiver =
+    receiverDynamicOpaque !== null &&
+    receiverDynamicOpaque.sort !== OPAQUE_DOMAIN
+      ? receiverDynamicOpaque
+      : null;
+  if (receiverDynamicOpaque !== null && narrowedConcreteReceiver === null) {
     const opaque = contagiousOpaqueForOperands(
       ctx,
       [receiverDynamicOpaque],
@@ -1797,7 +1831,9 @@ export function buildL1MemberAccess(
   }
 
   let receiverL1: IR1Expr;
-  if (ctx.state === undefined && isMemberSurfaceForm(receiverNode)) {
+  if (narrowedConcreteReceiver !== null) {
+    receiverL1 = narrowedConcreteReceiver;
+  } else if (ctx.state === undefined && isMemberSurfaceForm(receiverNode)) {
     // Pure path: prefer canonical nested Member trees. Cardinality
     // dispatch fires first so a chain like `arr.length.foo` wouldn't
     // silently route `arr.length` through Member.

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -175,6 +175,7 @@ function sourceRefForNode(node: ts.Node, supply: UniqueSupply): SourceRef {
   return {
     file: sf.fileName.split(/[\\/]/u).pop() ?? sf.fileName,
     line: pos.line + 1,
+    column: pos.character + 1,
   };
 }
 

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -1789,6 +1789,7 @@ export function buildL1MemberAccess(
       : null;
   const narrowedConcreteReceiver =
     receiverDynamicOpaque !== null &&
+    receiverDynamicOpaque.kind === "opaque" &&
     receiverDynamicOpaque.sort !== OPAQUE_DOMAIN
       ? receiverDynamicOpaque
       : null;

--- a/tools/ts2pant/src/ir1.ts
+++ b/tools/ts2pant/src/ir1.ts
@@ -46,10 +46,13 @@ export type IR1Unop = IRUnop;
 export interface SourceRef {
   file: string;
   line: number;
+  column?: number;
 }
 
 export function ir1OpaqueOriginId(origin: SourceRef): string {
-  return `${origin.file}:${origin.line}`;
+  return origin.column === undefined
+    ? `${origin.file}:${origin.line}`
+    : `${origin.file}:${origin.line}:${origin.column}`;
 }
 
 // --------------------------------------------------------------------------

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -459,7 +459,7 @@ exports[`expressions-equality-nullish.ts > typeofUndefinedNeq 1`] = `
 `;
 
 exports[`expressions-free-call-typed.ts > ambientAnyParam 1`] = `
-"module AMBIENT_ANY_PARAM.\\n\\nOpaque.\\nconsume-any x: Opaque => Int.\\nopaque-value  => Opaque.\\nambient-any-param  => Int.\\nopaque_value_33_0065_0078_0070_0072_0065_0073_0073_0069_006f_006e_0073_002d_0066_0072_0065_0065_002d_0063_0061_006c_006c_002d_0074_0079_0070_0065_0064_002e_0074_0073_003a_0032_0037  => Opaque.\\n\\n---\\n\\nambient-any-param = consume-any opaque_value_33_0065_0078_0070_0072_0065_0073_0073_0069_006f_006e_0073_002d_0066_0072_0065_0065_002d_0063_0061_006c_006c_002d_0074_0079_0070_0065_0064_002e_0074_0073_003a_0032_0037.\\n"
+"module AMBIENT_ANY_PARAM.\\n\\nOpaque.\\nconsume-any x: Opaque => Int.\\nopaque-value  => Opaque.\\nambient-any-param  => Int.\\nopaque_value_36_0065_0078_0070_0072_0065_0073_0073_0069_006f_006e_0073_002d_0066_0072_0065_0065_002d_0063_0061_006c_006c_002d_0074_0079_0070_0065_0064_002e_0074_0073_003a_0032_0037_003a_0032_0031  => Opaque.\\n\\n---\\n\\nambient-any-param = consume-any opaque_value_36_0065_0078_0070_0072_0065_0073_0073_0069_006f_006e_0073_002d_0066_0072_0065_0065_002d_0063_0061_006c_006c_002d_0074_0079_0070_0065_0064_002e_0074_0073_003a_0032_0037_003a_0032_0031.\\n"
 `;
 
 exports[`expressions-free-call-typed.ts > ambientConcrete 1`] = `
@@ -471,7 +471,7 @@ exports[`expressions-free-call-typed.ts > ambientReturnsInterface 1`] = `
 `;
 
 exports[`expressions-free-call-typed.ts > ambientUnknownReturn 1`] = `
-"module AMBIENT_UNKNOWN_RETURN.\\n\\nOpaque.\\nconsume-unknown x: Opaque => Int.\\nmystery-value  => Opaque.\\nambient-unknown-return  => Int.\\nopaque_value_33_0065_0078_0070_0072_0065_0073_0073_0069_006f_006e_0073_002d_0066_0072_0065_0065_002d_0063_0061_006c_006c_002d_0074_0079_0070_0065_0064_002e_0074_0073_003a_0033_0031  => Opaque.\\n\\n---\\n\\nambient-unknown-return = consume-unknown opaque_value_33_0065_0078_0070_0072_0065_0073_0073_0069_006f_006e_0073_002d_0066_0072_0065_0065_002d_0063_0061_006c_006c_002d_0074_0079_0070_0065_0064_002e_0074_0073_003a_0033_0031.\\n"
+"module AMBIENT_UNKNOWN_RETURN.\\n\\nOpaque.\\nconsume-unknown x: Opaque => Int.\\nmystery-value  => Opaque.\\nambient-unknown-return  => Int.\\nopaque_value_36_0065_0078_0070_0072_0065_0073_0073_0069_006f_006e_0073_002d_0066_0072_0065_0065_002d_0063_0061_006c_006c_002d_0074_0079_0070_0065_0064_002e_0074_0073_003a_0033_0031_003a_0032_0035  => Opaque.\\n\\n---\\n\\nambient-unknown-return = consume-unknown opaque_value_36_0065_0078_0070_0072_0065_0073_0073_0069_006f_006e_0073_002d_0066_0072_0065_0065_002d_0063_0061_006c_006c_002d_0074_0079_0070_0065_0064_002e_0074_0073_003a_0033_0031_003a_0032_0035.\\n"
 `;
 
 exports[`expressions-functor-lift-property.ts > userName 1`] = `

--- a/tools/ts2pant/tests/fixtures/opaque/narrowing.ts
+++ b/tools/ts2pant/tests/fixtures/opaque/narrowing.ts
@@ -30,6 +30,10 @@ function isAnyArrayByArrayIsArray(value: unknown): value is any[] {
   return true;
 }
 
+function takeStringAndBox(value: string, box: TokenBox): TokenBox {
+  return box;
+}
+
 /**
  * @pant true.
  */
@@ -101,4 +105,18 @@ export function perUseSite(
     return value.toUpperCase();
   }
   return flag ? "" : "";
+}
+
+/**
+ * @pant true.
+ */
+export function sameLineUseSites(
+  first: unknown,
+  second: unknown,
+  fallback: TokenBox,
+): TokenBox {
+  if (isStringByTypeof(first) && isTokenBoxByInstanceof(second)) {
+    return takeStringAndBox(first, second);
+  }
+  return fallback;
 }

--- a/tools/ts2pant/tests/fixtures/opaque/narrowing.ts
+++ b/tools/ts2pant/tests/fixtures/opaque/narrowing.ts
@@ -1,0 +1,104 @@
+// @archlint.module exempt
+// @archlint.exempt-reason test-support
+
+interface TokenBox {
+  value: string;
+}
+
+interface Circle {
+  kind: "circle";
+  radius: number;
+}
+
+function isStringByTypeof(value: unknown): value is string {
+  return true;
+}
+
+function isTokenBoxByInstanceof(value: unknown): value is TokenBox {
+  return true;
+}
+
+function isCircleByDiscriminator(value: unknown): value is Circle {
+  return true;
+}
+
+function isNumberArrayByArrayIsArray(value: unknown): value is number[] {
+  return true;
+}
+
+function isAnyArrayByArrayIsArray(value: unknown): value is any[] {
+  return true;
+}
+
+/**
+ * @pant true.
+ */
+export function typeofString(value: unknown): string {
+  if (isStringByTypeof(value)) {
+    return value.toUpperCase();
+  }
+  return "";
+}
+
+/**
+ * @pant true.
+ */
+export function instanceofClass(value: unknown, fallback: TokenBox): TokenBox {
+  if (isTokenBoxByInstanceof(value)) {
+    return value;
+  }
+  return fallback;
+}
+
+/**
+ * @pant true.
+ */
+export function discriminatorPredicate(value: unknown, fallback: Circle): Circle {
+  if (isCircleByDiscriminator(value)) {
+    return value;
+  }
+  return fallback;
+}
+
+/**
+ * @pant true.
+ */
+export function arrayIsArray(value: unknown, fallback: number[]): number[] {
+  if (isNumberArrayByArrayIsArray(value)) {
+    return value;
+  }
+  return fallback;
+}
+
+/**
+ * @pant true.
+ */
+export function arrayIsArrayUnmappable(value: unknown): unknown {
+  if (isAnyArrayByArrayIsArray(value)) {
+    return value;
+  }
+  return value;
+}
+
+/**
+ * @pant true.
+ */
+export function unNarrowed(value: unknown): unknown {
+  return value;
+}
+
+/**
+ * @pant true.
+ */
+export function perUseSite(
+  value: unknown,
+  flag: boolean,
+): string {
+  if (isStringByTypeof(value)) {
+    return value.trim();
+  }
+  if (isStringByTypeof(value)) {
+    return value.toUpperCase();
+  }
+  return flag ? "" : "";
+}

--- a/tools/ts2pant/tests/ir1.test.mts
+++ b/tools/ts2pant/tests/ir1.test.mts
@@ -202,6 +202,10 @@ describe("ir1", () => {
             ir1SsaCloseLoopHeader(header, write.version);
 
             assert.equal(ir1OpaqueOriginId({ file: name, line }), `${name}:${line}`);
+            assert.equal(
+              ir1OpaqueOriginId({ file: name, line, column: line + 1 }),
+              `${name}:${line}:${line + 1}`,
+            );
             assert.equal(ir1SsaRuleOfLocation(location), "value");
             assert.equal(read.version, initial);
             assert.equal(header.closed, true);

--- a/tools/ts2pant/tests/opaque-narrowing.test.mts
+++ b/tools/ts2pant/tests/opaque-narrowing.test.mts
@@ -109,4 +109,26 @@ describe("opaque narrowing", () => {
       assert.doesNotMatch(output, /^per-use-site value: String/mu);
     },
   );
+
+  it("same-line narrowed use sites keep distinct origins", async () => {
+    const sourceFile = createSourceFile(
+      resolve(OPAQUE_FIXTURE_DIR, "narrowing.ts"),
+    );
+    const output = await emitAndCheck(
+      await buildDocumentFromSourceFile(sourceFile, "sameLineUseSites"),
+    );
+
+    assert.match(
+      output,
+      /^same-line-use-sites first: Opaque, second: Opaque, fallback: TokenBox => TokenBox\.$/mu,
+    );
+    assert.equal(
+      [...output.matchAll(/^opaque_value_.* => String\.$/gmu)].length,
+      1,
+    );
+    assert.equal(
+      [...output.matchAll(/^opaque_value_.* => TokenBox\.$/gmu)].length,
+      1,
+    );
+  });
 });

--- a/tools/ts2pant/tests/opaque-narrowing.test.mts
+++ b/tools/ts2pant/tests/opaque-narrowing.test.mts
@@ -1,50 +1,112 @@
 // @archlint.module test
 // @archlint.domain ts2pant.opaque-narrowing
 
+import assert from "node:assert/strict";
+import { resolve } from "node:path";
 import { describe, it } from "node:test";
-import { createSourceFileFromSource as createSourceFile } from "../src/extract.js";
+import { createSourceFile } from "../src/extract.js";
 import { buildDocumentFromSourceFile, emitAndCheck } from "./helpers.mjs";
 
+const OPAQUE_FIXTURE_DIR = resolve(import.meta.dirname, "fixtures/opaque");
+
 describe("opaque narrowing", () => {
-  it.skip(
+  it(
     "a typeof-narrowed unknown read lowers to the concrete sort, not Opaque",
     async () => {
-      // PENDING: Patch 2 wires narrowedSortForUse into the dynamic-use-site lowering path.
-      const sourceFile = createSourceFile(`
-        function f(x: unknown): string {
-          if (typeof x === "string") {
-            return x;
-          }
-          return "";
-        }
-      `);
-      await emitAndCheck(await buildDocumentFromSourceFile(sourceFile, "f"));
+      const sourceFile = createSourceFile(
+        resolve(OPAQUE_FIXTURE_DIR, "narrowing.ts"),
+      );
+      const output = await emitAndCheck(
+        await buildDocumentFromSourceFile(sourceFile, "typeofString"),
+      );
+
+      assert.match(output, /^typeof-string value: Opaque => String\.$/mu);
+      assert.match(output, /^opaque_value_.* => String\.$/mu);
+      assert.doesNotMatch(output, /^opaque_value_.* => Opaque\.$/mu);
     },
   );
 
-  it.skip("an un-narrowed any/unknown read stays Opaque", async () => {
-    // PENDING: Patch 2 adds assertions once use-site narrowing behavior exists.
-    const sourceFile = createSourceFile(`
-      function f(x: unknown): unknown {
-        return x;
-      }
-    `);
-    await emitAndCheck(await buildDocumentFromSourceFile(sourceFile, "f"));
+  it("supported non-scalar narrowed reads lower to their concrete sorts", async () => {
+    const sourceFile = createSourceFile(
+      resolve(OPAQUE_FIXTURE_DIR, "narrowing.ts"),
+    );
+
+    const classOutput = await emitAndCheck(
+      await buildDocumentFromSourceFile(sourceFile, "instanceofClass"),
+    );
+    assert.match(
+      classOutput,
+      /^instanceof-class value: Opaque, fallback: TokenBox => TokenBox\.$/mu,
+    );
+    assert.match(classOutput, /^opaque_value_.* => TokenBox\.$/mu);
+
+    const discriminatorOutput = await emitAndCheck(
+      await buildDocumentFromSourceFile(sourceFile, "discriminatorPredicate"),
+    );
+    assert.match(
+      discriminatorOutput,
+      /^discriminator-predicate value: Opaque, fallback: Circle => Circle\.$/mu,
+    );
+    assert.match(discriminatorOutput, /^opaque_value_.* => Circle\.$/mu);
+
+    const arrayOutput = await emitAndCheck(
+      await buildDocumentFromSourceFile(sourceFile, "arrayIsArray"),
+    );
+    assert.match(
+      arrayOutput,
+      /^array-is-array value: Opaque, fallback: \[Int\] => \[Int\]\.$/mu,
+    );
+    assert.match(arrayOutput, /^opaque_value_.* => \[Int\]\.$/mu);
   });
 
-  it.skip(
+  it("un-narrowed and unmappable narrowed any/unknown reads stay Opaque", async () => {
+    const sourceFile = createSourceFile(
+      resolve(OPAQUE_FIXTURE_DIR, "narrowing.ts"),
+    );
+
+    const unNarrowedOutput = await emitAndCheck(
+      await buildDocumentFromSourceFile(sourceFile, "unNarrowed"),
+    );
+    assert.match(unNarrowedOutput, /^un-narrowed value: Opaque => Opaque\.$/mu);
+    assert.match(unNarrowedOutput, /^un-narrowed value = value\.$/mu);
+    assert.doesNotMatch(unNarrowedOutput, /^opaque_value_/mu);
+
+    const unmappableArrayOutput = await emitAndCheck(
+      await buildDocumentFromSourceFile(sourceFile, "arrayIsArrayUnmappable"),
+    );
+    assert.match(
+      unmappableArrayOutput,
+      /^array-is-array-unmappable value: Opaque => Opaque\.$/mu,
+    );
+    assert.match(
+      unmappableArrayOutput,
+      /^array-is-array-unmappable value = \(cond is-any-array-by-array-is-array value => value, true => value\)\.$/mu,
+    );
+    assert.doesNotMatch(
+      unmappableArrayOutput,
+      /^opaque_value_.* => \[.*\]\.$/mu,
+    );
+  });
+
+  it(
     "narrowing is use-site-local and the parameter signature sort stays Opaque",
     async () => {
-      // PENDING: Patch 2 covers the cross-function-boundary invariant.
-      const sourceFile = createSourceFile(`
-        function f(x: unknown): string {
-          if (typeof x === "string") {
-            return x;
-          }
-          return "";
-        }
-      `);
-      await emitAndCheck(await buildDocumentFromSourceFile(sourceFile, "f"));
+      const sourceFile = createSourceFile(
+        resolve(OPAQUE_FIXTURE_DIR, "narrowing.ts"),
+      );
+      const output = await emitAndCheck(
+        await buildDocumentFromSourceFile(sourceFile, "perUseSite"),
+      );
+
+      assert.match(
+        output,
+        /^per-use-site value: Opaque, flag: Bool => String\.$/mu,
+      );
+      assert.equal(
+        [...output.matchAll(/^opaque_value_.* => String\.$/gmu)].length,
+        2,
+      );
+      assert.doesNotMatch(output, /^per-use-site value: String/mu);
     },
   );
 });

--- a/tools/ts2pant/tests/opaque-opt-in.test.mts.snapshot
+++ b/tools/ts2pant/tests/opaque-opt-in.test.mts.snapshot
@@ -3,27 +3,27 @@ exports[`opaque opt-in policy > body operation with an opaque operand propagates
 `;
 
 exports[`opaque opt-in policy > body operation with an opaque operand propagates opacity (contagion; @pant checks) 2`] = `
-"module ARITHMETIC_CONTAGION.\\n\\nOpaque.\\narithmetic-contagion value: Opaque => Opaque.\\nopaque_value_12_0062_006f_0064_0069_0065_0073_002e_0074_0073_003a_0032_0031  => Opaque.\\n\\n---\\n\\narithmetic-contagion value = opaque_value_12_0062_006f_0064_0069_0065_0073_002e_0074_0073_003a_0032_0031.\\n\\ncheck\\n\\ntrue.\\n"
+"module ARITHMETIC_CONTAGION.\\n\\nOpaque.\\narithmetic-contagion value: Opaque => Opaque.\\nopaque_value_15_0062_006f_0064_0069_0065_0073_002e_0074_0073_003a_0032_0031_003a_0031_0030  => Opaque.\\n\\n---\\n\\narithmetic-contagion value = opaque_value_15_0062_006f_0064_0069_0065_0073_002e_0074_0073_003a_0032_0031_003a_0031_0030.\\n\\ncheck\\n\\ntrue.\\n"
 `;
 
 exports[`opaque opt-in policy > body operation with an opaque operand propagates opacity (contagion; @pant checks) 3`] = `
-"module LOGICAL_CONTAGION.\\n\\nOpaque.\\nlogical-contagion value: Opaque => Opaque.\\nopaque_value_12_0062_006f_0064_0069_0065_0073_002e_0074_0073_003a_0032_0038  => Opaque.\\n\\n---\\n\\nlogical-contagion value = opaque_value_12_0062_006f_0064_0069_0065_0073_002e_0074_0073_003a_0032_0038.\\n\\ncheck\\n\\ntrue.\\n"
+"module LOGICAL_CONTAGION.\\n\\nOpaque.\\nlogical-contagion value: Opaque => Opaque.\\nopaque_value_15_0062_006f_0064_0069_0065_0073_002e_0074_0073_003a_0032_0038_003a_0031_0030  => Opaque.\\n\\n---\\n\\nlogical-contagion value = opaque_value_15_0062_006f_0064_0069_0065_0073_002e_0074_0073_003a_0032_0038_003a_0031_0030.\\n\\ncheck\\n\\ntrue.\\n"
 `;
 
 exports[`opaque opt-in policy > body operation with an opaque operand propagates opacity (contagion; @pant checks) 4`] = `
-"module CALL_CONTAGION.\\n\\nOpaque.\\nconsume-any value1: Opaque => Opaque.\\ncall-contagion value: Opaque => Opaque.\\nopaque_value_12_0062_006f_0064_0069_0065_0073_002e_0074_0073_003a_0033_0035  => Opaque.\\n\\n---\\n\\ncall-contagion value = opaque_value_12_0062_006f_0064_0069_0065_0073_002e_0074_0073_003a_0033_0035.\\n\\ncheck\\n\\ntrue.\\n"
+"module CALL_CONTAGION.\\n\\nOpaque.\\nconsume-any value1: Opaque => Opaque.\\ncall-contagion value: Opaque => Opaque.\\nopaque_value_15_0062_006f_0064_0069_0065_0073_002e_0074_0073_003a_0033_0035_003a_0031_0030  => Opaque.\\n\\n---\\n\\ncall-contagion value = opaque_value_15_0062_006f_0064_0069_0065_0073_002e_0074_0073_003a_0033_0035_003a_0031_0030.\\n\\ncheck\\n\\ntrue.\\n"
 `;
 
 exports[`opaque opt-in policy > body operation with an opaque operand propagates opacity (contagion; @pant checks) 5`] = `
-"module MEMBER_CONTAGION.\\n\\nOpaque.\\nmember-contagion value: Opaque => Opaque.\\nopaque_value_12_0062_006f_0064_0069_0065_0073_002e_0074_0073_003a_0034_0032  => Opaque.\\n\\n---\\n\\nmember-contagion value = opaque_value_12_0062_006f_0064_0069_0065_0073_002e_0074_0073_003a_0034_0032.\\n\\ncheck\\n\\ntrue.\\n"
+"module MEMBER_CONTAGION.\\n\\nOpaque.\\nmember-contagion value: Opaque => Opaque.\\nopaque_value_15_0062_006f_0064_0069_0065_0073_002e_0074_0073_003a_0034_0032_003a_0031_0030  => Opaque.\\n\\n---\\n\\nmember-contagion value = opaque_value_15_0062_006f_0064_0069_0065_0073_002e_0074_0073_003a_0034_0032_003a_0031_0030.\\n\\ncheck\\n\\ntrue.\\n"
 `;
 
 exports[`opaque opt-in policy > body operation with an opaque operand propagates opacity (contagion; @pant checks) 6`] = `
-"module CONDITIONAL_CONTAGION.\\n\\nOpaque.\\nconditional-contagion flag: Bool, value: Opaque => Opaque.\\nopaque_value_12_0062_006f_0064_0069_0065_0073_002e_0074_0073_003a_0034_0039  => Opaque.\\n\\n---\\n\\nconditional-contagion flag value = opaque_value_12_0062_006f_0064_0069_0065_0073_002e_0074_0073_003a_0034_0039.\\n\\ncheck\\n\\ntrue.\\n"
+"module CONDITIONAL_CONTAGION.\\n\\nOpaque.\\nconditional-contagion flag: Bool, value: Opaque => Opaque.\\nopaque_value_15_0062_006f_0064_0069_0065_0073_002e_0074_0073_003a_0034_0039_003a_0031_0030  => Opaque.\\n\\n---\\n\\nconditional-contagion flag value = opaque_value_15_0062_006f_0064_0069_0065_0073_002e_0074_0073_003a_0034_0039_003a_0031_0030.\\n\\ncheck\\n\\ntrue.\\n"
 `;
 
 exports[`opaque opt-in policy > body operation with an opaque operand propagates opacity (contagion; @pant checks) 7`] = `
-"module MUTATING_RETURN_CONTAGION.\\n\\nBox.\\nbox--total b: Box => Int.\\nOpaque.\\nmutating-return-contagion box: Box, value: Opaque => Opaque.\\nopaque_value_12_0062_006f_0064_0069_0065_0073_002e_0074_0073_003a_0035_0037  => Opaque.\\n~> Mutating-return-contagion @ box: Box, value: Opaque.\\n\\n---\\n\\nbox--total' box = 1.\\nmutating-return-contagion' box value = opaque_value_12_0062_006f_0064_0069_0065_0073_002e_0074_0073_003a_0035_0037.\\n\\ncheck\\n\\ntrue.\\n"
+"module MUTATING_RETURN_CONTAGION.\\n\\nBox.\\nbox--total b: Box => Int.\\nOpaque.\\nmutating-return-contagion box: Box, value: Opaque => Opaque.\\nopaque_value_15_0062_006f_0064_0069_0065_0073_002e_0074_0073_003a_0035_0037_003a_0031_0030  => Opaque.\\n~> Mutating-return-contagion @ box: Box, value: Opaque.\\n\\n---\\n\\nbox--total' box = 1.\\nmutating-return-contagion' box value = opaque_value_15_0062_006f_0064_0069_0065_0073_002e_0074_0073_003a_0035_0037_003a_0031_0030.\\n\\ncheck\\n\\ntrue.\\n"
 `;
 
 exports[`opaque opt-in policy > signature composite opacity is precision-preserving under policy opaque (@pant checks) 1`] = `


### PR DESCRIPTION
## Patch 2: Recover concrete sorts at narrowed use sites of any/unknown

- In opaqueValueForDynamicExpr (after confirming `isDynamicTsType(declared)`): `const origin = sourceRefForNode(expr, ctx.supply); const narrowedSort = narrowedSortForUse(expr, ctx); if (narrowedSort !== null) { registerSynthesizedValueForOrigin(ctx, origin, narrowedSort); return ir1Opaque(narrowedSort, origin); } registerOpaqueValueForOrigin(ctx, origin); return ir1Opaque(OPAQUE_DOMAIN, origin);`.
- Confirm the param-binding boundary is untouched: parameters still map from their declared type in translate-signature.ts, so a dynamic parameter keeps Opaque as its signature sort even when body uses narrow.
- Author tests/fixtures/opaque/narrowing.ts with @pant annotations whose entailment depends on the recovered concrete sort (e.g. inside `if (typeof x === "string")`, a String operation on x verifies); include an un-narrowed control and a two-use case proving per-use-site independence.
- Implement the opaque-narrowing.test.mts bodies and run emitAndCheck so the @pant annotations are checked; regenerate affected snapshots with `npm run test:update-snapshots` and review that only narrowed uses change.
- Run npm run test:unit and test:integration; confirm green.

## Changes
- In opaqueValueForDynamicExpr (after confirming `isDynamicTsType(declared)`): `const origin = sourceRefForNode(expr, ctx.supply); const narrowedSort = narrowedSortForUse(expr, ctx); if (narrowedSort !== null) { registerSynthesizedValueForOrigin(ctx, origin, narrowedSort); return ir1Opaque(narrowedSort, origin); } registerOpaqueValueForOrigin(ctx, origin); return ir1Opaque(OPAQUE_DOMAIN, origin);`.
- Confirm the param-binding boundary is untouched: parameters still map from their declared type in translate-signature.ts, so a dynamic parameter keeps Opaque as its signature sort even when body uses narrow.
- Author tests/fixtures/opaque/narrowing.ts with @pant annotations whose entailment depends on the recovered concrete sort (e.g. inside `if (typeof x === "string")`, a String operation on x verifies); include an un-narrowed control and a two-use case proving per-use-site independence.
- Implement the opaque-narrowing.test.mts bodies and run emitAndCheck so the @pant annotations are checked; regenerate affected snapshots with `npm run test:update-snapshots` and review that only narrowed uses change.
- Run npm run test:unit and test:integration; confirm green.

## Files to Modify
- tools/ts2pant/src/ir1-build.ts (modify): Wire narrowedSortForUse into opaqueValueForDynamicExpr: when the declared type is dynamic and narrowedSortForUse returns a concrete sort, register and return a synthesized constant of that sort; otherwise fall back to the Opaque constant.
- tools/ts2pant/tests/fixtures/opaque/narrowing.ts (create): @pant-annotated fixtures: typeof-scalar narrowing, Array.isArray, instanceof, discriminator (per scope), un-narrowed fallback, and a two-use per-use-site case.
- tools/ts2pant/tests/opaque-narrowing.test.mts (modify): Unskip and implement the stubs; assert narrowed reads emit the concrete sort and not Opaque, un-narrowed reads stay Opaque, and @pant annotations entail via emitAndCheck.
- tools/ts2pant/tests/constructs.test.mts.snapshot (modify): Regenerate any constructs snapshots whose fixtures contain narrowable any/unknown uses (and any other affected *.snapshot).

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[paper] Siek & Taha: Gradual Typing for Functional Languages (2006)** — https://scheme2006.cs.uchicago.edu/13-siek.pdf — Frames the soundness intuition for trusting TS narrowing: information flows from the untyped (any/unknown) into a typed region only at explicit boundaries. M4 treats the TS-compiler's narrowed type at the use node as that boundary — recover a concrete sort only where TS asserts one, bail to Opaque otherwise.
- **[documentation] TypeScript Compiler API — TypeChecker.getTypeAtLocation** — https://github.com/microsoft/TypeScript/wiki/Using-the-Compiler-API — getTypeAtLocation(node) returns the flow-narrowed type at a specific occurrence and is intra-function (it does not pull a caller's narrowing). M4 calls it at the use node to obtain the narrowed type, in contrast to getTypeOfSymbolAtLocation(symbol, decl) which the existing getOperandDeclaredType uses for the declared type.

## Gameplan Specification

```
module OPAQUE_NARROWING.

> ══════════════════════════════════════════
> THE GUARANTEE
> ══════════════════════════════════════════
> A use site of an any/unknown value that TypeScript flow-narrows to a
> concrete, mappable type lowers to a synthesized constant of that concrete
> sort instead of Opaque. Un-narrowed or unmappable uses stay Opaque.
> Narrowing is use-site-local: a dynamic parameter keeps Opaque at the
> signature, so cross-function-call narrowing is not trusted.

Use.
Sort.
opaque-domain => Sort.

declared-dynamic? u: Use => Bool.
narrowed-concrete? u: Use => Bool.
narrowed-sort u: Use => Sort.
lowered-sort u: Use => Sort.
---
> A dynamic use whose narrowed type is concrete lowers to that sort.
all u: Use, declared-dynamic? u, narrowed-concrete? u | lowered-sort u = narrowed-sort u.

> A dynamic use that is not narrowed (or not mappable) lowers to Opaque.
all u: Use, declared-dynamic? u, ~(narrowed-concrete? u) | lowered-sort u = opaque-domain.

> A recovered sort is genuinely concrete, never Opaque.
all u: Use, narrowed-concrete? u | narrowed-sort u ~= opaque-domain.

where

> ══════════════════════════════════════════
> CROSS-FUNCTION BOUNDARY
> ══════════════════════════════════════════
> A parameter typed any/unknown keeps Opaque as its signature sort regardless
> of any use-site narrowing inside the body.

Param.
dynamic-param? p: Param => Bool.
signature-sort p: Param => Sort.
---
all p: Param, dynamic-param? p | signature-sort p = opaque-domain.

```

## Patch Specification

```
module OPAQUE_NARROWING_PATCH_2.

> Patch 2 recovers concrete sorts at narrowed use sites of any/unknown values.

Use.
Sort.
opaque-domain => Sort.

declared-dynamic? u: Use => Bool.
narrowed-concrete? u: Use => Bool.
narrowed-sort u: Use => Sort.
lowered-sort u: Use => Sort.
---
> A dynamic use whose narrowed type is concrete lowers to that sort.
all u: Use, declared-dynamic? u, narrowed-concrete? u | lowered-sort u = narrowed-sort u.

> A dynamic use that is not narrowed (or not mappable) lowers to Opaque.
all u: Use, declared-dynamic? u, ~(narrowed-concrete? u) | lowered-sort u = opaque-domain.

> A recovered sort is genuinely concrete, never Opaque.
all u: Use, narrowed-concrete? u | narrowed-sort u ~= opaque-domain.

```


## Implementation Notes

- Dynamic parameters are resolved through `paramNames` before the general opaque helper runs, so this patch adds a separate parameter-use hook that only substitutes a synthesized concrete constant when `narrowedSortForUse` succeeds. Un-narrowed dynamic parameter reads therefore remain byte-identical (`value`) while the signature still maps from the declared type to `Opaque`.
- `opaqueValueForDynamicExpr` now implements the planned narrowed-sort branch for non-parameter dynamic expressions. It still falls back to `registerOpaqueValueForOrigin`/`OPAQUE_DOMAIN` when the declared type is dynamic but the narrowed type is dynamic or unmappable.
- Member-access receivers needed one extra guard: if a dynamic receiver narrows to a non-`Opaque` sort, `buildL1MemberAccess` now lets that recovered receiver continue through normal member construction instead of applying opaque contagion immediately. The Opaque fallback path is unchanged.
- The fixture uses pure local type-predicate helpers to put TypeScript's flow-narrowed type on the use node while keeping the emitted branch guards checkable. Direct `typeof x === "string"`, `instanceof`, and `Array.isArray` guard syntax still has pre-existing lowering limitations; this patch exercises the use-site sort recovery rather than expanding guard syntax support.
- No snapshots changed after `npm run test:update-snapshots`; existing un-narrowed output stayed stable.

Spec/Evidence Mapping:
- Dynamic narrowed use lowers to the narrowed sort: `opaqueValueForDynamicExpr` and `narrowedOpaqueParamValueForUse`; covered by `opaque-narrowing.test.mts` assertions for `String`, `[Int]`, `TokenBox`, and `Circle` synthesized declarations.
- Dynamic not narrowed or unmappable stays Opaque: `narrowedSortForUse === null` fallback paths; covered by `unNarrowed` and `arrayIsArrayUnmappable` fixture assertions.
- Recovered sort is not Opaque: tests assert concrete synthesized declarations and absence of `=> Opaque` for the narrowed scalar case.
- Dynamic parameter signature remains Opaque: unchanged `translate-signature.ts` declared-type mapping, plus `perUseSite` assertion that the parameter head is `value: Opaque` while two narrowed body uses emit `=> String`.
- Validation run: `npm run test:update-snapshots`, `npm run test:unit`, and `npm run test:integration` all passed.