### PR TITLE
[ts2pant-body-lowering-completeness-rd2] Patch 5: Fieldwise record-return conditionals

### DIFF
--- a/tools/ts2pant/docs/body-lowering-rd2-patch5-corpus-diag.md
+++ b/tools/ts2pant/docs/body-lowering-rd2-patch5-corpus-diag.md
@@ -1,0 +1,27 @@
+# Body Lowering RD2 Patch 5 Corpus Diagnostic
+
+Generated on 2026-06-23 with:
+
+```sh
+cd tools/ts2pant && npx tsx scripts/corpus-diag.mts --summary-only
+```
+
+Prompt baseline:
+
+- `functions: 806`
+- `clean: 163`
+- record-return-with-branches bucket: `8`
+
+Patch 5 result:
+
+- `functions: 823`
+- `clean: 163`
+- `unsupported: 655`
+- `errors: 5`
+
+Relevant bucket movement:
+
+- `record return combined with early-return arms or if/else branches is not yet supported`: `2`
+- `record return branches must all return object literals with the same field set`: `4`
+- Additional record-shape rejects remain explicit, including spread/accessor and extra-field cases.
+

--- a/tools/ts2pant/docs/transformations.md
+++ b/tools/ts2pant/docs/transformations.md
@@ -54,10 +54,10 @@ target for *complete-dispatch* `if/else` returning from both branches.
 Constraints (mirrored by `extractReturnFromBranch` for terminal-position
 branches): no else, single-return body, side-effect-free predicate and value,
 TDZ-clean (no reference to bindings declared after the arm). Arms combined
-with a record-typed return are not yet supported — per-field `cond`
-decomposition would require every arm value to be an object literal of the
-same shape, and is left as a follow-on to keep the if-conversion change
-self-contained.
+with a record-typed return use the product-field variant described in
+§ "Record Returns" below: every branch value must be an explicit object
+literal with the same accepted field set, and each field receives its own
+conditional equation.
 
 ## Recursive Pure Block-Return Lowering
 
@@ -382,6 +382,43 @@ reg (registerShape r s) = r.
 See `tests/fixtures/constructs/expressions-record-return.ts` for the
 supported shapes and `tests/dogfood.test.mts` for the self-translation
 baseline (`emptyNameRegistry`).
+
+**Fieldwise record conditionals.**
+
+**Standard name:** If-conversion over product fields.
+**Reference:** Allen et al., POPL 1983.
+
+When a pure function returns a record through early-return arms or a terminal
+`if/else` chain, ts2pant distributes the conditional over each record field:
+
+```ts
+if (flag) return { x: n, y: n + 1 };
+return { x: 0, y: 1 };
+```
+
+becomes:
+
+```text
+x (pair n flag) = cond flag => n, true => 0.
+y (pair n flag) = cond flag => n + 1, true => 1.
+```
+
+This is the product-field form of the same observational encoding used for
+plain record returns. Pantagruel still has no record-constructor expression;
+the conditional therefore appears only at accessor equations' RHS positions.
+
+**Invariants / restrictions:**
+- Every conditional arm and the default/fallthrough value must be an object
+  literal accepted by the same field policy as `translateRecordReturn`.
+- All arm literals must provide the declared field set exactly. Mismatches,
+  extra fields, spreads, computed keys, methods, and accessors are rejected.
+- Each scalar field initializer is translated through the normal pure body
+  expression path before being placed under `cond`.
+- Nested object-literal fields recurse fieldwise; mixed nested-record/scalar
+  field arms are rejected.
+- Empty `Set`/`Map` record initializers remain outside this conditional
+  lowering because the plain record path emits quantified emptiness
+  assertions, not RHS expressions that can be guarded by `cond`.
 
 ## Structured Iteration (for-of, forEach, reduce)
 

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -99,7 +99,10 @@ import {
   nextSupply,
   type UniqueSupply,
 } from "./supply.js";
