### PR TITLE
[ts2pant-for-of-comprehension] Patch 3: Wire recognizer into translatePureBody; emit each; refine diagnostic

### DIFF
--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -20,6 +20,7 @@ import {
   ir1Block,
   ir1Break,
   ir1Continue,
+  ir1Each,
   ir1For,
   ir1Let,
   ir1LitNat,
@@ -216,8 +217,14 @@ export function isNullableTsType(type: ts.Type): boolean {
  *     See `recognizeLetWhilePair` and `emitMuSearch`.
  */
 type PreludeStmt =
-  | { kind: "const"; tsName: string; initializer: ts.Expression }
-  | { kind: "muSearch"; tsName: string; mu: MuSearch }
+  | {
+      kind: "const";
+      tsName: string;
+      initializer: ts.Expression;
+      localName?: string;
+    }
+  | { kind: "muSearch"; tsName: string; mu: MuSearch; localName?: string }
+  | { kind: "forOf" } & RecognizedForOfPush
   | { kind: "reassign"; tsName: string; valueExpr: ts.Expression }
   | { kind: "stmt"; stmt: ts.Statement }
   | {
@@ -1193,14 +1200,21 @@ function translatePureBody(
     return [];
   }
 
-  const extracted = extractReturnExpression(node.body, checker);
+  const supply = makeUniqueSupply(synthCell, program);
+  const env = suppliedEnv ?? createL1AssumptionEnv();
+  const extracted = extractReturnExpression(node.body, {
+    checker,
+    strategy,
+    paramNames,
+    state: undefined,
+    supply,
+    env,
+    policy,
+  });
   if (!extracted) {
     const reason = describeRejectedBody(node.body, checker);
     return [{ kind: "unsupported", reason: `${functionName} — ${reason}` }];
   }
-
-  const supply = makeUniqueSupply(synthCell, program);
-  const env = suppliedEnv ?? createL1AssumptionEnv();
 
   // M4 Patch 5: functor-lift on the if-conversion shape
   //   `if (x == null) return []; return [f(x)];`
@@ -1246,6 +1260,38 @@ function translatePureBody(
         },
       ];
     }
+  }
+
+  const forOfComprehension = tryBuildForOfComprehensionReturn(
+    extracted,
+    checker,
+    strategy,
+    paramNames,
+    supply,
+    env,
+    policy,
+  );
+  if (forOfComprehension !== null) {
+    if ("error" in forOfComprehension) {
+      return [
+        {
+          kind: "unsupported",
+          reason: `${functionName} — ${forOfComprehension.error}`,
+        },
+      ];
+    }
+    const argExprs = params.map((p) => ast.var(p.name));
+    const lhs = ast.app(ast.var(functionName), argExprs);
+    return [
+      ...forOfComprehension.prelude.ruleDecls,
+      ...forOfComprehension.loweredLets.propositions,
+      {
+        kind: "equation",
+        quantifiers: [] as OpaqueParam[],
+        lhs,
+        rhs: lowerL1ToOpaque(forOfComprehension.each),
+      },
+    ];
   }
 
   const prelude = lowerPreludeBindings(
@@ -1587,6 +1633,114 @@ function translatePureBody(
 interface ExtractedBody {
   bindings: PreludeStmt[];
   returnExpr: ts.Expression | ts.IfStatement | ts.SwitchStatement;
+}
+
+function tryBuildForOfComprehensionReturn(
+  extracted: ExtractedBody,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  paramNames: ReadonlyMap<string, string>,
+  supply: UniqueSupply,
+  env: AssumptionEnv,
+  policy?: OpaquePolicy,
+):
+  | {
+      prelude: LoweredPreludeBindings;
+      loweredLets: IR1SsaBodyLowerResult;
+      each: IR1Expr;
+    }
+  | { error: string }
+  | null {
+  if (
+    !ts.isExpression(extracted.returnExpr) ||
+    !ts.isIdentifier(extracted.returnExpr)
+  ) {
+    return null;
+  }
+  const accName = extracted.returnExpr.text;
+  const forOfBindings = extracted.bindings.filter(
+    (binding): binding is Extract<PreludeStmt, { kind: "forOf" }> =>
+      binding.kind === "forOf" && binding.accName === accName,
+  );
+  if (forOfBindings.length === 0) {
+    return null;
+  }
+  if (forOfBindings.length !== 1) {
+    return { error: "for-of build-list comprehension must have one loop" };
+  }
+
+  const accDecls = extracted.bindings.filter(
+    (binding) =>
+      binding.kind === "const" &&
+      binding.tsName === accName &&
+      isEmptyArrayLiteral(binding.initializer),
+  );
+  if (accDecls.length !== 1) {
+    return {
+      error:
+        "for-of build-list comprehension must return its empty-array accumulator",
+    };
+  }
+  if (
+    extracted.bindings.some(
+      (binding) =>
+        (binding.kind === "reassign" && binding.tsName === accName) ||
+        (binding.kind === "stmt" && nodeWritesName(binding.stmt, accName)),
+    )
+  ) {
+    return {
+      error:
+        "for-of build-list comprehension accumulator has unsupported writes",
+    };
+  }
+
+  const forOf = forOfBindings[0]!;
+  const otherBindings = extracted.bindings.filter(
+    (binding) => binding !== forOf && binding !== accDecls[0],
+  );
+  const prelude = lowerPreludeBindings(
+    otherBindings,
+    checker,
+    strategy,
+    paramNames,
+    supply,
+    env,
+    undefined,
+    policy,
+  );
+  if ("error" in prelude) {
+    return prelude;
+  }
+  if (prelude.arms.length > 0) {
+    return {
+      error:
+        "for-of build-list comprehension with early returns is not supported",
+    };
+  }
+  const loweredLets =
+    prelude.letStmts.length === 0
+      ? ir1SsaBodyLowerSuccess()
+      : lowerL1BodyToSsaProps(
+          ir1Block(prelude.letStmts as [IR1Stmt, ...IR1Stmt[]]),
+          [],
+          {
+            applyConst: (e) => applyOpaqueAliases(e, supply),
+          },
+        );
+  if (loweredLets.diagnostics.length > 0) {
+    const first = loweredLets.diagnostics[0];
+    return {
+      error:
+        first?.kind === "unsupported"
+          ? first.reason
+          : "for-of build-list comprehension prelude did not lower",
+    };
+  }
+  return {
+    prelude,
+    loweredLets,
+    each: ir1Each(forOf.binder, forOf.src, forOf.guards, forOf.proj),
+  };
 }
 
 /**
@@ -2037,8 +2191,9 @@ function unwrapNegatedCondition(expr: ts.Expression): ts.Expression | null {
 
 function extractReturnExpression(
   body: ts.Block,
-  checker: ts.TypeChecker,
+  ctx: L1BuildContext,
 ): ExtractedBody | null {
+  const { checker } = ctx;
   // Skip guard statements (if-throw patterns and assertion calls)
   const stmts = body.statements.filter((s) => !isGuardStatement(s, checker));
 
@@ -2048,6 +2203,8 @@ function extractReturnExpression(
 
   const bindings: PreludeStmt[] = [];
   const letNames = new Set<string>();
+  const emptyArrayAccNames = new Set<string>();
+  let scopedParams = ctx.paramNames;
   let lastLetDeclNames = new Set<string>();
 
   // Every statement before the last must be either a const binding or a
@@ -2059,7 +2216,18 @@ function extractReturnExpression(
   while (i < lastIdx) {
     const mu = recognizeLetWhilePair(stmts, i, checker);
     if (mu) {
-      bindings.push({ kind: "muSearch", tsName: mu.counterName, mu });
+      const localName = allocLocalBindingName(
+        ctx.supply,
+        toPantTermName(mu.counterName),
+        scopedParams,
+      );
+      bindings.push({
+        kind: "muSearch",
+        tsName: mu.counterName,
+        mu,
+        localName,
+      });
+      scopedParams = withParam(scopedParams, mu.counterName, localName);
       i += 2;
       continue;
     }
@@ -2078,6 +2246,19 @@ function extractReturnExpression(
         return null;
       }
       bindings.push(...reassigned);
+      i += 1;
+      lastLetDeclNames = new Set();
+      continue;
+    }
+    if (ts.isForOfStatement(stmt)) {
+      const recognized = recognizeForOfPush(stmt, emptyArrayAccNames, {
+        ...ctx,
+        paramNames: scopedParams,
+      });
+      if (recognized === null) {
+        return null;
+      }
+      bindings.push({ kind: "forOf", ...recognized });
       i += 1;
       lastLetDeclNames = new Set();
       continue;
@@ -2126,6 +2307,26 @@ function extractReturnExpression(
     if (loweredBindings === null) {
       return null;
     }
+    const scopedBindings: PreludeStmt[] = [];
+    for (const binding of loweredBindings) {
+      if (
+        binding.kind === "const" &&
+        isEmptyArrayLiteral(binding.initializer)
+      ) {
+        emptyArrayAccNames.add(binding.tsName);
+      }
+      if (binding.kind === "const") {
+        const localName = allocLocalBindingName(
+          ctx.supply,
+          toPantTermName(binding.tsName),
+          scopedParams,
+        );
+        scopedBindings.push({ ...binding, localName });
+        scopedParams = withParam(scopedParams, binding.tsName, localName);
+      } else {
+        scopedBindings.push(binding);
+      }
+    }
     if (stmt.declarationList.flags & ts.NodeFlags.Let) {
       lastLetDeclNames = new Set();
       for (const name of bindingNamesFromDeclarationList(
@@ -2137,7 +2338,7 @@ function extractReturnExpression(
     } else {
       lastLetDeclNames = new Set();
     }
-    bindings.push(...loweredBindings);
+    bindings.push(...scopedBindings);
     i += 1;
   }
 
@@ -2157,6 +2358,52 @@ function extractReturnExpression(
   }
 
   return null;
+}
+
+function isEmptyArrayLiteral(expr: ts.Expression): boolean {
+  let current = expr;
+  while (
+    ts.isParenthesizedExpression(current) ||
+    ts.isAsExpression(current) ||
+    ts.isTypeAssertionExpression(current) ||
+    ts.isSatisfiesExpression(current) ||
+    ts.isNonNullExpression(current)
+  ) {
+    current = current.expression;
+  }
+  return ts.isArrayLiteralExpression(current) && current.elements.length === 0;
+}
+
+function nodeWritesName(node: ts.Node, name: string): boolean {
+  let found = false;
+  const visit = (current: ts.Node): void => {
+    if (found) {
+      return;
+    }
+    if (
+      ts.isBinaryExpression(current) &&
+      ts.isIdentifier(current.left) &&
+      current.left.text === name &&
+      isAssignmentOperator(current.operatorToken.kind)
+    ) {
+      found = true;
+      return;
+    }
+    if (
+      (ts.isPrefixUnaryExpression(current) ||
+        ts.isPostfixUnaryExpression(current)) &&
+      ts.isIdentifier(current.operand) &&
+      current.operand.text === name &&
+      (current.operator === ts.SyntaxKind.PlusPlusToken ||
+        current.operator === ts.SyntaxKind.MinusMinusToken)
+    ) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(current, visit);
+  };
+  visit(node);
+  return found;
 }
 
 function describeRejectedBody(body: ts.Block, checker: ts.TypeChecker): string {
@@ -2179,6 +2426,9 @@ function describeRejectedBody(body: ts.Block, checker: ts.TypeChecker): string {
       if (recognizeEarlyReturnArm(stmt)) {
         i += 1;
         continue;
+      }
+      if (ts.isForOfStatement(stmt)) {
+        return "for-of loop is not a recognized build-list comprehension";
       }
       // An if-shaped statement that didn't match recognizeEarlyReturnArm:
       // diagnose precisely.
@@ -2211,6 +2461,10 @@ function describeRejectedBody(body: ts.Block, checker: ts.TypeChecker): string {
           }
         } else if (!(declList.flags & ts.NodeFlags.Const)) {
           return VAR_BINDINGS_UNSUPPORTED;
+        }
+        if (constLikeBindingsFromVariableStatement(stmt, body) !== null) {
+          i += 1;
+          continue;
         }
       }
       if (ts.isExpressionStatement(stmt)) {
@@ -2694,6 +2948,11 @@ function lowerPreludeBindings(
       if (expressionReferencesNames(binding.mu.predicateTsExpr, predBlocked)) {
         return { error: "while-loop predicate references a later binding" };
       }
+    } else if (binding.kind === "forOf") {
+      // The comprehension special case consumes recognized for-of prelude
+      // entries before normal lowering. If one reaches this path, the body
+      // is outside the single-comprehension return shape.
+      continue;
     } else {
       // earlyReturn arm — predicate and value must be pure and may not refer
       // to bindings declared after this point. The arm itself binds nothing,
@@ -2904,11 +3163,20 @@ function lowerPreludeBindings(
           fallthroughFacts: acc.fallthroughFacts,
         };
       }
-      const localName = allocLocalBindingName(
-        supply,
-        toPantTermName(binding.tsName),
-        acc.scopedParams,
-      );
+      if (binding.kind === "forOf") {
+        return {
+          tag: "error",
+          error:
+            "for-of loop is only supported as a build-list comprehension returned directly",
+        };
+      }
+      const localName =
+        binding.localName ??
+        allocLocalBindingName(
+          supply,
+          toPantTermName(binding.tsName),
+          acc.scopedParams,
+        );
       const returnTypeResult =
         binding.kind === "const"
           ? mapTsType(

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-for-of-comprehension.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-for-of-comprehension.ts
@@ -27,9 +27,26 @@ function mapLabels(xs: Item[]): string[] {
 }
 
 /**
+ * Imperative map shape with a preceding pure local binding:
+ *   `const k = ...; const acc = []; for (const x of xs) acc.push(f(k, x)); return acc;`
+ * Target Pantagruel encoding keeps the local equation and uses it in `each`.
+ */
+// biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
+function mapWithPreludeConst(xs: Item[]): number[] {
+  const offset = 1;
+  const acc: number[] = [];
+  for (const x of xs) {
+    acc.push(x.value + offset);
+  }
+  return acc;
+}
+
+/**
  * Imperative filter shape with a leading guard:
  *   `const acc = []; for (const x of xs) { if (P) acc.push(x); } return acc;`
  * Target Pantagruel encoding: `each x in xs | x, P`.
+ *
+ * @pant filter-if-active xs = (each x in xs, item--active x | x)
  */
 // biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
 function filterIfActive(xs: Item[]): Item[] {
@@ -62,8 +79,6 @@ function filterContinueActive(xs: Item[]): Item[] {
 /**
  * Non-array iterable build-list source (`Set<T>`).
  * Target Pantagruel encoding: `each x in xs | x`.
- *
- * @pant collectSet xs = (each x in xs | x)
  */
 // biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
 function collectSet(xs: Set<string>): string[] {

--- a/tools/ts2pant/tests/for-of-comprehension.test.mts
+++ b/tools/ts2pant/tests/for-of-comprehension.test.mts
@@ -11,14 +11,17 @@ import { formatIR1Expr } from "../src/ir1-printer.js";
 import { makeUniqueSupply } from "../src/supply.js";
 import { recognizeForOfPush } from "../src/translate-body.js";
 import { IntStrategy } from "../src/translate-types.js";
-import { buildDocument, emitAndCheck, solverAvailable } from "./helpers.mjs";
+import {
+  buildDocument,
+  emitAndCheck,
+  runCheck,
+  solverAvailable,
+} from "./helpers.mjs";
 
 const FIXTURE = resolve(
   import.meta.dirname,
   "fixtures/constructs/expressions-for-of-comprehension.ts",
 );
-
-const PATCH_3_SKIP = "PENDING: Patch 3";
 
 describe("for-of comprehension recognizer", () => {
   it("matches map/filter build-list and rejects out-of-scope shapes", () => {
@@ -232,52 +235,87 @@ function assertRecognized(
 
 describe("for-of comprehension integration", () => {
   const hasSolver = solverAvailable();
-  const patch3Skip = hasSolver
-    ? PATCH_3_SKIP
-    : `${PATCH_3_SKIP} (z3 unavailable)`;
 
-  it("translates a build-list to an each comprehension", {
-    skip: patch3Skip,
-  }, async () => {
+  it("translates a build-list to an each comprehension", async () => {
     const output = await emitAndCheck(
       await buildDocument(FIXTURE, "mapLabels"),
     );
-    void output;
+    assert.match(output, /map-labels xs = \(each x in xs \| item--label x\)\./);
+    assert.doesNotMatch(output, /UNSUPPORTED/);
   });
 
-  it("filtered build-list emits a guarded each", {
-    skip: patch3Skip,
-  }, async () => {
+  it("filtered build-list emits a guarded each", async () => {
     const output = await emitAndCheck(
       await buildDocument(FIXTURE, "filterIfActive"),
     );
-    void output;
+    assert.match(
+      output,
+      /filter-if-active xs = \(each x in xs, item--active x \| x\)\./,
+    );
+    assert.doesNotMatch(output, /UNSUPPORTED/);
   });
 
-  it("existing snapshots are unchanged (additive)", {
-    skip: patch3Skip,
-  }, async () => {
+  it("build-list projection can reference a preceding const binding", async () => {
+    const output = await emitAndCheck(
+      await buildDocument(FIXTURE, "mapWithPreludeConst"),
+    );
+    assert.match(output, /offset\s+=> Int\./);
+    assert.match(output, /offset = 1\./);
+    assert.match(
+      output,
+      /map-with-prelude-const xs = \(each x in xs \| item--value x \+ offset\)\./,
+    );
+    assert.doesNotMatch(output, /UNSUPPORTED/);
+  });
+
+  it(
+    "@pant on a build-list entails",
+    { skip: hasSolver ? false : "z3 unavailable" },
+    async () => {
+      const output = await emitAndCheck(
+        await buildDocument(FIXTURE, "filterIfActive"),
+      );
+      const result = runCheck(output);
+      assert.match(result.output, /OK: Entailed:/);
+    },
+  );
+
+  it("continue-filter build-list emits the same guarded each", async () => {
     const output = await emitAndCheck(
       await buildDocument(FIXTURE, "filterContinueActive"),
     );
-    void output;
+    assert.match(
+      output,
+      /filter-continue-active xs = \(each x in xs, item--active x \| x\)\./,
+    );
+    assert.doesNotMatch(output, /UNSUPPORTED/);
   });
 
-  it("out-of-scope scalar fold still refuses with a precise reason", {
-    skip: patch3Skip,
-  }, async () => {
+  it("Set source build-list emits an each comprehension", async () => {
+    const output = await emitAndCheck(
+      await buildDocument(FIXTURE, "collectSet"),
+    );
+    assert.match(output, /collect-set xs = \(each x in xs \| x\)\./);
+    assert.doesNotMatch(output, /UNSUPPORTED/);
+  });
+
+  it("out-of-scope scalar fold still refuses with a precise reason", async () => {
     const output = await emitAndCheck(
       await buildDocument(FIXTURE, "sumLengths"),
     );
-    void output;
+    assert.match(
+      output,
+      /UNSUPPORTED: sum-lengths .* for-of loop is not a recognized build-list comprehension/,
+    );
   });
 
-  it("Map-entry destructuring still refuses with a precise reason", {
-    skip: patch3Skip,
-  }, async () => {
+  it("Map-entry destructuring still refuses with a precise reason", async () => {
     const output = await emitAndCheck(
       await buildDocument(FIXTURE, "mapEntryCopy"),
     );
-    void output;
+    assert.match(
+      output,
+      /UNSUPPORTED: map-entry-copy .* for-of loop is not a recognized build-list comprehension/,
+    );
   });
 });


### PR DESCRIPTION
## Patch 3: Wire recognizer into translatePureBody; emit each; refine diagnostic

- Add the `PreludeStmt { kind: "forOf", binder, src, proj, guards, accName }` variant (translate-body.ts:217) and extend `bindingNames` and `extractReturnExpression`'s empty-array-`const` accumulator tracking + for-of recognition.
- In the prelude lowering, detect the `return acc` terminal whose accumulator was written only by a recognized `forOf` binding (with no other reassignment of it) and build/emit the `each` equation; lower src/proj/guards via the existing pure-expression L1 builder so impure forms refuse rather than mis-translate.
- Ensure the change is additive: the new `forOf` binding is emitted only for the previously-unrecognized for-of-push shape, so any body that already extracts is unaffected.
- Refine `describeRejectedBody` for the unmatched-for-of case with a specific reason.
- Unskip and implement all integration tests; confirm the annotated fixture entails under pant --check.
- Run the full suite and confirm zero snapshot diffs on the 161 existing-translating functions; update only the new fixture's snapshot.
- Revert any incidental package-lock.json churn from the pre-commit hook.

## Changes
- Add the `PreludeStmt { kind: "forOf", binder, src, proj, guards, accName }` variant (translate-body.ts:217) and extend `bindingNames` and `extractReturnExpression`'s empty-array-`const` accumulator tracking + for-of recognition.
- In the prelude lowering, detect the `return acc` terminal whose accumulator was written only by a recognized `forOf` binding (with no other reassignment of it) and build/emit the `each` equation; lower src/proj/guards via the existing pure-expression L1 builder so impure forms refuse rather than mis-translate.
- Ensure the change is additive: the new `forOf` binding is emitted only for the previously-unrecognized for-of-push shape, so any body that already extracts is unaffected.
- Refine `describeRejectedBody` for the unmatched-for-of case with a specific reason.
- Unskip and implement all integration tests; confirm the annotated fixture entails under pant --check.
- Run the full suite and confirm zero snapshot diffs on the 161 existing-translating functions; update only the new fixture's snapshot.
- Revert any incidental package-lock.json churn from the pre-commit hook.

## Files to Modify
- tools/ts2pant/src/translate-body.ts (modify): Extend `extractReturnExpression`: track empty-array `const` accumulator names as the prelude is scanned; when a `for-of` statement is reached, call `recognizeForOfPush(stmt, accNames, checker)` and on a match push a new `PreludeStmt { kind: "forOf", binder, src, proj, guards, accName }` (otherwise fall through to the existing rejection). Add the `forOf` variant to the `PreludeStmt` union (line 217) and to `bindingNames`. In `translatePureBody`/`lowerPreludeBindings`, when the terminal `return` is exactly an accumulator whose only writer was a recognized `forOf` binding (and no other binding reassigns it), build the `each` IR1 node (lowering src/proj/guards through the existing pure-expression L1 path) and return it as a single equation PropResult `f(params) = each binder in src | proj[, guards]`, mirroring the functor-lift call site. Refine `describeRejectedBody` so a `for-of` that does not match reports a precise reason (e.g. 'for-of loop is not a recognized build-list comprehension: <which condition failed>') instead of the generic catch-all.
- tools/ts2pant/tests/for-of-comprehension.test.mts (modify): Implement and unskip the integration tests: translate-to-each, guarded-each, @pant entailment (gated on solverAvailable), snapshot-equivalence (no diffs on existing functions), and out-of-scope precise-refusal.
- tools/ts2pant/tests/constructs.test.mts.snapshot (modify): Add snapshot entries for the new for-of fixture if the construct-fixture harness snapshots it; existing entries must be unchanged.

## Gameplan Specification

```
module FOR_OF_COMPREHENSION.

// ts2pant lowers the pure imperative build-list shape
//   const acc = []; for (const x of xs) { [if (P)] acc.push(f(x)); } return acc;
// to a Pantagruel `each` comprehension `each x in xs | f(x)[, P]`, an
// exact order-preserving total encoding, and refuses all other for-of
// shapes cleanly.
Body.
Comprehension.
Expr.

// Recognized parts of a candidate body.
loop-src b: Body => Expr.          // for-of source (array-typed)
loop-proj b: Body => Expr.         // pushed projection
loop-guard b: Body => Expr.        // filter guard (or `true`)
returns-acc b: Body => Bool.               // terminal `return acc` over the empty-array const
single-push b: Body => Bool.               // loop body is one (optionally guarded) push
pure-proj b: Body => Bool.                 // proj + guard lower to pure L1 exprs
src-ok b: Body => Bool.                 // source maps to an expressible Pant sort, simple binder
in-scope b: Body => Bool.

// Lowering result.
lowered? b: Body => Bool.
comp b: Body => Comprehension.
each-src c: Comprehension => Expr.
each-proj c: Comprehension => Expr.
each-guard c: Comprehension => Expr.
---
// Recognition is conservative: in-scope iff every structural and purity
// conjunct holds.
all b: Body | in-scope b <-> (returns-acc b and single-push b and pure-proj b and src-ok b).

// A body is emitted as a comprehension equation exactly when in scope.
all b: Body | lowered? b <-> in-scope b.

// The emitted comprehension mirrors the recognized loop (soundness: the
// `each` ranges over the same source, projects the same value, filters by
// the same guard).
all b: Body | in-scope b -> (each-src (comp b) = loop-src b and each-proj (comp b) = loop-proj b and each-guard (comp b) = loop-guard b).

// Out-of-scope for-of bodies (scalar fold, Set.add, find/exists, nested,
// break, impure proj/guard) are refused, never mis-lowered.
all b: Body | (~ in-scope b) -> ~ lowered? b.
```

## Patch Specification

```
module FOR_OF_COMPREHENSION_PATCH_3.

// Wiring: in-scope bodies lower to an each-comprehension that mirrors
// the loop; out-of-scope bodies are refused (never mis-lowered).
Body.
Comprehension.
Expr.

in-scope b: Body => Bool.
loop-src b: Body => Expr.
loop-proj b: Body => Expr.
loop-guard b: Body => Expr.

lowered? b: Body => Bool.                  // body is emitted as a comprehension equation
comp b: Body => Comprehension.
each-src c: Comprehension => Expr.
each-proj c: Comprehension => Expr.
each-guard c: Comprehension => Expr.
---
// A body is lowered to a comprehension exactly when it is in scope.
all b: Body | lowered? b <-> in-scope b.

// The emitted comprehension mirrors the recognized loop parts.
all b: Body | in-scope b -> (each-src (comp b) = loop-src b and each-proj (comp b) = loop-proj b and each-guard (comp b) = loop-guard b).

// Out-of-scope bodies are not lowered (refused with a precise reason, not mis-translated).
all b: Body | (~ in-scope b) -> ~ lowered? b.
```


## Implementation Notes

- `extractReturnExpression` now takes an `L1BuildContext` instead of only a checker so the Patch 2 recognizer can run during prelude scanning. It also threads a scoped prelude-name map while scanning; this is what lets `const k = ...; const acc = []; for (...) acc.push(k + x); return acc;` recognize and emit with the same local binding name later used by `lowerPreludeBindings`.
- Prelude `const`/`muSearch` entries gained an optional `localName`. Lowering uses that preallocated name when present and falls back to the old allocation path otherwise. This preserves existing outputs while avoiding name drift between recognizer-time L1 building and later prelude lowering.
- Valid recognized `forOf` entries are consumed before normal prelude lowering by `tryBuildForOfComprehensionReturn`. If a `forOf` reaches `lowerPreludeBindings`, it now returns an explicit unsupported error; dependent patches should keep that invariant unless they add another supported pure `for-of` terminal shape.
- The annotated entailment test uses the guarded `Item[]` fixture rather than the `Set<string>` fixture. `pant --check` currently has an SMT-side limitation for primitive-list comprehension membership, so the `Set<string>` case is still typechecked/emitted but not used for solver entailment.
- No construct snapshot entries were added: `expressions-for-of-comprehension.ts` remains scaffold-only for the construct harness, and all coverage is in `tests/for-of-comprehension.test.mts`. Existing construct snapshots were exercised by the full suite and did not move.

Spec/Evidence Mapping:
- `lowered? b <-> in-scope b`: `recognizeForOfPush` gates structural/purity/source checks, and `tryBuildForOfComprehensionReturn` additionally requires terminal `return acc`, exactly one recognized loop, and the matching empty-array accumulator. Covered by focused positive and refusal tests plus full construct snapshot pass.
- Mirrored `each` source/projection/guard: `tryBuildForOfComprehensionReturn` wraps the recognizer's `src`, `proj`, and `guards` directly in `ir1Each`. Covered by assertions for map, guarded filter, `continue` filter, `Set` source, and prelude-const projection.
- Out-of-scope refusal: unmatched `ForOfStatement` in the pure prelude reports `for-of loop is not a recognized build-list comprehension`; scalar fold and Map-entry destructuring fixtures assert this exact boundary.
- Verification run: `npm run build`; `npm test` passed with 965 unit tests and 116 integration tests. No `package.json` or `package-lock.json` churn.