### PR TITLE
[codex] Annotate local collection builder dogfood

### DIFF
--- a/lib/collect.ml
+++ b/lib/collect.ml
@@ -439,20 +439,29 @@ let recognize_rule_definition_eq
           acc arms
     | EForall (mb, metas) | EExists (mb, metas) | EEach (mb, metas, _) ->
         let params, guards, body = Ast.unbind_quant mb metas in
-        let bound =
+        let bound0 =
           List.fold_left
             (fun s (p : Ast.param) ->
               StringSet.add (Ast.lower_name p.param_name) s)
             StringSet.empty params
         in
-        let guard_vars =
-          List.fold_left
-            (fun acc -> function
-              | GParam _ -> acc
-              | GIn (_, list_expr) -> value_vars acc list_expr
-              | GExpr e -> value_vars acc e)
-            StringSet.empty guards
+        let rec collect_guards acc bound = function
+          | [] -> (acc, bound)
+          | GParam p :: rest ->
+              collect_guards acc
+                (StringSet.add (Ast.lower_name p.param_name) bound)
+                rest
+          | GIn (Lower n, list_expr) :: rest ->
+              let vars =
+                StringSet.diff (value_vars StringSet.empty list_expr) bound
+              in
+              collect_guards (StringSet.union acc vars) (StringSet.add n bound)
+                rest
+          | GExpr e :: rest ->
+              let vars = StringSet.diff (value_vars StringSet.empty e) bound in
+              collect_guards (StringSet.union acc vars) bound rest
         in
+        let guard_vars, bound = collect_guards StringSet.empty bound0 guards in
         StringSet.union acc
           (StringSet.diff
              (StringSet.union guard_vars (value_vars StringSet.empty body))

--- a/lib/collect.ml
+++ b/lib/collect.ml
@@ -413,6 +413,62 @@ let collect_chapter_head ~chapter ~doc_contexts env
 let recognize_rule_definition_eq
     (chapter_head : Ast.declaration Ast.located list) (e : Ast.expr) :
     (Ast.declaration * Ast.expr) option =
+  let module StringSet = Set.Make (String) in
+  let nullary_rule_names =
+    List.fold_left
+      (fun acc (decl : Ast.declaration Ast.located) ->
+        match[@warning "-4"] decl.value with
+        | DeclRule { name = Lower n; params = []; _ } -> StringSet.add n acc
+        | _ -> acc)
+      StringSet.empty chapter_head
+  in
+  let rec value_vars acc = function
+    | EVar (Lower n) | EPrimed (Lower n) -> StringSet.add n acc
+    | EApp (EVar _, args) -> List.fold_left value_vars acc args
+    | EApp (func, args) -> List.fold_left value_vars (value_vars acc func) args
+    | EBinop (_, e1, e2) -> value_vars (value_vars acc e1) e2
+    | EUnop (_, e) | EProj (e, _) | EInitially e -> value_vars acc e
+    | ETuple es -> List.fold_left value_vars acc es
+    | EOverride (_, pairs) ->
+        List.fold_left
+          (fun acc (k, v) -> value_vars (value_vars acc k) v)
+          acc pairs
+    | ECond arms ->
+        List.fold_left
+          (fun acc (g, c) -> value_vars (value_vars acc g) c)
+          acc arms
+    | EForall (mb, metas) | EExists (mb, metas) | EEach (mb, metas, _) ->
+        let params, guards, body = Ast.unbind_quant mb metas in
+        let bound =
+          List.fold_left
+            (fun s (p : Ast.param) ->
+              StringSet.add (Ast.lower_name p.param_name) s)
+            StringSet.empty params
+        in
+        let guard_vars =
+          List.fold_left
+            (fun acc -> function
+              | GParam _ -> acc
+              | GIn (_, list_expr) -> value_vars acc list_expr
+              | GExpr e -> value_vars acc e)
+            StringSet.empty guards
+        in
+        StringSet.union acc
+          (StringSet.diff
+             (StringSet.union guard_vars (value_vars StringSet.empty body))
+             bound)
+    | ELitNat _ | ELitReal _ | ELitString _ | ELitBool _ | EDomain _
+    | EQualified _ ->
+        acc
+  in
+  let rhs_vars_bound_by_lhs rhs arg_names =
+    let allowed =
+      List.fold_left
+        (fun acc name -> StringSet.add name acc)
+        nullary_rule_names arg_names
+    in
+    StringSet.subset (value_vars StringSet.empty rhs) allowed
+  in
   let arg_to_name (e : Ast.expr) : string option =
     match[@warning "-4"] e with EVar (Lower an) -> Some an | _ -> None
   in
@@ -440,7 +496,8 @@ let recognize_rule_definition_eq
                           (List.map
                              (fun (p : Ast.param) ->
                                Ast.lower_name p.param_name)
-                             params) ->
+                             params)
+                     && rhs_vars_bound_by_lhs rhs arg_names ->
                   Some (decl.value, rhs)
               | _ -> None)
             chapter_head)

--- a/lib/smt.ml
+++ b/lib/smt.ml
@@ -2689,10 +2689,10 @@ let invariant_expensive_for_consistency env (inv : expr located) =
         match[@warning "-4"]
           Check.infer_type { Check.env; loc = dummy_loc } list_expr
         with
-        | Ok (TyList elem_ty) ->
-            let list_expensive = expr_expensive env list_expr in
+        | Ok (TyList elem_ty) | Ok (TyDomain _ as elem_ty) ->
+            let rhs_expensive = expr_expensive env list_expr in
             let env = Env.with_vars [ (name, elem_ty) ] env in
-            (unbounded_ty elem_ty || list_expensive, env)
+            (unbounded_ty elem_ty || rhs_expensive, env)
         | Ok _ | Error _ -> (expr_expensive env list_expr, env))
     | GExpr e -> (expr_expensive env e, env)
   in

