### PR TITLE
[ts2pant-local-collection-builder-sequencing] Patch 2: Lower finite ordered list builders

### DIFF
--- a/tools/ts2pant/docs/transformations.md
+++ b/tools/ts2pant/docs/transformations.md
@@ -110,12 +110,15 @@ return out;
 ```
 
 The local list-builder recognizer treats this as a bounded ANF-like prelude
-with one private mutable accumulator. It does **not** lower `push` as a pure
+with one private mutable accumulator. The implementation entry point is
+`tryBuildLocalListBuilderReturn()`. It does **not** lower `push` as a pure
 expression and does not synthesize a list literal. Instead it emits constraints
 over the declared return rule: one cardinality assertion for the result and one
-1-based positional list-application assertion per pushed value. Ordinary const
-bindings before the pushes are lowered through the existing local-rule prelude
-machinery so pushed values can refer to hygienically scoped local names.
+1-based positional list-application assertion per pushed value, written in
+Pantagruel as `(f args) i = value_i` where `i` is a 1-based `Nat` index.
+Ordinary const bindings before the pushes are lowered through the existing
+local-rule prelude machinery so pushed values can refer to hygienically scoped
+local names.
 
 **Invariants:**
 - The returned identifier is the same local empty-array accumulator that

--- a/tools/ts2pant/docs/transformations.md
+++ b/tools/ts2pant/docs/transformations.md
@@ -90,8 +90,43 @@ bindings through `substituteIR1ExprSubtree()`.
 - Nested block locals never become Pant rule declarations or free variables.
 - Conservative refusal covers stateful expression statements, effectful const
   initializers, non-final returns, throws, breaks, and unsupported terminals.
-- Local accumulator sequencing such as `lines.push(...); return lines` is not
-  part of this transformation; it needs a separate collection-builder model.
+- Local accumulator sequencing such as `lines.push(...); return lines` is handled
+  by the separate collection-builder model below.
+
+## Local Collection Builder Recognition
+
+**Standard name:** A-normal-form local builder recognition / effect
+encapsulation.
+**Reference:** Flanagan et al., PLDI 1993; Dijkstra, CACM 1975.
+
+Some pure TypeScript functions are imperative internally but have a clear
+value-level target:
+
+```ts
+const out: T[] = [];
+out.push(e1);
+out.push(e2);
+return out;
+```
+
+The local list-builder recognizer treats this as a bounded ANF-like prelude
+with one private mutable accumulator. It does **not** lower `push` as a pure
+expression and does not synthesize a list literal. Instead it emits constraints
+over the declared return rule: one cardinality assertion for the result and one
+1-based positional list-application assertion per pushed value. Ordinary const
+bindings before the pushes are lowered through the existing local-rule prelude
+machinery so pushed values can refer to hygienically scoped local names.
+
+**Invariants:**
+- The returned identifier is the same local empty-array accumulator that
+  receives all pushes.
+- Push order is source order; emitted positions are `1..N`.
+- The accumulator is not aliased, read by a guard or pushed expression, passed
+  to another call, reassigned, or mutated by any method other than `.push`.
+- Const bindings are allowed only before the first push; later consts are
+  rejected to keep the model straight-line and unambiguous.
+- Unsupported builder shapes remain diagnostics. General expression statements
+  still flow through the normal prelude rejection path.
 
 ## Uninterpreted Functions (General Function Calls)
 

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -228,6 +228,7 @@ type PreludeStmt =
     }
   | { kind: "muSearch"; tsName: string; mu: MuSearch; localName?: string }
   | ({ kind: "forOf" } & RecognizedForOfPush)
+  | { kind: "builderPush"; accName: string; valueExpr: ts.Expression }
   | { kind: "reassign"; tsName: string; valueExpr: ts.Expression }
   | { kind: "stmt"; stmt: ts.Statement }
   | {
@@ -1298,6 +1299,58 @@ function translatePureBody(
     ];
   }
 
+  const localListBuilder = tryBuildLocalListBuilderReturn(
+    extracted,
+    checker,
+    strategy,
+    paramNames,
+    supply,
+    env,
+  );
+  if (localListBuilder !== null) {
+    if ("error" in localListBuilder) {
+      return [
+        {
+          kind: "unsupported",
+          reason: `${functionName} — ${localListBuilder.error}`,
+        },
+      ];
+    }
+    if (localListBuilder.diagnostics.length > 0) {
+      return localListBuilder.diagnostics;
+    }
+    const argExprs = params.map((p) => ast.var(p.name));
+    const resultApp = () => ast.app(ast.var(functionName), argExprs);
+    const assertions: PropResult[] = [
+      {
+        kind: "assertion",
+        quantifiers: [] as OpaqueParam[],
+        body: ast.binop(
+          ast.opEq(),
+          ast.unop(ast.opCard(), resultApp()),
+          ast.litNat(localListBuilder.pushed.length),
+        ),
+      },
+      ...localListBuilder.pushed.map((value, idx): PropResult => {
+        const valueExpr = applyOpaqueAliases(lowerL1ToOpaque(value), supply);
+        return {
+          kind: "assertion",
+          quantifiers: [] as OpaqueParam[],
+          body: ast.binop(
+            ast.opEq(),
+            ast.app(resultApp(), [ast.litNat(idx + 1)]),
+            valueExpr,
+          ),
+        };
+      }),
+    ];
+    return [
+      ...localListBuilder.prelude.ruleDecls,
+      ...localListBuilder.loweredLets.propositions,
+      ...assertions,
+    ];
+  }
+
   const prelude = lowerPreludeBindings(
     extracted.bindings,
     checker,
@@ -1744,6 +1797,14 @@ interface ExtractedBody {
   returnExpr: ts.Expression | ts.IfStatement | ts.SwitchStatement;
 }
 
+interface LocalListBuilderResult {
+  returnedAccumulatorName: string;
+  pushed: IR1Expr[];
+  prelude: LoweredPreludeBindings;
+  loweredLets: IR1SsaBodyLowerResult;
+  diagnostics: PropResult[];
+}
+
 function tryBuildForOfComprehensionReturn(
   extracted: ExtractedBody,
   checker: ts.TypeChecker,
@@ -1847,6 +1908,149 @@ function tryBuildForOfComprehensionReturn(
     prelude,
     loweredLets,
     each: ir1Each(forOf.binder, forOf.src, forOf.guards, forOf.proj),
+  };
+}
+
+function tryBuildLocalListBuilderReturn(
+  extracted: ExtractedBody,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  paramNames: ReadonlyMap<string, string>,
+  supply: UniqueSupply,
+  env: AssumptionEnv,
+): LocalListBuilderResult | { error: string } | null {
+  const builderPushes = extracted.bindings.filter(
+    (binding): binding is Extract<PreludeStmt, { kind: "builderPush" }> =>
+      binding.kind === "builderPush",
+  );
+  if (builderPushes.length === 0) {
+    return null;
+  }
+  if (
+    !ts.isExpression(extracted.returnExpr) ||
+    !ts.isIdentifier(extracted.returnExpr)
+  ) {
+    return {
+      error: "list builder must return its local accumulator",
+    };
+  }
+  const accName = extracted.returnExpr.text;
+  const accDecls = extracted.bindings.filter(
+    (binding): binding is Extract<PreludeStmt, { kind: "const" }> =>
+      binding.kind === "const" &&
+      binding.tsName === accName &&
+      isEmptyArrayLiteral(binding.initializer),
+  );
+  if (accDecls.length !== 1) {
+    return {
+      error:
+        "list builder must return the same local empty-array accumulator it pushes",
+    };
+  }
+  if (builderPushes.some((push) => push.accName !== accName)) {
+    return {
+      error: "list builder may only push to the returned local accumulator",
+    };
+  }
+  const accNames = new Set([accName]);
+  let seenPush = false;
+  const preludeBindings: PreludeStmt[] = [];
+  for (const binding of extracted.bindings) {
+    if (binding === accDecls[0]) {
+      continue;
+    }
+    if (binding.kind === "builderPush") {
+      seenPush = true;
+      if (expressionReferencesNames(binding.valueExpr, accNames)) {
+        return {
+          error: "list builder push argument may not read the accumulator",
+        };
+      }
+      continue;
+    }
+    if (binding.kind === "const") {
+      if (seenPush) {
+        return {
+          error:
+            "list builder const bindings must appear before pushed expressions",
+        };
+      }
+      if (expressionReferencesNames(binding.initializer, accNames)) {
+        return {
+          error: "list builder accumulator alias or escape is not supported",
+        };
+      }
+      preludeBindings.push(binding);
+      continue;
+    }
+    return {
+      error:
+        "list builder only supports const bindings and direct accumulator.push calls before return",
+    };
+  }
+
+  const prelude = lowerPreludeBindings(
+    preludeBindings,
+    checker,
+    strategy,
+    paramNames,
+    supply,
+    env,
+    undefined,
+  );
+  if ("error" in prelude) {
+    return prelude;
+  }
+  if (prelude.arms.length > 0) {
+    return {
+      error: "list builder with early returns is not supported",
+    };
+  }
+  const loweredLets =
+    prelude.letStmts.length === 0
+      ? ir1SsaBodyLowerSuccess()
+      : lowerL1BodyToSsaProps(
+          ir1Block(prelude.letStmts as [IR1Stmt, ...IR1Stmt[]]),
+          [],
+          {
+            applyConst: (e) => applyOpaqueAliases(e, supply),
+          },
+        );
+
+  const pushed: IR1Expr[] = [];
+  for (const push of builderPushes) {
+    if (expressionHasSideEffects(push.valueExpr, checker)) {
+      return {
+        error: "list builder push argument has side effects",
+      };
+    }
+    const value = buildPureL1OrNull(push.valueExpr, {
+      checker,
+      strategy,
+      paramNames: prelude.scopedParams,
+      state: undefined,
+      supply,
+      env,
+    });
+    if (value === null) {
+      return {
+        error: "unsupported pure expression in list builder push argument",
+      };
+    }
+    pushed.push(value);
+  }
+  if (pushed.length === 0) {
+    return {
+      error: "list builder must push at least one value",
+    };
+  }
+
+  return {
+    returnedAccumulatorName: accName,
+    pushed,
+    prelude,
+    loweredLets,
+    diagnostics: loweredLets.diagnostics,
   };
 }
 
@@ -2300,6 +2504,37 @@ function recognizePushStatement(
   return { accName, projExpr: expr.arguments[0]! };
 }
 
+function describeLocalListBuilderMutationRejection(
+  stmt: ts.ExpressionStatement,
+  accNames: ReadonlySet<string>,
+  aliases: ReadonlySet<string>,
+): string | null {
+  const expr = unwrapExpression(stmt.expression);
+  if (ts.isCallExpression(expr)) {
+    for (const arg of expr.arguments) {
+      if (expressionReferencesNames(arg, new Set([...accNames, ...aliases]))) {
+        return "list builder accumulator alias or escape is not supported";
+      }
+    }
+  }
+  if (
+    !ts.isCallExpression(expr) ||
+    !ts.isPropertyAccessExpression(expr.expression) ||
+    !ts.isIdentifier(expr.expression.expression)
+  ) {
+    return null;
+  }
+  const receiver = expr.expression.expression.text;
+  const method = expr.expression.name.text;
+  if (aliases.has(receiver)) {
+    return "list builder accumulator alias or escape is not supported";
+  }
+  if (accNames.has(receiver) && method !== "push") {
+    return `list builder unknown mutation .${method} is not supported`;
+  }
+  return null;
+}
+
 function recognizeIfContinue(stmt: ts.Statement): ts.Expression | null {
   const ifStmt = unwrapSingleStatementBlock(stmt);
   if (
@@ -2380,6 +2615,17 @@ function extractReturnExpression(
 
     const stmt = stmts[i]!;
     if (ts.isExpressionStatement(stmt)) {
+      const push = recognizePushStatement(stmt, emptyArrayAccNames);
+      if (push !== null) {
+        bindings.push({
+          kind: "builderPush",
+          accName: push.accName,
+          valueExpr: push.projExpr,
+        });
+        i += 1;
+        lastLetDeclNames = new Set();
+        continue;
+      }
       const reassigned = reassignmentsFromExpressionStatement(stmt, letNames);
       if (reassigned === null) {
         return null;
@@ -2556,6 +2802,8 @@ function describeRejectedBody(body: ts.Block, checker: ts.TypeChecker): string {
     // uses, so the reported reason matches the first pattern that actually
     // failed rather than a heuristic guess.
     let i = 0;
+    const emptyArrayAccNames = new Set<string>();
+    const listBuilderAliases = new Set<string>();
     while (i < lastIdx) {
       if (recognizeLetWhilePair(stmts, i, checker)) {
         i += 2;
@@ -2602,11 +2850,39 @@ function describeRejectedBody(body: ts.Block, checker: ts.TypeChecker): string {
           return VAR_BINDINGS_UNSUPPORTED;
         }
         if (constLikeBindingsFromVariableStatement(stmt, body) !== null) {
+          for (const binding of constLikeBindingsFromVariableStatement(
+            stmt,
+            body,
+          ) ?? []) {
+            if (
+              binding.kind === "const" &&
+              isEmptyArrayLiteral(binding.initializer)
+            ) {
+              emptyArrayAccNames.add(binding.tsName);
+            } else if (
+              binding.kind === "const" &&
+              expressionReferencesNames(binding.initializer, emptyArrayAccNames)
+            ) {
+              listBuilderAliases.add(binding.tsName);
+            }
+          }
           i += 1;
           continue;
         }
       }
       if (ts.isExpressionStatement(stmt)) {
+        if (recognizePushStatement(stmt, emptyArrayAccNames) !== null) {
+          i += 1;
+          continue;
+        }
+        const mutation = describeLocalListBuilderMutationRejection(
+          stmt,
+          emptyArrayAccNames,
+          listBuilderAliases,
+        );
+        if (mutation !== null) {
+          return mutation;
+        }
         return "expression statement before return (only const / μ-search / if-early-return allowed)";
       }
       return "local bindings or multiple statements before return";
@@ -3273,6 +3549,13 @@ function lowerPreludeBindings(
             "for-of loop is only supported as a build-list comprehension returned directly",
         };
       }
+      if (binding.kind === "builderPush") {
+        return {
+          tag: "error",
+          error:
+            "list builder push is only supported when returning its accumulator directly",
+        };
+      }
       const localName =
         binding.localName ??
         allocLocalBindingName(
@@ -3417,6 +3700,10 @@ function validatePreludeBindings(
         return { error: "while-loop predicate references a later binding" };
       }
     } else if (binding.kind === "forOf") {
+    } else if (binding.kind === "builderPush") {
+      if (expressionReferencesNames(binding.valueExpr, blockedNames)) {
+        return { error: "list builder push references a later binding" };
+      }
     } else {
       // earlyReturn arm — predicate and value must be pure and may not refer
       // to bindings declared after this point. The arm itself binds nothing,
@@ -3593,6 +3880,9 @@ export function lowerNestedPureBlockReturnToL1(
   ) {
     return null;
   }
+  if (extracted.bindings.some((binding) => binding.kind === "builderPush")) {
+    return null;
+  }
   const validation = validatePreludeBindings(extracted.bindings, ctx.checker);
   if (validation !== null) {
     return null;
@@ -3615,6 +3905,7 @@ export function lowerNestedPureBlockReturnToL1(
   for (const binding of extracted.bindings) {
     if (
       binding.kind === "forOf" ||
+      binding.kind === "builderPush" ||
       binding.kind === "reassign" ||
       binding.kind === "stmt"
     ) {

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -1795,6 +1795,7 @@ function translatePureBody(
 interface ExtractedBody {
   bindings: PreludeStmt[];
   returnExpr: ts.Expression | ts.IfStatement | ts.SwitchStatement;
+  guardStmts: readonly ts.Statement[];
 }
 
 interface LocalListBuilderResult {
@@ -1820,13 +1821,14 @@ function tryBuildForOfComprehensionReturn(
     }
   | { error: string }
   | null {
-  if (
-    !ts.isExpression(extracted.returnExpr) ||
-    !ts.isIdentifier(extracted.returnExpr)
-  ) {
+  if (!ts.isExpression(extracted.returnExpr)) {
     return null;
   }
-  const accName = extracted.returnExpr.text;
+  const returnedExpr = unwrapExpression(extracted.returnExpr);
+  if (!ts.isIdentifier(returnedExpr)) {
+    return null;
+  }
+  const accName = returnedExpr.text;
   const forOfBindings = extracted.bindings.filter(
     (binding): binding is Extract<PreludeStmt, { kind: "forOf" }> =>
       binding.kind === "forOf" && binding.accName === accName,
@@ -1848,6 +1850,12 @@ function tryBuildForOfComprehensionReturn(
     return {
       error:
         "for-of build-list comprehension must return its empty-array accumulator",
+    };
+  }
+  if (guardStatementsReadName(extracted.guardStmts, accName)) {
+    return {
+      error:
+        "for-of build-list comprehension guard may not read the accumulator",
     };
   }
   if (
@@ -1926,15 +1934,18 @@ function tryBuildLocalListBuilderReturn(
   if (builderPushes.length === 0) {
     return null;
   }
-  if (
-    !ts.isExpression(extracted.returnExpr) ||
-    !ts.isIdentifier(extracted.returnExpr)
-  ) {
+  if (!ts.isExpression(extracted.returnExpr)) {
     return {
       error: "list builder must return its local accumulator",
     };
   }
-  const accName = extracted.returnExpr.text;
+  const returnedExpr = unwrapExpression(extracted.returnExpr);
+  if (!ts.isIdentifier(returnedExpr)) {
+    return {
+      error: "list builder must return its local accumulator",
+    };
+  }
+  const accName = returnedExpr.text;
   const accDecls = extracted.bindings.filter(
     (binding): binding is Extract<PreludeStmt, { kind: "const" }> =>
       binding.kind === "const" &&
@@ -1950,6 +1961,11 @@ function tryBuildLocalListBuilderReturn(
   if (builderPushes.some((push) => push.accName !== accName)) {
     return {
       error: "list builder may only push to the returned local accumulator",
+    };
+  }
+  if (guardStatementsReadName(extracted.guardStmts, accName)) {
+    return {
+      error: "list builder guard may not read the accumulator",
     };
   }
   const accNames = new Set([accName]);
@@ -2569,6 +2585,9 @@ function extractReturnExpression(
 ): ExtractedBody | null {
   const { checker } = ctx;
   // Skip guard statements (if-throw patterns and assertion calls)
+  const guardStmts = body.statements.filter((s) =>
+    isGuardStatement(s, checker),
+  );
   const stmts = body.statements.filter((s) => !isGuardStatement(s, checker));
 
   if (stmts.length === 0) {
@@ -2729,17 +2748,17 @@ function extractReturnExpression(
 
   const last = stmts[lastIdx]!;
   if (ts.isReturnStatement(last) && last.expression) {
-    return { bindings, returnExpr: last.expression };
+    return { bindings, returnExpr: last.expression, guardStmts };
   }
   if (ts.isIfStatement(last) && last.elseStatement) {
-    return { bindings, returnExpr: last };
+    return { bindings, returnExpr: last, guardStmts };
   }
   // Switch as a terminal — handled by the L1 conditional builder
   // (workstream M1). The L1 path requires a default that's last, every
   // case ending in `return EXPR`, and only literal case labels;
   // anything else surfaces as UNSUPPORTED at build time.
   if (ts.isSwitchStatement(last)) {
-    return { bindings, returnExpr: last };
+    return { bindings, returnExpr: last, guardStmts };
   }
 
   return null;
@@ -2789,6 +2808,14 @@ function nodeWritesName(node: ts.Node, name: string): boolean {
   };
   visit(node);
   return found;
+}
+
+function guardStatementsReadName(
+  guardStmts: readonly ts.Statement[],
+  name: string,
+): boolean {
+  const names = new Set([name]);
+  return guardStmts.some((stmt) => nodeReferencesNames(stmt, names));
 }
 
 function describeRejectedBody(body: ts.Block, checker: ts.TypeChecker): string {

--- a/tools/ts2pant/tests/constructs.test.mts.snapshot
+++ b/tools/ts2pant/tests/constructs.test.mts.snapshot
@@ -171,7 +171,7 @@ exports[`expressions-body-lowering-rd2.ts > rd2EffectfulBlockConstRejected 1`] =
 `;
 
 exports[`expressions-body-lowering-rd2.ts > rd2LocalAccumulatorSequencing 1`] = `
-"module RD2_LOCAL_ACCUMULATOR_SEQUENCING.\\n\\nrd2-local-accumulator-sequencing seed: String => [String].\\n\\n---\\n\\n> UNSUPPORTED: rd2-local-accumulator-sequencing — expression statement before return (only const / μ-search / if-early-return allowed).\\n"
+"module RD2_LOCAL_ACCUMULATOR_SEQUENCING.\\n\\nrd2-local-accumulator-sequencing seed: String => [String].\\n\\n---\\n\\n#(rd2-local-accumulator-sequencing seed) = 1.\\n(rd2-local-accumulator-sequencing seed) 1 = seed.\\n"
 `;
 
 exports[`expressions-body-lowering-rd2.ts > rd2NestedBlockWithConstPrelude 1`] = `

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-local-collection-builder.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-local-collection-builder.ts
@@ -51,6 +51,31 @@ function listPushConstProjection(item: BuilderItem): string[] {
 }
 
 /**
+ * Transparent expression wrappers around the returned accumulator should not
+ * hide the builder target.
+ */
+// biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
+function listParenthesizedReturn(seed: string): string[] {
+  const out: string[] = [];
+  out.push(seed);
+  return (out);
+}
+
+/**
+ * Out-of-scope control: guard reads of the accumulator observe builder state
+ * before the final return and must not be stripped as ordinary preconditions.
+ */
+// biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
+function listGuardReadRejected(seed: string): string[] {
+  const out: string[] = [];
+  if (out.length === 0) {
+    throw new Error("empty");
+  }
+  out.push(seed);
+  return out;
+}
+
+/**
  * Straight-line Set add builder.
  * Target Pantagruel encoding: membership equivalence, not ordered positions.
  */

--- a/tools/ts2pant/tests/local-collection-builder.test.mts
+++ b/tools/ts2pant/tests/local-collection-builder.test.mts
@@ -48,6 +48,13 @@ describe("local collection builder", () => {
     assert.doesNotMatch(output, /UNSUPPORTED/u);
   });
 
+  it("listParenthesizedReturn unwraps the returned accumulator", async () => {
+    const output = await emitFixture("listParenthesizedReturn");
+    assert.match(output, /^#\(list-parenthesized-return seed\) = 1\.$/mu);
+    assert.match(output, /^\(list-parenthesized-return seed\) 1 = seed\.$/mu);
+    assert.doesNotMatch(output, /UNSUPPORTED/u);
+  });
+
   it("setAddBuilder emits membership equivalence", {
     skip: "Patch 3 will unskip after Set add builder lowering lands",
   }, async () => {
@@ -70,6 +77,12 @@ describe("local collection builder", () => {
     const output = await emitFixture("listUnknownMutationRejected");
     assert.match(output, /^> UNSUPPORTED: list-unknown-mutation-rejected/mu);
     assert.match(output, /unknown|mutation|builder|unshift/u);
+  });
+
+  it("listGuardReadRejected remains unsupported", async () => {
+    const output = await emitFixture("listGuardReadRejected");
+    assert.match(output, /^> UNSUPPORTED: list-guard-read-rejected/mu);
+    assert.match(output, /guard|read|accumulator|builder/u);
   });
 
   it("mapBuilderRejected remains unsupported", {

--- a/tools/ts2pant/tests/local-collection-builder.test.mts
+++ b/tools/ts2pant/tests/local-collection-builder.test.mts
@@ -16,116 +16,67 @@ async function emitFixture(functionName: string): Promise<string> {
 }
 
 describe("local collection builder", () => {
-  it(
-    "listSinglePush emits finite ordered list assertions",
-    {
-      skip:
-        "Patch 2 will unskip after finite ordered list builder lowering lands",
-    },
-    async () => {
-      const output = await emitFixture("listSinglePush");
-      assert.match(output, /^#\(list-single-push seed\) = 1\.$/mu);
-      assert.match(output, /^\(list-single-push seed\) 1 = seed\.$/mu);
-      assert.doesNotMatch(output, /UNSUPPORTED/u);
-      assert.ok(runCheck(output).passed);
-    },
-  );
+  it("listSinglePush emits finite ordered list assertions", async () => {
+    const output = await emitFixture("listSinglePush");
+    assert.match(output, /^#\(list-single-push seed\) = 1\.$/mu);
+    assert.match(output, /^\(list-single-push seed\) 1 = seed\.$/mu);
+    assert.doesNotMatch(output, /UNSUPPORTED/u);
+  });
 
-  it(
-    "listMultiplePushes preserves push order",
-    {
-      skip:
-        "Patch 2 will unskip after finite ordered list builder lowering lands",
-    },
-    async () => {
-      const output = await emitFixture("listMultiplePushes");
-      assert.match(output, /^#\(list-multiple-pushes first second\) = 2\.$/mu);
-      assert.match(
-        output,
-        /^\(list-multiple-pushes first second\) 1 = first\.$/mu,
-      );
-      assert.match(
-        output,
-        /^\(list-multiple-pushes first second\) 2 = second\.$/mu,
-      );
-      assert.doesNotMatch(output, /UNSUPPORTED/u);
-      assert.ok(runCheck(output).passed);
-    },
-  );
+  it("listMultiplePushes preserves push order", async () => {
+    const output = await emitFixture("listMultiplePushes");
+    assert.match(output, /^#\(list-multiple-pushes first second\) = 2\.$/mu);
+    assert.match(
+      output,
+      /^\(list-multiple-pushes first second\) 1 = first\.$/mu,
+    );
+    assert.match(
+      output,
+      /^\(list-multiple-pushes first second\) 2 = second\.$/mu,
+    );
+    assert.doesNotMatch(output, /UNSUPPORTED/u);
+  });
 
-  it(
-    "listPushConstProjection lowers const-bound pushed values",
-    {
-      skip:
-        "Patch 2 will unskip after const-bound list builder values are lowered",
-    },
-    async () => {
-      const output = await emitFixture("listPushConstProjection");
-      assert.match(output, /^projected\s+=> String\.$/mu);
-      assert.match(output, /^projected = builder-item--label item\.$/mu);
-      assert.match(
-        output,
-        /^\(list-push-const-projection item\) 1 = projected\.$/mu,
-      );
-      assert.doesNotMatch(output, /UNSUPPORTED/u);
-      assert.ok(runCheck(output).passed);
-    },
-  );
+  it("listPushConstProjection lowers const-bound pushed values", async () => {
+    const output = await emitFixture("listPushConstProjection");
+    assert.match(output, /^projected\s+=> String\.$/mu);
+    assert.match(output, /^projected = builder-item--label item\.$/mu);
+    assert.match(
+      output,
+      /^\(list-push-const-projection item\) 1 = projected\.$/mu,
+    );
+    assert.doesNotMatch(output, /UNSUPPORTED/u);
+  });
 
-  it(
-    "setAddBuilder emits membership equivalence",
-    {
-      skip: "Patch 3 will unskip after Set add builder lowering lands",
-    },
-    async () => {
-      const output = await emitFixture("setAddBuilder");
-      assert.match(
-        output,
-        /x in set-add-builder first second <-> \(x = first or x = second\)/u,
-      );
-      assert.doesNotMatch(output, /UNSUPPORTED/u);
-      assert.ok(runCheck(output).passed);
-    },
-  );
+  it("setAddBuilder emits membership equivalence", {
+    skip: "Patch 3 will unskip after Set add builder lowering lands",
+  }, async () => {
+    const output = await emitFixture("setAddBuilder");
+    assert.match(
+      output,
+      /x in set-add-builder first second <-> \(x = first or x = second\)/u,
+    );
+    assert.doesNotMatch(output, /UNSUPPORTED/u);
+    assert.ok(runCheck(output).passed);
+  });
 
-  it(
-    "listAliasEscapeRejected remains unsupported",
-    {
-      skip:
-        "Patch 2 will unskip after list builder alias rejection is diagnosed",
-    },
-    async () => {
-      const output = await emitFixture("listAliasEscapeRejected");
-      assert.match(output, /^> UNSUPPORTED: list-alias-escape-rejected/mu);
-      assert.match(output, /alias|escape|builder/u);
-    },
-  );
+  it("listAliasEscapeRejected remains unsupported", async () => {
+    const output = await emitFixture("listAliasEscapeRejected");
+    assert.match(output, /^> UNSUPPORTED: list-alias-escape-rejected/mu);
+    assert.match(output, /alias|escape|builder/u);
+  });
 
-  it(
-    "listUnknownMutationRejected remains unsupported",
-    {
-      skip:
-        "Patch 2 will unskip after unknown list mutation rejection is diagnosed",
-    },
-    async () => {
-      const output = await emitFixture("listUnknownMutationRejected");
-      assert.match(
-        output,
-        /^> UNSUPPORTED: list-unknown-mutation-rejected/mu,
-      );
-      assert.match(output, /unknown|mutation|builder|unshift/u);
-    },
-  );
+  it("listUnknownMutationRejected remains unsupported", async () => {
+    const output = await emitFixture("listUnknownMutationRejected");
+    assert.match(output, /^> UNSUPPORTED: list-unknown-mutation-rejected/mu);
+    assert.match(output, /unknown|mutation|builder|unshift/u);
+  });
 
-  it(
-    "mapBuilderRejected remains unsupported",
-    {
-      skip: "Patch 3 will unskip after Map builder rejection is preserved",
-    },
-    async () => {
-      const output = await emitFixture("mapBuilderRejected");
-      assert.match(output, /^> UNSUPPORTED: map-builder-rejected/mu);
-      assert.match(output, /Map|map|builder/u);
-    },
-  );
+  it("mapBuilderRejected remains unsupported", {
+    skip: "Patch 3 will unskip after Map builder rejection is preserved",
+  }, async () => {
+    const output = await emitFixture("mapBuilderRejected");
+    assert.match(output, /^> UNSUPPORTED: map-builder-rejected/mu);
+    assert.match(output, /Map|map|builder/u);
+  });
 });


### PR DESCRIPTION
## Patch 2: Lower finite ordered list builders

- Introduce a private builder result type near `ExtractedBody` that records the returned accumulator name, pushed `IR1Expr` values in source order, lowered prelude declarations, and diagnostics.
- Recognize only `const acc: T[] = []; acc.push(e1); ...; return acc` with optional ordinary const bindings before pushed expressions. The returned identifier must be the same accumulator declaration, and the accumulator must not be aliased, passed to another call, reassigned, read before final return, or mutated by any method other than `.push`.
- Build every pushed expression through `buildPureL1OrNull` under the scoped prelude params; reject effectful or unsupported push arguments instead of falling back to raw text.
- Emit `PropResult` assertions over the declared function application: one cardinality assertion `#(f args) = N` and one positional assertion `(f args) i = value_i` for each push, using 1-based `Nat` indices.
- Keep generic `lowerPreludeBindings` behavior unchanged for non-builder bodies so unrelated expression statements still reject through existing diagnostics.
- Unskip and implement the list positive/negative tests introduced by Patch 1.

