### PR TITLE
[ts2pant-iteration-builder-completeness] Patch 1: Add iteration-builder fixtures and skipped test stubs

### DIFF
--- a/tools/ts2pant/tests/constructs.test.mts
+++ b/tools/ts2pant/tests/constructs.test.mts
@@ -12,6 +12,7 @@ import { buildDocumentFromSourceFile, emitAndCheck } from "./helpers.mjs";
 const CONSTRUCTS_DIR = resolve(import.meta.dirname, "fixtures/constructs");
 const SCAFFOLD_ONLY_FIXTURES = new Set([
   "expressions-for-of-comprehension.ts",
+  "expressions-iteration-builder.ts",
   "expressions-local-collection-builder.ts",
   "foreign-accessor-dependency.ts",
 ]);

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-iteration-builder.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-iteration-builder.ts
@@ -1,0 +1,240 @@
+// @archlint.module exempt
+// @archlint.exempt-reason test-support
+
+// Iteration-builder shapes targeted by the Patch 2/3/4 iteration builder
+// completeness work. These functions stay unexported so the generic constructs
+// snapshot suite does not discover them before dedicated tests are unskipped.
+
+interface IterationItem {
+  active: boolean;
+  ready: boolean;
+  id: string;
+  label: string;
+  count: number;
+}
+
+/**
+ * For-of list builder with a loop-local const projection before the push.
+ * Target Pantagruel encoding: `each item in items | item--label item`.
+ *
+ * @pant list-const-projection items = (each item in items | iteration-item--label item).
+ */
+// biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
+function listConstProjection(items: IterationItem[]): string[] {
+  const out: string[] = [];
+  for (const item of items) {
+    const projected = item.label;
+    out.push(projected);
+  }
+  return out;
+}
+
+/**
+ * For-of list builder with a compound guard.
+ * Target Pantagruel encoding folds both conjuncts into the comprehension guard.
+ *
+ * @pant list-compound-guard items = (each item in items, iteration-item--active item, iteration-item--ready item | item).
+ */
+// biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
+function listCompoundGuard(items: IterationItem[]): IterationItem[] {
+  const out: IterationItem[] = [];
+  for (const item of items) {
+    if (item.active && item.ready) {
+      out.push(item);
+    }
+  }
+  return out;
+}
+
+/**
+ * For-of list builder with nested guard blocks.
+ * Target Pantagruel encoding folds both nested guards into the comprehension.
+ *
+ * @pant list-nested-guard items = (each item in items, iteration-item--active item, iteration-item--ready item | iteration-item--id item).
+ */
+// biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
+function listNestedGuard(items: IterationItem[]): string[] {
+  const out: string[] = [];
+  for (const item of items) {
+    if (item.active) {
+      if (item.ready) {
+        out.push(item.id);
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * For-of Set builder.
+ * Target Pantagruel encoding: membership equivalence over a `some`
+ * comprehension, not ordered list equality.
+ *
+ * @pant all x: String | x in set-add-for-of items <-> (some item in items | x = iteration-item--id item).
+ */
+// biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
+function setAddForOf(items: IterationItem[]): Set<string> {
+  const out = new Set<string>();
+  for (const item of items) {
+    out.add(item.id);
+  }
+  return out;
+}
+
+/**
+ * Pure additive scalar fold.
+ * Target Pantagruel encoding: identity plus `+ over each`.
+ *
+ * @pant sum-int-fold items = + over each item in items | iteration-item--count item.
+ */
+// biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
+function sumIntFold(items: IterationItem[]): number {
+  let total = 0;
+  for (const item of items) {
+    total += item.count;
+  }
+  return total;
+}
+
+/**
+ * Guarded count fold.
+ * Target Pantagruel encoding: guarded `+ over each` of one per matching item.
+ *
+ * @pant count-guarded-fold items = + over each item in items, iteration-item--active item | 1.
+ */
+// biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
+function countGuardedFold(items: IterationItem[]): number {
+  let count = 0;
+  for (const item of items) {
+    if (item.active) {
+      count++;
+    }
+  }
+  return count;
+}
+
+/**
+ * Boolean-and scalar fold.
+ * Target Pantagruel encoding: `and over each`.
+ *
+ * @pant all-active-fold items = and over each item in items | iteration-item--active item.
+ */
+// biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
+function allActiveFold(items: IterationItem[]): boolean {
+  let allActive = true;
+  for (const item of items) {
+    allActive &&= item.active;
+  }
+  return allActive;
+}
+
+/**
+ * Out-of-scope control: early return exits the outer function from inside the
+ * loop, so it is not a pure build-list comprehension.
+ */
+// biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
+function listEarlyReturnInLoopRejected(items: IterationItem[]): string[] {
+  const out: string[] = [];
+  for (const item of items) {
+    if (!item.active) {
+      return out;
+    }
+    out.push(item.id);
+  }
+  return out;
+}
+
+/**
+ * Out-of-scope control: break makes the result prefix-dependent.
+ */
+// biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
+function listBreakRejected(items: IterationItem[]): string[] {
+  const out: string[] = [];
+  for (const item of items) {
+    if (!item.ready) {
+      break;
+    }
+    out.push(item.id);
+  }
+  return out;
+}
+
+/**
+ * Out-of-scope control: nested loops are not a single-source builder.
+ */
+// biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
+function listNestedLoopRejected(items: IterationItem[][]): string[] {
+  const out: string[] = [];
+  for (const group of items) {
+    for (const item of group) {
+      out.push(item.id);
+    }
+  }
+  return out;
+}
+
+/**
+ * Out-of-scope control: accumulator aliasing hides the builder write target.
+ */
+// biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
+function listAccumulatorAliasRejected(items: IterationItem[]): string[] {
+  const out: string[] = [];
+  const alias = out;
+  for (const item of items) {
+    alias.push(item.id);
+  }
+  return out;
+}
+
+/**
+ * Out-of-scope control: Map construction is deferred to a Map-specific target.
+ */
+// biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
+function mapBuilderForOfRejected(items: IterationItem[]): Map<string, number> {
+  const out = new Map<string, number>();
+  for (const item of items) {
+    out.set(item.id, item.count);
+  }
+  return out;
+}
+
+/**
+ * Out-of-scope control: Set delete/clear mutation is not a Set add builder.
+ */
+// biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
+function setDeleteForOfRejected(items: IterationItem[]): Set<string> {
+  const out = new Set<string>();
+  for (const item of items) {
+    out.add(item.id);
+    if (!item.active) {
+      out.delete(item.id);
+    }
+  }
+  return out;
+}
+
+/**
+ * Out-of-scope scalar fold: null-seeded conjoin has no identity-bearing target
+ * in the current scalar fold lowering.
+ */
+// biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
+function conjoinNoIdentityRejected(items: IterationItem[]): boolean | null {
+  let result: boolean | null = null;
+  for (const item of items) {
+    result = result === null ? item.active : result && item.active;
+  }
+  return result;
+}
+
+/**
+ * Out-of-scope scalar fold: subtraction is order-dependent and
+ * non-commutative.
+ */
+// biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
+function foldNonCommutativeRejected(items: IterationItem[]): number {
+  let total = 0;
+  for (const item of items) {
+    total -= item.count;
+  }
+  return total;
+}

--- a/tools/ts2pant/tests/integration/iteration-builder.test.mts
+++ b/tools/ts2pant/tests/integration/iteration-builder.test.mts
@@ -1,0 +1,61 @@
+// @archlint.module test
+// @archlint.domain ts2pant.iteration-builder.integration
+
+import assert from "node:assert/strict";
+import { resolve } from "node:path";
+import { describe, it } from "node:test";
+import {
+  buildDocument,
+  emitAndCheck,
+  runCheck,
+  solverAvailable,
+} from "../helpers.mjs";
+
+const FIXTURE = resolve(
+  import.meta.dirname,
+  "../fixtures/constructs/expressions-iteration-builder.ts",
+);
+
+const hasSolver = solverAvailable();
+
+async function checkFixture(functionName: string): Promise<void> {
+  const output = await emitAndCheck(await buildDocument(FIXTURE, functionName));
+  if (!hasSolver) {
+    return;
+  }
+  const result = runCheck(output);
+  assert.ok(result.passed, `pant --check failed:\n${result.output}`);
+}
+
+describe("iteration builder integration", () => {
+  // Patch 2 unskips these list-builder checker stubs.
+  it(
+    "list builder positives pass pant --check",
+    { skip: "Patch 2 implements for-of list builder widening" },
+    async () => {
+      await checkFixture("listConstProjection");
+      await checkFixture("listCompoundGuard");
+      await checkFixture("listNestedGuard");
+    },
+  );
+
+  // Patch 3 unskips this Set-builder checker stub.
+  it(
+    "setAddForOf passes pant --check",
+    { skip: "Patch 3 implements for-of Set add builders" },
+    async () => {
+      await checkFixture("setAddForOf");
+    },
+  );
+
+  // Patch 4 unskips these scalar-fold checker stubs.
+  it(
+    "scalar fold positives pass pant --check",
+    { skip: "Patch 4 implements scalar fold lowering" },
+    async () => {
+      await checkFixture("sumIntFold");
+      await checkFixture("countGuardedFold");
+      await checkFixture("allActiveFold");
+    },
+  );
+});

--- a/tools/ts2pant/tests/iteration-builder.test.mts
+++ b/tools/ts2pant/tests/iteration-builder.test.mts
@@ -1,0 +1,226 @@
+// @archlint.module test
+// @archlint.domain ts2pant.iteration-builder
+
+import assert from "node:assert/strict";
+import { resolve } from "node:path";
+import { describe, it } from "node:test";
+import {
+  buildDocument,
+  emitAndCheck,
+  runCheck,
+  solverAvailable,
+} from "./helpers.mjs";
+
+const FIXTURE = resolve(
+  import.meta.dirname,
+  "fixtures/constructs/expressions-iteration-builder.ts",
+);
+
+const hasSolver = solverAvailable();
+
+async function emitFixture(functionName: string): Promise<string> {
+  return emitAndCheck(await buildDocument(FIXTURE, functionName));
+}
+
+function assertCheckerPasses(output: string): void {
+  if (!hasSolver) {
+    return;
+  }
+  const result = runCheck(output);
+  assert.ok(result.passed, `pant --check failed:\n${result.output}`);
+}
+
+describe("iteration builder", () => {
+  // Patch 2 unskips this list-builder widening case.
+  it(
+    "listConstProjection inlines loop-local const into the comprehension",
+    { skip: "Patch 2 implements for-of list builders with loop-local consts" },
+    async () => {
+      const output = await emitFixture("listConstProjection");
+      assert.match(
+        output,
+        /^list-const-projection items = \(each item in items \| iteration-item--label item\)\.$/mu,
+      );
+      assert.doesNotMatch(output, /UNSUPPORTED/u);
+      assertCheckerPasses(output);
+    },
+  );
+
+  // Patch 2 unskips this list-builder widening case.
+  it(
+    "listCompoundGuard folds both conjuncts into guards",
+    { skip: "Patch 2 implements compound for-of list-builder guards" },
+    async () => {
+      const output = await emitFixture("listCompoundGuard");
+      assert.match(
+        output,
+        /^list-compound-guard items = \(each item in items, iteration-item--active item, iteration-item--ready item \| item\)\.$/mu,
+      );
+      assert.doesNotMatch(output, /UNSUPPORTED/u);
+      assertCheckerPasses(output);
+    },
+  );
+
+  // Patch 2 unskips this list-builder widening case.
+  it(
+    "listNestedGuard folds nested if guards into the comprehension",
+    { skip: "Patch 2 implements nested for-of list-builder guards" },
+    async () => {
+      const output = await emitFixture("listNestedGuard");
+      assert.match(
+        output,
+        /^list-nested-guard items = \(each item in items, iteration-item--active item, iteration-item--ready item \| iteration-item--id item\)\.$/mu,
+      );
+      assert.doesNotMatch(output, /UNSUPPORTED/u);
+      assertCheckerPasses(output);
+    },
+  );
+
+  // Patch 3 unskips this Set-builder case.
+  it(
+    "setAddForOf emits membership equivalence over a some-comprehension",
+    { skip: "Patch 3 implements for-of Set add builders" },
+    async () => {
+      const output = await emitFixture("setAddForOf");
+      assert.match(
+        output,
+        /x in set-add-for-of items <-> \(some item in items \| x = iteration-item--id item\)/u,
+      );
+      assert.doesNotMatch(output, /UNSUPPORTED/u);
+      assertCheckerPasses(output);
+    },
+  );
+
+  // Patch 4 unskips this scalar-fold case.
+  it(
+    "sumIntFold lowers to init plus a sum comprehension",
+    { skip: "Patch 4 implements additive scalar folds" },
+    async () => {
+      const output = await emitFixture("sumIntFold");
+      assert.match(
+        output,
+        /^sum-int-fold items = \+ over each item in items \| iteration-item--count item\.$/mu,
+      );
+      assert.doesNotMatch(output, /UNSUPPORTED/u);
+      assertCheckerPasses(output);
+    },
+  );
+
+  // Patch 4 unskips this scalar-fold case.
+  it(
+    "countGuardedFold folds the guard into the sum comprehension",
+    { skip: "Patch 4 implements guarded count folds" },
+    async () => {
+      const output = await emitFixture("countGuardedFold");
+      assert.match(
+        output,
+        /^count-guarded-fold items = \+ over each item in items, iteration-item--active item \| 1\.$/mu,
+      );
+      assert.doesNotMatch(output, /UNSUPPORTED/u);
+      assertCheckerPasses(output);
+    },
+  );
+
+  // Patch 4 unskips this scalar-fold case.
+  it(
+    "allActiveFold lowers to an and comprehension",
+    { skip: "Patch 4 implements boolean-and scalar folds" },
+    async () => {
+      const output = await emitFixture("allActiveFold");
+      assert.match(
+        output,
+        /^all-active-fold items = and over each item in items \| iteration-item--active item\.$/mu,
+      );
+      assert.doesNotMatch(output, /UNSUPPORTED/u);
+      assertCheckerPasses(output);
+    },
+  );
+
+  // Patch 2 unskips this preserved list-builder rejection.
+  it(
+    "listEarlyReturnInLoopRejected remains unsupported",
+    { skip: "Patch 2 verifies early-return loop rejection" },
+    async () => {
+      const output = await emitFixture("listEarlyReturnInLoopRejected");
+      assert.match(output, /^> UNSUPPORTED: list-early-return-in-loop-rejected/mu);
+      assert.match(output, /for-of|return|loop/u);
+    },
+  );
+
+  // Patch 2 unskips this preserved list-builder rejection.
+  it(
+    "listBreakRejected remains unsupported",
+    { skip: "Patch 2 verifies break loop rejection" },
+    async () => {
+      const output = await emitFixture("listBreakRejected");
+      assert.match(output, /^> UNSUPPORTED: list-break-rejected/mu);
+      assert.match(output, /for-of|break|loop/u);
+    },
+  );
+
+  // Patch 2 unskips this preserved list-builder rejection.
+  it(
+    "listNestedLoopRejected remains unsupported",
+    { skip: "Patch 2 verifies nested loop rejection" },
+    async () => {
+      const output = await emitFixture("listNestedLoopRejected");
+      assert.match(output, /^> UNSUPPORTED: list-nested-loop-rejected/mu);
+      assert.match(output, /for-of|nested|loop/u);
+    },
+  );
+
+  // Patch 2 unskips this preserved list-builder rejection.
+  it(
+    "listAccumulatorAliasRejected remains unsupported",
+    { skip: "Patch 2 verifies accumulator alias rejection" },
+    async () => {
+      const output = await emitFixture("listAccumulatorAliasRejected");
+      assert.match(output, /^> UNSUPPORTED: list-accumulator-alias-rejected/mu);
+      assert.match(output, /alias|accumulator|builder/u);
+    },
+  );
+
+  // Patch 3 unskips this preserved Map-builder rejection.
+  it(
+    "mapBuilderForOfRejected remains unsupported",
+    { skip: "Patch 3 verifies Map builder rejection" },
+    async () => {
+      const output = await emitFixture("mapBuilderForOfRejected");
+      assert.match(output, /^> UNSUPPORTED: map-builder-for-of-rejected/mu);
+      assert.match(output, /Map|map|builder/u);
+    },
+  );
+
+  // Patch 3 unskips this preserved Set-builder rejection.
+  it(
+    "setDeleteForOfRejected remains unsupported",
+    { skip: "Patch 3 verifies Set delete rejection" },
+    async () => {
+      const output = await emitFixture("setDeleteForOfRejected");
+      assert.match(output, /^> UNSUPPORTED: set-delete-for-of-rejected/mu);
+      assert.match(output, /Set|delete|builder/u);
+    },
+  );
+
+  // Patch 4 unskips this preserved scalar-fold rejection.
+  it(
+    "conjoinNoIdentityRejected remains unsupported",
+    { skip: "Patch 4 verifies no-identity fold rejection" },
+    async () => {
+      const output = await emitFixture("conjoinNoIdentityRejected");
+      assert.match(output, /^> UNSUPPORTED: conjoin-no-identity-rejected/mu);
+      assert.match(output, /identity|null|fold|unsupported/u);
+    },
+  );
+
+  // Patch 4 unskips this preserved scalar-fold rejection.
+  it(
+    "foldNonCommutativeRejected remains unsupported",
+    { skip: "Patch 4 verifies non-commutative fold rejection" },
+    async () => {
+      const output = await emitFixture("foldNonCommutativeRejected");
+      assert.match(output, /^> UNSUPPORTED: fold-non-commutative-rejected/mu);
+      assert.match(output, /commutative|fold|unsupported/u);
+    },
+  );
+});

--- a/tools/ts2pant/tests/iteration-builder.test.mts
+++ b/tools/ts2pant/tests/iteration-builder.test.mts
@@ -4,30 +4,15 @@
 import assert from "node:assert/strict";
 import { resolve } from "node:path";
 import { describe, it } from "node:test";
-import {
-  buildDocument,
-  emitAndCheck,
-  runCheck,
-  solverAvailable,
-} from "./helpers.mjs";
+import { buildDocument, emitAndCheck } from "./helpers.mjs";
 
 const FIXTURE = resolve(
   import.meta.dirname,
   "fixtures/constructs/expressions-iteration-builder.ts",
 );
 
-const hasSolver = solverAvailable();
-
 async function emitFixture(functionName: string): Promise<string> {
   return emitAndCheck(await buildDocument(FIXTURE, functionName));
-}
-
-function assertCheckerPasses(output: string): void {
-  if (!hasSolver) {
-    return;
-  }
-  const result = runCheck(output);
-  assert.ok(result.passed, `pant --check failed:\n${result.output}`);
 }
 
 describe("iteration builder", () => {
@@ -42,7 +27,6 @@ describe("iteration builder", () => {
         /^list-const-projection items = \(each item in items \| iteration-item--label item\)\.$/mu,
       );
       assert.doesNotMatch(output, /UNSUPPORTED/u);
-      assertCheckerPasses(output);
     },
   );
 
@@ -57,7 +41,6 @@ describe("iteration builder", () => {
         /^list-compound-guard items = \(each item in items, iteration-item--active item, iteration-item--ready item \| item\)\.$/mu,
       );
       assert.doesNotMatch(output, /UNSUPPORTED/u);
-      assertCheckerPasses(output);
     },
   );
 
@@ -72,7 +55,6 @@ describe("iteration builder", () => {
         /^list-nested-guard items = \(each item in items, iteration-item--active item, iteration-item--ready item \| iteration-item--id item\)\.$/mu,
       );
       assert.doesNotMatch(output, /UNSUPPORTED/u);
-      assertCheckerPasses(output);
     },
   );
 
@@ -87,7 +69,6 @@ describe("iteration builder", () => {
         /x in set-add-for-of items <-> \(some item in items \| x = iteration-item--id item\)/u,
       );
       assert.doesNotMatch(output, /UNSUPPORTED/u);
-      assertCheckerPasses(output);
     },
   );
 
@@ -102,7 +83,6 @@ describe("iteration builder", () => {
         /^sum-int-fold items = \+ over each item in items \| iteration-item--count item\.$/mu,
       );
       assert.doesNotMatch(output, /UNSUPPORTED/u);
-      assertCheckerPasses(output);
     },
   );
 
@@ -117,7 +97,6 @@ describe("iteration builder", () => {
         /^count-guarded-fold items = \+ over each item in items, iteration-item--active item \| 1\.$/mu,
       );
       assert.doesNotMatch(output, /UNSUPPORTED/u);
-      assertCheckerPasses(output);
     },
   );
 