--- a/lib/smt.ml
+++ b/lib/smt.ml
@@ -2638,45 +2638,65 @@ let generate_action_entailment_query config env ~all_invariants ~index
 
 (** Generate all verification queries for a document *)
 let invariant_expensive_for_consistency env (inv : expr located) =
-  let unbounded_ty = function
+  let rec unbounded_ty = function
     | TyString | TyInt | TyReal -> true
-    | TyBool | TyNat | TyNat0 | TyNothing | TyDomain _ | TyList _ | TyProduct _
-    | TySum _ | TyFunc _ ->
-        false
+    | TyList ty -> unbounded_ty ty
+    | TyProduct tys | TySum tys -> List.exists unbounded_ty tys
+    | TyBool | TyNat | TyNat0 | TyNothing | TyDomain _ | TyFunc _ -> false
   in
-  let param_unbounded (p : param) =
-    match Collect.resolve_type env p.param_type dummy_loc with
-    | Ok ty -> unbounded_ty ty
-    | Error _ -> false
+  let param_ty env (p : param) =
+    Collect.resolve_type env p.param_type dummy_loc
   in
-  let rec expr_expensive = function
+  let param_unbounded env p =
+    match param_ty env p with Ok ty -> unbounded_ty ty | Error _ -> false
+  in
+  let bind_param env p =
+    match param_ty env p with
+    | Ok ty -> Env.with_vars [ (Ast.lower_name p.param_name, ty) ] env
+    | Error _ -> env
+  in
+  let rec expr_expensive env = function
     | EForall (mb, metas) | EExists (mb, metas) | EEach (mb, metas, _) ->
         let params, guards, body = Ast.unbind_quant mb metas in
-        List.exists param_unbounded params
-        || List.exists guard_expensive guards
-        || expr_expensive body
-    | EApp (func, args) -> List.exists expr_expensive (func :: args)
-    | EBinop (_, e1, e2) -> expr_expensive e1 || expr_expensive e2
-    | EUnop (_, e) | EProj (e, _) | EInitially e -> expr_expensive e
-    | ETuple es -> List.exists expr_expensive es
+        let params_expensive = List.exists (param_unbounded env) params in
+        let env = List.fold_left bind_param env params in
+        let guards_expensive, env =
+          List.fold_left
+            (fun (expensive, env) guard ->
+              let guard_expensive, env = guard_expensive env guard in
+              (expensive || guard_expensive, env))
+            (false, env) guards
+        in
+        params_expensive || guards_expensive || expr_expensive env body
+    | EApp (func, args) -> List.exists (expr_expensive env) (func :: args)
+    | EBinop (_, e1, e2) -> expr_expensive env e1 || expr_expensive env e2
+    | EUnop (_, e) | EProj (e, _) | EInitially e -> expr_expensive env e
+    | ETuple es -> List.exists (expr_expensive env) es
     | EOverride (_, pairs) ->
-        List.exists (fun (k, v) -> expr_expensive k || expr_expensive v) pairs
+        List.exists
+          (fun (k, v) -> expr_expensive env k || expr_expensive env v)
+          pairs
     | ECond arms ->
-        List.exists (fun (g, c) -> expr_expensive g || expr_expensive c) arms
+        List.exists
+          (fun (g, c) -> expr_expensive env g || expr_expensive env c)
+          arms
     | EVar _ | EPrimed _ | EDomain _ | EQualified _ | ELitNat _ | ELitReal _
     | ELitString _ | ELitBool _ ->
         false
-  and guard_expensive = function
-    | GParam p -> param_unbounded p
-    | GIn (_, list_expr) -> (
+  and guard_expensive env = function
+    | GParam p -> (param_unbounded env p, bind_param env p)
+    | GIn (Lower name, list_expr) -> (
         match[@warning "-4"]
           Check.infer_type { Check.env; loc = dummy_loc } list_expr
         with
-        | Ok (TyList elem_ty) -> unbounded_ty elem_ty
-        | Ok _ | Error _ -> expr_expensive list_expr)
-    | GExpr e -> expr_expensive e
+        | Ok (TyList elem_ty) ->
+            let list_expensive = expr_expensive env list_expr in
+            let env = Env.with_vars [ (name, elem_ty) ] env in
+            (unbounded_ty elem_ty || list_expensive, env)
+        | Ok _ | Error _ -> (expr_expensive env list_expr, env))
+    | GExpr e -> (expr_expensive env e, env)
   in
-  expr_expensive inv.value
+  expr_expensive env inv.value
 
 let generate_queries config env (doc : document) =
   let chapters = classify_chapters doc in

--- a/lib/smt.ml
+++ b/lib/smt.ml
@@ -233,6 +233,22 @@ and translate_app config env func args =
         | Ok ty -> Some ty
         | Error _ -> None)
   in
+  let list_index =
+    match args with
+    | [ arg ] -> (
+        match[@warning "-4"] infer_with_unprime func with
+        | Some (TyList elem_ty) -> (
+            match[@warning "-4"] infer_with_unprime arg with
+            | Some arg_ty when is_subtype arg_ty TyNat || is_numeric arg_ty ->
+                let func_s = Ast.show_expr func in
+                let arg_s = Ast.show_expr arg in
+                Some
+                  (intern_list_index_symbol ~func_s ~arg_s
+                     ~sort:(sort_of_ty elem_ty))
+            | _ -> None)
+        | _ -> None)
+    | _ -> None
+  in
   let list_search =
     match args with
     | [ arg ] -> (
@@ -255,71 +271,76 @@ and translate_app config env func args =
         | _ -> None)
     | _ -> None
   in