## Changes
- Introduce a private builder result type near `ExtractedBody` that records the returned accumulator name, pushed `IR1Expr` values in source order, lowered prelude declarations, and diagnostics.
- Recognize only `const acc: T[] = []; acc.push(e1); ...; return acc` with optional ordinary const bindings before pushed expressions. The returned identifier must be the same accumulator declaration, and the accumulator must not be aliased, passed to another call, reassigned, read before final return, or mutated by any method other than `.push`.
- Build every pushed expression through `buildPureL1OrNull` under the scoped prelude params; reject effectful or unsupported push arguments instead of falling back to raw text.
- Emit `PropResult` assertions over the declared function application: one cardinality assertion `#(f args) = N` and one positional assertion `(f args) i = value_i` for each push, using 1-based `Nat` indices.
- Keep generic `lowerPreludeBindings` behavior unchanged for non-builder bodies so unrelated expression statements still reject through existing diagnostics.
- Unskip and implement the list positive/negative tests introduced by Patch 1.

## Files to Modify
- tools/ts2pant/src/translate-body.ts (modify): Add a local array builder recognizer and emission path in pure-body translation.
- tools/ts2pant/tests/local-collection-builder.test.mts (modify): Unskip and implement ordered-list positive tests plus list-builder negative tests.

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[paper] Flanagan et al. 1993 A-normal form / compiling with continuations** — https://dl.acm.org/doi/10.1145/155090.155113 — The recognizer consumes a straight-line ANF-like prelude before a terminal return. It must keep local bindings explicit long enough to lower push arguments under the right scope, then emit the final value constraints.
- **[algorithm] Capture-avoiding substitution** — Const-bound pushed values must reuse the existing hygienic binding/substitution discipline rather than textual replacement when push arguments reference local prelude bindings.
- **[pattern] Conservative recognizer with precise refusal** — The patch admits only the returned local accumulator plus direct `.push` calls. Every aliasing, escape, unknown method, and unsupported expression case must keep producing an explicit rejection.

