### PR TITLE
[ts2pant-foreign-accessor-body-lowering] Patch 1: Pending tests for foreign accessor body lowering

### DIFF
--- a/tools/ts2pant/tests/constructs.test.mts
+++ b/tools/ts2pant/tests/constructs.test.mts
@@ -10,7 +10,10 @@ import { createSourceFile } from "../src/extract.js";
 import { buildDocumentFromSourceFile, emitAndCheck } from "./helpers.mjs";
 
 const CONSTRUCTS_DIR = resolve(import.meta.dirname, "fixtures/constructs");
-const SCAFFOLD_ONLY_FIXTURES = new Set(["expressions-for-of-comprehension.ts"]);
+const SCAFFOLD_ONLY_FIXTURES = new Set([
+  "expressions-for-of-comprehension.ts",
+  "foreign-accessor-dependency.ts",
+]);
 
 import { KNOWN_TYPECHECK_FAILURES } from "./known-typecheck-failures.mjs";
 

--- a/tools/ts2pant/tests/fixtures/constructs/foreign-accessor-dependency.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/foreign-accessor-dependency.ts
@@ -1,0 +1,14 @@
+import {
+  isReady,
+  type ForeignDependencyContainer,
+} from "../foreign-dependency/index.js";
+
+export function foreignLabels(c: ForeignDependencyContainer): string[] {
+  const labels: string[] = [];
+  for (const item of c.items) {
+    if (isReady(item)) {
+      labels.push(item.label);
+    }
+  }
+  return labels;
+}

--- a/tools/ts2pant/tests/fixtures/foreign-dependency/index.d.ts
+++ b/tools/ts2pant/tests/fixtures/foreign-dependency/index.d.ts
@@ -1,0 +1,10 @@
+export interface ForeignDependencyContainer {
+  readonly items: readonly ForeignDependencyItem[];
+}
+
+export interface ForeignDependencyItem {
+  readonly label: string;
+  readonly ready: boolean;
+}
+
+export declare function isReady(item: ForeignDependencyItem): boolean;

--- a/tools/ts2pant/tests/fixtures/foreign-dependency/package.json
+++ b/tools/ts2pant/tests/fixtures/foreign-dependency/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "foreign-dependency",
+  "version": "0.0.0",
+  "type": "module",
+  "exports": {
+    ".": "./index.d.ts"
+  }
+}

--- a/tools/ts2pant/tests/integration/dogfood.test.mts
+++ b/tools/ts2pant/tests/integration/dogfood.test.mts
@@ -60,6 +60,79 @@ describe("dogfood: foreign dependency type surfaces", () => {
       /binding-names-from-declaration-list decl-list: ForeignVariableDeclarationList => \[String\]\./u,
     );
   });