-  match list_search with
+  match list_index with
   | Some name -> name
   | None -> (
-      match[@warning "-4"] func with
-      | EOverride (Lower name, pairs) ->
-          (* f[k |-> v] applied to args: inline ite chain. For arity-1 rules
+      match list_search with
+      | Some name -> name
+      | None -> (
+          match[@warning "-4"] func with
+          | EOverride (Lower name, pairs) ->
+              (* f[k |-> v] applied to args: inline ite chain. For arity-1 rules
              the key is a bare expression compared against the single arg;
              for arity-N rules the key is an N-tuple whose components are
              compared componentwise against the args, yielding a conjunctive
              guard — McCarthy's [store] extended to multi-index arrays
              (Kroening & Strichman Ch. 7). *)
-          let sname = smt_rule_name env name (List.length args) in
-          let args_str = List.map (translate_expr config env) args in
-          let applied_args = String.concat " " args_str in
-          (match args_str with
-          | [] -> failwith "SMT translation: override applied with 0 arguments"
-          | _ -> ());
-          let rec build_chain = function
-            | [] -> Printf.sprintf "(%s %s)" sname applied_args
-            | (k, v) :: rest ->
-                let guard_str =
-                  match args_str with
-                  | [ arg ] ->
-                      (* Arity-1: bare-expression key, even when the key is
+              let sname = smt_rule_name env name (List.length args) in
+              let args_str = List.map (translate_expr config env) args in
+              let applied_args = String.concat " " args_str in
+              (match args_str with
+              | [] ->
+                  failwith "SMT translation: override applied with 0 arguments"
+              | _ -> ());
+              let rec build_chain = function
+                | [] -> Printf.sprintf "(%s %s)" sname applied_args
+                | (k, v) :: rest ->
+                    let guard_str =
+                      match args_str with
+                      | [ arg ] ->
+                          (* Arity-1: bare-expression key, even when the key is
                          itself a tuple literal (e.g. a rule whose single
                          parameter has a product type). *)
-                      Printf.sprintf "(= %s %s)" arg
-                        (translate_expr config env k)
-                  | _ -> (
-                      match[@warning "-4"] k with
-                      | ETuple parts ->
-                          if List.length parts <> List.length args_str then
-                            failwith
-                              "SMT translation: override key arity does not \
-                               match application arity";
-                          let eqs =
-                            List.map2
-                              (fun part arg ->
-                                Printf.sprintf "(= %s %s)" arg
-                                  (translate_expr config env part))
-                              parts args_str
-                          in
-                          Printf.sprintf "(and %s)" (String.concat " " eqs)
-                      | _ ->
-                          failwith
-                            "SMT translation: override key arity does not \
-                             match application arity")
-                in
-                Printf.sprintf "(ite %s %s %s)" guard_str
-                  (translate_expr config env v)
-                  (build_chain rest)
-          in
-          build_chain pairs
-      | _ ->
-          let arity = List.length args in
-          let func_str =
-            match[@warning "-4"] func with
-            | EVar (Lower name) -> smt_rule_name env name arity
-            | EPrimed (Lower name) -> smt_rule_name env name arity ^ "_prime"
-            | EQualified (Upper mod_name, name) ->
-                smt_qualified_rule_name env mod_name name arity
-            | _ -> translate_expr config env func
-          in
-          let args_str = List.map (translate_expr config env) args in
-          Printf.sprintf "(%s %s)" func_str (String.concat " " args_str))
+                          Printf.sprintf "(= %s %s)" arg
+                            (translate_expr config env k)
+                      | _ -> (
+                          match[@warning "-4"] k with
+                          | ETuple parts ->
+                              if List.length parts <> List.length args_str then
+                                failwith
+                                  "SMT translation: override key arity does \
+                                   not match application arity";
+                              let eqs =
+                                List.map2
+                                  (fun part arg ->
+                                    Printf.sprintf "(= %s %s)" arg
+                                      (translate_expr config env part))
+                                  parts args_str
+                              in
+                              Printf.sprintf "(and %s)" (String.concat " " eqs)
+                          | _ ->
+                              failwith
+                                "SMT translation: override key arity does not \
+                                 match application arity")
+                    in
+                    Printf.sprintf "(ite %s %s %s)" guard_str
+                      (translate_expr config env v)
+                      (build_chain rest)
+              in
+              build_chain pairs
+          | _ ->
+              let arity = List.length args in
+              let func_str =
+                match[@warning "-4"] func with
+                | EVar (Lower name) -> smt_rule_name env name arity
+                | EPrimed (Lower name) ->
+                    smt_rule_name env name arity ^ "_prime"
+                | EQualified (Upper mod_name, name) ->
+                    smt_qualified_rule_name env mod_name name arity
+                | _ -> translate_expr config env func
+              in
+              let args_str = List.map (translate_expr config env) args in
+              Printf.sprintf "(%s %s)" func_str (String.concat " " args_str)))
 
 and translate_binop config env op e1 e2 =
   match op with
@@ -572,13 +593,13 @@ and translate_card config env e =
              fresh non-negative integer constant so the gap is visible to
              downstream tooling rather than silently constrained to 0. *)
           let _ = set_str in
-          let name = fresh_fallback ~kind:"card" ~sort:"Int" in
+          let name = intern_card_symbol ~expr_s:(Ast.show_expr e) in
           add_fallback_assert (Printf.sprintf "(>= %s 0)" name);
           name
       | _ ->
           (* Can't determine element type at all — same fallback. *)
           let _ = set_str in
-          let name = fresh_fallback ~kind:"card" ~sort:"Int" in
+          let name = intern_card_symbol ~expr_s:(Ast.show_expr e) in
           add_fallback_assert (Printf.sprintf "(>= %s 0)" name);
           name)
 
@@ -2616,6 +2637,47 @@ let generate_action_entailment_query config env ~all_invariants ~index
   }
 
 (** Generate all verification queries for a document *)
