### PR TITLE
[ts2pant-body-lowering-completeness-rd2] Patch 2: Shared recursive pure block-return lowering helper

### DIFF
--- a/tools/ts2pant/docs/transformations.md
+++ b/tools/ts2pant/docs/transformations.md
@@ -59,6 +59,40 @@ decomposition would require every arm value to be an object literal of the
 same shape, and is left as a follow-on to keep the if-conversion change
 self-contained.
 
+## Recursive Pure Block-Return Lowering
+
+**Standard name:** If-conversion plus let-elimination.
+**Reference:** Allen et al., POPL 1983; Peyton Jones & Marlow, JFP 2002.
+
+Nested value-position consumers such as branches, switch clauses, and array
+callbacks need to treat a TS block as one expression without leaking
+branch-local bindings. `lowerNestedPureBlockReturn()` is the shared helper for
+that shape:
+
+```ts
+{
+  const x = e1;
+  if (p) return e2;
+  return e3;
+}
+```
+
+The helper first reuses `extractReturnExpression()` to recognize the same pure
+body surface as the top-level translator. It then runs the common prelude
+validator used by `lowerPreludeBindings()` so TDZ, forward-reference, and
+side-effect checks stay aligned. Finally it lowers predicates and return
+values through L1, builds one conditional value, and right-folds the local
+bindings through `substituteIR1ExprSubtree()`.
+
+**Invariants:**
+- No partial output: unsupported statements return `null`.
+- Let-elimination is capture-avoiding and uses the IR1 substitution primitive.
+- Nested block locals never become Pant rule declarations or free variables.
+- Conservative refusal covers stateful expression statements, effectful const
+  initializers, non-final returns, throws, breaks, and unsupported terminals.
+- Local accumulator sequencing such as `lines.push(...); return lines` is not
+  part of this transformation; it needs a separate collection-builder model.
+
 ## Uninterpreted Functions (General Function Calls)
 
 **Standard name:** EUF (Equality with Uninterpreted Functions).

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -3422,6 +3422,7 @@ function lowerNestedPureBlockReturnToL1(
   let scopedParams: ReadonlyMap<string, string> = ctx.paramNames;
   const substitutions: Array<{ localName: string; value: IR1Expr }> = [];
   const arms: Array<readonly [IR1Expr, IR1Expr]> = [];
+  const fallthroughFacts: Fact[] = [];
 
   for (const binding of extracted.bindings) {
     if (
@@ -3432,6 +3433,10 @@ function lowerNestedPureBlockReturnToL1(
       return null;
     }
     if (binding.kind === "earlyReturn") {
+      const currentFact = recognizeBranchFact(
+        binding.predicateExpr,
+        ctx.checker,
+      );
       const guard = buildL1SubExpr(binding.predicateExpr, {
         checker: ctx.checker,
         strategy: ctx.strategy,
@@ -3443,35 +3448,43 @@ function lowerNestedPureBlockReturnToL1(
       if (isUnsupported(guard) || isL1Unsupported(guard)) {
         return null;
       }
-      const value = lowerEarlyReturnArmValueToL1(
-        binding.blockBindings,
-        binding.valueExpr,
-        {
-          checker: ctx.checker,
-          strategy: ctx.strategy,
-          paramNames: scopedParams,
-          state: ctx.state ?? makeSymbolicState(),
-          supply: ctx.supply,
-          env: ctx.env,
-          ...(ctx.expectedReturnSort === undefined
-            ? {}
-            : { expectedReturnSort: ctx.expectedReturnSort }),
-        },
-      );
+      let value: IR1Expr | null = null;
+      enterFrame(ctx.env);
+      try {
+        for (const fact of [...fallthroughFacts, currentFact]) {
+          if (fact !== null) {
+            pushFact(ctx.env, fact);
+          }
+        }
+        value = lowerEarlyReturnArmValueToL1(
+          binding.blockBindings,
+          binding.valueExpr,
+          {
+            checker: ctx.checker,
+            strategy: ctx.strategy,
+            paramNames: scopedParams,
+            state: ctx.state ?? makeSymbolicState(),
+            supply: ctx.supply,
+            env: ctx.env,
+            ...(ctx.expectedReturnSort === undefined
+              ? {}
+              : { expectedReturnSort: ctx.expectedReturnSort }),
+          },
+        );
+      } finally {
+        exitFrame(ctx.env);
+      }
       if (value === null) {
         return null;
       }
       arms.push([guard, value] as const);
+      if (currentFact !== null) {
+        fallthroughFacts.push(negateFact(currentFact));
+      }
       continue;
     }
 
-    const localName =
-      binding.localName ??
-      allocLocalBindingName(
-        ctx.supply,
-        toPantTermName(binding.tsName),
-        scopedParams,
-      );
+    const localName = freshHygienicBinder(ctx.supply);
     const value =
       binding.kind === "const"
         ? buildL1SubExpr(binding.initializer, {
@@ -3497,11 +3510,20 @@ function lowerNestedPureBlockReturnToL1(
     scopedParams = withParam(scopedParams, binding.tsName, localName);
   }
 
-  const terminal = lowerNestedPureTerminalToL1(
-    extracted.returnExpr,
-    ctx,
-    scopedParams,
-  );
+  let terminal: IR1Expr | null = null;
+  enterFrame(ctx.env);
+  try {
+    for (const fact of fallthroughFacts) {
+      pushFact(ctx.env, fact);
+    }
+    terminal = lowerNestedPureTerminalToL1(
+      extracted.returnExpr,
+      ctx,
+      scopedParams,
+    );
+  } finally {
+    exitFrame(ctx.env);
+  }
   if (terminal === null) {
     return null;
   }

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -3495,7 +3495,7 @@ function lowerNestedPureBlockReturnToL1(
             checker: ctx.checker,
             strategy: ctx.strategy,
             paramNames: scopedParams,
-            state: ctx.state,
+            state: ctx.state ?? makeSymbolicState(),
             supply: ctx.supply,
             env: ctx.env,
           }),

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -19,6 +19,7 @@ import {
   ir1Binop,
   ir1Block,
   ir1Break,
+  ir1Cond,
   ir1Continue,
   ir1Each,
   ir1For,
@@ -2921,99 +2922,9 @@ function lowerPreludeBindings(
   state?: SymbolicState,
   expectedReturnSort?: string,
 ): LoweredPreludeBindings | { error: string } {
-  // Phase 1: TDZ validation — reject forward/self references on TS AST.
-  // For μ-search bindings, validate both the init and the predicate; the
-  // predicate may reference its own counter (that's the loop), so the
-  // counter is removed from the blocked set when checking the predicate.
-  // Side-effectful μ-search init/predicate and early-return predicate/value
-  // are also rejected here: translateBodyExpr has no explicit
-  // handler for ++/-- and silently falls through to `ast.var(getText())`,
-  // so without this screen a loop like `while (used.has(i++)) i++;`
-  // would lower to a Pant expression containing a bogus var `"i++"`.
-  for (const [idx, binding] of bindings.entries()) {
-    const blockedNames = new Set(
-      bindings.slice(idx).flatMap((b) => bindingNames(b) as string[]),
-    );
-    if (binding.kind === "const") {
-      if (expressionReferencesNames(binding.initializer, blockedNames)) {
-        return { error: "const initializer references a later binding" };
-      }
-    } else if (binding.kind === "reassign") {
-      if (expressionReferencesNames(binding.valueExpr, blockedNames)) {
-        return { error: "reassignment value references a later binding" };
-      }
-    } else if (binding.kind === "stmt") {
-      if (nodeReferencesNames(binding.stmt, blockedNames)) {
-        return { error: "statement before return references a later binding" };
-      }
-    } else if (binding.kind === "muSearch") {
-      if (expressionHasSideEffects(binding.mu.initTsExpr, checker)) {
-        return { error: "while-loop init has side effects" };
-      }
-      if (
-        expressionHasSideEffects(binding.mu.predicateTsExpr, checker, {
-          admitForeignBoolPredicates: true,
-        })
-      ) {
-        return { error: "while-loop predicate has side effects" };
-      }
-      if (expressionReferencesNames(binding.mu.initTsExpr, blockedNames)) {
-        return { error: "while-loop init references a later binding" };
-      }
-      const predBlocked = new Set(blockedNames);
-      predBlocked.delete(binding.mu.counterName);
-      if (expressionReferencesNames(binding.mu.predicateTsExpr, predBlocked)) {
-        return { error: "while-loop predicate references a later binding" };
-      }
-    } else if (binding.kind === "forOf") {
-    } else {
-      // earlyReturn arm — predicate and value must be pure and may not refer
-      // to bindings declared after this point. The arm itself binds nothing,
-      // so `blockedNames` here just contains the names of later const /
-      // μ-search bindings (earlyReturn entries contribute nothing).
-      if (
-        expressionHasSideEffects(binding.predicateExpr, checker, {
-          admitForeignBoolPredicates: true,
-        })
-      ) {
-        return { error: "early-return predicate has side effects" };
-      }
-      for (const [blockIdx, blockBinding] of binding.blockBindings.entries()) {
-        if (expressionHasSideEffects(blockBinding.initializer, checker)) {
-          return { error: "early-return block const has side effects" };
-        }
-        const blockBlockedNames = new Set(
-          binding.blockBindings.slice(blockIdx).map((b) => b.tsName),
-        );
-        if (
-          expressionReferencesNames(blockBinding.initializer, blockBlockedNames)
-        ) {
-          return {
-            error:
-              "early-return block const initializer references a later binding",
-          };
-        }
-        if (expressionReferencesNames(blockBinding.initializer, blockedNames)) {
-          return {
-            error:
-              "early-return block const initializer references a later binding",
-          };
-        }
-      }
-      if (
-        expressionHasSideEffects(binding.valueExpr, checker, {
-          admitForeignBoolPredicates: true,
-        })
-      ) {
-        return { error: "early-return value has side effects" };
-      }
-      if (expressionReferencesNames(binding.predicateExpr, blockedNames)) {
-        return { error: "early-return predicate references a later binding" };
-      }
-      if (expressionReferencesNames(binding.valueExpr, blockedNames)) {
-        return { error: "early-return value references a later binding" };
-      }
-    }
+  const validation = validatePreludeBindings(bindings, checker);
+  if (validation !== null) {
+    return validation;
   }
 
   // Phase 2: translate initializers as a left fold, threading scopedParams
@@ -3286,6 +3197,107 @@ function lowerPreludeBindings(
   };
 }
 
+function validatePreludeBindings(
+  bindings: readonly PreludeStmt[],
+  checker: ts.TypeChecker,
+): { error: string } | null {
+  // Phase 1: TDZ validation — reject forward/self references on TS AST.
+  // For μ-search bindings, validate both the init and the predicate; the
+  // predicate may reference its own counter (that's the loop), so the
+  // counter is removed from the blocked set when checking the predicate.
+  // Side-effectful μ-search init/predicate and early-return predicate/value
+  // are also rejected here: translateBodyExpr has no explicit
+  // handler for ++/-- and silently falls through to `ast.var(getText())`,
+  // so without this screen a loop like `while (used.has(i++)) i++;`
+  // would lower to a Pant expression containing a bogus var `"i++"`.
+  for (const [idx, binding] of bindings.entries()) {
+    const blockedNames = new Set(
+      bindings.slice(idx).flatMap((b) => bindingNames(b) as string[]),
+    );
+    if (binding.kind === "const") {
+      if (expressionReferencesNames(binding.initializer, blockedNames)) {
+        return { error: "const initializer references a later binding" };
+      }
+    } else if (binding.kind === "reassign") {
+      if (expressionReferencesNames(binding.valueExpr, blockedNames)) {
+        return { error: "reassignment value references a later binding" };
+      }
+    } else if (binding.kind === "stmt") {
+      if (nodeReferencesNames(binding.stmt, blockedNames)) {
+        return { error: "statement before return references a later binding" };
+      }
+    } else if (binding.kind === "muSearch") {
+      if (expressionHasSideEffects(binding.mu.initTsExpr, checker)) {
+        return { error: "while-loop init has side effects" };
+      }
+      if (
+        expressionHasSideEffects(binding.mu.predicateTsExpr, checker, {
+          admitForeignBoolPredicates: true,
+        })
+      ) {
+        return { error: "while-loop predicate has side effects" };
+      }
+      if (expressionReferencesNames(binding.mu.initTsExpr, blockedNames)) {
+        return { error: "while-loop init references a later binding" };
+      }
+      const predBlocked = new Set(blockedNames);
+      predBlocked.delete(binding.mu.counterName);
+      if (expressionReferencesNames(binding.mu.predicateTsExpr, predBlocked)) {
+        return { error: "while-loop predicate references a later binding" };
+      }
+    } else if (binding.kind === "forOf") {
+    } else {
+      // earlyReturn arm — predicate and value must be pure and may not refer
+      // to bindings declared after this point. The arm itself binds nothing,
+      // so `blockedNames` here just contains the names of later const /
+      // μ-search bindings (earlyReturn entries contribute nothing).
+      if (
+        expressionHasSideEffects(binding.predicateExpr, checker, {
+          admitForeignBoolPredicates: true,
+        })
+      ) {
+        return { error: "early-return predicate has side effects" };
+      }
+      for (const [blockIdx, blockBinding] of binding.blockBindings.entries()) {
+        if (expressionHasSideEffects(blockBinding.initializer, checker)) {
+          return { error: "early-return block const has side effects" };
+        }
+        const blockBlockedNames = new Set(
+          binding.blockBindings.slice(blockIdx).map((b) => b.tsName),
+        );
+        if (
+          expressionReferencesNames(blockBinding.initializer, blockBlockedNames)
+        ) {
+          return {
+            error:
+              "early-return block const initializer references a later binding",
+          };
+        }
+        if (expressionReferencesNames(blockBinding.initializer, blockedNames)) {
+          return {
+            error:
+              "early-return block const initializer references a later binding",
+          };
+        }
+      }
+      if (
+        expressionHasSideEffects(binding.valueExpr, checker, {
+          admitForeignBoolPredicates: true,
+        })
+      ) {
+        return { error: "early-return value has side effects" };
+      }
+      if (expressionReferencesNames(binding.predicateExpr, blockedNames)) {
+        return { error: "early-return predicate references a later binding" };
+      }
+      if (expressionReferencesNames(binding.valueExpr, blockedNames)) {
+        return { error: "early-return value references a later binding" };
+      }
+    }
+  }
+  return null;
+}
+
 type BindingInitResult = { value: OpaqueExpr } | { error: string };
 
 function translateEarlyReturnBlockValue(
@@ -3344,6 +3356,242 @@ function translateEarlyReturnBlockValue(
     value,
   );
   return { value: applyOpaqueAliases(lowerL1ToOpaque(inlined), ctx.supply) };
+}
+
+export interface NestedPureBlockReturnContext {
+  checker: ts.TypeChecker;
+  strategy: NumericStrategy;
+  paramNames: ReadonlyMap<string, string>;
+  state?: SymbolicState;
+  supply: UniqueSupply;
+  env: AssumptionEnv;
+  expectedReturnSort?: string;
+}
+
+/**
+ * Lower a TS block as one nested pure return value.
+ *
+ * This is the recursive block-return primitive used by later branch,
+ * switch, and callback consumers. It shares `extractReturnExpression` for
+ * shape recognition, `validatePreludeBindings` for TDZ/side-effect refusal,
+ * L1 if-conversion for terminal control flow, and IR1 capture-avoiding
+ * substitution for local const/μ let-elimination. Unsupported statement
+ * sequencing returns `null` rather than leaking a partially lowered value.
+ */
+export function lowerNestedPureBlockReturn(
+  block: ts.Block,
+  ctx: NestedPureBlockReturnContext,
+): BodyResult | null {
+  const lowered = lowerNestedPureBlockReturnToL1(block, ctx);
+  if (lowered === null) {
+    return null;
+  }
+  return { expr: applyOpaqueAliases(lowerL1ToOpaque(lowered), ctx.supply) };
+}
+
+function lowerNestedPureBlockReturnToL1(
+  block: ts.Block,
+  ctx: NestedPureBlockReturnContext,
+): IR1Expr | null {
+  const extracted = extractReturnExpression(block, {
+    checker: ctx.checker,
+    strategy: ctx.strategy,
+    paramNames: ctx.paramNames,
+    state: ctx.state,
+    supply: ctx.supply,
+    env: ctx.env,
+    ...(ctx.expectedReturnSort === undefined
+      ? {}
+      : { expectedSort: ctx.expectedReturnSort }),
+  });
+  if (extracted === null) {
+    return null;
+  }
+  if (
+    extracted.bindings.some(
+      (binding) => binding.kind === "reassign" || binding.kind === "stmt",
+    )
+  ) {
+    return null;
+  }
+  const validation = validatePreludeBindings(extracted.bindings, ctx.checker);
+  if (validation !== null) {
+    return null;
+  }
+
+  let scopedParams: ReadonlyMap<string, string> = ctx.paramNames;
+  const substitutions: Array<{ localName: string; value: IR1Expr }> = [];
+  const arms: Array<readonly [IR1Expr, IR1Expr]> = [];
+
+  for (const binding of extracted.bindings) {
+    if (
+      binding.kind === "forOf" ||
+      binding.kind === "reassign" ||
+      binding.kind === "stmt"
+    ) {
+      return null;
+    }
+    if (binding.kind === "earlyReturn") {
+      const guard = buildL1SubExpr(binding.predicateExpr, {
+        checker: ctx.checker,
+        strategy: ctx.strategy,
+        paramNames: scopedParams,
+        state: ctx.state ?? makeSymbolicState(),
+        supply: ctx.supply,
+        env: ctx.env,
+      });
+      if (isUnsupported(guard) || isL1Unsupported(guard)) {
+        return null;
+      }
+      const value = lowerEarlyReturnArmValueToL1(
+        binding.blockBindings,
+        binding.valueExpr,
+        {
+          checker: ctx.checker,
+          strategy: ctx.strategy,
+          paramNames: scopedParams,
+          state: ctx.state ?? makeSymbolicState(),
+          supply: ctx.supply,
+          env: ctx.env,
+          ...(ctx.expectedReturnSort === undefined
+            ? {}
+            : { expectedReturnSort: ctx.expectedReturnSort }),
+        },
+      );
+      if (value === null) {
+        return null;
+      }
+      arms.push([guard, value] as const);
+      continue;
+    }
+
+    const localName =
+      binding.localName ??
+      allocLocalBindingName(
+        ctx.supply,
+        toPantTermName(binding.tsName),
+        scopedParams,
+      );
+    const value =
+      binding.kind === "const"
+        ? buildL1SubExpr(binding.initializer, {
+            checker: ctx.checker,
+            strategy: ctx.strategy,
+            paramNames: scopedParams,
+            state: ctx.state ?? makeSymbolicState(),
+            supply: ctx.supply,
+            env: ctx.env,
+          })
+        : buildL1MuSearchCombTyped(binding.mu, {
+            checker: ctx.checker,
+            strategy: ctx.strategy,
+            paramNames: scopedParams,
+            state: ctx.state,
+            supply: ctx.supply,
+            env: ctx.env,
+          });
+    if (isUnsupported(value) || isL1Unsupported(value)) {
+      return null;
+    }
+    substitutions.push({ localName, value });
+    scopedParams = withParam(scopedParams, binding.tsName, localName);
+  }
+
+  const terminal = lowerNestedPureTerminalToL1(
+    extracted.returnExpr,
+    ctx,
+    scopedParams,
+  );
+  if (terminal === null) {
+    return null;
+  }
+  const withArms =
+    arms.length === 0
+      ? terminal
+      : ir1Cond(
+          arms as [readonly [IR1Expr, IR1Expr], ...typeof arms],
+          terminal,
+        );
+  return substitutions.reduceRight(
+    (acc, binding) =>
+      substituteIR1ExprSubtree(acc, ir1Var(binding.localName), binding.value),
+    withArms,
+  );
+}
+
+function lowerEarlyReturnArmValueToL1(
+  bindings: readonly ExtractedBlockConstBinding[],
+  valueExpr: ts.Expression,
+  ctx: {
+    checker: ts.TypeChecker;
+    strategy: NumericStrategy;
+    paramNames: ReadonlyMap<string, string>;
+    state: SymbolicState;
+    supply: UniqueSupply;
+    env: AssumptionEnv;
+  } & { expectedReturnSort?: string },
+): IR1Expr | null {
+  let scopedParams: ReadonlyMap<string, string> = new Map(ctx.paramNames);
+  const substitutions: Array<{ localName: string; value: IR1Expr }> = [];
+  for (const binding of bindings) {
+    const localName = freshHygienicBinder(ctx.supply);
+    const value = buildL1SubExpr(binding.initializer, {
+      checker: ctx.checker,
+      strategy: ctx.strategy,
+      paramNames: scopedParams,
+      state: ctx.state,
+      supply: ctx.supply,
+      env: ctx.env,
+    });
+    if (isUnsupported(value) || isL1Unsupported(value)) {
+      return null;
+    }
+    substitutions.push({ localName, value });
+    scopedParams = withParam(scopedParams, binding.tsName, localName);
+  }
+  const value = buildL1SubExpr(valueExpr, {
+    checker: ctx.checker,
+    strategy: ctx.strategy,
+    paramNames: scopedParams,
+    state: ctx.state,
+    supply: ctx.supply,
+    env: ctx.env,
+    ...(ctx.expectedReturnSort === undefined
+      ? {}
+      : { expectedSort: ctx.expectedReturnSort }),
+  });
+  if (isUnsupported(value) || isL1Unsupported(value)) {
+    return null;
+  }
+  return substitutions.reduceRight(
+    (acc, binding) =>
+      substituteIR1ExprSubtree(acc, ir1Var(binding.localName), binding.value),
+    value,
+  );
+}
+
+function lowerNestedPureTerminalToL1(
+  terminal: ts.Expression | ts.IfStatement | ts.SwitchStatement,
+  ctx: NestedPureBlockReturnContext,
+  scopedParams: ReadonlyMap<string, string>,
+): IR1Expr | null {
+  const l1Ctx = {
+    checker: ctx.checker,
+    strategy: ctx.strategy,
+    paramNames: scopedParams,
+    state: ctx.state ?? makeSymbolicState(),
+    supply: ctx.supply,
+    env: ctx.env,
+    ...(ctx.expectedReturnSort === undefined
+      ? {}
+      : { expectedSort: ctx.expectedReturnSort }),
+  };
+  if (ts.isIfStatement(terminal) || ts.isSwitchStatement(terminal)) {
+    const value = buildL1Conditional(terminal, l1Ctx);
+    return isL1Unsupported(value) ? null : value;
+  }
+  const value = buildL1SubExpr(terminal, l1Ctx);
+  return isUnsupported(value) || isL1Unsupported(value) ? null : value;
 }
 
 function translateBindingInit(

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -3437,43 +3437,39 @@ function lowerNestedPureBlockReturnToL1(
         binding.predicateExpr,
         ctx.checker,
       );
-      const guard = buildL1SubExpr(binding.predicateExpr, {
-        checker: ctx.checker,
-        strategy: ctx.strategy,
-        paramNames: scopedParams,
-        state: ctx.state ?? makeSymbolicState(),
-        supply: ctx.supply,
-        env: ctx.env,
-      });
+      const guard = withNestedFactFrame(ctx.env, fallthroughFacts, () =>
+        buildL1SubExpr(binding.predicateExpr, {
+          checker: ctx.checker,
+          strategy: ctx.strategy,
+          paramNames: scopedParams,
+          state: ctx.state ?? makeSymbolicState(),
+          supply: ctx.supply,
+          env: ctx.env,
+        }),
+      );
       if (isUnsupported(guard) || isL1Unsupported(guard)) {
         return null;
       }
-      let value: IR1Expr | null = null;
-      enterFrame(ctx.env);
-      try {
-        for (const fact of [...fallthroughFacts, currentFact]) {
-          if (fact !== null) {
-            pushFact(ctx.env, fact);
-          }
-        }
-        value = lowerEarlyReturnArmValueToL1(
-          binding.blockBindings,
-          binding.valueExpr,
-          {
-            checker: ctx.checker,
-            strategy: ctx.strategy,
-            paramNames: scopedParams,
-            state: ctx.state ?? makeSymbolicState(),
-            supply: ctx.supply,
-            env: ctx.env,
-            ...(ctx.expectedReturnSort === undefined
-              ? {}
-              : { expectedReturnSort: ctx.expectedReturnSort }),
-          },
-        );
-      } finally {
-        exitFrame(ctx.env);
-      }
+      const value = withNestedFactFrame(
+        ctx.env,
+        [...fallthroughFacts, currentFact],
+        () =>
+          lowerEarlyReturnArmValueToL1(
+            binding.blockBindings,
+            binding.valueExpr,
+            {
+              checker: ctx.checker,
+              strategy: ctx.strategy,
+              paramNames: scopedParams,
+              state: ctx.state ?? makeSymbolicState(),
+              supply: ctx.supply,
+              env: ctx.env,
+              ...(ctx.expectedReturnSort === undefined
+                ? {}
+                : { expectedReturnSort: ctx.expectedReturnSort }),
+            },
+          ),
+      );
       if (value === null) {
         return null;
       }
@@ -3485,7 +3481,7 @@ function lowerNestedPureBlockReturnToL1(
     }
 
     const localName = freshHygienicBinder(ctx.supply);
-    const value =
+    const value = withNestedFactFrame(ctx.env, fallthroughFacts, () =>
       binding.kind === "const"
         ? buildL1SubExpr(binding.initializer, {
             checker: ctx.checker,
@@ -3502,7 +3498,8 @@ function lowerNestedPureBlockReturnToL1(
             state: ctx.state,
             supply: ctx.supply,
             env: ctx.env,
-          });
+          }),
+    );
     if (isUnsupported(value) || isL1Unsupported(value)) {
       return null;
     }
@@ -3510,20 +3507,9 @@ function lowerNestedPureBlockReturnToL1(
     scopedParams = withParam(scopedParams, binding.tsName, localName);
   }
 
-  let terminal: IR1Expr | null = null;
-  enterFrame(ctx.env);
-  try {
-    for (const fact of fallthroughFacts) {
-      pushFact(ctx.env, fact);
-    }
-    terminal = lowerNestedPureTerminalToL1(
-      extracted.returnExpr,
-      ctx,
-      scopedParams,
-    );
-  } finally {
-    exitFrame(ctx.env);
-  }
+  const terminal = withNestedFactFrame(ctx.env, fallthroughFacts, () =>
+    lowerNestedPureTerminalToL1(extracted.returnExpr, ctx, scopedParams),
+  );
   if (terminal === null) {
     return null;
   }
@@ -3539,6 +3525,24 @@ function lowerNestedPureBlockReturnToL1(
       substituteIR1ExprSubtree(acc, ir1Var(binding.localName), binding.value),
     withArms,
   );
+}
+
+function withNestedFactFrame<T>(
+  env: AssumptionEnv,
+  facts: ReadonlyArray<Fact | null>,
+  fn: () => T,
+): T {
+  enterFrame(env);
+  try {
+    for (const fact of facts) {
+      if (fact !== null) {
+        pushFact(env, fact);
+      }
+    }
+    return fn();
+  } finally {
+    exitFrame(env);
+  }
 }
 
 function lowerEarlyReturnArmValueToL1(

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -182,6 +182,14 @@ exports[`expressions-body-lowering-rd2.ts > rd2NestedEarlyReturnBlock 1`] = `
 "module RD2_NESTED_EARLY_RETURN_BLOCK.\\n\\nrd2-nested-early-return-block n: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: rd2-nested-early-return-block — if-with-return block must contain only const bindings followed by a return.\\n"
 `;
 
+exports[`expressions-body-lowering-rd2.ts > rd2NullableNestedArm 1`] = `
+"module RD2_NULLABLE_NESTED_ARM.\\n\\nUser.\\nuser--active u1: User => Bool.\\nuser--score u1: User => Int.\\nuser--name u1: User => String.\\nrd2-nullable-nested-arm u: [User], flag: Bool => Int.\\n\\n---\\n\\n> UNSUPPORTED: rd2-nullable-nested-arm — if-with-return block must contain only const bindings followed by a return.\\n"
+`;
+
+exports[`expressions-body-lowering-rd2.ts > rd2NullableNestedTerminal 1`] = `
+"module RD2_NULLABLE_NESTED_TERMINAL.\\n\\nUser.\\nuser--active u1: User => Bool.\\nuser--score u1: User => Int.\\nuser--name u1: User => String.\\nrd2-nullable-nested-terminal u: [User], flag: Bool => Int.\\n\\n---\\n\\n> UNSUPPORTED: rd2-nullable-nested-terminal — if-with-return block must contain only const bindings followed by a return.\\n"
+`;
+
 exports[`expressions-body-lowering-rd2.ts > rd2RecordReturnConditional 1`] = `
 "module RD2_RECORD_RETURN_CONDITIONAL.\\n\\nPair.\\npair--x p: Pair => Int.\\npair--y p: Pair => Int.\\nrd2-record-return-conditional n: Int, flag: Bool => Pair.\\n\\n---\\n\\n> UNSUPPORTED: rd2-record-return-conditional — record return combined with early-return arms or if/else branches is not yet supported.\\n"
 `;

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-body-lowering-rd2.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-body-lowering-rd2.ts
@@ -35,6 +35,32 @@ export function rd2NestedBlockWithConstPrelude(n: number): number {
   return n;
 }
 
+export function rd2NullableNestedTerminal(
+  u: User | null,
+  flag: boolean,
+): number {
+  if (flag) {
+    if (u === null) {
+      return 0;
+    }
+    return u.score;
+  }
+  return 0;
+}
+
+export function rd2NullableNestedArm(
+  u: User | null,
+  flag: boolean,
+): number {
+  if (flag) {
+    if (u !== null) {
+      return u.score;
+    }
+    return 0;
+  }
+  return 0;
+}
+
 export function rd2TerminalIfElseBranchBlocks(
   n: number,
   flag: boolean,

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -10,6 +10,7 @@ import {
   createSourceFile,
   createSourceFileFromSource,
 } from "../src/extract.js";
+import { createL1AssumptionEnv } from "../src/ir1-build.js";
 import { getAst, loadAst } from "../src/pant-wasm.js";
 import * as Supply from "../src/supply.js";
 import * as TB from "../src/translate-body.js";
@@ -255,10 +256,8 @@ it("generated body helpers preserve structural translations", () => {
 // exhaustive construct coverage).
 
 describe("unsupported patterns", () => {
-  it.skip(
-    "PENDING Patch 2: nested pure block-return lowers to one value with inlined bindings",
-    () => {
-      const source = `
+  it("nested pure block-return helper lowers to one value with inlined bindings", () => {
+    const source = `
         function nested(n: number): number {
           if (n < 0) {
             const magnitude = 0 - n;
@@ -270,11 +269,69 @@ describe("unsupported patterns", () => {
           return n;
         }
       `;
-      const sourceFile = createSourceFileFromSource(source);
-      const props = translateBodyWithSynth(sourceFile, "nested");
-      assert.equal(props.some((p) => p.kind === "unsupported"), false);
-    },
-  );
+    const sourceFile = createSourceFileFromSource(source);
+    const checker = sourceFile.getProject().getTypeChecker().compilerObject;
+    const fn = sourceFile.getFunctionOrThrow("nested").compilerNode;
+    const first = fn.body?.statements[0];
+    assert.ok(first && ts.isIfStatement(first));
+    assert.ok(ts.isBlock(first.thenStatement));
+    const synthCell = newSynthCell();
+    const { paramNameMap } = translateSignature(
+      sourceFile,
+      "nested",
+      IntStrategy,
+      synthCell,
+    );
+    const result = TB.lowerNestedPureBlockReturn(first.thenStatement, {
+      checker,
+      strategy: IntStrategy,
+      paramNames: paramNameMap,
+      supply: Supply.makeUniqueSupply(synthCell),
+      env: createL1AssumptionEnv(),
+      expectedReturnSort: "Int",
+    });
+    assert.ok(result);
+    assert.equal("unsupported" in result, false);
+    assert.equal(
+      getAst().strExpr(TB.bodyExpr(result)),
+      "cond 0 - n > 10 => 0 - n, true => 0 - n + 1",
+    );
+  });
+
+  it("nested pure block-return helper rejects stateful statement sequencing", () => {
+    const source = `
+        function nested(n: number): number {
+          if (n < 0) {
+            const lines: number[] = [];
+            lines.push(n);
+            return lines.length;
+          }
+          return n;
+        }
+      `;
+    const sourceFile = createSourceFileFromSource(source);
+    const checker = sourceFile.getProject().getTypeChecker().compilerObject;
+    const fn = sourceFile.getFunctionOrThrow("nested").compilerNode;
+    const first = fn.body?.statements[0];
+    assert.ok(first && ts.isIfStatement(first));
+    assert.ok(ts.isBlock(first.thenStatement));
+    const synthCell = newSynthCell();
+    const { paramNameMap } = translateSignature(
+      sourceFile,
+      "nested",
+      IntStrategy,
+      synthCell,
+    );
+    const result = TB.lowerNestedPureBlockReturn(first.thenStatement, {
+      checker,
+      strategy: IntStrategy,
+      paramNames: paramNameMap,
+      supply: Supply.makeUniqueSupply(synthCell),
+      env: createL1AssumptionEnv(),
+      expectedReturnSort: "Int",
+    });
+    assert.equal(result, null);
+  });
 
   it.skip(
     "PENDING Patch 3: early-return arm block may contain nested early returns",

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -333,6 +333,90 @@ describe("unsupported patterns", () => {
     assert.equal(result, null);
   });
 
+  it("nested pure block-return helper threads branch facts into terminal", () => {
+    const source = `
+        interface User { score: number; }
+        function nested(u: User | null): number {
+          if (true) {
+            if (u === null) {
+              return 0;
+            }
+            return u.score;
+          }
+          return 0;
+        }
+      `;
+    const sourceFile = createSourceFileFromSource(source);
+    const checker = sourceFile.getProject().getTypeChecker().compilerObject;
+    const fn = sourceFile.getFunctionOrThrow("nested").compilerNode;
+    const first = fn.body?.statements[0];
+    assert.ok(first && ts.isIfStatement(first));
+    assert.ok(ts.isBlock(first.thenStatement));
+    const synthCell = newSynthCell();
+    const { paramNameMap } = translateSignature(
+      sourceFile,
+      "nested",
+      IntStrategy,
+      synthCell,
+    );
+    const result = TB.lowerNestedPureBlockReturn(first.thenStatement, {
+      checker,
+      strategy: IntStrategy,
+      paramNames: paramNameMap,
+      supply: Supply.makeUniqueSupply(synthCell),
+      env: createL1AssumptionEnv(),
+      expectedReturnSort: "Int",
+    });
+    assert.ok(result);
+    assert.equal("unsupported" in result, false);
+    assert.equal(
+      getAst().strExpr(TB.bodyExpr(result)),
+      "cond #u = 0 => 0, true => user--score (u 1)",
+    );
+  });
+
+  it("nested pure block-return helper threads branch facts into arm values", () => {
+    const source = `
+        interface User { score: number; }
+        function nested(u: User | null): number {
+          if (true) {
+            if (u !== null) {
+              return u.score;
+            }
+            return 0;
+          }
+          return 0;
+        }
+      `;
+    const sourceFile = createSourceFileFromSource(source);
+    const checker = sourceFile.getProject().getTypeChecker().compilerObject;
+    const fn = sourceFile.getFunctionOrThrow("nested").compilerNode;
+    const first = fn.body?.statements[0];
+    assert.ok(first && ts.isIfStatement(first));
+    assert.ok(ts.isBlock(first.thenStatement));
+    const synthCell = newSynthCell();
+    const { paramNameMap } = translateSignature(
+      sourceFile,
+      "nested",
+      IntStrategy,
+      synthCell,
+    );
+    const result = TB.lowerNestedPureBlockReturn(first.thenStatement, {
+      checker,
+      strategy: IntStrategy,
+      paramNames: paramNameMap,
+      supply: Supply.makeUniqueSupply(synthCell),
+      env: createL1AssumptionEnv(),
+      expectedReturnSort: "Int",
+    });
+    assert.ok(result);
+    assert.equal("unsupported" in result, false);
+    assert.equal(
+      getAst().strExpr(TB.bodyExpr(result)),
+      "cond ~(#u = 0) => user--score (u 1), true => 0",
+    );
+  });
+
   it.skip(
     "PENDING Patch 3: early-return arm block may contain nested early returns",
     () => {

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -417,6 +417,52 @@ describe("unsupported patterns", () => {
     );
   });
 
+  it("nested pure block-return helper threads facts into later guards and consts", () => {
+    const source = `
+        interface User { score: number; }
+        function nested(u: User | null): number {
+          if (true) {
+            if (u === null) {
+              return 0;
+            }
+            const score = u.score;
+            if (score > 10) {
+              return score;
+            }
+            return score + 1;
+          }
+          return 0;
+        }
+      `;
+    const sourceFile = createSourceFileFromSource(source);
+    const checker = sourceFile.getProject().getTypeChecker().compilerObject;
+    const fn = sourceFile.getFunctionOrThrow("nested").compilerNode;
+    const first = fn.body?.statements[0];
+    assert.ok(first && ts.isIfStatement(first));
+    assert.ok(ts.isBlock(first.thenStatement));
+    const synthCell = newSynthCell();
+    const { paramNameMap } = translateSignature(
+      sourceFile,
+      "nested",
+      IntStrategy,
+      synthCell,
+    );
+    const result = TB.lowerNestedPureBlockReturn(first.thenStatement, {
+      checker,
+      strategy: IntStrategy,
+      paramNames: paramNameMap,
+      supply: Supply.makeUniqueSupply(synthCell),
+      env: createL1AssumptionEnv(),
+      expectedReturnSort: "Int",
+    });
+    assert.ok(result);
+    assert.equal("unsupported" in result, false);
+    assert.equal(
+      getAst().strExpr(TB.bodyExpr(result)),
+      "cond #u = 0 => 0, user--score (u 1) > 10 => user--score (u 1), true => user--score (u 1) + 1",
+    );
+  });
+
   it.skip(
     "PENDING Patch 3: early-return arm block may contain nested early returns",
     () => {

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -333,6 +333,45 @@ describe("unsupported patterns", () => {
     assert.equal(result, null);
   });
 
+  it("nested pure block-return helper lowers mu-search without caller state", () => {
+    const source = `
+        function nested(used: ReadonlySet<number>): number {
+          if (true) {
+            let i = 0;
+            while (used.has(i)) {
+              i++;
+            }
+            return i;
+          }
+          return 0;
+        }
+      `;
+    const sourceFile = createSourceFileFromSource(source);
+    const checker = sourceFile.getProject().getTypeChecker().compilerObject;
+    const fn = sourceFile.getFunctionOrThrow("nested").compilerNode;
+    const first = fn.body?.statements[0];
+    assert.ok(first && ts.isIfStatement(first));
+    assert.ok(ts.isBlock(first.thenStatement));
+    const synthCell = newSynthCell();
+    const { paramNameMap } = translateSignature(
+      sourceFile,
+      "nested",
+      IntStrategy,
+      synthCell,
+    );
+    const result = TB.lowerNestedPureBlockReturn(first.thenStatement, {
+      checker,
+      strategy: IntStrategy,
+      paramNames: paramNameMap,
+      supply: Supply.makeUniqueSupply(synthCell),
+      env: createL1AssumptionEnv(),
+      expectedReturnSort: "Int",
+    });
+    assert.ok(result);
+    assert.equal("unsupported" in result, false);
+    assert.match(getAst().strExpr(TB.bodyExpr(result)), /min over each/u);
+  });
+
   it("nested pure block-return helper threads branch facts into terminal", () => {
     const source = `
         interface User { score: number; }


### PR DESCRIPTION
## Patch 2: Shared recursive pure block-return lowering helper

- Factor the supported pure-block lowering into a helper callable from branch, switch, and callback sites without duplicating AST walking.
- Preserve all existing TDZ and forward-reference checks from lowerPreludeBindings.
- Return null/unsupported rather than emitting partial output when a nested block includes stateful expression statements, effectful consts, non-final returns, throws, breaks, or unsupported terminal forms.
- Document the transformation and invariants in transformations.md.

## Changes
- Factor the supported pure-block lowering into a helper callable from branch, switch, and callback sites without duplicating AST walking.
- Preserve all existing TDZ and forward-reference checks from lowerPreludeBindings.
- Return null/unsupported rather than emitting partial output when a nested block includes stateful expression statements, effectful consts, non-final returns, throws, breaks, or unsupported terminal forms.
- Document the transformation and invariants in transformations.md.

## Files to Modify
- tools/ts2pant/src/translate-body.ts (modify): Add a shared helper that lowers a block as a nested pure body by reusing extractReturnExpression + lowerPreludeBindings, producing a BodyResult/L1 value or null on unsupported shapes.
- tools/ts2pant/tests/translate-body.test.mts (modify): Unskip and implement the direct helper tests without wiring external consumers yet.
- tools/ts2pant/docs/transformations.md (modify): Document recursive pure block-return lowering as if-conversion plus let-elimination, including conservative refusal conditions.

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[paper] Allen et al. 1983 if-conversion** — https://dl.acm.org/doi/10.1145/567067.567085 — The helper turns nested early-return control dependence into data dependence by producing one conditional value for the block.
- **[algorithm] Capture-avoiding substitution** — Local const bindings inside nested blocks must be inlined through the existing hygienic substitution path rather than by textual replacement.

## Gameplan Specification

```
module BODY_LOWERING_COMPLETENESS_RD2.

Body.
Block.
Arm.
Clause.
Callback.
RecordBranchSet.

supported-pure-block? b: Block => Bool.
block-lowered? b: Block => Bool.
nested-block-arm? a: Arm => Bool.
arm-lowered? a: Arm => Bool.
nested-switch-clause? c: Clause => Bool.
clause-lowered? c: Clause => Bool.
nested-callback-block? cb: Callback => Bool.
callback-lowered? cb: Callback => Bool.
same-field-set? r: RecordBranchSet => Bool.
fieldwise-cond-lowered? r: RecordBranchSet => Bool.
unsupported-shape? b: Body => Bool.
rejected? b: Body => Bool.
typechecks? b: Body => Bool.

---

all b: Block | supported-pure-block? b -> block-lowered? b.
all a: Arm | nested-block-arm? a -> arm-lowered? a.
all c: Clause | nested-switch-clause? c -> clause-lowered? c.
all cb: Callback | nested-callback-block? cb -> callback-lowered? cb.
all r: RecordBranchSet | same-field-set? r -> fieldwise-cond-lowered? r.
all b: Body | unsupported-shape? b -> rejected? b.
all b: Body | typechecks? b.
```

## Patch Specification

```
module BODY_LOWERING_COMPLETENESS_RD2_PATCH_2.

Block.
supported-pure-block? b: Block => Bool.
lowered-value? b: Block => Bool.
unsupported-block? b: Block => Bool.
conservative-reject? b: Block => Bool.

---

all b: Block | supported-pure-block? b -> lowered-value? b.
all b: Block | unsupported-block? b -> conservative-reject? b.
```


## Implementation Notes

- Added `lowerNestedPureBlockReturn(block, ctx)` as the dependent-patch API. It returns a `BodyResult | null` with a fully inlined `expr` on success; later branch/switch/callback wiring should treat `null` as "unsupported shape, fall back to existing diagnostic path" rather than trying to salvage partial lowering.
- I factored the TDZ/side-effect scan out of `lowerPreludeBindings` into `validatePreludeBindings` and kept `lowerPreludeBindings` calling it first, so existing top-level behavior still uses the same checks while the new nested helper can reuse those checks without emitting local rule declarations.
- Nested block locals are deliberately eliminated inside IR1 with `substituteIR1ExprSubtree` before lowering to Pant. The helper does not emit the `ruleDecls`/SSA propositions that top-level pure bodies use for local lets; this prevents branch-local bindings from leaking into later consumers.
- Conservative scope note for dependent patches: the helper accepts const/let-as-const, recognized μ-search, and prelude early-return arms from `extractReturnExpression`, but rejects `reassign`, generic `stmt`, and `forOf` prelude entries for nested pure values. Local accumulator sequencing remains out of scope by returning `null`.
- The helper currently lowers terminal `if`/`switch` through the existing L1 conditional builder. Consumers that need richer branch-block recursion should call this helper at the branch/clauses/callback boundary rather than expecting `buildL1Conditional` itself to recurse into blocks automatically.

Spec/Evidence Mapping:
- `supported-pure-block? -> lowered-value?`: `lowerNestedPureBlockReturnToL1` reuses `extractReturnExpression`, lowers early-return arms plus terminal expression to one IR1 value, and inlines locals with capture-avoiding substitution. Covered by `translate-body.test.mts` direct helper test for nested early return with const prelude.
- `unsupported-block? -> conservative-reject?`: unsupported sequencing paths return `null`, including stateful expression statements and non-pure prelude entries. Covered by the direct helper test that rejects `lines.push(...); return ...`.
- Required context consulted: `translate-body.ts`, `ts-ast-block-return.ts`, `ir1-substitute.ts`, `tools/ts2pant/AGENTS.md`, `docs/transformations.md`, and the relevant `translate-body.test.mts` stubs.
- Checks run: `just ts2pant-typecheck`, `just ts2pant-test-unit-rest`, and `just ts2pant-test-unit-constructs`.