### PR TITLE
[ts2pant-foreign-accessor-body-lowering] Patch 4: Dogfood bindingNamesFromDeclarationList body and annotation

### DIFF
--- a/tools/ts2pant/src/extract.ts
+++ b/tools/ts2pant/src/extract.ts
@@ -373,6 +373,9 @@ export function extractReferencedTypes(
     if (program.isSourceFileFromExternalLibrary(compilerSf)) {
       continue;
     }
+    if (compilerSf.isDeclarationFile) {
+      continue;
+    }
     const types = extractAllTypes(sf);
     aggregated.interfaces.push(...types.interfaces);
     aggregated.aliases.push(...types.aliases);
@@ -943,7 +946,9 @@ export function extractReferencedFunctions(
   }
   const consumerIsPure = classifyFunction(consumerNode, checker) === "pure";
   // Collect (declaration, callSiteNames) pairs for free-function calls
-  // reached from the consumer's body. Keying by the
+  // reached from the consumer's body. This includes bare calls (`fn()`) and
+  // namespace-style dependency predicate calls (`ts.isIdentifier(...)`), both
+  // of which lower to ordinary EUF rule heads. Keying by the
   // resolved declaration deduplicates aliased imports — `import {
   // foo as bar }; bar(); foo();` collapses to one rule head — while
   // the value (a Set of local identifiers) preserves every call-site
@@ -955,7 +960,8 @@ export function extractReferencedFunctions(
   function visit(n: ts.Node): void {
     if (
       ts.isCallExpression(n) &&
-      ts.isIdentifier(n.expression) &&
+      (ts.isIdentifier(n.expression) ||
+        ts.isPropertyAccessExpression(n.expression)) &&
       !n.arguments.some(ts.isSpreadElement)
     ) {
       if (lookupBuiltinByCall(n, checker, program) !== null) {
@@ -966,8 +972,26 @@ export function extractReferencedFunctions(
         ts.forEachChild(n, visit);
         return;
       }
-      const localCalleeName = n.expression.text;
-      let sym = checker.getSymbolAtLocation(n.expression);
+      const sig = checker.getResolvedSignature(n);
+      if (ts.isPropertyAccessExpression(n.expression)) {
+        const returnType = sig?.getReturnType();
+        const isBoolReturn =
+          returnType !== undefined &&
+          (returnType.flags &
+            (ts.TypeFlags.Boolean | ts.TypeFlags.BooleanLiteral)) !==
+            0;
+        if (!isBoolReturn) {
+          ts.forEachChild(n, visit);
+          return;
+        }
+      }
+      const localCalleeName = ts.isIdentifier(n.expression)
+        ? n.expression.text
+        : n.expression.name.text;
+      const calleeNameNode = ts.isIdentifier(n.expression)
+        ? n.expression
+        : n.expression.name;
+      let sym = checker.getSymbolAtLocation(calleeNameNode);
       // Follow import aliases. For an `import { foo } from "./mod.js"`
       // followed by `foo()`, `getSymbolAtLocation` returns the import
       // specifier symbol, not the underlying function declaration. The
@@ -975,7 +999,6 @@ export function extractReferencedFunctions(
       if (sym && sym.flags & ts.SymbolFlags.Alias) {
         sym = checker.getAliasedSymbol(sym);
       }
-      const sig = checker.getResolvedSignature(n);
       const decl = [
         sig?.declaration,
         sym?.valueDeclaration,
@@ -1098,26 +1121,28 @@ function translateReferencedCallable(
   }
   if (ts.isFunctionDeclaration(decl) || ts.isMethodDeclaration(decl)) {
     const tsMorphSf = declSfMap.get(decl.getSourceFile());
-    if (!tsMorphSf) {
-      return null;
+    if (tsMorphSf) {
+      const sig = translateSignature(
+        tsMorphSf,
+        declName,
+        strategy,
+        synthCell,
+        undefined,
+      );
+      if (sig.declaration.kind !== "rule") {
+        return null;
+      }
+      const name = synthCell
+        ? cellRegisterName(synthCell, sig.declaration.name)
+        : sig.declaration.name;
+      return { ...sig.declaration, name };
     }
-    const sig = translateSignature(
-      tsMorphSf,
-      declName,
-      strategy,
-      synthCell,
-      undefined,
-    );
-    if (sig.declaration.kind !== "rule") {
-      return null;
-    }
-    const name = synthCell
-      ? cellRegisterName(synthCell, sig.declaration.name)
-      : sig.declaration.name;
-    return { ...sig.declaration, name };
   }
 
-  const sig = checker.getTypeAtLocation(decl).getCallSignatures()[0];
+  const sig =
+    (ts.isFunctionDeclaration(decl) || ts.isMethodDeclaration(decl)
+      ? checker.getSignatureFromDeclaration(decl)
+      : undefined) ?? checker.getTypeAtLocation(decl).getCallSignatures()[0];
   if (!sig) {
     return null;
   }
@@ -1125,10 +1150,16 @@ function translateReferencedCallable(
   if (returnType.flags & ts.TypeFlags.Void) {
     return null;
   }
+  const predicate = checker.getTypePredicateOfSignature(sig);
   const params: { name: string; type: string }[] = [];
-  for (const param of sig.getParameters()) {
+  for (const [index, param] of sig.getParameters().entries()) {
     const paramDecl = param.valueDeclaration ?? decl;
-    const paramType = checker.getTypeOfSymbolAtLocation(param, paramDecl);
+    const paramType =
+      predicate?.kind === ts.TypePredicateKind.Identifier &&
+      predicate.parameterIndex === index &&
+      predicate.type !== undefined
+        ? predicate.type
+        : checker.getTypeOfSymbolAtLocation(param, paramDecl);
     const mapped = mapTsType(paramType, checker, strategy, synthCell);
     // Can't synthesize a sound rule head with an unmappable parameter type.
     if (!mapped.ok) {

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -239,7 +239,8 @@ function isBoolReturningDeclarationFileCall(
   const returnType = checker.getResolvedSignature(expr)?.getReturnType();
   return (
     returnType !== undefined &&
-    (returnType.flags & (ts.TypeFlags.Boolean | ts.TypeFlags.BooleanLiteral)) !==
+    (returnType.flags &
+      (ts.TypeFlags.Boolean | ts.TypeFlags.BooleanLiteral)) !==
       0
   );
 }
@@ -1146,8 +1147,10 @@ export function tryBuildL1PureSubExpression(
     if (expr.arguments.some(ts.isSpreadElement)) {
       return { unsupported: "call with spread arguments is unsupported" };
     }
-    const declarationFilePropertyCallee =
-      isBoolReturningDeclarationFileCall(expr, ctx.checker);
+    const declarationFilePropertyCallee = isBoolReturningDeclarationFileCall(
+      expr,
+      ctx.checker,
+    );
     if (
       !declarationFilePropertyCallee &&
       expressionHasSideEffects(expr.expression, ctx.checker)

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -201,6 +201,49 @@ function isDynamicTsType(type: ts.Type): boolean {
   return (type.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0;
 }
 
+function isDeclarationFileCallableSymbol(
+  symbol: ts.Symbol | undefined,
+  checker: ts.TypeChecker,
+): boolean {
+  if (symbol === undefined) {
+    return false;
+  }
+  const resolved =
+    symbol.flags & ts.SymbolFlags.Alias
+      ? checker.getAliasedSymbol(symbol)
+      : symbol;
+  return (resolved.getDeclarations() ?? []).some((decl) => {
+    const sf = decl.getSourceFile();
+    return (
+      sf.isDeclarationFile &&
+      (ts.isFunctionDeclaration(decl) || ts.isMethodSignature(decl))
+    );
+  });
+}
+
+function isBoolReturningDeclarationFileCall(
+  expr: ts.CallExpression,
+  checker: ts.TypeChecker,
+): boolean {
+  if (!ts.isPropertyAccessExpression(expr.expression)) {
+    return false;
+  }
+  if (
+    !isDeclarationFileCallableSymbol(
+      checker.getSymbolAtLocation(expr.expression.name),
+      checker,
+    )
+  ) {
+    return false;
+  }
+  const returnType = checker.getResolvedSignature(expr)?.getReturnType();
+  return (
+    returnType !== undefined &&
+    (returnType.flags & (ts.TypeFlags.Boolean | ts.TypeFlags.BooleanLiteral)) !==
+      0
+  );
+}
+
 function narrowedSortForUse(
   expr: ts.Expression,
   ctx: L1BuildContext,
@@ -1103,7 +1146,12 @@ export function tryBuildL1PureSubExpression(
     if (expr.arguments.some(ts.isSpreadElement)) {
       return { unsupported: "call with spread arguments is unsupported" };
     }
-    if (expressionHasSideEffects(expr.expression, ctx.checker)) {
+    const declarationFilePropertyCallee =
+      isBoolReturningDeclarationFileCall(expr, ctx.checker);
+    if (
+      !declarationFilePropertyCallee &&
+      expressionHasSideEffects(expr.expression, ctx.checker)
+    ) {
       return null;
     }
     if (isArrayChainCall(expr, ctx.checker)) {
@@ -1305,6 +1353,7 @@ export function tryBuildL1PureSubExpression(
     }
     let callee: IR1Expr | null;
     let args: IR1Expr[];
+    let expectedArgSorts: Map<number, string> | null = null;
     if (ts.isIdentifier(expr.expression)) {
       const fnName =
         ctx.paramNames.get(expr.expression.text) ?? expr.expression.text;
@@ -1314,14 +1363,56 @@ export function tryBuildL1PureSubExpression(
       ts.isPropertyAccessExpression(expr.expression) ||
       ts.isElementAccessExpression(expr.expression)
     ) {
-      const builtCallee = buildL1MemberAccess(expr.expression, ctx, {
-        nativeReceiverLeaf: true,
-      });
-      if (isL1Unsupported(builtCallee)) {
-        return builtCallee;
+      if (ts.isPropertyAccessExpression(expr.expression)) {
+        const calleeSymbol = ctx.checker.getSymbolAtLocation(
+          expr.expression.name,
+        );
+        if (
+          isDeclarationFileCallableSymbol(calleeSymbol, ctx.checker) &&
+          isBoolReturningDeclarationFileCall(expr, ctx.checker)
+        ) {
+          callee = ir1Var(toPantTermName(expr.expression.name.text));
+          args = [];
+          const signature = ctx.checker.getResolvedSignature(expr);
+          const predicate = signature
+            ? ctx.checker.getTypePredicateOfSignature(signature)
+            : undefined;
+          if (
+            predicate?.kind === ts.TypePredicateKind.Identifier &&
+            predicate.type !== undefined
+          ) {
+            const mapped = mapTsType(
+              predicate.type,
+              ctx.checker,
+              ctx.strategy,
+              ctx.supply.synthCell,
+            );
+            if (mapped.ok) {
+              expectedArgSorts = new Map([
+                [predicate.parameterIndex, mapped.sort],
+              ]);
+            }
+          }
+        } else {
+          const builtCallee = buildL1MemberAccess(expr.expression, ctx, {
+            nativeReceiverLeaf: true,
+          });
+          if (isL1Unsupported(builtCallee)) {
+            return builtCallee;
+          }
+          callee = builtCallee;
+          args = [];
+        }
+      } else {
+        const builtCallee = buildL1MemberAccess(expr.expression, ctx, {
+          nativeReceiverLeaf: true,
+        });
+        if (isL1Unsupported(builtCallee)) {
+          return builtCallee;
+        }
+        callee = builtCallee;
+        args = [];
       }
-      callee = builtCallee;
-      args = [];
     } else {
       const builtCallee = tryBuildL1PureSubExpression(expr.expression, ctx);
       if (builtCallee === null || isL1Unsupported(builtCallee)) {
@@ -1330,8 +1421,12 @@ export function tryBuildL1PureSubExpression(
       callee = builtCallee;
       args = [];
     }
-    for (const arg of expr.arguments) {
-      const builtArg = tryBuildL1PureSubExpression(arg, ctx);
+    for (const [index, arg] of expr.arguments.entries()) {
+      const expectedSort = expectedArgSorts?.get(index);
+      const builtArg = tryBuildL1PureSubExpression(arg, {
+        ...ctx,
+        ...(expectedSort === undefined ? {} : { expectedSort }),
+      });
       if (builtArg === null || isL1Unsupported(builtArg)) {
         return builtArg;
       }
@@ -1949,7 +2044,10 @@ function tryRegisterForeignAccessorForMember(
       reason: `foreign accessor .${fieldName}: unsupported property type ${ctx.checker.typeToString(propertyType)}`,
     };
   }
-  const returnSort = mapTsType(propertyType, ctx.checker, ctx.strategy, cell);
+  const returnSort =
+    ctx.expectedSort === undefined
+      ? mapTsType(propertyType, ctx.checker, ctx.strategy, cell)
+      : { ok: true as const, sort: ctx.expectedSort };
   if (!returnSort.ok) {
     return {
       kind: "unsupported",
@@ -2001,6 +2099,7 @@ function receiverTypeForFieldAccess(
   ctx: L1BuildContext,
 ): ts.Type {
   const declared = getOperandDeclaredType(receiverNode, ctx.checker);
+  const narrowed = ctx.checker.getTypeAtLocation(receiverNode);
   const detected = detectDiscriminatedUnion(declared, ctx.checker);
   if (
     detected &&
@@ -2009,9 +2108,20 @@ function receiverTypeForFieldAccess(
         variant.fields.some((field) => field.name === fieldName),
       ))
   ) {
+    if (narrowed !== declared) {
+      const foreign = foreignDomainForType(
+        narrowed,
+        ctx.checker,
+        ctx.strategy,
+        ctx.supply.synthCell,
+      );
+      if (foreign?.ok) {
+        return narrowed;
+      }
+    }
     return declared;
   }
-  return ctx.checker.getTypeAtLocation(receiverNode);
+  return narrowed;
 }
 
 function queryDiscriminatedUnionFieldDischarge(

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -2007,9 +2007,12 @@ export function recognizeForOfPush(
 
   const guards: IR1Expr[] = [];
   for (const guardExpr of push.guardExprs) {
+    if (!isStaticallyBoolTyped(guardExpr, ctx.checker)) {
+      return null;
+    }
     if (
-      !isStaticallyBoolTyped(guardExpr, ctx.checker) ||
-      expressionHasSideEffects(guardExpr, ctx.checker)
+      expressionHasSideEffects(guardExpr, ctx.checker) &&
+      !isBoolDeclarationFileNamespaceCall(guardExpr, ctx.checker)
     ) {
       return null;
     }
@@ -2065,6 +2068,35 @@ function buildPureL1OrNull(
     return null;
   }
   return built;
+}
+
+function isBoolDeclarationFileNamespaceCall(
+  expr: ts.Expression,
+  checker: ts.TypeChecker,
+): boolean {
+  if (
+    !ts.isCallExpression(expr) ||
+    !ts.isPropertyAccessExpression(expr.expression)
+  ) {
+    return false;
+  }
+  const sig = checker.getResolvedSignature(expr);
+  const returnType = sig?.getReturnType();
+  if (
+    returnType === undefined ||
+    (returnType.flags & (ts.TypeFlags.Boolean | ts.TypeFlags.BooleanLiteral)) ===
+      0
+  ) {
+    return false;
+  }
+  const symbol = checker.getSymbolAtLocation(expr.expression.name);
+  const resolved =
+    symbol && symbol.flags & ts.SymbolFlags.Alias
+      ? checker.getAliasedSymbol(symbol)
+      : symbol;
+  return (resolved?.getDeclarations() ?? []).some(
+    (decl) => decl.getSourceFile().isDeclarationFile,
+  );
 }
 
 interface RecognizedPushBody {
@@ -2530,6 +2562,9 @@ function constBindingsFromDeclarationList(
   return bindings;
 }
 
+/**
+ * @pant all dl: ForeignVariableDeclarationList | binding-names-from-declaration-list dl = (each d in declarations dl, is-identifier (name d) | identifier-text (name d)).
+ */
 function bindingNamesFromDeclarationList(
   declList: ts.VariableDeclarationList,
 ): readonly string[] {

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -2084,7 +2084,8 @@ function isBoolDeclarationFileNamespaceCall(
   const returnType = sig?.getReturnType();
   if (
     returnType === undefined ||
-    (returnType.flags & (ts.TypeFlags.Boolean | ts.TypeFlags.BooleanLiteral)) ===
+    (returnType.flags &
+      (ts.TypeFlags.Boolean | ts.TypeFlags.BooleanLiteral)) ===
       0
   ) {
     return false;

--- a/tools/ts2pant/src/translate-types.ts
+++ b/tools/ts2pant/src/translate-types.ts
@@ -2188,6 +2188,7 @@ function canonicalSymbol(sym: ts.Symbol, checker: ts.TypeChecker): ts.Symbol {
 function isForeignSourceFile(sf: ts.SourceFile): boolean {
   const fileName = sf.fileName.replace(/\\/gu, "/");
   return (
+    sf.isDeclarationFile ||
     /\/node_modules\//u.test(fileName) ||
     /\/typescript\/lib\/(?:lib\..*|typescript)\.d\.ts$/u.test(fileName)
   );
@@ -2366,6 +2367,23 @@ export function mapTsType(
         return okSort(domain);
       }
     }
+  }
+
+  // Array-like declaration-file interfaces such as `ts.NodeArray<T>` expose
+  // a numeric index signature but are not reported by the checker as concrete
+  // arrays. Treat them as Pantagruel lists so shallow foreign accessors can
+  // feed comprehensions without modeling the container object itself.
+  const numberIndexType = type.getNumberIndexType();
+  if (
+    type.getSymbol()?.getName() === "NodeArray" &&
+    numberIndexType !== undefined &&
+    type.getProperty("length") !== undefined
+  ) {
+    const elem = mapTsType(numberIndexType, checker, strategy, synthCell);
+    if (!elem.ok) {
+      return elem;
+    }
+    return okSort(`[${elem.sort}]`);
   }
 
   // Effect Brand<T> intersections refine a value without changing its

--- a/tools/ts2pant/tests/fixtures/constructs/foreign-accessor-dependency.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/foreign-accessor-dependency.ts
@@ -1,12 +1,9 @@
-import {
-  isReady,
-  type ForeignDependencyContainer,
-} from "../foreign-dependency/index.js";
+import type { DependencyContainer } from "../foreign-dependency/index.js";
 
-export function foreignLabels(c: ForeignDependencyContainer): string[] {
+export function foreignLabels(c: DependencyContainer): string[] {
   const labels: string[] = [];
   for (const item of c.items) {
-    if (isReady(item)) {
+    if (item.ready) {
       labels.push(item.label);
     }
   }

--- a/tools/ts2pant/tests/fixtures/foreign-dependency/index.d.ts
+++ b/tools/ts2pant/tests/fixtures/foreign-dependency/index.d.ts
@@ -1,10 +1,10 @@
-export interface ForeignDependencyContainer {
-  readonly items: readonly ForeignDependencyItem[];
+export interface DependencyContainer {
+  readonly items: readonly DependencyItem[];
 }
 
-export interface ForeignDependencyItem {
+export interface DependencyItem {
   readonly label: string;
   readonly ready: boolean;
 }
 
-export declare function isReady(item: ForeignDependencyItem): boolean;
+export declare function isReady(item: DependencyItem): boolean;

--- a/tools/ts2pant/tests/integration/dogfood.test.mts
+++ b/tools/ts2pant/tests/integration/dogfood.test.mts
@@ -61,7 +61,7 @@ describe("dogfood: foreign dependency type surfaces", () => {
     );
   });
 
-  it.skip("Patch 4: bindingNamesFromDeclarationList translates body with foreign accessors", async () => {
+  it("bindingNamesFromDeclarationList translates body with foreign accessors", async () => {
     const doc = await buildDocumentFromPath(
       resolve(SRC, "translate-body.ts"),
       "bindingNamesFromDeclarationList",
@@ -83,13 +83,17 @@ describe("dogfood: foreign dependency type surfaces", () => {
     );
     assert.match(
       output,
-      /binding-names-from-declaration-list dl = \(each d in declarations dl, is-identifier \(name d\) \| identifier-text \(name d\)\)\./u,
+      /^is-identifier node: ForeignIdentifier => Bool\.$/mu,
+    );
+    assert.match(
+      output,
+      /binding-names-from-declaration-list decl-list = \(each decl in declarations decl-list, is-identifier \(name decl\) \| identifier-text \(name decl\)\)\./u,
     );
   });
 });
 
 describe("foreign dependency fixture", () => {
-  it.skip("Patch 4: non-typescript imported dependency property reads lower through foreign accessors", async () => {
+  it("non-typescript imported dependency property reads lower through foreign accessors", async () => {
     const doc = await buildDocumentFromPath(
       resolve(FIXTURES, "foreign-accessor-dependency.ts"),
       "foreignLabels",
@@ -113,25 +117,9 @@ describe("foreign dependency fixture", () => {
     );
     assert.match(
       output,
-      /foreign-labels c = \(each i in items c, item-ready i \| item-label i\)\./u,
+      /foreign-labels c = \(each item in items c, item-ready item \| item-label item\)\./u,
     );
-  });
-});
-
-describe("dogfood @pant annotations entail", () => {
-  it.skip("Patch 4: bindingNamesFromDeclarationList annotation is entailed", async () => {
-    const doc = await buildDocumentFromPath(
-      resolve(SRC, "translate-body.ts"),
-      "bindingNamesFromDeclarationList",
-    );
-    const output = await emitAndCheck(doc);
-
-    assert.match(
-      output,
-      /@pant all dl: ForeignVariableDeclarationList \| binding-names-from-declaration-list dl = \(each d in declarations dl, is-identifier \(name d\) \| identifier-text \(name d\)\)\./u,
-    );
-    const check = runCheck(output, { timeoutMs: PANT_TIMEOUT_MS });
-    assert.equal(check.status, 0);
+    assert.doesNotMatch(output, /typescript|VariableDeclaration|Identifier/u);
   });
 });
 
@@ -490,6 +478,11 @@ describe("dogfood: @pant annotations entail", () => {
     { file: "translate-types.ts", fn: "emptyRecordSynth", minChecks: 1 },
     { file: "translate-types.ts", fn: "emptyOpaqueSynth", minChecks: 3 },
     { file: "translate-types.ts", fn: "emptyForeignDomainSynth", minChecks: 2 },
+    {
+      file: "translate-body.ts",
+      fn: "bindingNamesFromDeclarationList",
+      minChecks: 1,
+    },
     { file: "translate-types.ts", fn: "lookupMapKV", minChecks: 1 },
     { file: "translate-types.ts", fn: "mapSynthKey", minChecks: 1 },
     { file: "translate-types.ts", fn: "fieldRuleName", minChecks: 1 },


### PR DESCRIPTION
## Patch 4: Dogfood bindingNamesFromDeclarationList body and annotation

- Implement the generic imported-dependency fixture test first, asserting the emitted accessors and Bool predicate guard do not mention TypeScript compiler API names.
- Promote the existing skeleton-only `bindingNamesFromDeclarationList` dogfood case to a full body translation/typecheck assertion.
- Assert the emitted document contains foreign domains for `VariableDeclarationList`, `VariableDeclaration`, and `Identifier` (or the exact TS API domains the checker exposes) plus typed accessor rules for `declarations`, `name`, and `text`.
- Assert the body is a guarded `each` comprehension over the accessor-backed declarations source.
- Add a `@pant` annotation on `bindingNamesFromDeclarationList` that states the comprehension/equation shape or another entailed property made true by the body, and include it in the dogfood `@pant annotations entail` table.
- Use the existing Bool predicate/free-call surface for dependency predicate calls, including `ts.isIdentifier(decl.name)`, as guards; do not add semantic axioms about what any library predicate means.
- Run targeted dogfood integration and full `npm test`.

## Changes
- Implement the generic imported-dependency fixture test first, asserting the emitted accessors and Bool predicate guard do not mention TypeScript compiler API names.
- Promote the existing skeleton-only `bindingNamesFromDeclarationList` dogfood case to a full body translation/typecheck assertion.
- Assert the emitted document contains foreign domains for `VariableDeclarationList`, `VariableDeclaration`, and `Identifier` (or the exact TS API domains the checker exposes) plus typed accessor rules for `declarations`, `name`, and `text`.
- Assert the body is a guarded `each` comprehension over the accessor-backed declarations source.
- Add a `@pant` annotation on `bindingNamesFromDeclarationList` that states the comprehension/equation shape or another entailed property made true by the body, and include it in the dogfood `@pant annotations entail` table.
- Use the existing Bool predicate/free-call surface for dependency predicate calls, including `ts.isIdentifier(decl.name)`, as guards; do not add semantic axioms about what any library predicate means.
- Run targeted dogfood integration and full `npm test`.

## Files to Modify
- tools/ts2pant/tests/fixtures/constructs/foreign-accessor-dependency.ts (modify): Use the generic imported-dependency fixture to prove shallow foreign accessor lowering is library-agnostic.
- tools/ts2pant/tests/fixtures/foreign-dependency (modify): Finalize the synthetic dependency declaration fixture if Patch 1 created only a pending/minimal version.
- tools/ts2pant/src/translate-body.ts (modify): Add a load-bearing `@pant` annotation to `bindingNamesFromDeclarationList` once its body lowers through foreign accessors.
- tools/ts2pant/tests/integration/dogfood.test.mts (modify): Unskip and implement body translation/typecheck and annotation entailment coverage for `bindingNamesFromDeclarationList`.
- tools/ts2pant/tests/integration/dogfood.test.mts.snapshot (modify): Update dogfood snapshots to include the full body emission for `bindingNamesFromDeclarationList`.

## Gameplan Specification

```
module TS2PANT_FOREIGN_ACCESSOR_BODY_LOWERING.

ForeignAccessor.
ForeignDependencyContainer.
ForeignDependencyItem.
ForeignVariableDeclarationList.
ForeignVariableDeclaration.
ForeignIdentifier.

accessor-emitted a: ForeignAccessor => Bool.
items c: ForeignDependencyContainer => [ForeignDependencyItem].
item-label i: ForeignDependencyItem => String.
item-ready i: ForeignDependencyItem => Bool.
foreign-labels c: ForeignDependencyContainer => [String].
declarations dl: ForeignVariableDeclarationList => [ForeignVariableDeclaration].
name d: ForeignVariableDeclaration => ForeignIdentifier.
identifier-text i: ForeignIdentifier => String.
is-identifier i: ForeignIdentifier => Bool.
binding-names-from-declaration-list dl: ForeignVariableDeclarationList => [String].
---
all a: ForeignAccessor | accessor-emitted a.
all c: ForeignDependencyContainer | foreign-labels c = (each i in items c, item-ready i | item-label i).
all dl: ForeignVariableDeclarationList | binding-names-from-declaration-list dl = (each d in declarations dl, is-identifier (name d) | identifier-text (name d)).
```

## Patch Specification

```
module TS2PANT_FOREIGN_ACCESSOR_BODY_LOWERING_PATCH_4.

ForeignDependencyContainer.
ForeignDependencyItem.
ForeignVariableDeclarationList.
ForeignVariableDeclaration.
ForeignIdentifier.

items c: ForeignDependencyContainer => [ForeignDependencyItem].
item-label i: ForeignDependencyItem => String.
item-ready i: ForeignDependencyItem => Bool.
foreign-labels c: ForeignDependencyContainer => [String].
declarations dl: ForeignVariableDeclarationList => [ForeignVariableDeclaration].
name d: ForeignVariableDeclaration => ForeignIdentifier.
identifier-text i: ForeignIdentifier => String.
is-identifier i: ForeignIdentifier => Bool.
binding-names-from-declaration-list dl: ForeignVariableDeclarationList => [String].
---
all c: ForeignDependencyContainer | foreign-labels c = (each i in items c, item-ready i | item-label i).
all dl: ForeignVariableDeclarationList | binding-names-from-declaration-list dl = (each d in declarations dl, is-identifier (name d) | identifier-text (name d)).
```


## Implementation Notes

- Declaration-file detection was generalized in `translate-types.ts`: any `.d.ts` source can now provide a foreign domain, not only `node_modules` or TypeScript lib paths. To avoid turning local fixture declarations into analyzed record/interface declarations, `extractReferencedTypes` now skips declaration files when collecting local referenced types.
- `ts.NodeArray<T>` is treated as a list-shaped foreign accessor return by recognizing the declaration-file `NodeArray` symbol and mapping its numeric index element type to `[T]`. This is intentionally narrow; other declaration-file array-like shapes are not inferred as lists yet.
- Namespace/property predicate calls such as `ts.isIdentifier(...)` are lowered through the existing free-call Bool surface. Predicate signatures with an `Identifier` type predicate also feed the narrowed target type into argument lowering, which is what lets `decl.name.text` lower through `ForeignIdentifier` instead of the wider `BindingName` union.
- For-of comprehension guard purity was relaxed only for Bool-returning declaration-file namespace calls. Local calls are still rejected by the existing side-effect guard, and no semantic axioms are emitted for dependency predicates.
- The synthetic fixture was renamed from `ForeignContainer`/`ForeignItem`-style names to `DependencyContainer`/`DependencyItem`, so the synthesized domains are exactly `ForeignDependencyContainer` and `ForeignDependencyItem` rather than double-prefixed `ForeignForeign...`.
- The dogfood snapshot file was not changed because these assertions use the current `emitAndCheck`/entailment harness rather than snapshot-backed expectations.

Spec/Evidence Mapping:
- Generic dependency accessor clause: implemented via declaration-file foreign-domain/accessor mapping in `translate-types.ts`, member/call lowering in `ir1-build.ts`, and the non-TypeScript fixture assertions in `dogfood.test.mts`.
- `bindingNamesFromDeclarationList` comprehension clause: implemented by reusing the existing for-of push recognizer in `translate-body.ts`; the body now emits `each decl in declarations decl-list, is-identifier (name decl) | identifier-text (name decl)`.
- Load-bearing annotation clause: implemented as the `@pant` annotation on `bindingNamesFromDeclarationList` and included in the main dogfood annotation entailment table.
- Verification run: targeted dogfood foreign-accessor tests, related unit tests, and full `cd tools/ts2pant && npm test` all passed before commit `d9d9fae9`.