### PR TITLE
[ts2pant-foreign-call-guard-admission] Patch 1: Fixtures + skipped stubs for foreign-call guard admission

### DIFF
--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -458,6 +458,26 @@ exports[`expressions-equality-nullish.ts > typeofUndefinedNeq 1`] = `
 "module TYPEOF_UNDEFINED_NEQ.\\n\\ntypeof-undefined-neq x: [Int] => Bool.\\n\\n---\\n\\ntypeof-undefined-neq x = (~(#x = 0)).\\n"
 `;
 
+exports[`expressions-foreign-call-predicate.ts > foreignCallCompoundPredicate 1`] = `
+"module FOREIGN_CALL_COMPOUND_PREDICATE.\\n\\nForeignDependencyItem.\\nforeign-call-compound-predicate item: ForeignDependencyItem => Int.\\n\\n---\\n\\n> UNSUPPORTED: foreign-call-compound-predicate — early-return predicate has side effects.\\n\\ncheck\\n\\nforeign-call-compound-predicate item = (cond is-labeled item or has-ready-flag item => 1, true => 0).\\n"
+`;
+
+exports[`expressions-foreign-call-predicate.ts > foreignCallEarlyReturn 1`] = `
+"module FOREIGN_CALL_EARLY_RETURN.\\n\\nForeignDependencyItem.\\nforeign-call-early-return item: ForeignDependencyItem => Int.\\n\\n---\\n\\n> UNSUPPORTED: foreign-call-early-return — early-return predicate has side effects.\\n\\ncheck\\n\\nforeign-call-early-return item = (cond is-labeled item => 1, true => 0).\\n"
+`;
+
+exports[`expressions-foreign-call-predicate.ts > foreignCallMutatingIf 1`] = `
+"module FOREIGN_CALL_MUTATING_IF.\\n\\nAccount.\\naccount--balance a: Account => Int.\\nForeignDependencyItem.\\n~> Foreign-call-mutating-if @ account: Account, item: ForeignDependencyItem.\\n\\n---\\n\\n> UNSUPPORTED: impure if-condition in mutating body.\\n"
+`;
+
+exports[`expressions-foreign-call-predicate.ts > foreignCallWhilePredicate 1`] = `
+"module FOREIGN_CALL_WHILE_PREDICATE.\\n\\nForeignDependencyItem.\\nforeign-call-while-predicate item: ForeignDependencyItem => Int.\\n\\n---\\n\\n> UNSUPPORTED: foreign-call-while-predicate — while-loop predicate has side effects.\\n"
+`;
+
+exports[`expressions-foreign-call-predicate.ts > foreignNonBoolCallPredicate 1`] = `
+"module FOREIGN_NON_BOOL_CALL_PREDICATE.\\n\\nForeignDependencyItem.\\nforeign-non-bool-call-predicate item: ForeignDependencyItem => Int.\\n\\n---\\n\\n> UNSUPPORTED: foreign-non-bool-call-predicate — early-return predicate has side effects.\\n"
+`;
+
 exports[`expressions-free-call-typed.ts > ambientAnyParam 1`] = `
 "module AMBIENT_ANY_PARAM.\\n\\nOpaque.\\nconsume-any x: Opaque => Int.\\nopaque-value  => Opaque.\\nambient-any-param  => Int.\\nopaque_value_36_0065_0078_0070_0072_0065_0073_0073_0069_006f_006e_0073_002d_0066_0072_0065_0065_002d_0063_0061_006c_006c_002d_0074_0079_0070_0065_0064_002e_0074_0073_003a_0032_0037_003a_0032_0031  => Opaque.\\n\\n---\\n\\nambient-any-param = consume-any opaque_value_36_0065_0078_0070_0072_0065_0073_0073_0069_006f_006e_0073_002d_0066_0072_0065_0065_002d_0063_0061_006c_006c_002d_0074_0079_0070_0065_0064_002e_0074_0073_003a_0032_0037_003a_0032_0031.\\n"
 `;

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-foreign-call-predicate.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-foreign-call-predicate.ts
@@ -1,0 +1,65 @@
+// @archlint.module exempt
+// @archlint.exempt-reason test-support
+
+import type { DependencyItem } from "../foreign-dependency/index.js";
+
+interface Account {
+  balance: number;
+}
+
+/**
+ * PENDING Patch 3: `item.isLabeled()` should lower as an uninterpreted Bool
+ * rule head (`is-labeled item`) used as the cond antecedent.
+ *
+ * @pant foreign-call-early-return item = cond is-labeled item => 1, true => 0.
+ */
+export function foreignCallEarlyReturn(item: DependencyItem): number {
+  if (item.isLabeled()) {
+    return 1;
+  }
+  return 0;
+}
+
+/**
+ * PENDING Patch 3: both declaration-file Bool method calls should lower as
+ * EUF Bool rule heads, with the disjunction used as the cond antecedent.
+ *
+ * @pant foreign-call-compound-predicate item = cond is-labeled item or has-ready-flag item => 1, true => 0.
+ */
+export function foreignCallCompoundPredicate(item: DependencyItem): number {
+  if (item.isLabeled() || item.hasReadyFlag()) {
+    return 1;
+  }
+  return 0;
+}
+
+/**
+ * PENDING Patch 3: the counter-dependent declaration-file Bool method call
+ * should be admitted at the pure μ-search predicate gate and lower as an EUF
+ * Bool rule head inside the bounded-search guard.
+ */
+export function foreignCallWhilePredicate(item: DependencyItem): number {
+  let i = 0;
+  while (item.hasIndex(i)) {
+    i++;
+  }
+  return i;
+}
+
+/** NEGATIVE Decision B: mutating conditions must not admit foreign Bool calls. */
+export function foreignCallMutatingIf(
+  account: Account,
+  item: DependencyItem,
+): void {
+  if (item.isLabeled()) {
+    account.balance = account.balance + 1;
+  }
+}
+
+/** NEGATIVE out of scope: non-Bool foreign value calls stay rejected. */
+export function foreignNonBoolCallPredicate(item: DependencyItem): number {
+  if (item.getLabel()) {
+    return 1;
+  }
+  return 0;
+}

