### PR TITLE
[ts2pant-body-lowering-completeness-rd2] Patch 1: Commit corpus diagnostic and add round-2 fixture stubs

### DIFF
--- a/tools/ts2pant/scripts/corpus-diag.mts
+++ b/tools/ts2pant/scripts/corpus-diag.mts
@@ -1,0 +1,147 @@
+// @archlint.module exempt
+// @archlint.exempt-reason read-only diagnostic script
+
+import { readdirSync } from "node:fs";
+import { relative, resolve } from "node:path";
+import process from "node:process";
+import { emitDocument } from "../src/emit.js";
+import { createSourceFile } from "../src/extract.js";
+import { buildPantDocument } from "../src/pipeline.js";
+import { IntStrategy } from "../src/translate-types.js";
+
+const SRC_DIR = resolve(import.meta.dirname, "../src");
+const SUMMARY_ONLY = process.argv.includes("--summary-only");
+
+interface DiagnosticResult {
+  file: string;
+  functionName: string;
+  output?: string;
+  unsupportedReasons: string[];
+  error?: string;
+}
+
+function sourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = resolve(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...sourceFiles(path));
+      continue;
+    }
+    if (entry.isFile() && entry.name.endsWith(".ts")) {
+      out.push(path);
+    }
+  }
+  return out.sort();
+}
+
+function unsupportedReasons(output: string): string[] {
+  const reasons: string[] = [];
+  const re = /^> UNSUPPORTED: (?<reason>.+?)\.?$/gmu;
+  for (const match of output.matchAll(re)) {
+    const reason = match.groups?.reason;
+    if (reason) {
+      reasons.push(reason);
+    }
+  }
+  return reasons;
+}
+
+function normalizeReason(reason: string): string {
+  return reason
+    .replace(/^[^—]+ — /u, "")
+    .replace(/\b\d+\b/gu, "<n>")
+    .trim();
+}
+
+function printDocument(result: DiagnosticResult): void {
+  console.log(`\n===== ${result.file} > ${result.functionName} =====\n`);
+  if (result.output !== undefined) {
+    console.log(result.output.trimEnd());
+    return;
+  }
+  console.log(`ERROR: ${result.error ?? "unknown error"}`);
+}
+
+const results: DiagnosticResult[] = [];
+
+for (const filePath of sourceFiles(SRC_DIR)) {
+  const relFile = relative(SRC_DIR, filePath);
+  const sourceFile = createSourceFile(filePath);
+  try {
+    const functionNames = sourceFile
+      .getFunctions()
+      .map((fn) => fn.getName())
+      .filter((name): name is string => name !== undefined)
+      .sort();
+
+    for (const functionName of functionNames) {
+      try {
+        const doc = await buildPantDocument({
+          sourceFile,
+          functionName,
+          strategy: IntStrategy,
+        });
+        const output = emitDocument(doc);
+        const result = {
+          file: relFile,
+          functionName,
+          output,
+          unsupportedReasons: unsupportedReasons(output),
+        };
+        results.push(result);
+        if (!SUMMARY_ONLY) {
+          printDocument(result);
+        }
+      } catch (err) {
+        const result = {
+          file: relFile,
+          functionName,
+          unsupportedReasons: [],
+          error: err instanceof Error ? err.message : String(err),
+        };
+        results.push(result);
+        if (!SUMMARY_ONLY) {
+          printDocument(result);
+        }
+      }
+    }
+  } finally {
+    sourceFile.getProject().removeSourceFile(sourceFile);
+  }
+}
+
+const buckets = new Map<string, number>();
+let clean = 0;
+let unsupported = 0;
+let errored = 0;
+
+for (const result of results) {
+  if (result.error !== undefined) {
+    errored += 1;
+    const bucket = `ERROR: ${result.error.split("\n", 1)[0]}`;
+    buckets.set(bucket, (buckets.get(bucket) ?? 0) + 1);
+    continue;
+  }
+  if (result.unsupportedReasons.length === 0) {
+    clean += 1;
+    continue;
+  }
+  unsupported += 1;
+  for (const reason of result.unsupportedReasons) {
+    const bucket = normalizeReason(reason);
+    buckets.set(bucket, (buckets.get(bucket) ?? 0) + 1);
+  }
+}
+
+console.log("\n===== SUMMARY =====");
+console.log(`functions: ${results.length}`);
+console.log(`clean: ${clean}`);
+console.log(`unsupported: ${unsupported}`);
+console.log(`errors: ${errored}`);
+console.log("\nUNSUPPORTED buckets:");
+for (const [reason, count] of [...buckets.entries()].sort(
+  (a, b) => b[1] - a[1] || a[0].localeCompare(b[0]),
+)) {
+  console.log(`${count}\t${reason}`);
+}

