### PR TITLE
[ts2pant-local-collection-builder-sequencing] Patch 4: Document local builder lowering and M2 diagnostics

### DIFF
--- a/tools/ts2pant/docs/transformations.md
+++ b/tools/ts2pant/docs/transformations.md
@@ -93,7 +93,7 @@ bindings through `substituteIR1ExprSubtree()`.
 - Local accumulator sequencing such as `lines.push(...); return lines` is handled
   by the separate collection-builder model below.
 
-## Local Collection Builder Recognition
+## Local Collection Builders
 
 **Standard name:** A-normal-form local builder recognition / effect
 encapsulation.
@@ -109,27 +109,94 @@ out.push(e2);
 return out;
 ```
 
-The local list-builder recognizer treats this as a bounded ANF-like prelude
-with one private mutable accumulator. The implementation entry point is
-`tryBuildLocalListBuilderReturn()`. It does **not** lower `push` as a pure
-expression and does not synthesize a list literal. Instead it emits constraints
-over the declared return rule: one cardinality assertion for the result and one
-1-based positional list-application assertion per pushed value, written in
-Pantagruel as `(f args) i = value_i` where `i` is a 1-based `Nat` index.
-Ordinary const bindings before the pushes are lowered through the existing
-local-rule prelude machinery so pushed values can refer to hygienically scoped
-local names.
+Local collection builders are recognized as bounded ANF-like preludes with one
+private mutable accumulator. The implementation entry points are
+`tryBuildLocalListBuilderReturn()` and `tryBuildLocalSetBuilderReturn()`. They
+do **not** lower `push` / `add` as pure expressions, and they do not synthesize
+target-language collection literals.
+
+### Ordered list builders
+
+For `T[]` builders, ts2pant emits constraints over the declared return rule:
+one cardinality assertion for the result and one positional list-application
+assertion per pushed value. Positions are 1-based Pantagruel `Nat` indexes, so:
+
+```ts
+const out: T[] = [];
+out.push(e1);
+out.push(e2);
+return out;
+```
+
+emits the assertion shape:
+
+```text
+#(f args) = 2.
+(f args) 1 = e1.
+(f args) 2 = e2.
+```
+
+The result remains the function's declared `[T]` rule. No list literal,
+synthetic finite tuple, or helper domain is introduced. Ordinary const bindings
+before the pushes are lowered through the existing local-rule prelude machinery
+so pushed values can refer to hygienically scoped local names.
+
+### Set builders
+
+For `Set<T>` / `ReadonlySet<T>` builders, ts2pant uses the existing Set-as-list
+encoding and emits membership assertions over the returned value. For direct
+straight-line `.add` calls:
+
+```ts
+const out = new Set<T>();
+out.add(e1);
+out.add(e2);
+return out;
+```
+
+the emitted assertion shape is a quantified equivalence:
+
+```text
+all x: T | x in f args <-> (x = e1 or x = e2).
+```
+
+Insertion order and duplicate insertion are intentionally not modeled beyond
+membership. An empty local Set builder emits universal non-membership:
+
+```text
+all x: T | ~(x in f args).
+```
+
+### Exclusions
 
 **Invariants:**
 - The returned identifier is the same local empty-array accumulator that
-  receives all pushes.
-- Push order is source order; emitted positions are `1..N`.
-- The accumulator is not aliased, read by a guard or pushed expression, passed
-  to another call, reassigned, or mutated by any method other than `.push`.
-- Const bindings are allowed only before the first push; later consts are
+  receives all pushes, or the same local empty-`Set` accumulator that receives
+  all adds.
+- List push order is source order; emitted positions are `1..N`.
+- Set additions are membership-only; no insertion order or uniqueness axioms are
+  emitted beyond the membership equivalence.
+- The accumulator is not aliased, read by a guard or pushed/added expression,
+  passed to another call, reassigned, or mutated by any method other than the
+  admitted builder method (`.push` for lists, `.add` for Sets).
+- Const bindings are allowed only before the first push/add; later consts are
   rejected to keep the model straight-line and unambiguous.
 - Unsupported builder shapes remain diagnostics. General expression statements
   still flow through the normal prelude rejection path.
+
+**Explicitly unsupported in M2:**
+- Map builders such as `const m = new Map(); m.set(k, v); return m`. Map
+  construction is deferred because it must respect the guarded membership/value
+  rule pair described in "Partial Rules (Map<K, V>)" below.
+- Set `.delete` and `.clear` builders. Straight-line local Set construction only
+  admits `.add` calls against a fresh empty local Set.
+- Accumulator aliasing or escape: returning an alias, assigning the accumulator
+  to another variable, capturing it in a closure, passing it to another call, or
+  reading it from a guard/value expression.
+- Unknown mutating methods on the accumulator.
+- Loop-backed builders outside the already-supported for-of build-list
+  comprehension path. Broader `for-of` and `forEach` builder completeness is a
+  separate iteration milestone.
 
 ## Uninterpreted Functions (General Function Calls)
 

--- a/workstreams/ts2pant-body-completeness.md
+++ b/workstreams/ts2pant-body-completeness.md
@@ -187,7 +187,7 @@ fresh residual ranking before committing to M2's exact fixture set.
 ### Milestone 2: local-collection-builder-sequencing — PLANNED
 
 > Planned by
-> `/Users/zax/.local/share/onton/ts2pant-local-collection-builder-sequencing/artifacts/gameplan.json`.
+> the M2 local-collection-builder-sequencing gameplan.
 > The M2 gameplan resolves the representation questions below: finite ordered
 > list builders emit cardinality plus 1-based positional assertions over the
 > declared return rule; straight-line Set `.add` builders emit membership

--- a/workstreams/ts2pant-body-completeness.md
+++ b/workstreams/ts2pant-body-completeness.md
@@ -184,21 +184,36 @@ fresh residual ranking before committing to M2's exact fixture set.
 
 ---
 
-### Milestone 2: local-collection-builder-sequencing
+### Milestone 2: local-collection-builder-sequencing — PLANNED
+
+> Planned by
+> `/Users/zax/.local/share/onton/ts2pant-local-collection-builder-sequencing/artifacts/gameplan.json`.
+> The M2 gameplan resolves the representation questions below: finite ordered
+> list builders emit cardinality plus 1-based positional assertions over the
+> declared return rule; straight-line Set `.add` builders emit membership
+> assertions over the Set-as-list return value; Map builders are deferred to a
+> Map-specific milestone.
 
 **Definition of Done**:
 - The pure-body prelude recognizes bounded local collection builders such as
-  `const xs = []; xs.push(e); return xs` and small straight-line variants with
-  const-bound projected values.
-- The lowering emits a Pantagruel list/set/map value using existing list
-  comprehensions or a small synthesized helper, not by treating `push` or
-  `set` as a pure expression.
-- Multiple pushes preserve source order when the target is an ordered list;
-  Set/Map builders preserve membership/lookup semantics consistent with the
-  existing Map/Set encoding.
+  `const xs = []; xs.push(e); return xs`, `const s = new Set<T>();
+  s.add(e); return s`, and small straight-line variants with const-bound
+  projected values.
+- Ordered list lowering emits assertions over the declared `[T]` return rule:
+  `#(f args) = N` plus one 1-based positional equation `(f args) i = value_i`
+  per pushed value. It does not use list literals, synthetic finite tuples, or
+  helper domains.
+- Set lowering emits assertions over the returned Set/list value: membership is
+  equivalent to the straight-line `.add` values, and empty Set builders emit
+  universal non-membership. It does not track insertion order or duplicate adds
+  beyond membership.
+- Map builder construction remains unsupported in M2. It is deferred because
+  Map construction must respect the guarded Stage A/Stage B membership/value
+  rule-pair contract.
 - Unsupported variants stay rejected: dynamic aliasing of the accumulator,
