### PR TITLE
[ts2pant-local-collection-builder-sequencing] Patch 1: Add local collection builder fixture stubs

### DIFF
--- a/tools/ts2pant/tests/constructs.test.mts
+++ b/tools/ts2pant/tests/constructs.test.mts
@@ -12,6 +12,7 @@ import { buildDocumentFromSourceFile, emitAndCheck } from "./helpers.mjs";
 const CONSTRUCTS_DIR = resolve(import.meta.dirname, "fixtures/constructs");
 const SCAFFOLD_ONLY_FIXTURES = new Set([
   "expressions-for-of-comprehension.ts",
+  "expressions-local-collection-builder.ts",
   "foreign-accessor-dependency.ts",
 ]);
 

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-local-collection-builder.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-local-collection-builder.ts
@@ -1,0 +1,97 @@
+// @archlint.module exempt
+// @archlint.exempt-reason test-support
+
+// Local collection builder shapes targeted by the Patch 2/3 local collection
+// builder sequencing work. These functions stay unexported so the generic
+// constructs snapshot suite does not discover them before dedicated tests are
+// unskipped.
+
+interface BuilderItem {
+  id: string;
+  label: string;
+  rank: number;
+}
+
+/**
+ * Straight-line single-push list builder:
+ *   `const out = []; out.push(seed); return out;`
+ * Target Pantagruel encoding: cardinality plus positional assertions.
+ */
+// biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
+function listSinglePush(seed: string): string[] {
+  const out: string[] = [];
+  out.push(seed);
+  return out;
+}
+
+/**
+ * Straight-line multi-push list builder.
+ * Target Pantagruel encoding must preserve push order in positional
+ * assertions over the returned rule.
+ */
+// biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
+function listMultiplePushes(first: string, second: string): string[] {
+  const out: string[] = [];
+  out.push(first);
+  out.push(second);
+  return out;
+}
+
+/**
+ * Push values through preceding pure const bindings and property projection.
+ * Target Pantagruel encoding should inline or name the const-bound projection
+ * without treating `push` as a pure expression.
+ */
+// biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
+function listPushConstProjection(item: BuilderItem): string[] {
+  const projected = item.label;
+  const out: string[] = [];
+  out.push(projected);
+  return out;
+}
+
+/**
+ * Straight-line Set add builder.
+ * Target Pantagruel encoding: membership equivalence, not ordered positions.
+ */
+// biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
+function setAddBuilder(first: string, second: string): Set<string> {
+  const out = new Set<string>();
+  out.add(first);
+  out.add(second);
+  return out;
+}
+
+/**
+ * Out-of-scope control: an alias escapes the local builder identity.
+ * Target Pantagruel encoding: none (must keep refusing).
+ */
+// biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
+function listAliasEscapeRejected(seed: string): string[] {
+  const out: string[] = [];
+  const alias = out;
+  alias.push(seed);
+  return out;
+}
+
+/**
+ * Out-of-scope control: unknown mutating methods are not collection builders.
+ * Target Pantagruel encoding: none (must keep refusing).
+ */
+// biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
+function listUnknownMutationRejected(seed: string): string[] {
+  const out: string[] = [];
+  out.unshift(seed);
+  return out;
+}
+
+/**
+ * Out-of-scope control for this milestone: Map construction is deferred until
+ * a Map-specific plan handles the guarded key/value rule-pair contract.
+ */
+// biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
+function mapBuilderRejected(key: string, value: number): Map<string, number> {
+  const out = new Map<string, number>();
+  out.set(key, value);
+  return out;
+}

--- a/tools/ts2pant/tests/local-collection-builder.test.mts
+++ b/tools/ts2pant/tests/local-collection-builder.test.mts
@@ -96,7 +96,7 @@ describe("local collection builder", () => {
     },
     async () => {
       const output = await emitFixture("listAliasEscapeRejected");
-      assert.match(output, /UNSUPPORTED: list-alias-escape-rejected/u);
+      assert.match(output, /^> UNSUPPORTED: list-alias-escape-rejected/mu);
       assert.match(output, /alias|escape|builder/u);
     },
   );
@@ -109,7 +109,10 @@ describe("local collection builder", () => {
     },
     async () => {
       const output = await emitFixture("listUnknownMutationRejected");
-      assert.match(output, /UNSUPPORTED: list-unknown-mutation-rejected/u);
+      assert.match(
+        output,
+        /^> UNSUPPORTED: list-unknown-mutation-rejected/mu,
+      );
       assert.match(output, /unknown|mutation|builder|unshift/u);
     },
   );
