### PR TITLE
[ts2pant-for-of-comprehension] Patch 1: Fixtures + skipped test stubs for for-of comprehension

### DIFF
--- a/tools/ts2pant/tests/constructs.test.mts
+++ b/tools/ts2pant/tests/constructs.test.mts
@@ -10,6 +10,7 @@ import { createSourceFile } from "../src/extract.js";
 import { buildDocumentFromSourceFile, emitAndCheck } from "./helpers.mjs";
 
 const CONSTRUCTS_DIR = resolve(import.meta.dirname, "fixtures/constructs");
+const SCAFFOLD_ONLY_FIXTURES = new Set(["expressions-for-of-comprehension.ts"]);
 
 import { KNOWN_TYPECHECK_FAILURES } from "./known-typecheck-failures.mjs";
 
@@ -43,6 +44,7 @@ function discoverTestTargets(sourceFile: SourceFile): string[] {
 
 const fixtureFiles = readdirSync(CONSTRUCTS_DIR)
   .filter((f) => f.endsWith(".ts"))
+  .filter((f) => !SCAFFOLD_ONLY_FIXTURES.has(f))
   .sort();
 
 for (const file of fixtureFiles) {
@@ -50,9 +52,7 @@ for (const file of fixtureFiles) {
     const filePath = resolve(CONSTRUCTS_DIR, file);
     const discoverySourceFile = createSourceFile(filePath);
     const targets = discoverTestTargets(discoverySourceFile);
-    discoverySourceFile
-      .getProject()
-      .removeSourceFile(discoverySourceFile);
+    discoverySourceFile.getProject().removeSourceFile(discoverySourceFile);
     if (targets.length === 0) {
       throw new Error(`No exported snapshot targets found in ${file}`);
     }

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-for-of-comprehension.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-for-of-comprehension.ts
@@ -17,7 +17,8 @@ interface Item {
  *   `const acc = []; for (const x of xs) acc.push(f(x)); return acc;`
  * Target Pantagruel encoding: `each x in xs | f(x)`.
  */
-function _mapLabels(xs: Item[]): string[] {
+// biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
+function mapLabels(xs: Item[]): string[] {
   const acc: string[] = [];
   for (const x of xs) {
     acc.push(x.label);
@@ -30,7 +31,8 @@ function _mapLabels(xs: Item[]): string[] {
  *   `const acc = []; for (const x of xs) { if (P) acc.push(x); } return acc;`
  * Target Pantagruel encoding: `each x in xs | x, P`.
  */
-function _filterIfActive(xs: Item[]): Item[] {
+// biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
+function filterIfActive(xs: Item[]): Item[] {
   const acc: Item[] = [];
   for (const x of xs) {
     if (x.active) {
@@ -45,7 +47,8 @@ function _filterIfActive(xs: Item[]): Item[] {
  *   `const acc = []; for (const x of xs) { if (!P) continue; acc.push(x); } return acc;`
  * Target Pantagruel encoding: `each x in xs | x, P`.
  */
-function _filterContinueActive(xs: Item[]): Item[] {
+// biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
+function filterContinueActive(xs: Item[]): Item[] {
   const acc: Item[] = [];
   for (const x of xs) {
     if (!x.active) {
@@ -60,9 +63,10 @@ function _filterContinueActive(xs: Item[]): Item[] {
  * Non-array iterable build-list source (`Set<T>`).
  * Target Pantagruel encoding: `each x in xs | x`.
  *
- * @pant _collectSet xs = each x in xs | x
+ * @pant collectSet xs = (each x in xs | x)
  */
-function _collectSet(xs: Set<string>): string[] {
+// biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
+function collectSet(xs: Set<string>): string[] {
   const acc: string[] = [];
   for (const x of xs) {
     acc.push(x);
@@ -74,7 +78,8 @@ function _collectSet(xs: Set<string>): string[] {
  * Out-of-scope control: a scalar fold with `+=` must keep refusing.
  * Target Pantagruel encoding: none (explicitly out of scope).
  */
-function _sumLengths(xs: string[]): number {
+// biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
+function sumLengths(xs: string[]): number {
   let total = 0;
   for (const x of xs) {
     total += x.length;
@@ -86,7 +91,8 @@ function _sumLengths(xs: string[]): number {
  * Out-of-scope control: Map-entry destructuring must keep refusing.
  * Target Pantagruel encoding: none (explicitly out of scope).
  */
-function _mapEntryCopy(m: Map<string, number>): number[] {
+// biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
+function mapEntryCopy(m: Map<string, number>): number[] {
   const acc: number[] = [];
   for (const [k, v] of m) {
     void k;

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-for-of-comprehension.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-for-of-comprehension.ts
@@ -1,0 +1,96 @@
+// @archlint.module exempt
+// @archlint.exempt-reason test-support
+
+// For-of build-list shapes targeted by the Patch 1/2/3 for-of comprehension
+// workstream. These functions stay unexported so the auto-discovered
+// constructs snapshot suite does not pick them up before the dedicated tests
+// land.
+
+interface Item {
+  active: boolean;
+  label: string;
+  value: number;
+}
+
+/**
+ * Imperative map shape:
+ *   `const acc = []; for (const x of xs) acc.push(f(x)); return acc;`
+ * Target Pantagruel encoding: `each x in xs | f(x)`.
+ */
+function _mapLabels(xs: Item[]): string[] {
+  const acc: string[] = [];
+  for (const x of xs) {
+    acc.push(x.label);
+  }
+  return acc;
+}
+
+/**
+ * Imperative filter shape with a leading guard:
+ *   `const acc = []; for (const x of xs) { if (P) acc.push(x); } return acc;`
+ * Target Pantagruel encoding: `each x in xs | x, P`.
+ */
+function _filterIfActive(xs: Item[]): Item[] {
+  const acc: Item[] = [];
+  for (const x of xs) {
+    if (x.active) {
+      acc.push(x);
+    }
+  }
+  return acc;
+}
+
+/**
+ * Imperative filter shape with `continue`:
+ *   `const acc = []; for (const x of xs) { if (!P) continue; acc.push(x); } return acc;`
+ * Target Pantagruel encoding: `each x in xs | x, P`.
+ */
+function _filterContinueActive(xs: Item[]): Item[] {
+  const acc: Item[] = [];
+  for (const x of xs) {
+    if (!x.active) {
+      continue;
+    }
+    acc.push(x);
+  }
+  return acc;
+}
+
+/**
+ * Non-array iterable build-list source (`Set<T>`).
+ * Target Pantagruel encoding: `each x in xs | x`.
+ *
+ * @pant _collectSet xs = each x in xs | x
+ */
+function _collectSet(xs: Set<string>): string[] {
+  const acc: string[] = [];
+  for (const x of xs) {
+    acc.push(x);
+  }
+  return acc;
+}
+
+/**
+ * Out-of-scope control: a scalar fold with `+=` must keep refusing.
+ * Target Pantagruel encoding: none (explicitly out of scope).
+ */
+function _sumLengths(xs: string[]): number {
+  let total = 0;
+  for (const x of xs) {
+    total += x.length;
+  }
+  return total;
+}
+
+/**
+ * Out-of-scope control: Map-entry destructuring must keep refusing.
+ * Target Pantagruel encoding: none (explicitly out of scope).
+ */
+function _mapEntryCopy(m: Map<string, number>): number[] {
+  const acc: number[] = [];
+  for (const [k, v] of m) {
+    void k;
+    acc.push(v);
+  }
+  return acc;
+}

--- a/tools/ts2pant/tests/for-of-comprehension.test.mts
+++ b/tools/ts2pant/tests/for-of-comprehension.test.mts
@@ -1,0 +1,87 @@
+// @archlint.module test
+// @archlint.domain ts2pant.for-of-comprehension
+
+import { resolve } from "node:path";
+import { describe, it } from "node:test";
+import {
+  buildDocument,
+  emitAndCheck,
+  runCheck,
+  solverAvailable,
+} from "./helpers.mjs";
+
+const FIXTURE = resolve(
+  import.meta.dirname,
+  "fixtures/constructs/expressions-for-of-comprehension.ts",
+);
+
+const PATCH_2_SKIP = "PENDING: Patch 2";
+const PATCH_3_SKIP = "PENDING: Patch 3";
+
+describe("for-of comprehension recognizer", () => {
+  it("matches map/filter build-list and rejects out-of-scope shapes", {
+    skip: PATCH_2_SKIP,
+  }, async () => {
+    await buildDocument(FIXTURE, "_mapLabels");
+  });
+});
+
+describe("for-of comprehension integration", () => {
+  const hasSolver = solverAvailable();
+  const patch3Skip = hasSolver
+    ? PATCH_3_SKIP
+    : `${PATCH_3_SKIP} (z3 unavailable)`;
+
+  it("translates a build-list to an each comprehension", {
+    skip: patch3Skip,
+  }, async () => {
+    const output = await emitAndCheck(
+      await buildDocument(FIXTURE, "_mapLabels"),
+    );
+    void output;
+  });
+
+  it("filtered build-list emits a guarded each", {
+    skip: patch3Skip,
+  }, async () => {
+    const output = await emitAndCheck(
+      await buildDocument(FIXTURE, "_filterIfActive"),
+    );
+    void output;
+  });
+
+  it("@pant on a build-list entails", { skip: patch3Skip }, async () => {
+    const output = await emitAndCheck(
+      await buildDocument(FIXTURE, "_collectSet"),
+    );
+    const result = runCheck(output);
+    void result;
+  });
+
+  it("existing snapshots are unchanged (additive)", {
+    skip: patch3Skip,
+  }, async () => {
+    const output = await emitAndCheck(
+      await buildDocument(FIXTURE, "_filterContinueActive"),
+    );
+    void output;
+  });
+
+  it("out-of-scope scalar fold still refuses with a precise reason", {
+    skip: patch3Skip,
+  }, async () => {
+    const output = await emitAndCheck(
+      await buildDocument(FIXTURE, "_sumLengths"),
+    );
+    void output;
+  });
+
+  it("Map-entry destructuring still refuses with a precise reason", {
+    skip: patch3Skip,
+  }, async () => {
+    const output = await emitAndCheck(
+      await buildDocument(FIXTURE, "_mapEntryCopy"),
+    );
+    void output;
+  });
+});

--- a/tools/ts2pant/tests/for-of-comprehension.test.mts
+++ b/tools/ts2pant/tests/for-of-comprehension.test.mts
@@ -3,12 +3,7 @@
 
 import { resolve } from "node:path";
 import { describe, it } from "node:test";
-import {
-  buildDocument,
-  emitAndCheck,
-  runCheck,
-  solverAvailable,
-} from "./helpers.mjs";
+import { buildDocument, emitAndCheck, solverAvailable } from "./helpers.mjs";
 
 const FIXTURE = resolve(
   import.meta.dirname,
@@ -22,7 +17,7 @@ describe("for-of comprehension recognizer", () => {
   it("matches map/filter build-list and rejects out-of-scope shapes", {
     skip: PATCH_2_SKIP,
   }, async () => {
-    await buildDocument(FIXTURE, "_mapLabels");
+    await buildDocument(FIXTURE, "mapLabels");
   });
 });
 
@@ -36,7 +31,7 @@ describe("for-of comprehension integration", () => {
     skip: patch3Skip,
   }, async () => {
     const output = await emitAndCheck(
-      await buildDocument(FIXTURE, "_mapLabels"),
+      await buildDocument(FIXTURE, "mapLabels"),
     );
     void output;
   });
@@ -45,24 +40,16 @@ describe("for-of comprehension integration", () => {
     skip: patch3Skip,
   }, async () => {
     const output = await emitAndCheck(
-      await buildDocument(FIXTURE, "_filterIfActive"),
+      await buildDocument(FIXTURE, "filterIfActive"),
     );
     void output;
-  });
-
-  it("@pant on a build-list entails", { skip: patch3Skip }, async () => {
-    const output = await emitAndCheck(
-      await buildDocument(FIXTURE, "_collectSet"),
-    );
-    const result = runCheck(output);
-    void result;
   });
 
   it("existing snapshots are unchanged (additive)", {
     skip: patch3Skip,
   }, async () => {
     const output = await emitAndCheck(
-      await buildDocument(FIXTURE, "_filterContinueActive"),
+      await buildDocument(FIXTURE, "filterContinueActive"),
     );
     void output;
   });
@@ -71,7 +58,7 @@ describe("for-of comprehension integration", () => {
     skip: patch3Skip,
   }, async () => {
     const output = await emitAndCheck(
-      await buildDocument(FIXTURE, "_sumLengths"),
+      await buildDocument(FIXTURE, "sumLengths"),
     );
     void output;
   });
@@ -80,7 +67,7 @@ describe("for-of comprehension integration", () => {
     skip: patch3Skip,
   }, async () => {
     const output = await emitAndCheck(
-      await buildDocument(FIXTURE, "_mapEntryCopy"),
+      await buildDocument(FIXTURE, "mapEntryCopy"),
     );
     void output;
   });

--- a/tools/ts2pant/tests/integration/for-of-comprehension.test.mts
+++ b/tools/ts2pant/tests/integration/for-of-comprehension.test.mts
@@ -1,0 +1,36 @@
+// @archlint.module test
+// @archlint.domain ts2pant.for-of-comprehension.integration
+
+import assert from "node:assert/strict";
+import { resolve } from "node:path";
+import { before, describe, it } from "node:test";
+import { loadAst } from "../../src/pant-wasm.js";
+import { buildDocument, emitAndCheck, runCheck } from "../helpers.mjs";
+
+const FIXTURE = resolve(
+  import.meta.dirname,
+  "../fixtures/constructs/expressions-for-of-comprehension.ts",
+);
+
+before(async () => {
+  await loadAst();
+});
+
+describe("for-of comprehension integration", () => {
+  it("@pant on a build-list entails", {
+    skip: "PENDING: Patch 3",
+  }, async () => {
+    const output = await emitAndCheck(
+      await buildDocument(FIXTURE, "collectSet"),
+    );
+    const result = runCheck(output);
+    const entailments = result.checks.filter(
+      (c) =>
+        c.message.startsWith("OK: Entailed:") ||
+        c.message.startsWith("FAIL: Not entailed:"),
+    );
+    assert.ok(entailments.length >= 1, "expected an entailment result");
+    assert.ok(result.passed, `pant --check failed:\n${result.output}`);
+    assert.ok(entailments.every((c) => c.passed));
+  });
+});


### PR DESCRIPTION
## Patch 1: Fixtures + skipped test stubs for for-of comprehension

- Create the fixture file with the five shapes (map, filter-if, filter-continue, annotated, out-of-scope fold control).
- Add the `@pant` annotation on one in-scope function expressing its `each` equivalent (model on tests/fixtures/recursive-union/cases.ts).
- Create the test file with `it(..., { skip: ... })` / pending stubs labeled with the implementing patch number; no assertions executed yet.
- Confirm `npm run test` passes with the new tests skipped and `tsc`/`biome` clean.

## Changes
- Create the fixture file with the five shapes (map, filter-if, filter-continue, annotated, out-of-scope fold control).
- Add the `@pant` annotation on one in-scope function expressing its `each` equivalent (model on tests/fixtures/recursive-union/cases.ts).
- Create the test file with `it(..., { skip: ... })` / pending stubs labeled with the implementing patch number; no assertions executed yet.
- Confirm `npm run test` passes with the new tests skipped and `tsc`/`biome` clean.

## Files to Modify
- tools/ts2pant/tests/fixtures/constructs/expressions-for-of-comprehension.ts (create): Fixture functions: (a) map — `const acc=[]; for (const x of xs) acc.push(f(x)); return acc;`; (b) filter via leading `if`; (c) filter via `if (!P) continue;`; (d) a build-list over a non-array iterable source (`Set<T>` or `string`); (e) one of the above with a `@pant` annotation stating the equivalent `each` comprehension equation for an entailment test; (f) out-of-scope controls that must still refuse: a scalar `+=` fold, and a Map-entry destructuring `for (const [k, v] of m)`. Each with a docstring naming the intended Pantagruel encoding. Tag with the repo's archlint module/exempt headers like sibling fixtures.
- tools/ts2pant/tests/for-of-comprehension.test.mts (create): Test scaffold with skipped/pending stubs: recognizer unit tests (PENDING: Patch 2) and integration tests for translate-to-each / typecheck / entailment / snapshot-equivalence / out-of-scope-refusal (PENDING: Patch 3). Import helpers (buildDocument, emitAndCheck, runCheck, solverAvailable) following tests/helpers.mts and the recursive-union test style.

## Gameplan Specification

```
module FOR_OF_COMPREHENSION.

// ts2pant lowers the pure imperative build-list shape
//   const acc = []; for (const x of xs) { [if (P)] acc.push(f(x)); } return acc;
// to a Pantagruel `each` comprehension `each x in xs | f(x)[, P]`, an
// exact order-preserving total encoding, and refuses all other for-of
// shapes cleanly.
Body.
Comprehension.
Expr.

// Recognized parts of a candidate body.
loop-src b: Body => Expr.          // for-of source (array-typed)
loop-proj b: Body => Expr.         // pushed projection
loop-guard b: Body => Expr.        // filter guard (or `true`)
returns-acc b: Body => Bool.               // terminal `return acc` over the empty-array const
single-push b: Body => Bool.               // loop body is one (optionally guarded) push
pure-proj b: Body => Bool.                 // proj + guard lower to pure L1 exprs
src-ok b: Body => Bool.                 // source maps to an expressible Pant sort, simple binder
in-scope b: Body => Bool.

// Lowering result.
lowered? b: Body => Bool.
comp b: Body => Comprehension.
each-src c: Comprehension => Expr.
each-proj c: Comprehension => Expr.
each-guard c: Comprehension => Expr.
---
// Recognition is conservative: in-scope iff every structural and purity
// conjunct holds.
all b: Body | in-scope b <-> (returns-acc b and single-push b and pure-proj b and src-ok b).

// A body is emitted as a comprehension equation exactly when in scope.
all b: Body | lowered? b <-> in-scope b.

// The emitted comprehension mirrors the recognized loop (soundness: the
// `each` ranges over the same source, projects the same value, filters by
// the same guard).
all b: Body | in-scope b -> (each-src (comp b) = loop-src b and each-proj (comp b) = loop-proj b and each-guard (comp b) = loop-guard b).

// Out-of-scope for-of bodies (scalar fold, Set.add, find/exists, nested,
// break, impure proj/guard) are refused, never mis-lowered.
all b: Body | (~ in-scope b) -> ~ lowered? b.
```

## Patch Specification

```
module FOR_OF_COMPREHENSION_PATCH_1.

// Vocabulary only: the imperative build-list body and its target
// comprehension. No invariants yet — fixtures and skipped stubs.
Body.
Comprehension.
Expr.

acc-init b: Body => Expr.
loop-src b: Body => Expr.
loop-proj b: Body => Expr.
loop-guard b: Body => Expr.
---
// A body always exposes its parsed parts (total accessors); recognition
// and lowering invariants arrive in later patches.
all b: Body | loop-src b = loop-src b.
```


## Implementation Notes

- The new fixture is intentionally kept out of `tests/constructs.test.mts` auto-discovery for this patch. That suite only snapshots exported targets, so the scaffold fixture uses private `_name` functions and the constructs test explicitly filters this file out. This keeps Patch 1 inert while still making the corpus available to the dedicated for-of test file.
- The fixture covers the intended shape split directly in one file: map, leading-`if` filter, `continue`-based filter, non-array iterable (`Set<string>`), a `@pant` entailment case, and the two out-of-scope refusals (`+=` scalar fold and Map-entry destructuring). The `@pant` annotation is on the `Set` case so Patch 3 can reuse the same build-list shape for both typechecking and entailment.
- The new test file is a pure scaffold: every case is skipped and labeled `PENDING: Patch 2` or `PENDING: Patch 3`. It imports the same helper surface used by the existing integration tests, but executes no assertions yet.
- I did not add any new production code in this patch. The only behavior change is test harness isolation. That means downstream patches can wire the recognizer into the existing pipeline without having to unwind any scaffold-specific runtime behavior.
- Spec/Evidence mapping:
  - Fixture corpus requirement: `tools/ts2pant/tests/fixtures/constructs/expressions-for-of-comprehension.ts` contains the five requested shapes plus the two refusal controls.
  - Skipped stubs requirement: `tools/ts2pant/tests/for-of-comprehension.test.mts` contains the Patch 2 / Patch 3 `it(..., { skip: ... })` cases.
  - Safety/compatibility: `npm run test`, `npx tsc --noEmit`, and `npx biome check --write ...` all passed after the scaffold-only changes.