### PR TITLE
Dogfood the recursive-DU surface: field-readers + IR1Expr predicates

### DIFF
--- a/tools/ts2pant/src/ir1-printer.ts
+++ b/tools/ts2pant/src/ir1-printer.ts
@@ -846,14 +846,23 @@ function formatVersionedAsTightPrefixArg(
     : formatVersionedAsAppArg(expr, readLabels);
 }
 
+/**
+ * @pant needsCalleeParens expr <-> ir1-expr--kind expr = "binop" or ir1-expr--kind expr = "cond".
+ */
 function needsCalleeParens(expr: IR1Expr): boolean {
   return expr.kind === "binop" || expr.kind === "cond";
 }
 
+/**
+ * @pant needsAppArgParens expr <-> ir1-expr--kind expr = "app" or ir1-expr--kind expr = "cond".
+ */
 function needsAppArgParens(expr: IR1Expr): boolean {
   return expr.kind === "app" || expr.kind === "cond";
 }
 
+/**
+ * @pant needsMemberReceiverParens expr <-> ir1-expr--kind expr = "binop" or ir1-expr--kind expr = "member".
+ */
 function needsMemberReceiverParens(expr: IR1Expr): boolean {
   return expr.kind === "binop" || expr.kind === "member";
 }

--- a/tools/ts2pant/tests/fixtures/recursive-union/cases.ts
+++ b/tools/ts2pant/tests/fixtures/recursive-union/cases.ts
@@ -16,6 +16,33 @@ export function treeKind(t: Tree): string {
   return t.kind;
 }
 
+/**
+ * Field-reader on a recursive DU: reads the `leaf`-variant `value` field,
+ * discharged by the `kind === "leaf"` discriminant narrowing (same shape as
+ * the non-recursive `getRadius`, now over a self-referential domain).
+ *
+ * @pant leafValue t = cond tree--kind t = "leaf" => tree--value t, true => 0.
+ */
+export function leafValue(t: Tree): number {
+  if (t.kind === "leaf") {
+    return t.value;
+  }
+  return 0;
+}
+
+/**
+ * Reads a self-referential field (`node.left: Tree`) under narrowing, then its
+ * discriminant — exercising the recursive accessor `tree--left … => Tree`.
+ *
+ * @pant leftChildKind t = cond tree--kind t = "node" => tree--kind (tree--left t), true => tree--kind t.
+ */
+export function leftChildKind(t: Tree): string {
+  if (t.kind === "node") {
+    return t.left.kind;
+  }
+  return t.kind;
+}
+
 // `Shape` is a NON-recursive discriminated union — the control. It must keep
 // registering to a synthesized domain (the cycle guard never fires for it).
 type Shape =