@@ -132,7 +111,6 @@ describe("iteration builder", () => {
         /^all-active-fold items = and over each item in items \| iteration-item--active item\.$/mu,
       );
       assert.doesNotMatch(output, /UNSUPPORTED/u);
-      assertCheckerPasses(output);
     },
   );
 


### PR DESCRIPTION
## Patch 1: Add iteration-builder fixtures and skipped test stubs

- Create fixture functions: list positives `listConstProjection`, `listCompoundGuard`, `listNestedGuard`; Set positive `setAddForOf`; scalar-fold positives `sumIntFold`, `countGuardedFold`, `allActiveFold`; and negatives `listEarlyReturnInLoopRejected`, `listBreakRejected`, `listNestedLoopRejected`, `listAccumulatorAliasRejected`, `mapBuilderForOfRejected`, `setDeleteForOfRejected`, `conjoinNoIdentityRejected`, `foldNonCommutativeRejected`.
- Mark all new dedicated tests skipped with comments naming the patch that will unskip and implement each (Patch 2 for list cases, Patch 3 for Set cases, Patch 4 for scalar-fold cases).
- Use `buildDocument`, `emitAndCheck`, `runCheck`, and `solverAvailable` from the existing test helpers; mirror the structure of `local-collection-builder.test.mts` rather than spawning dune or invoking the pant binary directly.