--- a/tools/ts2pant/tests/fixtures/foreign-dependency/index.d.ts
+++ b/tools/ts2pant/tests/fixtures/foreign-dependency/index.d.ts
@@ -5,6 +5,10 @@ export interface DependencyContainer {
 export interface DependencyItem {
   readonly label: string;
   readonly ready: boolean;
+  isLabeled(): boolean;
+  hasReadyFlag(): boolean;
+  hasIndex(index: number): boolean;
+  getLabel(): string;
 }
 
 export declare function isReady(item: DependencyItem): boolean;

--- a/tools/ts2pant/tests/integration/dogfood.test.mts
+++ b/tools/ts2pant/tests/integration/dogfood.test.mts
@@ -121,6 +121,24 @@ describe("foreign dependency fixture", () => {
     );
     assert.doesNotMatch(output, /typescript|VariableDeclaration|Identifier/u);
   });
+
+  it.skip("PENDING Patch 3: foreign-call-predicate fixture @pant annotation is entailed", async () => {
+    const doc = await buildDocumentFromPath(
+      resolve(FIXTURES, "expressions-foreign-call-predicate.ts"),
+      "foreignCallEarlyReturn",
+    );
+    const output = await emitAndCheck(doc);
+    const result = runCheck(output, {
+      projectRoot: PROJECT_ROOT,
+      pantBin: getPantBin(),
+    });
+    const entailments = result.checks.filter((c) =>
+      c.message.startsWith("OK: Entailed:"),
+    );
+
+    assert.ok(entailments.length >= 1);
+    assert.ok(result.passed, `pant --check failed:\n${result.output}`);
+  });
 });
 
 describe("dogfood: src/translate-types.ts", () => {

--- a/tools/ts2pant/tests/known-typecheck-failures.mts
+++ b/tools/ts2pant/tests/known-typecheck-failures.mts
@@ -65,6 +65,18 @@ export const KNOWN_TYPECHECK_FAILURES = new Map<string, string>([
   ["expressions-boolean.ts > or", "$-binder-leak"],
   ["expressions-discriminated-union.ts > ambiguousOwner", "ambiguous-owner"],
   [
+    "expressions-foreign-call-predicate.ts > foreignCallEarlyReturn",
+    "foreign-call-predicate",
+  ],
+  [
+    "expressions-foreign-call-predicate.ts > foreignCallCompoundPredicate",
+    "foreign-call-predicate",
+  ],
+  [
+    "expressions-foreign-call-predicate.ts > foreignCallWhilePredicate",
+    "foreign-call-predicate",
+  ],
+  [
     "expressions-let-closure-captured.ts > letForEachCapturedTotal",
     "closure-captured-reassignment",
   ],

--- a/tools/ts2pant/tests/purity.test.mts
+++ b/tools/ts2pant/tests/purity.test.mts
@@ -447,6 +447,41 @@ describe("isKnownPureCall", () => {
 });
 
 describe("isEffectFree", () => {
+  it.skip("PENDING Patch 2: effect oracle admits a declaration-file bool call under admitForeignBoolPredicates", () => {
+    const sf = createSourceFile(
+      resolve(
+        import.meta.dirname,
+        "fixtures/constructs/expressions-foreign-call-predicate.ts",
+      ),
+    );
+    const checker = getChecker(sf);
+    const call = findCallInNamedFunction(
+      sf.compilerNode,
+      "foreignCallEarlyReturn",
+    );
+
+    assert.equal(
+      isEffectFree(call, checker, { admitForeignBoolPredicates: true }),
+      true,
+    );
+  });
+
+  it.skip("PENDING Patch 2: effect oracle keeps a declaration-file bool call effectful by default", () => {
+    const sf = createSourceFile(
+      resolve(
+        import.meta.dirname,
+        "fixtures/constructs/expressions-foreign-call-predicate.ts",
+      ),
+    );
+    const checker = getChecker(sf);
+    const call = findCallInNamedFunction(
+      sf.compilerNode,
+      "foreignCallEarlyReturn",
+    );
+
+    assert.equal(isEffectFree(call, checker), false);
+  });
+
   it("treats known-pure builtin calls as effect-free", () => {
     assert.equal(
       checkEffectFree(`

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -2,10 +2,14 @@
 // @archlint.domain ts2pant.translate-body
 
 import assert from "node:assert/strict";
+import { resolve } from "node:path";
 import { before, describe, it } from "node:test";
 import * as fc from "fast-check";
 import ts from "typescript";
-import { createSourceFileFromSource } from "../src/extract.js";
+import {
+  createSourceFile,
+  createSourceFileFromSource,
+} from "../src/extract.js";
 import { getAst, loadAst } from "../src/pant-wasm.js";
 import * as Supply from "../src/supply.js";
 import * as TB from "../src/translate-body.js";
@@ -651,6 +655,28 @@ describe("unsupported patterns", () => {
 });
 
 describe("if-early-return prelude arms", () => {
+  it.skip("PENDING Patch 3: foreign bool call in early-return predicate lowers to its EUF rule", () => {
+    const sourceFile = createSourceFile(
+      resolve(
+        import.meta.dirname,
+        "fixtures/constructs/expressions-foreign-call-predicate.ts",
+      ),
+    );
+
+    const admitted = translateBodyWithSynth(sourceFile, "foreignCallEarlyReturn");
+    assert.equal(
+      getAst().strExpr(finalEquation(admitted).rhs),
+      "cond is-labeled item => 1, true => 0",
+    );
+
+    const rejected = translateBodyWithSynth(sourceFile, "foreignCallMutatingIf");
+    assertUnsupportedReason(
+      rejected,
+      /impure if-condition in mutating body/u,
+      "foreign bool mutating if-condition",
+    );
+  });
+
   it("translates a single early-return arm followed by a return", () => {
     const source = `
       export function f(n: number): number {


### PR DESCRIPTION
## Patch 1: Fixtures + skipped stubs for foreign-call guard admission

- Introduce pending/skipped tests and fixtures only; no production behavior change.
- Name each pending test with the patch that implements it.
- Keep the negative cases (mutating-if foreign condition; non-bool foreign call) as fixtures that must remain rejected.
- Document expected emitted shape in comments: an uninterpreted Bool rule head for the predicate, used as a cond antecedent.

## Changes
- Introduce pending/skipped tests and fixtures only; no production behavior change.
- Name each pending test with the patch that implements it.
- Keep the negative cases (mutating-if foreign condition; non-bool foreign call) as fixtures that must remain rejected.
- Document expected emitted shape in comments: an uninterpreted Bool rule head for the predicate, used as a cond antecedent.

## Files to Modify
- tools/ts2pant/tests/fixtures/foreign-dependency/index.d.ts (modify): Add a declaration-file boolean predicate to a dependency interface (e.g. an `isLabeled(): boolean` method on `DependencyItem`, and/or a bool-returning namespaced/property-access function) so fixture calls are property-access form matching `isBoolReturningDeclarationFileCall`.
- tools/ts2pant/tests/fixtures/constructs/expressions-foreign-call-predicate.ts (create): Pure functions whose early-return predicate is a declaration-file bool call (single + compound `||`); a μ-search/bounded-while variant if expressible; a NEGATIVE mutating function with a foreign-call if-condition (must stay rejected, Decision B); and a NEGATIVE non-bool foreign call in predicate position (out of scope). Mirror expressions-pure-call-predicate.ts.
- tools/ts2pant/tests/purity.test.mts (modify): Add skipped stubs (PENDING Patch 2) asserting the oracle admits a declaration-file bool call under `admitForeignBoolPredicates` and keeps it effectful by default.
- tools/ts2pant/tests/translate-body.test.mts (modify): Add a skipped stub (PENDING Patch 3) asserting a foreign bool call in an early-return predicate lowers to its EUF rule and that a mutating-if foreign condition still rejects.
- tools/ts2pant/tests/integration/dogfood.test.mts (modify): Add a skipped stub (PENDING Patch 3) expecting the foreign-call-predicate fixture to translate, typecheck, and carry an entailed @pant annotation.
- tools/ts2pant/tests/known-typecheck-failures.mts (modify): Register the positive foreign-call-predicate fixture under a new `foreign-call-predicate` tag (cleared in Patch 3).

## Gameplan Specification

```
module TS2PANT_FOREIGN_CALL_GUARD_ADMISSION.

> A declaration-file boolean call in a pure-rule predicate position is
> reclassified from effectful to effect-free and modeled as an
> uninterpreted Bool rule application; the reclassification is trusted
> only in pure-rule contexts. Mutating-context gates are unchanged.

Call.
Context.

declaration-file-bool-call? e: Call => Bool.
receiver-and-args-pure? e: Call => Bool.
pure-rule-position? c: Context => Bool.
mutating-condition? c: Context => Bool.
effect-free-in? e: Call, c: Context => Bool.
admitted-in? e: Call, c: Context => Bool.
lowers-to-euf-rule? e: Call => Bool.

---

> Decision A: in a pure-rule position (predicate/bool-value/guard), a declaration-file bool
> call whose receiver/args are pure is effect-free and admitted.
all e: Call, c: Context | declaration-file-bool-call? e and receiver-and-args-pure? e and pure-rule-position? c -> effect-free-in? e c and admitted-in? e c.
> An admitted call lowers to its uninterpreted Bool rule-head application.
all e: Call | declaration-file-bool-call? e -> lowers-to-euf-rule? e.
> Decision B: mutating-condition contexts are unchanged — the call stays
> effectful, so no real mutation is dropped.
all e: Call, c: Context | declaration-file-bool-call? e and mutating-condition? c -> ~ effect-free-in? e c.
```

## Patch Specification

```
module TS2PANT_FOREIGN_CALL_GUARD_ADMISSION_PATCH_1.

TestStub.
introduced s: TestStub => Bool.
---
all s: TestStub | introduced s.
```


## Implementation Notes

- The synthetic dependency fixture now exposes declaration-file methods on `DependencyItem` rather than adding new bare functions. This keeps all new positive cases on the property-access callee path that later patches are expected to admit/lower.
- The new construct fixture intentionally snapshots current rejection output for the positive cases. The `@pant` annotations are still emitted in the check block beside the unsupported body, giving Patch 3 exact expected shapes to make entailed once the predicates lower.
- Positive known-typecheck-failure entries were added only for the three pure-rule cases: single early return, compound early return, and while/μ-search. The mutating-if and non-bool predicate fixtures are not allowlisted because they should remain deliberate unsupported outputs.
- One minor extension beyond the minimum fixture dependency shape: `DependencyItem.getLabel(): string` was added solely to express the non-bool foreign-call negative case as the same property-access form as the bool predicates.

Spec/Evidence Mapping:
- `introduced s`: skipped stubs were added in `purity.test.mts`, `translate-body.test.mts`, and `integration/dogfood.test.mts`; the construct fixture is auto-discovered by `constructs.test.mts`.
- Negative mutating-context invariant: `foreignCallMutatingIf` snapshots `impure if-condition in mutating body`, proving this patch does not loosen mutating gates.
- Negative non-bool invariant: `foreignNonBoolCallPredicate` snapshots the current early-return side-effect rejection, preserving the out-of-scope non-bool call behavior.
- Required context consulted: the existing foreign dependency fixture, the pure-call-predicate fixture, and the construct/purity/translate-body/dogfood harnesses.
- Verification run: `just ts2pant-precommit` passed, including Biome, `tsc --noEmit`, WASM build, unit tests, and integration tests.