--- a/tools/ts2pant/scripts/corpus-diag.mts
+++ b/tools/ts2pant/scripts/corpus-diag.mts
@@ -111,7 +111,8 @@ for (const filePath of sourceFiles(SRC_DIR)) {
   }
 }
 
-const buckets = new Map<string, number>();
+const unsupportedBuckets = new Map<string, number>();
+const errorBuckets = new Map<string, number>();
 let clean = 0;
 let unsupported = 0;
 let errored = 0;
@@ -120,7 +121,7 @@ for (const result of results) {
   if (result.error !== undefined) {
     errored += 1;
     const bucket = `ERROR: ${result.error.split("\n", 1)[0]}`;
-    buckets.set(bucket, (buckets.get(bucket) ?? 0) + 1);
+    errorBuckets.set(bucket, (errorBuckets.get(bucket) ?? 0) + 1);
     continue;
   }
   if (result.unsupportedReasons.length === 0) {
@@ -130,7 +131,7 @@ for (const result of results) {
   unsupported += 1;
   for (const reason of result.unsupportedReasons) {
     const bucket = normalizeReason(reason);
-    buckets.set(bucket, (buckets.get(bucket) ?? 0) + 1);
+    unsupportedBuckets.set(bucket, (unsupportedBuckets.get(bucket) ?? 0) + 1);
   }
 }
 
@@ -140,8 +141,17 @@ console.log(`clean: ${clean}`);
 console.log(`unsupported: ${unsupported}`);
 console.log(`errors: ${errored}`);
 console.log("\nUNSUPPORTED buckets:");
-for (const [reason, count] of [...buckets.entries()].sort(
+for (const [reason, count] of [...unsupportedBuckets.entries()].sort(
   (a, b) => b[1] - a[1] || a[0].localeCompare(b[0]),
 )) {
   console.log(`${count}\t${reason}`);
+}
+
+if (errorBuckets.size > 0) {
+  console.log("\nERROR buckets:");
+  for (const [reason, count] of [...errorBuckets.entries()].sort(
+    (a, b) => b[1] - a[1] || a[0].localeCompare(b[0]),
+  )) {
+    console.log(`${count}\t${reason}`);
+  }
 }

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -162,6 +162,50 @@ exports[`expressions-block-early-return.ts > blockEarlyReturnSingleBinding 1`] =
 "module BLOCK_EARLY_RETURN_SINGLE_BINDING.\\n\\nblock-early-return-single-binding n: Int => Int.\\n\\n---\\n\\nblock-early-return-single-binding n = (cond n < 0 => 0 - n, true => n + 1).\\n"
 `;
 
+exports[`expressions-body-lowering-rd2.ts > rd2CallbackNestedBlock 1`] = `
+"module RD2_CALLBACK_NESTED_BLOCK.\\n\\nUser.\\nuser--active u: User => Bool.\\nuser--score u: User => Int.\\nuser--name u: User => String.\\nrd2-callback-nested-block users: [User] => [Int].\\n\\n---\\n\\n> UNSUPPORTED: array callback block body must be a single return.\\n"
+`;
+
+exports[`expressions-body-lowering-rd2.ts > rd2EffectfulBlockConstRejected 1`] = `
+"module RD2_EFFECTFUL_BLOCK_CONST_REJECTED.\\n\\ncompute n1: Int => Int.\\nrd2-effectful-block-const-rejected n: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: rd2-effectful-block-const-rejected — if-with-return block must contain only const bindings followed by a return.\\n"
+`;
+
+exports[`expressions-body-lowering-rd2.ts > rd2LocalAccumulatorSequencing 1`] = `
+"module RD2_LOCAL_ACCUMULATOR_SEQUENCING.\\n\\nrd2-local-accumulator-sequencing seed: String => [String].\\n\\n---\\n\\n> UNSUPPORTED: rd2-local-accumulator-sequencing — expression statement before return (only const / μ-search / if-early-return allowed).\\n"
+`;
+
+exports[`expressions-body-lowering-rd2.ts > rd2NestedBlockWithConstPrelude 1`] = `
+"module RD2_NESTED_BLOCK_WITH_CONST_PRELUDE.\\n\\nrd2-nested-block-with-const-prelude n: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: rd2-nested-block-with-const-prelude — if-with-return block must contain only const bindings followed by a return.\\n"
+`;
+
+exports[`expressions-body-lowering-rd2.ts > rd2NestedEarlyReturnBlock 1`] = `
+"module RD2_NESTED_EARLY_RETURN_BLOCK.\\n\\nrd2-nested-early-return-block n: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: rd2-nested-early-return-block — if-with-return block must contain only const bindings followed by a return.\\n"
+`;
+
+exports[`expressions-body-lowering-rd2.ts > rd2RecordReturnConditional 1`] = `
+"module RD2_RECORD_RETURN_CONDITIONAL.\\n\\nPair.\\npair--x p: Pair => Int.\\npair--y p: Pair => Int.\\nrd2-record-return-conditional n: Int, flag: Bool => Pair.\\n\\n---\\n\\n> UNSUPPORTED: rd2-record-return-conditional — record return combined with early-return arms or if/else branches is not yet supported.\\n"
+`;
+
+exports[`expressions-body-lowering-rd2.ts > rd2RecordReturnMismatchedFields 1`] = `
+"module RD2_RECORD_RETURN_MISMATCHED_FIELDS.\\n\\nXRec.\\nx-rec--x r: XRec => Int.\\nXYRec.\\nxy-rec--x r1: XYRec => Int.\\nxy-rec--y r1: XYRec => Int.\\nrd2-record-return-mismatched-fields n: Int, flag: Bool => XRec + XYRec.\\n\\n---\\n\\n> UNSUPPORTED: rd2-record-return-mismatched-fields — record return combined with early-return arms or if/else branches is not yet supported.\\n"
+`;
+
+exports[`expressions-body-lowering-rd2.ts > rd2SwitchFallThrough 1`] = `
+"module RD2_SWITCH_FALL_THROUGH.\\n\\nrd2-switch-fall-through x: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: rd2-switch-fall-through — switch case must end with \`return EXPR\` (no fall-through, no break/throw cases in M1).\\n"
+`;
+
+exports[`expressions-body-lowering-rd2.ts > rd2SwitchNestedBlockClause 1`] = `
+"module RD2_SWITCH_NESTED_BLOCK_CLAUSE.\\n\\nrd2-switch-nested-block-clause x: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: rd2-switch-nested-block-clause — switch case must end with \`return EXPR\` (no fall-through, no break/throw cases in M1).\\n"
+`;
+
+exports[`expressions-body-lowering-rd2.ts > rd2SwitchNonLiteralLabel 1`] = `
+"module RD2_SWITCH_NON_LITERAL_LABEL.\\n\\nrd2-switch-non-literal-label x: Int, k: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: rd2-switch-non-literal-label — switch case label must be a literal (number/string/bool).\\n"
+`;
+
+exports[`expressions-body-lowering-rd2.ts > rd2TerminalIfElseBranchBlocks 1`] = `
+"module RD2_TERMINAL_IF_ELSE_BRANCH_BLOCKS.\\n\\nrd2-terminal-if-else-branch-blocks n: Int, flag: Bool => Int.\\n\\n---\\n\\n> UNSUPPORTED: rd2-terminal-if-else-branch-blocks — if-then branch must contain a single return-with-value.\\n"
+`;
+
 exports[`expressions-boolean.ts > and 1`] = `
 "module AND.\\n\\nand a: Bool, b: Bool => Bool.\\n\\n---\\n\\nand a b = (a and b).\\n"
 `;

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-body-lowering-rd2.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-body-lowering-rd2.ts
@@ -1,0 +1,142 @@
+// @archlint.module exempt
+// @archlint.exempt-reason test-support
+
+interface User {
+  active: boolean;
+  score: number;
+  name: string;
+}
+
+interface Pair {
+  x: number;
+  y: number;
+}
+
+declare function compute(n: number): number;
+
+export function rd2NestedEarlyReturnBlock(n: number): number {
+  if (n < 0) {
+    if (n < -10) {
+      return 10;
+    }
+    return 0 - n;
+  }
+  return n;
+}
+
+export function rd2NestedBlockWithConstPrelude(n: number): number {
+  if (n < 0) {
+    const magnitude = 0 - n;
+    if (magnitude > 10) {
+      return magnitude;
+    }
+    return magnitude + 1;
+  }
+  return n;
+}
+
+export function rd2TerminalIfElseBranchBlocks(
+  n: number,
+  flag: boolean,
+): number {
+  if (flag) {
+    if (n < 0) {
+      return 0 - n;
+    }
+    return n + 1;
+  } else {
+    const shifted = n + 2;
+    if (shifted > 10) {
+      return shifted;
+    }
+    return 10;
+  }
+}
+
+export function rd2SwitchNestedBlockClause(x: number): number {
+  switch (x) {
+    case 0: {
+      if (x < 1) {
+        return x + 10;
+      }
+      return x;
+    }
+    default: {
+      const fallback = x + 1;
+      if (fallback > 5) {
+        return fallback;
+      }
+      return 5;
+    }
+  }
+}
+
+export function rd2CallbackNestedBlock(users: User[]): number[] {
+  return users.map((u) => {
+    if (u.active) {
+      if (u.score > 0) {
+        return u.score;
+      }
+      return 0;
+    }
+    return -1;
+  });
+}
+
+export function rd2RecordReturnConditional(n: number, flag: boolean): Pair {
+  if (flag) {
+    return { x: n, y: n + 1 };
+  }
+  return { x: 0, y: 1 };
+}
+
+export function rd2LocalAccumulatorSequencing(seed: string): string[] {
+  const lines: string[] = [];
+  lines.push(seed);
+  return lines;
+}
+
+export function rd2EffectfulBlockConstRejected(n: number): number {
+  if (n < 0) {
+    const value = compute(n);
+    if (value > 10) {
+      return value;
+    }
+    return 10;
+  }
+  return n;
+}
+
+export function rd2SwitchNonLiteralLabel(x: number, k: number): number {
+  switch (x) {
+    case k: {
+      if (x > 0) {
+        return 1;
+      }
+      return 0;
+    }
+    default:
+      return -1;
+  }
+}
+
+export function rd2SwitchFallThrough(x: number): number {
+  switch (x) {
+    case 0: {
+      const ignored = x + 1;
+      void ignored;
+    }
+    default:
+      return x;
+  }
+}
+
+export function rd2RecordReturnMismatchedFields(
+  n: number,
+  flag: boolean,
+): { x: number } | { x: number; y: number } {
+  if (flag) {
+    return { x: n, y: n + 1 };
+  }
+  return { x: n };
+}

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -255,6 +255,100 @@ it("generated body helpers preserve structural translations", () => {
 // exhaustive construct coverage).
 
 describe("unsupported patterns", () => {
+  it.skip(
+    "PENDING Patch 2: nested pure block-return lowers to one value with inlined bindings",
+    () => {
+      const source = `
+        function nested(n: number): number {
+          if (n < 0) {
+            const magnitude = 0 - n;
+            if (magnitude > 10) {
+              return magnitude;
+            }
+            return magnitude + 1;
+          }
+          return n;
+        }
+      `;
+      const sourceFile = createSourceFileFromSource(source);
+      const props = translateBodyWithSynth(sourceFile, "nested");
+      assert.equal(props.some((p) => p.kind === "unsupported"), false);
+    },
+  );
+
+  it.skip(
+    "PENDING Patch 3: early-return arm block may contain nested early returns",
+    () => {
+      const source = `
+        function arm(n: number): number {
+          if (n < 0) {
+            if (n < -10) {
+              return 10;
+            }
+            return 0 - n;
+          }
+          return n;
+        }
+      `;
+      const sourceFile = createSourceFileFromSource(source);
+      const props = translateBodyWithSynth(sourceFile, "arm");
+      assert.equal(props.some((p) => p.kind === "unsupported"), false);
+    },
+  );
+
+  it.skip(
+    "PENDING Patch 4: switch and callback block consumers reuse nested pure block lowering",
+    () => {
+      const source = `
+        interface User { active: boolean; score: number; }
+        function scores(users: User[]): number[] {
+          return users.map((u) => {
+            if (u.active) {
+              return u.score;
+            }
+            return 0;
+          });
+        }
+        function choose(x: number): number {
+          switch (x) {
+            case 0: {
+              if (x < 1) {
+                return x + 10;
+              }
+              return x;
+            }
+            default:
+              return x + 1;
+          }
+        }
+      `;
+      const sourceFile = createSourceFileFromSource(source);
+      for (const functionName of ["scores", "choose"]) {
+        const props = translateBodyWithSynth(sourceFile, functionName);
+        assert.equal(props.some((p) => p.kind === "unsupported"), false);
+      }
+    },
+  );
+
+  it.skip(
+    "PENDING Patch 5: record-return conditional lowers fieldwise",
+    () => {
+      const source = `
+        interface Pair { x: number; y: number; }
+        function pair(n: number, flag: boolean): Pair {
+          if (flag) {
+            return { x: n, y: n + 1 };
+          }
+          return { x: 0, y: 1 };
+        }
+      `;
+      const sourceFile = createSourceFileFromSource(source);
+      const props = translateBodyWithSynth(sourceFile, "pair");
+      assert.equal(props.some((p) => p.kind === "unsupported"), false);
+      assert.equal(props.filter((p) => p.kind === "equation").length, 2);
+    },
+  );
+
   it("returns empty for function with no body", () => {
     const source = `
       declare function external(x: number): number;


### PR DESCRIPTION
## Patch 1: Commit corpus diagnostic and add round-2 fixture stubs

- Commit the corpus diagnostic script reconstructed during planning; keep it read-only and free of test-suite side effects.
- Add one constructs fixture file that isolates each targeted shape and each preserved-rejection shape.
- Add skipped unit stubs for nested pure block-return helper behavior, branch/switch/callback consumers, and record-return conditional lowering.
- Snapshot the fixture file before behavior changes, showing the current UNSUPPORTED lines.

## Changes
- Commit the corpus diagnostic script reconstructed during planning; keep it read-only and free of test-suite side effects.
- Add one constructs fixture file that isolates each targeted shape and each preserved-rejection shape.
- Add skipped unit stubs for nested pure block-return helper behavior, branch/switch/callback consumers, and record-return conditional lowering.
- Snapshot the fixture file before behavior changes, showing the current UNSUPPORTED lines.

## Files to Modify
- tools/ts2pant/scripts/corpus-diag.mts (create): Read-only dogfood diagnostic that scans top-level ts2pant src functions, emits each document, and ranks normalized UNSUPPORTED buckets.
- tools/ts2pant/tests/fixtures/constructs/expressions-body-lowering-rd2.ts (create): Positive and negative fixtures for nested branch blocks, terminal if/else branch blocks, switch nested block clauses, callback block bodies, record-return conditionals, and deferred local accumulator sequencing.
- tools/ts2pant/tests/translate-body.test.mts (modify): Add skipped unit-test stubs for the shared helper and each behavior patch, marked PENDING with owning patch numbers.
- tools/ts2pant/tests/constructs.test.mts.snapshot (modify): Snapshot the new fixtures in their current rejected state.

## Gameplan Specification

```
module BODY_LOWERING_COMPLETENESS_RD2.

Body.
Block.
Arm.
Clause.
Callback.
RecordBranchSet.

supported-pure-block? b: Block => Bool.
block-lowered? b: Block => Bool.
nested-block-arm? a: Arm => Bool.
arm-lowered? a: Arm => Bool.
nested-switch-clause? c: Clause => Bool.
clause-lowered? c: Clause => Bool.
nested-callback-block? cb: Callback => Bool.
callback-lowered? cb: Callback => Bool.
same-field-set? r: RecordBranchSet => Bool.
fieldwise-cond-lowered? r: RecordBranchSet => Bool.
unsupported-shape? b: Body => Bool.
rejected? b: Body => Bool.
typechecks? b: Body => Bool.

---

all b: Block | supported-pure-block? b -> block-lowered? b.
all a: Arm | nested-block-arm? a -> arm-lowered? a.
all c: Clause | nested-switch-clause? c -> clause-lowered? c.
all cb: Callback | nested-callback-block? cb -> callback-lowered? cb.
all r: RecordBranchSet | same-field-set? r -> fieldwise-cond-lowered? r.
all b: Body | unsupported-shape? b -> rejected? b.
all b: Body | typechecks? b.
```

## Patch Specification

```
module BODY_LOWERING_COMPLETENESS_RD2_PATCH_1.

Fixture.
positive? f: Fixture => Bool.
negative? f: Fixture => Bool.
snapshotted? f: Fixture => Bool.

---

all f: Fixture | positive? f or negative? f -> snapshotted? f.
```


## Implementation Notes

- The corpus diagnostic intentionally uses the production pipeline (`buildPantDocument` + `emitDocument`) rather than test helpers, so it stays read-only and does not invoke wasm typechecking or mutate snapshots. It supports `--summary-only`; without that flag it prints every emitted document before the bucket summary.
- Bucket normalization only strips the leading `<function> — ` prefix and numeric literals. I initially considered masking kebab-case names, but that hid important diagnostic labels like `if-with-return`, so those are preserved for before/after comparisons.
- The new construct fixture mixes future-positive shapes with preserved-rejection shapes. All entries are currently snapshotted as `UNSUPPORTED`; dependent behavior patches should update only the snapshots for the shapes they intentionally admit and leave local accumulator sequencing, non-literal switch labels, fall-through, effectful consts, and mismatched record fields rejected.
- The skipped unit tests are deliberately placed near existing translate-body unsupported/edge-case tests and named with owning patch numbers (`PENDING Patch 2` through `PENDING Patch 5`) to make unskipping ownership explicit.

Spec/Evidence Mapping:
- `positive? f or negative? f -> snapshotted? f`: implemented by `tools/ts2pant/tests/fixtures/constructs/expressions-body-lowering-rd2.ts` plus generated entries in `tools/ts2pant/tests/constructs.test.mts.snapshot`.
- Required context consulted: existing construct harness/snapshots, `translate-body.test.mts`, existing round-1 block/switch/record fixtures, and the gameplan corpus diagnostic context.
- Evidence: `just ts2pant-test-update-snapshots` passed with 1500 pass / 7 skipped / 0 fail; `NODE_OPTIONS=--max-old-space-size=6144 npx tsx scripts/corpus-diag.mts --summary-only` passed and reported the expected baseline of 806 functions, 163 clean, and 64 `if-with-return block must contain only const bindings followed by a return`.