+let invariant_expensive_for_consistency env (inv : expr located) =
+  let unbounded_ty = function
+    | TyString | TyInt | TyReal -> true
+    | TyBool | TyNat | TyNat0 | TyNothing | TyDomain _ | TyList _ | TyProduct _
+    | TySum _ | TyFunc _ ->
+        false
+  in
+  let param_unbounded (p : param) =
+    match Collect.resolve_type env p.param_type dummy_loc with
+    | Ok ty -> unbounded_ty ty
+    | Error _ -> false
+  in
+  let rec expr_expensive = function
+    | EForall (mb, metas) | EExists (mb, metas) | EEach (mb, metas, _) ->
+        let params, guards, body = Ast.unbind_quant mb metas in
+        List.exists param_unbounded params
+        || List.exists guard_expensive guards
+        || expr_expensive body
+    | EApp (func, args) -> List.exists expr_expensive (func :: args)
+    | EBinop (_, e1, e2) -> expr_expensive e1 || expr_expensive e2
+    | EUnop (_, e) | EProj (e, _) | EInitially e -> expr_expensive e
+    | ETuple es -> List.exists expr_expensive es
+    | EOverride (_, pairs) ->
+        List.exists (fun (k, v) -> expr_expensive k || expr_expensive v) pairs
+    | ECond arms ->
+        List.exists (fun (g, c) -> expr_expensive g || expr_expensive c) arms
+    | EVar _ | EPrimed _ | EDomain _ | EQualified _ | ELitNat _ | ELitReal _
+    | ELitString _ | ELitBool _ ->
+        false
+  and guard_expensive = function
+    | GParam p -> param_unbounded p
+    | GIn (_, list_expr) -> (
+        match[@warning "-4"]
+          Check.infer_type { Check.env; loc = dummy_loc } list_expr
+        with
+        | Ok (TyList elem_ty) -> unbounded_ty elem_ty
+        | Ok _ | Error _ -> expr_expensive list_expr)
+    | GExpr e -> expr_expensive e
+  in
+  expr_expensive inv.value
+
 let generate_queries config env (doc : document) =
   let chapters = classify_chapters doc in
   let invariants = collect_invariants chapters in
@@ -2624,8 +2686,14 @@ let generate_queries config env (doc : document) =
   let queries = ref [] in
   let add f = queries := with_cond_aux f :: !queries in
   (* Invariant consistency query *)
-  if invariants <> [] then
-    add (fun () -> generate_invariant_consistency_query config env invariants);
+  let consistency_invariants =
+    List.filter
+      (fun inv -> not (invariant_expensive_for_consistency env inv))
+      invariants
+  in
+  if consistency_invariants <> [] then
+    add (fun () ->
+        generate_invariant_consistency_query config env consistency_invariants);
   (* Init consistency query *)
   if init_props <> [] then
     add (fun () -> generate_init_consistency_query config env init_props);

--- a/lib/smt_state.ml
+++ b/lib/smt_state.ml
@@ -45,9 +45,15 @@ let fallback_counter = ref 0
 
 let fallback_decls : string list ref = ref []
 
+let fallback_cache : (string * string * string, string) Hashtbl.t =
+  Hashtbl.create 16
+
+let reset_fallback_cache () = Hashtbl.clear fallback_cache
+
 let reset_fallbacks () =
   fallback_counter := 0;
-  fallback_decls := []
+  fallback_decls := [];
+  reset_fallback_cache ()
 
 let fresh_fallback ~kind ~sort =
   let n = !fallback_counter in
@@ -56,11 +62,6 @@ let fresh_fallback ~kind ~sort =
   fallback_decls :=
     Printf.sprintf "(declare-const %s %s)" name sort :: !fallback_decls;
   name
-
-let fallback_cache : (string * string * string, string) Hashtbl.t =
-  Hashtbl.create 16
-
-let reset_fallback_cache () = Hashtbl.clear fallback_cache
 
 let intern_fallback_symbol ~kind ~sort ~key =
   match Hashtbl.find_opt fallback_cache (kind, sort, key) with

--- a/lib/smt_state.ml
+++ b/lib/smt_state.ml
@@ -57,20 +57,33 @@ let fresh_fallback ~kind ~sort =
     Printf.sprintf "(declare-const %s %s)" name sort :: !fallback_decls;
   name
 
+let fallback_cache : (string * string * string, string) Hashtbl.t =
+  Hashtbl.create 16
+
+let reset_fallback_cache () = Hashtbl.clear fallback_cache
+
+let intern_fallback_symbol ~kind ~sort ~key =
+  match Hashtbl.find_opt fallback_cache (kind, sort, key) with
+  | Some name -> name
+  | None ->
+      let name = fresh_fallback ~kind ~sort in
+      Hashtbl.add fallback_cache (kind, sort, key) name;
+      name
+
 (** Query-local cache of list-search placeholder symbols. Identical
     [(func_s, arg_s)] keys reuse the same fresh constant so that [xs x = xs x]
     translates to a referentially stable equality. *)
-let list_search_cache : (string * string, string) Hashtbl.t = Hashtbl.create 8
-
-let reset_list_search_cache () = Hashtbl.clear list_search_cache
+let reset_list_search_cache () = reset_fallback_cache ()
 
 let intern_list_search_symbol ~func_s ~arg_s =
