### PR TITLE
Type-mapping returns a Result; fix recursive-DU crash

### DIFF
--- a/tools/ts2pant/src/extract.ts
+++ b/tools/ts2pant/src/extract.ts
@@ -779,7 +779,13 @@ export function extractModuleConsts(
       continue;
     }
     const tsType = checker.getTypeAtLocation(decl);
-    const pantType = mapTsType(tsType, checker, strategy, synthCell);
+    const pantTypeResult = mapTsType(tsType, checker, strategy, synthCell);
+    if (!pantTypeResult.ok) {
+      // The const's type has no Pant sort — skip it rather than emit a
+      // refusal reason as a rule's return type.
+      continue;
+    }
+    const pantType = pantTypeResult.sort;
     // Kebab from the *declaration's* name (not any local alias spelling)
     // so all aliases route to the same Pant rule. With
     // `import { ERR, ERR as Err }`, both `ERR` and `Err` should resolve
@@ -1120,27 +1126,35 @@ function translateReferencedCallable(
   if (returnType.flags & ts.TypeFlags.Void) {
     return null;
   }
-  const params = sig.getParameters().map((param) => {
+  const params: { name: string; type: string }[] = [];
+  for (const param of sig.getParameters()) {
     const paramDecl = param.valueDeclaration ?? decl;
     const paramType = checker.getTypeOfSymbolAtLocation(param, paramDecl);
-    const pantType = mapTsType(paramType, checker, strategy, synthCell, {
+    const mapped = mapTsType(paramType, checker, strategy, synthCell, {
       policy: "opaque",
     });
+    // Can't synthesize a sound rule head with an unmappable parameter type.
+    if (!mapped.ok) {
+      return null;
+    }
     const pantName = synthCell
       ? cellRegisterName(synthCell, toPantTermName(param.name))
       : toPantTermName(param.name);
-    return { name: pantName, type: pantType };
-  });
+    params.push({ name: pantName, type: mapped.sort });
+  }
   const pantReturnType = mapTsType(returnType, checker, strategy, synthCell, {
     policy: "opaque",
   });
+  if (!pantReturnType.ok) {
+    return null;
+  }
   return {
     kind: "rule",
     name: synthCell
       ? cellRegisterName(synthCell, toPantTermName(declName))
       : toPantTermName(declName),
     params,
-    returnType: pantReturnType,
+    returnType: pantReturnType.sort,
   };
 }
 

--- a/tools/ts2pant/src/ir-build.ts
+++ b/tools/ts2pant/src/ir-build.ts
@@ -918,8 +918,26 @@ function buildCollectionMembershipCall(
   if (typeArgs.length !== 2) {
     return { unsupported: "Map with unexpected arity" };
   }
-  const kType = mapTsType(typeArgs[0]!, checker, strategy, supply.synthCell);
-  const vType = mapTsType(typeArgs[1]!, checker, strategy, supply.synthCell);
+  const kTypeResult = mapTsType(
+    typeArgs[0]!,
+    checker,
+    strategy,
+    supply.synthCell,
+  );
+  if (!kTypeResult.ok) {
+    return { unsupported: `Map key type: ${kTypeResult.reason}` };
+  }
+  const vTypeResult = mapTsType(
+    typeArgs[1]!,
+    checker,
+    strategy,
+    supply.synthCell,
+  );
+  if (!vTypeResult.ok) {
+    return { unsupported: `Map value type: ${vTypeResult.reason}` };
+  }
+  const kType = kTypeResult.sort;
+  const vType = vTypeResult.sort;
   let info = supply.synthCell
     ? lookupMapKV(supply.synthCell.synth, kType, vType)
     : undefined;

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -131,7 +131,6 @@ import {
   fieldRuleName,
   isMapType,
   isSetType,
-  isUnsupportedUnknown,
   lookupMapKV,
   mapTsType,
   type NumericStrategy,
@@ -219,7 +218,7 @@ function narrowedSortForUse(
     ctx.supply.synthCell,
     { policy: "reject" },
   );
-  return isUnsupportedUnknown(sort) ? null : sort;
+  return sort.ok ? sort.sort : null;
 }
 
 function opaqueValueForDynamicExpr(
@@ -526,7 +525,7 @@ export function tryBuildBuiltinCall(
       ctx.supply.synthCell,
       { policy: ctx.policy },
     );
-    if (sourceType === "[String * Int]") {
+    if (sourceType.ok && sourceType.sort === "[String * Int]") {
       rule = "JS_ARRAY::from-entries";
     }
   }
@@ -832,10 +831,10 @@ function resolveStageASetReadType(
     ctx.supply.synthCell,
     { policy: ctx.policy },
   );
-  if (isUnsupportedUnknown(ownerType) || isUnsupportedUnknown(elemType)) {
+  if (!ownerType.ok || !elemType.ok) {
     return null;
   }
-  return { ownerType, elemType };
+  return { ownerType: ownerType.sort, elemType: elemType.sort };
 }
 
 /**
@@ -878,10 +877,10 @@ function resolveStageAMapReadType(
     ctx.supply.synthCell,
     { policy: ctx.policy },
   );
-  if (isUnsupportedUnknown(ownerType) || isUnsupportedUnknown(keyType)) {
+  if (!ownerType.ok || !keyType.ok) {
     return null;
   }
-  return { ownerType, keyType };
+  return { ownerType: ownerType.sort, keyType: keyType.sort };
 }
 
 /**
@@ -1258,31 +1257,31 @@ export function tryBuildL1PureSubExpression(
         if (typeArgs.length !== 2) {
           return { unsupported: "Map with unexpected arity" };
         }
-        const kType = mapTsType(
+        const kTypeResult = mapTsType(
           typeArgs[0]!,
           ctx.checker,
           ctx.strategy,
           ctx.supply.synthCell,
           { policy: ctx.policy },
         );
-        const vType = mapTsType(
+        const vTypeResult = mapTsType(
           typeArgs[1]!,
           ctx.checker,
           ctx.strategy,
           ctx.supply.synthCell,
           { policy: ctx.policy },
         );
-        // mapTsType returns the unsupported-unknown sentinel for
-        // unresolvable TS types (e.g., raw `unknown`). Bail before
-        // lookupMapKV / cellRegisterMap so we don't synthesize a domain
-        // built on the sentinel — translate-types.ts already guards this
-        // path elsewhere.
-        if (isUnsupportedUnknown(kType) || isUnsupportedUnknown(vType)) {
+        // mapTsType refuses unresolvable TS types (e.g., raw `unknown`). Bail
+        // before lookupMapKV / cellRegisterMap so we don't synthesize a domain
+        // built on a non-sort.
+        if (!kTypeResult.ok || !vTypeResult.ok) {
           return {
             unsupported:
               "Map key or value type is unsupported in native call lowering",
           };
         }
+        const kType = kTypeResult.sort;
+        const vType = vTypeResult.sort;
         // `cellRegisterMap` is idempotent (returns the cached entry on
         // re-registration), so always-register-then-lookup is the
         // simplest safe shape. `lookupMapKV` returns `undefined`
@@ -1414,18 +1413,25 @@ function buildL1Stringification(
   if (opaque !== null) {
     return opaque;
   }
-  const pantType = mapTsType(
+  const pantTypeResult = mapTsType(
     tsType,
     ctx.checker,
     ctx.strategy,
     ctx.supply.synthCell,
     { policy: ctx.policy },
   );
-  if (!STRINGIFIABLE_PRIMITIVES.has(pantType)) {
+  if (
+    !pantTypeResult.ok ||
+    !STRINGIFIABLE_PRIMITIVES.has(pantTypeResult.sort)
+  ) {
+    const shown = pantTypeResult.ok
+      ? pantTypeResult.sort
+      : pantTypeResult.reason;
     return {
-      unsupported: `template literal substitution has unsupported type "${pantType}" — only String, Int, Real, Bool are stringifiable`,
+      unsupported: `template literal substitution has unsupported type "${shown}" — only String, Int, Real, Bool are stringifiable`,
     };
   }
+  const pantType = pantTypeResult.sort;
   if (pantType === "String") {
     return value;
   }

--- a/tools/ts2pant/src/narrowing-recognizer.ts
+++ b/tools/ts2pant/src/narrowing-recognizer.ts
@@ -14,7 +14,6 @@ import {
 import {
   detectDiscriminatedUnion,
   IntStrategy,
-  isUnsupportedUnknown,
   mapTsType,
 } from "./translate-types.js";
 
@@ -198,7 +197,7 @@ function isTractableTypePredicateTarget(
     return false;
   }
   const mapped = mapTsType(type, checker, IntStrategy, undefined);
-  return !isUnsupportedUnknown(mapped);
+  return mapped.ok;
 }
 
 /** Recognize a TypeScript boolean test as a narrowing fact. */

--- a/tools/ts2pant/src/pipeline.ts
+++ b/tools/ts2pant/src/pipeline.ts
@@ -18,13 +18,11 @@ import { findFunction, translateSignature } from "./translate-signature.js";
 import {
   cellEmitSynth,
   fieldRuleName,
-  isUnsupportedUnknown,
   mapTsType,
   type NumericStrategy,
   newSynthCell,
   toPantTermName,
   translateTypes,
-  UNSUPPORTED_UNKNOWN_REASON,
 } from "./translate-types.js";
 import type { PantDeclaration, PantDocument, PantRule } from "./types.js";
 
@@ -66,11 +64,11 @@ function mutatingReturnValueDeclarations(
   const returnType = mapTsType(tsReturnType, checker, strategy, synthCell, {
     policy,
   });
-  if (isUnsupportedUnknown(returnType)) {
+  if (!returnType.ok) {
     return [
       {
         kind: "unsupported",
-        reason: `${baseName} return: ${UNSUPPORTED_UNKNOWN_REASON}`,
+        reason: `${baseName} return: ${returnType.reason}`,
       },
     ];
   }
@@ -79,7 +77,7 @@ function mutatingReturnValueDeclarations(
     kind: "rule",
     name: baseName,
     params: sigDecl.params,
-    returnType,
+    returnType: returnType.sort,
   };
   return [returnDecl];
 }

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -115,15 +115,14 @@ import {
   fieldRuleName,
   isMapType,
   isSetType,
-  isUnsupportedUnknown,
   lookupMapKV,
   mapTsType,
   type NumericStrategy,
+  okSort,
   resolveFieldOwner,
   type SynthCell,
   toPantTermName,
   UNSUPPORTED_NON_DISCRIMINATED_UNION_FIELD_ACCESS_REASON,
-  UNSUPPORTED_UNKNOWN_REASON,
 } from "./translate-types.js";
 import {
   type ExtractedBlockConstBinding,
@@ -1097,11 +1096,11 @@ export function translateBody(opts: TranslateBodyOptions): PropResult[] {
       // declaration for this case, so the right move here is to bail
       // with a single unsupported PropResult rather than emit broken
       // equations.
-      if (isUnsupportedUnknown(typeName)) {
+      if (!typeName.ok) {
         return [
           {
             kind: "unsupported",
-            reason: `${functionName} param '${param.name}': ${UNSUPPORTED_UNKNOWN_REASON}`,
+            reason: `${functionName} param '${param.name}': ${typeName.reason}`,
           },
         ];
       }
@@ -1112,7 +1111,7 @@ export function translateBody(opts: TranslateBodyOptions): PropResult[] {
       const pantName =
         paramNameMap?.get(param.name) ?? toPantTermName(param.name);
       paramNames.set(param.name, pantName);
-      paramList.push({ name: pantName, type: typeName });
+      paramList.push({ name: pantName, type: typeName.sort });
     }
   }
 
@@ -2669,7 +2668,7 @@ function lowerPreludeBindings(
         toPantTermName(binding.tsName),
         acc.scopedParams,
       );
-      const returnType =
+      const returnTypeResult =
         binding.kind === "const"
           ? mapTsType(
               checker.getTypeAtLocation(binding.initializer),
@@ -2678,13 +2677,14 @@ function lowerPreludeBindings(
               supply.synthCell,
               { policy },
             )
-          : strategy.mapNumber();
-      if (isUnsupportedUnknown(returnType)) {
+          : okSort(strategy.mapNumber());
+      if (!returnTypeResult.ok) {
         return {
           tag: "error",
-          error: `${binding.tsName}: ${UNSUPPORTED_UNKNOWN_REASON}`,
+          error: `${binding.tsName}: ${returnTypeResult.reason}`,
         };
       }
+      const returnType = returnTypeResult.sort;
       const initExpr =
         binding.kind === "const"
           ? buildL1SubExpr(binding.initializer, {
@@ -3869,9 +3869,13 @@ function getArrayElementType(
     return null;
   }
   const typeArgs = checker.getTypeArguments(sourceType as ts.TypeReference);
-  return typeArgs.length === 1
-    ? mapTsType(typeArgs[0]!, checker, strategy, undefined, { policy })
-    : "?";
+  if (typeArgs.length !== 1) {
+    return "?";
+  }
+  const mapped = mapTsType(typeArgs[0]!, checker, strategy, undefined, {
+    policy,
+  });
+  return mapped.ok ? mapped.sort : null;
 }
 
 /**
@@ -4317,6 +4321,12 @@ export function translateCallExpr(
         supply.synthCell,
         { policy },
       );
+      if (!ownerType.ok) {
+        return { unsupported: `Set mutation owner type: ${ownerType.reason}` };
+      }
+      if (!elemType.ok) {
+        return { unsupported: `Set mutation element type: ${elemType.reason}` };
+      }
       const objOpaque = lowerL1ToOpaque(memberR.receiver);
       let elemOpaque: OpaqueExpr | null = null;
       if (methodName !== "clear") {
@@ -4340,8 +4350,8 @@ export function translateCallExpr(
         effect: {
           op: methodName as "add" | "delete" | "clear",
           ruleName: fieldName,
-          ownerType,
-          elemType,
+          ownerType: ownerType.sort,
+          elemType: elemType.sort,
           objExpr: objOpaque,
           elemExpr: elemOpaque,
         },
@@ -4447,13 +4457,21 @@ export function translateCallExpr(
           supply.synthCell,
           { policy },
         );
+        if (!ownerType.ok) {
+          return {
+            unsupported: `Map mutation owner type: ${ownerType.reason}`,
+          };
+        }
+        if (!keyType.ok) {
+          return { unsupported: `Map mutation key type: ${keyType.reason}` };
+        }
         return {
           effect: {
             op: methodName as "set" | "delete",
             ruleName: fieldName,
             keyPredName: `${fieldName}-key`,
-            ownerType,
-            keyType,
+            ownerType: ownerType.sort,
+            keyType: keyType.sort,
             objExpr: lowerL1ToOpaque(memberR.receiver),
             keyExpr: bodyExpr(kExpr),
             valueExpr,
@@ -4470,20 +4488,28 @@ export function translateCallExpr(
       if (typeArgs.length !== 2) {
         return { unsupported: "Map with unexpected arity" };
       }
-      const kType = mapTsType(
+      const kTypeResult = mapTsType(
         typeArgs[0]!,
         checker,
         strategy,
         supply.synthCell,
         { policy },
       );
-      const vType = mapTsType(
+      if (!kTypeResult.ok) {
+        return { unsupported: `Map key type: ${kTypeResult.reason}` };
+      }
+      const vTypeResult = mapTsType(
         typeArgs[1]!,
         checker,
         strategy,
         supply.synthCell,
         { policy },
       );
+      if (!vTypeResult.ok) {
+        return { unsupported: `Map value type: ${vTypeResult.reason}` };
+      }
+      const kType = kTypeResult.sort;
+      const vType = vTypeResult.sort;
       let info = supply.synthCell
         ? lookupMapKV(supply.synthCell.synth, kType, vType)
         : undefined;
@@ -4606,14 +4632,20 @@ export function translateCallExpr(
           supply.synthCell,
           { policy },
         );
+        if (!ownerType.ok) {
+          return { unsupported: `Map read owner type: ${ownerType.reason}` };
+        }
+        if (!keyType.ok) {
+          return { unsupported: `Map read key type: ${keyType.reason}` };
+        }
         return {
           expr: readMapThroughWrites(
             state,
             methodName as "get" | "has",
             fieldName,
             `${fieldName}-key`,
-            ownerType,
-            keyType,
+            ownerType.sort,
+            keyType.sort,
             lowerL1ToOpaque(memberR.receiver),
             bodyExpr(kExpr),
           ),
@@ -4633,20 +4665,28 @@ export function translateCallExpr(
       if (typeArgs.length !== 2) {
         return { unsupported: "Map with unexpected arity" };
       }
-      const kType = mapTsType(
+      const kTypeResult = mapTsType(
         typeArgs[0]!,
         checker,
         strategy,
         supply.synthCell,
         { policy },
       );
-      const vType = mapTsType(
+      if (!kTypeResult.ok) {
+        return { unsupported: `Map key type: ${kTypeResult.reason}` };
+      }
+      const vTypeResult = mapTsType(
         typeArgs[1]!,
         checker,
         strategy,
         supply.synthCell,
         { policy },
       );
+      if (!vTypeResult.ok) {
+        return { unsupported: `Map value type: ${vTypeResult.reason}` };
+      }
+      const kType = kTypeResult.sort;
+      const vType = vTypeResult.sort;
       let info = supply.synthCell
         ? lookupMapKV(supply.synthCell.synth, kType, vType)
         : undefined;
@@ -4793,13 +4833,13 @@ export function translateCallExpr(
                     policy,
                   })
                 : null;
-            if (elemType !== null) {
+            if (ownerType.ok && elemType?.ok) {
               return {
                 expr: readSetThroughWrites(
                   state,
                   fieldName,
-                  ownerType,
-                  elemType,
+                  ownerType.sort,
+                  elemType.sort,
                   lowerL1ToOpaque(memberR.receiver),
                   bodyExpr(arg),
                 ),

--- a/tools/ts2pant/src/translate-record.ts
+++ b/tools/ts2pant/src/translate-record.ts
@@ -19,7 +19,6 @@ import {
   isAnonymousRecord,
   isMapType,
   isSetType,
-  isUnsupportedUnknown,
   lookupMapKV,
   mapTsType,
   type NumericStrategy,
@@ -150,19 +149,19 @@ export function translateRecordReturn(
     const mapped = mapTsType(returnType, checker, strategy, synthCell, {
       policy,
     });
-    if (isUnsupportedUnknown(mapped)) {
+    if (!mapped.ok) {
+      if (mapped.reason === UNSUPPORTED_ANONYMOUS_RECORD) {
+        return [
+          {
+            kind: "unsupported",
+            reason: `${functionName} — anonymous record return shape could not be synthesized`,
+          },
+        ];
+      }
       return [
         {
           kind: "unsupported",
-          reason: `${functionName}: ${UNSUPPORTED_UNKNOWN_REASON}`,
-        },
-      ];
-    }
-    if (mapped === UNSUPPORTED_ANONYMOUS_RECORD) {
-      return [
-        {
-          kind: "unsupported",
-          reason: `${functionName} — anonymous record return shape could not be synthesized`,
+          reason: `${functionName}: ${mapped.reason}`,
         },
       ];
     }
@@ -642,7 +641,7 @@ function getSetElementTypeName(
       const mapped = mapTsType(typeArgs[0]!, checker, strategy, synthCell, {
         policy,
       });
-      return isUnsupportedUnknown(mapped) ? null : mapped;
+      return mapped.ok ? mapped.sort : null;
     }
   }
   return null;
@@ -676,7 +675,7 @@ function getMapKeyTypeName(
       const mapped = mapTsType(typeArgs[0]!, checker, strategy, synthCell, {
         policy,
       });
-      return isUnsupportedUnknown(mapped) ? null : mapped;
+      return mapped.ok ? mapped.sort : null;
     }
   }
   return null;
@@ -698,7 +697,7 @@ function getMapValueTypeName(
       const mapped = mapTsType(typeArgs[1]!, checker, strategy, synthCell, {
         policy,
       });
-      return isUnsupportedUnknown(mapped) ? null : mapped;
+      return mapped.ok ? mapped.sort : null;
     }
   }
   return null;

--- a/tools/ts2pant/src/translate-signature.ts
+++ b/tools/ts2pant/src/translate-signature.ts
@@ -37,14 +37,14 @@ import {
   cellIsUsed,
   cellRegisterName,
   isMapType,
-  isUnsupportedUnknown,
+  isUnsupportedMappedType,
   type MapTsTypeOptions,
   mapTsType,
   mapTsTypeFromTypeNode,
   type NumericStrategy,
   type SynthCell,
   toPantTermName,
-  UNSUPPORTED_UNKNOWN_REASON,
+  unsupportedMappedTypeReason,
 } from "./translate-types.js";
 import type { PantAction, PantDeclaration, PantRule } from "./types.js";
 
@@ -1625,15 +1625,16 @@ export function translateSignature(
             opts?.typeMapping,
           );
     const paramType = overrides?.get(param.name) ?? defaultType;
-    if (isUnsupportedUnknown(paramType)) {
+    if (isUnsupportedMappedType(paramType)) {
       // Don't let the sentinel reach the emitted rule head — route
       // through the unsupported declaration variant so the document's
       // surrounding text stays parseable and the user sees a clear
-      // reason. Mirrors the PropResult `unsupported` flow.
+      // reason. Mirrors the PropResult `unsupported` flow. Covers both the
+      // `unknown` sentinel and the recursive-discriminated-union refusal.
       return {
         declaration: {
           kind: "unsupported",
-          reason: `${baseName} param '${param.name}': ${UNSUPPORTED_UNKNOWN_REASON}`,
+          reason: `${baseName} param '${param.name}': ${unsupportedMappedTypeReason(paramType)}`,
         },
         classification,
         paramNameMap,
@@ -1702,11 +1703,11 @@ export function translateSignature(
             synthCell,
             opts?.typeMapping,
           );
-    if (isUnsupportedUnknown(returnType)) {
+    if (isUnsupportedMappedType(returnType)) {
       return {
         declaration: {
           kind: "unsupported",
-          reason: `${baseName} return: ${UNSUPPORTED_UNKNOWN_REASON}`,
+          reason: `${baseName} return: ${unsupportedMappedTypeReason(returnType)}`,
         },
         classification,
         paramNameMap,

--- a/tools/ts2pant/src/translate-signature.ts
+++ b/tools/ts2pant/src/translate-signature.ts
@@ -37,14 +37,12 @@ import {
   cellIsUsed,
   cellRegisterName,
   isMapType,
-  isUnsupportedMappedType,
   type MapTsTypeOptions,
   mapTsType,
   mapTsTypeFromTypeNode,
   type NumericStrategy,
   type SynthCell,
   toPantTermName,
-  unsupportedMappedTypeReason,
 } from "./translate-types.js";
 import type { PantAction, PantDeclaration, PantRule } from "./types.js";
 
@@ -1624,22 +1622,26 @@ export function translateSignature(
             synthCell,
             opts?.typeMapping,
           );
-    const paramType = overrides?.get(param.name) ?? defaultType;
-    if (isUnsupportedMappedType(paramType)) {
-      // Don't let the sentinel reach the emitted rule head — route
-      // through the unsupported declaration variant so the document's
-      // surrounding text stays parseable and the user sees a clear
-      // reason. Mirrors the PropResult `unsupported` flow. Covers both the
-      // `unknown` sentinel and the recursive-discriminated-union refusal.
+    const override = overrides?.get(param.name);
+    let paramType: string;
+    if (override !== undefined) {
+      paramType = override;
+    } else if (!defaultType.ok) {
+      // Don't let a refusal reach the emitted rule head — route through the
+      // unsupported declaration variant so the document stays parseable and
+      // the user sees a clear reason (covers the `unknown` refusal, the
+      // recursive-discriminated-union refusal, etc.).
       return {
         declaration: {
           kind: "unsupported",
-          reason: `${baseName} param '${param.name}': ${unsupportedMappedTypeReason(paramType)}`,
+          reason: `${baseName} param '${param.name}': ${defaultType.reason}`,
         },
         classification,
         paramNameMap,
         synthCell,
       };
+    } else {
+      paramType = defaultType.sort;
     }
     const pantName = synthCell
       ? cellRegisterName(synthCell, toPantTermName(param.name))
@@ -1703,11 +1705,11 @@ export function translateSignature(
             synthCell,
             opts?.typeMapping,
           );
-    if (isUnsupportedMappedType(returnType)) {
+    if (!returnType.ok) {
       return {
         declaration: {
           kind: "unsupported",
-          reason: `${baseName} return: ${unsupportedMappedTypeReason(returnType)}`,
+          reason: `${baseName} return: ${returnType.reason}`,
         },
         classification,
         paramNameMap,
@@ -1718,7 +1720,7 @@ export function translateSignature(
       kind: "rule",
       name: baseName,
       params,
-      returnType,
+      returnType: returnType.sort,
     };
     if (combinedGuard) {
       decl.guard = combinedGuard;

--- a/tools/ts2pant/src/translate-types.ts
+++ b/tools/ts2pant/src/translate-types.ts
@@ -77,14 +77,14 @@ export function isUnsupportedDiscriminatedUnionRegistration(
   return pantType === UNSUPPORTED_DISCRIMINATED_UNION_REGISTRATION_REASON;
 }
 
-function isUnsupportedMappedType(pantType: string): boolean {
+export function isUnsupportedMappedType(pantType: string): boolean {
   return (
     isUnsupportedUnknown(pantType) ||
     isUnsupportedDiscriminatedUnionRegistration(pantType)
   );
 }
 
-function unsupportedMappedTypeReason(pantType: string): string {
+export function unsupportedMappedTypeReason(pantType: string): string {
   if (isUnsupportedUnknown(pantType)) {
     return UNSUPPORTED_UNKNOWN_REASON;
   }
@@ -822,6 +822,7 @@ export function cellRegisterDiscriminatedUnion(
       if (
         isUnsupportedUnknown(mapped) ||
         mapped === UNSUPPORTED_ANONYMOUS_RECORD ||
+        isUnsupportedDiscriminatedUnionRegistration(mapped) ||
         !isValidPantFieldType(mapped) ||
         !/^[A-Za-z_][A-Za-z0-9_]*$/u.test(field.name)
       ) {
@@ -1256,6 +1257,16 @@ export interface SynthCell {
   opaqueSynth: OpaqueSynth;
   registry: NameRegistry;
   tupleSynth: TupleSynth;
+  /**
+   * Types currently mid-registration as a synthesized domain (discriminated
+   * union or anonymous record). Bounds synthesis-time recursion: a
+   * variant/field whose type is the container being registered re-enters
+   * `mapTsType` on the same `ts.Type`, so without this guard a self-referential
+   * type (e.g. `IR1Expr`) recurses forever. Transient — added before a
+   * container's field loop and removed (in a `finally`) after, so it is empty
+   * between top-level registrations.
+   */
+  visiting: Set<ts.Type>;
   sourceFile?: ts.SourceFile;
   /**
    * Dep modules that build sites have requested at translation time.
@@ -1287,6 +1298,7 @@ export function newSynthCell(
     opaqueSynth: emptyOpaqueSynth(),
     registry: registry ?? emptyNameRegistry(),
     tupleSynth: emptyTupleSynth(),
+    visiting: new Set(),
     imports: new Set(),
     definednessObligations: [],
   };
@@ -1999,17 +2011,30 @@ export function mapTsType(
     if (synthCell) {
       const detection = detectDiscriminatedUnion(type, checker);
       if (detection) {
-        const domain = cellRegisterDiscriminatedUnion(
-          synthCell,
-          detection,
-          checker,
-          strategy,
-          discriminatedUnionPreferredDomain(type),
-        );
-        if (domain !== null) {
-          return domain;
+        // Recursive discriminated union: a variant field whose type is the
+        // union currently being registered re-enters here on the same
+        // `ts.Type`. Refuse rather than recurse forever (a self-referential
+        // synthesized domain is valid Pant, but the sound recursive encoding
+        // is a separate change — for now this is a graceful UNSUPPORTED).
+        if (synthCell.visiting.has(type)) {
+          return UNSUPPORTED_DISCRIMINATED_UNION_REGISTRATION_REASON;
         }
-        return UNSUPPORTED_DISCRIMINATED_UNION_REGISTRATION_REASON;
+        synthCell.visiting.add(type);
+        try {
+          const domain = cellRegisterDiscriminatedUnion(
+            synthCell,
+            detection,
+            checker,
+            strategy,
+            discriminatedUnionPreferredDomain(type),
+          );
+          if (domain !== null) {
+            return domain;
+          }
+          return UNSUPPORTED_DISCRIMINATED_UNION_REGISTRATION_REASON;
+        } finally {
+          synthCell.visiting.delete(type);
+        }
       }
     }
     // List-lift encoding for optionality: strip null/undefined/void before
@@ -2049,15 +2074,24 @@ export function mapTsType(
   // synthesized domain has not actually been registered.
   if (isAnonymousRecord(type)) {
     if (synthCell) {
-      const domain = registerAnonymousRecord(
-        type,
-        checker,
-        strategy,
-        synthCell,
-        opts,
-      );
-      if (domain !== null) {
-        return domain;
+      // Same recursion guard as the discriminated-union branch: a field whose
+      // type is the record currently being registered would recurse forever.
+      if (!synthCell.visiting.has(type)) {
+        synthCell.visiting.add(type);
+        try {
+          const domain = registerAnonymousRecord(
+            type,
+            checker,
+            strategy,
+            synthCell,
+            opts,
+          );
+          if (domain !== null) {
+            return domain;
+          }
+        } finally {
+          synthCell.visiting.delete(type);
+        }
       }
     }
     return UNSUPPORTED_ANONYMOUS_RECORD;
@@ -2222,6 +2256,11 @@ function registerAnonymousRecord(
     // Without this, the parent shape would register with the sentinel
     // string as a field type and emit invalid output.
     if (mapped === UNSUPPORTED_ANONYMOUS_RECORD) {
+      return null;
+    }
+    // A field whose type is a recursive discriminated union was refused by
+    // the cycle guard; propagate the refusal rather than emit the sentinel.
+    if (isUnsupportedDiscriminatedUnionRegistration(mapped)) {
       return null;
     }
     fields.push({ name: prop.getName(), type: mapped });

--- a/tools/ts2pant/src/translate-types.ts
+++ b/tools/ts2pant/src/translate-types.ts
@@ -56,39 +56,23 @@ export const UNSUPPORTED_DISCRIMINATED_UNION_REGISTRATION_REASON =
   "discriminated union could not be registered for tagged Pantagruel encoding";
 
 /**
- * True if `pantType` is the `unknown` rejection sentinel. Composite
- * type branches in `mapTsType` (tuple, array, set, Map K/V, union,
- * anonymous record field) propagate the sentinel by checking each
- * recursive result — otherwise nested shapes like `{ x: unknown }`,
- * `Map<unknown, Int>`, or `[unknown, Int]` would synthesize broken
- * declarations referencing `__unsupported_unknown__` as if it were a
- * real Pantagruel type.
- *
- * @pant isUnsupportedUnknown UNSUPPORTED_UNKNOWN.
- * @pant ~(isUnsupportedUnknown "Int").
+ * Result of mapping a TypeScript type to a Pantagruel sort. Failure is
+ * carried out-of-band (the `ok: false` variant) so a refusal reason can never
+ * be emitted as if it were a real sort — the structural replacement for the
+ * old in-band sentinel strings (`__unsupported_unknown__` etc.). Mirrors the
+ * tagged-union result discipline already used by `BodyResult`
+ * (`translate-body.ts`) and `PantDeclaration` (`types.ts`).
  */
-export function isUnsupportedUnknown(pantType: string): boolean {
-  return pantType === UNSUPPORTED_UNKNOWN;
+export type MapTsTypeResult =
+  | { readonly ok: true; readonly sort: string }
+  | { readonly ok: false; readonly reason: string };
+
+export function okSort(sort: string): MapTsTypeResult {
+  return { ok: true, sort };
 }
 
-export function isUnsupportedDiscriminatedUnionRegistration(
-  pantType: string,
-): boolean {
-  return pantType === UNSUPPORTED_DISCRIMINATED_UNION_REGISTRATION_REASON;
-}
-
-export function isUnsupportedMappedType(pantType: string): boolean {
-  return (
-    isUnsupportedUnknown(pantType) ||
-    isUnsupportedDiscriminatedUnionRegistration(pantType)
-  );
-}
-
-export function unsupportedMappedTypeReason(pantType: string): string {
-  if (isUnsupportedUnknown(pantType)) {
-    return UNSUPPORTED_UNKNOWN_REASON;
-  }
-  return pantType;
+export function unsupportedType(reason: string): MapTsTypeResult {
+  return { ok: false, reason };
 }
 
 /**
@@ -820,22 +804,20 @@ export function cellRegisterDiscriminatedUnion(
       }
       const mapped = mapTsType(field.type, checker, strategy, cell);
       if (
-        isUnsupportedUnknown(mapped) ||
-        mapped === UNSUPPORTED_ANONYMOUS_RECORD ||
-        isUnsupportedDiscriminatedUnionRegistration(mapped) ||
-        !isValidPantFieldType(mapped) ||
+        !mapped.ok ||
+        !isValidPantFieldType(mapped.sort) ||
         !/^[A-Za-z_][A-Za-z0-9_]*$/u.test(field.name)
       ) {
         return null;
       }
-      fields.push({ name: field.name, type: mapped });
+      fields.push({ name: field.name, type: mapped.sort });
       const slot = fieldVariants.get(field.name) ?? {
         variantKeys: [],
         types: [],
       };
       slot.variantKeys.push(key);
-      if (!slot.types.includes(mapped)) {
-        slot.types.push(mapped);
+      if (!slot.types.includes(mapped.sort)) {
+        slot.types.push(mapped.sort);
       }
       fieldVariants.set(field.name, slot);
     }
@@ -1547,20 +1529,13 @@ export function resolveRecordOwner(
   // preferring it here would break lockstep with the synth's emission.
   if (synthCell && isAnonymousRecord(type)) {
     const mapped = mapTsType(type, checker, strategy, synthCell);
-    // Filter both unsupported sentinels — `mapped` may be
-    // `UNSUPPORTED_ANONYMOUS_RECORD` (synth failure / cell-less path)
-    // or `UNSUPPORTED_UNKNOWN` (a field typed `unknown` propagated up
-    // from `registerAnonymousRecord`). Either as a record-owner name
-    // would emit a bogus qualified accessor like
-    // `__unsupported_unknown__--name r`. Fall through to the named-
-    // symbol path; for an anonymous shape there is no meaningful
-    // fallback owner, so the resolver returns null and the caller
-    // rejects the field access.
-    if (
-      mapped !== UNSUPPORTED_ANONYMOUS_RECORD &&
-      !isUnsupportedUnknown(mapped)
-    ) {
-      return mapped;
+    // Only a successfully-synthesized domain is a usable record owner. Any
+    // failure (synth-unavailable, or a field typed `unknown`/recursive)
+    // falls through to the named-symbol path; for an anonymous shape there is
+    // no meaningful fallback owner, so the resolver returns null and the
+    // caller rejects the field access.
+    if (mapped.ok) {
+      return mapped.sort;
     }
   }
   const sym = type.symbol ?? type.aliasSymbol;
@@ -1572,19 +1547,13 @@ export function resolveRecordOwner(
 }
 
 /** Cell-mutating wrapper around `registerMapKV` for the legacy call shape.
- *  Defensively rejects either argument being the `unknown` sentinel — the
- *  sentinel string passes `manglePantTypeToFragment`'s identifier-shape
- *  check (it's all underscores+letters) so without this guard a body-level
- *  call site that forwards the sentinel into `cellRegisterMap` would
- *  synthesize a Map domain like `__unsupported_unknown__ToIntMap`. */
+ *  Callers pass already-mapped sorts (unwrapped from `mapTsType`'s Result), so
+ *  a refusal can no longer reach this synthesizer as a sentinel string. */
 export function cellRegisterMap(
   cell: SynthCell,
   kType: string,
   vType: string,
 ): string | null {
-  if (isUnsupportedUnknown(kType) || isUnsupportedUnknown(vType)) {
-    return null;
-  }
   const r = registerMapKV(cell.synth, cell.registry, kType, vType);
   cell.synth = r.synth;
   cell.registry = r.registry;
@@ -1592,16 +1561,12 @@ export function cellRegisterMap(
 }
 
 /** Cell-mutating wrapper around `registerRecordShape`. `fields` must be in
- *  canonical (alphabetically sorted) order. Defensively rejects when any
- *  field type is the `unknown` sentinel, for the same reason as
- *  `cellRegisterMap`. */
+ *  canonical (alphabetically sorted) order. Field types are already-mapped
+ *  sorts (unwrapped from `mapTsType`'s Result). */
 export function cellRegisterRecord(
   cell: SynthCell,
   fields: ReadonlyArray<RecordSynthField>,
 ): string | null {
-  if (fields.some((f) => isUnsupportedUnknown(f.type))) {
-    return null;
-  }
   const r = registerRecordShape(cell.recordSynth, cell.registry, fields);
   cell.recordSynth = r.synth;
   cell.registry = r.registry;
@@ -1731,13 +1696,8 @@ export function cellRegisterTupleConstructor(
   cell: SynthCell,
   shape: TupleShape,
 ): TupleCtorRef | null {
-  // Defensive: the `unknown` sentinel passes the identifier-shape check
-  // in `manglePantTypeToFragment`, so without this guard a tuple shape
-  // carrying it would synthesize a constructor name like
-  // `make-__unsupported_unknown__-int`.
-  if (shape.elementPantTypes.some(isUnsupportedUnknown)) {
-    return null;
-  }
+  // `elementPantTypes` are already-mapped sorts (unwrapped from `mapTsType`'s
+  // Result), so a refusal can no longer reach this synthesizer.
   const depModuleName = cell.sourceFile
     ? depModuleNameForFile(cell.sourceFile.fileName)
     : "TUPLES";
@@ -1878,7 +1838,7 @@ export function mapTsType(
   strategy: NumericStrategy,
   synthCell?: SynthCell,
   opts?: MapTsTypeOptions,
-): string {
+): MapTsTypeResult {
   const flags = type.flags;
 
   // Reject `any` / `unknown` explicitly. Pantagruel is monomorphic over
@@ -1890,19 +1850,19 @@ export function mapTsType(
       if (synthCell) {
         cellRegisterOpaqueDomain(synthCell);
       }
-      return OPAQUE_DOMAIN;
+      return okSort(OPAQUE_DOMAIN);
     }
-    return UNSUPPORTED_UNKNOWN;
+    return unsupportedType(UNSUPPORTED_UNKNOWN_REASON);
   }
 
   if (flags & ts.TypeFlags.String || flags & ts.TypeFlags.StringLiteral) {
-    return "String";
+    return okSort("String");
   }
   if (flags & ts.TypeFlags.Number || flags & ts.TypeFlags.NumberLiteral) {
-    return strategy.mapNumber();
+    return okSort(strategy.mapNumber());
   }
   if (flags & ts.TypeFlags.Boolean || flags & ts.TypeFlags.BooleanLiteral) {
-    return "Bool";
+    return okSort("Bool");
   }
   // Top-level `null` / `undefined` / `void` have no Pantagruel encoding.
   // Fall through to the generic `checker.typeToString` fallback below so
@@ -1912,22 +1872,24 @@ export function mapTsType(
   const iteratorElem = getBuiltinIteratorElementType(type, checker);
   if (iteratorElem !== null) {
     const elem = mapTsType(iteratorElem, checker, strategy, synthCell, opts);
-    if (isUnsupportedUnknown(elem)) {
-      return UNSUPPORTED_UNKNOWN;
+    if (!elem.ok) {
+      return elem;
     }
-    return `[${elem}]`;
+    return okSort(`[${elem.sort}]`);
   }
 
   // Tuple (check before array since tuples are also type references)
   if (checker.isTupleType(type)) {
     const typeArgs = checker.getTypeArguments(type as ts.TypeReference);
-    const elements = typeArgs.map((t) =>
-      mapTsType(t, checker, strategy, synthCell, opts),
-    );
-    if (elements.some(isUnsupportedUnknown)) {
-      return UNSUPPORTED_UNKNOWN;
+    const elements: string[] = [];
+    for (const t of typeArgs) {
+      const elem = mapTsType(t, checker, strategy, synthCell, opts);
+      if (!elem.ok) {
+        return elem;
+      }
+      elements.push(elem.sort);
     }
-    return elements.join(" * ");
+    return okSort(elements.join(" * "));
   }
 
   // Array
@@ -1935,12 +1897,12 @@ export function mapTsType(
     const typeArgs = checker.getTypeArguments(type as ts.TypeReference);
     if (typeArgs.length === 1) {
       const elem = mapTsType(typeArgs[0]!, checker, strategy, synthCell, opts);
-      if (isUnsupportedUnknown(elem)) {
-        return UNSUPPORTED_UNKNOWN;
+      if (!elem.ok) {
+        return elem;
       }
-      return `[${elem}]`;
+      return okSort(`[${elem.sort}]`);
     }
-    return checker.typeToString(type);
+    return okSort(checker.typeToString(type));
   }
 
   // Set — modeled as a list. Pantagruel lists already encode membership
@@ -1950,12 +1912,12 @@ export function mapTsType(
     const typeArgs = checker.getTypeArguments(type as ts.TypeReference);
     if (typeArgs.length === 1) {
       const elem = mapTsType(typeArgs[0]!, checker, strategy, synthCell, opts);
-      if (isUnsupportedUnknown(elem)) {
-        return UNSUPPORTED_UNKNOWN;
+      if (!elem.ok) {
+        return elem;
       }
-      return `[${elem}]`;
+      return okSort(`[${elem.sort}]`);
     }
-    return checker.typeToString(type);
+    return okSort(checker.typeToString(type));
   }
 
   // Map — synthesize a domain when a synthesizer cell is provided. If the
@@ -1966,17 +1928,18 @@ export function mapTsType(
     const typeArgs = checker.getTypeArguments(type as ts.TypeReference);
     if (typeArgs.length === 2) {
       const kType = mapTsType(typeArgs[0]!, checker, strategy, synthCell, opts);
-      const vType = mapTsType(typeArgs[1]!, checker, strategy, synthCell, opts);
-      // Propagate `unknown` rather than registering a Map keyed by or
-      // valued in the sentinel — that would synthesize a domain like
-      // `__unsupported_unknown__ToIntMap` (the underscore-only sentinel
-      // passes `manglePantTypeToFragment`'s identifier check).
-      if (isUnsupportedUnknown(kType) || isUnsupportedUnknown(vType)) {
-        return UNSUPPORTED_UNKNOWN;
+      // Propagate the refusal rather than registering a Map keyed by or
+      // valued in a non-sort — the failure can no longer reach a domain name.
+      if (!kType.ok) {
+        return kType;
       }
-      const domain = cellRegisterMap(synthCell, kType, vType);
+      const vType = mapTsType(typeArgs[1]!, checker, strategy, synthCell, opts);
+      if (!vType.ok) {
+        return vType;
+      }
+      const domain = cellRegisterMap(synthCell, kType.sort, vType.sort);
       if (domain !== null) {
-        return domain;
+        return okSort(domain);
       }
     }
   }
@@ -1992,13 +1955,15 @@ export function mapTsType(
       if (nonBrandParts.length === 1) {
         return mapTsType(nonBrandParts[0]!, checker, strategy, synthCell, opts);
       }
-      const parts = nonBrandParts.map((part) =>
-        mapTsType(part, checker, strategy, synthCell, opts),
-      );
-      if (parts.some(isUnsupportedUnknown)) {
-        return UNSUPPORTED_UNKNOWN;
+      const parts: string[] = [];
+      for (const part of nonBrandParts) {
+        const mapped = mapTsType(part, checker, strategy, synthCell, opts);
+        if (!mapped.ok) {
+          return mapped;
+        }
+        parts.push(mapped.sort);
       }
-      return parts.filter((v, i, a) => a.indexOf(v) === i).join(" + ");
+      return okSort(parts.filter((v, i, a) => a.indexOf(v) === i).join(" + "));
     }
   }
 
@@ -2006,7 +1971,7 @@ export function mapTsType(
   if (type.isUnion()) {
     // Boolean is represented as true | false union
     if (type.types.every((t) => t.flags & ts.TypeFlags.BooleanLiteral)) {
-      return "Bool";
+      return okSort("Bool");
     }
     if (synthCell) {
       const detection = detectDiscriminatedUnion(type, checker);
@@ -2017,7 +1982,9 @@ export function mapTsType(
         // synthesized domain is valid Pant, but the sound recursive encoding
         // is a separate change — for now this is a graceful UNSUPPORTED).
         if (synthCell.visiting.has(type)) {
-          return UNSUPPORTED_DISCRIMINATED_UNION_REGISTRATION_REASON;
+          return unsupportedType(
+            UNSUPPORTED_DISCRIMINATED_UNION_REGISTRATION_REASON,
+          );
         }
         synthCell.visiting.add(type);
         try {
@@ -2029,9 +1996,11 @@ export function mapTsType(
             discriminatedUnionPreferredDomain(type),
           );
           if (domain !== null) {
-            return domain;
+            return okSort(domain);
           }
-          return UNSUPPORTED_DISCRIMINATED_UNION_REGISTRATION_REASON;
+          return unsupportedType(
+            UNSUPPORTED_DISCRIMINATED_UNION_REGISTRATION_REASON,
+          );
         } finally {
           synthCell.visiting.delete(type);
         }
@@ -2048,19 +2017,21 @@ export function mapTsType(
       // Degenerate `null | undefined` — no non-null members. Fall through
       // to the generic checker fallback below so the broken output mirrors
       // the source rather than an internal sentinel.
-      return checker.typeToString(type);
+      return okSort(checker.typeToString(type));
     }
-    const parts = nonNullTypes.map((t) =>
-      mapTsType(t, checker, strategy, synthCell, opts),
-    );
-    if (parts.some(isUnsupportedUnknown)) {
-      return UNSUPPORTED_UNKNOWN;
+    const parts: string[] = [];
+    for (const t of nonNullTypes) {
+      const mapped = mapTsType(t, checker, strategy, synthCell, opts);
+      if (!mapped.ok) {
+        return mapped;
+      }
+      parts.push(mapped.sort);
     }
     const unique = parts.filter((v, i, a) => a.indexOf(v) === i);
     if (hasNullish) {
-      return `[${unique.join(" + ")}]`;
+      return okSort(`[${unique.join(" + ")}]`);
     }
-    return unique.join(" + ");
+    return okSort(unique.join(" + "));
   }
 
   // Anonymous record type — synthesize a domain + accessor rules per
@@ -2073,37 +2044,36 @@ export function mapTsType(
   // silently mark the function as a supported record return whose
   // synthesized domain has not actually been registered.
   if (isAnonymousRecord(type)) {
-    if (synthCell) {
-      // Same recursion guard as the discriminated-union branch: a field whose
-      // type is the record currently being registered would recurse forever.
-      if (!synthCell.visiting.has(type)) {
-        synthCell.visiting.add(type);
-        try {
-          const domain = registerAnonymousRecord(
-            type,
-            checker,
-            strategy,
-            synthCell,
-            opts,
-          );
-          if (domain !== null) {
-            return domain;
-          }
-        } finally {
-          synthCell.visiting.delete(type);
-        }
+    // Same recursion guard as the discriminated-union branch: a field whose
+    // type is the record currently being registered would recurse forever.
+    if (synthCell && !synthCell.visiting.has(type)) {
+      synthCell.visiting.add(type);
+      try {
+        return registerAnonymousRecord(
+          type,
+          checker,
+          strategy,
+          synthCell,
+          opts,
+        );
+      } finally {
+        synthCell.visiting.delete(type);
       }
     }
-    return UNSUPPORTED_ANONYMOUS_RECORD;
+    // No synth cell, or a recursive cycle. `UNSUPPORTED_ANONYMOUS_RECORD` is
+    // carried as the failure reason (not as a sort) so consumers that need to
+    // distinguish this case from `unknown` (e.g. `translateRecordReturn`) can
+    // still match on `reason`.
+    return unsupportedType(UNSUPPORTED_ANONYMOUS_RECORD);
   }
 
   // Named type (interface, class, enum, type alias)
   const symbol = type.aliasSymbol ?? type.symbol;
   if (symbol) {
-    return symbol.getName();
+    return okSort(symbol.getName());
   }
 
-  return checker.typeToString(type);
+  return okSort(checker.typeToString(type));
 }
 
 function isDynamicTypeNode(node: ts.TypeNode): boolean {
@@ -2125,14 +2095,14 @@ function isNullishTypeNode(node: ts.TypeNode): boolean {
 function mapDynamicTypeNode(
   synthCell: SynthCell | undefined,
   opts: MapTsTypeOptions | undefined,
-): string {
+): MapTsTypeResult {
   if (effectiveOpacityPolicy(opts) === "opaque") {
     if (synthCell) {
       cellRegisterOpaqueDomain(synthCell);
     }
-    return OPAQUE_DOMAIN;
+    return okSort(OPAQUE_DOMAIN);
   }
-  return UNSUPPORTED_UNKNOWN;
+  return unsupportedType(UNSUPPORTED_UNKNOWN_REASON);
 }
 
 function mapTsTypeNodePart(
@@ -2141,7 +2111,7 @@ function mapTsTypeNodePart(
   strategy: NumericStrategy,
   synthCell?: SynthCell,
   opts?: MapTsTypeOptions,
-): string {
+): MapTsTypeResult {
   if (isDynamicTypeNode(node)) {
     return mapDynamicTypeNode(synthCell, opts);
   }
@@ -2168,7 +2138,7 @@ export function mapTsTypeFromTypeNode(
   strategy: NumericStrategy,
   synthCell?: SynthCell,
   opts?: MapTsTypeOptions,
-): string {
+): MapTsTypeResult {
   if (!ts.isUnionTypeNode(node) || !node.types.some(isDynamicTypeNode)) {
     return mapTsType(fallbackType, checker, strategy, synthCell, opts);
   }
@@ -2176,21 +2146,23 @@ export function mapTsTypeFromTypeNode(
   const hasNullish = node.types.some(isNullishTypeNode);
   const nonNullTypes = node.types.filter((part) => !isNullishTypeNode(part));
   if (nonNullTypes.length === 0) {
-    return checker.typeToString(fallbackType);
+    return okSort(checker.typeToString(fallbackType));
   }
 
-  const parts = nonNullTypes.map((part) =>
-    mapTsTypeNodePart(part, checker, strategy, synthCell, opts),
-  );
-  if (parts.some(isUnsupportedUnknown)) {
-    return UNSUPPORTED_UNKNOWN;
+  const parts: string[] = [];
+  for (const part of nonNullTypes) {
+    const mapped = mapTsTypeNodePart(part, checker, strategy, synthCell, opts);
+    if (!mapped.ok) {
+      return mapped;
+    }
+    parts.push(mapped.sort);
   }
 
   const unique = parts.filter((v, i, a) => a.indexOf(v) === i);
   if (hasNullish) {
-    return `[${unique.join(" + ")}]`;
+    return okSort(`[${unique.join(" + ")}]`);
   }
-  return unique.join(" + ");
+  return okSort(unique.join(" + "));
 }
 
 function getBuiltinIteratorElementType(
@@ -2225,7 +2197,7 @@ function registerAnonymousRecord(
   strategy: NumericStrategy,
   synthCell: SynthCell,
   opts?: MapTsTypeOptions,
-): string | null {
+): MapTsTypeResult {
   const properties = type.getProperties();
   const fields: RecordSynthField[] = [];
   for (const prop of properties) {
@@ -2240,34 +2212,23 @@ function registerAnonymousRecord(
       ? checker.getTypeOfSymbolAtLocation(prop, decl)
       : (prop as unknown as { type?: ts.Type }).type;
     if (!propType) {
-      return null;
+      return unsupportedType(UNSUPPORTED_ANONYMOUS_RECORD);
     }
     const mapped = mapTsType(propType, checker, strategy, synthCell, opts);
-    // Propagate `unknown` as the specific UNSUPPORTED_UNKNOWN sentinel
-    // so the outer `mapTsType` anonymous-record branch can pass it back
-    // to *its* caller — otherwise nested shapes like `[{ x: unknown },
-    // Int]` would mask the unknown cause as
-    // UNSUPPORTED_ANONYMOUS_RECORD, which the tuple/array/set branches
-    // do not propagate.
-    if (isUnsupportedUnknown(mapped)) {
-      return UNSUPPORTED_UNKNOWN;
+    // Propagate the field's refusal reason unchanged (unknown, nested
+    // anonymous-record, or recursive discriminated union) so the cause is
+    // not masked as a generic anonymous-record failure.
+    if (!mapped.ok) {
+      return mapped;
     }
-    // Propagate failure from a nested anonymous-record synthesis.
-    // Without this, the parent shape would register with the sentinel
-    // string as a field type and emit invalid output.
-    if (mapped === UNSUPPORTED_ANONYMOUS_RECORD) {
-      return null;
-    }
-    // A field whose type is a recursive discriminated union was refused by
-    // the cycle guard; propagate the refusal rather than emit the sentinel.
-    if (isUnsupportedDiscriminatedUnionRegistration(mapped)) {
-      return null;
-    }
-    fields.push({ name: prop.getName(), type: mapped });
+    fields.push({ name: prop.getName(), type: mapped.sort });
   }
   // Canonical order: sort alphabetically by field name.
   fields.sort((a, b) => a.name.localeCompare(b.name));
-  return cellRegisterRecord(synthCell, fields);
+  const domain = cellRegisterRecord(synthCell, fields);
+  return domain !== null
+    ? okSort(domain)
+    : unsupportedType(UNSUPPORTED_ANONYMOUS_RECORD);
 }
 
 /**
@@ -2390,15 +2351,17 @@ export function translateTypes(
             synthCell,
             opts,
           );
-          if (
-            isUnsupportedMappedType(kType) ||
-            isUnsupportedMappedType(vType)
-          ) {
+          if (!kType.ok) {
             decls.push({
               kind: "unsupported",
-              reason: `${iface.name}.${prop.name}: ${unsupportedMappedTypeReason(
-                isUnsupportedMappedType(kType) ? kType : vType,
-              )}`,
+              reason: `${iface.name}.${prop.name}: ${kType.reason}`,
+            });
+            continue;
+          }
+          if (!vType.ok) {
+            decls.push({
+              kind: "unsupported",
+              reason: `${iface.name}.${prop.name}: ${vType.reason}`,
             });
             continue;
           }
@@ -2409,7 +2372,7 @@ export function translateTypes(
             name: keyPredName,
             params: [
               { name: pName, type: iface.name },
-              { name: kName, type: kType },
+              { name: kName, type: kType.sort },
             ],
             returnType: "Bool",
           });
@@ -2419,9 +2382,9 @@ export function translateTypes(
             name: ruleName,
             params: [
               { name: pName, type: iface.name },
-              { name: kName, type: kType },
+              { name: kName, type: kType.sort },
             ],
-            returnType: vType,
+            returnType: vType.sort,
             guard: ast.app(ast.var(keyPredName), [
               ast.var(pName),
               ast.var(kName),
@@ -2437,12 +2400,10 @@ export function translateTypes(
         synthCell,
         opts,
       );
-      if (isUnsupportedMappedType(fieldType)) {
+      if (!fieldType.ok) {
         decls.push({
           kind: "unsupported",
-          reason: `${iface.name}.${prop.name}: ${unsupportedMappedTypeReason(
-            fieldType,
-          )}`,
+          reason: `${iface.name}.${prop.name}: ${fieldType.reason}`,
         });
         continue;
       }
@@ -2450,26 +2411,24 @@ export function translateTypes(
         kind: "rule",
         name: ruleName,
         params: [{ name: pName, type: iface.name }],
-        returnType: fieldType,
+        returnType: fieldType.sort,
       });
     }
   }
 
   for (const alias of extracted.aliases) {
     const aliasType = mapTsType(alias.type, checker, strategy, synthCell, opts);
-    if (isUnsupportedMappedType(aliasType)) {
+    if (!aliasType.ok) {
       decls.push({
         kind: "unsupported",
-        reason: `alias ${alias.name}: ${unsupportedMappedTypeReason(
-          aliasType,
-        )}`,
+        reason: `alias ${alias.name}: ${aliasType.reason}`,
       });
       continue;
     }
     decls.push({
       kind: "alias",
       name: alias.name,
-      type: aliasType,
+      type: aliasType.sort,
     });
   }
 

--- a/tools/ts2pant/tests/du-cutover.test.mts
+++ b/tools/ts2pant/tests/du-cutover.test.mts
@@ -75,10 +75,10 @@ describe("du-cutover", () => {
       newSynthCell(),
     );
 
-    assert.equal(
-      mapped,
-      UNSUPPORTED_DISCRIMINATED_UNION_REGISTRATION_REASON,
-    );
-    assert.doesNotMatch(mapped, / \+ /u);
+    // Refused (not fallen through to the `A + B` union encoding).
+    assert.deepEqual(mapped, {
+      ok: false,
+      reason: UNSUPPORTED_DISCRIMINATED_UNION_REGISTRATION_REASON,
+    });
   });
 });

--- a/tools/ts2pant/tests/fixtures/recursive-union/cases.ts
+++ b/tools/ts2pant/tests/fixtures/recursive-union/cases.ts
@@ -1,0 +1,23 @@
+// @archlint.module exempt
+// @archlint.exempt-reason test-support
+
+// `Tree` is a self-referential discriminated union (the `node` variant's
+// `left`/`right` fields are `Tree`). Mapping it used to recurse forever in the
+// DU synthesis (stack overflow); it must now refuse gracefully.
+type Tree =
+  | { kind: "leaf"; value: number }
+  | { kind: "node"; left: Tree; right: Tree };
+
+export function treeKind(t: Tree): string {
+  return t.kind;
+}
+
+// `Shape` is a NON-recursive discriminated union — the control. It must keep
+// registering to a synthesized domain (the cycle guard never fires for it).
+type Shape =
+  | { kind: "circle"; r: number }
+  | { kind: "square"; s: number };
+
+export function shapeKind(s: Shape): string {
+  return s.kind;
+}

--- a/tools/ts2pant/tests/integration/dogfood.test.mts
+++ b/tools/ts2pant/tests/integration/dogfood.test.mts
@@ -164,33 +164,6 @@ describe("dogfood: src/translate-types.ts", () => {
     );
   });
 
-  it("isUnsupportedUnknown — translates and type-checks", async (t) => {
-    const doc = await buildDocumentFromPath(filePath, "isUnsupportedUnknown");
-    const output = await emitAndCheck(doc);
-    t.assert.snapshot(output);
-    assertPantTypeChecks(output, PANT_TIMEOUT_MS);
-    // Module-level `const UNSUPPORTED_UNKNOWN = "__unsupported_unknown__"`
-    // emits as a 0-arity rule + value equation (extractModuleConsts).
-    // Reference-filtered: the sibling `UNSUPPORTED_ANONYMOUS_RECORD` /
-    // `UNSUPPORTED_UNKNOWN_REASON` consts in the same module are NOT
-    // pulled in because `isUnsupportedUnknown`'s body doesn't reference
-    // them.
-    t.assert.match(output, /unsupported-unknown\s+=> String\./u);
-    t.assert.match(
-      output,
-      /unsupported-unknown = "__unsupported_unknown__"\./u,
-    );
-    t.assert.doesNotMatch(output, /unsupported-anonymous-record/u);
-    t.assert.doesNotMatch(output, /unsupported-unknown-reason/u);
-    // Body equation rewrites the identifier reference through
-    // `paramNameMap` so `UNSUPPORTED_UNKNOWN` resolves to the kebab'd
-    // 0-arity rule, not the raw TS-cased name.
-    t.assert.match(
-      output,
-      /is-unsupported-unknown pant-type = \(pant-type = unsupported-unknown\)\./u,
-    );
-  });
-
   it("manglePantTypeToFragment — translates and type-checks", async (t) => {
     const doc = await buildDocumentFromPath(filePath, "manglePantTypeToFragment");
     const output = await emitAndCheck(doc);
@@ -410,7 +383,6 @@ describe("dogfood: @pant annotations entail", () => {
   const annotated: Array<{ file: string; fn: string; minChecks: number }> = [
     { file: "name-registry.ts", fn: "isUsed", minChecks: 2 },
     { file: "name-registry.ts", fn: "emptyNameRegistry", minChecks: 1 },
-    { file: "translate-types.ts", fn: "isUnsupportedUnknown", minChecks: 2 },
     { file: "translate-types.ts", fn: "manglePantTypeToFragment", minChecks: 2 },
     { file: "translate-types.ts", fn: "emptyMapSynth", minChecks: 1 },
     { file: "translate-types.ts", fn: "emptyRecordSynth", minChecks: 1 },

--- a/tools/ts2pant/tests/recursive-union.test.mts
+++ b/tools/ts2pant/tests/recursive-union.test.mts
@@ -1,0 +1,39 @@
+// @archlint.module test
+// @archlint.domain ts2pant.recursive-union
+
+import assert from "node:assert/strict";
+import { resolve } from "node:path";
+import { describe, it } from "node:test";
+
+import { emitDocument } from "../src/emit.js";
+import { buildDocument } from "./helpers.mjs";
+
+const FIXTURE = resolve(
+  import.meta.dirname,
+  "fixtures/recursive-union/cases.ts",
+);
+
+describe("recursive discriminated union", () => {
+  it("refuses gracefully instead of crashing (regression)", async () => {
+    // `treeKind`'s parameter is a self-referential discriminated union
+    // (`Tree` node variant has `left`/`right`: `Tree`). DU synthesis used to
+    // recurse forever and throw `RangeError: Maximum call stack size
+    // exceeded`. It must now build without throwing and refuse the function
+    // with a clean UNSUPPORTED skip — not leak the refusal sentinel into a
+    // rule head.
+    await assert.doesNotReject(buildDocument(FIXTURE, "treeKind"));
+    const output = emitDocument(await buildDocument(FIXTURE, "treeKind"));
+    assert.match(output, /> UNSUPPORTED: tree-kind param 't'/u);
+    assert.doesNotMatch(
+      output,
+      /tree-kind t: discriminated union could not be registered/u,
+    );
+  });
+
+  it("a non-recursive discriminated union still registers (control)", async () => {
+    const output = emitDocument(await buildDocument(FIXTURE, "shapeKind"));
+    assert.doesNotMatch(output, /UNSUPPORTED/u);
+    assert.match(output, /^Shape\.$/mu);
+    assert.match(output, /shape--kind s: Shape => String\./u);
+  });
+});

--- a/tools/ts2pant/tests/translate-types.test.mts
+++ b/tools/ts2pant/tests/translate-types.test.mts
@@ -28,6 +28,7 @@ import {
   detectDiscriminatedUnion,
   emitTupleCtorModule,
   IntStrategy,
+  type MapTsTypeResult,
   mapTsType,
   newSynthCell,
   RealStrategy,
@@ -37,6 +38,16 @@ import {
   UNSUPPORTED_UNKNOWN,
 } from "../src/translate-types.js";
 import type { PantDeclaration } from "../src/types.js";
+
+// Narrow a MapTsTypeResult to its sort, failing the test if it is unsupported.
+// Keeps the success-expecting assertions going *through* the Result type rather
+// than reaching past it with a bare `.sort` on an un-narrowed union.
+function expectSort(result: MapTsTypeResult): string {
+  if (!result.ok) {
+    throw new Error(`expected a Pant sort, got unsupported: ${result.reason}`);
+  }
+  return result.sort;
+}
 
 before(async () => {
   await loadAst();
@@ -104,11 +115,6 @@ it("generated type helpers preserve synth registrations", () => {
       );
       const opaqueReg = TT.registerOpaqueValue(cell.opaqueSynth, "opaque-id");
 
-      assert.equal(TT.isUnsupportedUnknown(TT.UNSUPPORTED_UNKNOWN), true);
-      assert.equal(
-        TT.isUnsupportedDiscriminatedUnionRegistration("Int"),
-        false,
-      );
       assert.equal(TT.isTsNullish(checker.getNullType()), true);
       assert.equal(TT.manglePantTypeToFragment("[Int]"), "ListInt");
       assert.equal(
@@ -198,12 +204,15 @@ it("generated type helpers preserve synth registrations", () => {
       assert.equal(TT.isAnonymousRecord(type), false);
       assert.equal(TT.isMapType(type), false);
       assert.equal(TT.isSetType(type), false);
-      assert.equal(TT.mapTsType(type, checker, IntStrategy, cell), "Int");
+      assert.deepEqual(TT.mapTsType(type, checker, IntStrategy, cell), {
+        ok: true,
+        sort: "Int",
+      });
       const aliasNode = sourceFile
         .getTypeAliasOrThrow("Maybe")
         .getTypeNodeOrThrow().compilerNode;
       const aliasType = checker.getTypeAtLocation(aliasNode);
-      assert.equal(
+      assert.deepEqual(
         TT.mapTsTypeFromTypeNode(
           aliasNode,
           aliasType,
@@ -211,7 +220,7 @@ it("generated type helpers preserve synth registrations", () => {
           IntStrategy,
           cell,
         ),
-        "[Int]",
+        { ok: true, sort: "[Int]" },
       );
       assert.equal(
         TT.resolveFieldOwner(
@@ -307,7 +316,6 @@ it("generated names and type fragments remain Pant-safe", () => {
         assert.notEqual(TT.manglePantTypeToFragment(pantType), "");
         assert.match(TT.depModuleNameForFile(fileName), /^[A-Z][A-Z0-9_]*$/u);
         assert.equal(TT.fieldRuleName(name, "value"), `${term}--value`);
-        assert.equal(TT.isUnsupportedUnknown(TT.UNSUPPORTED_UNKNOWN), true);
       },
     ),
   );
@@ -584,7 +592,10 @@ describe("emitDiscriminatedUnionSynthDecls", () => {
     `);
     const cell = newSynthCell();
 
-    assert.equal(mapTsType(alias.type, checker, IntStrategy, cell), "Shape");
+    assert.equal(
+      expectSort(mapTsType(alias.type, checker, IntStrategy, cell)),
+      "Shape",
+    );
     assert.deepEqual(
       ["kind", "r", "shared"].map((field) =>
         resolveFieldOwner(alias.type, field, checker, IntStrategy, cell),
@@ -616,7 +627,10 @@ describe("emitDiscriminatedUnionSynthDecls", () => {
     const cell = newSynthCell();
     const mapped = mapTsType(alias.type, checker, IntStrategy, cell);
 
-    assert.equal(mapped, "LeftOwnerRec + OwnerRightRec");
+    assert.deepEqual(mapped, {
+      ok: true,
+      sort: "LeftOwnerRec + OwnerRightRec",
+    });
     assert.deepEqual(
       resolveFieldOwner(alias.type, "owner", checker, IntStrategy, cell),
       {
@@ -664,9 +678,11 @@ describe("mapTsType", () => {
     const prop = extractAllTypes(sourceFile).interfaces[0].properties[0];
 
     assert.equal(
-      mapTsType(prop.type, checker, IntStrategy, cell, {
-        policy: "opaque",
-      }),
+      expectSort(
+        mapTsType(prop.type, checker, IntStrategy, cell, {
+          policy: "opaque",
+        }),
+      ),
       OPAQUE_DOMAIN,
     );
     assert.deepEqual(emitSynthDeclsOnly(cell), [
@@ -684,9 +700,11 @@ describe("mapTsType", () => {
     const prop = extractAllTypes(sourceFile).interfaces[0].properties[0];
 
     assert.equal(
-      mapTsType(prop.type, checker, IntStrategy, cell, {
-        policy: "opaque",
-      }),
+      expectSort(
+        mapTsType(prop.type, checker, IntStrategy, cell, {
+          policy: "opaque",
+        }),
+      ),
       OPAQUE_DOMAIN,
     );
     assert.deepEqual(emitSynthDeclsOnly(cell), [
@@ -703,9 +721,11 @@ describe("mapTsType", () => {
     const prop = extractAllTypes(sourceFile).interfaces[0].properties[0];
 
     assert.equal(
-      mapTsType(prop.type, checker, IntStrategy, cell, {
-        policy: "opaque",
-      }),
+      expectSort(
+        mapTsType(prop.type, checker, IntStrategy, cell, {
+          policy: "opaque",
+        }),
+      ),
       "Int",
     );
     assert.deepEqual(emitSynthDeclsOnly(cell), []);
@@ -721,14 +741,14 @@ describe("mapTsType", () => {
     assert.equal(
       mapTsType(anyProp.type, checker, IntStrategy, undefined, {
         policy: "reject",
-      }),
-      UNSUPPORTED_UNKNOWN,
+      }).ok,
+      false,
     );
     assert.equal(
       mapTsType(unknownProp.type, checker, IntStrategy, undefined, {
         policy: "reject",
-      }),
-      UNSUPPORTED_UNKNOWN,
+      }).ok,
+      false,
     );
   });
 
@@ -739,9 +759,11 @@ describe("mapTsType", () => {
     const prop = extractAllTypes(sourceFile).interfaces[0].properties[0];
 
     assert.equal(
-      mapTsType(prop.type, checker, IntStrategy, undefined, {
-        policy: "opaque",
-      }),
+      expectSort(
+        mapTsType(prop.type, checker, IntStrategy, undefined, {
+          policy: "opaque",
+        }),
+      ),
       OPAQUE_DOMAIN,
     );
   });
@@ -755,9 +777,11 @@ describe("mapTsType", () => {
     const prop = extractAllTypes(sourceFile).interfaces[0].properties[0];
 
     assert.equal(
-      mapTsType(prop.type, checker, IntStrategy, cell, {
-        policy: "opaque",
-      }),
+      expectSort(
+        mapTsType(prop.type, checker, IntStrategy, cell, {
+          policy: "opaque",
+        }),
+      ),
       OPAQUE_DOMAIN,
     );
     cellRegisterOpaqueValue(cell, "foo.ts:1");
@@ -792,9 +816,11 @@ describe("mapTsType", () => {
     const prop = extractAllTypes(sourceFile).interfaces[0].properties[0];
 
     assert.equal(
-      mapTsType(prop.type, checker, IntStrategy, cell, {
-        policy: "opaque",
-      }),
+      expectSort(
+        mapTsType(prop.type, checker, IntStrategy, cell, {
+          policy: "opaque",
+        }),
+      ),
       "StringToListOpaqueMap",
     );
 
@@ -848,7 +874,10 @@ describe("mapTsType", () => {
     const extracted = extractAllTypes(sourceFile);
     const prop = extracted.interfaces[0].properties[0];
 
-    assert.equal(mapTsType(prop.type, checker, IntStrategy), "undefined");
+    assert.equal(
+      expectSort(mapTsType(prop.type, checker, IntStrategy)),
+      "undefined",
+    );
   });
 
   it("list-lifts `T | null` to `[T]`", () => {
@@ -858,7 +887,10 @@ describe("mapTsType", () => {
     const extracted = extractAllTypes(sourceFile);
     const prop = extracted.interfaces[0].properties[0];
 
-    assert.equal(mapTsType(prop.type, checker, IntStrategy), "[String]");
+    assert.equal(
+      expectSort(mapTsType(prop.type, checker, IntStrategy)),
+      "[String]",
+    );
   });
 
   it("list-lifts multi-arm union with null to `[A + B]`", () => {
@@ -873,7 +905,10 @@ describe("mapTsType", () => {
     const foo = extracted.interfaces.find((i: any) => i.name === "Foo")!;
     const prop = foo.properties[0];
 
-    assert.equal(mapTsType(prop.type, checker, IntStrategy), "[A + B]");
+    assert.equal(
+      expectSort(mapTsType(prop.type, checker, IntStrategy)),
+      "[A + B]",
+    );
   });
 
   it("rejects `unknown`", () => {
@@ -890,8 +925,8 @@ describe("mapTsType", () => {
     assert.equal(
       mapTsType(prop.type, checker, IntStrategy, undefined, {
         policy: "reject",
-      }),
-      UNSUPPORTED_UNKNOWN,
+      }).ok,
+      false,
     );
   });
 
@@ -905,8 +940,8 @@ describe("mapTsType", () => {
     assert.equal(
       mapTsType(prop.type, checker, IntStrategy, undefined, {
         policy: "reject",
-      }),
-      UNSUPPORTED_UNKNOWN,
+      }).ok,
+      false,
     );
   });
 
@@ -920,8 +955,8 @@ describe("mapTsType", () => {
     assert.equal(
       mapTsType(prop.type, checker, IntStrategy, undefined, {
         policy: "reject",
-      }),
-      UNSUPPORTED_UNKNOWN,
+      }).ok,
+      false,
     );
   });
 
@@ -935,8 +970,8 @@ describe("mapTsType", () => {
     assert.equal(
       mapTsType(prop.type, checker, IntStrategy, undefined, {
         policy: "reject",
-      }),
-      UNSUPPORTED_UNKNOWN,
+      }).ok,
+      false,
     );
   });
 
@@ -952,8 +987,8 @@ describe("mapTsType", () => {
     assert.equal(
       mapTsType(propK.type, getChecker(sfK), IntStrategy, cellK, {
         policy: "reject",
-      }),
-      UNSUPPORTED_UNKNOWN,
+      }).ok,
+      false,
     );
     // No partial Map domain leaked into the synth state.
     assert.equal(cellK.synth.byKV.size, 0);
@@ -965,8 +1000,8 @@ describe("mapTsType", () => {
     assert.equal(
       mapTsType(propV.type, getChecker(sfV), IntStrategy, cellV, {
         policy: "reject",
-      }),
-      UNSUPPORTED_UNKNOWN,
+      }).ok,
+      false,
     );
     assert.equal(cellV.synth.byKV.size, 0);
   });
@@ -985,8 +1020,8 @@ describe("mapTsType", () => {
     assert.equal(
       mapTsType(prop.type, checker, IntStrategy, undefined, {
         policy: "reject",
-      }),
-      UNSUPPORTED_UNKNOWN,
+      }).ok,
+      false,
     );
   });
 
@@ -1000,8 +1035,8 @@ describe("mapTsType", () => {
     assert.equal(
       mapTsType(returnType, checker, IntStrategy, cell, {
         policy: "reject",
-      }),
-      UNSUPPORTED_UNKNOWN,
+      }).ok,
+      false,
     );
     // No partial record domain leaked into the synth state.
     assert.equal(cell.recordSynth.byShape.size, 0);
@@ -1043,39 +1078,10 @@ describe("translateTypes routes `unknown` through `unsupported` declaration", ()
   });
 });
 
-describe("cellRegisterMap / cellRegisterRecord / cellRegisterTupleConstructor reject `unknown` defensively", () => {
-  it("cellRegisterMap returns null when K is the sentinel", async () => {
-    const { cellRegisterMap, newSynthCell, UNSUPPORTED_UNKNOWN } = await import(
-      "../src/translate-types.js"
-    );
-    const cell = newSynthCell();
-    assert.equal(cellRegisterMap(cell, UNSUPPORTED_UNKNOWN, "Int"), null);
-    assert.equal(cell.synth.byKV.size, 0);
-  });
-
-  it("cellRegisterRecord returns null when a field type is the sentinel", async () => {
-    const { cellRegisterRecord, newSynthCell, UNSUPPORTED_UNKNOWN } =
-      await import("../src/translate-types.js");
-    const cell = newSynthCell();
-    assert.equal(
-      cellRegisterRecord(cell, [{ name: "x", type: UNSUPPORTED_UNKNOWN }]),
-      null,
-    );
-    assert.equal(cell.recordSynth.byShape.size, 0);
-  });
-
-  it("cellRegisterTupleConstructor returns null when an element is the sentinel", async () => {
-    const { UNSUPPORTED_UNKNOWN } = await import("../src/translate-types.js");
-    const cell = newSynthCell();
-    assert.equal(
-      cellRegisterTupleConstructor(cell, {
-        elementPantTypes: [UNSUPPORTED_UNKNOWN, "Int"],
-      }),
-      null,
-    );
-    assert.equal(cellTupleShapes(cell).length, 0);
-  });
-});
+// The previous `cellRegister* reject `unknown` defensively` suite was removed:
+// callers now unwrap `mapTsType`'s Result before passing sorts to the
+// synthesizers, so a refusal can no longer reach them as a sentinel string —
+// the guard is enforced by the type system rather than a runtime check.
 
 describe("cellRegisterOpaqueValue / cellEmitSynth", () => {
   it("emits nothing while no opaque id is registered", async () => {


### PR DESCRIPTION
Two related changes that retire a recurring bug class — the type-mapping layer leaking internal sentinel strings into generated Pantagruel.

## Commit 1 — Fix stack-overflow crash on recursive discriminated unions

A function whose signature mentions a **recursive** discriminated union (e.g. `IR1Expr`, whose variants have `IR1Expr` fields) crashed the translator with `RangeError: Maximum call stack size exceeded`: `mapTsType` → `cellRegisterDiscriminatedUnion`'s variant-field loop → `mapTsType` on the same `ts.Type`, with no cycle guard. `registerAnonymousRecord` had the identical latent crash.

Adds a transient `SynthCell.visiting: Set<ts.Type>` cycle guard around both registration paths: a same-type re-entry refuses gracefully (a clean `> UNSUPPORTED:` skip) instead of recursing. A new `tests/fixtures/recursive-union/` fixture + test assert graceful refusal (and reproduce the `RangeError` when the guard is disabled); a non-recursive DU control is unchanged. (The *sound* recursive encoding that would make recursive DUs translate is a separate follow-on.)

## Commit 2 — Return a Result from the type-mapping layer

`mapTsType(...) => string` signaled failure **in-band** — failure was a magic string (`__unsupported_unknown__`, `__unsupported_anon_record__`, the DU-registration reason) in the *same* `string` channel as a real Pant sort, so a caller that forgot a sentinel emitted it as a sort (commit 1 patched one such leak; an inventory found ~19 latent leak sites). The rest of the pipeline already uses tagged-union results (`BodyResult`, `PantDeclaration`); the type-mapping layer was the stringly-typed holdout.

`mapTsType` / `mapTsTypeFromTypeNode` (and `mapDynamicTypeNode` / `mapTsTypeNodePart`) now return `MapTsTypeResult = { ok: true; sort } | { ok: false; reason }`. A sentinel **cannot** be emitted as a sort — it's a compile error, not a runtime convention. Composites propagate monadically (`if (!r.ok) return r`); the deliberate `checker.typeToString` "mirror the source" fallbacks stay in the success channel (behavior preserved). The four dead sentinel detectors are removed; reason strings are retained; the orthogonal `isValidPantFieldType` / `isTsNullish` / `isAnonymousRecord` / `__type` checks are untouched. ~57 call sites migrated across 8 modules. `isUnsupportedUnknown` (now unused) and its dogfood `@pant` entries are dropped.

## Verification

Pure refactor — `tsc --noEmit` + `biome check src` clean, unit **385 + 944/947** (3 pre-existing skips), integration **109/109**, and **zero `.snapshot` churn** (same sorts, same refusals, structurally enforced). The −2 integration count is the removed `isUnsupportedUnknown` dogfood entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)