-import { translateRecordReturn } from "./translate-record.js";
+import {
+  translateRecordConditionalReturn,
+  translateRecordReturn,
+} from "./translate-record.js";
 import {
   classifyFunction,
   containsUnsupportedOperator,
@@ -1361,6 +1364,91 @@ function translatePureBody(
       synthCell,
       (e) => applyOpaqueAliases(e, supply),
     );
+  }
+
+  if (terminalIsObjLit && prelude.arms.length > 0) {
+    const recordArms = collectPreludeRecordArms(
+      extracted.bindings,
+      prelude.arms,
+    );
+    if ("error" in recordArms) {
+      return [
+        {
+          kind: "unsupported",
+          reason: `${functionName} — ${recordArms.error}`,
+        },
+      ];
+    }
+    const conditionalResults = translateRecordConditionalReturn(
+      recordArms.arms,
+      extracted.returnExpr as ts.ObjectLiteralExpression,
+      functionName,
+      params,
+      node,
+      checker,
+      strategy,
+      prelude.scopedParams,
+      supply,
+      synthCell,
+      (e) => applyOpaqueAliases(e, supply),
+    );
+    return [
+      ...prelude.ruleDecls,
+      ...loweredLets.propositions,
+      ...conditionalResults,
+    ];
+  }
+
+  if (ts.isIfStatement(extracted.returnExpr) && terminalIfHasObjLitBranch) {
+    const preludeRecordArms = collectPreludeRecordArms(
+      extracted.bindings,
+      prelude.arms,
+    );
+    if ("error" in preludeRecordArms) {
+      return [
+        {
+          kind: "unsupported",
+          reason: `${functionName} — ${preludeRecordArms.error}`,
+        },
+      ];
+    }
+    const recordIf = collectIfRecordConditionalArms(extracted.returnExpr, {
+      checker,
+      strategy,
+      paramNames: prelude.scopedParams,
+      state: undefined,
+      supply,
+      env,
+      ...(expectedReturnSort === undefined
+        ? {}
+        : { expectedSort: expectedReturnSort }),
+    });
+    if ("error" in recordIf) {
+      return [
+        {
+          kind: "unsupported",
+          reason: `${functionName} — ${recordIf.error}`,
+        },
+      ];
+    }
+    const conditionalResults = translateRecordConditionalReturn(
+      [...preludeRecordArms.arms, ...recordIf.arms],
+      recordIf.otherwise,
+      functionName,
+      params,
+      node,
+      checker,
+      strategy,
+      prelude.scopedParams,
+      supply,
+      synthCell,
+      (e) => applyOpaqueAliases(e, supply),
+    );
+    return [
+      ...prelude.ruleDecls,
+      ...loweredLets.propositions,
+      ...conditionalResults,
+    ];
   }
 
   if (terminalIsObjLit || armHasObjLit || terminalIfHasObjLitBranch) {
@@ -4888,6 +4976,91 @@ function ifTerminalHasObjLitBranch(
     return ifTerminalHasObjLitBranch(stmt.elseStatement, checker);
   }
   return branchHasObjLit(stmt.elseStatement);
+}
+
+function collectPreludeRecordArms(
+  bindings: readonly PreludeStmt[],
+  loweredArms: ReadonlyArray<readonly [OpaqueExpr, OpaqueExpr]>,
+):
+  | { arms: Array<readonly [OpaqueExpr, ts.ObjectLiteralExpression]> }
+  | { error: string } {
+  const earlyReturns = bindings.filter(
+    (b): b is Extract<PreludeStmt, { kind: "earlyReturn" }> =>
+      b.kind === "earlyReturn",
+  );
+  if (earlyReturns.length !== loweredArms.length) {
+    return {
+      error:
+        "record return branch collection lost an early-return guard during lowering",
+    };
+  }
+  const arms: Array<readonly [OpaqueExpr, ts.ObjectLiteralExpression]> = [];
+  for (const [idx, binding] of earlyReturns.entries()) {
+    if (
+      binding.valueExpr === undefined ||
+      !ts.isObjectLiteralExpression(binding.valueExpr)
+    ) {
+      return {
+        error:
+          "record return branches must all return object literals with the same field set",
+      };
+    }
+    arms.push([loweredArms[idx]![0], binding.valueExpr] as const);
+  }
+  return { arms };
+}
+
+function collectIfRecordConditionalArms(
+  stmt: ts.IfStatement,
+  ctx: L1BuildContext,
+):
+  | {
+      arms: Array<readonly [OpaqueExpr, ts.ObjectLiteralExpression]>;
+      otherwise: ts.ObjectLiteralExpression;
+    }
+  | { error: string } {
+  const arms: Array<readonly [OpaqueExpr, ts.ObjectLiteralExpression]> = [];
+  let current: ts.IfStatement = stmt;
+  while (true) {
+    const guard = buildL1SubExpr(current.expression, {
+      ...ctx,
+      state: ctx.state ?? makeSymbolicState(),
+    });
+    if (isUnsupported(guard) || isL1Unsupported(guard)) {
+      return { error: guard.unsupported };
+    }
+    const thenExpr = extractReturnFromBranch(
+      current.thenStatement,
+      ctx.checker,
+    );
+    if (thenExpr === null || !ts.isObjectLiteralExpression(thenExpr)) {
+      return {
+        error:
+          "record return branches must all return object literals with the same field set",
+      };
+    }
+    arms.push([lowerL1ToOpaque(guard), thenExpr] as const);
+    if (!current.elseStatement) {
+      return {
+        error: "record return if/else chain must have a final else branch",
+      };
+    }
+    if (ts.isIfStatement(current.elseStatement)) {
+      current = current.elseStatement;
+      continue;
+    }
+    const elseExpr = extractReturnFromBranch(
+      current.elseStatement,
+      ctx.checker,
+    );
+    if (elseExpr === null || !ts.isObjectLiteralExpression(elseExpr)) {
+      return {
+        error:
+          "record return branches must all return object literals with the same field set",
+      };
+    }
+    return { arms, otherwise: elseExpr };
+  }
 }
 
 /** Get element type name for an array-typed TS expression, or null. */