-  match Hashtbl.find_opt list_search_cache (func_s, arg_s) with
-  | Some name -> name
-  | None ->
-      let name = fresh_fallback ~kind:"list_search" ~sort:"Int" in
-      Hashtbl.add list_search_cache (func_s, arg_s) name;
-      name
+  intern_fallback_symbol ~kind:"list_search" ~sort:"Int"
+    ~key:(func_s ^ "\x00" ^ arg_s)
+
+let intern_list_index_symbol ~func_s ~arg_s ~sort =
+  intern_fallback_symbol ~kind:"list_index" ~sort ~key:(func_s ^ "\x00" ^ arg_s)
+
+let intern_card_symbol ~expr_s =
+  intern_fallback_symbol ~kind:"card" ~sort:"Int" ~key:expr_s
 
 (** Queue an additional [(assert ...)] alongside the most recently declared
     fallback constant — useful for soft constraints like non-negativity. *)

--- a/lib/smt_state.mli
+++ b/lib/smt_state.mli
@@ -11,6 +11,11 @@ val reset_fallbacks : unit -> unit
 val fresh_fallback : kind:string -> sort:string -> string
 val reset_list_search_cache : unit -> unit
 val intern_list_search_symbol : func_s:string -> arg_s:string -> string
+
+val intern_list_index_symbol :
+  func_s:string -> arg_s:string -> sort:string -> string
+
+val intern_card_symbol : expr_s:string -> string
 val add_fallback_assert : string -> unit
 val drain_fallback_decls : unit -> string
 val insert_fallback_decls : string -> string

--- a/test/regression/bug_list_index_check.pant
+++ b/test/regression/bug_list_index_check.pant
@@ -1,0 +1,13 @@
+module BUG_LIST_INDEX_CHECK.
+
+build seed: String => [String].
+
+---
+
+#(build seed) = 1.
+(build seed) 1 = seed.
+
+check
+
+#(build seed) = 1.
+(build seed) 1 = seed.

--- a/test/regression/bug_set_string_precheck_timeout.pant
+++ b/test/regression/bug_set_string_precheck_timeout.pant
@@ -1,0 +1,13 @@
+module BUG_SET_STRING_PRECHECK_TIMEOUT.
+
+build first: String, second: String => [String].
+
+---
+
+all first: String, second: String |
+  all x: String | x in build first second <-> x = first or x = second.
+
+check
+
+all first: String, second: String |
+  all x: String | x in build first second <-> x = first or x = second.

--- a/test/regression/free_vars.baseline
+++ b/test/regression/free_vars.baseline
@@ -2,7 +2,10 @@ bug_action_body_rule_params.pant	0	0	a,balance
 bug_action_body_rule_params.pant	0	1	a1,owner
 bug_action_param_shadows_rule.pant	0	0	a1,balance
 bug_card_zero.pant	0	0	dim,v
+bug_list_index_check.pant	0	0	build,seed
+bug_list_index_check.pant	0	1	build,seed
 bug_nested_binder_collision.pant	0	0	p
 bug_overquantify.pant	0	0	
 bug_rename_app_head.pant	0	0	p
 bug_rule_param_collision.pant	0	0	makePoint,name
+bug_set_string_precheck_timeout.pant	0	0	build

--- a/test/test_smt.ml
+++ b/test/test_smt.ml
@@ -316,6 +316,19 @@ let test_split_form_rejects_rhs_free_param () =
   let chapter = List.hd doc.chapters in
   check int "free-param equation remains in body" 3 (List.length chapter.body)
 
+let test_split_form_allows_rhs_guard_binder () =
+  let env, doc =
+    parse_and_collect
+      "module Test.\n\
+       ok xs: [String] => Bool.\n\
+       ---\n\
+       ok xs = (all x in xs | x = x).\n"
+  in
+  let env, _doc = Collect.recognize_split_form_bodies env doc in
+  match Env.lookup_rule_body_arity "ok" 1 env with
+  | Some _ -> ()
+  | None -> fail "expected guard-bound RHS variable to attach rule body"
+
 let test_recursive_rule_emits_define_fun_rec () =
   let env, doc =
     parse_and_collect
@@ -1463,6 +1476,32 @@ let test_expensive_string_quantifier_skips_consistency_only () =
   check bool "keeps entailment query" true
     (List.exists (fun (q : Smt.query) -> q.kind = Smt.Entailment) queries)
 
+let test_expensive_composite_param_skips_consistency () =
+  let env, doc =
+    parse_and_collect
+      "module Test.\nmarker => Bool.\n---\nall xs: [String] | xs = xs.\n"
+  in
+  let queries = Smt.generate_queries config env doc in
+  check bool "skips list<string> invariant consistency" false
+    (List.exists
+       (fun (q : Smt.query) -> q.kind = Smt.InvariantConsistency)
+       queries)
+
+let test_expensive_gin_uses_quantifier_env () =
+  let env, doc =
+    parse_and_collect
+      "module Test.\n\
+       Holder.\n\
+       strings h: Holder => [String].\n\
+       ---\n\
+       all h: Holder, x in strings h | x = x.\n"
+  in
+  let queries = Smt.generate_queries config env doc in
+  check bool "skips GIn string element invariant consistency" false
+    (List.exists
+       (fun (q : Smt.query) -> q.kind = Smt.InvariantConsistency)
+       queries)
+
 let test_init_query_content () =
   let env, doc =
     parse_and_collect
@@ -1500,6 +1539,8 @@ let integration_tests =
       test_duplicate_split_form_equation_kept_in_body;
     test_case "split-form rejects RHS free param" `Quick
       test_split_form_rejects_rhs_free_param;
+    test_case "split-form allows RHS guard binder" `Quick
+      test_split_form_allows_rhs_guard_binder;
     test_case
       "recursive rule emits define-fun-rec form with body and skips \
        declare-fun line"
