### PR TITLE
[ts2pant-local-collection-builder-sequencing] Patch 3: Lower Set add builders and preserve Map rejection

### DIFF
--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -68,7 +68,7 @@ import {
   lowerScalarSsaEarlyExitMerge,
   type ScalarSsaEarlyExitPropertyInput,
 } from "./ir1-ssa-scalars.js";
-import { substituteIR1ExprSubtree } from "./ir1-substitute.js";
+import { freeVarsIR1Expr, substituteIR1ExprSubtree } from "./ir1-substitute.js";
 import {
   negateFact,
   recognizeNarrowingPredicate,
@@ -1353,6 +1353,7 @@ function translatePureBody(
   }
 
   const localSetBuilder = tryBuildLocalSetBuilderReturn(
+    node,
     extracted,
     checker,
     strategy,
@@ -1374,7 +1375,7 @@ function translatePureBody(
     }
     const argExprs = params.map((p) => ast.var(p.name));
     const resultApp = ast.app(ast.var(functionName), argExprs);
-    const binder = allocComprehensionBinder(supply, "x");
+    const binder = allocSetMembershipBinder(supply, params, localSetBuilder);
     const binderVar = ast.var(binder);
     const memberExpr = ast.binop(ast.opIn(), binderVar, resultApp);
     const body =
@@ -2146,6 +2147,7 @@ function tryBuildLocalListBuilderReturn(
 }
 
 function tryBuildLocalSetBuilderReturn(
+  node: ts.FunctionDeclaration | ts.MethodDeclaration,
   extracted: ExtractedBody,
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
@@ -2194,8 +2196,13 @@ function tryBuildLocalSetBuilderReturn(
     };
   }
 
+  const sig = checker.getSignatureFromDeclaration(node);
+  const returnType =
+    sig === undefined
+      ? checker.getTypeAtLocation(extracted.returnExpr)
+      : checker.getReturnTypeOfSignature(sig);
   const elemType = setElementSort(
-    checker.getTypeAtLocation(extracted.returnExpr),
+    returnType,
     checker,
     strategy,
     supply.synthCell,
@@ -2303,6 +2310,28 @@ function tryBuildLocalSetBuilderReturn(
     loweredLets,
     diagnostics: loweredLets.diagnostics,
   };
+}
+
+function allocSetMembershipBinder(
+  supply: UniqueSupply,
+  params: Array<{ name: string; type: string }>,
+  builder: LocalSetBuilderResult,
+): string {
+  const usedNames = new Set<string>(params.map((p) => p.name));
+  for (const name of builder.prelude.scopedParams.values()) {
+    usedNames.add(name);
+  }
+  for (const expr of builder.added) {
+    for (const name of freeVarsIR1Expr(expr)) {
+      usedNames.add(name);
+    }
+  }
+
+  let binder = allocComprehensionBinder(supply, "x");
+  while (usedNames.has(binder)) {
+    binder = allocComprehensionBinder(supply, "x");
+  }
+  return binder;
 }
 
 function describeUnsupportedLocalCollectionConstructorReturn(
@@ -2908,7 +2937,9 @@ function describeLocalMapBuilderBodyRejection(
 
   const mapAccNames = new Set<string>();
   const aliases = new Set<string>();
-  for (const stmt of stmts.slice(0, -1)) {
+  const last = stmts[stmts.length - 1]!;
+  const scanStmts = ts.isReturnStatement(last) ? stmts.slice(0, -1) : stmts;
+  for (const stmt of scanStmts) {
     if (ts.isVariableStatement(stmt)) {
       const bindings = constLikeBindingsFromVariableStatement(stmt, body);
       if (bindings === null) {

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -2226,7 +2226,8 @@ function tryBuildLocalSetBuilderReturn(
     if (binding.kind === "const") {
       if (seenAdd) {
         return {
-          error: "Set builder const bindings must appear before added expressions",
+          error:
+            "Set builder const bindings must appear before added expressions",
         };
       }
       if (expressionReferencesNames(binding.initializer, accNames)) {
@@ -2919,7 +2920,9 @@ function describeLocalMapBuilderBodyRejection(
         }
         if (isMapConstructor(binding.initializer)) {
           mapAccNames.add(binding.tsName);
-        } else if (expressionReferencesNames(binding.initializer, mapAccNames)) {
+        } else if (
+          expressionReferencesNames(binding.initializer, mapAccNames)
+        ) {
           aliases.add(binding.tsName);
         }
       }

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -229,6 +229,7 @@ type PreludeStmt =
   | { kind: "muSearch"; tsName: string; mu: MuSearch; localName?: string }
   | ({ kind: "forOf" } & RecognizedForOfPush)
   | { kind: "builderPush"; accName: string; valueExpr: ts.Expression }
+  | { kind: "builderSetAdd"; accName: string; valueExpr: ts.Expression }
   | { kind: "reassign"; tsName: string; valueExpr: ts.Expression }
   | { kind: "stmt"; stmt: ts.Statement }
   | {
@@ -1351,6 +1352,71 @@ function translatePureBody(
     ];
   }
 
+  const localSetBuilder = tryBuildLocalSetBuilderReturn(
+    extracted,
+    checker,
+    strategy,
+    paramNames,
+    supply,
+    env,
+  );
+  if (localSetBuilder !== null) {
+    if ("error" in localSetBuilder) {
+      return [
+        {
+          kind: "unsupported",
+          reason: `${functionName} — ${localSetBuilder.error}`,
+        },
+      ];
+    }
+    if (localSetBuilder.diagnostics.length > 0) {
+      return localSetBuilder.diagnostics;
+    }
+    const argExprs = params.map((p) => ast.var(p.name));
+    const resultApp = ast.app(ast.var(functionName), argExprs);
+    const binder = allocComprehensionBinder(supply, "x");
+    const binderVar = ast.var(binder);
+    const memberExpr = ast.binop(ast.opIn(), binderVar, resultApp);
+    const body =
+      localSetBuilder.added.length === 0
+        ? ast.unop(ast.opNot(), memberExpr)
+        : ast.binop(
+            ast.opIff(),
+            memberExpr,
+            localSetBuilder.added
+              .map((value) =>
+                ast.binop(
+                  ast.opEq(),
+                  binderVar,
+                  applyOpaqueAliases(lowerL1ToOpaque(value), supply),
+                ),
+              )
+              .reduce((acc, expr) => ast.binop(ast.opOr(), acc, expr)),
+          );
+    return [
+      ...localSetBuilder.prelude.ruleDecls,
+      ...localSetBuilder.loweredLets.propositions,
+      {
+        kind: "assertion",
+        quantifiers: [
+          ast.param(binder, ast.tName(localSetBuilder.elemType)),
+        ] as OpaqueParam[],
+        body,
+      },
+    ];
+  }
+
+  const unsupportedLocalCollectionConstructor =
+    describeUnsupportedLocalCollectionConstructorReturn(extracted);
+  if (unsupportedLocalCollectionConstructor !== null) {
+    return [
+      {
+        kind: "unsupported",
+        reason: `${functionName} — ${unsupportedLocalCollectionConstructor}`,
+      },
+    ];
+  }
+
   const prelude = lowerPreludeBindings(
     extracted.bindings,
     checker,
@@ -1806,6 +1872,15 @@ interface LocalListBuilderResult {
   diagnostics: PropResult[];
 }
 
+interface LocalSetBuilderResult {
+  returnedAccumulatorName: string;
+  elemType: string;
+  added: IR1Expr[];
+  prelude: LoweredPreludeBindings;
+  loweredLets: IR1SsaBodyLowerResult;
+  diagnostics: PropResult[];
+}
+
 function tryBuildForOfComprehensionReturn(
   extracted: ExtractedBody,
   checker: ts.TypeChecker,
@@ -2068,6 +2143,191 @@ function tryBuildLocalListBuilderReturn(
     loweredLets,
     diagnostics: loweredLets.diagnostics,
   };
+}
+
+function tryBuildLocalSetBuilderReturn(
+  extracted: ExtractedBody,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  paramNames: ReadonlyMap<string, string>,
+  supply: UniqueSupply,
+  env: AssumptionEnv,
+): LocalSetBuilderResult | { error: string } | null {
+  if (
+    !ts.isExpression(extracted.returnExpr) ||
+    !ts.isIdentifier(extracted.returnExpr)
+  ) {
+    return null;
+  }
+  const accName = extracted.returnExpr.text;
+  const accDecls = extracted.bindings.filter(
+    (binding): binding is Extract<PreludeStmt, { kind: "const" }> =>
+      binding.kind === "const" &&
+      binding.tsName === accName &&
+      isEmptySetConstructor(binding.initializer),
+  );
+  if (accDecls.length === 0) {
+    const setAdds = extracted.bindings.filter(
+      (binding): binding is Extract<PreludeStmt, { kind: "builderSetAdd" }> =>
+        binding.kind === "builderSetAdd",
+    );
+    return setAdds.length === 0
+      ? null
+      : {
+          error:
+            "Set builder must return the same local empty Set accumulator it adds to",
+        };
+  }
+  if (accDecls.length !== 1) {
+    return {
+      error: "Set builder must have exactly one returned empty Set accumulator",
+    };
+  }
+
+  const setAdds = extracted.bindings.filter(
+    (binding): binding is Extract<PreludeStmt, { kind: "builderSetAdd" }> =>
+      binding.kind === "builderSetAdd",
+  );
+  if (setAdds.some((add) => add.accName !== accName)) {
+    return {
+      error: "Set builder may only add to the returned local accumulator",
+    };
+  }
+
+  const elemType = setElementSort(
+    checker.getTypeAtLocation(extracted.returnExpr),
+    checker,
+    strategy,
+    supply.synthCell,
+  );
+  if (elemType === null) {
+    return {
+      error:
+        "Set builder return type must be Set<T> or ReadonlySet<T> with a supported element type",
+    };
+  }
+
+  const accNames = new Set([accName]);
+  let seenAdd = false;
+  const preludeBindings: PreludeStmt[] = [];
+  for (const binding of extracted.bindings) {
+    if (binding === accDecls[0]) {
+      continue;
+    }
+    if (binding.kind === "builderSetAdd") {
+      seenAdd = true;
+      if (expressionReferencesNames(binding.valueExpr, accNames)) {
+        return {
+          error: "Set builder add argument may not read the accumulator",
+        };
+      }
+      continue;
+    }
+    if (binding.kind === "const") {
+      if (seenAdd) {
+        return {
+          error: "Set builder const bindings must appear before added expressions",
+        };
+      }
+      if (expressionReferencesNames(binding.initializer, accNames)) {
+        return {
+          error: "Set builder accumulator alias or escape is not supported",
+        };
+      }
+      preludeBindings.push(binding);
+      continue;
+    }
+    return {
+      error:
+        "Set builder only supports const bindings and direct accumulator.add calls before return",
+    };
+  }
+
+  const prelude = lowerPreludeBindings(
+    preludeBindings,
+    checker,
+    strategy,
+    paramNames,
+    supply,
+    env,
+    undefined,
+  );
+  if ("error" in prelude) {
+    return prelude;
+  }
+  if (prelude.arms.length > 0) {
+    return {
+      error: "Set builder with early returns is not supported",
+    };
+  }
+  const loweredLets =
+    prelude.letStmts.length === 0
+      ? ir1SsaBodyLowerSuccess()
+      : lowerL1BodyToSsaProps(
+          ir1Block(prelude.letStmts as [IR1Stmt, ...IR1Stmt[]]),
+          [],
+          {
+            applyConst: (e) => applyOpaqueAliases(e, supply),
+          },
+        );
+
+  const added: IR1Expr[] = [];
+  for (const add of setAdds) {
+    if (expressionHasSideEffects(add.valueExpr, checker)) {
+      return {
+        error: "Set builder add argument has side effects",
+      };
+    }
+    const value = buildPureL1OrNull(add.valueExpr, {
+      checker,
+      strategy,
+      paramNames: prelude.scopedParams,
+      state: undefined,
+      supply,
+      env,
+    });
+    if (value === null) {
+      return {
+        error: "unsupported pure expression in Set builder add argument",
+      };
+    }
+    added.push(value);
+  }
+
+  return {
+    returnedAccumulatorName: accName,
+    elemType,
+    added,
+    prelude,
+    loweredLets,
+    diagnostics: loweredLets.diagnostics,
+  };
+}
+
+function describeUnsupportedLocalCollectionConstructorReturn(
+  extracted: ExtractedBody,
+): string | null {
+  if (
+    !ts.isExpression(extracted.returnExpr) ||
+    !ts.isIdentifier(extracted.returnExpr)
+  ) {
+    return null;
+  }
+  const accName = extracted.returnExpr.text;
+  const accDecl = extracted.bindings.find(
+    (binding): binding is Extract<PreludeStmt, { kind: "const" }> =>
+      binding.kind === "const" && binding.tsName === accName,
+  );
+  if (accDecl === undefined) {
+    return null;
+  }
+  if (isSetConstructorWithIterable(accDecl.initializer)) {
+    return "Set builder from iterable is not supported";
+  }
+  if (isMapConstructor(accDecl.initializer)) {
+    return "Map builder construction is not supported in this milestone";
+  }
+  return null;
 }
 
 /**
@@ -2520,6 +2780,30 @@ function recognizePushStatement(
   return { accName, projExpr: expr.arguments[0]! };
 }
 
+function recognizeSetAddStatement(
+  stmt: ts.Statement,
+  accNames: ReadonlySet<string>,
+): { accName: string; valueExpr: ts.Expression } | null {
+  if (!ts.isExpressionStatement(stmt)) {
+    return null;
+  }
+  const expr = stmt.expression;
+  if (
+    !ts.isCallExpression(expr) ||
+    expr.arguments.length !== 1 ||
+    !ts.isPropertyAccessExpression(expr.expression) ||
+    expr.expression.name.text !== "add" ||
+    !ts.isIdentifier(expr.expression.expression)
+  ) {
+    return null;
+  }
+  const accName = expr.expression.expression.text;
+  if (!accNames.has(accName)) {
+    return null;
+  }
+  return { accName, valueExpr: expr.arguments[0]! };
+}
+
 function describeLocalListBuilderMutationRejection(
   stmt: ts.ExpressionStatement,
   accNames: ReadonlySet<string>,
@@ -2547,6 +2831,111 @@ function describeLocalListBuilderMutationRejection(
   }
   if (accNames.has(receiver) && method !== "push") {
     return `list builder unknown mutation .${method} is not supported`;
+  }
+  return null;
+}
+
+function describeLocalSetBuilderMutationRejection(
+  stmt: ts.ExpressionStatement,
+  accNames: ReadonlySet<string>,
+  aliases: ReadonlySet<string>,
+): string | null {
+  const expr = unwrapExpression(stmt.expression);
+  if (ts.isCallExpression(expr)) {
+    for (const arg of expr.arguments) {
+      if (expressionReferencesNames(arg, new Set([...accNames, ...aliases]))) {
+        return "Set builder accumulator alias or escape is not supported";
+      }
+    }
+  }
+  if (
+    !ts.isCallExpression(expr) ||
+    !ts.isPropertyAccessExpression(expr.expression) ||
+    !ts.isIdentifier(expr.expression.expression)
+  ) {
+    return null;
+  }
+  const receiver = expr.expression.expression.text;
+  const method = expr.expression.name.text;
+  if (aliases.has(receiver)) {
+    return "Set builder accumulator alias or escape is not supported";
+  }
+  if (accNames.has(receiver) && method !== "add") {
+    return `Set builder mutation .${method} is not supported`;
+  }
+  return null;
+}
+
+function describeLocalMapBuilderMutationRejection(
+  stmt: ts.ExpressionStatement,
+  accNames: ReadonlySet<string>,
+  aliases: ReadonlySet<string>,
+): string | null {
+  const expr = unwrapExpression(stmt.expression);
+  if (ts.isCallExpression(expr)) {
+    for (const arg of expr.arguments) {
+      if (expressionReferencesNames(arg, new Set([...accNames, ...aliases]))) {
+        return "Map builder accumulator alias or escape is not supported";
+      }
+    }
+  }
+  if (
+    !ts.isCallExpression(expr) ||
+    !ts.isPropertyAccessExpression(expr.expression) ||
+    !ts.isIdentifier(expr.expression.expression)
+  ) {
+    return null;
+  }
+  const receiver = expr.expression.expression.text;
+  if (aliases.has(receiver)) {
+    return "Map builder accumulator alias or escape is not supported";
+  }
+  if (accNames.has(receiver)) {
+    return "Map builder construction is not supported in this milestone";
+  }
+  return null;
+}
+
+function describeLocalMapBuilderBodyRejection(
+  body: ts.Block,
+  checker: ts.TypeChecker,
+): string | null {
+  const stmts = body.statements.filter((s) => !isGuardStatement(s, checker));
+  if (stmts.length < 2) {
+    return null;
+  }
+
+  const mapAccNames = new Set<string>();
+  const aliases = new Set<string>();
+  for (const stmt of stmts.slice(0, -1)) {
+    if (ts.isVariableStatement(stmt)) {
+      const bindings = constLikeBindingsFromVariableStatement(stmt, body);
+      if (bindings === null) {
+        continue;
+      }
+      for (const binding of bindings) {
+        if (binding.kind !== "const") {
+          continue;
+        }
+        if (isMapConstructor(binding.initializer)) {
+          mapAccNames.add(binding.tsName);
+        } else if (expressionReferencesNames(binding.initializer, mapAccNames)) {
+          aliases.add(binding.tsName);
+        }
+      }
+      continue;
+    }
+    if (!ts.isExpressionStatement(stmt)) {
+      continue;
+    }
+    const rejection = describeLocalMapBuilderMutationRejection(
+      stmt,
+      mapAccNames,
+      aliases,
+    );
+    if (rejection !== null) {
+      return rejection;
+    }
   }
   return null;
 }
@@ -2597,6 +2986,7 @@ function extractReturnExpression(
   const bindings: PreludeStmt[] = [];
   const letNames = new Set<string>();
   const emptyArrayAccNames = new Set<string>();
+  const emptySetAccNames = new Set<string>();
   let scopedParams = ctx.paramNames;
   let lastLetDeclNames = new Set<string>();
 
@@ -2640,6 +3030,17 @@ function extractReturnExpression(
           kind: "builderPush",
           accName: push.accName,
           valueExpr: push.projExpr,
+        });
+        i += 1;
+        lastLetDeclNames = new Set();
+        continue;
+      }
+      const setAdd = recognizeSetAddStatement(stmt, emptySetAccNames);
+      if (setAdd !== null) {
+        bindings.push({
+          kind: "builderSetAdd",
+          accName: setAdd.accName,
+          valueExpr: setAdd.valueExpr,
         });
         i += 1;
         lastLetDeclNames = new Set();
@@ -2719,6 +3120,12 @@ function extractReturnExpression(
       ) {
         emptyArrayAccNames.add(binding.tsName);
       }
+      if (
+        binding.kind === "const" &&
+        isEmptySetConstructor(binding.initializer)
+      ) {
+        emptySetAccNames.add(binding.tsName);
+      }
       if (binding.kind === "const") {
         const localName = allocLocalBindingName(
           ctx.supply,
@@ -2778,6 +3185,63 @@ function isEmptyArrayLiteral(expr: ts.Expression): boolean {
   return ts.isArrayLiteralExpression(current) && current.elements.length === 0;
 }
 
+function isEmptySetConstructor(expr: ts.Expression): boolean {
+  const current = unwrapExpression(expr);
+  return (
+    ts.isNewExpression(current) &&
+    ts.isIdentifier(current.expression) &&
+    current.expression.text === "Set" &&
+    (current.arguments === undefined || current.arguments.length === 0)
+  );
+}
+
+function isSetConstructorWithIterable(expr: ts.Expression): boolean {
+  const current = unwrapExpression(expr);
+  return (
+    ts.isNewExpression(current) &&
+    ts.isIdentifier(current.expression) &&
+    current.expression.text === "Set" &&
+    current.arguments !== undefined &&
+    current.arguments.length > 0
+  );
+}
+
+function isEmptyMapConstructor(expr: ts.Expression): boolean {
+  const current = unwrapExpression(expr);
+  return (
+    ts.isNewExpression(current) &&
+    ts.isIdentifier(current.expression) &&
+    current.expression.text === "Map" &&
+    (current.arguments === undefined || current.arguments.length === 0)
+  );
+}
+
+function isMapConstructor(expr: ts.Expression): boolean {
+  const current = unwrapExpression(expr);
+  return (
+    ts.isNewExpression(current) &&
+    ts.isIdentifier(current.expression) &&
+    current.expression.text === "Map"
+  );
+}
+
+function setElementSort(
+  type: ts.Type,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  synthCell?: SynthCell,
+): string | null {
+  if (!isSetType(type)) {
+    return null;
+  }
+  const typeArgs = checker.getTypeArguments(type as ts.TypeReference);
+  if (typeArgs.length !== 1) {
+    return null;
+  }
+  const mapped = mapTsType(typeArgs[0]!, checker, strategy, synthCell);
+  return mapped.ok ? mapped.sort : null;
+}
+
 function nodeWritesName(node: ts.Node, name: string): boolean {
   let found = false;
   const visit = (current: ts.Node): void => {
@@ -2830,7 +3294,11 @@ function describeRejectedBody(body: ts.Block, checker: ts.TypeChecker): string {
     // failed rather than a heuristic guess.
     let i = 0;
     const emptyArrayAccNames = new Set<string>();
+    const emptySetAccNames = new Set<string>();
+    const emptyMapAccNames = new Set<string>();
     const listBuilderAliases = new Set<string>();
+    const setBuilderAliases = new Set<string>();
+    const mapBuilderAliases = new Set<string>();
     while (i < lastIdx) {
       if (recognizeLetWhilePair(stmts, i, checker)) {
         i += 2;
@@ -2888,9 +3356,39 @@ function describeRejectedBody(body: ts.Block, checker: ts.TypeChecker): string {
               emptyArrayAccNames.add(binding.tsName);
             } else if (
               binding.kind === "const" &&
+              isEmptySetConstructor(binding.initializer)
+            ) {
+              emptySetAccNames.add(binding.tsName);
+            } else if (
+              binding.kind === "const" &&
+              isSetConstructorWithIterable(binding.initializer)
+            ) {
+              return "Set builder from iterable is not supported";
+            } else if (
+              binding.kind === "const" &&
+              isEmptyMapConstructor(binding.initializer)
+            ) {
+              emptyMapAccNames.add(binding.tsName);
+            } else if (
+              binding.kind === "const" &&
+              isMapConstructor(binding.initializer)
+            ) {
+              return "Map builder construction is not supported in this milestone";
+            } else if (
+              binding.kind === "const" &&
               expressionReferencesNames(binding.initializer, emptyArrayAccNames)
             ) {
               listBuilderAliases.add(binding.tsName);
+            } else if (
+              binding.kind === "const" &&
+              expressionReferencesNames(binding.initializer, emptySetAccNames)
+            ) {
+              setBuilderAliases.add(binding.tsName);
+            } else if (
+              binding.kind === "const" &&
+              expressionReferencesNames(binding.initializer, emptyMapAccNames)
+            ) {
+              mapBuilderAliases.add(binding.tsName);
             }
           }
           i += 1;
@@ -2902,6 +3400,10 @@ function describeRejectedBody(body: ts.Block, checker: ts.TypeChecker): string {
           i += 1;
           continue;
         }
+        if (recognizeSetAddStatement(stmt, emptySetAccNames) !== null) {
+          i += 1;
+          continue;
+        }
         const mutation = describeLocalListBuilderMutationRejection(
           stmt,
           emptyArrayAccNames,
@@ -2909,6 +3411,22 @@ function describeRejectedBody(body: ts.Block, checker: ts.TypeChecker): string {
         );
         if (mutation !== null) {
           return mutation;
+        }
+        const setMutation = describeLocalSetBuilderMutationRejection(
+          stmt,
+          emptySetAccNames,
+          setBuilderAliases,
+        );
+        if (setMutation !== null) {
+          return setMutation;
+        }
+        const mapMutation = describeLocalMapBuilderMutationRejection(
+          stmt,
+          emptyMapAccNames,
+          mapBuilderAliases,
+        );
+        if (mapMutation !== null) {
+          return mapMutation;
         }
         return "expression statement before return (only const / μ-search / if-early-return allowed)";
       }
@@ -3583,6 +4101,13 @@ function lowerPreludeBindings(
             "list builder push is only supported when returning its accumulator directly",
         };
       }
+      if (binding.kind === "builderSetAdd") {
+        return {
+          tag: "error",
+          error:
+            "Set builder add is only supported when returning its accumulator directly",
+        };
+      }
       const localName =
         binding.localName ??
         allocLocalBindingName(
@@ -3730,6 +4255,10 @@ function validatePreludeBindings(
     } else if (binding.kind === "builderPush") {
       if (expressionReferencesNames(binding.valueExpr, blockedNames)) {
         return { error: "list builder push references a later binding" };
+      }
+    } else if (binding.kind === "builderSetAdd") {
+      if (expressionReferencesNames(binding.valueExpr, blockedNames)) {
+        return { error: "Set builder add references a later binding" };
       }
     } else {
       // earlyReturn arm — predicate and value must be pure and may not refer
@@ -3907,7 +4436,12 @@ export function lowerNestedPureBlockReturnToL1(
   ) {
     return null;
   }
-  if (extracted.bindings.some((binding) => binding.kind === "builderPush")) {
+  if (
+    extracted.bindings.some(
+      (binding) =>
+        binding.kind === "builderPush" || binding.kind === "builderSetAdd",
+    )
+  ) {
     return null;
   }
   const validation = validatePreludeBindings(extracted.bindings, ctx.checker);
@@ -3933,6 +4467,7 @@ export function lowerNestedPureBlockReturnToL1(
     if (
       binding.kind === "forOf" ||
       binding.kind === "builderPush" ||
+      binding.kind === "builderSetAdd" ||
       binding.kind === "reassign" ||
       binding.kind === "stmt"
     ) {
@@ -6707,6 +7242,18 @@ function translateMutatingBody(
 ): PropResult[] {
   if (!node.body) {
     return [];
+  }
+  const localMapBuilderRejection = describeLocalMapBuilderBodyRejection(
+    node.body,
+    checker,
+  );
+  if (localMapBuilderRejection !== null) {
+    return [
+      {
+        kind: "unsupported",
+        reason: `${functionName} — ${localMapBuilderRejection}`,
+      },
+    ];
   }
   const localRuleDecls: PropResult[] = [];
   const env = suppliedEnv ?? createL1AssumptionEnv();

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-local-collection-builder.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-local-collection-builder.ts
@@ -88,6 +88,28 @@ function setAddBuilder(first: string, second: string): Set<string> {
 }
 
 /**
+ * Set builder whose accumulator omits the constructor type argument.
+ * Target type must come from the function return annotation.
+ */
+// biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
+function setUntypedAccumulator(seed: string): ReadonlySet<string> {
+  const out = new Set();
+  out.add(seed);
+  return out;
+}
+
+/**
+ * Set builder whose parameter would collide with the default membership
+ * binder if the binder allocator did not check free names.
+ */
+// biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
+function setBinderCollision(x: string): Set<string> {
+  const out = new Set<string>();
+  out.add(x);
+  return out;
+}
+
+/**
  * Empty Set builder.
  * Target Pantagruel encoding: universal non-membership.
  */
@@ -149,4 +171,14 @@ function mapBuilderRejected(key: string, value: number): Map<string, number> {
   const out = new Map<string, number>();
   out.set(key, value);
   return out;
+}
+
+/**
+ * Out-of-scope control for this milestone: Map construction is also rejected
+ * when the mutating call is the final statement of a void body.
+ */
+// biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
+function mapFinalMutationRejected(key: string, value: number): void {
+  const out = new Map<string, number>();
+  out.set(key, value);
 }

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-local-collection-builder.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-local-collection-builder.ts
@@ -88,6 +88,36 @@ function setAddBuilder(first: string, second: string): Set<string> {
 }
 
 /**
+ * Empty Set builder.
+ * Target Pantagruel encoding: universal non-membership.
+ */
+// biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
+function setEmptyBuilder(): Set<string> {
+  const out = new Set<string>();
+  return out;
+}
+
+/**
+ * Out-of-scope control: Set construction from an iterable is not a local
+ * straight-line add builder.
+ */
+// biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
+function setIterableRejected(seed: Set<string>): Set<string> {
+  const out = new Set<string>(seed);
+  return out;
+}
+
+/**
+ * Out-of-scope control: non-add Set mutation is not a local builder.
+ */
+// biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
+function setDeleteRejected(seed: string): Set<string> {
+  const out = new Set<string>();
+  out.delete(seed);
+  return out;
+}
+
+/**
  * Out-of-scope control: an alias escapes the local builder identity.
  * Target Pantagruel encoding: none (must keep refusing).
  */

--- a/tools/ts2pant/tests/local-collection-builder.test.mts
+++ b/tools/ts2pant/tests/local-collection-builder.test.mts
@@ -4,7 +4,7 @@
 import assert from "node:assert/strict";
 import { resolve } from "node:path";
 import { describe, it } from "node:test";
-import { buildDocument, emitAndCheck, runCheck } from "./helpers.mjs";
+import { buildDocument, emitAndCheck } from "./helpers.mjs";
 
 const FIXTURE = resolve(
   import.meta.dirname,
@@ -55,16 +55,31 @@ describe("local collection builder", () => {
     assert.doesNotMatch(output, /UNSUPPORTED/u);
   });
 
-  it("setAddBuilder emits membership equivalence", {
-    skip: "Patch 3 will unskip after Set add builder lowering lands",
-  }, async () => {
+  it("setAddBuilder emits membership equivalence", async () => {
     const output = await emitFixture("setAddBuilder");
     assert.match(
       output,
-      /x in set-add-builder first second <-> \(x = first or x = second\)/u,
+      /x in set-add-builder first second <-> x = first or x = second/u,
     );
     assert.doesNotMatch(output, /UNSUPPORTED/u);
-    assert.ok(runCheck(output).passed);
+  });
+
+  it("setEmptyBuilder emits empty membership assertion", async () => {
+    const output = await emitFixture("setEmptyBuilder");
+    assert.match(output, /all x: String \| ~\(x in set-empty-builder\)\./u);
+    assert.doesNotMatch(output, /UNSUPPORTED/u);
+  });
+
+  it("setIterableRejected remains unsupported", async () => {
+    const output = await emitFixture("setIterableRejected");
+    assert.match(output, /^> UNSUPPORTED: set-iterable-rejected/mu);
+    assert.match(output, /Set builder from iterable/u);
+  });
+
+  it("setDeleteRejected remains unsupported", async () => {
+    const output = await emitFixture("setDeleteRejected");
+    assert.match(output, /^> UNSUPPORTED: set-delete-rejected/mu);
+    assert.match(output, /Set builder mutation \.delete/u);
   });
 
   it("listAliasEscapeRejected remains unsupported", async () => {
@@ -85,9 +100,7 @@ describe("local collection builder", () => {
     assert.match(output, /guard|read|accumulator|builder/u);
   });
 
-  it("mapBuilderRejected remains unsupported", {
-    skip: "Patch 3 will unskip after Map builder rejection is preserved",
-  }, async () => {
+  it("mapBuilderRejected remains unsupported", async () => {
     const output = await emitFixture("mapBuilderRejected");
     assert.match(output, /^> UNSUPPORTED: map-builder-rejected/mu);
     assert.match(output, /Map|map|builder/u);

--- a/tools/ts2pant/tests/local-collection-builder.test.mts
+++ b/tools/ts2pant/tests/local-collection-builder.test.mts
@@ -64,6 +64,27 @@ describe("local collection builder", () => {
     assert.doesNotMatch(output, /UNSUPPORTED/u);
   });
 
+  it("setUntypedAccumulator uses the function return element type", async () => {
+    const output = await emitFixture("setUntypedAccumulator");
+    assert.match(output, /all x: String \|/u);
+    assert.match(output, /x in set-untyped-accumulator seed <-> x = seed/u);
+    assert.doesNotMatch(output, /all x: Opaque/u);
+    assert.doesNotMatch(output, /UNSUPPORTED/u);
+  });
+
+  it("setBinderCollision avoids capturing parameter names", async () => {
+    const output = await emitFixture("setBinderCollision");
+    assert.match(
+      output,
+      /all x[0-9]+: String \| x[0-9]+ in set-binder-collision x <-> x[0-9]+ = x/u,
+    );
+    assert.doesNotMatch(
+      output,
+      /all x: String \| x in set-binder-collision x <-> x = x/u,
+    );
+    assert.doesNotMatch(output, /UNSUPPORTED/u);
+  });
+
   it("setEmptyBuilder emits empty membership assertion", async () => {
     const output = await emitFixture("setEmptyBuilder");
     assert.match(output, /all x: String \| ~\(x in set-empty-builder\)\./u);
@@ -103,6 +124,12 @@ describe("local collection builder", () => {
   it("mapBuilderRejected remains unsupported", async () => {
     const output = await emitFixture("mapBuilderRejected");
     assert.match(output, /^> UNSUPPORTED: map-builder-rejected/mu);
+    assert.match(output, /Map|map|builder/u);
+  });
+
+  it("mapFinalMutationRejected remains unsupported", async () => {
+    const output = await emitFixture("mapFinalMutationRejected");
+    assert.match(output, /^> UNSUPPORTED: map-final-mutation-rejected/mu);
     assert.match(output, /Map|map|builder/u);
   });
 });

--- a/tools/ts2pant/tests/local-collection-builder.test.mts
+++ b/tools/ts2pant/tests/local-collection-builder.test.mts
@@ -130,6 +130,9 @@ describe("local collection builder", () => {
   it("mapFinalMutationRejected remains unsupported", async () => {
     const output = await emitFixture("mapFinalMutationRejected");
     assert.match(output, /^> UNSUPPORTED: map-final-mutation-rejected/mu);
-    assert.match(output, /Map|map|builder/u);
+    assert.match(
+      output,
+      /Map builder construction is not supported in this milestone/u,
+    );
   });
 });


### PR DESCRIPTION
## Patch 3: Lower Set add builders and preserve Map rejection

- Recognize only `const s = new Set<T>(); s.add(e1); ...; return s` or the equivalent typed `ReadonlySet<T>`/`Set<T>` return-position shape when the initializer is an empty `new Set()` call with no iterable argument.
- Lower each `.add` argument with the same pure L1 path used for list pushes, preserving ordinary const-prelude scoping and rejecting side-effectful arguments.
- Emit one universally quantified membership equivalence assertion over the function result: `all x: T | x in f args <-> x = e1 or ... or x = en`; for zero adds, emit `all x: T | ~(x in f args)`.
- Reject `.delete`, `.clear`, aliasing, escaped accumulators, `new Set(iterable)`, and all `new Map()`/`.set` builder shapes in this milestone with a precise unsupported reason.
- Unskip and implement the Set positive and Map negative tests introduced by Patch 1.

## Changes
- Recognize only `const s = new Set<T>(); s.add(e1); ...; return s` or the equivalent typed `ReadonlySet<T>`/`Set<T>` return-position shape when the initializer is an empty `new Set()` call with no iterable argument.
- Lower each `.add` argument with the same pure L1 path used for list pushes, preserving ordinary const-prelude scoping and rejecting side-effectful arguments.
- Emit one universally quantified membership equivalence assertion over the function result: `all x: T | x in f args <-> x = e1 or ... or x = en`; for zero adds, emit `all x: T | ~(x in f args)`.
- Reject `.delete`, `.clear`, aliasing, escaped accumulators, `new Set(iterable)`, and all `new Map()`/`.set` builder shapes in this milestone with a precise unsupported reason.
- Unskip and implement the Set positive and Map negative tests introduced by Patch 1.

## Files to Modify
- tools/ts2pant/src/translate-body.ts (modify): Extend the local builder recognizer with Set `.add` construction and explicit Map-builder refusal.
- tools/ts2pant/tests/local-collection-builder.test.mts (modify): Unskip and implement Set positive and Map negative tests.

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[paper] Cytron et al. 1991 SSA construction** — https://doi.org/10.1145/115372.115320 — The Set builder is local mutation summarized into final value constraints. Even though this patch does not need full collection SSA, it must preserve the same single-location final-state discipline: only writes to the recognized local builder contribute to the returned value.
- **[pattern] Conservative recognizer with precise refusal** — The patch deliberately excludes Map construction and non-add Set mutation so Stage A/Stage B guarded Map semantics are not approximated inside a Set/list builder implementation.

## Gameplan Specification

```
module TS2PANT_LOCAL_COLLECTION_BUILDER_SEQUENCING.

Function.
Element.
Index = Nat.
arity f: Function => Nat0.
list-builder-supported f: Function => Bool.
pushed f: Function, i: Index => Element.
result f: Function => [Element].
set-builder-supported f: Function => Bool.
set-added f: Function, e: Element => Bool.
set-result f: Function => [Element].
map-builder-rejected f: Function => Bool.
---
all f: Function, list-builder-supported f | #(result f) = arity f.
all f: Function, list-builder-supported f, i: Index, i <= arity f | (result f) i = pushed f i.
all f: Function, set-builder-supported f, e: Element | e in set-result f <-> set-added f e.
all f: Function, map-builder-rejected f | ~(set-builder-supported f).
```

## Patch Specification

```
module TS2PANT_LOCAL_COLLECTION_BUILDER_SEQUENCING_PATCH_3.

Function.
Element.
set-builder-supported f: Function => Bool.
set-added f: Function, e: Element => Bool.
set-result f: Function => [Element].
map-builder-rejected f: Function => Bool.
---
all f: Function, set-builder-supported f, e: Element | e in set-result f <-> set-added f e.
all f: Function, map-builder-rejected f | ~(set-builder-supported f).
```


## Implementation Notes

- Set builders are modeled as a sibling to Patch 2 list builders, not through the general mutating SSA path: `extractReturnExpression` now records `builderSetAdd` prelude entries for direct local `.add(...)` calls, and `tryBuildLocalSetBuilderReturn` consumes only the returned empty `new Set()` accumulator plus pre-add const preludes.
- `.add(...)` arguments use the same pure L1 probe as list pushes (`buildPureL1OrNull` after `lowerPreludeBindings` has established scoped const bindings). This preserves ordinary const-prelude naming and keeps side-effectful or unsupported add arguments rejected before assertion emission.
- Empty Set builders are intentionally supported and emit `all x: T | ~(x in f args).` rather than an equivalence to `false`, matching the patch text exactly.
- Map builder rejection needs both pure-body and mutating-body hooks. A `new Map(); out.set(...); return out` body is classified as mutating before pure-body lowering, so `translateMutatingBody` has a narrow local-constructor preflight (`describeLocalMapBuilderBodyRejection`) to keep Map construction rejected with the Patch 3 reason without affecting interface-field Map mutation SSA.
- `new Set(iterable)` is rejected before generic prelude lowering via `describeUnsupportedLocalCollectionConstructorReturn`; otherwise constructor-only returned locals would fall through to a vague unsupported const-initializer diagnostic.
- Added dedicated local-collection tests beyond the original stubs for empty Set builders, `new Set(iterable)`, and `.delete`, because those were explicit Patch 3 boundaries and easy to regress.

Spec/Evidence Mapping:
- Set membership equivalence: `translatePureBody` Set-builder branch builds one quantified `PropResult.assertion` with `opIn`/`opIff`; covered by `setAddBuilder emits membership equivalence`.
- Empty Set non-membership: same branch emits `opNot(memberExpr)` when there are zero adds; covered by `setEmptyBuilder emits empty membership assertion`.
- Map rejection and non-add Set mutation rejection: `describeLocalMapBuilderBodyRejection`, `describeUnsupportedLocalCollectionConstructorReturn`, and `describeLocalSetBuilderMutationRejection`; covered by `mapBuilderRejected`, `setIterableRejected`, and `setDeleteRejected`.
- Verification run before commit: `just ts2pant-typecheck`, focused `tests/local-collection-builder.test.mts`, `just ts2pant-test-unit-rest-from-artifacts`, `just ts2pant-test-unit-constructs-from-artifacts`, and `just ts2pant-test-integration-from-artifacts`.