+
+  it.skip("Patch 4: bindingNamesFromDeclarationList translates body with foreign accessors", async () => {
+    const doc = await buildDocumentFromPath(
+      resolve(SRC, "translate-body.ts"),
+      "bindingNamesFromDeclarationList",
+    );
+    const output = await emitAndCheck(doc);
+
+    assertPantTypeChecks(output, PANT_TIMEOUT_MS);
+    assert.match(
+      output,
+      /^declarations dl: ForeignVariableDeclarationList => \[ForeignVariableDeclaration\]\.$/mu,
+    );
+    assert.match(
+      output,
+      /^name d: ForeignVariableDeclaration => ForeignIdentifier\.$/mu,
+    );
+    assert.match(
+      output,
+      /^identifier-text i: ForeignIdentifier => String\.$/mu,
+    );
+    assert.match(
+      output,
+      /binding-names-from-declaration-list dl = \(each d in declarations dl, is-identifier \(name d\) \| identifier-text \(name d\)\)\./u,
+    );
+  });
+});
+
+describe("foreign dependency fixture", () => {
+  it.skip("Patch 4: non-typescript imported dependency property reads lower through foreign accessors", async () => {
+    const doc = await buildDocumentFromPath(
+      resolve(FIXTURES, "foreign-accessor-dependency.ts"),
+      "foreignLabels",
+    );
+    const output = await emitAndCheck(doc);
+
+    assertPantTypeChecks(output, PANT_TIMEOUT_MS);
+    assert.match(output, /^ForeignDependencyContainer\.$/mu);
+    assert.match(output, /^ForeignDependencyItem\.$/mu);
+    assert.match(
+      output,
+      /^items c: ForeignDependencyContainer => \[ForeignDependencyItem\]\.$/mu,
+    );
+    assert.match(
+      output,
+      /^item-label i: ForeignDependencyItem => String\.$/mu,
+    );
+    assert.match(
+      output,
+      /^item-ready i: ForeignDependencyItem => Bool\.$/mu,
+    );
+    assert.match(
+      output,
+      /foreign-labels c = \(each i in items c, item-ready i \| item-label i\)\./u,
+    );
+  });
+});
+
+describe("dogfood @pant annotations entail", () => {
+  it.skip("Patch 4: bindingNamesFromDeclarationList annotation is entailed", async () => {
+    const doc = await buildDocumentFromPath(
+      resolve(SRC, "translate-body.ts"),
+      "bindingNamesFromDeclarationList",
+    );
+    const output = await emitAndCheck(doc);
+
+    assert.match(
+      output,
+      /@pant all dl: ForeignVariableDeclarationList \| binding-names-from-declaration-list dl = \(each d in declarations dl, is-identifier \(name d\) \| identifier-text \(name d\)\)\./u,
+    );
+    const check = runCheck(output, { timeoutMs: PANT_TIMEOUT_MS });
+    assert.equal(check.status, 0);
+  });
 });
 
 describe("dogfood: src/translate-types.ts", () => {

--- a/tools/ts2pant/tests/ir1-build-property.test.mts
+++ b/tools/ts2pant/tests/ir1-build-property.test.mts
@@ -440,4 +440,37 @@ describe("ir1-build-property", () => {
     );
     assert.equal(templateOpaque, dottedOpaque);
   });
+
+  it.skip("Patch 3: foreign receiver property access lowers to synthesized accessor", () => {
+    // Intended Patch 3 shape for a foreign declaration-file receiver:
+    // `c.items` lowers to `items c`, registers
+    // `items c: ForeignDependencyContainer => [ForeignDependencyItem].`,
+    // and nested `item.label` lowers through `item-label item`.
+    const output = [
+      "items c: ForeignDependencyContainer => [ForeignDependencyItem].",
+      "item-label i: ForeignDependencyItem => String.",
+      "foreign-labels c = (each i in items c, item-ready i | item-label i).",
+    ].join("\n");
+
+    assert.match(
+      output,
+      /^items c: ForeignDependencyContainer => \[ForeignDependencyItem\]\.$/mu,
+    );
+    assert.match(
+      output,
+      /^item-label i: ForeignDependencyItem => String\.$/mu,
+    );
+    assert.match(output, /each i in items c, item-ready i \| item-label i/u);
+  });
+
+  it.skip("Patch 3: unsupported foreign property type refuses without dangling rules", () => {
+    // Intended Patch 3 fallback: if the checker cannot map the property type
+    // to a Pant sort or another foreign domain, member lowering returns
+    // unsupported and does not register a partial accessor declaration.
+    const output =
+      "> UNSUPPORTED: foreign property 'metadata' has unsupported type";
+
+    assert.match(output, /^> UNSUPPORTED: foreign property 'metadata'/mu);
+    assert.doesNotMatch(output, /^metadata .* =>/mu);
+  });
 });

--- a/tools/ts2pant/tests/translate-types.test.mts
+++ b/tools/ts2pant/tests/translate-types.test.mts
@@ -857,6 +857,36 @@ describe("mapTsType", () => {
     assert.deepEqual(emitSynthDeclsOnly(cell), []);
   });
 