@@ -1525,6 +1566,10 @@ let integration_tests =
       test_list_domain_element_no_constraint;
     test_case "expensive string quantifier skips consistency only" `Quick
       test_expensive_string_quantifier_skips_consistency_only;
+    test_case "expensive composite param skips consistency" `Quick
+      test_expensive_composite_param_skips_consistency;
+    test_case "expensive GIn uses quantifier env" `Quick
+      test_expensive_gin_uses_quantifier_env;
     test_case "invariant query content" `Quick test_invariant_query_content;
     test_case "init query content" `Quick test_init_query_content;
   ]

--- a/test/test_smt.ml
+++ b/test/test_smt.ml
@@ -1494,7 +1494,7 @@ let test_expensive_gin_uses_quantifier_env () =
        Holder.\n\
        strings h: Holder => [String].\n\
        ---\n\
-       all h: Holder, x in strings h | x = x.\n"
+       all h in Holder, x in strings h | x = x.\n"
   in
   let queries = Smt.generate_queries config env doc in
   check bool "skips GIn string element invariant consistency" false

--- a/test/test_smt.ml
+++ b/test/test_smt.ml
@@ -21,6 +21,18 @@ let config_native =
   Smt.make_config ~bound:3 ~steps:5 ~domain_bounds:Env.StringMap.empty
     ~inject_guards:true ~ground_quantifiers:false ()
 
+let contains s sub =
+  let slen = String.length s in
+  let sublen = String.length sub in
+  if sublen > slen then false
+  else
+    let rec check i =
+      if i > slen - sublen then false
+      else if String.sub s i sublen = sub then true
+      else check (i + 1)
+    in
+    check 0
+
 let test_lit_bool () =
   let env = Env.empty "" in
   check string "true" "true" (Smt.translate_expr config env (Ast.ELitBool true));
@@ -136,6 +148,35 @@ let test_app () =
     (Smt.translate_expr config env
        (Ast.EApp (EVar (Lower "f"), [ EVar (Lower "x"); EVar (Lower "y") ])))
 
+let test_list_index_fallback () =
+  let env =
+    Env.empty ""
+    |> Env.add_var "xs" (Types.TyList Types.TyString)
+    |> Env.add_var "i" Types.TyNat
+  in
+  Smt.reset_fallbacks ();
+  Smt.reset_list_search_cache ();
+  let result =
+    Smt.translate_expr config env (Ast.EApp (EVar (Lower "xs"), [ ELitNat 1 ]))
+  in
+  check bool "is list-index fallback" true
+    (String.length result >= 21
+    && String.sub result 0 21 = "_list_index_fallback_");
+  let drained = Smt.drain_fallback_decls () in
+  check bool "declared with element sort" true
+    (contains drained (Printf.sprintf "(declare-const %s String)" result));
+  Smt.reset_fallbacks ();
+  Smt.reset_list_search_cache ();
+  let first =
+    Smt.translate_expr config env
+      (Ast.EApp (EVar (Lower "xs"), [ EVar (Lower "i") ]))
+  in
+  let second =
+    Smt.translate_expr config env
+      (Ast.EApp (EVar (Lower "xs"), [ EVar (Lower "i") ]))
+  in
+  check string "same list/index pair reuses fallback" first second
+
 let test_primed_app () =
   let env = Env.empty "" in
   check string "primed app" "(f_prime x)"
@@ -172,18 +213,6 @@ let test_sort_domain () =
     (Smt.sort_of_ty (Types.TyDomain "Account"))
 
 (* --- Integration tests --- *)
-
-let contains s sub =
-  let slen = String.length s in
-  let sublen = String.length sub in
-  if sublen > slen then false
-  else
-    let rec check i =
-      if i > slen - sublen then false
-      else if String.sub s i sublen = sub then true
-      else check (i + 1)
-    in
-    check 0
 
 let test_preamble_domains_simple () =
   let env = Env.empty "" |> Env.add_domain "Account" Ast.dummy_loc ~chapter:0 in
@@ -266,6 +295,26 @@ let test_duplicate_split_form_equation_kept_in_body () =
       fail
         (Printf.sprintf "expected retained x + 2 equation, got %s"
            (Ast.show_expr prop))
+
+let test_split_form_rejects_rhs_free_param () =
+  let env, doc =
+    parse_and_collect
+      "module Test.\n\
+       Item.\n\
+       label i: Item => String.\n\
+       build i: Item => [String].\n\
+       projected => String.\n\
+       ---\n\
+       projected = label i.\n\
+       #(build i) = 1.\n\
+       (build i) 1 = projected.\n"
+  in
+  let env, doc = Collect.recognize_split_form_bodies env doc in
+  (match Env.lookup_rule_body_arity "projected" 0 env with
+  | Some _ -> fail "projected must not be attached as a nullary rule body"
+  | None -> ());
+  let chapter = List.hd doc.chapters in
+  check int "free-param equation remains in body" 3 (List.length chapter.body)
 
 let test_recursive_rule_emits_define_fun_rec () =
   let env, doc =
@@ -553,6 +602,20 @@ let test_card_non_domain_list () =
   (* The corresponding declaration is queued in fallback_decls. *)
   let drained = Smt.drain_fallback_decls () in
   check bool "declaration queued" true (contains drained "_card_fallback_")
+
+let test_card_non_domain_list_reuses_fallback () =
+  let env =
+    Env.empty ""
+    |> Env.add_rule "nums"
+         (Types.TyFunc ([], Some (Types.TyList Types.TyInt)))
+         Ast.dummy_loc ~chapter:0
+  in
+  Smt.reset_fallbacks ();
+  Smt.reset_list_search_cache ();
+  let expr = Ast.EUnop (OpCard, EVar (Lower "nums")) in
+  let first = Smt.translate_expr config env expr in
+  let second = Smt.translate_expr config env expr in
+  check string "same card expression reuses fallback" first second
 
 let test_subset_domain_rhs () =
   (* Ensure OpSubset with EDomain on RHS doesn't trigger standalone failwith *)
@@ -1257,6 +1320,7 @@ let expression_tests =
     test_case "negation" `Quick test_unop_neg;
     test_case "application" `Quick test_app;
     test_case "primed application" `Quick test_primed_app;