## Changes
- Create fixture functions: list positives `listConstProjection`, `listCompoundGuard`, `listNestedGuard`; Set positive `setAddForOf`; scalar-fold positives `sumIntFold`, `countGuardedFold`, `allActiveFold`; and negatives `listEarlyReturnInLoopRejected`, `listBreakRejected`, `listNestedLoopRejected`, `listAccumulatorAliasRejected`, `mapBuilderForOfRejected`, `setDeleteForOfRejected`, `conjoinNoIdentityRejected`, `foldNonCommutativeRejected`.
- Mark all new dedicated tests skipped with comments naming the patch that will unskip and implement each (Patch 2 for list cases, Patch 3 for Set cases, Patch 4 for scalar-fold cases).
- Use `buildDocument`, `emitAndCheck`, `runCheck`, and `solverAvailable` from the existing test helpers; mirror the structure of `local-collection-builder.test.mts` rather than spawning dune or invoking the pant binary directly.

## Files to Modify
- tools/ts2pant/tests/fixtures/constructs/expressions-iteration-builder.ts (create): Scaffold unexported fixtures: positive for-of list builders with a loop-local const projection, a compound guard, and a nested guard; a positive for-of Set builder; positive scalar folds (sum, guarded count, boolean-and); and negatives for early-return-in-loop, break, nested loop, accumulator alias/escape, Map builder, Set delete/clear, no-identity null-seeded reduce, and non-commutative accumulation.
- tools/ts2pant/tests/constructs.test.mts (modify): Add `expressions-iteration-builder.ts` to `SCAFFOLD_ONLY_FIXTURES` so the generic snapshot suite ignores it.
- tools/ts2pant/tests/iteration-builder.test.mts (create): Add skipped `node:test` cases that build selected fixture functions, inspect emitted Pantagruel, and run the wasm/pant checker via the shared helpers.

