### PR TITLE
[ts2pant-for-of-comprehension] Patch 2: Pure recognizer: recognizeForOfPush (not yet wired)

### DIFF
--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -37,6 +37,7 @@ import {
   isL1ConditionalForm,
   isL1StmtUnsupported,
   isL1Unsupported,
+  type L1BuildContext,
   lowerL1ToOpaque,
   tryBuildBuiltinCall,
   tryBuildL1Cardinality,
@@ -225,6 +226,14 @@ type PreludeStmt =
       valueExpr: ts.Expression;
       blockBindings: readonly ExtractedBlockConstBinding[];
     };
+
+export interface RecognizedForOfPush {
+  binder: string;
+  src: IR1Expr;
+  proj: IR1Expr;
+  guards: IR1Expr[];
+  accName: string;
+}
 
 /** Names a binding introduces into scope (none for an early-return arm). */
 function bindingNames(b: PreludeStmt): readonly string[] {
@@ -1792,6 +1801,238 @@ function recognizeEarlyReturnArm(stmt: ts.Statement): {
     valueExpr: extracted.returnExpr,
     blockBindings: extracted.bindings,
   };
+}
+
+/**
+ * Recognize the pure build-list loop:
+ *
+ *   for (const x of xs) { [if (P)] acc.push(f(x)); }
+ *
+ * The recognizer is intentionally not wired into extraction in Patch 2.
+ * It is a conservative AST matcher plus pure-L1 lowering probe that returns
+ * the exact pieces Patch 3 will wrap in `ir1Each`.
+ */
+export function recognizeForOfPush(
+  stmt: ts.ForOfStatement,
+  accNames: ReadonlySet<string>,
+  ctx: L1BuildContext,
+): RecognizedForOfPush | null {
+  const init = stmt.initializer;
+  if (
+    !ts.isVariableDeclarationList(init) ||
+    !(init.flags & ts.NodeFlags.Const) ||
+    init.declarations.length !== 1
+  ) {
+    return null;
+  }
+  const decl = init.declarations[0]!;
+  if (!ts.isIdentifier(decl.name)) {
+    return null;
+  }
+
+  const binderTsName = decl.name.text;
+  const binder = toPantTermName(binderTsName);
+  const scopedParams = new Map(ctx.paramNames);
+  scopedParams.set(binderTsName, binder);
+  const scopedCtx: L1BuildContext = { ...ctx, paramNames: scopedParams };
+
+  if (!forOfSourceIsExpressible(stmt, decl, ctx)) {
+    return null;
+  }
+
+  const src = buildPureL1OrNull(stmt.expression, ctx);
+  if (src === null) {
+    return null;
+  }
+
+  const push = recognizeForOfPushBody(stmt.statement, accNames);
+  if (push === null) {
+    return null;
+  }
+  if (expressionHasSideEffects(push.projExpr, ctx.checker)) {
+    return null;
+  }
+  const proj = buildPureL1OrNull(push.projExpr, scopedCtx);
+  if (proj === null) {
+    return null;
+  }
+
+  const guards: IR1Expr[] = [];
+  for (const guardExpr of push.guardExprs) {
+    if (
+      !isStaticallyBoolTyped(guardExpr, ctx.checker) ||
+      expressionHasSideEffects(guardExpr, ctx.checker)
+    ) {
+      return null;
+    }
+    const guard = buildPureL1OrNull(guardExpr, scopedCtx);
+    if (guard === null) {
+      return null;
+    }
+    guards.push(guard);
+  }
+
+  return {
+    binder,
+    src,
+    proj,
+    guards,
+    accName: push.accName,
+  };
+}
+
+function forOfSourceIsExpressible(
+  stmt: ts.ForOfStatement,
+  decl: ts.VariableDeclaration,
+  ctx: L1BuildContext,
+): boolean {
+  const sourceType = mapTsType(
+    ctx.checker.getTypeAtLocation(stmt.expression),
+    ctx.checker,
+    ctx.strategy,
+    ctx.supply.synthCell,
+    { policy: ctx.policy },
+  );
+  if (!sourceType.ok) {
+    return false;
+  }
+
+  const binderType = mapTsType(
+    ctx.checker.getTypeAtLocation(decl.name),
+    ctx.checker,
+    ctx.strategy,
+    ctx.supply.synthCell,
+    { policy: ctx.policy },
+  );
+  if (!binderType.ok) {
+    return false;
+  }
+  return sourceType.sort === `[${binderType.sort}]`;
+}
+
+function buildPureL1OrNull(
+  expr: ts.Expression,
+  ctx: L1BuildContext,
+): IR1Expr | null {
+  const built = tryBuildL1PureSubExpression(expr, ctx);
+  if (built === null || isL1Unsupported(built)) {
+    return null;
+  }
+  return built;
+}
+
+interface RecognizedPushBody {
+  accName: string;
+  projExpr: ts.Expression;
+  guardExprs: ts.Expression[];
+}
+
+function recognizeForOfPushBody(
+  stmt: ts.Statement,
+  accNames: ReadonlySet<string>,
+): RecognizedPushBody | null {
+  if (ts.isBlock(stmt) && stmt.statements.length === 2) {
+    const guard = recognizeIfContinue(stmt.statements[0]!);
+    if (guard === null) {
+      return null;
+    }
+    const push = recognizePushStatement(stmt.statements[1]!, accNames);
+    if (push === null) {
+      return null;
+    }
+    return {
+      ...push,
+      guardExprs: [guard],
+    };
+  }
+
+  const bodyStmt = unwrapSingleStatementBlock(stmt);
+  if (bodyStmt === null) {
+    return null;
+  }
+
+  const direct = recognizePushStatement(bodyStmt, accNames);
+  if (direct !== null) {
+    return { ...direct, guardExprs: [] };
+  }
+
+  if (ts.isIfStatement(bodyStmt)) {
+    if (bodyStmt.elseStatement !== undefined) {
+      return null;
+    }
+    const guardedPush = recognizeForOfPushBody(
+      bodyStmt.thenStatement,
+      accNames,
+    );
+    if (guardedPush === null || guardedPush.guardExprs.length !== 0) {
+      return null;
+    }
+    return {
+      ...guardedPush,
+      guardExprs: [bodyStmt.expression],
+    };
+  }
+
+  return null;
+}
+
+function unwrapSingleStatementBlock(stmt: ts.Statement): ts.Statement | null {
+  if (!ts.isBlock(stmt)) {
+    return stmt;
+  }
+  return stmt.statements.length === 1 ? stmt.statements[0]! : null;
+}
+
+function recognizePushStatement(
+  stmt: ts.Statement,
+  accNames: ReadonlySet<string>,
+): Omit<RecognizedPushBody, "guardExprs"> | null {
+  if (!ts.isExpressionStatement(stmt)) {
+    return null;
+  }
+  const expr = stmt.expression;
+  if (
+    !ts.isCallExpression(expr) ||
+    expr.arguments.length !== 1 ||
+    !ts.isPropertyAccessExpression(expr.expression) ||
+    expr.expression.name.text !== "push" ||
+    !ts.isIdentifier(expr.expression.expression)
+  ) {
+    return null;
+  }
+  const accName = expr.expression.expression.text;
+  if (!accNames.has(accName)) {
+    return null;
+  }
+  return { accName, projExpr: expr.arguments[0]! };
+}
+
+function recognizeIfContinue(stmt: ts.Statement): ts.Expression | null {
+  const ifStmt = unwrapSingleStatementBlock(stmt);
+  if (
+    ifStmt === null ||
+    !ts.isIfStatement(ifStmt) ||
+    ifStmt.elseStatement !== undefined ||
+    !isContinueOnly(ifStmt.thenStatement)
+  ) {
+    return null;
+  }
+  return unwrapNegatedCondition(ifStmt.expression);
+}
+
+function isContinueOnly(stmt: ts.Statement): boolean {
+  const inner = unwrapSingleStatementBlock(stmt);
+  return inner !== null && ts.isContinueStatement(inner);
+}
+
+function unwrapNegatedCondition(expr: ts.Expression): ts.Expression | null {
+  if (
+    ts.isPrefixUnaryExpression(expr) &&
+    expr.operator === ts.SyntaxKind.ExclamationToken
+  ) {
+    return expr.operand;
+  }
+  return null;
 }
 
 function extractReturnExpression(

--- a/tools/ts2pant/tests/for-of-comprehension.test.mts
+++ b/tools/ts2pant/tests/for-of-comprehension.test.mts
@@ -1,8 +1,16 @@
 // @archlint.module test
 // @archlint.domain ts2pant.for-of-comprehension
 
+import assert from "node:assert/strict";
 import { resolve } from "node:path";
 import { describe, it } from "node:test";
+import ts from "typescript";
+import { createSourceFileFromSource, getChecker } from "../src/extract.js";
+import { createL1AssumptionEnv } from "../src/ir1-build.js";
+import { formatIR1Expr } from "../src/ir1-printer.js";
+import { makeUniqueSupply } from "../src/supply.js";
+import { recognizeForOfPush } from "../src/translate-body.js";
+import { IntStrategy } from "../src/translate-types.js";
 import { buildDocument, emitAndCheck, solverAvailable } from "./helpers.mjs";
 
 const FIXTURE = resolve(
@@ -10,16 +18,217 @@ const FIXTURE = resolve(
   "fixtures/constructs/expressions-for-of-comprehension.ts",
 );
 
-const PATCH_2_SKIP = "PENDING: Patch 2";
 const PATCH_3_SKIP = "PENDING: Patch 3";
 
 describe("for-of comprehension recognizer", () => {
-  it("matches map/filter build-list and rejects out-of-scope shapes", {
-    skip: PATCH_2_SKIP,
-  }, async () => {
-    await buildDocument(FIXTURE, "mapLabels");
+  it("matches map/filter build-list and rejects out-of-scope shapes", () => {
+    const positiveCases: Array<{
+      name: string;
+      body: string;
+      expected: {
+        binder: string;
+        src: string;
+        proj: string;
+        guards: string[];
+        accName: string;
+      };
+    }> = [
+      {
+        name: "direct push",
+        body: "for (const user of users) out.push(user.label);",
+        expected: {
+          binder: "user",
+          src: "users",
+          proj: "user--label user",
+          guards: [],
+          accName: "out",
+        },
+      },
+      {
+        name: "block push",
+        body: "{ for (const user of users) { out.push(user.label); } }",
+        expected: {
+          binder: "user",
+          src: "users",
+          proj: "user--label user",
+          guards: [],
+          accName: "out",
+        },
+      },
+      {
+        name: "if push",
+        body: "for (const user of users) { if (user.active) { out.push(user.label); } }",
+        expected: {
+          binder: "user",
+          src: "users",
+          proj: "user--label user",
+          guards: ["user--active user"],
+          accName: "out",
+        },
+      },
+      {
+        name: "if continue then push",
+        body: "for (const user of users) { if (!user.active) continue; out.push(user.label); }",
+        expected: {
+          binder: "user",
+          src: "users",
+          proj: "user--label user",
+          guards: ["user--active user"],
+          accName: "out",
+        },
+      },
+      {
+        name: "Set source",
+        body: "for (const label of labelSet) out.push(label);",
+        expected: {
+          binder: "label",
+          src: "labelSet",
+          proj: "label",
+          guards: [],
+          accName: "out",
+        },
+      },
+    ];
+
+    for (const testCase of positiveCases) {
+      const { stmt, ctx } = setup(testCase.body);
+      const result = recognizeForOfPush(stmt, new Set(["out"]), ctx);
+      assertRecognized(testCase.name, result, testCase.expected);
+    }
+
+    const rejectionCases = [
+      {
+        name: "non-candidate accumulator",
+        body: "for (const user of users) other.push(user.label);",
+      },
+      {
+        name: "multiple statements",
+        body: "for (const user of users) { out.push(user.label); out.push(user.label); }",
+      },
+      {
+        name: "nested loop",
+        body: "for (const user of users) { for (const label of labels) out.push(label); }",
+      },
+      {
+        name: "break",
+        body: "for (const user of users) { if (!user.active) break; out.push(user.label); }",
+      },
+      {
+        name: "early return",
+        body: "for (const user of users) { if (!user.active) return []; out.push(user.label); }",
+      },
+      {
+        name: "scalar fold",
+        body: "for (const user of users) total += user.label.length;",
+      },
+      {
+        name: "Set.add",
+        body: "for (const user of users) out.add(user.label);",
+      },
+      {
+        name: "destructuring binder",
+        body: "for (const [key, value] of entries) out.push(value);",
+      },
+      {
+        name: "impure projection",
+        body: "for (const user of users) out.push(tick(user.label));",
+      },
+      {
+        name: "impure guard",
+        body: "for (const user of users) { if (tick(user.active)) out.push(user.label); }",
+      },
+      {
+        name: "generic iterable",
+        body: "for (const user of genericUsers) out.push(user.label);",
+      },
+    ];
+
+    for (const testCase of rejectionCases) {
+      const { stmt, ctx } = setup(testCase.body);
+      const result = recognizeForOfPush(stmt, new Set(["out"]), ctx);
+      assert.equal(result, null, testCase.name);
+    }
   });
 });
+
+function sourceFor(body: string): string {
+  return `
+    interface User {
+      readonly label: string;
+      readonly active: boolean;
+    }
+    declare function tick<T>(value: T): T;
+    function f(
+      users: readonly User[],
+      labels: readonly string[],
+      labelSet: ReadonlySet<string>,
+      entries: ReadonlyMap<string, string>,
+      genericUsers: Iterable<any>,
+    ): string[] {
+      const out: string[] = [];
+      let total = 0;
+      ${body}
+      return out;
+    }
+  `;
+}
+
+function setup(body: string) {
+  const sourceFile = createSourceFileFromSource(sourceFor(body));
+  const checker = getChecker(sourceFile);
+  const fn = sourceFile.compilerNode.statements.find(ts.isFunctionDeclaration);
+  if (fn === undefined) {
+    throw new Error("expected function declaration");
+  }
+  const paramNames = new Map<string, string>();
+  for (const param of fn.parameters) {
+    if (ts.isIdentifier(param.name)) {
+      paramNames.set(param.name.text, param.name.text);
+    }
+  }
+  let stmt: ts.ForOfStatement | undefined;
+  function visit(node: ts.Node): void {
+    if (stmt === undefined && ts.isForOfStatement(node)) {
+      stmt = node;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  }
+  visit(sourceFile.compilerNode);
+  if (stmt === undefined) {
+    throw new Error(`expected for-of statement in test body: ${body}`);
+  }
+  return {
+    stmt,
+    ctx: {
+      checker,
+      strategy: IntStrategy,
+      paramNames,
+      state: undefined,
+      supply: makeUniqueSupply(),
+      env: createL1AssumptionEnv(),
+    },
+  };
+}
+
+function assertRecognized(
+  label: string,
+  result: ReturnType<typeof recognizeForOfPush>,
+  expected: {
+    binder: string;
+    src: string;
+    proj: string;
+    guards: string[];
+    accName: string;
+  },
+): void {
+  assert.notEqual(result, null, label);
+  assert.equal(result.binder, expected.binder, label);
+  assert.equal(formatIR1Expr(result.src), expected.src, label);
+  assert.equal(formatIR1Expr(result.proj), expected.proj, label);
+  assert.deepEqual(result.guards.map(formatIR1Expr), expected.guards, label);
+  assert.equal(result.accName, expected.accName, label);
+}
 
 describe("for-of comprehension integration", () => {
   const hasSolver = solverAvailable();


### PR DESCRIPTION
## Patch 2: Pure recognizer: recognizeForOfPush (not yet wired)

- Implement `recognizeForOfPush` as a pure AST matcher over (forOf statement, candidate accumulator names) returning the parts or null, mirroring tryRecognizeFunctorLift's structure and reusing the purity oracle to gate proj/guard.
- Cover the in-scope spellings (push, block-push, if-push, if-continue-then-push) and the out-of-scope rejections in the unit test.
- Do NOT call the recognizer from extractReturnExpression in this patch — no observable translation change.
- Verify `tsc --noEmit` and `biome check src` are clean and the recognizer unit test passes.

## Changes
- Implement `recognizeForOfPush` as a pure AST matcher over (forOf statement, candidate accumulator names) returning the parts or null, mirroring tryRecognizeFunctorLift's structure and reusing the purity oracle to gate proj/guard.
- Cover the in-scope spellings (push, block-push, if-push, if-continue-then-push) and the out-of-scope rejections in the unit test.
- Do NOT call the recognizer from extractReturnExpression in this patch — no observable translation change.
- Verify `tsc --noEmit` and `biome check src` are clean and the recognizer unit test passes.

## Files to Modify
- tools/ts2pant/src/translate-body.ts (modify): Add the pure function `recognizeForOfPush(stmt, accNames, checker)` that matches a `for-of` whose body only pushes a projection to one of the candidate accumulators in `accNames`, returning { binder, src, proj, guards, accName } or null. It must: (1) accept loop bodies of `acc.push(PROJ)`, `{ acc.push(PROJ) }`, `if (P) acc.push(PROJ)`, `{ if (P) { acc.push(PROJ) } }`, `{ if (!P) continue; acc.push(PROJ) }` where `acc` is in `accNames`; (2) reject bodies that do anything besides a single guarded push (multiple statements, writes to a non-candidate name, nested loops, break, early return, scalar fold, Set.add); (3) reject (via the purity oracle / pure-expr lowering) impure PROJ or guard; (4) accept any iterable source whose element type maps to an expressible Pant sort via `mapTsType` and whose binder is a simple identifier — refuse generic/non-expressible iterables and destructuring binders (e.g. Map entries). Pure and side-effect free; not yet called from extractReturnExpression. (The empty-array-accumulator tracking and return-is-acc gate live in Patch 3.)
- tools/ts2pant/tests/for-of-comprehension.test.mts (modify): Implement and unskip the recognizer unit test: assert it returns the correct {binder, src, proj, guards, accName} for in-scope shapes (given a candidate accNames set) and null for each out-of-scope shape.

## Gameplan Specification

```
module FOR_OF_COMPREHENSION.

// ts2pant lowers the pure imperative build-list shape
//   const acc = []; for (const x of xs) { [if (P)] acc.push(f(x)); } return acc;
// to a Pantagruel `each` comprehension `each x in xs | f(x)[, P]`, an
// exact order-preserving total encoding, and refuses all other for-of
// shapes cleanly.
Body.
Comprehension.
Expr.

// Recognized parts of a candidate body.
loop-src b: Body => Expr.          // for-of source (array-typed)
loop-proj b: Body => Expr.         // pushed projection
loop-guard b: Body => Expr.        // filter guard (or `true`)
returns-acc b: Body => Bool.               // terminal `return acc` over the empty-array const
single-push b: Body => Bool.               // loop body is one (optionally guarded) push
pure-proj b: Body => Bool.                 // proj + guard lower to pure L1 exprs
src-ok b: Body => Bool.                 // source maps to an expressible Pant sort, simple binder
in-scope b: Body => Bool.

// Lowering result.
lowered? b: Body => Bool.
comp b: Body => Comprehension.
each-src c: Comprehension => Expr.
each-proj c: Comprehension => Expr.
each-guard c: Comprehension => Expr.
---
// Recognition is conservative: in-scope iff every structural and purity
// conjunct holds.
all b: Body | in-scope b <-> (returns-acc b and single-push b and pure-proj b and src-ok b).

// A body is emitted as a comprehension equation exactly when in scope.
all b: Body | lowered? b <-> in-scope b.

// The emitted comprehension mirrors the recognized loop (soundness: the
// `each` ranges over the same source, projects the same value, filters by
// the same guard).
all b: Body | in-scope b -> (each-src (comp b) = loop-src b and each-proj (comp b) = loop-proj b and each-guard (comp b) = loop-guard b).

// Out-of-scope for-of bodies (scalar fold, Set.add, find/exists, nested,
// break, impure proj/guard) are refused, never mis-lowered.
all b: Body | (~ in-scope b) -> ~ lowered? b.
```

## Patch Specification

```
module FOR_OF_COMPREHENSION_PATCH_2.

// The recognizer classifies a body as in-scope iff it matches the
// build-list shape AND its projection/guard are pure.
Body.
Expr.

returns-acc b: Body => Bool.       // terminal `return acc` over the empty-array const
single-push b: Body => Bool.       // loop body is exactly one (optionally guarded) push to acc
pure-proj b: Body => Bool.         // projection and guard lower to pure L1 expressions
src-ok b: Body => Bool.         // for-of source maps to an expressible Pant sort, simple binder
in-scope b: Body => Bool.
---
// Recognition is conservative: every conjunct is necessary.
all b: Body | in-scope b <-> (returns-acc b and single-push b and pure-proj b and src-ok b).

// The recognizer is sound w.r.t. refusal: a body missing any conjunct is not in scope.
all b: Body | (~ pure-proj b) -> ~ in-scope b.
```


## Implementation Notes

- The recognizer API is `recognizeForOfPush(stmt, accNames, ctx)` rather than the prose shorthand `(..., checker)`. It needs the full `L1BuildContext` so source/projection/guard checks use the same `mapTsType`, `tryBuildL1PureSubExpression`, `paramNames`, strategy, and synth-cell policy as the surrounding pure-body pipeline.
- `RecognizedForOfPush` returns already-built L1 expressions for `src`, `proj`, and `guards`; Patch 3 should be able to wrap these directly in `ir1Each(result.binder, result.src, result.guards, result.proj)` after it verifies the accumulator declaration/return shape.
- The loop binder is normalized with `toPantTermName` and installed into a scoped `paramNames` map before lowering the projection/guard. This keeps projection references to the TS loop variable aligned with the eventual comprehension binder name.
- `src-ok` is intentionally stricter than a bare `mapTsType(...).ok`: the source sort must equal `[${binderSort}]`. This prevents generic fallbacks such as `Iterable<any>` from being treated as valid iterable sources just because `mapTsType` can produce a printable fallback sort. Arrays and Sets whose element sort maps cleanly are covered.
- The continue-filter spelling accepted here is specifically `if (!P) continue; acc.push(...)`. I avoided synthesizing a `!P` expression for the more general `if (P) continue; ...` case because synthetic TS nodes are not reliable inputs to the checker-backed purity/type gates.
- This patch does not extend `PreludeStmt`, does not call the recognizer from `extractReturnExpression`, and should not change translation output. The new export is only exercised by the direct unit test.

Spec/Evidence Mapping:
- `single-push`: `recognizeForOfPushBody`, `recognizePushStatement`, and `recognizeIfContinue` implement the accepted push/block/if/continue shapes and reject extra statements or other effects; covered by `tests/for-of-comprehension.test.mts`.
- `pure-proj`: `expressionHasSideEffects`, `isStaticallyBoolTyped`, and `tryBuildL1PureSubExpression` gate projection and guard lowering in `recognizeForOfPush`; covered by impure projection/guard rejection cases.
- `src-ok`: `forOfSourceIsExpressible` checks simple identifier binder plus exact list-sort source/binder compatibility through `mapTsType`; covered by array, Set, destructuring, and generic iterable cases.
- Verification run: `npx tsx --test --test-timeout=300000 tests/for-of-comprehension.test.mts`, `npx tsc --noEmit`, `npx biome check src`, and `npx biome check tests/for-of-comprehension.test.mts`.