### PR TITLE
[ts2pant-foreign-accessor-body-lowering] Patch 3: Lower member access through foreign accessors

### DIFF
--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -119,15 +119,18 @@ import {
 } from "./translate-body.js";
 import {
   cellRegisterMap,
+  cellRegisterForeignAccessor,
   cellRegisterName,
   cellRegisterSynthesizedValue,
   type DiscriminantLiteral,
   detectDiscriminatedUnion,
   fieldRuleName,
+  foreignDomainForType,
   isMapType,
   isSetType,
   lookupMapKV,
   mapTsType,
+  resolveFieldOwner,
   type NumericStrategy,
   toPantTermName,
   UNSUPPORTED_NON_DISCRIMINATED_UNION_FIELD_ACCESS_REASON,
@@ -1790,7 +1793,7 @@ export function buildL1MemberAccess(
     fieldName,
     ctx,
   );
-  const qualifiedStrict = qualifyFieldAccess(
+  const owner = resolveFieldOwner(
     receiverType,
     fieldName,
     ctx.checker,
@@ -1798,21 +1801,35 @@ export function buildL1MemberAccess(
     ctx.supply.synthCell,
   );
   let qualified: string;
-  if (qualifiedStrict !== null) {
-    qualified = qualifiedStrict;
-  } else if (ambiguousMode === "bare-kebab") {
+  if (owner.kind === "resolved") {
+    qualified = fieldRuleName(owner.owner, fieldName);
+  } else if (owner.kind === "ambiguous" && ambiguousMode === "bare-kebab") {
     // Signature-side best-effort: ambiguous union/intersection
     // owners fall back to the bare kebab'd field name so optional
     // analyses (guard extraction, call-following) can continue past
     // an inherently-ambiguous accessor instead of bailing the whole
     // analysis on a single ambiguous read.
     qualified = toPantTermName(fieldName);
-  } else {
+  } else if (owner.kind === "ambiguous") {
     return {
       unsupported:
         `property access .${fieldName}: ` +
         UNSUPPORTED_NON_DISCRIMINATED_UNION_FIELD_ACCESS_REASON,
     };
+  } else {
+    const foreignAccessor = tryRegisterForeignAccessorForMember(
+      stripped,
+      receiverType,
+      fieldName,
+      ctx,
+    );
+    if (foreignAccessor.kind === "registered") {
+      qualified = foreignAccessor.ruleName;
+    } else if (foreignAccessor.kind === "unsupported") {
+      return { unsupported: foreignAccessor.reason };
+    } else {
+      qualified = toPantTermName(fieldName);
+    }
   }
 
   let receiverL1: IR1Expr;
@@ -1889,6 +1906,87 @@ export function buildL1MemberAccess(
     discriminantDischarge ??
       queryTypePredicateFieldDischarge(ctx, receiverNode as ts.Expression),
   );
+}
+
+type ForeignAccessorBuild =
+  | { kind: "registered"; ruleName: string }
+  | { kind: "unsupported"; reason: string }
+  | { kind: "none" };
+
+function tryRegisterForeignAccessorForMember(
+  node: ts.PropertyAccessExpression | ts.ElementAccessExpression,
+  receiverType: ts.Type,
+  fieldName: string,
+  ctx: L1BuildContext,
+): ForeignAccessorBuild {
+  const cell = ctx.supply.synthCell;
+  const ownerDomain = foreignDomainForType(
+    receiverType,
+    ctx.checker,
+    ctx.strategy,
+    cell,
+  );
+  if (ownerDomain === null) {
+    return { kind: "none" };
+  }
+  if (!ownerDomain.ok) {
+    return {
+      kind: "unsupported",
+      reason: `foreign accessor .${fieldName}: ${ownerDomain.reason}`,
+    };
+  }
+  const prop = propertySymbolForMember(node, receiverType, fieldName, ctx);
+  if (prop === undefined) {
+    return { kind: "none" };
+  }
+  const propertyType = ctx.checker.getTypeAtLocation(node);
+  if (
+    propertyType.getCallSignatures().length > 0 ||
+    propertyType.getConstructSignatures().length > 0
+  ) {
+    return {
+      kind: "unsupported",
+      reason: `foreign accessor .${fieldName}: unsupported property type ${ctx.checker.typeToString(propertyType)}`,
+    };
+  }
+  const returnSort = mapTsType(propertyType, ctx.checker, ctx.strategy, cell);
+  if (!returnSort.ok) {
+    return {
+      kind: "unsupported",
+      reason: `foreign accessor .${fieldName}: unsupported property type (${returnSort.reason})`,
+    };
+  }
+  if (cell === undefined) {
+    return {
+      kind: "unsupported",
+      reason: `foreign accessor .${fieldName}: missing synth cell for accessor declaration`,
+    };
+  }
+  const entry = cellRegisterForeignAccessor(
+    cell,
+    ownerDomain.sort,
+    fieldName,
+    returnSort.sort,
+  );
+  if (entry === null) {
+    return {
+      kind: "unsupported",
+      reason: `foreign accessor .${fieldName}: unsupported property type ${ctx.checker.typeToString(propertyType)}`,
+    };
+  }
+  return { kind: "registered", ruleName: entry.ruleName };
+}
+
+function propertySymbolForMember(
+  node: ts.PropertyAccessExpression | ts.ElementAccessExpression,
+  receiverType: ts.Type,
+  fieldName: string,
+  ctx: L1BuildContext,
+): ts.Symbol | undefined {
+  if (ts.isPropertyAccessExpression(node)) {
+    return ctx.checker.getSymbolAtLocation(node.name);
+  }
+  return ctx.checker.getPropertyOfType(receiverType, fieldName);
 }
 
 function discriminantLiteralToFactLiteral(

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -118,8 +118,8 @@ import {
   symbolicKey,
 } from "./translate-body.js";
 import {
-  cellRegisterMap,
   cellRegisterForeignAccessor,
+  cellRegisterMap,
   cellRegisterName,
   cellRegisterSynthesizedValue,
   type DiscriminantLiteral,
@@ -130,8 +130,8 @@ import {
   isSetType,
   lookupMapKV,
   mapTsType,
-  resolveFieldOwner,
   type NumericStrategy,
+  resolveFieldOwner,
   toPantTermName,
   UNSUPPORTED_NON_DISCRIMINATED_UNION_FIELD_ACCESS_REASON,
 } from "./translate-types.js";

--- a/tools/ts2pant/src/translate-types.ts
+++ b/tools/ts2pant/src/translate-types.ts
@@ -2215,6 +2215,35 @@ function foreignSymbolKey(
   };
 }
 
+export function foreignDomainForType(
+  type: ts.Type,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  synthCell: SynthCell | undefined,
+): MapTsTypeResult | null {
+  if (synthCell === undefined) {
+    return null;
+  }
+  const symbol = type.aliasSymbol ?? type.symbol;
+  if (symbol === undefined) {
+    return null;
+  }
+  const canonical = canonicalSymbol(symbol, checker);
+  if (
+    canonical.declarations?.every((decl) =>
+      /\/typescript\/lib\/lib\..*\.d\.ts$/u.test(
+        decl.getSourceFile().fileName.replace(/\\/gu, "/"),
+      ),
+    )
+  ) {
+    return null;
+  }
+  if (foreignSymbolKey(symbol, checker) === null) {
+    return null;
+  }
+  return mapTsType(type, checker, strategy, synthCell);
+}
+
 export const RealStrategy: NumericStrategy = {
   mapNumber() {
     return "Real";

--- a/tools/ts2pant/tests/ir1-build-property.test.mts
+++ b/tools/ts2pant/tests/ir1-build-property.test.mts
@@ -24,7 +24,11 @@ import {
 } from "../src/extract.js";
 import { lowerExpr } from "../src/ir-emit.js";
 import type { IR1Expr } from "../src/ir1.js";
-import { buildL1MemberAccess, type L1BuildContext } from "../src/ir1-build.js";
+import {
+  buildL1MemberAccess,
+  createL1AssumptionEnv,
+  type L1BuildContext,
+} from "../src/ir1-build.js";
 import { lowerL1Expr } from "../src/ir1-lower.js";
 import { getAst, loadAst } from "../src/pant-wasm.js";
 import type { UniqueSupply } from "../src/supply.js";
@@ -100,6 +104,7 @@ function setupAccess(source: string): AccessSetup {
     paramNames,
     state: undefined,
     supply,
+    env: createL1AssumptionEnv(),
   };
   const stmt = fn.body.statements[0];
   if (!stmt || !ts.isReturnStatement(stmt) || !stmt.expression) {
@@ -158,6 +163,7 @@ function setupDependencySource(
       paramNames,
       state: undefined,
       supply,
+      env: createL1AssumptionEnv(),
     },
   };
 }

--- a/tools/ts2pant/tests/ir1-build-property.test.mts
+++ b/tools/ts2pant/tests/ir1-build-property.test.mts
@@ -15,8 +15,13 @@
 
 import assert from "node:assert/strict";
 import { before, describe, it } from "node:test";
+import { Project } from "ts-morph";
 import ts from "typescript";
-import { createSourceFileFromSource, getChecker } from "../src/extract.js";
+import {
+  COMPILER_OPTIONS,
+  createSourceFileFromSource,
+  getChecker,
+} from "../src/extract.js";
 import { lowerExpr } from "../src/ir-emit.js";
 import type { IR1Expr } from "../src/ir1.js";
 import { buildL1MemberAccess, type L1BuildContext } from "../src/ir1-build.js";
@@ -25,6 +30,7 @@ import { getAst, loadAst } from "../src/pant-wasm.js";
 import type { UniqueSupply } from "../src/supply.js";
 import { qualifyFieldAccess } from "../src/translate-body.js";
 import {
+  cellEmitSynth,
   cellRegisterName,
   IntStrategy,
   newSynthCell,
@@ -42,6 +48,12 @@ interface PropertyAccessSetup {
 
 interface AccessSetup {
   node: ts.PropertyAccessExpression | ts.ElementAccessExpression;
+  ctx: L1BuildContext;
+}
+
+interface DependencyAccessSetup {
+  sourceFile: ts.SourceFile;
+  checker: ts.TypeChecker;
   ctx: L1BuildContext;
 }
 
@@ -103,6 +115,78 @@ function setupAccess(source: string): AccessSetup {
     );
   }
   return { node: expr, ctx };
+}
+
+function setupDependencySource(
+  source: string,
+  dependencyDeclarations: string,
+): DependencyAccessSetup {
+  const project = new Project({
+    compilerOptions: COMPILER_OPTIONS,
+    useInMemoryFileSystem: true,
+  });
+  project.createSourceFile(
+    "/project/node_modules/dep/package.json",
+    JSON.stringify({ name: "dep", types: "index.d.ts" }),
+  );
+  project.createSourceFile(
+    "/project/node_modules/dep/index.d.ts",
+    dependencyDeclarations,
+  );
+  const sourceFile = project.createSourceFile("/project/src/main.ts", source);
+  project.resolveSourceFileDependencies();
+  const checker = project.getTypeChecker().compilerObject;
+  const fn = sourceFile.compilerNode.statements.find(ts.isFunctionDeclaration);
+  if (!fn?.body) {
+    throw new Error("setupDependencySource: expected function with body");
+  }
+  const synthCell = newSynthCell();
+  const paramNames = new Map<string, string>();
+  for (const p of fn.parameters) {
+    if (ts.isIdentifier(p.name)) {
+      const pantName = cellRegisterName(synthCell, toPantTermName(p.name.text));
+      paramNames.set(p.name.text, pantName);
+    }
+  }
+  const supply: UniqueSupply = { n: 0, synthCell };
+  return {
+    sourceFile: sourceFile.compilerNode,
+    checker,
+    ctx: {
+      checker,
+      strategy: IntStrategy,
+      paramNames,
+      state: undefined,
+      supply,
+    },
+  };
+}
+
+function returnExpression(sourceFile: ts.SourceFile): ts.Expression {
+  const fn = sourceFile.statements.find(ts.isFunctionDeclaration);
+  const stmt = fn?.body?.statements.find(ts.isReturnStatement);
+  if (!stmt?.expression) {
+    throw new Error("returnExpression: expected return expression");
+  }
+  return stmt.expression;
+}
+
+function collectAccesses(
+  node: ts.Node,
+): Array<ts.PropertyAccessExpression | ts.ElementAccessExpression> {
+  const out: Array<ts.PropertyAccessExpression | ts.ElementAccessExpression> =
+    [];
+  const visit = (current: ts.Node): void => {
+    if (
+      ts.isPropertyAccessExpression(current) ||
+      ts.isElementAccessExpression(current)
+    ) {
+      out.push(current);
+    }
+    current.forEachChild(visit);
+  };
+  visit(node);
+  return out;
 }
 
 function expectMember(result: IR1Expr | { unsupported: string }): {
@@ -441,36 +525,188 @@ describe("ir1-build-property", () => {
     assert.equal(templateOpaque, dottedOpaque);
   });
 
-  it.skip("Patch 3: foreign receiver property access lowers to synthesized accessor", () => {
-    // Intended Patch 3 shape for a foreign declaration-file receiver:
-    // `c.items` lowers to `items c`, registers
-    // `items c: ForeignDependencyContainer => [ForeignDependencyItem].`,
-    // and nested `item.label` lowers through `item-label item`.
-    const output = [
-      "items c: ForeignDependencyContainer => [ForeignDependencyItem].",
-      "item-label i: ForeignDependencyItem => String.",
-      "foreign-labels c = (each i in items c, item-ready i | item-label i).",
-    ].join("\n");
+  it("foreign receiver property access lowers to synthesized accessor", () => {
+    const { sourceFile, ctx } = setupDependencySource(
+      `
+        import type { DependencyContainer } from "dep";
+        export function f(c: DependencyContainer) {
+          return c.items;
+        }
+      `,
+      `
+        export interface DependencyItem {
+          readonly label: string;
+          readonly ready: boolean;
+        }
+        export interface DependencyContainer {
+          readonly items: readonly DependencyItem[];
+        }
+      `,
+    );
+    const expr = returnExpression(sourceFile);
+    assert.ok(ts.isPropertyAccessExpression(expr));
 
-    assert.match(
-      output,
-      /^items c: ForeignDependencyContainer => \[ForeignDependencyItem\]\.$/mu,
-    );
-    assert.match(
-      output,
-      /^item-label i: ForeignDependencyItem => String\.$/mu,
-    );
-    assert.match(output, /each i in items c, item-ready i \| item-label i/u);
+    const result = buildL1MemberAccess(expr, ctx);
+    const { receiver, name } = expectMember(result);
+    assert.equal(name, "items");
+    assert.equal(receiver.kind, "var");
+    assert.equal(receiver.name, "c");
+    assert.deepEqual(cellEmitSynth(ctx.supply.synthCell!).decls, [
+      { kind: "domain", name: "ForeignDependencyContainer" },
+      { kind: "domain", name: "ForeignDependencyItem" },
+      {
+        kind: "rule",
+        name: "items",
+        params: [{ name: "c", type: "ForeignDependencyContainer" }],
+        returnType: "[ForeignDependencyItem]",
+      },
+    ]);
   });
 
-  it.skip("Patch 3: unsupported foreign property type refuses without dangling rules", () => {
-    // Intended Patch 3 fallback: if the checker cannot map the property type
-    // to a Pant sort or another foreign domain, member lowering returns
-    // unsupported and does not register a partial accessor declaration.
-    const output =
-      "> UNSUPPORTED: foreign property 'metadata' has unsupported type";
+  it("nested foreign reads compose through synthesized accessors", () => {
+    const { sourceFile, ctx } = setupDependencySource(
+      `
+        import type { VariableDeclaration } from "dep";
+        export function f(decl: VariableDeclaration) {
+          return decl.name.text;
+        }
+      `,
+      `
+        export interface Identifier {
+          readonly text: string;
+        }
+        export interface VariableDeclaration {
+          readonly name: Identifier;
+        }
+      `,
+    );
+    const expr = returnExpression(sourceFile);
+    assert.ok(ts.isPropertyAccessExpression(expr));
 
-    assert.match(output, /^> UNSUPPORTED: foreign property 'metadata'/mu);
-    assert.doesNotMatch(output, /^metadata .* =>/mu);
+    const result = buildL1MemberAccess(expr, ctx);
+    const outer = expectMember(result);
+    assert.equal(outer.name, "identifier-text");
+    const inner = expectMember(outer.receiver);
+    assert.equal(inner.name, "name");
+    assert.deepEqual(
+      cellEmitSynth(ctx.supply.synthCell!).decls.filter(
+        (decl) => decl.kind === "rule",
+      ),
+      [
+        {
+          kind: "rule",
+          name: "identifier-text",
+          params: [{ name: "i", type: "ForeignIdentifier" }],
+          returnType: "String",
+        },
+        {
+          kind: "rule",
+          name: "name",
+          params: [{ name: "d", type: "ForeignVariableDeclaration" }],
+          returnType: "ForeignIdentifier",
+        },
+      ],
+    );
+  });
+
+  it("repeated foreign reads share one synthesized declaration", () => {
+    const { sourceFile, ctx } = setupDependencySource(
+      `
+        import type { DependencyContainer } from "dep";
+        export function f(c: DependencyContainer) {
+          return c.items.length + c.items.length;
+        }
+      `,
+      `
+        export interface DependencyItem { readonly label: string; }
+        export interface DependencyContainer {
+          readonly items: readonly DependencyItem[];
+        }
+      `,
+    );
+    const accesses = collectAccesses(returnExpression(sourceFile)).filter(
+      (access): access is ts.PropertyAccessExpression =>
+        ts.isPropertyAccessExpression(access) && access.name.text === "items",
+    );
+    assert.equal(accesses.length, 2);
+
+    for (const access of accesses) {
+      const result = buildL1MemberAccess(access, ctx);
+      assert.equal(expectMember(result).name, "items");
+    }
+    const rules = cellEmitSynth(ctx.supply.synthCell!).decls.filter(
+      (decl) => decl.kind === "rule" && decl.name === "items",
+    );
+    assert.equal(rules.length, 1);
+  });
+
+  it("declList.declarations lowers through a TypeScript dependency accessor", () => {
+    const { sourceFile, ctx } = setupDependencySource(
+      `
+        import type { VariableDeclarationList } from "dep";
+        export function f(declList: VariableDeclarationList) {
+          return declList.declarations;
+        }
+      `,
+      `
+        export interface VariableDeclaration {
+          readonly name: Identifier;
+        }
+        export interface Identifier {
+          readonly text: string;
+        }
+        export interface VariableDeclarationList {
+          readonly declarations: readonly VariableDeclaration[];
+        }
+      `,
+    );
+    const expr = returnExpression(sourceFile);
+    assert.ok(ts.isPropertyAccessExpression(expr));
+
+    const result = buildL1MemberAccess(expr, ctx);
+    assert.equal(expectMember(result).name, "declarations");
+    assert.deepEqual(
+      cellEmitSynth(ctx.supply.synthCell!).decls.filter(
+        (decl) => decl.kind === "rule",
+      ),
+      [
+        {
+          kind: "rule",
+          name: "declarations",
+          params: [{ name: "dl", type: "ForeignVariableDeclarationList" }],
+          returnType: "[ForeignVariableDeclaration]",
+        },
+      ],
+    );
+  });
+
+  it("unsupported foreign property type refuses without dangling rules", () => {
+    const { sourceFile, ctx } = setupDependencySource(
+      `
+        import type { DependencyContainer } from "dep";
+        export function f(c: DependencyContainer) {
+          return c.metadata;
+        }
+      `,
+      `
+        export interface DependencyContainer {
+          readonly metadata: () => void;
+        }
+      `,
+    );
+    const expr = returnExpression(sourceFile);
+    assert.ok(ts.isPropertyAccessExpression(expr));
+
+    const result = buildL1MemberAccess(expr, ctx);
+    assert.ok("unsupported" in result);
+    if ("unsupported" in result) {
+      assert.match(result.unsupported, /foreign accessor \.metadata/u);
+      assert.match(result.unsupported, /unsupported property type/u);
+    }
+    const decls = cellEmitSynth(ctx.supply.synthCell!).decls;
+    assert.deepEqual(
+      decls.filter((decl) => decl.kind === "rule"),
+      [],
+    );
   });
 });


### PR DESCRIPTION
## Patch 3: Lower member access through foreign accessors

- Add a helper that can determine whether a receiver type maps to a synthesized foreign domain and return that domain name without creating incompatible duplicate domains.
- In `buildL1MemberAccess`, after ordinary `qualifyFieldAccess` fails, inspect the property symbol/type on the receiver. If the receiver maps to a foreign domain and the property type maps successfully, register a foreign accessor and emit an `ir1Member`/application using that accessor rule.
- Allow nested chains to compose through synthesized accessors: `decl.name.text` lowers by first mapping `decl.name`, then mapping `.text` on the narrowed/foreign receiver type at that use site.
- Preserve existing dynamic `Opaque` behavior and user/interface/record owner behavior unchanged.
- If the property type cannot map, return the current unsupported shape with a precise foreign-accessor reason.
- Implement tests for a non-`typescript` imported dependency receiver, `declList.declarations`, nested foreign reads, repeated reads sharing one declaration, and unsupported property types refusing cleanly.

## Changes
- Add a helper that can determine whether a receiver type maps to a synthesized foreign domain and return that domain name without creating incompatible duplicate domains.
- In `buildL1MemberAccess`, after ordinary `qualifyFieldAccess` fails, inspect the property symbol/type on the receiver. If the receiver maps to a foreign domain and the property type maps successfully, register a foreign accessor and emit an `ir1Member`/application using that accessor rule.
- Allow nested chains to compose through synthesized accessors: `decl.name.text` lowers by first mapping `decl.name`, then mapping `.text` on the narrowed/foreign receiver type at that use site.
- Preserve existing dynamic `Opaque` behavior and user/interface/record owner behavior unchanged.
- If the property type cannot map, return the current unsupported shape with a precise foreign-accessor reason.
- Implement tests for a non-`typescript` imported dependency receiver, `declList.declarations`, nested foreign reads, repeated reads sharing one declaration, and unsupported property types refusing cleanly.

## Files to Modify
- tools/ts2pant/src/ir1-build.ts (modify): Teach `buildL1MemberAccess` to use foreign accessor synths when owner resolution fails because the receiver is a synthesized foreign domain.
- tools/ts2pant/src/translate-types.ts (modify): Expose helper(s) needed by member lowering to identify foreign-domain receiver sorts and map property return types.
- tools/ts2pant/tests/ir1-build-property.test.mts (modify): Implement the foreign member access lowering and unsupported fallback tests introduced in Patch 1.

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[pattern] Uninterpreted function abstraction for opaque foreign objects** — Foreign property reads should be represented as typed EUF/accessor applications, not structural models. This patch implements the shallow abstraction boundary for member lowering.

## Gameplan Specification

```
module TS2PANT_FOREIGN_ACCESSOR_BODY_LOWERING.

ForeignAccessor.
ForeignDependencyContainer.
ForeignDependencyItem.
ForeignVariableDeclarationList.
ForeignVariableDeclaration.
ForeignIdentifier.

accessor-emitted a: ForeignAccessor => Bool.
items c: ForeignDependencyContainer => [ForeignDependencyItem].
item-label i: ForeignDependencyItem => String.
item-ready i: ForeignDependencyItem => Bool.
foreign-labels c: ForeignDependencyContainer => [String].
declarations dl: ForeignVariableDeclarationList => [ForeignVariableDeclaration].
name d: ForeignVariableDeclaration => ForeignIdentifier.
identifier-text i: ForeignIdentifier => String.
is-identifier i: ForeignIdentifier => Bool.
binding-names-from-declaration-list dl: ForeignVariableDeclarationList => [String].
---
all a: ForeignAccessor | accessor-emitted a.
all c: ForeignDependencyContainer | foreign-labels c = (each i in items c, item-ready i | item-label i).
all dl: ForeignVariableDeclarationList | binding-names-from-declaration-list dl = (each d in declarations dl, is-identifier (name d) | identifier-text (name d)).
```

## Patch Specification

```
module TS2PANT_FOREIGN_ACCESSOR_BODY_LOWERING_PATCH_3.

ForeignOwner.
ForeignValue.

foreign-accessor o: ForeignOwner, field: String => ForeignValue.
lowerable o: ForeignOwner, field: String => Bool.
unsupported o: ForeignOwner, field: String => Bool.
---
all o: ForeignOwner, f: String | lowerable o f -> ~ unsupported o f.
all o: ForeignOwner, f: String | lowerable o f -> foreign-accessor o f = foreign-accessor o f.
```


## Implementation Notes

- `foreignDomainForType` is intentionally narrower than `mapTsType`: it only returns a synthesized foreign receiver domain when a synth cell is present and the receiver's symbol is from an external dependency or `typescript.d.ts`. It explicitly excludes standard `lib.*.d.ts` symbols so builtins like `Math.max`, `Array.prototype.includes`, and cardinality paths keep their existing special handling instead of being mistaken for foreign object access.
- `buildL1MemberAccess` now uses `resolveFieldOwner` directly so it can distinguish resolved owners, ambiguous owners, and unowned receivers. The foreign-accessor probe only runs for the unowned case; resolved user/interface/record/discriminated-union owners and ambiguous-union rejection are unchanged.
- Foreign accessor registration happens before receiver L1 recursion, using the TypeScript checker's type at the current member node. This is what lets nested chains such as `decl.name.text` register both the outer primitive projection and the inner foreign projection while still lowering to nested `IR1Member` nodes.
- Callable/constructable foreign property values are refused with a `foreign accessor .field: unsupported property type ...` reason. This avoids accepting function-valued dependency fields as a bogus named sort.
- Repeated foreign reads dedupe through Patch 2's `(ownerDomain, fieldName, returnSort)` key; no additional dedupe layer was added in member lowering.

Spec/Evidence Mapping:
- Lowerable foreign receiver property reads -> `foreignDomainForType` plus `tryRegisterForeignAccessorForMember` in `tools/ts2pant/src/ir1-build.ts`; covered by `foreign receiver property access lowers to synthesized accessor`.
- Nested foreign accessor composition -> current-node property type mapping plus existing recursive member lowering; covered by `nested foreign reads compose through synthesized accessors`.
- Stable declaration reuse -> Patch 2 `cellRegisterForeignAccessor` key reuse, exercised from member lowering; covered by `repeated foreign reads share one synthesized declaration`.
- Clean unsupported fallback -> callable property refusal before synth registration; covered by `unsupported foreign property type refuses without dangling rules`.
- Non-TypeScript dependency coverage and declaration-list dogfood shape -> in-memory `node_modules/dep` fixtures in `ir1-build-property.test.mts`; covered by the generic dependency receiver test and `declList.declarations lowers through a TypeScript dependency accessor`.

Verification run after implementation: focused property test, `just ts2pant-typecheck`, `just ts2pant-test-unit-rest`, `just ts2pant-test-unit-constructs`, and `just ts2pant-test-integration` all passed.