### PR TITLE
Add read-only monomorphization survey (M5)

### DIFF
--- a/tools/ts2pant/docs/opaque-mono-survey.json
+++ b/tools/ts2pant/docs/opaque-mono-survey.json
@@ -1,0 +1,93 @@
+{
+  "files": [
+    "annotations.ts",
+    "assumption-env.ts",
+    "ast-equal.ts",
+    "brand-precondition.ts",
+    "builtins.ts",
+    "definedness-obligation.ts",
+    "effect-error-channel.ts",
+    "emit.ts",
+    "extract.ts",
+    "index.ts",
+    "ir-build.ts",
+    "ir-emit.ts",
+    "ir.ts",
+    "ir1-build-body.ts",
+    "ir1-build.ts",
+    "ir1-lower-body.ts",
+    "ir1-lower.ts",
+    "ir1-printer.ts",
+    "ir1-ssa-collections.ts",
+    "ir1-ssa-counter-loop.ts",
+    "ir1-ssa-fixed-point.ts",
+    "ir1-ssa-foreach.ts",
+    "ir1-ssa-lower.ts",
+    "ir1-ssa-scalars.ts",
+    "ir1-substitute.ts",
+    "ir1.ts",
+    "mono-survey.ts",
+    "name-registry.ts",
+    "narrowing-recognizer.ts",
+    "nullish-recognizer.ts",
+    "opaque.ts",
+    "pant-ast.ts",
+    "pant-wasm.ts",
+    "pipeline.ts",
+    "purity.ts",
+    "supply.ts",
+    "translate-body.ts",
+    "translate-record.ts",
+    "translate-signature.ts",
+    "translate-types.ts",
+    "ts-ast-block-return.ts",
+    "types.ts"
+  ],
+  "totalFunctions": 770,
+  "candidateFunctions": 1,
+  "byVerdict": {
+    "all-agree": 0,
+    "disagree-but-bounded": 0,
+    "disagree-unbounded": 1,
+    "recursive": 0,
+    "oversized": 0,
+    "no-visible-call-sites": 0
+  },
+  "allAgreeFraction": 0,
+  "allAgreeFractionWithCallSites": 0,
+  "dynamicReturnFunctions": 1,
+  "functions": [
+    {
+      "file": "emit.ts",
+      "name": "isExecError",
+      "line": 274,
+      "bodyLoc": 3,
+      "exported": false,
+      "dynamicParams": [
+        "err"
+      ],
+      "dynamicReturn": false,
+      "recursive": false,
+      "callSites": [
+        {
+          "file": "emit.ts",
+          "line": 210,
+          "observed": [
+            {
+              "param": "err",
+              "type": "unknown",
+              "dynamic": true
+            }
+          ]
+        }
+      ],
+      "observedTypesByParam": {
+        "err": [
+          "unknown"
+        ]
+      },
+      "externalCallersUnknown": false,
+      "verdict": "disagree-unbounded"
+    }
+  ]
+}

--- a/tools/ts2pant/docs/opaque-mono-survey.md
+++ b/tools/ts2pant/docs/opaque-mono-survey.md
@@ -1,0 +1,42 @@
+# Opaque Monomorphization Survey
+
+**Workstream:** ts2pant `any`/`unknown` handling via Opaque sort — Milestone 5 (`ts2pant-opaque-mono-survey`). **Date:** 2026-06-22. **Method:** read-only whole-program pass over ts2pant `src/` (its own corpus); no translation output is modified.
+
+## Summary
+
+- Files surveyed: **42**
+- Top-level function declarations: **770**
+- Monomorphization candidates (>=1 top-level `any`/`unknown` parameter): **1**
+- Functions with a top-level `any`/`unknown` return (context): **1**
+
+### Verdict distribution
+
+| Verdict | Count |
+| --- | --- |
+| all-agree | 0 |
+| disagree-but-bounded | 0 |
+| disagree-unbounded | 1 |
+| recursive | 0 |
+| oversized | 0 |
+| no-visible-call-sites | 0 |
+
+### M6 decision metric
+
+- all-agree fraction (of all candidates): **0.0%**
+- all-agree fraction (of candidates with >=1 visible call site): **0.0%**
+- Threshold to proceed to M6 (`ts2pant-opaque-mono`): **>= 25.0% all-agree**.
+
+### Verdict
+
+**Do not proceed to M6 on this corpus.** 0.0% of candidates are all-agree, below the 25.0% threshold.
+
+- The dogfood corpus is a strict, self-hosted TypeScript codebase that avoids top-level `any`/`unknown` by construction, so it is **not representative** of the `any`/`unknown`-heavy user code M6 targets (third-party APIs, JSON, gradual code). A near-zero candidate count here reflects the corpus, not the value of monomorphization for real inputs.
+- Treat this run as evidence that the dogfood corpus alone cannot justify M6. A go decision needs a re-survey over representative `any`/`unknown`-heavy user TypeScript; absent that, the workstream legitimately closes at M5 (the M5 Definition of Done permits this).
+
+## Per-function detail
+
+| Function | Dynamic params | Call sites | Verdict | Exported | Body LOC |
+| --- | --- | --- | --- | --- | --- |
+| `emit.ts:isExecError` (L274) | err | 1 | disagree-unbounded | no | 3 |
+
+- `emit.ts:isExecError` — observed: err: {unknown}

--- a/tools/ts2pant/package.json
+++ b/tools/ts2pant/package.json
@@ -18,7 +18,8 @@
     "test": "npm run test:unit && npm run test:integration",
     "test:update-snapshots": "NODE_OPTIONS=--max-old-space-size=6144 npx tsx --test --test-update-snapshots --test-timeout=600000 tests/*.test.mts tests/integration/*.test.mts",
     "lint": "biome check src",