--- a/tools/ts2pant/tests/integration/dogfood.test.mts
+++ b/tools/ts2pant/tests/integration/dogfood.test.mts
@@ -401,6 +401,9 @@ describe("dogfood: @pant annotations entail", () => {
     { file: "translate-types.ts", fn: "tupleDepModuleName", minChecks: 1 },
     { file: "translate-types.ts", fn: "emptyTupleSynth", minChecks: 1 },
     { file: "opaque.ts", fn: "isOpaqueExpr", minChecks: 1 },
+    { file: "ir1-printer.ts", fn: "needsCalleeParens", minChecks: 1 },
+    { file: "ir1-printer.ts", fn: "needsAppArgParens", minChecks: 1 },
+    { file: "ir1-printer.ts", fn: "needsMemberReceiverParens", minChecks: 1 },
     {
       file: resolve(FIXTURES, "expressions-discriminant-narrowing.ts"),
       fn: "getRadius",

--- a/tools/ts2pant/tests/integration/recursive-union.test.mts
+++ b/tools/ts2pant/tests/integration/recursive-union.test.mts
@@ -23,11 +23,20 @@ describe("recursive discriminated union integration", () => {
     await loadAst();
   });
 
-  it("a @pant annotation over a recursive union entails", {
-    skip: !solverAvailable() ? "z3 not available" : undefined,
-  }, async () => {
-    const output = await emitAndCheck(await buildDocument(FIXTURE, "treeKind"));
-    const result = runCheck(output);
-    assert.ok(result.passed, `pant --check failed:\n${result.output}`);
-  });
+  for (const fn of ["treeKind", "leafValue", "leftChildKind"]) {
+    it(`@pant on \`${fn}\` (recursive union) entails`, {
+      skip: !solverAvailable() ? "z3 not available" : undefined,
+    }, async () => {
+      const output = await emitAndCheck(await buildDocument(FIXTURE, fn));
+      const result = runCheck(output);
+      const entailments = result.checks.filter(
+        (c) =>
+          c.message.startsWith("OK: Entailed:") ||
+          c.message.startsWith("FAIL: Not entailed:"),
+      );
+      assert.ok(entailments.length >= 1, "expected an entailment result");
+      assert.ok(result.passed, `pant --check failed:\n${result.output}`);
+      assert.ok(entailments.every((c) => c.passed));
+    });
+  }
 });

--- a/tools/ts2pant/tests/recursive-union.test.mts
+++ b/tools/ts2pant/tests/recursive-union.test.mts
@@ -5,15 +5,9 @@ import assert from "node:assert/strict";
 import { resolve } from "node:path";
 import { before, describe, it } from "node:test";
 
-import { emitDocument, runCheck } from "../src/emit.js";
+import { emitDocument } from "../src/emit.js";
 import { loadAst } from "../src/pant-wasm.js";
-import {
-  buildDocument,
-  emitAndCheck,
-  getPantBin,
-  PROJECT_ROOT,
-  solverAvailable,
-} from "./helpers.mjs";
+import { buildDocument, emitAndCheck } from "./helpers.mjs";
 
 const FIXTURE = resolve(
   import.meta.dirname,
@@ -46,22 +40,8 @@ describe("recursive discriminated union", () => {
   // `node.left: Tree` field under `kind === "node"` narrowing, then its
   // discriminant — exercising the recursive accessor `tree--left … => Tree`.
   for (const fn of ["treeKind", "leafValue", "leftChildKind"]) {
-    it(`@pant on \`${fn}\` (recursive union) entails`, {
-      skip: !solverAvailable() ? "z3 not available" : undefined,
-    }, async () => {
-      const output = await emitAndCheck(await buildDocument(FIXTURE, fn));
-      const result = runCheck(output, {
-        projectRoot: PROJECT_ROOT,
-        pantBin: getPantBin(),
-      });
-      const entailments = result.checks.filter(
-        (c) =>
-          c.message.startsWith("OK: Entailed:") ||
-          c.message.startsWith("FAIL: Not entailed:"),
-      );
-      assert.ok(entailments.length >= 1, "expected an entailment result");
-      assert.ok(result.passed, `pant --check failed:\n${result.output}`);
-      assert.ok(entailments.every((c) => c.passed));
+    it(`emits and type-checks @pant on \`${fn}\` (recursive union)`, async () => {
+      await emitAndCheck(await buildDocument(FIXTURE, fn));
     });
   }
 

--- a/tools/ts2pant/tests/recursive-union.test.mts
+++ b/tools/ts2pant/tests/recursive-union.test.mts
@@ -5,9 +5,15 @@ import assert from "node:assert/strict";
 import { resolve } from "node:path";
 import { before, describe, it } from "node:test";
 
-import { emitDocument } from "../src/emit.js";
+import { emitDocument, runCheck } from "../src/emit.js";
 import { loadAst } from "../src/pant-wasm.js";
-import { buildDocument, emitAndCheck } from "./helpers.mjs";
+import {
+  buildDocument,
+  emitAndCheck,
+  getPantBin,
+  PROJECT_ROOT,
+  solverAvailable,
+} from "./helpers.mjs";
 
 const FIXTURE = resolve(
   import.meta.dirname,
@@ -28,17 +34,43 @@ describe("recursive discriminated union", () => {
     const output = await emitAndCheck(await buildDocument(FIXTURE, "treeKind"));
     assert.doesNotMatch(output, /UNSUPPORTED/u);
     assert.match(output, /^Tree\.$/mu);
-    assert.match(
-      output,
-      /tree--left s: Tree, tree--kind s = "node" => Tree\./u,
-    );
-    assert.match(
-      output,
-      /tree--value s: Tree, tree--kind s = "leaf" => Int\./u,
-    );
+    assert.match(output, /tree--left s: Tree, tree--kind s = "node" => Tree\./u);
+    assert.match(output, /tree--value s: Tree, tree--kind s = "leaf" => Int\./u);
     // The body resolves against the same `Tree` domain, not a duplicate.
     assert.match(output, /tree-kind t = tree--kind t\./u);
     assert.doesNotMatch(output, /Tree1|Tree2/u);
+  });
+
+  // `treeKind` reads the discriminant; `leafValue` reads a leaf field under
+  // `kind === "leaf"` narrowing; `leftChildKind` reads the *self-referential*
+  // `node.left: Tree` field under `kind === "node"` narrowing, then its
+  // discriminant — exercising the recursive accessor `tree--left … => Tree`.
+  for (const fn of ["treeKind", "leafValue", "leftChildKind"]) {
+    it(`@pant on \`${fn}\` (recursive union) entails`, {
+      skip: !solverAvailable() ? "z3 not available" : undefined,
+    }, async () => {
+      const output = await emitAndCheck(await buildDocument(FIXTURE, fn));
+      const result = runCheck(output, {
+        projectRoot: PROJECT_ROOT,
+        pantBin: getPantBin(),
+      });
+      const entailments = result.checks.filter(
+        (c) =>
+          c.message.startsWith("OK: Entailed:") ||
+          c.message.startsWith("FAIL: Not entailed:"),
+      );
+      assert.ok(entailments.length >= 1, "expected an entailment result");
+      assert.ok(result.passed, `pant --check failed:\n${result.output}`);
+      assert.ok(entailments.every((c) => c.passed));
+    });
+  }
+
+  it("reads a self-referential field under narrowing", async () => {
+    const output = await emitAndCheck(
+      await buildDocument(FIXTURE, "leftChildKind"),
+    );
+    // The `node.left` read resolves through the recursive accessor.
+    assert.match(output, /tree--kind \(tree--left t\)/u);
   });
 
   it("a non-recursive discriminated union still registers (control)", async () => {


### PR DESCRIPTION
Builds on the sound recursive-DU encoding (#338, merged), exercising the newly-translatable recursive IR surface with `@pant` annotations.

## 1. Field-readers over a recursive DU (fixture)
A field read discharged by discriminant narrowing now works over a *self-referential* domain — the same shape as the non-recursive `getRadius`, on a `Tree`. Two `@pant`-annotated field-readers, both **entailing under z3**:
- **`leafValue`** — reads the `leaf` `value` field under `kind = "leaf"` narrowing → `cond tree--kind t = "leaf" => tree--value t, true => 0`.
- **`leftChildKind`** — reads the **self-referential** `node.left: Tree` field under `kind = "node"` narrowing, then its discriminant → `tree--kind (tree--left t)`, exercising the recursive accessor `tree--left … => Tree`.

Proves the recursive encoding and the discriminant-narrowing layer **compose**. Also **restores the recursive-union entailment coverage** the #338 squash had dropped (now a loop over all three functions).

## 2. IR1Expr discriminant predicates (ts2pant's own code)
Three `@pant` annotations over the real recursive `IR1Expr` union — the printer's parenthesization predicates (read only `.kind`, `isOpaqueExpr`-tier), each entailing under z3 and added to the dogfood list:
- `needsCalleeParens` <-> `kind = "binop" or kind = "cond"`
- `needsAppArgParens` <-> `kind = "app" or kind = "cond"`
- `needsMemberReceiverParens` <-> `kind = "binop" or kind = "member"`

## Note on ts2pant's own field-readers
There are no small standalone *field-reader* functions in ts2pant's IR code — field reads live in large recursive walkers (`ir1-printer`, `ir1-substitute`, `ir1SsaExprEquals`) and AST-constructors (`negateFact`), which are blocked on **body-lowering completeness**, not the type encoding. So this PR dogfoods the discriminant-predicate slice of the own-code IR surface and demonstrates the field-reader tier via fixtures; body-lowering is the next lever for the rest.

## Verification
`tsc` + biome clean, unit 385 + 948/951, integration **114/114**, **zero `.snapshot` churn**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)