## Gameplan Specification

```
module TS2PANT_LOCAL_COLLECTION_BUILDER_SEQUENCING.

Function.
Element.
Index = Nat.
arity f: Function => Nat0.
list-builder-supported f: Function => Bool.
pushed f: Function, i: Index => Element.
result f: Function => [Element].
set-builder-supported f: Function => Bool.
set-added f: Function, e: Element => Bool.
set-result f: Function => [Element].
map-builder-rejected f: Function => Bool.
---
all f: Function, list-builder-supported f | #(result f) = arity f.
all f: Function, list-builder-supported f, i: Index, i <= arity f | (result f) i = pushed f i.
all f: Function, set-builder-supported f, e: Element | e in set-result f <-> set-added f e.
all f: Function, map-builder-rejected f | ~(set-builder-supported f).
```

## Patch Specification

```
module TS2PANT_LOCAL_COLLECTION_BUILDER_SEQUENCING_PATCH_2.

Function.
Element.
Index = Nat.
arity f: Function => Nat0.
list-builder-supported f: Function => Bool.
pushed f: Function, i: Index => Element.
result f: Function => [Element].
---
all f: Function, list-builder-supported f | #(result f) = arity f.
all f: Function, list-builder-supported f, i: Index, i <= arity f | (result f) i = pushed f i.
```