-    "lint:fix": "biome check --write src"
+    "lint:fix": "biome check --write src",
+    "survey": "npx tsx scripts/mono-survey.mts"
   },
   "dependencies": {
     "commander": "^13.0.0",

--- a/tools/ts2pant/scripts/mono-survey.mts
+++ b/tools/ts2pant/scripts/mono-survey.mts
@@ -16,9 +16,22 @@ const here = dirname(fileURLToPath(import.meta.url));
 const SRC = resolve(here, "../src");
 const DOCS = resolve(here, "../docs");
 
-const files = readdirSync(SRC)
-  .filter((f) => f.endsWith(".ts"))
-  .map((f) => resolve(SRC, f));
+function collectTsFiles(dir: string): string[] {
+  const files: string[] = [];
+
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = resolve(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectTsFiles(fullPath));
+    } else if (entry.isFile() && entry.name.endsWith(".ts")) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+const files = collectTsFiles(SRC);
 
 const report = surveyMonomorphization(files);
 

--- a/tools/ts2pant/scripts/mono-survey.mts
+++ b/tools/ts2pant/scripts/mono-survey.mts
@@ -1,0 +1,55 @@
+// Runner for the read-only monomorphization survey (workstream M5,
+// ts2pant-opaque-mono-survey). Surveys ts2pant's own src/ corpus and writes a
+// machine-readable JSON report plus a human-readable Markdown summary, then
+// prints the M6 decision metric. Invoke: `npm run survey`.
+
+import { readdirSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  formatMonoSurveyMarkdown,
+  surveyMonomorphization,
+} from "../src/mono-survey.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const SRC = resolve(here, "../src");
+const DOCS = resolve(here, "../docs");
+
+const files = readdirSync(SRC)
+  .filter((f) => f.endsWith(".ts"))
+  .map((f) => resolve(SRC, f));
+
+const report = surveyMonomorphization(files);
+
+const date = process.env.SURVEY_DATE ?? "(date unset)";
+const markdown = formatMonoSurveyMarkdown(report, {
+  title: "Opaque Monomorphization Survey",
+  date,
+  corpus: "ts2pant `src/` (its own corpus)",
+  notes: [
+    "The dogfood corpus is a strict, self-hosted TypeScript codebase that avoids top-level `any`/`unknown` by construction, so it is **not representative** of the `any`/`unknown`-heavy user code M6 targets (third-party APIs, JSON, gradual code). A near-zero candidate count here reflects the corpus, not the value of monomorphization for real inputs.",
+    "Treat this run as evidence that the dogfood corpus alone cannot justify M6. A go decision needs a re-survey over representative `any`/`unknown`-heavy user TypeScript; absent that, the workstream legitimately closes at M5 (the M5 Definition of Done permits this).",
+  ],
+});
+
+writeFileSync(
+  resolve(DOCS, "opaque-mono-survey.json"),
+  `${JSON.stringify(report, null, 2)}\n`,
+);
+writeFileSync(resolve(DOCS, "opaque-mono-survey.md"), markdown);
+
+// Console summary for the operator's M6 go/no-go.
+process.stdout.write(
+  [
+    `files: ${report.files.length}`,
+    `top-level functions: ${report.totalFunctions}`,
+    `candidates (top-level any/unknown param): ${report.candidateFunctions}`,
+    `dynamic-return functions (context): ${report.dynamicReturnFunctions}`,
+    `by verdict: ${JSON.stringify(report.byVerdict)}`,
+    `all-agree fraction (all candidates): ${(report.allAgreeFraction * 100).toFixed(1)}%`,
+    `all-agree fraction (with call sites): ${(report.allAgreeFractionWithCallSites * 100).toFixed(1)}%`,
+    "M6 threshold: >= 25% all-agree",
+    "",
+  ].join("\n"),
+);

--- a/tools/ts2pant/scripts/mono-survey.mts
+++ b/tools/ts2pant/scripts/mono-survey.mts
@@ -19,7 +19,9 @@ const DOCS = resolve(here, "../docs");
 function collectTsFiles(dir: string): string[] {
   const files: string[] = [];
 
-  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+  for (const entry of readdirSync(dir, { withFileTypes: true }).sort((a, b) =>
+    a.name.localeCompare(b.name),
+  )) {
     const fullPath = resolve(dir, entry.name);
     if (entry.isDirectory()) {
       files.push(...collectTsFiles(fullPath));

--- a/tools/ts2pant/src/extract.ts
+++ b/tools/ts2pant/src/extract.ts
@@ -59,7 +59,7 @@ export interface ExtractedTypes {
   enums: ExtractedEnum[];
 }
 
-const COMPILER_OPTIONS = {
+export const COMPILER_OPTIONS = {
   target: ts.ScriptTarget.ES2022,
   module: ts.ModuleKind.NodeNext,
   moduleResolution: ts.ModuleResolutionKind.NodeNext,

--- a/tools/ts2pant/src/mono-survey.ts
+++ b/tools/ts2pant/src/mono-survey.ts
@@ -1,0 +1,483 @@
+// @archlint.module core
+// @archlint.domain ts2pant.mono-survey
+
+import { Project } from "ts-morph";
+import ts from "typescript";
+
+import { COMPILER_OPTIONS } from "./extract.js";
+
+// Read-only monomorphization survey (workstream ts2pant-any-unknown-opaque,
+// milestone M5). For every function whose signature has a top-level
+// `any`/`unknown` parameter, find its call sites across the program and
+// record the observed argument type at each site, then classify how
+// amenable the function is to call-site monomorphization (M6). This pass
+// never changes translation output — it only measures.
+
+/** Monomorphization-friendliness verdict for one candidate function. */
+export type Verdict =
+  | "all-agree"
+  | "disagree-but-bounded"
+  | "disagree-unbounded"
+  | "recursive"
+  | "oversized"
+  | "no-visible-call-sites";
+
+export interface ObservedArg {
+  /** Parameter name the argument flows into. */
+  readonly param: string;
+  /** `checker.typeToString` of the (flow-narrowed) argument type. */
+  readonly type: string;
+  /** The observed type is itself `any`/`unknown` (pins no concrete type). */
+  readonly dynamic: boolean;
+}
+
+export interface CallSiteSurvey {
+  readonly file: string;
+  readonly line: number;
+  readonly observed: readonly ObservedArg[];
+}
+
+export interface FunctionSurvey {
+  readonly file: string;
+  readonly name: string;
+  readonly line: number;
+  readonly bodyLoc: number;
+  readonly exported: boolean;
+  /** Top-level `any`/`unknown` parameters — the monomorphization targets. */
+  readonly dynamicParams: readonly string[];
+  /** The return type is (top-level) `any`/`unknown`. Informational. */
+  readonly dynamicReturn: boolean;
+  readonly recursive: boolean;
+  readonly callSites: readonly CallSiteSurvey[];
+  /** Per dynamic param: the distinct observed argument types across sites. */
+  readonly observedTypesByParam: Readonly<Record<string, readonly string[]>>;
+  /**
+   * Exported functions can be called from outside the surveyed program, so
+   * their full caller set is unknown and the function cannot be soundly
+   * replaced wholesale (only per-visible-site specialization is sound).
+   */
+  readonly externalCallersUnknown: boolean;
+  readonly verdict: Verdict;
+}
+
+export interface MonoSurveyReport {
+  readonly files: readonly string[];
+  readonly totalFunctions: number;
+  readonly candidateFunctions: number;
+  readonly byVerdict: Readonly<Record<Verdict, number>>;
+  /** all-agree / candidateFunctions. */
+  readonly allAgreeFraction: number;
+  /** all-agree / (candidates with >= 1 visible call site). */
+  readonly allAgreeFractionWithCallSites: number;
+  /** Context: functions with a top-level `any`/`unknown` return. */
+  readonly dynamicReturnFunctions: number;
+  readonly functions: readonly FunctionSurvey[];
+}
+
+/** Body line count above which a function is treated as oversized (tunable). */
+export const OVERSIZED_LOC = 30;
+/** Max distinct observed types for a position to count as "bounded". */
+export const BOUNDED_MAX = 3;
+
+const EMPTY_VERDICT_COUNTS: Record<Verdict, number> = {
+  "all-agree": 0,
+  "disagree-but-bounded": 0,
+  "disagree-unbounded": 0,
+  recursive: 0,
+  oversized: 0,
+  "no-visible-call-sites": 0,
+};
+
+function isDynamic(type: ts.Type): boolean {
+  return (type.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0;
+}
+
+function lineOf(node: ts.Node, sf: ts.SourceFile): number {
+  return sf.getLineAndCharacterOfPosition(node.getStart(sf)).line + 1;
+}
+
+function isExported(node: ts.FunctionDeclaration): boolean {
+  return (ts.getCombinedModifierFlags(node) & ts.ModifierFlags.Export) !== 0;
+}
+
+/**
+ * Resolve a call's callee to a function declaration node, mirroring the
+ * conservative idiom in translate-signature.ts: identifier calls only (no
+ * dynamic dispatch), follow `getResolvedSignature` then a const-bound symbol,
+ * and bail on node_modules / non-function targets.
+ */
+function resolveCalleeDecl(
+  call: ts.CallExpression,
+  checker: ts.TypeChecker,
+): ts.SignatureDeclaration | undefined {
+  if (!ts.isIdentifier(call.expression)) {
+    return undefined;
+  }
+  const sig = checker.getResolvedSignature(call);
+  let decl: ts.Declaration | undefined = sig?.declaration;
+  if (!decl || !ts.isFunctionLike(decl)) {
+    const symbol = checker.getSymbolAtLocation(call.expression);
+    decl = symbol?.valueDeclaration;
+  }
+  if (!decl || !ts.isFunctionLike(decl)) {
+    return undefined;
+  }
+  if (decl.getSourceFile().fileName.includes("node_modules")) {
+    return undefined;
+  }
+  return decl;
+}
+
+interface Candidate {
+  readonly node: ts.FunctionDeclaration;
+  readonly sf: ts.SourceFile;
+  readonly file: string;
+  readonly name: string;
+  readonly dynamicParamIndices: readonly { name: string; index: number }[];
+  readonly dynamicReturn: boolean;
+  readonly callSites: CallSiteSurvey[];
+  recursive: boolean;
+}
+
+function collectCandidates(
+  sf: ts.SourceFile,
+  file: string,
+  checker: ts.TypeChecker,
+): Candidate[] {
+  const out: Candidate[] = [];
+  for (const stmt of sf.statements) {
+    if (!ts.isFunctionDeclaration(stmt) || !stmt.body || !stmt.name) {
+      continue;
+    }
+    const sig = checker.getSignatureFromDeclaration(stmt);
+    if (!sig) {
+      continue;
+    }
+    const dynamicParamIndices: { name: string; index: number }[] = [];
+    sig.getParameters().forEach((param, index) => {
+      const t = checker.getTypeOfSymbolAtLocation(
+        param,
+        param.valueDeclaration ?? stmt,
+      );
+      if (isDynamic(t)) {
+        dynamicParamIndices.push({ name: param.getName(), index });
+      }
+    });
+    const dynamicReturn = isDynamic(sig.getReturnType());
+    if (dynamicParamIndices.length === 0) {
+      // Not a param-monomorphization candidate; only track dynamic-return
+      // context via a zero-param sentinel handled by the caller.
+      if (dynamicReturn) {
+        out.push({
+          node: stmt,
+          sf,
+          file,
+          name: stmt.name.text,
+          dynamicParamIndices: [],
+          dynamicReturn: true,
+          callSites: [],
+          recursive: false,
+        });
+      }
+      continue;
+    }
+    out.push({
+      node: stmt,
+      sf,
+      file,
+      name: stmt.name.text,
+      dynamicParamIndices,
+      dynamicReturn,
+      callSites: [],
+      recursive: false,
+    });
+  }
+  return out;
+}
+
+function classify(candidate: Candidate): {
+  observedTypesByParam: Record<string, string[]>;
+  verdict: Verdict;
+} {
+  const observedTypesByParam: Record<string, string[]> = {};
+  for (const { name } of candidate.dynamicParamIndices) {
+    observedTypesByParam[name] = [];
+  }
+  let sawDynamicObservation = false;
+  for (const site of candidate.callSites) {
+    for (const obs of site.observed) {
+      const bucket = observedTypesByParam[obs.param];
+      if (bucket && !bucket.includes(obs.type)) {
+        bucket.push(obs.type);
+      }
+      if (obs.dynamic) {
+        sawDynamicObservation = true;
+      }
+    }
+  }
+
+  let verdict: Verdict;
+  if (candidate.recursive) {
+    verdict = "recursive";
+  } else if (
+    candidate.node.body &&
+    bodyLineCount(candidate.node.body, candidate.sf) > OVERSIZED_LOC
+  ) {
+    verdict = "oversized";
+  } else if (candidate.callSites.length === 0) {
+    verdict = "no-visible-call-sites";
+  } else {
+    const distinctCounts = Object.values(observedTypesByParam).map(
+      (types) => types.length,
+    );
+    const maxDistinct = distinctCounts.reduce((a, b) => Math.max(a, b), 0);
+    if (!sawDynamicObservation && maxDistinct === 1) {
+      verdict = "all-agree";
+    } else if (!sawDynamicObservation && maxDistinct <= BOUNDED_MAX) {
+      verdict = "disagree-but-bounded";
+    } else {
+      verdict = "disagree-unbounded";
+    }
+  }
+  return { observedTypesByParam, verdict };
+}
+
+function bodyLineCount(body: ts.Node, sf: ts.SourceFile): number {
+  const start = sf.getLineAndCharacterOfPosition(body.getStart(sf)).line;
+  const end = sf.getLineAndCharacterOfPosition(body.getEnd()).line;
+  return end - start + 1;
+}
+
+/** Run the read-only monomorphization survey over the given source files. */
+export function surveyMonomorphization(filePaths: string[]): MonoSurveyReport {
+  const project = new Project({ compilerOptions: COMPILER_OPTIONS });
+  project.addSourceFilesAtPaths(filePaths);
+  project.resolveSourceFileDependencies();
+  const program = project.getProgram().compilerObject;
+  const checker = project.getTypeChecker().compilerObject;
+
+  const requested = new Set(filePaths.map((p) => program.getSourceFile(p)));
+  const inProgram = program
+    .getSourceFiles()
+    .filter(
+      (sf) =>
+        !program.isSourceFileDefaultLibrary(sf) &&
+        !program.isSourceFileFromExternalLibrary(sf),
+    );
+
+  // Candidates come only from the requested files; call sites are scanned
+  // across the whole (non-foreign) program so cross-file calls are visible.
+  const byNode = new Map<ts.FunctionDeclaration, Candidate>();
+  const candidates: Candidate[] = [];
+  let totalFunctions = 0;
+  for (const sf of inProgram) {
+    if (!requested.has(sf)) {
+      continue;
+    }
+    const file = baseName(sf.fileName);
+    for (const stmt of sf.statements) {
+      if (ts.isFunctionDeclaration(stmt) && stmt.body && stmt.name) {
+        totalFunctions += 1;
+      }
+    }
+    for (const c of collectCandidates(sf, file, checker)) {
+      candidates.push(c);
+      byNode.set(c.node, c);
+    }
+  }
+
+  // Single pass over every call expression in the program: attribute each to
+  // its callee candidate (if any) and record the observed argument types at
+  // the dynamic parameter positions; flag direct recursion.
+  for (const sf of inProgram) {
+    const visit = (node: ts.Node): void => {
+      if (ts.isCallExpression(node)) {
+        const decl = resolveCalleeDecl(node, checker);
+        if (decl && ts.isFunctionDeclaration(decl)) {
+          const candidate = byNode.get(decl);
+          if (candidate) {
+            recordCall(candidate, node, sf, checker);
+          }
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(sf);
+  }
+
+  const functions: FunctionSurvey[] = candidates
+    .filter((c) => c.dynamicParamIndices.length > 0)
+    .map((c) => {
+      const { observedTypesByParam, verdict } = classify(c);
+      return {
+        file: c.file,
+        name: c.name,
+        line: lineOf(c.node, c.sf),
+        bodyLoc: c.node.body ? bodyLineCount(c.node.body, c.sf) : 0,
+        exported: isExported(c.node),
+        dynamicParams: c.dynamicParamIndices.map((p) => p.name),
+        dynamicReturn: c.dynamicReturn,
+        recursive: c.recursive,
+        callSites: c.callSites,
+        observedTypesByParam,
+        externalCallersUnknown: isExported(c.node),
+        verdict,
+      };
+    })
+    .sort(
+      (a, b) => a.file.localeCompare(b.file) || a.name.localeCompare(b.name),
+    );
+
+  const byVerdict = { ...EMPTY_VERDICT_COUNTS };
+  for (const f of functions) {
+    byVerdict[f.verdict] += 1;
+  }
+  const withCallSites = functions.filter((f) => f.callSites.length > 0).length;
+  const allAgree = byVerdict["all-agree"];
+
+  return {
+    files: filePaths.map(baseName).sort(),
+    totalFunctions,
+    candidateFunctions: functions.length,
+    byVerdict,
+    allAgreeFraction: functions.length === 0 ? 0 : allAgree / functions.length,
+    allAgreeFractionWithCallSites:
+      withCallSites === 0 ? 0 : allAgree / withCallSites,
+    dynamicReturnFunctions: candidates.filter(
+      (c) => c.dynamicReturn && c.dynamicParamIndices.length === 0,
+    ).length,
+    functions,
+  };
+}
+
+function recordCall(
+  candidate: Candidate,
+  call: ts.CallExpression,
+  sf: ts.SourceFile,
+  checker: ts.TypeChecker,
+): void {
+  // Direct recursion: the call is lexically inside the candidate's own body.
+  if (callIsInside(call, candidate.node)) {
+    candidate.recursive = true;
+  }
+  if (call.arguments.some(ts.isSpreadElement)) {
+    return;
+  }
+  const observed: ObservedArg[] = [];
+  for (const { name, index } of candidate.dynamicParamIndices) {
+    const arg = call.arguments[index];
+    if (!arg) {
+      continue;
+    }
+    const t = checker.getTypeAtLocation(arg);
+    observed.push({
+      param: name,
+      type: checker.typeToString(t),
+      dynamic: isDynamic(t),
+    });
+  }
+  candidate.callSites.push({
+    file: baseName(sf.fileName),
+    line: lineOf(call, sf),
+    observed,
+  });
+}
+
+function callIsInside(call: ts.Node, fn: ts.FunctionDeclaration): boolean {
+  let n: ts.Node | undefined = call;
+  while (n) {
+    if (n === fn) {
+      return true;
+    }
+    n = n.parent;
+  }
+  return false;
+}
+
+function baseName(path: string): string {
+  return path.split(/[\\/]/u).pop() ?? path;
+}
+
+/** Threshold (all-agree fraction) at or above which M6 is justified. */
+export const M6_THRESHOLD = 0.25;
+
+/** Render the survey as a human-readable Markdown report. */
+export function formatMonoSurveyMarkdown(
+  report: MonoSurveyReport,
+  meta: {
+    title: string;
+    date: string;
+    corpus: string;
+    /** Corpus-specific interpretive caveats appended to the verdict. */
+    notes?: readonly string[];
+  },
+): string {
+  const lines: string[] = [];
+  lines.push(`# ${meta.title}`, "");
+  lines.push(
+    `**Workstream:** ts2pant \`any\`/\`unknown\` handling via Opaque sort — Milestone 5 (\`ts2pant-opaque-mono-survey\`). **Date:** ${meta.date}. **Method:** read-only whole-program pass over ${meta.corpus}; no translation output is modified.`,
+    "",
+  );
+  lines.push("## Summary", "");
+  lines.push(
+    `- Files surveyed: **${report.files.length}**`,
+    `- Top-level function declarations: **${report.totalFunctions}**`,
+    `- Monomorphization candidates (>=1 top-level \`any\`/\`unknown\` parameter): **${report.candidateFunctions}**`,
+    `- Functions with a top-level \`any\`/\`unknown\` return (context): **${report.dynamicReturnFunctions}**`,
+    "",
+  );
+  lines.push("### Verdict distribution", "");
+  lines.push("| Verdict | Count |", "| --- | --- |");
+  for (const v of Object.keys(EMPTY_VERDICT_COUNTS) as Verdict[]) {
+    lines.push(`| ${v} | ${report.byVerdict[v]} |`);
+  }
+  lines.push("");
+  lines.push("### M6 decision metric", "");
+  lines.push(
+    `- all-agree fraction (of all candidates): **${pct(report.allAgreeFraction)}**`,
+    `- all-agree fraction (of candidates with >=1 visible call site): **${pct(report.allAgreeFractionWithCallSites)}**`,
+    `- Threshold to proceed to M6 (\`ts2pant-opaque-mono\`): **>= ${pct(M6_THRESHOLD)} all-agree**.`,
+    "",
+  );
+  lines.push("### Verdict", "");
+  const proceed = report.allAgreeFraction >= M6_THRESHOLD;
+  lines.push(
+    proceed
+      ? `**Proceed to M6.** ${pct(report.allAgreeFraction)} of candidates are all-agree, at or above the ${pct(M6_THRESHOLD)} threshold.`
+      : `**Do not proceed to M6 on this corpus.** ${pct(report.allAgreeFraction)} of candidates are all-agree, below the ${pct(M6_THRESHOLD)} threshold.`,
+    "",
+  );
+  for (const note of meta.notes ?? []) {
+    lines.push(`- ${note}`);
+  }
+  if (meta.notes && meta.notes.length > 0) {
+    lines.push("");
+  }
+  lines.push("## Per-function detail", "");
+  if (report.functions.length === 0) {
+    lines.push("_No monomorphization candidates found in the corpus._", "");
+  } else {
+    lines.push(
+      "| Function | Dynamic params | Call sites | Verdict | Exported | Body LOC |",
+      "| --- | --- | --- | --- | --- | --- |",
+    );
+    for (const f of report.functions) {
+      lines.push(
+        `| \`${f.file}:${f.name}\` (L${f.line}) | ${f.dynamicParams.join(", ")} | ${f.callSites.length} | ${f.verdict} | ${f.externalCallersUnknown ? "yes" : "no"} | ${f.bodyLoc} |`,
+      );
+    }
+    lines.push("");
+    for (const f of report.functions) {
+      const observed = Object.entries(f.observedTypesByParam)
+        .map(([p, types]) => `${p}: {${types.join(", ") || "—"}}`)
+        .join("; ");
+      lines.push(`- \`${f.file}:${f.name}\` — observed: ${observed}`);
+    }
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
+function pct(x: number): string {
+  return `${(x * 100).toFixed(1)}%`;
+}

--- a/tools/ts2pant/tests/fixtures/mono-survey/cases.ts
+++ b/tools/ts2pant/tests/fixtures/mono-survey/cases.ts
@@ -1,0 +1,80 @@
+// @archlint.module exempt
+// @archlint.exempt-reason test-support
+
+// Fixtures for the monomorphization-survey classifier. Each exported function
+// has a top-level `any` parameter (a candidate); `driver` supplies call sites
+// with typed arguments so each verdict branch is exercised.
+
+export function allAgree(x: any): number {
+  return x ? 1 : 0;
+}
+
+export function bounded(x: any): number {
+  return x ? 1 : 0;
+}
+
+export function unbounded(x: any): number {
+  return x ? 1 : 0;
+}
+
+export function recursiveFn(x: any): number {
+  return recursiveFn(x);
+}
+
+export function uncalled(x: any): number {
+  return x ? 1 : 0;
+}
+
+export function oversizedFn(x: any): number {
+  // padding to exceed the OVERSIZED_LOC (30) body-line threshold:
+  //  1
+  //  2
+  //  3
+  //  4
+  //  5
+  //  6
+  //  7
+  //  8
+  //  9
+  // 10
+  // 11
+  // 12
+  // 13
+  // 14
+  // 15
+  // 16
+  // 17
+  // 18
+  // 19
+  // 20
+  // 21
+  // 22
+  // 23
+  // 24
+  // 25
+  // 26
+  // 27
+  // 28
+  // 29
+  // 30
+  return x ? 1 : 0;
+}
+
+const s1: string = "a";
+const s2: string = "b";
+const n1: number = 1;
+const b1: boolean = true;
+
+export function driver(): number {
+  return (
+    allAgree(s1) +
+    allAgree(s2) +
+    bounded(s1) +
+    bounded(n1) +
+    unbounded(s1) +
+    unbounded(n1) +
+    unbounded(b1) +
+    unbounded({}) +
+    oversizedFn(s1)
+  );
+}

--- a/tools/ts2pant/tests/mono-survey.test.mts
+++ b/tools/ts2pant/tests/mono-survey.test.mts
@@ -1,0 +1,54 @@
+// @archlint.module test
+// @archlint.domain ts2pant.mono-survey
+
+import assert from "node:assert/strict";
+import { resolve } from "node:path";
+import { describe, it } from "node:test";
+
+import {
+  M6_THRESHOLD,
+  surveyMonomorphization,
+} from "../src/mono-survey.js";
+
+const CASES = resolve(
+  import.meta.dirname,
+  "fixtures/mono-survey/cases.ts",
+);
+
+describe("monomorphization survey classifier", () => {
+  const report = surveyMonomorphization([CASES]);
+  const byName = new Map(report.functions.map((f) => [f.name, f]));
+
+  it("classifies each verdict branch", () => {
+    assert.equal(byName.get("allAgree")?.verdict, "all-agree");
+    assert.equal(byName.get("bounded")?.verdict, "disagree-but-bounded");
+    assert.equal(byName.get("unbounded")?.verdict, "disagree-unbounded");
+    assert.equal(byName.get("recursiveFn")?.verdict, "recursive");
+    assert.equal(byName.get("uncalled")?.verdict, "no-visible-call-sites");
+    assert.equal(byName.get("oversizedFn")?.verdict, "oversized");
+  });
+
+  it("records observed argument types per dynamic parameter", () => {
+    assert.deepEqual(byName.get("allAgree")?.observedTypesByParam, {
+      x: ["string"],
+    });
+    const bounded = byName.get("bounded")?.observedTypesByParam.x ?? [];
+    assert.deepEqual([...bounded].sort(), ["number", "string"]);
+  });
+
+  it("flags exported candidates as external-callers-unknown", () => {
+    assert.equal(byName.get("allAgree")?.externalCallersUnknown, true);
+  });
+
+  it("`driver` is not a candidate (no dynamic parameter)", () => {
+    assert.equal(byName.has("driver"), false);
+  });
+
+  it("computes the M6 decision metric over the candidate set", () => {
+    // 6 candidates; exactly one (allAgree) is all-agree.
+    assert.equal(report.candidateFunctions, 6);
+    assert.equal(report.byVerdict["all-agree"], 1);
+    assert.equal(report.allAgreeFraction, 1 / 6);
+    assert.equal(report.allAgreeFraction < M6_THRESHOLD, true);
+  });
+});

--- a/workstreams/ts2pant-any-unknown-opaque.md
+++ b/workstreams/ts2pant-any-unknown-opaque.md
@@ -82,6 +82,8 @@ Give ts2pant a principled, two-layer mechanism for handling TypeScript `any` and
 
 ### Milestone 3: ts2pant-opaque-default
 
+*(Planned 2026-06-21 — `gameplans/ts2pant-opaque-default.json`. The M2→M3 observation-window blocker — an opaque-contagion crash on synthetic SSA loop-body nodes — was fixed in PR #329; the corpus runs 111/111 under opaque.)*
+
 **Definition of Done**:
 - Default value of `mapTsType`'s `policy` parameter flips from `"reject"` to `"opaque"`.
 - Every fixture in the corpus that previously rejected on `any` / `unknown` now produces Pant with the `Opaque` encoding; snapshots regenerate exactly once and the regenerated output is the new baseline.
@@ -92,12 +94,15 @@ Give ts2pant a principled, two-layer mechanism for handling TypeScript `any` and
 
 **Unlocks**: M4 has a stable target (the opaque baseline is now what narrowing recovers from), M5 has a meaningful sample (the corpus now contains `OpaqueValue` instances to survey).
 
-**Open Questions** (resolve during write-gameplan):
-- Snapshot regeneration discipline — single commit that regenerates all affected snapshots, or per-fixture cleanup commits? Existing precedent in this repo favors single regeneration commits.
+**Open Questions** (resolved during write-gameplan):
+- ~~Snapshot regeneration discipline — single commit vs. per-fixture cleanup commits?~~ **Resolved**: single regeneration co-located with the flip patch (Patch 2), forced by gameplan atomicity — a flip that left snapshots stale would leave the suite red between patches. Matches the repo's single-regeneration-commit precedent.
+- ~~Default-resolution point — flip the pipeline default only, or resolve inside `mapTsType`?~~ **Resolved** (Design B): resolve the default inside `mapTsType` via `opts?.policy ?? DEFAULT_OPAQUE_POLICY` (single source of truth), not only at the pipeline boundary, matching the DoD wording.
 
 ---
 
 ### Milestone 4: ts2pant-opaque-narrowing
+
+*(Planned 2026-06-21 — `gameplans/ts2pant-opaque-narrowing.json`; built atop the landed opaque-default flip.)*
 
 **Definition of Done**:
 - At use sites of `any` / `unknown` values, `checker.getTypeAtLocation(useNode)` is consulted. If the narrowed type is concrete (not `any` / `unknown`), the use lowers to that concrete sort instead of `OpaqueValue`.
@@ -108,15 +113,19 @@ Give ts2pant a principled, two-layer mechanism for handling TypeScript `any` and
 
 **Why this is a safe pause point**: Pure precision improvement. The encoding remains sound (we narrow only when the TS compiler asserts the narrowed type, which is a property the TS language already guarantees). Reverting M4 is mechanical (drop the `getTypeAtLocation` call site).
 
-**Unlocks**: M5's survey now reflects post-narrowing opacity — sites that are still opaque after narrowing are the real monomorphization candidates.
+**Unlocks**: M5's survey now reflects post-narrowing opacity — sites that are still opaque after narrowing are the real monomorphization candidates. Also unblocks the guard-analysis workstream's M3b-deferred type-predicate cases — the "future M3c" that `tools/ts2pant/docs/guard-narrowing.md` notes needs a refined-type representation now has the opaque sort-recovery layer to build on.
 
-**Open Questions** (resolve during write-gameplan):
-- Which narrowing forms to handle in the first cut and which to defer (the long tail of narrowing forms — assertion functions, custom type guards, `in` operator — has diminishing returns)?
-- How to express the "cross-function narrowing not trusted" boundary in the printer / diagnostics — does the user see a hint that a parameter is opaque because we declined to follow the caller's narrowing?
+**Open Questions** (resolved during write-gameplan):
+- ~~Which narrowing forms to handle in the first cut and which to defer?~~ **Resolved**: recover every narrowed type that `mapTsType` supports under reject policy (scalars + supported composites + instanceof-class), with a conservative bail to Opaque on `UNSUPPORTED_UNKNOWN`. This covers typeof / `Array.isArray` / `instanceof` / discriminator automatically (TS does the narrowing; we map the result), needs no bespoke per-form allowlist, and ships ungated.
+- ~~How to express the "cross-function narrowing not trusted" boundary in the printer / diagnostics?~~ **Resolved**: no per-occurrence diagnostic — the Opaque sort is already visible in output, and the boundary is documented in `opaque-narrowing.md`. Consistent with the M3 decision to add no opaque diagnostic.
 
 ---
 
 ### Milestone 5: ts2pant-opaque-mono-survey
+
+*(Executed 2026-06-22 — not gameplanned: a read-only survey has no behavior change, feature flag, patch-sequencing, or atomicity surface, so it was implemented directly. Survey tool: `tools/ts2pant/src/mono-survey.ts` + `scripts/mono-survey.mts` (`npm run survey`); report at `tools/ts2pant/docs/opaque-mono-survey.{md,json}`.)*
+
+**Outcome**: Over the dogfood corpus (42 files, 770 top-level functions), **1** function has a top-level `any`/`unknown` parameter (`emit.ts:isExecError`, verdict `disagree-unbounded`); **0%** all-agree, far below the 25% threshold. The dogfood corpus is a strict, self-hosted codebase that avoids top-level `any`/`unknown` by construction, so it is **not representative** of the `any`/`unknown`-heavy user code M6 targets — a near-zero count reflects the corpus, not the value of monomorphization. **Decision: do not proceed to M6 on this evidence; the workstream pauses at M5.** A go decision requires re-surveying representative `any`/`unknown`-heavy user TypeScript; absent that, M5 is the workstream's terminal milestone (the M5 DoD permits closing here). The classifier was validated against `tests/fixtures/mono-survey/cases.ts` (all six verdict branches) so a future re-survey over real inputs is a config change, not new work.
 
 **Definition of Done**:
 - A read-only whole-program pass walks every function whose signature contains `any` / `unknown` (declaration site) and records every call site within the same module (and dep modules if reachable).
@@ -134,10 +143,12 @@ Give ts2pant a principled, two-layer mechanism for handling TypeScript `any` and
 - Decision criterion to proceed to M6: at least 25% of sites are in category (a). Below that threshold, the precision recovery is not worth the implementation cost; close the workstream after M5.
 - If proceeding, record the LOC threshold and the maximum-distinct-types threshold for M6 as part of the gameplan handoff.
 
-**Open Questions** (resolve during write-gameplan):
-- Report format — JSON shape for machine consumption (CI artifact?) and Markdown shape for human review?
-- Cross-module reach — do we follow imports into dep modules, or limit to the source file?
-- Treatment of exported functions whose callers are outside the visible program — they cannot be specialized soundly; the report flags them as "external-callers-unknown."
+**Open Questions** (resolved during implementation):
+- ~~Report format?~~ **Resolved**: `opaque-mono-survey.json` (machine, regenerable) + `opaque-mono-survey.md` (human summary with a derived threshold verdict), both written by `npm run survey`.
+- ~~Cross-module reach?~~ **Resolved**: candidates come from the requested files; call sites are scanned across the whole non-foreign program (`resolveSourceFileDependencies` + filter out default-lib/node_modules), so cross-file calls within the corpus are visible without chasing foreign imports.
+- ~~Exported functions with external callers?~~ **Resolved**: flagged `externalCallersUnknown` (a function can be soundly specialized only per-visible-site, never replaced wholesale, when its full caller set is outside the surveyed program).
+
+**Known limitation**: the survey scans top-level `FunctionDeclaration`s only (not class methods or arrow-const bindings). A grep confirmed this does not undercount the dogfood corpus (no arrow-const any/unknown-param helpers exist), but a re-survey over user code should lift this.
 
 ---
 
@@ -180,7 +191,7 @@ M3 and M4 can proceed in parallel once M2 has landed and the observation window 
 | `Opaque` granularity — single global sort vs. per-module-boundary | Decided: single global sort (simpler, can revisit if proofs need finer-grained distinctness). Listed here for traceability. | Resolved at workstream draft |
 | Equality semantics on `Opaque` values | TS structural identity vs. Pant reference identity. Needs a fixture and a documented stance. | M1 gameplan |
 | Interaction with `IsNullish` / list-lift encoding | `unknown \| null` after null-check is `unknown`. Likely composes as `[Opaque]`, but verify. | M2 gameplan |
-| Diagnostic surfacing for opaque-containing rules | Existing `UNSUPPORTED-skip` infrastructure is for rejected files. Opaque-containing files verify; do we still surface a hint? | M3 gameplan |
+| ~~Diagnostic surfacing for opaque-containing rules~~ | **Resolved (M3 gameplan)**: no opaque-origin diagnostic in M3 — the Opaque domain is visible in emitted Pant; revisit only if dogfood shows silent opacity is confusing. | Resolved 2026-06-21 |
 | Cross-module monomorphization | Visibility constraints across dep modules. The survey (M5) measures the cost of *not* crossing modules. | M5 report informs M6 |
 | Treatment of generic functions whose type parameters happen to bind to `any` / `unknown` at a call site | Out of scope for this workstream — generics handling is a separate problem. Recorded to avoid scope creep. | Out of scope |
 
@@ -193,5 +204,9 @@ M3 and M4 can proceed in parallel once M2 has landed and the observation window 
 | No global `Any` top-type with implicit coercions | Considered and rejected. A universal sort with coercions poisons every operation involving it (every Pant rule becomes trivially satisfiable on `Any` arguments). The opaque-sort-with-no-operations encoding preserves soundness because operations on `Opaque` either propagate opacity or are rejected at type-check, neither of which silently succeeds. |
 | Cross-function-call narrowing not trusted by default (M4) | TS flow narrowing across call boundaries depends on assertion-function and predicate-type machinery that does not always survive ts2pant's intermediate representations. Conservative default: at every function boundary, parameters typed `any` / `unknown` re-enter as fresh `OpaqueValue`. Caller-side narrowing applies within the caller only. |
 | Opt-in `"opaque"` policy before default flip (M2 → M3 split) | Lets us validate the encoding on a controlled subset before the corpus-wide regeneration. The observation window between M2 and M3 is the structural reason this workstream is not a single gameplan — it is exactly the kind of pause a gameplan cannot contain. |
+| Resolve the opacity default inside `mapTsType` (M3, Design B) | `mapTsType` resolves an unspecified policy via `opts?.policy ?? DEFAULT_OPAQUE_POLICY`, giving one source of truth shared by the pipeline, direct callers, and tests — matching the DoD's "mapTsType's policy parameter default flips". Design A (flip the pipeline default only) was rejected: it would leave `mapTsType`'s literal default diverging from the product default. Cost: ~10 reject unit tests pinned to explicit `policy: "reject"`, which also keeps the reject path covered. |
+| No opaque-origin diagnostic in M3 | M3 stays a pure default flip. Opacity is already observable in the emitted Pant (the `Opaque` domain), so it is not hidden; adding an informational hint would be a second behavior change with its own snapshot churn. Deferred, to revisit if dogfood shows the silent opacity is confusing. |
+| Opaque-narrowing (M4) reads `getTypeAtLocation` directly, orthogonal to the guard-analysis AssumptionEnv | The AssumptionEnv tracks discriminant/non-null/predicate facts to discharge definedness obligations (partial-access safety); M4 is *sort selection* at a use site. TS's own intra-function flow narrowing is the authority for the narrowed type, so M4 reads `checker.getTypeAtLocation(useNode)` directly rather than inventing a redundant fact kind. The two narrowing layers are complementary, not the same mechanism. |
+| Opaque-narrowing (M4) reuses the synthesized-opaque form's `sort` field | A narrowed-but-unconstrained value is represented as a fresh nullary rule `name => <narrowedSort>` — the existing opaque form already carries `sort` and the lowering/printer honor it, so no new L1 vocabulary is needed. Pant has no `Opaque`→concrete projection, so minting a fresh constant of the narrowed sort is the sound representation (consistent with the per-occurrence opaque-constant model). |
 | Survey-before-implement for monomorphization (M5 → M6 split) | Two reasons: (a) the decision to proceed is conditional on the survey's verdict, which a gameplan cannot encode; (b) the survey itself produces useful diagnostic output even if M6 never lands, so M5 has independent value. |
 | No dedicated design-doc milestone | Project convention: design questions live in the open-questions of the milestone they gate and are resolved during write-gameplan. Recorded here to short-circuit a recurring drafting mistake. |

--- a/workstreams/ts2pant-any-unknown-opaque.md
+++ b/workstreams/ts2pant-any-unknown-opaque.md
@@ -82,7 +82,7 @@ Give ts2pant a principled, two-layer mechanism for handling TypeScript `any` and
 
 ### Milestone 3: ts2pant-opaque-default
 
-*(Planned 2026-06-21 — `gameplans/ts2pant-opaque-default.json`. The M2→M3 observation-window blocker — an opaque-contagion crash on synthetic SSA loop-body nodes — was fixed in PR #329; the corpus runs 111/111 under opaque.)*
+*(✅ COMPLETE — PRs #330–#332. The M2→M3 observation-window blocker — an opaque-contagion crash on synthetic SSA loop-body nodes — was fixed first in PR #329; the corpus runs 111/111 under opaque.)*
 
 **Definition of Done**:
 - Default value of `mapTsType`'s `policy` parameter flips from `"reject"` to `"opaque"`.
@@ -102,7 +102,7 @@ Give ts2pant a principled, two-layer mechanism for handling TypeScript `any` and
 
 ### Milestone 4: ts2pant-opaque-narrowing
 
-*(Planned 2026-06-21 — `gameplans/ts2pant-opaque-narrowing.json`; built atop the landed opaque-default flip.)*
+*(✅ COMPLETE — PRs #333–#335; built atop the landed opaque-default flip.)*
 
 **Definition of Done**:
 - At use sites of `any` / `unknown` values, `checker.getTypeAtLocation(useNode)` is consulted. If the narrowed type is concrete (not `any` / `unknown`), the use lowers to that concrete sort instead of `OpaqueValue`.

--- a/workstreams/ts2pant-discriminated-union.md
+++ b/workstreams/ts2pant-discriminated-union.md
@@ -101,7 +101,7 @@ the shape this workstream generalizes.
 
 ## Milestones
 
-### Milestone 1: du-tagged-encoding — planned (`gameplans/ts2pant-du-tagged-encoding.json`)
+### Milestone 1: du-tagged-encoding — ✅ COMPLETE (PRs #290–#291)
 
 > **Being executed now**, ahead of further guard-analysis work: M1 is independent
 > of guard-analysis (it is the encoding, not narrowing) and unblocks M2 and — with
@@ -220,7 +220,7 @@ invariants to add first).
 
 ---
 
-### Milestone 3: du-discriminant-narrowing
+### Milestone 3: du-discriminant-narrowing — ✅ COMPLETE (PRs #299–#301, #303–#304)
 
 > **Update (2026-05-28):** the guard-analysis M3a gameplan
 > (`gameplans/ts2pant-du-discriminant-narrowing-layer.json`) ships the
@@ -278,7 +278,7 @@ has no remaining advantage for discriminated unions and can be retired.
 
 ---
 
-### Milestone 4: du-cutover — planned (`gameplans/ts2pant-du-cutover.json`)
+### Milestone 4: du-cutover — ✅ COMPLETE (PRs #307–#311)
 
 > **Planned (2026-05-29).** Two "handled-or-refused" choices in the original
 > DoD were resolved while planning: nested DUs are **handled** by recursive

--- a/workstreams/ts2pant-guard-analysis.md
+++ b/workstreams/ts2pant-guard-analysis.md
@@ -101,7 +101,7 @@ union, `yield* new ErrorClass()`) is unimplemented.
 
 ## Milestones
 
-### Milestone 1: guard-purity-user-calls — planned (`gameplans/ts2pant-guard-purity-user-calls.json`)
+### Milestone 1: guard-purity-user-calls — ✅ COMPLETE (PRs #284–#287)
 
 **Definition of Done**:
 - **Purity-oracle consolidation (sequenced first within M1):** the two purity
@@ -206,7 +206,7 @@ interface the DU workstream can commit to.
 > consults it to discharge guards; pop on exit), intra-function only, no field-name
 > special-casing, facts rendered as z3 path conditions.
 
-### Milestone 3a: du-discriminant-narrowing-layer — planned (`gameplans/ts2pant-du-discriminant-narrowing-layer.json`)
+### Milestone 3a: du-discriminant-narrowing-layer — ✅ COMPLETE (PRs #292, #294–#297)
 
 > **Planning decision (2026-05-28):** M3a absorbs the variant-field-rule discharge
 > wiring (Patch 5 in the gameplan) rather than deferring it to DU M3. Reason: the
@@ -260,7 +260,7 @@ and path-condition precedents are consumed here directly.
 
 ---
 
-### Milestone 3b: nullish-and-predicate-narrowing
+### Milestone 3b: nullish-and-predicate-narrowing — ✅ COMPLETE (PRs #312, #315, #320, #322)
 
 **Definition of Done**:
 - Extends the M3a assumption environment with **nullish** narrowing (`x != null` /
@@ -285,7 +285,7 @@ corpus (165 nullish sites + the type-guard tail).
 
 ---
 
-### Milestone 4: guard-effect-error-channel
+### Milestone 4: guard-effect-error-channel — ✅ COMPLETE (PRs #313, #314, #318, #319)
 
 **Definition of Done**:
 - Extract the error channel `E` from `Effect<A, E, R>` signatures to enumerate

--- a/workstreams/ts2pant-ir1-substitution.md
+++ b/workstreams/ts2pant-ir1-substitution.md
@@ -128,7 +128,7 @@ operand rewrites land in the same place.
 
 ## Milestones
 
-### Milestone 1: ir1-substitution
+### Milestone 1: ir1-substitution — ✅ COMPLETE (PRs #231–#235)
 
 **Definition of Done**:
 


### PR DESCRIPTION
## Context

Milestone **M5 (`ts2pant-opaque-mono-survey`)** of the `any`/`unknown`-opaque workstream. With the opaque default (M3) and use-site narrowing (M4) landed, M5 is the *measure-before-implement* gate for M6 (`opaque-mono`, call-site monomorphization): a read-only survey that measures whether real call graphs are closed enough for specialization to recover precision.

Implemented **directly rather than as a gameplan** — a read-only survey has no behavior change, feature flag, patch-sequencing, or atomicity surface, so the gameplan ceremony would add nothing.

## What it does

For every function with a top-level `any`/`unknown` parameter, scan call sites across the whole program, record the observed argument type at each site via `getTypeAtLocation`, and classify monomorphization-friendliness: `all-agree` / `disagree-but-bounded` / `disagree-unbounded` / `recursive` / `oversized` / `no-visible-call-sites`. Never changes translation output.

- `src/mono-survey.ts` — survey + classifier + Markdown formatter (with a derived threshold verdict).
- `scripts/mono-survey.mts` + `npm run survey` — runner over the `src/` corpus; writes `docs/opaque-mono-survey.{json,md}` and prints the M6 decision metric.
- `tests/mono-survey.test.mts` + `tests/fixtures/mono-survey/cases.ts` — classifier coverage for all six verdict branches (the real corpora exercise only `disagree-unbounded` / `no-visible-call-sites`).
- `extract.ts` — export `COMPILER_OPTIONS` so the survey reuses the same program build.

## Finding & decision

Over the dogfood corpus (**42 files, 770 functions**): **1 candidate** (`emit.ts:isExecError`, `disagree-unbounded`), **0% all-agree** — far below the 25% threshold.

**Do not proceed to M6 on this evidence.** The dogfood corpus is a strict, self-hosted codebase that avoids top-level `any`/`unknown` by construction, so it is *not representative* of the `any`/`unknown`-heavy user code M6 targets — a near-zero count reflects the corpus, not the value of monomorphization. A go decision needs a re-survey over representative user TypeScript; absent that, **M5 is the workstream's terminal milestone** (its DoD permits closing here). The classifier is validated, so re-running over real inputs is a config change, not new work.

## Workstream write-back

Also writes the M3 / M4 / M5 milestone outcomes back to `workstreams/ts2pant-any-unknown-opaque.md` (M5 marked executed, its open questions resolved, the M5→M6 decision recorded). No gameplan JSON is included in this PR.

## Verification

tsc clean, biome clean, unit **385 + 950 / 0 fail** (incl. the new classifier test), integration **111/111** (the survey touches no translation path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)