--- a/tools/ts2pant/src/translate-record.ts
+++ b/tools/ts2pant/src/translate-record.ts
@@ -59,184 +59,15 @@ export function translateRecordReturn(
   applyConst: (e: OpaqueExpr) => OpaqueExpr,
 ): PropResult[] {
   const ast = getAst();
-
-  // Resolve return type. Use the signature's declared return rather than
-  // the object literal's inferred type (which would be
-  // `{ f1: SetLike, ... }` with contextual widening not applied).
-  const sig = checker.getSignatureFromDeclaration(fnNode);
-  const returnType = sig?.getReturnType();
-  if (!returnType) {
-    return [
-      {
-        kind: "unsupported",
-        reason: `${functionName} — cannot resolve return type for record return`,
-      },
-    ];
-  }
-  const returnSymbol = returnType.aliasSymbol ?? returnType.symbol;
-  const returnTypeName = returnSymbol?.getName();
-  if (!returnTypeName) {
-    return [
-      {
-        kind: "unsupported",
-        reason: `${functionName} — cannot resolve return type name for record return`,
-      },
-    ];
-  }
-  // Anonymous record return: the `mapTsType` branch during signature
-  // translation has already registered the shape with the synth cell,
-  // so the synthesized domain and its accessor rules are declared by
-  // the time the body is translated. The field-emission loop below
-  // works unchanged — it iterates `returnType.getProperties()` (which
-  // enumerates the anonymous shape's declared fields just as well as
-  // an interface's) and emits one equation per field, applying each
-  // accessor rule to the function application.
-  //
-  // `isAnonymousRecord` inspects the underlying structural symbol
-  // (`type.getSymbol()?.getName() === "__type"`), so it matches both
-  // bare anonymous returns and alias-backed ones (`type Point = {x, y}`)
-  // — the alias name doesn't correspond to a declared Pantagruel
-  // domain, so we must resolve through the synth even when `aliasSymbol`
-  // is set. Reject only when the cell is missing or upstream synth
-  // registration failed.
-  if (isAnonymousRecord(returnType)) {
-    if (!synthCell) {
-      return [
-        {
-          kind: "unsupported",
-          reason: `${functionName} — anonymous record return requires a synth cell`,
-        },
-      ];
-    }
-    if (returnType.getCallSignatures().length > 0) {
-      return [
-        {
-          kind: "unsupported",
-          reason: `${functionName} — callable anonymous return type`,
-        },
-      ];
-    }
-    if (returnType.getConstructSignatures().length > 0) {
-      return [
-        {
-          kind: "unsupported",
-          reason: `${functionName} — constructible anonymous return type`,
-        },
-      ];
-    }
-    if (
-      returnType.getStringIndexType() !== undefined ||
-      returnType.getNumberIndexType() !== undefined
-    ) {
-      return [
-        {
-          kind: "unsupported",
-          reason: `${functionName} — index-signature anonymous return type (unbounded dictionary, not a finite record)`,
-        },
-      ];
-    }
-    // Re-run the (idempotent) synth-mapping to confirm registration
-    // actually succeeded for this shape. If a field type is unmangleable
-    // the synth returns the failure sentinel rather than a domain name,
-    // and the body emission below would otherwise reference accessor
-    // rules that were never declared.
-    const mapped = mapTsType(returnType, checker, strategy, synthCell);
-    if (!mapped.ok) {
-      if (mapped.reason === UNSUPPORTED_ANONYMOUS_RECORD) {
-        return [
-          {
-            kind: "unsupported",
-            reason: `${functionName} — anonymous record return shape could not be synthesized`,
-          },
-        ];
-      }
-      return [
-        {
-          kind: "unsupported",
-          reason: `${functionName}: ${mapped.reason}`,
-        },
-      ];
-    }
-  }
-
-  // Collect declared fields. For named interfaces this is the declared
-  // property list; for anonymous records it's the same shape seen through
-  // the structural type's properties. Canonical order matches the synth's
-  // sorted order (by field name) so the emission stays deterministic.
-  const declaredFields = returnType
-    .getProperties()
-    .map((prop) => ({
-      name: prop.getName(),
-      type: checker.getTypeOfSymbolAtLocation(prop, fnNode),
-    }))
-    .sort((a, b) => a.name.localeCompare(b.name));
-
-  // Index literal properties by name. Reject unsupported property kinds
-  // and duplicate keys (the spec requires exactly one assignment per
-  // declared field).
-  const literalByName = new Map<string, ts.Expression>();
-  for (const prop of lit.properties) {
-    if (ts.isPropertyAssignment(prop)) {
-      if (!ts.isIdentifier(prop.name) && !ts.isStringLiteral(prop.name)) {
-        return [
-          {
-            kind: "unsupported",
-            reason: `${functionName} — record return with computed or non-simple key`,
-          },
-        ];
-      }
-      if (literalByName.has(prop.name.text)) {
-        return [
-          {
-            kind: "unsupported",
-            reason: `${functionName} — record return repeats field '${prop.name.text}'`,
-          },
-        ];
-      }
-      literalByName.set(prop.name.text, prop.initializer);
-    } else if (ts.isShorthandPropertyAssignment(prop)) {
-      if (literalByName.has(prop.name.text)) {
-        return [
-          {
-            kind: "unsupported",
-            reason: `${functionName} — record return repeats field '${prop.name.text}'`,
-          },
-        ];
-      }
-      literalByName.set(prop.name.text, prop.name);
-    } else {
-      return [
-        {
-          kind: "unsupported",
-          reason: `${functionName} — record return with spread/method/accessor property`,
-        },
-      ];
-    }
-  }
-
-  // Every declared field must be supplied. Extra fields on the literal
-  // are flagged separately below.
-  const missing = declaredFields
-    .filter((f) => !literalByName.has(f.name))
-    .map((f) => f.name);
-  if (missing.length > 0) {
-    return [
-      {
-        kind: "unsupported",
-        reason: `${functionName} — record return missing field(s): ${missing.join(", ")}`,
-      },
-    ];
-  }
-  const extras = [...literalByName.keys()].filter(
-    (n) => !declaredFields.some((f) => f.name === n),
+  const plan = planRecordReturn(
+    functionName,
+    fnNode,
+    checker,
+    strategy,
+    synthCell,
   );
-  if (extras.length > 0) {
-    return [
-      {
-        kind: "unsupported",
-        reason: `${functionName} — record return has extra field(s): ${extras.join(", ")}`,
-      },
-    ];
+  if ("unsupported" in plan) {
+    return [plan.unsupported];
   }
 
   const argExprs = params.map((p) => ast.var(p.name));
@@ -270,8 +101,8 @@ export function translateRecordReturn(
   return emitRecordEquations(
     lit,
     fnApp,
-    returnType,
-    declaredFields,
+    plan.returnType,
+    plan.declaredFields,
     functionName,
     checker,
     strategy,
@@ -281,6 +112,434 @@ export function translateRecordReturn(
     applyConst,
     allocEmittedBinder,
   );
+}
+
+export function translateRecordConditionalReturn(
+  arms: ReadonlyArray<readonly [OpaqueExpr, ts.ObjectLiteralExpression]>,
+  otherwise: ts.ObjectLiteralExpression,
+  functionName: string,
+  params: Array<{ name: string; type: string }>,
+  fnNode: ts.FunctionDeclaration | ts.MethodDeclaration,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  scopedParams: ReadonlyMap<string, string>,
+  supply: UniqueSupply,
+  synthCell: SynthCell | undefined,
+  applyConst: (e: OpaqueExpr) => OpaqueExpr,
+): PropResult[] {
+  const ast = getAst();
+  const plan = planRecordReturn(
+    functionName,
+    fnNode,
+    checker,
+    strategy,
+    synthCell,
+  );
+  if ("unsupported" in plan) {
+    return [plan.unsupported];
+  }
+  const argExprs = params.map((p) => ast.var(p.name));
+  const receiverExpr = ast.app(ast.var(functionName), argExprs);
+  return emitRecordConditionalEquations(
+    arms,
+    otherwise,
+    receiverExpr,
+    plan.returnType,
+    plan.declaredFields,
+    functionName,
+    checker,
+    strategy,
+    scopedParams,
+    supply,
+    synthCell,
+    applyConst,
+  );
+}
+
+function planRecordReturn(
+  functionName: string,
+  fnNode: ts.FunctionDeclaration | ts.MethodDeclaration,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  synthCell: SynthCell | undefined,
+):
+  | {
+      returnType: ts.Type;
+      declaredFields: Array<{ name: string; type: ts.Type }>;
+    }
+  | { unsupported: PropResult } {
+  // Resolve return type. Use the signature's declared return rather than
+  // the object literal's inferred type (which would be
+  // `{ f1: SetLike, ... }` with contextual widening not applied).
+  const sig = checker.getSignatureFromDeclaration(fnNode);
+  const returnType = sig?.getReturnType();
+  if (!returnType) {
+    return {
+      unsupported: {
+        kind: "unsupported",
+        reason: `${functionName} — cannot resolve return type for record return`,
+      },
+    };
+  }
+  const returnSymbol = returnType.aliasSymbol ?? returnType.symbol;
+  const returnTypeName = returnSymbol?.getName();
+  if (!returnTypeName) {
+    return {
+      unsupported: {
+        kind: "unsupported",
+        reason: `${functionName} — cannot resolve return type name for record return`,
+      },
+    };
+  }
+  // Anonymous record return: the `mapTsType` branch during signature
+  // translation has already registered the shape with the synth cell,
+  // so the synthesized domain and its accessor rules are declared by
+  // the time the body is translated. The field-emission loop below
+  // works unchanged — it iterates `returnType.getProperties()` (which
+  // enumerates the anonymous shape's declared fields just as well as
+  // an interface's) and emits one equation per field, applying each
+  // accessor rule to the function application.
+  //
+  // `isAnonymousRecord` inspects the underlying structural symbol
+  // (`type.getSymbol()?.getName() === "__type"`), so it matches both
+  // bare anonymous returns and alias-backed ones (`type Point = {x, y}`)
+  // — the alias name doesn't correspond to a declared Pantagruel
+  // domain, so we must resolve through the synth even when `aliasSymbol`
+  // is set. Reject only when the cell is missing or upstream synth
+  // registration failed.
+  if (isAnonymousRecord(returnType)) {
+    if (!synthCell) {
+      return {
+        unsupported: {
+          kind: "unsupported",
+          reason: `${functionName} — anonymous record return requires a synth cell`,
+        },
+      };
+    }
+    if (returnType.getCallSignatures().length > 0) {
+      return {
+        unsupported: {
+          kind: "unsupported",
+          reason: `${functionName} — callable anonymous return type`,
+        },
+      };
+    }
+    if (returnType.getConstructSignatures().length > 0) {
+      return {
+        unsupported: {
+          kind: "unsupported",
+          reason: `${functionName} — constructible anonymous return type`,
+        },
+      };
+    }
+    if (
+      returnType.getStringIndexType() !== undefined ||
+      returnType.getNumberIndexType() !== undefined
+    ) {
+      return {
+        unsupported: {
+          kind: "unsupported",
+          reason: `${functionName} — index-signature anonymous return type (unbounded dictionary, not a finite record)`,
+        },
+      };
+    }
+    // Re-run the (idempotent) synth-mapping to confirm registration
+    // actually succeeded for this shape. If a field type is unmangleable
+    // the synth returns the failure sentinel rather than a domain name,
+    // and the body emission below would otherwise reference accessor
+    // rules that were never declared.
+    const mapped = mapTsType(returnType, checker, strategy, synthCell);
+    if (!mapped.ok) {
+      if (mapped.reason === UNSUPPORTED_ANONYMOUS_RECORD) {
+        return {
+          unsupported: {
+            kind: "unsupported",
+            reason: `${functionName} — anonymous record return shape could not be synthesized`,
+          },
+        };
+      }
+      return {
+        unsupported: {
+          kind: "unsupported",
+          reason: `${functionName}: ${mapped.reason}`,
+        },
+      };
+    }
+  }
+
+  // Collect declared fields. For named interfaces this is the declared
+  // property list; for anonymous records it's the same shape seen through
+  // the structural type's properties. Canonical order matches the synth's
+  // sorted order (by field name) so the emission stays deterministic.
+  const declaredFields = returnType
+    .getProperties()
+    .map((prop) => ({
+      name: prop.getName(),
+      type: checker.getTypeOfSymbolAtLocation(prop, fnNode),
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+  return { returnType, declaredFields };
+}
+
+function indexRecordLiteralFields(
+  lit: ts.ObjectLiteralExpression,
+  declaredFields: Array<{ name: string; type: ts.Type }>,
+  functionName: string,
+  context: string,
+): Map<string, ts.Expression> | PropResult {
+  const literalByName = new Map<string, ts.Expression>();
+  for (const prop of lit.properties) {
+    if (ts.isPropertyAssignment(prop)) {
+      if (!ts.isIdentifier(prop.name) && !ts.isStringLiteral(prop.name)) {
+        return {
+          kind: "unsupported",
+          reason: `${functionName} — ${context} with computed or non-simple key`,
+        };
+      }
+      if (literalByName.has(prop.name.text)) {
+        return {
+          kind: "unsupported",
+          reason: `${functionName} — ${context} repeats field '${prop.name.text}'`,
+        };
+      }
+      literalByName.set(prop.name.text, prop.initializer);
+    } else if (ts.isShorthandPropertyAssignment(prop)) {
+      if (literalByName.has(prop.name.text)) {
+        return {
+          kind: "unsupported",
+          reason: `${functionName} — ${context} repeats field '${prop.name.text}'`,
+        };
+      }
+      literalByName.set(prop.name.text, prop.name);
+    } else {
+      return {
+        kind: "unsupported",
+        reason: `${functionName} — ${context} with spread/method/accessor property`,
+      };
+    }
+  }
+
+  const missing = declaredFields
+    .filter((f) => !literalByName.has(f.name))
+    .map((f) => f.name);
+  if (missing.length > 0) {
+    return {
+      kind: "unsupported",
+      reason: `${functionName} — ${context} missing field(s): ${missing.join(", ")}`,
+    };
+  }
+  const extras = [...literalByName.keys()].filter(
+    (n) => !declaredFields.some((f) => f.name === n),
+  );
+  if (extras.length > 0) {
+    return {
+      kind: "unsupported",
+      reason: `${functionName} — ${context} has extra field(s): ${extras.join(", ")}`,
+    };
+  }
+  return literalByName;
+}
+
+function isUnsupportedProp(result: unknown): result is PropResult {
+  return (
+    typeof result === "object" &&
+    result !== null &&
+    "kind" in result &&
+    (result as { kind: unknown }).kind === "unsupported"
+  );
+}
+
+function emitRecordConditionalEquations(
+  arms: ReadonlyArray<readonly [OpaqueExpr, ts.ObjectLiteralExpression]>,
+  otherwise: ts.ObjectLiteralExpression,
+  receiverExpr: OpaqueExpr,
+  receiverType: ts.Type,
+  declaredFields: Array<{ name: string; type: ts.Type }>,
+  functionName: string,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  scopedParams: ReadonlyMap<string, string>,
+  supply: UniqueSupply,
+  synthCell: SynthCell | undefined,
+  applyConst: (e: OpaqueExpr) => OpaqueExpr,
+): PropResult[] {
+  const ast = getAst();
+  const ownerName = resolveRecordOwner(
+    receiverType,
+    checker,
+    strategy,
+    synthCell,
+  );
+  const ruleSymbol = (fieldName: string): string =>
+    ownerName ? fieldRuleName(ownerName, fieldName) : fieldName;
+
+  const indexedArms: Array<readonly [OpaqueExpr, Map<string, ts.Expression>]> =
+    [];
+  for (const [guard, lit] of arms) {
+    const indexed = indexRecordLiteralFields(
+      lit,
+      declaredFields,
+      functionName,
+      "record return branch",
+    );
+    if (isUnsupportedProp(indexed)) {
+      return [indexed];
+    }
+    indexedArms.push([guard, indexed] as const);
+  }
+  const indexedOtherwise = indexRecordLiteralFields(
+    otherwise,
+    declaredFields,
+    functionName,
+    "record return branch",
+  );
+  if (isUnsupportedProp(indexedOtherwise)) {
+    return [indexedOtherwise];
+  }
+
+  const results: PropResult[] = [];
+  for (const field of declaredFields) {
+    const fieldApp = ast.app(ast.var(ruleSymbol(field.name)), [receiverExpr]);
+    const branchInitializers = indexedArms.map(([guard, fields]) => {
+      const initializer = fields.get(field.name);
+      if (initializer === undefined) {
+        throw new Error("record literal validation lost a declared field");
+      }
+      return [guard, initializer] as const;
+    });
+    const otherwiseInitializer = indexedOtherwise.get(field.name);
+    if (otherwiseInitializer === undefined) {
+      throw new Error("record literal validation lost a declared field");
+    }
+
+    if (
+      branchInitializers.some(([, initializer]) =>
+        isEmptySetConstruction(initializer),
+      ) ||
+      isEmptySetConstruction(otherwiseInitializer) ||
+      branchInitializers.some(([, initializer]) =>
+        isEmptyMapConstruction(initializer),
+      ) ||
+      isEmptyMapConstruction(otherwiseInitializer)
+    ) {
+      return [
+        {
+          kind: "unsupported",
+          reason: `${functionName} — conditional record field '${field.name}' uses empty Set/Map initializer`,
+        },
+      ];
+    }
+    if (isMapType(field.type)) {
+      return [
+        {
+          kind: "unsupported",
+          reason: `${functionName} — conditional Map-valued record field '${field.name}'`,
+        },
+      ];
+    }
+
+    if (
+      branchInitializers.every(([, initializer]) =>
+        ts.isObjectLiteralExpression(initializer),
+      ) &&
+      ts.isObjectLiteralExpression(otherwiseInitializer)
+    ) {
+      const subFields = field.type
+        .getProperties()
+        .map((prop) => ({
+          name: prop.getName(),
+          type: checker.getTypeOfSymbolAtLocation(prop, otherwiseInitializer),
+        }))
+        .sort((a, b) => a.name.localeCompare(b.name));
+      const subResults = emitRecordConditionalEquations(
+        branchInitializers.map(
+          ([guard, initializer]) =>
+            [guard, initializer as ts.ObjectLiteralExpression] as const,
+        ),
+        otherwiseInitializer,
+        fieldApp,
+        field.type,
+        subFields,
+        `${functionName}.${field.name}`,
+        checker,
+        strategy,
+        scopedParams,
+        supply,
+        synthCell,
+        applyConst,
+      );
+      const subUnsupported = subResults.find((p) => p.kind === "unsupported");
+      if (subUnsupported) {
+        return [subUnsupported];
+      }
+      results.push(...subResults);
+      continue;
+    }
+    if (
+      branchInitializers.some(([, initializer]) =>
+        ts.isObjectLiteralExpression(initializer),
+      ) ||
+      ts.isObjectLiteralExpression(otherwiseInitializer)
+    ) {
+      return [
+        {
+          kind: "unsupported",
+          reason: `${functionName} — conditional record field '${field.name}' mixes nested record and scalar initializers`,
+        },
+      ];
+    }
+
+    const lowerField = (
+      initializer: ts.Expression,
+      context: string,
+    ): OpaqueExpr | PropResult => {
+      const body = translateBodyExpr(
+        initializer,
+        checker,
+        strategy,
+        scopedParams,
+        undefined,
+        supply,
+        undefined,
+      );
+      if (isBodyUnsupported(body)) {
+        return {
+          kind: "unsupported",
+          reason: `${context} — ${body.unsupported}`,
+        };
+      }
+      if (isBodyEffect(body)) {
+        return {
+          kind: "unsupported",
+          reason: `${context} — effect outside statement position`,
+        };
+      }
+      return applyConst(bodyExpr(body));
+    };
+    const condArms: Array<[OpaqueExpr, OpaqueExpr]> = [];
+    for (const [guard, initializer] of branchInitializers) {
+      const value = lowerField(initializer, `${functionName}.${field.name}`);
+      if (isUnsupportedProp(value)) {
+        return [value];
+      }
+      condArms.push([guard, value]);
+    }
+    const otherwiseValue = lowerField(
+      otherwiseInitializer,
+      `${functionName}.${field.name}`,
+    );
+    if (isUnsupportedProp(otherwiseValue)) {
+      return [otherwiseValue];
+    }
+    condArms.push([ast.litBool(true), otherwiseValue]);
+    results.push({
+      kind: "equation",
+      quantifiers: [],
+      lhs: fieldApp,
+      rhs: ast.cond(condArms),
+    });
+  }
+  return results;
 }
 
 /**
@@ -335,56 +594,14 @@ function emitRecordEquations(
   // calls each index their own literal. Apply the same exact-field
   // contract as the top-level record return: reject unsupported property
   // kinds, duplicate keys, missing fields, and extra fields.
-  const literalByName = new Map<string, ts.Expression>();
-  for (const prop of lit.properties) {
-    if (ts.isPropertyAssignment(prop)) {
-      if (!ts.isIdentifier(prop.name) && !ts.isStringLiteral(prop.name)) {
-        return [
-          {
-            kind: "unsupported",
-            reason: `${functionName} — nested record literal with computed or non-simple key`,
-          },
-        ];
-      }
-      if (literalByName.has(prop.name.text)) {
-        return [
-          {
-            kind: "unsupported",
-            reason: `${functionName} — nested record literal repeats field '${prop.name.text}'`,
-          },
-        ];
-      }
-      literalByName.set(prop.name.text, prop.initializer);
-    } else if (ts.isShorthandPropertyAssignment(prop)) {
-      if (literalByName.has(prop.name.text)) {
-        return [
-          {
-            kind: "unsupported",
-            reason: `${functionName} — nested record literal repeats field '${prop.name.text}'`,
-          },
-        ];
-      }
-      literalByName.set(prop.name.text, prop.name);
-    } else {
-      return [
-        {
-          kind: "unsupported",
-          reason: `${functionName} — nested record literal with spread/method/accessor property`,
-        },
-      ];
-    }
-  }
-
-  const extras = [...literalByName.keys()].filter(
-    (n) => !declaredFields.some((f) => f.name === n),
+  const literalByName = indexRecordLiteralFields(
+    lit,
+    declaredFields,
+    functionName,
+    "nested record literal",
   );
-  if (extras.length > 0) {
-    return [
-      {
-        kind: "unsupported",
-        reason: `${functionName} — nested record literal has extra field(s): ${extras.join(", ")}`,
-      },
-    ];
+  if (isUnsupportedProp(literalByName)) {
+    return [literalByName];
   }
 
   const results: PropResult[] = [];

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -191,11 +191,11 @@ exports[`expressions-body-lowering-rd2.ts > rd2NullableNestedTerminal 1`] = `
 `;
 
 exports[`expressions-body-lowering-rd2.ts > rd2RecordReturnConditional 1`] = `
-"module RD2_RECORD_RETURN_CONDITIONAL.\\n\\nPair.\\npair--x p: Pair => Int.\\npair--y p: Pair => Int.\\nrd2-record-return-conditional n: Int, flag: Bool => Pair.\\n\\n---\\n\\n> UNSUPPORTED: rd2-record-return-conditional — record return combined with early-return arms or if/else branches is not yet supported.\\n"
+"module RD2_RECORD_RETURN_CONDITIONAL.\\n\\nPair.\\npair--x p: Pair => Int.\\npair--y p: Pair => Int.\\nrd2-record-return-conditional n: Int, flag: Bool => Pair.\\n\\n---\\n\\npair--x (rd2-record-return-conditional n flag) = (cond flag => n, true => 0).\\npair--y (rd2-record-return-conditional n flag) = (cond flag => n + 1, true => 1).\\n"
 `;
 
 exports[`expressions-body-lowering-rd2.ts > rd2RecordReturnMismatchedFields 1`] = `
-"module RD2_RECORD_RETURN_MISMATCHED_FIELDS.\\n\\nXRec.\\nx-rec--x r: XRec => Int.\\nXYRec.\\nxy-rec--x r1: XYRec => Int.\\nxy-rec--y r1: XYRec => Int.\\nrd2-record-return-mismatched-fields n: Int, flag: Bool => XRec + XYRec.\\n\\n---\\n\\n> UNSUPPORTED: rd2-record-return-mismatched-fields — record return combined with early-return arms or if/else branches is not yet supported.\\n"
+"module RD2_RECORD_RETURN_MISMATCHED_FIELDS.\\n\\nXRec.\\nx-rec--x r: XRec => Int.\\nXYRec.\\nxy-rec--x r1: XYRec => Int.\\nxy-rec--y r1: XYRec => Int.\\nrd2-record-return-mismatched-fields n: Int, flag: Bool => XRec + XYRec.\\n\\n---\\n\\n> UNSUPPORTED: rd2-record-return-mismatched-fields — cannot resolve return type name for record return.\\n"
 `;
 
 exports[`expressions-body-lowering-rd2.ts > rd2SwitchFallThrough 1`] = `

--- a/tools/ts2pant/tests/translate-body.test.mts
+++ b/tools/ts2pant/tests/translate-body.test.mts
@@ -586,7 +586,7 @@ describe("unsupported patterns", () => {
     }
   });
 
-  it.skip("PENDING Patch 5: record-return conditional lowers fieldwise", () => {
+  it("record-return conditional lowers fieldwise", () => {
     const source = `
         interface Pair { x: number; y: number; }
         function pair(n: number, flag: boolean): Pair {
@@ -1313,7 +1313,7 @@ describe("if-early-return prelude arms", () => {
     assert.equal(props[0]?.kind, "unsupported");
   });
 
-  it("rejects early-return + record return (per-field cond decomposition not yet supported)", () => {
+  it("lowers early-return + record return fieldwise", () => {
     const source = `
       interface Pair { a: number; b: number }
       export function f(n: number): Pair {
@@ -1327,14 +1327,11 @@ describe("if-early-return prelude arms", () => {
       functionName: "f",
       strategy: IntStrategy,
     });
-    assert.equal(props.length, 1);
-    assert.equal(props[0]?.kind, "unsupported");
-    if (props[0]?.kind === "unsupported") {
-      assert.match(
-        props[0].reason,
-        /record return combined with early-return arms or if\/else branches/u,
-      );
-    }
+    assert.equal(
+      props.some((p) => p.kind === "unsupported"),
+      false,
+    );
+    assert.equal(props.filter((p) => p.kind === "equation").length, 2);
   });
 
   it("rejects record-shaped arm value with non-literal terminal", () => {
@@ -1362,7 +1359,7 @@ describe("if-early-return prelude arms", () => {
     }
   });
 
-  it("rejects record-shaped if/else terminal branches", () => {
+  it("lowers record-shaped if/else terminal branches fieldwise", () => {
     const source = `
       interface Pair { a: number; b: number }
       export function f(n: number): Pair {
@@ -1379,14 +1376,11 @@ describe("if-early-return prelude arms", () => {
       functionName: "f",
       strategy: IntStrategy,
     });
-    assert.equal(props.length, 1);
-    assert.equal(props[0]?.kind, "unsupported");
-    if (props[0]?.kind === "unsupported") {
-      assert.match(
-        props[0].reason,
-        /record return combined with early-return arms or if\/else branches/u,
-      );
-    }
+    assert.equal(
+      props.some((p) => p.kind === "unsupported"),
+      false,
+    );
+    assert.equal(props.filter((p) => p.kind === "equation").length, 2);
   });
 
   const unknownCollectionCases = [


### PR DESCRIPTION
## Patch 5: Fieldwise record-return conditionals

- Detect the bounded shape: every early-return/if/else/default value is an object literal accepted by translateRecordReturn's field policy, and all arms have the same explicit field set.
- For each output field, emit the same declaration/equation shape translateRecordReturn emits today, with the RHS built as a cond over that field's arm value.
- Reject mismatched fields, spreads, accessors, methods, unsupported field initializers, or mixed record/scalar arms.
- Rerun the corpus diagnostic and record the bucket movement in the PR body or a small generated note; do not require any human decision between patches.

## Changes
- Detect the bounded shape: every early-return/if/else/default value is an object literal accepted by translateRecordReturn's field policy, and all arms have the same explicit field set.
- For each output field, emit the same declaration/equation shape translateRecordReturn emits today, with the RHS built as a cond over that field's arm value.
- Reject mismatched fields, spreads, accessors, methods, unsupported field initializers, or mixed record/scalar arms.
- Rerun the corpus diagnostic and record the bucket movement in the PR body or a small generated note; do not require any human decision between patches.

## Files to Modify
- tools/ts2pant/src/translate-body.ts (modify): Replace the record-return-with-branches rejection with fieldwise conditional record equations for matching object-literal arms.
- tools/ts2pant/src/translate-record.ts (modify): Expose/reuse record field normalization helpers needed to lower each field expression without duplicating translateRecordReturn policy.
- tools/ts2pant/docs/transformations.md (modify): Document fieldwise record conditional lowering and its same-field-set restriction.
- tools/ts2pant/tests/translate-body.test.mts (modify): Unskip and implement the fieldwise record-return conditional test.
- tools/ts2pant/tests/constructs.test.mts.snapshot (modify): Update snapshots for record-return conditional fixtures and preserved negative cases.

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[algorithm] If-conversion over product fields** — A conditional record value with identical field sets can be distributed into one conditional expression per field, matching the existing record-return equation surface.

## Gameplan Specification

```
module BODY_LOWERING_COMPLETENESS_RD2.

Body.
Block.
Arm.
Clause.
Callback.
RecordBranchSet.

supported-pure-block? b: Block => Bool.
block-lowered? b: Block => Bool.
nested-block-arm? a: Arm => Bool.
arm-lowered? a: Arm => Bool.
nested-switch-clause? c: Clause => Bool.
clause-lowered? c: Clause => Bool.
nested-callback-block? cb: Callback => Bool.
callback-lowered? cb: Callback => Bool.
same-field-set? r: RecordBranchSet => Bool.
fieldwise-cond-lowered? r: RecordBranchSet => Bool.
unsupported-shape? b: Body => Bool.
rejected? b: Body => Bool.
typechecks? b: Body => Bool.

---

all b: Block | supported-pure-block? b -> block-lowered? b.
all a: Arm | nested-block-arm? a -> arm-lowered? a.
all c: Clause | nested-switch-clause? c -> clause-lowered? c.
all cb: Callback | nested-callback-block? cb -> callback-lowered? cb.
all r: RecordBranchSet | same-field-set? r -> fieldwise-cond-lowered? r.
all b: Body | unsupported-shape? b -> rejected? b.
all b: Body | typechecks? b.
```

## Patch Specification

```
module BODY_LOWERING_COMPLETENESS_RD2_PATCH_5.

RecordBranchSet.
same-field-set? r: RecordBranchSet => Bool.
fieldwise-cond-lowered? r: RecordBranchSet => Bool.
unsupported-record-shape? r: RecordBranchSet => Bool.
rejected? r: RecordBranchSet => Bool.

---

all r: RecordBranchSet | same-field-set? r -> fieldwise-cond-lowered? r.
all r: RecordBranchSet | unsupported-record-shape? r -> rejected? r.
```


## Implementation Notes

- Split `translate-record.ts` record-return handling into reusable planning/field-indexing helpers, then added `translateRecordConditionalReturn(...)` as the new branch-aware entry point. Plain `translateRecordReturn(...)` still emits through the existing `emitRecordEquations(...)` path.
- Conditional record lowering is intentionally equation-only: scalar fields become `accessor (fn args) = cond ...`; nested object-literal fields recurse fieldwise. Empty `new Set()` / `new Map()` initializers remain rejected in conditional branches because the plain record path emits quantified emptiness assertions, not RHS values that can be placed under `cond`.
- `translate-body.ts` only routes to the new record conditional path when all branch/default values are syntactic object literals. Mixed record/scalar branches still fall through to the existing combined-record rejection. Union return types without a single record owner now reject via the shared return-type planning (`cannot resolve return type name for record return`), which is why the mismatched-fields RD2 fixture snapshot changed to that more specific reason.
- Corpus diagnostic output was recorded in `tools/ts2pant/docs/body-lowering-rd2-patch5-corpus-diag.md`. The prompt baseline had 8 record-return-with-branches rejects; after this patch the old bucket is 2, with 4 now classified under the explicit same-object-literal branch restriction.

Spec/Evidence Mapping:
- `same-field-set? -> fieldwise-cond-lowered?`: implemented by `translateRecordConditionalReturn(...)` / `emitRecordConditionalEquations(...)`; covered by `translate-body.test.mts` record conditional tests and the `rd2RecordReturnConditional` construct snapshot.
- `unsupported-record-shape? -> rejected?`: enforced by shared `indexRecordLiteralFields(...)` plus conditional-only rejections for mixed nested/scalar fields, Map-valued fields, and empty Set/Map initializer assertions; covered by preserved negative translate-body tests and RD2 mismatched snapshot.
- `typechecks?`: verified with `just ts2pant-test-unit`, `npm run build`, `npm run lint` (exits 0, with an unrelated existing warning in `src/purity.ts`), and `just ts2pant-test-integration`.