## Gameplan Specification

```
module ITERATION_BUILDER_COMPLETENESS.

ForOfFn.
Elem.
Source = [Elem].
src f: ForOfFn => Source.
proj f: ForOfFn, n: Elem => Elem.
guard f: ForOfFn, n: Elem => Bool.

Collection.
builder-kind f: ForOfFn => Collection.
list => Collection.
set => Collection.
list-result f: ForOfFn => [Elem].
set-result f: ForOfFn => [Elem].

LoopShape.
shape f: ForOfFn => LoopShape.
supported-shape s: LoopShape => Bool.
guarded-push => LoopShape.
const-then-push => LoopShape.
compound-guard-push => LoopShape.
early-exit => LoopShape.
nested-loop => LoopShape.
scalar-fold => LoopShape.
aliased => LoopShape.
map-build => LoopShape.
supported f: ForOfFn => Bool.

FoldFn.
FoldCombiner.
fadd => FoldCombiner.
fmul => FoldCombiner.
fand => FoldCombiner.
for => FoldCombiner.
fold-combiner g: FoldFn => FoldCombiner.
fold-identity-bearing c: FoldCombiner => Bool.
fold-supported g: FoldFn => Bool.
no-identity-reduce g: FoldFn => Bool.
---
all s: LoopShape | supported-shape s = cond
  s = guarded-push => true,
  s = const-then-push => true,
  s = compound-guard-push => true,
  true => false.
all f: ForOfFn | supported f <-> supported-shape (shape f).
all f: ForOfFn, supported f, builder-kind f = list
  | list-result f = (each n in (src f), guard f n | proj f n).
all f: ForOfFn, supported f, builder-kind f = set, e: Elem
  | e in (set-result f) <-> (some n in (src f), guard f n | e = proj f n).
all c: FoldCombiner | fold-identity-bearing c = cond
  c = fadd => true,
  c = fmul => true,
  c = fand => true,
  c = for => true,
  true => false.
all g: FoldFn, fold-supported g | fold-identity-bearing (fold-combiner g).
all g: FoldFn, no-identity-reduce g | ~(fold-supported g).
```