+  it.skip("Patch 2: foreign accessors register stable typed accessor declarations", () => {
+    // Intended Patch 2 shape: registering the same shallow accessor twice is
+    // idempotent, keyed by (foreign owner domain, property name, mapped return
+    // sort), and emits only EUF-style rule declarations.
+    const output = [
+      "ForeignDependencyContainer.",
+      "ForeignDependencyItem.",
+      "items c: ForeignDependencyContainer => [ForeignDependencyItem].",
+      "item-label i: ForeignDependencyItem => String.",
+      "item-ready i: ForeignDependencyItem => Bool.",
+    ].join("\n");
+
+    assert.match(
+      output,
+      /^items c: ForeignDependencyContainer => \[ForeignDependencyItem\]\.$/mu,
+    );
+    assert.match(
+      output,
+      /^item-label i: ForeignDependencyItem => String\.$/mu,
+    );
+    assert.match(
+      output,
+      /^item-ready i: ForeignDependencyItem => Bool\.$/mu,
+    );
+    assert.equal(
+      output.match(/^items c: ForeignDependencyContainer/mgu)?.length,
+      1,
+    );
+  });
+
   it("top-level undefined falls through to checker.typeToString", () => {
     // Lone null/undefined/void has no Pantagruel encoding. mapTsType no
     // longer returns an internal sentinel; it falls through to


### PR DESCRIPTION
## Patch 1: Pending tests for foreign accessor body lowering

- Introduce pending/skipped tests only; do not change production behavior.
- Name each pending test with the patch that will implement it.
- Assert intended emitted shapes in comments or skipped bodies for both the generic dependency fixture and the dogfood target: generic foreign accessors, `variable-declaration-list--declarations`, `variable-declaration--name`, `identifier--text`, and guarded `each` output.
- Keep the existing skeleton-only foreign dependency type test in place.

## Changes
- Introduce pending/skipped tests only; do not change production behavior.
- Name each pending test with the patch that will implement it.
- Assert intended emitted shapes in comments or skipped bodies for both the generic dependency fixture and the dogfood target: generic foreign accessors, `variable-declaration-list--declarations`, `variable-declaration--name`, `identifier--text`, and guarded `each` output.
- Keep the existing skeleton-only foreign dependency type test in place.

## Files to Modify
- tools/ts2pant/tests/fixtures/foreign-dependency (create): Add a test-local synthetic dependency declaration surface (or equivalent fixture arrangement) with non-`typescript` foreign types and predicate functions used by the new tests.
- tools/ts2pant/tests/fixtures/constructs/foreign-accessor-dependency.ts (create): Add a TypeScript fixture that imports the synthetic dependency types/functions and exercises shallow property reads plus a dependency predicate guard.
- tools/ts2pant/tests/translate-types.test.mts (modify): Add skipped tests for foreign accessor registration/idempotency and emitted declaration shape.
- tools/ts2pant/tests/ir1-build-property.test.mts (modify): Add skipped tests for foreign receiver property access lowering and unsupported fallback.
- tools/ts2pant/tests/integration/dogfood.test.mts (modify): Add skipped dogfood tests that expect `bindingNamesFromDeclarationList` to translate with a body and carry an entailed annotation once later patches land.

## Gameplan Specification

```
module TS2PANT_FOREIGN_ACCESSOR_BODY_LOWERING.

ForeignAccessor.
ForeignDependencyContainer.
ForeignDependencyItem.
ForeignVariableDeclarationList.
ForeignVariableDeclaration.
ForeignIdentifier.

accessor-emitted a: ForeignAccessor => Bool.
items c: ForeignDependencyContainer => [ForeignDependencyItem].
item-label i: ForeignDependencyItem => String.
item-ready i: ForeignDependencyItem => Bool.
foreign-labels c: ForeignDependencyContainer => [String].
declarations dl: ForeignVariableDeclarationList => [ForeignVariableDeclaration].
name d: ForeignVariableDeclaration => ForeignIdentifier.
identifier-text i: ForeignIdentifier => String.
is-identifier i: ForeignIdentifier => Bool.
binding-names-from-declaration-list dl: ForeignVariableDeclarationList => [String].
---
all a: ForeignAccessor | accessor-emitted a.
all c: ForeignDependencyContainer | foreign-labels c = (each i in items c, item-ready i | item-label i).
all dl: ForeignVariableDeclarationList | binding-names-from-declaration-list dl = (each d in declarations dl, is-identifier (name d) | identifier-text (name d)).
```

## Patch Specification

```
module TS2PANT_FOREIGN_ACCESSOR_BODY_LOWERING_PATCH_1.

TestStub.
introduced s: TestStub => Bool.
---
all s: TestStub | introduced s.
```


## Implementation Notes

- The new generic dependency fixture is intentionally scaffold-only in `constructs.test.mts`; otherwise the automatic construct snapshot discovery would make this Patch 1 fixture an active failing translation test before the lowering patches exist.
- The synthetic dependency lives as a declaration-only package shape under `tests/fixtures/foreign-dependency`, and the construct fixture imports `../foreign-dependency/index.js` so NodeNext-style resolution can pair the `.js` specifier with `index.d.ts` later.
- Skipped assertions use future emitted Pant text directly rather than importing future APIs. This keeps the patch behavior-free while still pinning expected rule names, idempotency, unsupported fallback, and guarded `each` shapes for dependent patches.
- Minor naming note for dependent patches: the PR body mentions `variable-declaration-list--declarations`, but the pending dogfood assertions follow the final spec names: `declarations`, `name`, `identifier-text`, and `is-identifier`.

Spec/Evidence Mapping:
- `TestStub introduced`: satisfied by adding skipped test stubs only, with no production code changes.
- Generic dependency acceptance: `foreign-accessor-dependency.ts` plus skipped `foreign dependency fixture` integration case documents `items`, `item-label`, `item-ready`, and `foreign-labels` comprehension shape.
- Dogfood acceptance: skipped dogfood cases document `bindingNamesFromDeclarationList` body emission and annotation entailment expectations.
- Verification run: `just ts2pant-test-unit-rest`, `just ts2pant-test-unit-constructs`, `just ts2pant-test-integration`, and `git diff --check` all passed before commit.