### PR TITLE
[ts2pant-body-lowering-completeness-rd2] Patch 4: Reuse nested pure block lowering for switch clauses and callbacks

### DIFF
--- a/tools/ts2pant/src/ir1-build.ts
+++ b/tools/ts2pant/src/ir1-build.ts
@@ -118,6 +118,7 @@ import {
   expressionReferencesNames,
   extractReturnFromBranch,
   isNullableTsType,
+  lowerNestedPureBlockReturnToL1,
   qualifyFieldAccess,
   symbolicKey,
 } from "./translate-body.js";
@@ -3380,14 +3381,32 @@ function lowerCaseReturnValue(
   clause: ts.CaseClause | ts.DefaultClause,
   ctx: L1BuildContext,
 ): L1BuildResult | null {
-  const extracted = extractCaseReturn(clause);
-  if (extracted === null) {
+  const stmt = extractCaseEffectiveStatement(clause);
+  if (stmt === null) {
     return null;
   }
-  if (extracted.bindings.length === 0) {
-    return buildSubExpr(extracted.returnExpr, ctx);
+  if (ts.isBlock(stmt)) {
+    const lowered = lowerNestedPureBlockReturnToL1(stmt, {
+      checker: ctx.checker,
+      strategy: ctx.strategy,
+      paramNames: ctx.paramNames,
+      supply: ctx.supply,
+      env: ctx.env,
+      ...(ctx.state === undefined ? {} : { state: ctx.state }),
+      ...(ctx.expectedSort === undefined
+        ? {}
+        : { expectedReturnSort: ctx.expectedSort }),
+    });
+    if (lowered !== null) {
+      return lowered;
+    }
+    const extracted = extractBlockReturn(stmt);
+    return extracted === null ? null : lowerBlockReturnValue(extracted, ctx);
   }
-  return lowerBlockReturnValue(extracted, ctx);
+  if (ts.isReturnStatement(stmt) && stmt.expression) {
+    return buildSubExpr(stmt.expression, ctx);
+  }
+  return null;
 }
 
 function lowerBlockReturnValue(
@@ -3447,9 +3466,9 @@ function withParam<K, V>(m: ReadonlyMap<K, V>, k: K, v: V): ReadonlyMap<K, V> {
   return next;
 }
 
-function extractCaseReturn(
+function extractCaseEffectiveStatement(
   clause: ts.CaseClause | ts.DefaultClause,
-): ExtractedBlockReturn | null {
+): ts.Statement | null {
   // Filter to the structural body. Each case body is a list of
   // statements at the top level (TS doesn't wrap them in a Block by default).
   // M1 requires exactly one effective statement: either `return EXPR;` or a
@@ -3470,14 +3489,7 @@ function extractCaseReturn(
   if (lastIdx !== 0) {
     return null;
   }
-  const last: ts.Statement = stmts[lastIdx]!;
-  if (ts.isBlock(last)) {
-    return extractBlockReturn(last);
-  }
-  if (ts.isReturnStatement(last) && last.expression) {
-    return { bindings: [], returnExpr: last.expression };
-  }
-  return null;
+  return stmts[lastIdx]!;
 }
 
 // ---------------------------------------------------------------------------

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -3566,7 +3566,7 @@ export function lowerNestedPureBlockReturn(
   return { expr: applyOpaqueAliases(lowerL1ToOpaque(lowered), ctx.supply) };
 }
 
-function lowerNestedPureBlockReturnToL1(
+export function lowerNestedPureBlockReturnToL1(
   block: ts.Block,
   ctx: NestedPureBlockReturnContext,
 ): IR1Expr | null {
@@ -6170,27 +6170,23 @@ function extractArrowBody(
   arrowParams.set((param.name as ts.Identifier).text, binderName);
 
   if (ts.isBlock(expr.body)) {
-    // Only allow a single return (after filtering guards), same rule as
-    // extractReturnExpression — blocks with locals or multiple statements
-    // would introduce free variables in the generated comprehension.
-    const nonGuard = expr.body.statements.filter(
-      (s) => !isGuardStatement(s, checker),
+    const lowered = lowerNestedPureBlockReturn(expr.body, {
+      checker,
+      strategy,
+      paramNames: arrowParams,
+      supply,
+      env,
+    });
+    return (
+      lowered ??
+      lowerNestedCallbackBlockReturn(expr.body, {
+        checker,
+        strategy,
+        paramNames: arrowParams,
+        supply,
+        env,
+      })
     );
-    if (nonGuard.length === 1) {
-      const s = nonGuard[0]!;
-      if (ts.isReturnStatement(s) && s.expression) {
-        return translateBodyExpr(
-          s.expression,
-          checker,
-          strategy,
-          arrowParams,
-          undefined,
-          supply,
-          env,
-        );
-      }
-    }
-    return null;
   }
 
   // Expression body
@@ -6203,6 +6199,180 @@ function extractArrowBody(
     supply,
     env,
   );
+}
+
+function lowerNestedCallbackBlockReturn(
+  block: ts.Block,
+  ctx: NestedPureBlockReturnContext,
+): BodyResult | null {
+  const lowered = lowerNestedCallbackBlockReturnToL1(block, ctx);
+  if (lowered === null) {
+    return null;
+  }
+  return { expr: applyOpaqueAliases(lowerL1ToOpaque(lowered), ctx.supply) };
+}
+
+function lowerNestedCallbackBlockReturnToL1(
+  block: ts.Block,
+  ctx: NestedPureBlockReturnContext,
+): IR1Expr | null {
+  const stmts = block.statements.filter(
+    (s) => !isGuardStatement(s, ctx.checker),
+  );
+  if (stmts.length === 0) {
+    return null;
+  }
+
+  let scopedParams: ReadonlyMap<string, string> = ctx.paramNames;
+  const substitutions: Array<{ localName: string; value: IR1Expr }> = [];
+  const arms: Array<readonly [IR1Expr, IR1Expr]> = [];
+  const lastIdx = stmts.length - 1;
+
+  for (let i = 0; i < lastIdx; i++) {
+    const stmt = stmts[i]!;
+    if (ts.isVariableStatement(stmt)) {
+      if (!(stmt.declarationList.flags & ts.NodeFlags.Const)) {
+        return null;
+      }
+      const bindings = constBindingsFromDeclarationList(stmt.declarationList);
+      if (bindings === null) {
+        return null;
+      }
+      for (const binding of bindings) {
+        if (binding.kind !== "const") {
+          return null;
+        }
+        const blockedNames = callbackConstNamesFrom(stmts, i);
+        if (expressionHasSideEffects(binding.initializer, ctx.checker)) {
+          return null;
+        }
+        if (expressionReferencesNames(binding.initializer, blockedNames)) {
+          return null;
+        }
+        const localName = allocLocalBindingName(
+          ctx.supply,
+          toPantTermName(binding.tsName),
+          scopedParams,
+        );
+        const value = buildL1SubExpr(binding.initializer, {
+          checker: ctx.checker,
+          strategy: ctx.strategy,
+          paramNames: scopedParams,
+          state: ctx.state ?? makeSymbolicState(),
+          supply: ctx.supply,
+          env: ctx.env,
+        });
+        if (isUnsupported(value) || isL1Unsupported(value)) {
+          return null;
+        }
+        substitutions.push({ localName, value });
+        scopedParams = withParam(scopedParams, binding.tsName, localName);
+      }
+      continue;
+    }
+
+    if (!ts.isIfStatement(stmt) || stmt.elseStatement) {
+      return null;
+    }
+    const blockedNames = callbackConstNamesFrom(stmts, i + 1);
+    if (
+      expressionReferencesNames(stmt.expression, blockedNames) ||
+      nodeReferencesNames(stmt.thenStatement, blockedNames)
+    ) {
+      return null;
+    }
+    const guard = buildL1SubExpr(stmt.expression, {
+      checker: ctx.checker,
+      strategy: ctx.strategy,
+      paramNames: scopedParams,
+      state: ctx.state ?? makeSymbolicState(),
+      supply: ctx.supply,
+      env: ctx.env,
+    });
+    if (isUnsupported(guard) || isL1Unsupported(guard)) {
+      return null;
+    }
+    const value = lowerCallbackReturnArmToL1(stmt.thenStatement, {
+      ...ctx,
+      paramNames: scopedParams,
+    });
+    if (value === null) {
+      return null;
+    }
+    arms.push([guard, value] as const);
+  }
+
+  const terminal = lowerCallbackTerminalStatementToL1(stmts[lastIdx]!, {
+    ...ctx,
+    paramNames: scopedParams,
+  });
+  if (terminal === null) {
+    return null;
+  }
+  const withArms =
+    arms.length === 0
+      ? terminal
+      : ir1Cond(
+          arms as [readonly [IR1Expr, IR1Expr], ...typeof arms],
+          terminal,
+        );
+  return substitutions.reduceRight(
+    (acc, binding) =>
+      substituteIR1ExprSubtree(acc, ir1Var(binding.localName), binding.value),
+    withArms,
+  );
+}
+
+function lowerCallbackReturnArmToL1(
+  stmt: ts.Statement,
+  ctx: NestedPureBlockReturnContext,
+): IR1Expr | null {
+  if (ts.isReturnStatement(stmt) && stmt.expression !== undefined) {
+    const value = buildL1SubExpr(stmt.expression, {
+      checker: ctx.checker,
+      strategy: ctx.strategy,
+      paramNames: ctx.paramNames,
+      state: ctx.state ?? makeSymbolicState(),
+      supply: ctx.supply,
+      env: ctx.env,
+    });
+    return isUnsupported(value) || isL1Unsupported(value) ? null : value;
+  }
+  return ts.isBlock(stmt)
+    ? lowerNestedCallbackBlockReturnToL1(stmt, ctx)
+    : null;
+}
+
+function lowerCallbackTerminalStatementToL1(
+  stmt: ts.Statement,
+  ctx: NestedPureBlockReturnContext,
+): IR1Expr | null {
+  if (ts.isReturnStatement(stmt) && stmt.expression !== undefined) {
+    return lowerNestedPureTerminalToL1(stmt.expression, ctx, ctx.paramNames);
+  }
+  if (ts.isIfStatement(stmt) && stmt.elseStatement !== undefined) {
+    return lowerNestedPureTerminalToL1(stmt, ctx, ctx.paramNames);
+  }
+  if (ts.isSwitchStatement(stmt)) {
+    return lowerNestedPureTerminalToL1(stmt, ctx, ctx.paramNames);
+  }
+  return null;
+}
+
+function callbackConstNamesFrom(
+  stmts: readonly ts.Statement[],
+  startIdx: number,
+): Set<string> {
+  const names = new Set<string>();
+  for (const stmt of stmts.slice(startIdx)) {
+    if (!ts.isVariableStatement(stmt)) {
+      continue;
+    }
+    for (const name of bindingNamesFromDeclarationList(stmt.declarationList)) {
+      names.add(name);
+    }
+  }
+  return names;
 }
 
 // --- Mutating function body translation ---

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -6249,11 +6249,7 @@ function lowerNestedCallbackBlockReturnToL1(
         if (expressionReferencesNames(binding.initializer, blockedNames)) {
           return null;
         }
-        const localName = allocLocalBindingName(
-          ctx.supply,
-          toPantTermName(binding.tsName),
-          scopedParams,
-        );
+        const localName = freshHygienicBinder(ctx.supply);
         const value = buildL1SubExpr(binding.initializer, {
           checker: ctx.checker,
           strategy: ctx.strategy,

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -163,7 +163,7 @@ exports[`expressions-block-early-return.ts > blockEarlyReturnSingleBinding 1`] =
 `;
 
 exports[`expressions-body-lowering-rd2.ts > rd2CallbackNestedBlock 1`] = `
-"module RD2_CALLBACK_NESTED_BLOCK.\\n\\nUser.\\nuser--active u: User => Bool.\\nuser--score u: User => Int.\\nuser--name u: User => String.\\nrd2-callback-nested-block users: [User] => [Int].\\n\\n---\\n\\n> UNSUPPORTED: array callback block body must be a single return.\\n"
+"module RD2_CALLBACK_NESTED_BLOCK.\\n\\nUser.\\nuser--active u: User => Bool.\\nuser--score u: User => Int.\\nuser--name u: User => String.\\nrd2-callback-nested-block users: [User] => [Int].\\n\\n---\\n\\nrd2-callback-nested-block users = (each x in users | cond user--active x => (cond user--score x > 0 => user--score x, true => 0), true => -1).\\n"
 `;
 
 exports[`expressions-body-lowering-rd2.ts > rd2EffectfulBlockConstRejected 1`] = `
@@ -203,7 +203,7 @@ exports[`expressions-body-lowering-rd2.ts > rd2SwitchFallThrough 1`] = `
 `;
 
 exports[`expressions-body-lowering-rd2.ts > rd2SwitchNestedBlockClause 1`] = `
-"module RD2_SWITCH_NESTED_BLOCK_CLAUSE.\\n\\nrd2-switch-nested-block-clause x: Int => Int.\\n\\n---\\n\\n> UNSUPPORTED: rd2-switch-nested-block-clause — switch case must end with \`return EXPR\` (no fall-through, no break/throw cases in M1).\\n"
+"module RD2_SWITCH_NESTED_BLOCK_CLAUSE.\\n\\nrd2-switch-nested-block-clause x: Int => Int.\\n\\n---\\n\\nrd2-switch-nested-block-clause x = (cond x = 0 => (cond x < 1 => x + 10, true => x), true => (cond x + 1 > 5 => x + 1, true => 5)).\\n"
 `;
 
 exports[`expressions-body-lowering-rd2.ts > rd2SwitchNonLiteralLabel 1`] = `
@@ -1591,7 +1591,7 @@ exports[`types-primitives.ts > isActive 1`] = `
 `;
 
 exports[`unsupported.ts > arrowWithLocals 1`] = `
-"module ARROW_WITH_LOCALS.\\n\\nUser.\\nuser--name u: User => String.\\nuser--active u: User => Bool.\\nuser--score u: User => Int.\\narrow-with-locals users: [User] => [String].\\n\\n---\\n\\n> UNSUPPORTED: array callback block body must be a single return.\\n"
+"module ARROW_WITH_LOCALS.\\n\\nUser.\\nuser--name u: User => String.\\nuser--active u: User => Bool.\\nuser--score u: User => Int.\\narrow-with-locals users: [User] => [String].\\n\\n---\\n\\narrow-with-locals users = (each x1 in users, user--active x1 | user--name x1).\\n"
 `;
 
 exports[`unsupported.ts > destructuredParam 1`] = `

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -552,8 +552,10 @@ describe("unsupported patterns", () => {
     );
   });
 
-  it.skip("PENDING Patch 4: switch and callback block consumers reuse nested pure block lowering", () => {
-    const source = `
+  it(
+    "switch and callback block consumers reuse nested pure block lowering",
+    () => {
+      const source = `
         interface User { active: boolean; score: number; }
         function scores(users: User[]): number[] {
           return users.map((u) => {

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -588,6 +588,31 @@ describe("unsupported patterns", () => {
     }
   });
 
+  it("callback block locals do not capture property accessor names", () => {
+    const source = `
+      interface User { active: boolean; score: number; }
+      function scores(users: User[]): number[] {
+        return users.map((u) => {
+          const score = u.score + 1;
+          if (u.active) {
+            return u.score;
+          }
+          return score;
+        });
+      }
+    `;
+    const sourceFile = createSourceFileFromSource(source);
+    const props = translateBodyWithSynth(sourceFile, "scores");
+    assert.equal(
+      props.some((p) => p.kind === "unsupported"),
+      false,
+    );
+    assert.equal(
+      equationRhsText(props),
+      "each x in users | cond user--active x => user--score x, true => user--score x + 1",
+    );
+  });
+
   it("record-return conditional lowers fieldwise", () => {
     const source = `
         interface Pair { x: number; y: number; }


### PR DESCRIPTION
## Patch 4: Reuse nested pure block lowering for switch clauses and callbacks

- Route switch case/default block values through the nested helper when the clause body is a single block; keep multi-statement fall-through cases rejected.
- Route block-bodied array callbacks through the nested helper using the callback binder in scoped params.
- Confirm negative switch fixtures for fall-through, break-only, throw-only, and non-literal labels still reject.
- Clear only the fixture outputs owned by this patch.

## Changes
- Route switch case/default block values through the nested helper when the clause body is a single block; keep multi-statement fall-through cases rejected.
- Route block-bodied array callbacks through the nested helper using the callback binder in scoped params.
- Confirm negative switch fixtures for fall-through, break-only, throw-only, and non-literal labels still reject.
- Clear only the fixture outputs owned by this patch.

## Files to Modify
- tools/ts2pant/src/ir1-build.ts (modify): Teach lowerCaseReturnValue/extractCaseReturn to accept a block clause lowered by the shared nested pure block helper, while preserving switch fall-through and label restrictions.
- tools/ts2pant/src/translate-body.ts (modify): Use the shared helper in extractArrowBody so supported callback block bodies no longer require one direct return.
- tools/ts2pant/tests/translate-body.test.mts (modify): Unskip and implement switch/callback block consumer tests.
- tools/ts2pant/tests/constructs.test.mts.snapshot (modify): Update snapshots for switch and callback fixtures that now translate.

## Gameplan Specification

```
module BODY_LOWERING_COMPLETENESS_RD2.

Body.
Block.
Arm.
Clause.
Callback.
RecordBranchSet.

supported-pure-block? b: Block => Bool.
block-lowered? b: Block => Bool.
nested-block-arm? a: Arm => Bool.
arm-lowered? a: Arm => Bool.
nested-switch-clause? c: Clause => Bool.
clause-lowered? c: Clause => Bool.
nested-callback-block? cb: Callback => Bool.
callback-lowered? cb: Callback => Bool.
same-field-set? r: RecordBranchSet => Bool.
fieldwise-cond-lowered? r: RecordBranchSet => Bool.
unsupported-shape? b: Body => Bool.
rejected? b: Body => Bool.
typechecks? b: Body => Bool.

---

all b: Block | supported-pure-block? b -> block-lowered? b.
all a: Arm | nested-block-arm? a -> arm-lowered? a.
all c: Clause | nested-switch-clause? c -> clause-lowered? c.
all cb: Callback | nested-callback-block? cb -> callback-lowered? cb.
all r: RecordBranchSet | same-field-set? r -> fieldwise-cond-lowered? r.
all b: Body | unsupported-shape? b -> rejected? b.
all b: Body | typechecks? b.
```

## Patch Specification

```
module BODY_LOWERING_COMPLETENESS_RD2_PATCH_4.

Clause.
Callback.
nested-switch-clause? c: Clause => Bool.
clause-lowered? c: Clause => Bool.
nested-callback-block? cb: Callback => Bool.
callback-lowered? cb: Callback => Bool.

---

all c: Clause | nested-switch-clause? c -> clause-lowered? c.
all cb: Callback | nested-callback-block? cb -> callback-lowered? cb.
```


## Implementation Notes

- Exported `lowerNestedPureBlockReturnToL1` from `translate-body.ts` so switch lowering can consume the shared nested pure-block primitive without round-tripping through opaque Pant expressions. The existing opaque wrapper remains the callback-facing/default expression API.
- Switch clauses now first extract a single effective case/default statement, preserving the old fall-through/default/label policy. If that statement is a block, the recursive helper is tried first; the old `(const)* return` block path remains as a fallback so existing explicit switch block diagnostics for simple bad const blocks are preserved where possible.
- Callback block bodies first try the shared nested pure-block helper with the callback binder installed in `paramNames`. There is a callback-scoped fallback for nested early-return arm blocks because this branch is based on patch 2, not patch 3; that fallback is intentionally local to array callbacks so it does not enable patch-3 top-level pure-body behavior or move unrelated snapshots.
- The callback fallback includes later-const TDZ checks before lowering const initializers, predicates, or nested arm bodies. This is important because it performs local substitution after L1 lowering and must not leak callback-local TS names into generated IR.
- Snapshot movement was limited to the newly supported switch/callback outputs: `rd2SwitchNestedBlockClause`, `rd2CallbackNestedBlock`, and the pre-existing `arrowWithLocals` callback fixture. Negative switch fixtures for fall-through and non-literal labels remained unchanged and passed in constructs.

Spec/Evidence Mapping:
- `nested-switch-clause? -> clause-lowered?`: `lowerCaseReturnValue` in `ir1-build.ts` routes single block clauses through `lowerNestedPureBlockReturnToL1`; proven by `translate-body.test.mts` unskipped patch-4 test and constructs snapshots for `rd2SwitchNestedBlockClause`.
- `nested-callback-block? -> callback-lowered?`: `extractArrowBody` in `translate-body.ts` installs the callback binder and uses nested block lowering plus the callback-scoped recursive fallback; proven by the unskipped patch-4 test, `rd2CallbackNestedBlock`, and `arrowWithLocals`.
- Unsupported switch shapes remain rejected: `extractCaseEffectiveStatement` still requires one effective clause statement and `buildCaseLabel` still rejects non-literal labels; proven by passing constructs fixtures `rd2SwitchFallThrough`, `rd2SwitchNonLiteralLabel`, `switchBlockClauseFallThrough`, and `switchBlockClauseNonLiteralLabel`.
- Verification run: `just ts2pant-typecheck`, `just ts2pant-test-unit-rest`, `just ts2pant-test-unit-constructs`, and full `just ts2pant-test` all passed. Biome passed on touched source files; full `just ts2pant-lint-ci` still reports an unrelated existing nursery warning in `src/purity.ts`.