@@ -121,7 +124,7 @@ describe("local collection builder", () => {
     },
     async () => {
       const output = await emitFixture("mapBuilderRejected");
-      assert.match(output, /UNSUPPORTED: map-builder-rejected/u);
+      assert.match(output, /^> UNSUPPORTED: map-builder-rejected/mu);
       assert.match(output, /Map|map|builder/u);
     },
   );

--- a/tools/ts2pant/tests/local-collection-builder.test.mts
+++ b/tools/ts2pant/tests/local-collection-builder.test.mts
@@ -1,0 +1,128 @@
+// @archlint.module test
+// @archlint.domain ts2pant.local-collection-builder
+
+import assert from "node:assert/strict";
+import { resolve } from "node:path";
+import { describe, it } from "node:test";
+import { buildDocument, emitAndCheck, runCheck } from "./helpers.mjs";
+
+const FIXTURE = resolve(
+  import.meta.dirname,
+  "fixtures/constructs/expressions-local-collection-builder.ts",
+);
+
+async function emitFixture(functionName: string): Promise<string> {
+  return emitAndCheck(await buildDocument(FIXTURE, functionName));
+}
+
+describe("local collection builder", () => {
+  it(
+    "listSinglePush emits finite ordered list assertions",
+    {
+      skip:
+        "Patch 2 will unskip after finite ordered list builder lowering lands",
+    },
+    async () => {
+      const output = await emitFixture("listSinglePush");
+      assert.match(output, /^#\(list-single-push seed\) = 1\.$/mu);
+      assert.match(output, /^\(list-single-push seed\) 1 = seed\.$/mu);
+      assert.doesNotMatch(output, /UNSUPPORTED/u);
+      assert.ok(runCheck(output).passed);
+    },
+  );
+
+  it(
+    "listMultiplePushes preserves push order",
+    {
+      skip:
+        "Patch 2 will unskip after finite ordered list builder lowering lands",
+    },
+    async () => {
+      const output = await emitFixture("listMultiplePushes");
+      assert.match(output, /^#\(list-multiple-pushes first second\) = 2\.$/mu);
+      assert.match(
+        output,
+        /^\(list-multiple-pushes first second\) 1 = first\.$/mu,
+      );
+      assert.match(
+        output,
+        /^\(list-multiple-pushes first second\) 2 = second\.$/mu,
+      );
+      assert.doesNotMatch(output, /UNSUPPORTED/u);
+      assert.ok(runCheck(output).passed);
+    },
+  );
+
+  it(
+    "listPushConstProjection lowers const-bound pushed values",
+    {
+      skip:
+        "Patch 2 will unskip after const-bound list builder values are lowered",
+    },
+    async () => {
+      const output = await emitFixture("listPushConstProjection");
+      assert.match(output, /^projected\s+=> String\.$/mu);
+      assert.match(output, /^projected = builder-item--label item\.$/mu);
+      assert.match(
+        output,
+        /^\(list-push-const-projection item\) 1 = projected\.$/mu,
+      );
+      assert.doesNotMatch(output, /UNSUPPORTED/u);
+      assert.ok(runCheck(output).passed);
+    },
+  );
+
+  it(
+    "setAddBuilder emits membership equivalence",
+    {
+      skip: "Patch 3 will unskip after Set add builder lowering lands",
+    },
+    async () => {
+      const output = await emitFixture("setAddBuilder");
+      assert.match(
+        output,
+        /x in set-add-builder first second <-> \(x = first or x = second\)/u,
+      );
+      assert.doesNotMatch(output, /UNSUPPORTED/u);
+      assert.ok(runCheck(output).passed);
+    },
+  );
+
+  it(
+    "listAliasEscapeRejected remains unsupported",
+    {
+      skip:
+        "Patch 2 will unskip after list builder alias rejection is diagnosed",
+    },
+    async () => {
+      const output = await emitFixture("listAliasEscapeRejected");
+      assert.match(output, /UNSUPPORTED: list-alias-escape-rejected/u);
+      assert.match(output, /alias|escape|builder/u);
+    },
+  );
+
+  it(
+    "listUnknownMutationRejected remains unsupported",
+    {
+      skip:
+        "Patch 2 will unskip after unknown list mutation rejection is diagnosed",
+    },
+    async () => {
+      const output = await emitFixture("listUnknownMutationRejected");
+      assert.match(output, /UNSUPPORTED: list-unknown-mutation-rejected/u);
+      assert.match(output, /unknown|mutation|builder|unshift/u);
+    },
+  );
+
+  it(
+    "mapBuilderRejected remains unsupported",
+    {
+      skip: "Patch 3 will unskip after Map builder rejection is preserved",
+    },
+    async () => {
+      const output = await emitFixture("mapBuilderRejected");
+      assert.match(output, /UNSUPPORTED: map-builder-rejected/u);
+      assert.match(output, /Map|map|builder/u);
+    },
+  );
+});


### PR DESCRIPTION
## Patch 1: Add local collection builder fixture stubs

- Create fixture functions named `listSinglePush`, `listMultiplePushes`, `listPushConstProjection`, `setAddBuilder`, `listAliasEscapeRejected`, `listUnknownMutationRejected`, and `mapBuilderRejected`.
- Mark all new dedicated tests skipped with comments naming the patch that will unskip and implement them.
- Use `buildDocument`, `emitAndCheck`, and `runCheck` from the existing test helpers rather than spawning dune or invoking the pant binary directly from a per-file test worker.

## Changes
- Create fixture functions named `listSinglePush`, `listMultiplePushes`, `listPushConstProjection`, `setAddBuilder`, `listAliasEscapeRejected`, `listUnknownMutationRejected`, and `mapBuilderRejected`.
- Mark all new dedicated tests skipped with comments naming the patch that will unskip and implement them.
- Use `buildDocument`, `emitAndCheck`, and `runCheck` from the existing test helpers rather than spawning dune or invoking the pant binary directly from a per-file test worker.

## Files to Modify
- tools/ts2pant/tests/fixtures/constructs/expressions-local-collection-builder.ts (create): Scaffold unexported fixture functions for ordered list builders, Set add builders, alias/escape negatives, unknown method negatives, and Map builder rejection.
- tools/ts2pant/tests/constructs.test.mts (modify): Add the new fixture filename to `SCAFFOLD_ONLY_FIXTURES` so the generic snapshot suite ignores it.
- tools/ts2pant/tests/local-collection-builder.test.mts (create): Add skipped `node:test` cases that build selected fixture functions, inspect emitted Pantagruel, and run the wasm/pant checker.

## Gameplan Specification

```
module TS2PANT_LOCAL_COLLECTION_BUILDER_SEQUENCING.

Function.
Element.
Index = Nat.
arity f: Function => Nat0.
list-builder-supported f: Function => Bool.
pushed f: Function, i: Index => Element.
result f: Function => [Element].
set-builder-supported f: Function => Bool.
set-added f: Function, e: Element => Bool.
set-result f: Function => [Element].
map-builder-rejected f: Function => Bool.
---
all f: Function, list-builder-supported f | #(result f) = arity f.
all f: Function, list-builder-supported f, i: Index, i <= arity f | (result f) i = pushed f i.
all f: Function, set-builder-supported f, e: Element | e in set-result f <-> set-added f e.
all f: Function, map-builder-rejected f | ~(set-builder-supported f).
```

## Patch Specification

```
module TS2PANT_LOCAL_COLLECTION_BUILDER_SEQUENCING_PATCH_1.

Fixture.
TestStub.
fixture-file f: Fixture => String.
test-stub-name t: TestStub => String.
test-stub-skipped t: TestStub => Bool.
---
all t: TestStub | test-stub-skipped t.
```


## Implementation Notes

- Fixture functions are intentionally unexported and the new fixture file is listed in `SCAFFOLD_ONLY_FIXTURES`; this keeps the generic constructs snapshot suite from discovering unsupported bodies before the implementation patches land.
- The skipped test bodies are deliberately executable-looking handoff stubs: they already use `buildDocument`, `emitAndCheck`, and `runCheck`, so Patch 2/3 should only need to remove or adjust skips and tighten the expected emitted Pant text as the exact printer shape lands.
- Skip ownership is split by future implementation scope: list positives and list negative diagnostics point to Patch 2; Set add lowering and Map rejection point to Patch 3.
- No translator behavior or public test helper APIs changed in this patch.

Spec/Evidence Mapping:
- `Fixture` / `fixture-file`: added `expressions-local-collection-builder.ts` with all seven requested local-builder fixture functions.
- `all t: TestStub | test-stub-skipped t`: all seven dedicated `node:test` cases in `local-collection-builder.test.mts` are skipped with patch-specific unskip reasons.
- Required context consulted: `workstreams/ts2pant-body-completeness.md`, `constructs.test.mts`, `helpers.mts`, `integration/for-of-comprehension.test.mts`, and `expressions-for-of-comprehension.ts`.
- Verification run from existing artifacts: local skipped test file, unit-rest, constructs, and integration suites all passed with no failures.