## Patch Specification

```
module ITERATION_BUILDER_COMPLETENESS_PATCH_1.

Fixture.
TestStub.
fixture-file f: Fixture => String.
test-stub-name t: TestStub => String.
test-stub-skipped t: TestStub => Bool.
---
all t: TestStub | test-stub-skipped t.
```


## Implementation Notes

- The new iteration-builder fixture file is intentionally unexported and added to `SCAFFOLD_ONLY_FIXTURES`; dependent patches should unskip and exercise cases through `iteration-builder.test.mts`, not through the generic constructs snapshot suite.
- Skipped tests already contain the intended future assertions and helper wiring. They call `emitAndCheck` and conditionally run `runCheck` only when `solverAvailable()` is true, so unskipping should not introduce a hard z3 dependency beyond existing checker-gated patterns.
- The Set negative fixture uses `.delete` inside the loop after an `.add`; there is no separate `.clear` fixture despite the broader prose saying delete/clear. The concrete requested test stub name was `setDeleteForOfRejected`.
- Scalar-fold fixtures are scaffolded as representative source shapes only. `conjoinNoIdentityRejected` returns `boolean | null` to model a null-seeded/no-identity conjoin; Patch 4 may need to preserve rejection at signature/body translation boundaries if union return handling surfaces before fold recognition.
- Spec/Evidence Mapping: Patch spec `all t: TestStub | test-stub-skipped t` is implemented by every new `node:test` case in `tools/ts2pant/tests/iteration-builder.test.mts` carrying a Patch 2/3/4 `skip` reason. The fixture-file requirement is implemented by `tools/ts2pant/tests/fixtures/constructs/expressions-iteration-builder.ts` and the scaffold exclusion in `tools/ts2pant/tests/constructs.test.mts`. Required context consulted: `workstreams/ts2pant-body-completeness.md`, `tools/ts2pant/tests/helpers.mts`, `tools/ts2pant/tests/local-collection-builder.test.mts`, existing for-of tests/fixtures. Evidence: `just ts2pant-test-unit` and `just ts2pant-test-integration` both passed.