### PR TITLE
[ts2pant-body-lowering-completeness-rd2] Patch 3: Wire nested pure block returns into early-return arms and terminal branches

### DIFF
--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -230,8 +230,9 @@ type PreludeStmt =
   | {
       kind: "earlyReturn";
       predicateExpr: ts.Expression;
-      valueExpr: ts.Expression;
+      valueExpr?: ts.Expression;
       blockBindings: readonly ExtractedBlockConstBinding[];
+      nestedBlock?: ts.Block;
     };
 
 export interface RecognizedForOfPush {
@@ -1223,6 +1224,7 @@ function translatePureBody(
   if (
     extracted.bindings.length === 1 &&
     extracted.bindings[0]!.kind === "earlyReturn" &&
+    extracted.bindings[0]!.valueExpr !== undefined &&
     ts.isExpression(extracted.returnExpr)
   ) {
     const arm = extracted.bindings[0] as Extract<
@@ -1232,7 +1234,7 @@ function translatePureBody(
     const lifted = tryRecognizeFunctorLift(
       {
         guard: arm.predicateExpr,
-        thenExpr: arm.valueExpr,
+        thenExpr: arm.valueExpr!,
         elseExpr: extracted.returnExpr,
         contextNode: node,
       },
@@ -1335,7 +1337,9 @@ function translatePureBody(
   // garbage Pantagruel — reject those uniformly.
   const armHasObjLit = extracted.bindings.some(
     (b) =>
-      b.kind === "earlyReturn" && ts.isObjectLiteralExpression(b.valueExpr),
+      b.kind === "earlyReturn" &&
+      b.valueExpr !== undefined &&
+      ts.isObjectLiteralExpression(b.valueExpr),
   );
   const terminalIsObjLit =
     ts.isExpression(extracted.returnExpr) &&
@@ -1412,7 +1416,25 @@ function translatePureBody(
         // itself a cond we
         // splice its arms in to keep the output flat (matching the
         // legacy single-cond shape).
-        const terminalL1 = buildL1Conditional(extracted.returnExpr, l1Ctx);
+        const terminalL1 = ts.isIfStatement(extracted.returnExpr)
+          ? (lowerNestedPureIfStatementToL1(
+              extracted.returnExpr,
+              {
+                checker,
+                strategy,
+                paramNames: prelude.scopedParams,
+                supply,
+                env,
+                ...(expectedReturnSort === undefined
+                  ? {}
+                  : { expectedReturnSort }),
+              },
+              prelude.scopedParams,
+            ) ?? {
+              unsupported:
+                "if-then branch must contain a single return-with-value",
+            })
+          : buildL1Conditional(extracted.returnExpr, l1Ctx);
         if (isL1Unsupported(terminalL1)) {
           return [
             {
@@ -1918,8 +1940,9 @@ function recognizeLetWhilePair(
  */
 function recognizeEarlyReturnArm(stmt: ts.Statement): {
   predicateExpr: ts.Expression;
-  valueExpr: ts.Expression;
+  valueExpr?: ts.Expression;
   blockBindings: readonly ExtractedBlockConstBinding[];
+  nestedBlock?: ts.Block;
 } | null {
   if (!ts.isIfStatement(stmt)) {
     return null;
@@ -1943,13 +1966,42 @@ function recognizeEarlyReturnArm(stmt: ts.Statement): {
   }
   const extracted = extractBlockReturn(body);
   if (extracted === null) {
-    return null;
+    if (!blockHasReturnTerminal(body)) {
+      return null;
+    }
+    return {
+      predicateExpr: stmt.expression,
+      blockBindings: [],
+      nestedBlock: body,
+    };
   }
   return {
     predicateExpr: stmt.expression,
     valueExpr: extracted.returnExpr,
     blockBindings: extracted.bindings,
   };
+}
+
+function blockHasReturnTerminal(block: ts.Block): boolean {
+  const last = [...block.statements].at(-1);
+  return last !== undefined && statementHasReturnTerminal(last);
+}
+
+function statementHasReturnTerminal(stmt: ts.Statement): boolean {
+  if (ts.isReturnStatement(stmt)) {
+    return stmt.expression !== undefined;
+  }
+  if (ts.isBlock(stmt)) {
+    return blockHasReturnTerminal(stmt);
+  }
+  if (ts.isIfStatement(stmt)) {
+    return (
+      stmt.elseStatement !== undefined &&
+      statementHasReturnTerminal(stmt.thenStatement) &&
+      statementHasReturnTerminal(stmt.elseStatement)
+    );
+  }
+  return ts.isSwitchStatement(stmt);
 }
 
 /**
@@ -2968,7 +3020,31 @@ function lowerPreludeBindings(
               pushFact(env, fact);
             }
           }
-          if (binding.blockBindings.length === 0) {
+          if (binding.nestedBlock !== undefined) {
+            const value = lowerNestedPureBlockReturnToL1(binding.nestedBlock, {
+              checker,
+              strategy,
+              paramNames: acc.scopedParams,
+              state: state ?? makeSymbolicState(),
+              supply,
+              env,
+              ...(expectedReturnSort === undefined
+                ? {}
+                : { expectedReturnSort }),
+            });
+            valRes =
+              value === null
+                ? {
+                    error:
+                      "if-with-return block must contain only const bindings followed by a return",
+                  }
+                : {
+                    value: applyOpaqueAliases(lowerL1ToOpaque(value), supply),
+                  };
+          } else if (
+            binding.valueExpr !== undefined &&
+            binding.blockBindings.length === 0
+          ) {
             const definednessSnapshot = supply.synthCell
               ? [...supply.synthCell.definednessObligations]
               : null;
@@ -3010,7 +3086,7 @@ function lowerPreludeBindings(
                       env,
                     );
                   })();
-          } else {
+          } else if (binding.valueExpr !== undefined) {
             valRes = translateEarlyReturnBlockValue(
               binding.blockBindings,
               binding.valueExpr,
@@ -3026,6 +3102,11 @@ function lowerPreludeBindings(
                   : { expectedReturnSort }),
               },
             );
+          } else {
+            valRes = {
+              error:
+                "if-with-return block must contain only const bindings followed by a return",
+            };
           }
         } finally {
           exitFrame(env);
@@ -3280,17 +3361,25 @@ function validatePreludeBindings(
           };
         }
       }
-      if (
-        expressionHasSideEffects(binding.valueExpr, checker, {
-          admitForeignBoolPredicates: true,
-        })
-      ) {
-        return { error: "early-return value has side effects" };
-      }
       if (expressionReferencesNames(binding.predicateExpr, blockedNames)) {
         return { error: "early-return predicate references a later binding" };
       }
-      if (expressionReferencesNames(binding.valueExpr, blockedNames)) {
+      if (binding.valueExpr !== undefined) {
+        if (
+          expressionHasSideEffects(binding.valueExpr, checker, {
+            admitForeignBoolPredicates: true,
+          })
+        ) {
+          return { error: "early-return value has side effects" };
+        }
+        if (expressionReferencesNames(binding.valueExpr, blockedNames)) {
+          return { error: "early-return value references a later binding" };
+        }
+      }
+      if (
+        binding.nestedBlock !== undefined &&
+        nodeReferencesNames(binding.nestedBlock, blockedNames)
+      ) {
         return { error: "early-return value references a later binding" };
       }
     }
@@ -3418,6 +3507,15 @@ function lowerNestedPureBlockReturnToL1(
   if (validation !== null) {
     return null;
   }
+  if (
+    extracted.bindings.some(
+      (binding) =>
+        binding.kind === "const" &&
+        expressionHasSideEffects(binding.initializer, ctx.checker),
+    )
+  ) {
+    return null;
+  }
 
   let scopedParams: ReadonlyMap<string, string> = ctx.paramNames;
   const substitutions: Array<{ localName: string; value: IR1Expr }> = [];
@@ -3453,11 +3551,9 @@ function lowerNestedPureBlockReturnToL1(
       const value = withNestedFactFrame(
         ctx.env,
         [...fallthroughFacts, currentFact],
-        () =>
-          lowerEarlyReturnArmValueToL1(
-            binding.blockBindings,
-            binding.valueExpr,
-            {
+        () => {
+          if (binding.nestedBlock !== undefined) {
+            return lowerNestedPureBlockReturnToL1(binding.nestedBlock, {
               checker: ctx.checker,
               strategy: ctx.strategy,
               paramNames: scopedParams,
@@ -3467,8 +3563,27 @@ function lowerNestedPureBlockReturnToL1(
               ...(ctx.expectedReturnSort === undefined
                 ? {}
                 : { expectedReturnSort: ctx.expectedReturnSort }),
-            },
-          ),
+            });
+          }
+          if (binding.valueExpr !== undefined) {
+            return lowerEarlyReturnArmValueToL1(
+              binding.blockBindings,
+              binding.valueExpr,
+              {
+                checker: ctx.checker,
+                strategy: ctx.strategy,
+                paramNames: scopedParams,
+                state: ctx.state ?? makeSymbolicState(),
+                supply: ctx.supply,
+                env: ctx.env,
+                ...(ctx.expectedReturnSort === undefined
+                  ? {}
+                  : { expectedReturnSort: ctx.expectedReturnSort }),
+              },
+            );
+          }
+          return null;
+        },
       );
       if (value === null) {
         return null;
@@ -3612,12 +3727,146 @@ function lowerNestedPureTerminalToL1(
       ? {}
       : { expectedSort: ctx.expectedReturnSort }),
   };
-  if (ts.isIfStatement(terminal) || ts.isSwitchStatement(terminal)) {
+  if (ts.isIfStatement(terminal)) {
+    return lowerNestedPureIfStatementToL1(terminal, ctx, scopedParams);
+  }
+  if (ts.isSwitchStatement(terminal)) {
     const value = buildL1Conditional(terminal, l1Ctx);
     return isL1Unsupported(value) ? null : value;
   }
   const value = buildL1SubExpr(terminal, l1Ctx);
   return isUnsupported(value) || isL1Unsupported(value) ? null : value;
+}
+
+function lowerNestedPureIfStatementToL1(
+  stmt: ts.IfStatement,
+  ctx: NestedPureBlockReturnContext,
+  scopedParams: ReadonlyMap<string, string>,
+): IR1Expr | null {
+  const arms: Array<readonly [IR1Expr, IR1Expr]> = [];
+  let current: ts.IfStatement = stmt;
+  const elsePathFacts: Fact[] = [];
+
+  while (true) {
+    if (!current.elseStatement) {
+      return null;
+    }
+    const currentFact = recognizeBranchFact(current.expression, ctx.checker);
+    const guard = lowerWithFactsFrame(ctx.env, elsePathFacts, () =>
+      buildL1SubExpr(current.expression, {
+        checker: ctx.checker,
+        strategy: ctx.strategy,
+        paramNames: scopedParams,
+        state: ctx.state ?? makeSymbolicState(),
+        supply: ctx.supply,
+        env: ctx.env,
+      }),
+    );
+    if (isUnsupported(guard) || isL1Unsupported(guard)) {
+      return null;
+    }
+
+    const thenValue = lowerWithFactsFrame(
+      ctx.env,
+      [...elsePathFacts, currentFact],
+      () =>
+        lowerNestedPureBranchStatementToL1(
+          current.thenStatement,
+          ctx,
+          scopedParams,
+        ),
+    );
+    if (thenValue === null) {
+      return null;
+    }
+    arms.push([guard, thenValue] as const);
+
+    const elseFact = currentFact === null ? null : negateFact(currentFact);
+    if (ts.isIfStatement(current.elseStatement)) {
+      if (elseFact !== null) {
+        elsePathFacts.push(elseFact);
+      }
+      current = current.elseStatement;
+      continue;
+    }
+
+    const elseValue = lowerWithFactsFrame(
+      ctx.env,
+      [...elsePathFacts, elseFact],
+      () =>
+        lowerNestedPureBranchStatementToL1(
+          current.elseStatement!,
+          ctx,
+          scopedParams,
+        ),
+    );
+    if (elseValue === null || arms.length === 0) {
+      return null;
+    }
+    return ir1Cond(
+      arms as [readonly [IR1Expr, IR1Expr], ...typeof arms],
+      elseValue,
+    );
+  }
+}
+
+function lowerNestedPureBranchStatementToL1(
+  branch: ts.Statement,
+  ctx: NestedPureBlockReturnContext,
+  scopedParams: ReadonlyMap<string, string>,
+): IR1Expr | null {
+  if (ts.isReturnStatement(branch) && branch.expression !== undefined) {
+    const value = buildL1SubExpr(branch.expression, {
+      checker: ctx.checker,
+      strategy: ctx.strategy,
+      paramNames: scopedParams,
+      state: ctx.state ?? makeSymbolicState(),
+      supply: ctx.supply,
+      env: ctx.env,
+      ...(ctx.expectedReturnSort === undefined
+        ? {}
+        : { expectedSort: ctx.expectedReturnSort }),
+    });
+    return isUnsupported(value) || isL1Unsupported(value) ? null : value;
+  }
+  if (ts.isBlock(branch)) {
+    return lowerNestedPureBlockReturnToL1(branch, {
+      checker: ctx.checker,
+      strategy: ctx.strategy,
+      paramNames: scopedParams,
+      state: ctx.state ?? makeSymbolicState(),
+      supply: ctx.supply,
+      env: ctx.env,
+      ...(ctx.expectedReturnSort === undefined
+        ? {}
+        : { expectedReturnSort: ctx.expectedReturnSort }),
+    });
+  }
+  if (ts.isIfStatement(branch)) {
+    return lowerNestedPureIfStatementToL1(branch, ctx, scopedParams);
+  }
+  return null;
+}
+
+function lowerWithFactsFrame<T>(
+  env: AssumptionEnv,
+  facts: ReadonlyArray<Fact | null>,
+  lower: () => T,
+): T {
+  if (facts.every((fact) => fact === null)) {
+    return lower();
+  }
+  enterFrame(env);
+  try {
+    for (const fact of facts) {
+      if (fact !== null) {
+        pushFact(env, fact);
+      }
+    }
+    return lower();
+  } finally {
+    exitFrame(env);
+  }
 }
 
 function translateBindingInit(

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -175,19 +175,19 @@ exports[`expressions-body-lowering-rd2.ts > rd2LocalAccumulatorSequencing 1`] = 
 `;
 
 exports[`expressions-body-lowering-rd2.ts > rd2NestedBlockWithConstPrelude 1`] = `
-"module RD2_NESTED_BLOCK_WITH_CONST_PRELUDE.\\n\\nrd2-nested-block-with-const-prelude n: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: rd2-nested-block-with-const-prelude — if-with-return block must contain only const bindings followed by a return.\\n"
+"module RD2_NESTED_BLOCK_WITH_CONST_PRELUDE.\\n\\nrd2-nested-block-with-const-prelude n: Int => Int.\\n\\n---\\n\\nrd2-nested-block-with-const-prelude n = (cond n < 0 => (cond 0 - n > 10 => 0 - n, true => 0 - n + 1), true => n).\\n"
 `;
 
 exports[`expressions-body-lowering-rd2.ts > rd2NestedEarlyReturnBlock 1`] = `
-"module RD2_NESTED_EARLY_RETURN_BLOCK.\\n\\nrd2-nested-early-return-block n: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: rd2-nested-early-return-block — if-with-return block must contain only const bindings followed by a return.\\n"
+"module RD2_NESTED_EARLY_RETURN_BLOCK.\\n\\nrd2-nested-early-return-block n: Int => Int.\\n\\n---\\n\\nrd2-nested-early-return-block n = (cond n < 0 => (cond n < -10 => 10, true => 0 - n), true => n).\\n"
 `;
 
 exports[`expressions-body-lowering-rd2.ts > rd2NullableNestedArm 1`] = `
-"module RD2_NULLABLE_NESTED_ARM.\\n\\nUser.\\nuser--active u1: User => Bool.\\nuser--score u1: User => Int.\\nuser--name u1: User => String.\\nrd2-nullable-nested-arm u: [User], flag: Bool => Int.\\n\\n---\\n\\n> UNSUPPORTED: rd2-nullable-nested-arm — if-with-return block must contain only const bindings followed by a return.\\n"
+"module RD2_NULLABLE_NESTED_ARM.\\n\\nUser.\\nuser--active u1: User => Bool.\\nuser--score u1: User => Int.\\nuser--name u1: User => String.\\nrd2-nullable-nested-arm u: [User], flag: Bool => Int.\\n\\n---\\n\\nrd2-nullable-nested-arm u flag = (cond flag => (cond ~(#u = 0) => user--score (u 1), true => 0), true => 0).\\n\\ncheck\\n\\ntrue.\\n"
 `;
 
 exports[`expressions-body-lowering-rd2.ts > rd2NullableNestedTerminal 1`] = `
-"module RD2_NULLABLE_NESTED_TERMINAL.\\n\\nUser.\\nuser--active u1: User => Bool.\\nuser--score u1: User => Int.\\nuser--name u1: User => String.\\nrd2-nullable-nested-terminal u: [User], flag: Bool => Int.\\n\\n---\\n\\n> UNSUPPORTED: rd2-nullable-nested-terminal — if-with-return block must contain only const bindings followed by a return.\\n"
+"module RD2_NULLABLE_NESTED_TERMINAL.\\n\\nUser.\\nuser--active u1: User => Bool.\\nuser--score u1: User => Int.\\nuser--name u1: User => String.\\nrd2-nullable-nested-terminal u: [User], flag: Bool => Int.\\n\\n---\\n\\nrd2-nullable-nested-terminal u flag = (cond flag => (cond #u = 0 => 0, true => user--score (u 1)), true => 0).\\n\\ncheck\\n\\ntrue.\\n"
 `;
 
 exports[`expressions-body-lowering-rd2.ts > rd2RecordReturnConditional 1`] = `
@@ -211,7 +211,7 @@ exports[`expressions-body-lowering-rd2.ts > rd2SwitchNonLiteralLabel 1`] = `
 `;
 
 exports[`expressions-body-lowering-rd2.ts > rd2TerminalIfElseBranchBlocks 1`] = `
-"module RD2_TERMINAL_IF_ELSE_BRANCH_BLOCKS.\\n\\nrd2-terminal-if-else-branch-blocks n: Int, flag: Bool => Int.\\n\\n---\\n\\n> UNSUPPORTED: rd2-terminal-if-else-branch-blocks — if-then branch must contain a single return-with-value.\\n"
+"module RD2_TERMINAL_IF_ELSE_BRANCH_BLOCKS.\\n\\nrd2-terminal-if-else-branch-blocks n: Int, flag: Bool => Int.\\n\\n---\\n\\nrd2-terminal-if-else-branch-blocks n flag = (cond flag => (cond n < 0 => 0 - n, true => n + 1), true => (cond n + 2 > 10 => n + 2, true => 10)).\\n"
 `;
 
 exports[`expressions-boolean.ts > and 1`] = `

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -502,30 +502,58 @@ describe("unsupported patterns", () => {
     );
   });
 
-  it.skip(
-    "PENDING Patch 3: early-return arm block may contain nested early returns",
-    () => {
-      const source = `
-        function arm(n: number): number {
-          if (n < 0) {
-            if (n < -10) {
-              return 10;
-            }
-            return 0 - n;
+  it("early-return arm block may contain nested early returns", () => {
+    const source = `
+      function arm(n: number): number {
+        if (n < 0) {
+          if (n < -10) {
+            return 10;
           }
-          return n;
+          return 0 - n;
         }
-      `;
-      const sourceFile = createSourceFileFromSource(source);
-      const props = translateBodyWithSynth(sourceFile, "arm");
-      assert.equal(props.some((p) => p.kind === "unsupported"), false);
-    },
-  );
+        return n;
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBodyWithSynth(sourceFile, "arm");
+    assert.equal(
+      props.some((p) => p.kind === "unsupported"),
+      false,
+    );
+    assert.equal(
+      equationRhsText(props),
+      "cond n < 0 => (cond n < -10 => 10, true => 0 - n), true => n",
+    );
+  });
 
-  it.skip(
-    "PENDING Patch 4: switch and callback block consumers reuse nested pure block lowering",
-    () => {
-      const source = `
+  it("terminal if branches may contain nested pure block returns", () => {
+    const source = `
+      function branch(n: number): number {
+        if (n < 0) {
+          const m = 0 - n;
+          if (m > 10) {
+            return m + 1;
+          }
+          return m;
+        } else {
+          return n + 1;
+        }
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBodyWithSynth(sourceFile, "branch");
+    assert.equal(
+      props.some((p) => p.kind === "unsupported"),
+      false,
+    );
+    assert.equal(
+      equationRhsText(props),
+      "cond n < 0 => (cond 0 - n > 10 => 0 - n + 1, true => 0 - n), true => n + 1",
+    );
+  });
+
+  it.skip("PENDING Patch 4: switch and callback block consumers reuse nested pure block lowering", () => {
+    const source = `
         interface User { active: boolean; score: number; }
         function scores(users: User[]): number[] {
           return users.map((u) => {
@@ -548,18 +576,18 @@ describe("unsupported patterns", () => {
           }
         }
       `;
-      const sourceFile = createSourceFileFromSource(source);
-      for (const functionName of ["scores", "choose"]) {
-        const props = translateBodyWithSynth(sourceFile, functionName);
-        assert.equal(props.some((p) => p.kind === "unsupported"), false);
-      }
-    },
-  );
+    const sourceFile = createSourceFileFromSource(source);
+    for (const functionName of ["scores", "choose"]) {
+      const props = translateBodyWithSynth(sourceFile, functionName);
+      assert.equal(
+        props.some((p) => p.kind === "unsupported"),
+        false,
+      );
+    }
+  });
 
-  it.skip(
-    "PENDING Patch 5: record-return conditional lowers fieldwise",
-    () => {
-      const source = `
+  it.skip("PENDING Patch 5: record-return conditional lowers fieldwise", () => {
+    const source = `
         interface Pair { x: number; y: number; }
         function pair(n: number, flag: boolean): Pair {
           if (flag) {
@@ -568,12 +596,14 @@ describe("unsupported patterns", () => {
           return { x: 0, y: 1 };
         }
       `;
-      const sourceFile = createSourceFileFromSource(source);
-      const props = translateBodyWithSynth(sourceFile, "pair");
-      assert.equal(props.some((p) => p.kind === "unsupported"), false);
-      assert.equal(props.filter((p) => p.kind === "equation").length, 2);
-    },
-  );
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBodyWithSynth(sourceFile, "pair");
+    assert.equal(
+      props.some((p) => p.kind === "unsupported"),
+      false,
+    );
+    assert.equal(props.filter((p) => p.kind === "equation").length, 2);
+  });
 
   it("returns empty for function with no body", () => {
     const source = `
@@ -1165,7 +1195,7 @@ describe("if-early-return prelude arms", () => {
     }
   });
 
-  it("rejects pure block-bodied early-return arms with branch-local guards", () => {
+  it("allows pure block-bodied early-return arms with branch-local guards", () => {
     const source = `
       function assert(condition: unknown): asserts condition {
         if (!condition) throw new Error("no");
@@ -1185,14 +1215,11 @@ describe("if-early-return prelude arms", () => {
       functionName: "f",
       strategy: IntStrategy,
     });
-    assert.equal(props.length, 1);
-    assert.equal(props[0]?.kind, "unsupported");
-    if (props[0]?.kind === "unsupported") {
-      assert.match(
-        props[0].reason,
-        /only const bindings followed by a return/u,
-      );
-    }
+    assert.equal(
+      props.some((p) => p.kind === "unsupported"),
+      false,
+    );
+    assert.equal(equationRhsText(props), "cond n < 0 => 0 - n, true => n + 1");
   });
 
   it("composes arms with a μ-search prelude", () => {
@@ -1218,7 +1245,7 @@ describe("if-early-return prelude arms", () => {
     }
   });
 
-  it("rejects a block early-return arm with non-const local bindings", () => {
+  it("allows const-like let bindings in block early-return arms", () => {
     const source = `
       export function f(n: number): number {
         if (n < 0) {
@@ -1234,14 +1261,11 @@ describe("if-early-return prelude arms", () => {
       functionName: "f",
       strategy: IntStrategy,
     });
-    assert.equal(props.length, 1);
-    assert.equal(props[0]?.kind, "unsupported");
-    if (props[0]?.kind === "unsupported") {
-      assert.match(
-        props[0].reason,
-        /only const bindings followed by a return/u,
-      );
-    }
+    assert.equal(
+      props.some((p) => p.kind === "unsupported"),
+      false,
+    );
+    assert.equal(equationRhsText(props), "cond n < 0 => 1, true => n");
   });
 
   it("rejects an if-with-else in non-final position", () => {


### PR DESCRIPTION
## Patch 3: Wire nested pure block returns into early-return arms and terminal branches

- Change early-return arm recognition from returning only raw TS return expressions plus simple block bindings to accepting a pre-lowered nested value when the then-block is a supported pure body.
- Update terminal if/else branch extraction so branch blocks with local consts and nested early returns lower consistently with top-level pure bodies.
- Ensure fallthrough facts and branch assumption frames are preserved when the nested block contains its own early-return arms.
- Keep the diagnostic for unsupported nested block contents precise and unchanged where possible.

## Changes
- Change early-return arm recognition from returning only raw TS return expressions plus simple block bindings to accepting a pre-lowered nested value when the then-block is a supported pure body.
- Update terminal if/else branch extraction so branch blocks with local consts and nested early returns lower consistently with top-level pure bodies.
- Ensure fallthrough facts and branch assumption frames are preserved when the nested block contains its own early-return arms.
- Keep the diagnostic for unsupported nested block contents precise and unchanged where possible.

## Files to Modify
- tools/ts2pant/src/translate-body.ts (modify): Use the shared helper from recognizeEarlyReturnArm and extractReturnFromBranch/terminal-if handling so nested block bodies produce cond values.
- tools/ts2pant/tests/translate-body.test.mts (modify): Unskip and implement early-return arm block tests.
- tools/ts2pant/tests/constructs.test.mts.snapshot (modify): Update snapshots for early-return and terminal if/else fixtures that now translate.

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[paper] Allen et al. 1983 if-conversion** — https://dl.acm.org/doi/10.1145/567067.567085 — Nested early returns in branch blocks are converted into conditional values at the branch boundary.

## Gameplan Specification

```
module BODY_LOWERING_COMPLETENESS_RD2.

Body.
Block.
Arm.
Clause.
Callback.
RecordBranchSet.

supported-pure-block? b: Block => Bool.
block-lowered? b: Block => Bool.
nested-block-arm? a: Arm => Bool.
arm-lowered? a: Arm => Bool.
nested-switch-clause? c: Clause => Bool.
clause-lowered? c: Clause => Bool.
nested-callback-block? cb: Callback => Bool.
callback-lowered? cb: Callback => Bool.
same-field-set? r: RecordBranchSet => Bool.
fieldwise-cond-lowered? r: RecordBranchSet => Bool.
unsupported-shape? b: Body => Bool.
rejected? b: Body => Bool.
typechecks? b: Body => Bool.

---

all b: Block | supported-pure-block? b -> block-lowered? b.
all a: Arm | nested-block-arm? a -> arm-lowered? a.
all c: Clause | nested-switch-clause? c -> clause-lowered? c.
all cb: Callback | nested-callback-block? cb -> callback-lowered? cb.
all r: RecordBranchSet | same-field-set? r -> fieldwise-cond-lowered? r.
all b: Body | unsupported-shape? b -> rejected? b.
all b: Body | typechecks? b.
```

## Patch Specification

```
module BODY_LOWERING_COMPLETENESS_RD2_PATCH_3.

Arm.
TerminalBranch.
nested-block-arm? a: Arm => Bool.
arm-lowered? a: Arm => Bool.
nested-terminal-branch? b: TerminalBranch => Bool.
branch-lowered? b: TerminalBranch => Bool.

---

all a: Arm | nested-block-arm? a -> arm-lowered? a.
all b: TerminalBranch | nested-terminal-branch? b -> branch-lowered? b.
```


## Implementation Notes

- Early-return arms now carry either the legacy raw `valueExpr`/`blockBindings` shape or a `nestedBlock`; `lowerPreludeBindings` lowers the nested block inside the same branch assumption frame used for simple early-return values. This avoids pre-lowering during extraction, because narrowing facts and accumulated fallthrough facts are only available during prelude lowering.
- Terminal `if` lowering in `translatePureBody` now uses the local recursive branch path for `IfStatement` terminals instead of `buildL1Conditional` directly. The shared `buildL1Conditional` path in `ir1-build.ts` is unchanged; dependent patches that wire switch clauses/callbacks should call `lowerNestedPureBlockReturn` at their boundary rather than expecting `buildL1Conditional` to recurse into branch blocks.
- The structural recognizer only treats block-bodied early-return arms as nested pure candidates when the block has a recursive return terminal. This prevents assignment-only mutating branch blocks from being misclassified as pure early returns.
- Nested pure block lowering now rejects effectful nested `const` initializers explicitly. This preserves the existing rd2 effectful-block rejection while still allowing pure const/const-like local preludes and nested early returns.
- Nested helper lowering now threads branch facts through nested early-return arm values and pushes accumulated negated fallthrough facts around the nested terminal. This is intentionally scoped to nested pure lowering and does not change the broader L1 conditional builder API.

Spec/Evidence Mapping:
- `nested-block-arm? -> arm-lowered?`: implemented by `recognizeEarlyReturnArm` producing `nestedBlock` and `lowerPreludeBindings` lowering it through `lowerNestedPureBlockReturnToL1`; covered by `translate-body.test.mts` early-return nested block test and rd2 construct snapshots.
- `nested-terminal-branch? -> branch-lowered?`: implemented by `lowerNestedPureIfStatementToL1` / `lowerNestedPureBranchStatementToL1`; covered by the terminal-if unit test and `rd2TerminalIfElseBranchBlocks` snapshot.
- Unsupported shapes remain rejected: stateful local accumulator sequencing and effectful nested const fixtures still snapshot as unsupported.
- Verification run: `just ts2pant-typecheck`, `just ts2pant-test-unit-rest`, `just ts2pant-test-unit-constructs`, and `just ts2pant-test-integration`.