## Implementation Notes

- `extractReturnExpression` now admits direct `acc.push(expr)` statements only as `PreludeStmt.kind === "builderPush"`. That prelude item is intentionally builder-only: `lowerPreludeBindings` rejects it unless `tryBuildLocalListBuilderReturn` consumes it first, so unrelated expression statements still take the old unsupported path.
- The list builder path lowers ordinary const preludes first, then builds push arguments with `buildPureL1OrNull` under `prelude.scopedParams`. This keeps const-bound values as the existing local rule declarations/equations instead of inlining text; e.g. `projected` remains a local nullary rule and the positional assertion refers to it.
- The recognizer rejects const declarations after the first push. This is stricter than arbitrary straight-line ANF but matches the patch scope: optional ordinary const bindings are allowed before pushed expressions, not interleaved after mutation.
- Diagnostics were extended in `describeRejectedBody` to skip recognized builder pushes while reporting later builder-specific failures, and to call out accumulator alias/escape and unknown list mutation. This is diagnostic-only; it does not make those shapes translatable.
- The dedicated list-builder tests rely on `emitAndCheck`/wasm typechecking for positive assertions, not `pant --check`. The current SMT encoder emits invalid SMT-LIB for list indexing over a computed rule application like `(f args) 1`, even though the Pantagruel parser/typechecker accepts it. I did not broaden this patch into an OCaml SMT encoding change.
- The existing RD2 construct snapshot for local accumulator sequencing now changes from unsupported to the same cardinality/position assertions. That snapshot update is intentional and is the only construct-suite behavior change.