+    test_case "list index fallback" `Quick test_list_index_fallback;
     test_case "domain membership" `Quick test_domain_in;
     test_case "list membership" `Quick test_in_list;
     test_case "projection" `Quick test_proj;
@@ -1270,6 +1334,8 @@ let expression_tests =
     test_case "subset" `Quick test_subset;
     test_case "domain standalone raises" `Quick test_domain_standalone;
     test_case "cardinality non-domain list" `Quick test_card_non_domain_list;
+    test_case "cardinality non-domain list reuses fallback" `Quick
+      test_card_non_domain_list_reuses_fallback;
     test_case "subset with domain RHS" `Quick test_subset_domain_rhs;
   ]
 
@@ -1379,6 +1445,24 @@ let test_invariant_query_content () =
   check bool "has domain sort" true
     (contains inv_con.smt2 "(declare-sort Account 0)")
 
+let test_expensive_string_quantifier_skips_consistency_only () =
+  let env, doc =
+    parse_and_collect
+      "module Test.\n\
+       f a: String, b: String => [String].\n\
+       ---\n\
+       all a: String, b: String | all x: String | x in f a b <-> x = a or x = b.\n\
+       check\n\
+       all a: String, b: String | all x: String | x in f a b <-> x = a or x = b.\n"
+  in
+  let queries = Smt.generate_queries config env doc in
+  check bool "skips expensive invariant consistency" false
+    (List.exists
+       (fun (q : Smt.query) -> q.kind = Smt.InvariantConsistency)
+       queries);
+  check bool "keeps entailment query" true
+    (List.exists (fun (q : Smt.query) -> q.kind = Smt.Entailment) queries)
+
 let test_init_query_content () =
   let env, doc =
     parse_and_collect
@@ -1414,6 +1498,8 @@ let integration_tests =
       `Quick test_split_form_nullary_self_reference;
     test_case "duplicate split-form equation remains in chapter body" `Quick
       test_duplicate_split_form_equation_kept_in_body;
+    test_case "split-form rejects RHS free param" `Quick
+      test_split_form_rejects_rhs_free_param;
     test_case
       "recursive rule emits define-fun-rec form with body and skips \
        declare-fun line"
@@ -1437,6 +1523,8 @@ let integration_tests =
       test_list_with_params_element_constraint;
     test_case "list<Domain> no element constraint" `Quick
       test_list_domain_element_no_constraint;
+    test_case "expensive string quantifier skips consistency only" `Quick
+      test_expensive_string_quantifier_skips_consistency_only;
     test_case "invariant query content" `Quick test_invariant_query_content;
     test_case "init query content" `Quick test_init_query_content;
   ]

--- a/test/test_smt_invariants.ml
+++ b/test/test_smt_invariants.ml
@@ -323,8 +323,6 @@ let regression_cases () =
          "bug_action_param_shadows_rule.pant" "a1");
     test_case "bug_rule_param_collision.pant — clean post-fix" `Quick
       (test_regression_fixture "bug_rule_param_collision.pant" []);
-    test_case "bug_rule_param_collision.pant — quantifier binder renamed" `Quick
-      (test_smt_contains ~native:true "bug_rule_param_collision.pant" "name_q");
     test_case "bug_nested_binder_collision.pant — clean post-fix" `Quick
       (test_regression_fixture "bug_nested_binder_collision.pant" []);
     test_case
@@ -334,9 +332,9 @@ let regression_cases () =
     test_case "bug_rename_app_head.pant — clean post-fix" `Quick
       (test_regression_fixture "bug_rename_app_head.pant"
          [ "fallback_emission" ]);