-  unknown mutating method calls, mutation after the accumulator escapes,
-  nested loops not handled by the milestone, and ambiguous element order.
+  unknown mutating method calls, mutation after the accumulator escapes, Set
+  `.delete` / `.clear` builders, Map builders, nested loops not handled by the
+  milestone, and ambiguous element order.
 - The targeted `expression statement before return` bucket moves down in the
   post-M2 corpus diagnostic.
 - Constructs and dogfood tests cover both positive local builder cases and
@@ -223,11 +238,10 @@ Follow-on iteration completeness: once straight-line builders are expressible,
   choose the largest family that reuses the M2 builder representation.
 
 **Open Questions**:
-- Should list builders with multiple straight-line `push` calls emit an
-  explicit concatenation form, a synthetic helper rule, or a comprehension over
-  a finite tuple? Resolve during the M2 gameplan.
-- Is Map builder construction in scope for M2, or does M2 only cover list/set
-  builders and leave Map initialization to a later Map-specific milestone?
+- Resolved by the M2 gameplan: finite ordered list builders use cardinality
+  plus 1-based positional assertions over the declared return rule.
+- Resolved by the M2 gameplan: M2 covers straight-line list and Set builders;
+  Map builders are deferred to a later Map-specific milestone.
 
 ---
 


### PR DESCRIPTION
## Patch 4: Document local builder lowering and M2 diagnostics

