### PR TITLE
[ts2pant-foreign-call-guard-admission] Patch 2: Canonical foreign-bool-call detector + dormant admitForeignBoolPredicates oracle option

### DIFF
--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -101,7 +101,11 @@ import {
 import { contagiousOpaque, isOpaqueExpr, OPAQUE_DOMAIN } from "./opaque.js";
 import type { OpaqueExpr } from "./pant-ast.js";
 import { getAst } from "./pant-wasm.js";
-import { isStaticallyBoolTyped } from "./purity.js";
+import {
+  isBoolReturningDeclarationFileCall,
+  isDeclarationFileCallableSymbol,
+  isStaticallyBoolTyped,
+} from "./purity.js";
 import {
   freshHygienicBinder,
   freshSyntheticOrigin,
@@ -199,50 +203,6 @@ function registerSynthesizedValueForOrigin(
 
 function isDynamicTsType(type: ts.Type): boolean {
   return (type.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0;
-}
-
-function isDeclarationFileCallableSymbol(
-  symbol: ts.Symbol | undefined,
-  checker: ts.TypeChecker,
-): boolean {
-  if (symbol === undefined) {
-    return false;
-  }
-  const resolved =
-    symbol.flags & ts.SymbolFlags.Alias
-      ? checker.getAliasedSymbol(symbol)
-      : symbol;
-  return (resolved.getDeclarations() ?? []).some((decl) => {
-    const sf = decl.getSourceFile();
-    return (
-      sf.isDeclarationFile &&
-      (ts.isFunctionDeclaration(decl) || ts.isMethodSignature(decl))
-    );
-  });
-}
-
-function isBoolReturningDeclarationFileCall(
-  expr: ts.CallExpression,
-  checker: ts.TypeChecker,
-): boolean {
-  if (!ts.isPropertyAccessExpression(expr.expression)) {
-    return false;
-  }
-  if (
-    !isDeclarationFileCallableSymbol(
-      checker.getSymbolAtLocation(expr.expression.name),
-      checker,
-    )
-  ) {
-    return false;
-  }
-  const returnType = checker.getResolvedSignature(expr)?.getReturnType();
-  return (
-    returnType !== undefined &&
-    (returnType.flags &
-      (ts.TypeFlags.Boolean | ts.TypeFlags.BooleanLiteral)) !==
-      0
-  );
 }
 
 function narrowedSortForUse(

--- a/tools/ts2pant/src/purity.ts
+++ b/tools/ts2pant/src/purity.ts
@@ -449,12 +449,19 @@ export function isBoolReturningDeclarationFileCall(
     return false;
   }
   const returnType = checker.getResolvedSignature(expr)?.getReturnType();
-  return (
-    returnType !== undefined &&
+  if (
+    returnType === undefined ||
     (returnType.flags &
-      (ts.TypeFlags.Boolean | ts.TypeFlags.BooleanLiteral)) !==
+      (ts.TypeFlags.Boolean | ts.TypeFlags.BooleanLiteral)) ===
       0
-  );
+  ) {
+    return false;
+  }
+  return isPredicateLikeDeclarationFileBoolCallName(expr.expression.name.text);
+}
+
+function isPredicateLikeDeclarationFileBoolCallName(name: string): boolean {
+  return /^(is|has)[A-Z_]/.test(name);
 }
 
 /**

--- a/tools/ts2pant/src/purity.ts
+++ b/tools/ts2pant/src/purity.ts
@@ -409,6 +409,54 @@ const EFFECT_PURE_EXPORTS: ReadonlyMap<string, ReadonlySet<string>> = new Map([
 // Public API
 // ---------------------------------------------------------------------------
 
+export interface EffectOracleOptions {
+  admitForeignBoolPredicates?: boolean;
+}
+
+export function isDeclarationFileCallableSymbol(
+  symbol: ts.Symbol | undefined,
+  checker: ts.TypeChecker,
+): boolean {
+  if (symbol === undefined) {
+    return false;
+  }
+  const resolved =
+    symbol.flags & ts.SymbolFlags.Alias
+      ? checker.getAliasedSymbol(symbol)
+      : symbol;
+  return (resolved.getDeclarations() ?? []).some((decl) => {
+    const sf = decl.getSourceFile();
+    return (
+      sf.isDeclarationFile &&
+      (ts.isFunctionDeclaration(decl) || ts.isMethodSignature(decl))
+    );
+  });
+}
+
+export function isBoolReturningDeclarationFileCall(
+  expr: ts.CallExpression,
+  checker: ts.TypeChecker,
+): boolean {
+  if (!ts.isPropertyAccessExpression(expr.expression)) {
+    return false;
+  }
+  if (
+    !isDeclarationFileCallableSymbol(
+      checker.getSymbolAtLocation(expr.expression.name),
+      checker,
+    )
+  ) {
+    return false;
+  }
+  const returnType = checker.getResolvedSignature(expr)?.getReturnType();
+  return (
+    returnType !== undefined &&
+    (returnType.flags &
+      (ts.TypeFlags.Boolean | ts.TypeFlags.BooleanLiteral)) !==
+      0
+  );
+}
+
 /**
  * Determine whether a call expression is known to be pure (no side effects).
  *
@@ -624,8 +672,9 @@ export function isPureUserFunction(
 export function isEffectFree(
   expr: ts.Expression,
   checker: ts.TypeChecker,
+  options: EffectOracleOptions = {},
 ): boolean {
-  return !expressionHasSideEffects(expr, checker);
+  return !expressionHasSideEffects(expr, checker, options);
 }
 
 /**
@@ -636,6 +685,7 @@ export function isEffectFree(
 export function expressionHasSideEffects(
   expr: ts.Expression,
   checker: ts.TypeChecker,
+  options: EffectOracleOptions = {},
 ): boolean {
   expr = unwrapEffectExpression(expr);
 
@@ -646,19 +696,32 @@ export function expressionHasSideEffects(
   if (ts.isBinaryExpression(expr)) {
     return (
       isAssignmentOperator(expr.operatorToken.kind) ||
-      expressionHasSideEffects(expr.left, checker) ||
-      expressionHasSideEffects(expr.right, checker)
+      expressionHasSideEffects(expr.left, checker, options) ||
+      expressionHasSideEffects(expr.right, checker, options)
     );
   }
 
   if (ts.isCallExpression(expr)) {
+    if (
+      options.admitForeignBoolPredicates === true &&
+      canAdmitForeignBoolPredicate(expr, checker)
+    ) {
+      return (
+        expressionHasSideEffects(expr.expression, checker, options) ||
+        expr.arguments.some((arg) =>
+          expressionHasSideEffects(arg, checker, options),
+        )
+      );
+    }
     if (isKnownPureCall(expr, checker)) {
       // Known-pure callees still require pure receiver/callee and arguments:
       // e.g. `makeString().trim()` matches the String method allowlist, but
       // the receiver call itself has unknown effects.
       return (
-        expressionHasSideEffects(expr.expression, checker) ||
-        expr.arguments.some((arg) => expressionHasSideEffects(arg, checker))
+        expressionHasSideEffects(expr.expression, checker, options) ||
+        expr.arguments.some((arg) =>
+          expressionHasSideEffects(arg, checker, options),
+        )
       );
     }
     return true;
@@ -673,15 +736,28 @@ export function expressionHasSideEffects(
     return (
       op === ts.SyntaxKind.PlusPlusToken ||
       op === ts.SyntaxKind.MinusMinusToken ||
-      expressionHasSideEffects(expr.operand, checker)
+      expressionHasSideEffects(expr.operand, checker, options)
     );
   }
 
   return (
     ts.forEachChild(expr, (child) =>
-      ts.isExpression(child) ? expressionHasSideEffects(child, checker) : false,
+      ts.isExpression(child)
+        ? expressionHasSideEffects(child, checker, options)
+        : false,
     ) ?? false
   );
+}
+
+function canAdmitForeignBoolPredicate(
+  expr: ts.CallExpression,
+  checker: ts.TypeChecker,
+): boolean {
+  try {
+    return isBoolReturningDeclarationFileCall(expr, checker);
+  } catch {
+    return false;
+  }
 }
 
 function unwrapEffectExpression(expr: ts.Expression): ts.Expression {

--- a/tools/ts2pant/src/purity.ts
+++ b/tools/ts2pant/src/purity.ts
@@ -461,7 +461,7 @@ export function isBoolReturningDeclarationFileCall(
 }
 
 function isPredicateLikeDeclarationFileBoolCallName(name: string): boolean {
-  return /^(is|has)[A-Z_]/.test(name);
+  return /^(?:is|has)(?:[A-Z_]|$)/.test(name);
 }
 
 /**

--- a/tools/ts2pant/tests/purity.test.mts
+++ b/tools/ts2pant/tests/purity.test.mts
@@ -14,6 +14,7 @@ import {
 import { getAst, loadAst } from "../src/pant-wasm.js";
 import {
   expressionHasSideEffects,
+  isBoolReturningDeclarationFileCall,
   isEffectFree,
   isKnownPureCall,
   isPureUserCall,
@@ -493,6 +494,16 @@ describe("isEffectFree", () => {
       isEffectFree(call, checker, { admitForeignBoolPredicates: true }),
       false,
     );
+  });
+
+  it("recognizes exact declaration-file has predicates", () => {
+    const sf = createSourceFileFromSource(`
+      function f(xs: Set<string>, value: string) { return xs.has(value); }
+    `);
+    const checker = getChecker(sf);
+    const call = findCallInNamedFunction(sf.compilerNode, "f");
+
+    assert.equal(isBoolReturningDeclarationFileCall(call, checker), true);
   });
 
   it("treats known-pure builtin calls as effect-free", () => {

--- a/tools/ts2pant/tests/purity.test.mts
+++ b/tools/ts2pant/tests/purity.test.mts
@@ -447,7 +447,7 @@ describe("isKnownPureCall", () => {
 });
 
 describe("isEffectFree", () => {
-  it.skip("PENDING Patch 2: effect oracle admits a declaration-file bool call under admitForeignBoolPredicates", () => {
+  it("admits a declaration-file bool call under admitForeignBoolPredicates", () => {
     const sf = createSourceFile(
       resolve(
         import.meta.dirname,
@@ -466,7 +466,7 @@ describe("isEffectFree", () => {
     );
   });
 
-  it.skip("PENDING Patch 2: effect oracle keeps a declaration-file bool call effectful by default", () => {
+  it("keeps a declaration-file bool call effectful by default", () => {
     const sf = createSourceFile(
       resolve(
         import.meta.dirname,

--- a/tools/ts2pant/tests/purity.test.mts
+++ b/tools/ts2pant/tests/purity.test.mts
@@ -482,6 +482,19 @@ describe("isEffectFree", () => {
     assert.equal(isEffectFree(call, checker), false);
   });
 
+  it("does not admit declaration-file boolean mutators", () => {
+    const sf = createSourceFileFromSource(`
+      function f(xs: Set<string>, value: string) { return xs.delete(value); }
+    `);
+    const checker = getChecker(sf);
+    const call = findCallInNamedFunction(sf.compilerNode, "f");
+
+    assert.equal(
+      isEffectFree(call, checker, { admitForeignBoolPredicates: true }),
+      false,
+    );
+  });
+
   it("treats known-pure builtin calls as effect-free", () => {
     assert.equal(
       checkEffectFree(`


### PR DESCRIPTION
## Patch 2: Canonical foreign-bool-call detector + dormant admitForeignBoolPredicates oracle option

- Define `EffectOracleOptions` and thread it through the full recursive walk so compound predicates are admitted whole.
- Make the relocated detector the single canonical home; preserve its exact predicate (property-access callee, declaration-file callable symbol, boolean return type).
- Verify no caller passes the option yet (dormant) and confirm no constructs snapshot changes.
- Preserve the oracle's try/catch-to-effectful fallback.

## Changes
- Define `EffectOracleOptions` and thread it through the full recursive walk so compound predicates are admitted whole.
- Make the relocated detector the single canonical home; preserve its exact predicate (property-access callee, declaration-file callable symbol, boolean return type).
- Verify no caller passes the option yet (dormant) and confirm no constructs snapshot changes.
- Preserve the oracle's try/catch-to-effectful fallback.

## Files to Modify
- tools/ts2pant/src/purity.ts (modify): Relocate `isBoolReturningDeclarationFileCall` + `isDeclarationFileCallableSymbol` here and export them. Add `EffectOracleOptions { admitForeignBoolPredicates?: boolean }`; thread it through `expressionHasSideEffects` (and `isEffectFree`). In the call branch, when the option is set and `isBoolReturningDeclarationFileCall` matches, treat the callee as effect-free but still recurse into receiver/args under the same options. Option absent ⇒ byte-identical to today.
- tools/ts2pant/src/ir1-build.ts (modify): Delete the local detector definitions; import `isBoolReturningDeclarationFileCall` / `isDeclarationFileCallableSymbol` from purity.ts. No change to the lowering logic at 1150/1373.
- tools/ts2pant/tests/purity.test.mts (modify): Unskip and implement the two oracle-option stubs from Patch 1.

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[paper] Kroening & Strichman, Decision Procedures Ch. 4 (Equality with Uninterpreted Functions)** — https://www.decision-procedures.org/ — The admitted foreign bool call lowers to an uninterpreted-function application whose only built-in axiom is congruence; this is why classifying it effect-free for modeling purposes introduces no unsound value assertion. Informs the soundness framing of the oracle option.

## Gameplan Specification

```
module TS2PANT_FOREIGN_CALL_GUARD_ADMISSION.

> A declaration-file boolean call in a pure-rule predicate position is
> reclassified from effectful to effect-free and modeled as an
> uninterpreted Bool rule application; the reclassification is trusted
> only in pure-rule contexts. Mutating-context gates are unchanged.

Call.
Context.

declaration-file-bool-call? e: Call => Bool.
receiver-and-args-pure? e: Call => Bool.
pure-rule-position? c: Context => Bool.
mutating-condition? c: Context => Bool.
effect-free-in? e: Call, c: Context => Bool.
admitted-in? e: Call, c: Context => Bool.
lowers-to-euf-rule? e: Call => Bool.

---

> Decision A: in a pure-rule position (predicate/bool-value/guard), a declaration-file bool
> call whose receiver/args are pure is effect-free and admitted.
all e: Call, c: Context | declaration-file-bool-call? e and receiver-and-args-pure? e and pure-rule-position? c -> effect-free-in? e c and admitted-in? e c.
> An admitted call lowers to its uninterpreted Bool rule-head application.
all e: Call | declaration-file-bool-call? e -> lowers-to-euf-rule? e.
> Decision B: mutating-condition contexts are unchanged — the call stays
> effectful, so no real mutation is dropped.
all e: Call, c: Context | declaration-file-bool-call? e and mutating-condition? c -> ~ effect-free-in? e c.
```

## Patch Specification

```
module TS2PANT_FOREIGN_CALL_GUARD_ADMISSION_PATCH_2.

Call.

declaration-file-bool-call? c: Call => Bool.
admit-foreign? => Bool.
effect-free? c: Call => Bool.
receiver-and-args-pure? c: Call => Bool.
---
> Dormant: with admission off, a declaration-file bool call is not
> treated as effect-free (default behavior unchanged).
all c: Call | ~ admit-foreign? and declaration-file-bool-call? c -> ~ effect-free? c.
> With admission on, it is effect-free exactly when its receiver and
> arguments are pure.
all c: Call | admit-foreign? and declaration-file-bool-call? c and receiver-and-args-pure? c -> effect-free? c.
```


## Implementation Notes

- The new option is intentionally dormant in production: `admitForeignBoolPredicates` appears only in `purity.ts` and the two unit tests. No source call site passes it yet, so Patch 3 can opt in only at the pure-rule gates.
- The declaration-file Bool detector was moved from `ir1-build.ts` into `purity.ts`: property-access callee only, symbol resolves to a declaration-file `FunctionDeclaration` or `MethodSignature`, and resolved return type has `Boolean` or `BooleanLiteral` flags. In response to review, it now also requires a predicate-like property name (`is*`, `has*`, or exact `is`/`has`) so Boolean-returning declaration-file mutators such as `Set.prototype.delete` and `Map.prototype.delete` are not admitted. `ir1-build.ts` imports the exported detector, so the oracle admission path and existing EUF lowering path share the same predicate.
- The option is threaded through every recursive `expressionHasSideEffects` call. For an admitted foreign Bool call, the call itself is considered effect-free, but the callee expression and all arguments are still checked under the same options. This is what lets compound predicates become effect-free without admitting effectful receiver/argument evaluation.
- The checker-dependent admission probe is wrapped in `canAdmitForeignBoolPredicate`; checker failures fail closed to effectful. Existing default behavior is unchanged when the option is absent.
- I did not remove or redirect `translate-body.ts`’s existing `isBoolDeclarationFileNamespaceCall` for-of special case. The gameplan assigns unifying that gate to Patch 3, and doing it here would have made this patch non-dormant.

Spec/Evidence Mapping:
- Patch dormant/default-off clause: implemented by the default `{}` option in `isEffectFree` / `expressionHasSideEffects`; proved by `purity.test.mts` “keeps a declaration-file bool call effectful by default”.
- Admission-on clause: implemented in the call-expression branch of `expressionHasSideEffects` via `canAdmitForeignBoolPredicate` plus recursive callee/argument checks; proved by `purity.test.mts` “admits a declaration-file bool call under admitForeignBoolPredicates”. The mutator exclusion is covered by “does not admit declaration-file boolean mutators”.
- No snapshot/translation behavior change: no production caller passes the option; `npm run test:unit:constructs` passed with no snapshot updates.
- Additional checks run: `npx tsc --noEmit`, focused `tests/purity.test.mts`, `npm run test:unit:rest`, and `tests/integration/dogfood.test.mts`.