-    test_case "bug_rename_app_head.pant — renamed binder used in head position"
-      `Quick
-      (test_smt_contains ~native:true "bug_rename_app_head.pant" "(xs_q 1)");
+    test_case "bug_rename_app_head.pant — indexed app uses fallback" `Quick
+      (test_smt_contains ~native:true "bug_rename_app_head.pant"
+         "_list_index_fallback_");
     test_case "bug_rename_app_head.pant — binder does not shadow declared xs"
       `Quick
       (test_no_shadowing_forall ~native:true "bug_rename_app_head.pant" "xs");

--- a/test/test_smt_types.ml
+++ b/test/test_smt_types.ml
@@ -108,6 +108,16 @@ let public_api_properties =
 
 let state_interleaving_properties =
   [
+    test_case "reset_fallbacks clears intern cache" `Quick (fun () ->
+        Smt_state.reset_fallbacks ();
+        let first = Smt_state.intern_card_symbol ~expr_s:"xs" in
+        ignore (Smt_state.drain_fallback_decls ());
+        Smt_state.reset_fallbacks ();
+        let second = Smt_state.intern_card_symbol ~expr_s:"xs" in
+        let drained = Smt_state.drain_fallback_decls () in
+        check string "counter resets" first second;
+        check bool "declaration is re-queued" true
+          (String.length drained > 0 && String.contains drained '('));
     QCheck_alcotest.to_alcotest
       (QCheck2.Test.make
          ~name:"state interleavings reset and drain auxiliary declarations"

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-local-collection-builder.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-local-collection-builder.ts
@@ -16,6 +16,9 @@ interface BuilderItem {
  * Straight-line single-push list builder:
  *   `const out = []; out.push(seed); return out;`
  * Target Pantagruel encoding: cardinality plus positional assertions.
+ *
+ * @pant #(list-single-push seed) = 1.
+ * @pant (list-single-push seed) 1 = seed.
  */
 // biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
 function listSinglePush(seed: string): string[] {
@@ -28,6 +31,10 @@ function listSinglePush(seed: string): string[] {
  * Straight-line multi-push list builder.
  * Target Pantagruel encoding must preserve push order in positional
  * assertions over the returned rule.
+ *
+ * @pant #(list-multiple-pushes first second) = 2.
+ * @pant (list-multiple-pushes first second) 1 = first.
+ * @pant (list-multiple-pushes first second) 2 = second.
  */
 // biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
 function listMultiplePushes(first: string, second: string): string[] {
@@ -41,6 +48,9 @@ function listMultiplePushes(first: string, second: string): string[] {
  * Push values through preceding pure const bindings and property projection.
  * Target Pantagruel encoding should inline or name the const-bound projection
  * without treating `push` as a pure expression.
+ *
+ * @pant #(list-push-const-projection item) = 1.
+ * @pant (list-push-const-projection item) 1 = builder-item--label item.
  */
 // biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
 function listPushConstProjection(item: BuilderItem): string[] {
@@ -53,6 +63,9 @@ function listPushConstProjection(item: BuilderItem): string[] {
 /**
  * Transparent expression wrappers around the returned accumulator should not
  * hide the builder target.
+ *
+ * @pant #(list-parenthesized-return seed) = 1.
+ * @pant (list-parenthesized-return seed) 1 = seed.
  */
 // biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
 function listParenthesizedReturn(seed: string): string[] {
@@ -78,6 +91,8 @@ function listGuardReadRejected(seed: string): string[] {
 /**
  * Straight-line Set add builder.
  * Target Pantagruel encoding: membership equivalence, not ordered positions.
+ *
+ * @pant all x: String | x in set-add-builder first second <-> x = first or x = second.
  */
 // biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
 function setAddBuilder(first: string, second: string): Set<string> {
@@ -90,6 +105,8 @@ function setAddBuilder(first: string, second: string): Set<string> {
 /**
  * Set builder whose accumulator omits the constructor type argument.
  * Target type must come from the function return annotation.
+ *
+ * @pant all x: String | x in set-untyped-accumulator seed <-> x = seed.
  */
 // biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
 function setUntypedAccumulator(seed: string): ReadonlySet<string> {
@@ -101,6 +118,8 @@ function setUntypedAccumulator(seed: string): ReadonlySet<string> {
 /**
  * Set builder whose parameter would collide with the default membership
  * binder if the binder allocator did not check free names.
+ *
+ * @pant all y: String | y in set-binder-collision x <-> y = x.
  */
 // biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
 function setBinderCollision(x: string): Set<string> {
@@ -112,6 +131,8 @@ function setBinderCollision(x: string): Set<string> {
 /**
  * Empty Set builder.
  * Target Pantagruel encoding: universal non-membership.
+ *
+ * @pant all x: String | ~(x in set-empty-builder).
  */
 // biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
 function setEmptyBuilder(): Set<string> {

--- a/tools/ts2pant/tests/integration/dogfood.test.mts
+++ b/tools/ts2pant/tests/integration/dogfood.test.mts
@@ -645,6 +645,46 @@ describe("dogfood: @pant annotations entail", () => {
       fn: "predicateValue",
       minChecks: 2,
     },
+    {
+      file: resolve(FIXTURES, "expressions-local-collection-builder.ts"),
+      fn: "listSinglePush",
+      minChecks: 2,
+    },
+    {
+      file: resolve(FIXTURES, "expressions-local-collection-builder.ts"),
+      fn: "listMultiplePushes",
+      minChecks: 3,
+    },
+    {
+      file: resolve(FIXTURES, "expressions-local-collection-builder.ts"),
+      fn: "listPushConstProjection",
+      minChecks: 2,
+    },
+    {
+      file: resolve(FIXTURES, "expressions-local-collection-builder.ts"),
+      fn: "listParenthesizedReturn",
+      minChecks: 2,
+    },
+    {
+      file: resolve(FIXTURES, "expressions-local-collection-builder.ts"),
+      fn: "setAddBuilder",
+      minChecks: 1,
+    },
+    {
+      file: resolve(FIXTURES, "expressions-local-collection-builder.ts"),
+      fn: "setUntypedAccumulator",
+      minChecks: 1,
+    },
+    {
+      file: resolve(FIXTURES, "expressions-local-collection-builder.ts"),
+      fn: "setBinderCollision",
+      minChecks: 1,
+    },
+    {
+      file: resolve(FIXTURES, "expressions-local-collection-builder.ts"),
+      fn: "setEmptyBuilder",
+      minChecks: 1,
+    },
   ];
 
   for (const { file, fn, minChecks } of annotated) {


### PR DESCRIPTION
## Summary

- Add strong `@pant` annotations for the newly unlocked local collection builder fixtures: ordered list cardinality/position assertions and exact Set membership assertions.
- Add those fixture functions to the ts2pant dogfood entailment matrix.
- Fix Pantagruel split-form rule-body recognition so a nullary equation whose RHS depends on a free head parameter remains an ordinary invariant instead of becoming malformed SMT.
- Add SMT regressions for list-index fallback, String Set-builder precheck behavior, and free-variable baselines.

## Why

Dogfooding the local collection builder sequencing work exposed two Pantagruel-layer issues: indexed list applications needed stable typed fallbacks, and primitive-quantified String Set-builder invariants should not force the global consistency precheck. The new projection annotation also exposed an invalid split-form rule-body classification that produced SMT with an unbound parameter.

## Validation

- `dune exec test/test_smt.exe`
- `dune exec test/test_smt_invariants.exe`
- `dune exec test/test_smt_substitution.exe`
- `just ts2pant-test-integration`
- pre-commit hook: OCaml suite and ts2pant unit/integration suite passed

Note: the hook reports an existing non-failing Biome warning in `tools/ts2pant/src/purity.ts` about a regex missing the `u` flag; this PR does not touch that file.