- Add a `Local Collection Builders` section to `tools/ts2pant/docs/transformations.md` or replace the existing M1 deferral note with the implemented M2 contract.
- Document the ordered-list assertion shape: cardinality plus 1-based index equations.
- Document the Set assertion shape: membership equivalence over the returned Set/list value.
- Document the explicit exclusions: Map builders, Set delete/clear builders, accumulator aliasing/escape, unknown mutating methods, and loop-backed builders outside the already-supported for-of comprehension path.
- Update `workstreams/ts2pant-body-completeness.md` to record M2 as planned and capture the decisions that Map builders are deferred and finite ordered lists use positional assertions.

## Changes
- Add a `Local Collection Builders` section to `tools/ts2pant/docs/transformations.md` or replace the existing M1 deferral note with the implemented M2 contract.
- Document the ordered-list assertion shape: cardinality plus 1-based index equations.
- Document the Set assertion shape: membership equivalence over the returned Set/list value.
- Document the explicit exclusions: Map builders, Set delete/clear builders, accumulator aliasing/escape, unknown mutating methods, and loop-backed builders outside the already-supported for-of comprehension path.
- Update `workstreams/ts2pant-body-completeness.md` to record M2 as planned and capture the decisions that Map builders are deferred and finite ordered lists use positional assertions.

## Files to Modify
- tools/ts2pant/docs/transformations.md (modify): Document the local collection builder model, list positional assertions, Set membership assertions, and Map deferral.
- workstreams/ts2pant-body-completeness.md (modify): Mark M2 as planned with this gameplan path and reconcile the M2 scope decisions for list representation and Map deferral.

## Gameplan Specification

```
module TS2PANT_LOCAL_COLLECTION_BUILDER_SEQUENCING.

Function.
Element.
Index = Nat.
arity f: Function => Nat0.
list-builder-supported f: Function => Bool.
pushed f: Function, i: Index => Element.
result f: Function => [Element].
set-builder-supported f: Function => Bool.
set-added f: Function, e: Element => Bool.
set-result f: Function => [Element].
map-builder-rejected f: Function => Bool.
---
all f: Function, list-builder-supported f | #(result f) = arity f.
all f: Function, list-builder-supported f, i: Index, i <= arity f | (result f) i = pushed f i.
all f: Function, set-builder-supported f, e: Element | e in set-result f <-> set-added f e.
all f: Function, map-builder-rejected f | ~(set-builder-supported f).
```

## Patch Specification

```
module TS2PANT_LOCAL_COLLECTION_BUILDER_SEQUENCING_PATCH_4.

DocSection.
Decision.
documents d: DocSection, q: Decision => Bool.
ordered-list-assertions => Decision.
set-membership-assertions => Decision.
map-builders-deferred => Decision.
---
some d: DocSection | documents d ordered-list-assertions.
some d: DocSection | documents d set-membership-assertions.
some d: DocSection | documents d map-builders-deferred.
```


## Implementation Notes

- This patch is documentation-only. It builds on the Patch 2/3 implementation names already present in the dependency branch: `tryBuildLocalListBuilderReturn()` and `tryBuildLocalSetBuilderReturn()`.
- The transformation catalogue section was renamed from `Local Collection Builder Recognition` to `Local Collection Builders` so list and Set builders can share one documented contract. No code APIs, fixtures, or snapshots changed.
- The ordered-list examples intentionally show emitted assertion shapes over `f args`, not list construction syntax. The docs state that no list literal, finite tuple, helper domain, or synthesized value constructor is introduced.
- The Set docs explicitly separate the non-empty equivalence shape from the empty-Set universal non-membership shape, matching Patch 3's implementation notes.
- The workstream now records M2 as `PLANNED`, not complete, because this branch is still part of the milestone stack. It also resolves the two M2 open questions in-place: positional assertions for lists, Map builders deferred.

Spec/Evidence Mapping:
- `documents ordered-list-assertions`: covered in `tools/ts2pant/docs/transformations.md` under `Ordered list builders`; required context consulted: `tools/ts2pant/docs/transformations.md`, `tools/ts2pant/AGENTS.md`, and `workstreams/ts2pant-body-completeness.md`; verified by `git diff --check`, `just ts2pant-test-unit`, and `just ts2pant-test-integration`.
- `documents set-membership-assertions`: covered in `tools/ts2pant/docs/transformations.md` under `Set builders`, including empty Set non-membership; same verification as above.
- `documents map-builders-deferred`: covered in both the transformation exclusions and the M2 workstream entry; same verification as above.