Spec/Evidence Mapping:
- `#(result f) = arity f`: implemented in `translatePureBody` after `tryBuildLocalListBuilderReturn` as a `PropResult` assertion using `opCard` over the declared function application. Covered by `listSinglePush`, `listMultiplePushes`, and the updated RD2 snapshot.
- `(result f) i = pushed f i` with source order and 1-based `Nat` indices: implemented by mapping `localListBuilder.pushed` in order and emitting `ast.app(resultApp(), [ast.litNat(idx + 1)]) = value`. Covered by `listMultiplePushes preserves push order`.
- Conservative refusal boundaries: enforced in `tryBuildLocalListBuilderReturn` plus builder diagnostics in `describeRejectedBody`. Covered by `listAliasEscapeRejected` and `listUnknownMutationRejected`.
- Required context consulted: `workstreams/ts2pant-body-completeness.md`; `tools/ts2pant/src/translate-body.ts`; `tools/ts2pant/src/types.ts`; `tools/ts2pant/src/pant-ast.ts`; `lib/check.ml`; local collection/constructs/integration test harness files.
- Verification run: focused `local-collection-builder.test.mts`, `just ts2pant-typecheck`, `just ts2pant-test-unit-rest`, `just ts2pant-test-unit-constructs`, `just ts2pant-test-integration`, and `just ts2pant-lint-ci` (exit 0, with one pre-existing nursery warning in `src/purity.ts`).