### PR TITLE
[ts2pant-foreign-call-guard-admission] Patch 3: Admit foreign bool predicates at the pure-rule predicate gates

### DIFF
--- a/tools/ts2pant/src/extract.ts
+++ b/tools/ts2pant/src/extract.ts
@@ -1072,6 +1072,7 @@ function isCallableDeclaration(d: ts.Declaration): boolean {
   return (
     ts.isFunctionDeclaration(d) ||
     ts.isMethodDeclaration(d) ||
+    ts.isMethodSignature(d) ||
     ts.isFunctionExpression(d) ||
     ts.isArrowFunction(d) ||
     ts.isVariableDeclaration(d)
@@ -1084,6 +1085,9 @@ function isNamedCallableDeclaration(d: ts.Declaration): boolean {
   }
   if (ts.isMethodDeclaration(d)) {
     return d.name !== undefined && ts.isIdentifier(d.name);
+  }
+  if (ts.isMethodSignature(d)) {
+    return ts.isIdentifier(d.name);
   }
   if (ts.isVariableDeclaration(d)) {
     return ts.isIdentifier(d.name);
@@ -1100,6 +1104,9 @@ function declarationName(d: ts.Declaration): string | null {
     d.name !== undefined &&
     ts.isIdentifier(d.name)
   ) {
+    return d.name.text;
+  }
+  if (ts.isMethodSignature(d) && ts.isIdentifier(d.name)) {
     return d.name.text;
   }
   if (ts.isVariableDeclaration(d) && ts.isIdentifier(d.name)) {
@@ -1152,6 +1159,17 @@ function translateReferencedCallable(
   }
   const predicate = checker.getTypePredicateOfSignature(sig);
   const params: { name: string; type: string }[] = [];
+  if (ts.isMethodSignature(decl)) {
+    const receiverType = checker.getTypeAtLocation(decl.parent);
+    const mapped = mapTsType(receiverType, checker, strategy, synthCell);
+    if (!mapped.ok) {
+      return null;
+    }
+    const pantName = synthCell
+      ? cellRegisterName(synthCell, "receiver")
+      : "receiver";
+    params.push({ name: pantName, type: mapped.sort });
+  }
   for (const [index, param] of sig.getParameters().entries()) {
     const paramDecl = param.valueDeclaration ?? decl;
     const paramType =

--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -1336,6 +1336,23 @@ export function tryBuildL1PureSubExpression(
         ) {
           callee = ir1Var(toPantTermName(expr.expression.name.text));
           args = [];
+          const calleeDecls =
+            calleeSymbol === undefined
+              ? []
+              : calleeSymbol.flags & ts.SymbolFlags.Alias
+                ? (ctx.checker.getAliasedSymbol(calleeSymbol).declarations ??
+                  [])
+                : (calleeSymbol.declarations ?? []);
+          if (calleeDecls.some((decl) => ts.isMethodSignature(decl))) {
+            const receiver = tryBuildL1PureSubExpression(
+              expr.expression.expression,
+              ctx,
+            );
+            if (receiver === null || isL1Unsupported(receiver)) {
+              return receiver;
+            }
+            args.push(receiver);
+          }
           const signature = ctx.checker.getResolvedSignature(expr);
           const predicate = signature
             ? ctx.checker.getTypePredicateOfSignature(signature)

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -2011,8 +2011,9 @@ export function recognizeForOfPush(
       return null;
     }
     if (
-      expressionHasSideEffects(guardExpr, ctx.checker) &&
-      !isBoolDeclarationFileNamespaceCall(guardExpr, ctx.checker)
+      !isEffectFree(guardExpr, ctx.checker, {
+        admitForeignBoolPredicates: true,
+      })
     ) {
       return null;
     }
@@ -2068,36 +2069,6 @@ function buildPureL1OrNull(
     return null;
   }
   return built;
-}
-
-function isBoolDeclarationFileNamespaceCall(
-  expr: ts.Expression,
-  checker: ts.TypeChecker,
-): boolean {
-  if (
-    !ts.isCallExpression(expr) ||
-    !ts.isPropertyAccessExpression(expr.expression)
-  ) {
-    return false;
-  }
-  const sig = checker.getResolvedSignature(expr);
-  const returnType = sig?.getReturnType();
-  if (
-    returnType === undefined ||
-    (returnType.flags &
-      (ts.TypeFlags.Boolean | ts.TypeFlags.BooleanLiteral)) ===
-      0
-  ) {
-    return false;
-  }
-  const symbol = checker.getSymbolAtLocation(expr.expression.name);
-  const resolved =
-    symbol && symbol.flags & ts.SymbolFlags.Alias
-      ? checker.getAliasedSymbol(symbol)
-      : symbol;
-  return (resolved?.getDeclarations() ?? []).some(
-    (decl) => decl.getSourceFile().isDeclarationFile,
-  );
 }
 
 interface RecognizedPushBody {
@@ -2979,7 +2950,11 @@ function lowerPreludeBindings(
       if (expressionHasSideEffects(binding.mu.initTsExpr, checker)) {
         return { error: "while-loop init has side effects" };
       }
-      if (expressionHasSideEffects(binding.mu.predicateTsExpr, checker)) {
+      if (
+        expressionHasSideEffects(binding.mu.predicateTsExpr, checker, {
+          admitForeignBoolPredicates: true,
+        })
+      ) {
         return { error: "while-loop predicate has side effects" };
       }
       if (expressionReferencesNames(binding.mu.initTsExpr, blockedNames)) {
@@ -2996,7 +2971,11 @@ function lowerPreludeBindings(
       // to bindings declared after this point. The arm itself binds nothing,
       // so `blockedNames` here just contains the names of later const /
       // μ-search bindings (earlyReturn entries contribute nothing).
-      if (expressionHasSideEffects(binding.predicateExpr, checker)) {
+      if (
+        expressionHasSideEffects(binding.predicateExpr, checker, {
+          admitForeignBoolPredicates: true,
+        })
+      ) {
         return { error: "early-return predicate has side effects" };
       }
       for (const [blockIdx, blockBinding] of binding.blockBindings.entries()) {
@@ -3021,7 +3000,11 @@ function lowerPreludeBindings(
           };
         }
       }
-      if (expressionHasSideEffects(binding.valueExpr, checker)) {
+      if (
+        expressionHasSideEffects(binding.valueExpr, checker, {
+          admitForeignBoolPredicates: true,
+        })
+      ) {
         return { error: "early-return value has side effects" };
       }
       if (expressionReferencesNames(binding.predicateExpr, blockedNames)) {

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -459,7 +459,7 @@ exports[`expressions-equality-nullish.ts > typeofUndefinedNeq 1`] = `
 `;
 
 exports[`expressions-foreign-call-predicate.ts > foreignCallBoolValue 1`] = `
-"module FOREIGN_CALL_BOOL_VALUE.\\n\\nForeignDependencyItem.\\nhas-ready-flag receiver: ForeignDependencyItem => Bool.\\nis-labeled receiver1: ForeignDependencyItem => Bool.\\nforeign-call-bool-value item: ForeignDependencyItem => Bool.\\n\\n---\\n\\nforeign-call-bool-value item = (cond has-ready-flag item => is-labeled item, true => false).\\n\\ncheck\\n\\nforeign-call-bool-value item <-> is-labeled item.\\n"
+"module FOREIGN_CALL_BOOL_VALUE.\\n\\nForeignDependencyItem.\\nhas-ready-flag receiver: ForeignDependencyItem => Bool.\\nis-labeled receiver1: ForeignDependencyItem => Bool.\\nforeign-call-bool-value item: ForeignDependencyItem => Bool.\\n\\n---\\n\\nforeign-call-bool-value item = (cond has-ready-flag item => is-labeled item, true => false).\\n\\ncheck\\n\\nforeign-call-bool-value item <-> has-ready-flag item and is-labeled item.\\n"
 `;
 
 exports[`expressions-foreign-call-predicate.ts > foreignCallCompoundPredicate 1`] = `

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -458,12 +458,16 @@ exports[`expressions-equality-nullish.ts > typeofUndefinedNeq 1`] = `
 "module TYPEOF_UNDEFINED_NEQ.\\n\\ntypeof-undefined-neq x: [Int] => Bool.\\n\\n---\\n\\ntypeof-undefined-neq x = (~(#x = 0)).\\n"
 `;
 
+exports[`expressions-foreign-call-predicate.ts > foreignCallBoolValue 1`] = `
+"module FOREIGN_CALL_BOOL_VALUE.\\n\\nForeignDependencyItem.\\nhas-ready-flag receiver: ForeignDependencyItem => Bool.\\nis-labeled receiver1: ForeignDependencyItem => Bool.\\nforeign-call-bool-value item: ForeignDependencyItem => Bool.\\n\\n---\\n\\nforeign-call-bool-value item = (cond has-ready-flag item => is-labeled item, true => false).\\n\\ncheck\\n\\nforeign-call-bool-value item <-> is-labeled item.\\n"
+`;
+
 exports[`expressions-foreign-call-predicate.ts > foreignCallCompoundPredicate 1`] = `
-"module FOREIGN_CALL_COMPOUND_PREDICATE.\\n\\nForeignDependencyItem.\\nforeign-call-compound-predicate item: ForeignDependencyItem => Int.\\n\\n---\\n\\n> UNSUPPORTED: foreign-call-compound-predicate — early-return predicate has side effects.\\n\\ncheck\\n\\nforeign-call-compound-predicate item = (cond is-labeled item or has-ready-flag item => 1, true => 0).\\n"
+"module FOREIGN_CALL_COMPOUND_PREDICATE.\\n\\nForeignDependencyItem.\\nis-labeled receiver: ForeignDependencyItem => Bool.\\nhas-ready-flag receiver1: ForeignDependencyItem => Bool.\\nforeign-call-compound-predicate item: ForeignDependencyItem => Int.\\n\\n---\\n\\nforeign-call-compound-predicate item = (cond is-labeled item or has-ready-flag item => 1, true => 0).\\n\\ncheck\\n\\nforeign-call-compound-predicate item = (cond is-labeled item or has-ready-flag item => 1, true => 0).\\n"
 `;
 
 exports[`expressions-foreign-call-predicate.ts > foreignCallEarlyReturn 1`] = `
-"module FOREIGN_CALL_EARLY_RETURN.\\n\\nForeignDependencyItem.\\nforeign-call-early-return item: ForeignDependencyItem => Int.\\n\\n---\\n\\n> UNSUPPORTED: foreign-call-early-return — early-return predicate has side effects.\\n\\ncheck\\n\\nforeign-call-early-return item = (cond is-labeled item => 1, true => 0).\\n"
+"module FOREIGN_CALL_EARLY_RETURN.\\n\\nForeignDependencyItem.\\nis-labeled receiver: ForeignDependencyItem => Bool.\\nforeign-call-early-return item: ForeignDependencyItem => Int.\\n\\n---\\n\\nforeign-call-early-return item = (cond is-labeled item => 1, true => 0).\\n\\ncheck\\n\\nforeign-call-early-return item = (cond is-labeled item => 1, true => 0).\\n"
 `;
 
 exports[`expressions-foreign-call-predicate.ts > foreignCallMutatingIf 1`] = `
@@ -471,7 +475,7 @@ exports[`expressions-foreign-call-predicate.ts > foreignCallMutatingIf 1`] = `
 `;
 
 exports[`expressions-foreign-call-predicate.ts > foreignCallWhilePredicate 1`] = `
-"module FOREIGN_CALL_WHILE_PREDICATE.\\n\\nForeignDependencyItem.\\nforeign-call-while-predicate item: ForeignDependencyItem => Int.\\n\\n---\\n\\n> UNSUPPORTED: foreign-call-while-predicate — while-loop predicate has side effects.\\n"
+"module FOREIGN_CALL_WHILE_PREDICATE.\\n\\nForeignDependencyItem.\\nhas-index receiver: ForeignDependencyItem, index: Int => Bool.\\nforeign-call-while-predicate item: ForeignDependencyItem => Int.\\ni  => Int.\\n\\n---\\n\\ni = (min over each j: Int, j >= 0, ~(has-index item j) | j).\\nforeign-call-while-predicate item = i.\\n"
 `;
 
 exports[`expressions-foreign-call-predicate.ts > foreignNonBoolCallPredicate 1`] = `

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-for-of-comprehension.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-for-of-comprehension.ts
@@ -6,6 +6,8 @@
 // constructs snapshot suite does not pick them up before the dedicated tests
 // land.
 
+import type { DependencyItem } from "../foreign-dependency/index.js";
+
 interface Item {
   active: boolean;
   label: string;
@@ -72,6 +74,21 @@ function filterContinueActive(xs: Item[]): Item[] {
       continue;
     }
     acc.push(x);
+  }
+  return acc;
+}
+
+/**
+ * Compound declaration-file Bool guard. The recursive effect oracle admits
+ * both EUF predicates as a pure comprehension guard.
+ */
+// biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
+function filterForeignCompound(items: DependencyItem[]): DependencyItem[] {
+  const acc: DependencyItem[] = [];
+  for (const item of items) {
+    if (item.isLabeled() || item.hasReadyFlag()) {
+      acc.push(item);
+    }
   }
   return acc;
 }

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-foreign-call-predicate.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-foreign-call-predicate.ts
@@ -28,7 +28,7 @@ export function foreignCallCompoundPredicate(item: DependencyItem): number {
 }
 
 /**
- * @pant foreign-call-bool-value item <-> is-labeled item.
+ * @pant foreign-call-bool-value item <-> (has-ready-flag item and is-labeled item).
  */
 export function foreignCallBoolValue(item: DependencyItem): boolean {
   if (item.hasReadyFlag()) {

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-foreign-call-predicate.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-foreign-call-predicate.ts
@@ -8,9 +8,6 @@ interface Account {
 }
 
 /**
- * PENDING Patch 3: `item.isLabeled()` should lower as an uninterpreted Bool
- * rule head (`is-labeled item`) used as the cond antecedent.
- *
  * @pant foreign-call-early-return item = cond is-labeled item => 1, true => 0.
  */
 export function foreignCallEarlyReturn(item: DependencyItem): number {
@@ -21,9 +18,6 @@ export function foreignCallEarlyReturn(item: DependencyItem): number {
 }
 
 /**
- * PENDING Patch 3: both declaration-file Bool method calls should lower as
- * EUF Bool rule heads, with the disjunction used as the cond antecedent.
- *
  * @pant foreign-call-compound-predicate item = cond is-labeled item or has-ready-flag item => 1, true => 0.
  */
 export function foreignCallCompoundPredicate(item: DependencyItem): number {
@@ -34,8 +28,17 @@ export function foreignCallCompoundPredicate(item: DependencyItem): number {
 }
 
 /**
- * PENDING Patch 3: the counter-dependent declaration-file Bool method call
- * should be admitted at the pure μ-search predicate gate and lower as an EUF
+ * @pant foreign-call-bool-value item <-> is-labeled item.
+ */
+export function foreignCallBoolValue(item: DependencyItem): boolean {
+  if (item.hasReadyFlag()) {
+    return item.isLabeled();
+  }
+  return false;
+}
+
+/**
+ * The counter-dependent declaration-file Bool method call lowers as an EUF
  * Bool rule head inside the bounded-search guard.
  */
 export function foreignCallWhilePredicate(item: DependencyItem): number {

--- a/tools/ts2pant/tests/for-of-comprehension.test.mts
+++ b/tools/ts2pant/tests/for-of-comprehension.test.mts
@@ -292,6 +292,25 @@ describe("for-of comprehension integration", () => {
     assert.doesNotMatch(output, /UNSUPPORTED/u);
   });
 
+  it("compound foreign-bool build-list guard emits a guarded each", async () => {
+    const output = await emitAndCheck(
+      await buildDocument(FIXTURE, "filterForeignCompound"),
+    );
+    assert.match(
+      output,
+      /^is-labeled receiver: ForeignDependencyItem => Bool\.$/mu,
+    );
+    assert.match(
+      output,
+      /^has-ready-flag receiver1: ForeignDependencyItem => Bool\.$/mu,
+    );
+    assert.match(
+      output,
+      /filter-foreign-compound items = \(each item in items, \(is-labeled item or has-ready-flag item\) \| item\)\./u,
+    );
+    assert.doesNotMatch(output, /UNSUPPORTED/u);
+  });
+
   it("Set source build-list emits an each comprehension", async () => {
     const output = await emitAndCheck(
       await buildDocument(FIXTURE, "collectSet"),

--- a/tools/ts2pant/tests/integration/dogfood.test.mts
+++ b/tools/ts2pant/tests/integration/dogfood.test.mts
@@ -90,6 +90,8 @@ describe("dogfood: foreign dependency type surfaces", () => {
 });
 
 describe("foreign dependency fixture", () => {
+  const hasSolver = solverAvailable();
+
   it("non-typescript imported dependency property reads lower through foreign accessors", async () => {
     const doc = await buildDocumentFromPath(
       resolve(FIXTURES, "foreign-accessor-dependency.ts"),
@@ -113,7 +115,9 @@ describe("foreign dependency fixture", () => {
     assert.doesNotMatch(output, /typescript|VariableDeclaration|Identifier/u);
   });
 
-  it("foreign-call-predicate fixture @pant annotation is entailed", async () => {
+  it("foreign-call-predicate fixture @pant annotation is entailed", {
+    skip: !hasSolver ? "z3 not available" : undefined,
+  }, async () => {
     const doc = await buildDocumentFromPath(
       resolve(FIXTURES, "expressions-foreign-call-predicate.ts"),
       "foreignCallEarlyReturn",

--- a/tools/ts2pant/tests/integration/dogfood.test.mts
+++ b/tools/ts2pant/tests/integration/dogfood.test.mts
@@ -81,10 +81,7 @@ describe("dogfood: foreign dependency type surfaces", () => {
       output,
       /^identifier-text i: ForeignIdentifier => String\.$/mu,
     );
-    assert.match(
-      output,
-      /^is-identifier node: ForeignIdentifier => Bool\.$/mu,
-    );
+    assert.match(output, /^is-identifier node: ForeignIdentifier => Bool\.$/mu);
     assert.match(
       output,
       /binding-names-from-declaration-list decl-list = \(each decl in declarations decl-list, is-identifier \(name decl\) \| identifier-text \(name decl\)\)\./u,
@@ -107,14 +104,8 @@ describe("foreign dependency fixture", () => {
       output,
       /^items c: ForeignDependencyContainer => \[ForeignDependencyItem\]\.$/mu,
     );
-    assert.match(
-      output,
-      /^item-label i: ForeignDependencyItem => String\.$/mu,
-    );
-    assert.match(
-      output,
-      /^item-ready i: ForeignDependencyItem => Bool\.$/mu,
-    );
+    assert.match(output, /^item-label i: ForeignDependencyItem => String\.$/mu);
+    assert.match(output, /^item-ready i: ForeignDependencyItem => Bool\.$/mu);
     assert.match(
       output,
       /foreign-labels c = \(each item in items c, item-ready item \| item-label item\)\./u,
@@ -122,7 +113,7 @@ describe("foreign dependency fixture", () => {
     assert.doesNotMatch(output, /typescript|VariableDeclaration|Identifier/u);
   });
 
-  it.skip("PENDING Patch 3: foreign-call-predicate fixture @pant annotation is entailed", async () => {
+  it("foreign-call-predicate fixture @pant annotation is entailed", async () => {
     const doc = await buildDocumentFromPath(
       resolve(FIXTURES, "expressions-foreign-call-predicate.ts"),
       "foreignCallEarlyReturn",

--- a/tools/ts2pant/tests/known-typecheck-failures.mts
+++ b/tools/ts2pant/tests/known-typecheck-failures.mts
@@ -65,18 +65,6 @@ export const KNOWN_TYPECHECK_FAILURES = new Map<string, string>([
   ["expressions-boolean.ts > or", "$-binder-leak"],
   ["expressions-discriminated-union.ts > ambiguousOwner", "ambiguous-owner"],
   [
-    "expressions-foreign-call-predicate.ts > foreignCallEarlyReturn",
-    "foreign-call-predicate",
-  ],
-  [
-    "expressions-foreign-call-predicate.ts > foreignCallCompoundPredicate",
-    "foreign-call-predicate",
-  ],
-  [
-    "expressions-foreign-call-predicate.ts > foreignCallWhilePredicate",
-    "foreign-call-predicate",
-  ],
-  [
     "expressions-let-closure-captured.ts > letForEachCapturedTotal",
     "closure-captured-reassignment",
   ],

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -655,7 +655,7 @@ describe("unsupported patterns", () => {
 });
 
 describe("if-early-return prelude arms", () => {
-  it.skip("PENDING Patch 3: foreign bool call in early-return predicate lowers to its EUF rule", () => {
+  it("foreign bool call in early-return predicate lowers to its EUF rule", () => {
     const sourceFile = createSourceFile(
       resolve(
         import.meta.dirname,
@@ -663,13 +663,19 @@ describe("if-early-return prelude arms", () => {
       ),
     );
 
-    const admitted = translateBodyWithSynth(sourceFile, "foreignCallEarlyReturn");
+    const admitted = translateBodyWithSynth(
+      sourceFile,
+      "foreignCallEarlyReturn",
+    );
     assert.equal(
       getAst().strExpr(finalEquation(admitted).rhs),
       "cond is-labeled item => 1, true => 0",
     );
 
-    const rejected = translateBodyWithSynth(sourceFile, "foreignCallMutatingIf");
+    const rejected = translateBodyWithSynth(
+      sourceFile,
+      "foreignCallMutatingIf",
+    );
     assertUnsupportedReason(
       rejected,
       /impure if-condition in mutating body/u,


### PR DESCRIPTION
## Patch 3: Admit foreign bool predicates at the pure-rule predicate gates

- Flip the option at the two pure-rule predicate gate sites; confirm the mutating gates are untouched.
- Unify the for-of guard gate onto the canonical detector + recursive oracle and delete `isBoolDeclarationFileNamespaceCall`; this is strictly additive (only more for-of comprehensions translate).
- Confirm the admitted predicate lowers through the existing ir1-build.ts:1373 declaration-file rule-head path (head emitted, document typechecks).
- Verify the negative fixtures still reject (mutating-if foreign condition; non-bool foreign call).
- Clear the allowlist entry and regenerate snapshots; review any for-of snapshot changes to confirm they are additive comprehension lowerings, not regressions.
- Run biome, tsc, test:unit, test:integration.

## Changes
- Flip the option at the two pure-rule predicate gate sites; confirm the mutating gates are untouched.
- Unify the for-of guard gate onto the canonical detector + recursive oracle and delete `isBoolDeclarationFileNamespaceCall`; this is strictly additive (only more for-of comprehensions translate).
- Confirm the admitted predicate lowers through the existing ir1-build.ts:1373 declaration-file rule-head path (head emitted, document typechecks).
- Verify the negative fixtures still reject (mutating-if foreign condition; non-bool foreign call).
- Clear the allowlist entry and regenerate snapshots; review any for-of snapshot changes to confirm they are additive comprehension lowerings, not regressions.
- Run biome, tsc, test:unit, test:integration.

## Files to Modify
- tools/ts2pant/src/translate-body.ts (modify): Pass `{ admitForeignBoolPredicates: true }` to the oracle at the μ-search predicate gate (2982), the early-return predicate gate (3000), and the early-return value gate (3024). Unify the for-of guard gate (2014) onto the same canonical detector + recursive oracle (replace the `expressionHasSideEffects(g) && !isBoolDeclarationFileNamespaceCall(g)` exception with `!isEffectFree(g, { admitForeignBoolPredicates: true })`) and delete the now-unused `isBoolDeclarationFileNamespaceCall` (2073). Leave the mutating-body and SSA-exit gates unchanged. Add a load-bearing @pant annotation to the chosen dogfood target if applicable.
- tools/ts2pant/tests/known-typecheck-failures.mts (modify): Remove the `foreign-call-predicate` entry.
- tools/ts2pant/tests/constructs.test.mts.snapshot (modify): Add the snapshot for the newly-lowered foreign-call-predicate fixture (predicate as a Bool rule-head cond antecedent).
- tools/ts2pant/tests/translate-body.test.mts (modify): Unskip and implement: foreign bool call in early-return predicate lowers to its EUF rule; mutating-if foreign condition still rejects.
- tools/ts2pant/tests/integration/dogfood.test.mts (modify): Unskip and implement the @pant entailment check for the foreign-call-predicate fixture.

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[paper] Kroening & Strichman, Decision Procedures Ch. 4 (Equality with Uninterpreted Functions)** — https://www.decision-procedures.org/ — The newly-admitted predicate becomes an uninterpreted Bool application used as a cond antecedent; soundness rests on congruence alone, which is why admitting it in a pure-rule context (which models no effects) introduces no unsound axiom.

## Gameplan Specification

```
module TS2PANT_FOREIGN_CALL_GUARD_ADMISSION.

> A declaration-file boolean call in a pure-rule predicate position is
> reclassified from effectful to effect-free and modeled as an
> uninterpreted Bool rule application; the reclassification is trusted
> only in pure-rule contexts. Mutating-context gates are unchanged.

Call.
Context.

declaration-file-bool-call? e: Call => Bool.
receiver-and-args-pure? e: Call => Bool.
pure-rule-position? c: Context => Bool.
mutating-condition? c: Context => Bool.
effect-free-in? e: Call, c: Context => Bool.
admitted-in? e: Call, c: Context => Bool.
lowers-to-euf-rule? e: Call => Bool.

---

> Decision A: in a pure-rule position (predicate/bool-value/guard), a declaration-file bool
> call whose receiver/args are pure is effect-free and admitted.
all e: Call, c: Context | declaration-file-bool-call? e and receiver-and-args-pure? e and pure-rule-position? c -> effect-free-in? e c and admitted-in? e c.
> An admitted call lowers to its uninterpreted Bool rule-head application.
all e: Call | declaration-file-bool-call? e -> lowers-to-euf-rule? e.
> Decision B: mutating-condition contexts are unchanged — the call stays
> effectful, so no real mutation is dropped.
all e: Call, c: Context | declaration-file-bool-call? e and mutating-condition? c -> ~ effect-free-in? e c.
```

## Patch Specification

```
module TS2PANT_FOREIGN_CALL_GUARD_ADMISSION_PATCH_3.

Call.
Context.

pure-rule-position? c: Context => Bool.
mutating-condition? c: Context => Bool.
declaration-file-bool-call? e: Call => Bool.
effect-free-in? e: Call, c: Context => Bool.
admitted-in? e: Call, c: Context => Bool.
lowers-to-euf-rule? e: Call => Bool.
---
> In pure-rule positions (predicate, bool-value, or comprehension guard), a declaration-file bool call is
> effect-free, admitted, and lowers to its uninterpreted Bool rule.
all e: Call, c: Context | declaration-file-bool-call? e and pure-rule-position? c -> effect-free-in? e c and admitted-in? e c.
all e: Call | declaration-file-bool-call? e -> lowers-to-euf-rule? e.
> Mutating-condition contexts are unchanged: the call stays effectful.
all e: Call, c: Context | declaration-file-bool-call? e and mutating-condition? c -> ~ effect-free-in? e c.
```


## Implementation Notes

- The declared-call lowering needed one supporting fix beyond the original gate flip: `.d.ts` `MethodSignature`s are now recognized by `extractReferencedFunctions` and emitted as receiver-first EUF rule heads. This is what makes instance forms such as `item.isLabeled()` typecheck as `is-labeled item`; namespace function forms still keep their normal argument list.
- `ir1-build.ts` mirrors that receiver-first convention only for declaration-file method signatures. It detects method signatures from the callee symbol declarations and prepends the lowered receiver before the call arguments; declaration-file namespace functions such as `ts.isIdentifier(x)` are unchanged.
- The for-of coverage is not snapshot-based because `expressions-for-of-comprehension.ts` is intentionally scaffold-only. The new `filterForeignCompound` fixture is exercised by `for-of-comprehension.test.mts` and proves that a compound guard lowers to a parenthesized guarded `each`.
- The broader `biome check src tests` command formatted a few existing assertions in `dogfood.test.mts` while touching that file to unskip the foreign-call-predicate entailment test.

Spec/Evidence Mapping:
- Pure-rule predicate/bool-value admission: `lowerPreludeBindings` in `translate-body.ts` passes `admitForeignBoolPredicates: true` for μ-search predicates, early-return predicates, and early-return values. Proven by `expressions-foreign-call-predicate.ts` snapshots, `translate-body.test.mts`, and the dogfood entailment test.
- Pure-rule comprehension guard admission: `recognizeForOfPush` now uses `isEffectFree(..., { admitForeignBoolPredicates: true })` recursively. Proven by `filterForeignCompound` in `for-of-comprehension.test.mts`.
- EUF rule-head lowering: `extract.ts` emits declaration-file method-signature rule heads and `ir1-build.ts` emits receiver-first applications. Proven by the new `is-labeled`, `has-ready-flag`, and `has-index` heads in `constructs.test.mts.snapshot`.
- Mutating contexts unchanged: the mutating-body and SSA-exit gates still call the default oracle. Proven by `foreignCallMutatingIf` remaining unsupported and by full `npm run test:unit` / `npm run test:integration`.
- Verification run: `npx biome check src tests`, `npx tsc --noEmit`, `npm run test:unit`, and `npm run test:integration`.