### PR TITLE
[ts2pant-iteration-builder-completeness] Patch 2: Widen for-of list builders for loop-local consts and compound guards

### DIFF
--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -2661,7 +2661,8 @@ export function recognizeForOfPush(
   if (expressionHasSideEffects(push.projExpr, ctx.checker)) {
     return null;
   }
-  if (expressionReferencesNames(push.projExpr, accNames)) {
+  const accNameSet = new Set(accNames);
+  if (expressionReferencesNames(push.projExpr, accNameSet)) {
     return null;
   }
   const proj = buildPureL1OrNull(push.projExpr, localBindings.scopedCtx);
@@ -2671,7 +2672,7 @@ export function recognizeForOfPush(
 
   const guards: IR1Expr[] = [];
   for (const guardExpr of push.guardExprs) {
-    if (expressionReferencesNames(guardExpr, accNames)) {
+    if (expressionReferencesNames(guardExpr, accNameSet)) {
       return null;
     }
     if (!isStaticallyBoolTyped(guardExpr, ctx.checker)) {
@@ -2701,7 +2702,7 @@ export function recognizeForOfPush(
 }
 
 function lowerForOfLoopLocalConstBindings(
-  bindings: readonly Array<{ tsName: string; initializer: ts.Expression }>,
+  bindings: ReadonlyArray<{ tsName: string; initializer: ts.Expression }>,
   ctx: L1BuildContext,
   accNames: ReadonlySet<string>,
 ): {
@@ -2710,6 +2711,7 @@ function lowerForOfLoopLocalConstBindings(
 } | null {
   let scopedParams: ReadonlyMap<string, string> = ctx.paramNames;
   const substitutions: Array<{ localName: string; value: IR1Expr }> = [];
+  const accNameSet = new Set(accNames);
 
   for (const [idx, binding] of bindings.entries()) {
     const blockedNames = new Set(bindings.slice(idx).map((b) => b.tsName));
@@ -2717,7 +2719,7 @@ function lowerForOfLoopLocalConstBindings(
       return null;
     }
     if (
-      expressionReferencesNames(binding.initializer, accNames) ||
+      expressionReferencesNames(binding.initializer, accNameSet) ||
       expressionReferencesNames(binding.initializer, blockedNames)
     ) {
       return null;

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -2650,16 +2650,30 @@ export function recognizeForOfPush(
   if (push === null) {
     return null;
   }
+  const localBindings = lowerForOfLoopLocalConstBindings(
+    push.localBindings,
+    scopedCtx,
+    accNames,
+  );
+  if (localBindings === null) {
+    return null;
+  }
   if (expressionHasSideEffects(push.projExpr, ctx.checker)) {
     return null;
   }
-  const proj = buildPureL1OrNull(push.projExpr, scopedCtx);
+  if (expressionReferencesNames(push.projExpr, accNames)) {
+    return null;
+  }
+  const proj = buildPureL1OrNull(push.projExpr, localBindings.scopedCtx);
   if (proj === null) {
     return null;
   }
 
   const guards: IR1Expr[] = [];
   for (const guardExpr of push.guardExprs) {
+    if (expressionReferencesNames(guardExpr, accNames)) {
+      return null;
+    }
     if (!isStaticallyBoolTyped(guardExpr, ctx.checker)) {
       return null;
     }
@@ -2670,20 +2684,71 @@ export function recognizeForOfPush(
     ) {
       return null;
     }
-    const guard = buildPureL1OrNull(guardExpr, scopedCtx);
+    const guard = buildPureL1OrNull(guardExpr, localBindings.scopedCtx);
     if (guard === null) {
       return null;
     }
-    guards.push(guard);
+    guards.push(inlineForOfLoopLocalConstBindings(guard, localBindings));
   }
 
   return {
     binder,
     src,
-    proj,
+    proj: inlineForOfLoopLocalConstBindings(proj, localBindings),
     guards,
     accName: push.accName,
   };
+}
+
+function lowerForOfLoopLocalConstBindings(
+  bindings: readonly Array<{ tsName: string; initializer: ts.Expression }>,
+  ctx: L1BuildContext,
+  accNames: ReadonlySet<string>,
+): {
+  scopedCtx: L1BuildContext;
+  substitutions: Array<{ localName: string; value: IR1Expr }>;
+} | null {
+  let scopedParams: ReadonlyMap<string, string> = ctx.paramNames;
+  const substitutions: Array<{ localName: string; value: IR1Expr }> = [];
+
+  for (const [idx, binding] of bindings.entries()) {
+    const blockedNames = new Set(bindings.slice(idx).map((b) => b.tsName));
+    if (expressionHasSideEffects(binding.initializer, ctx.checker)) {
+      return null;
+    }
+    if (
+      expressionReferencesNames(binding.initializer, accNames) ||
+      expressionReferencesNames(binding.initializer, blockedNames)
+    ) {
+      return null;
+    }
+    const localName = freshHygienicBinder(ctx.supply);
+    const value = buildPureL1OrNull(binding.initializer, {
+      ...ctx,
+      paramNames: scopedParams,
+    });
+    if (value === null) {
+      return null;
+    }
+    substitutions.push({ localName, value });
+    scopedParams = withParam(scopedParams, binding.tsName, localName);
+  }
+
+  return {
+    scopedCtx: { ...ctx, paramNames: scopedParams },
+    substitutions,
+  };
+}
+
+function inlineForOfLoopLocalConstBindings(
+  expr: IR1Expr,
+  bindings: { substitutions: Array<{ localName: string; value: IR1Expr }> },
+): IR1Expr {
+  return bindings.substitutions.reduceRight(
+    (acc, binding) =>
+      substituteIR1ExprSubtree(acc, ir1Var(binding.localName), binding.value),
+    expr,
+  );
 }
 
 function forOfSourceIsExpressible(
@@ -2728,24 +2793,70 @@ interface RecognizedPushBody {
   accName: string;
   projExpr: ts.Expression;
   guardExprs: ts.Expression[];
+  localBindings: Array<{
+    tsName: string;
+    initializer: ts.Expression;
+  }>;
 }
 
 function recognizeForOfPushBody(
   stmt: ts.Statement,
   accNames: ReadonlySet<string>,
 ): RecognizedPushBody | null {
-  if (ts.isBlock(stmt) && stmt.statements.length === 2) {
-    const guard = recognizeIfContinue(stmt.statements[0]!);
+  if (ts.isBlock(stmt)) {
+    const localBindings: RecognizedPushBody["localBindings"] = [];
+    let idx = 0;
+    while (idx < stmt.statements.length) {
+      const current = stmt.statements[idx]!;
+      if (!ts.isVariableStatement(current)) {
+        break;
+      }
+      if (!(current.declarationList.flags & ts.NodeFlags.Const)) {
+        return null;
+      }
+      const bindings = constBindingsFromDeclarationList(
+        current.declarationList,
+      );
+      if (bindings === null) {
+        return null;
+      }
+      for (const binding of bindings) {
+        if (binding.kind !== "const") {
+          return null;
+        }
+        localBindings.push({
+          tsName: binding.tsName,
+          initializer: binding.initializer,
+        });
+      }
+      idx += 1;
+    }
+
+    const remaining = stmt.statements.slice(idx);
+    if (remaining.length === 1) {
+      const body = recognizeForOfPushBody(remaining[0]!, accNames);
+      return body === null
+        ? null
+        : {
+            ...body,
+            localBindings: [...localBindings, ...body.localBindings],
+          };
+    }
+    if (remaining.length !== 2) {
+      return null;
+    }
+    const guard = recognizeIfContinue(remaining[0]!);
     if (guard === null) {
       return null;
     }
-    const push = recognizePushStatement(stmt.statements[1]!, accNames);
+    const push = recognizePushStatement(remaining[1]!, accNames);
     if (push === null) {
       return null;
     }
     return {
       ...push,
-      guardExprs: [guard],
+      guardExprs: flattenConjunctiveGuards(guard),
+      localBindings,
     };
   }
 
@@ -2756,7 +2867,7 @@ function recognizeForOfPushBody(
 
   const direct = recognizePushStatement(bodyStmt, accNames);
   if (direct !== null) {
-    return { ...direct, guardExprs: [] };
+    return { ...direct, guardExprs: [], localBindings: [] };
   }
 
   if (ts.isIfStatement(bodyStmt)) {
@@ -2767,16 +2878,33 @@ function recognizeForOfPushBody(
       bodyStmt.thenStatement,
       accNames,
     );
-    if (guardedPush === null || guardedPush.guardExprs.length !== 0) {
+    if (guardedPush === null) {
       return null;
     }
     return {
       ...guardedPush,
-      guardExprs: [bodyStmt.expression],
+      guardExprs: [
+        ...flattenConjunctiveGuards(bodyStmt.expression),
+        ...guardedPush.guardExprs,
+      ],
     };
   }
 
   return null;
+}
+
+function flattenConjunctiveGuards(expr: ts.Expression): ts.Expression[] {
+  const unwrapped = unwrapExpression(expr);
+  if (
+    ts.isBinaryExpression(unwrapped) &&
+    unwrapped.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken
+  ) {
+    return [
+      ...flattenConjunctiveGuards(unwrapped.left),
+      ...flattenConjunctiveGuards(unwrapped.right),
+    ];
+  }
+  return [expr];
 }
 
 function unwrapSingleStatementBlock(stmt: ts.Statement): ts.Statement | null {
@@ -2789,7 +2917,7 @@ function unwrapSingleStatementBlock(stmt: ts.Statement): ts.Statement | null {
 function recognizePushStatement(
   stmt: ts.Statement,
   accNames: ReadonlySet<string>,
-): Omit<RecognizedPushBody, "guardExprs"> | null {
+): Omit<RecognizedPushBody, "guardExprs" | "localBindings"> | null {
   if (!ts.isExpressionStatement(stmt)) {
     return null;
   }

--- a/tools/ts2pant/tests/iteration-builder.test.mts
+++ b/tools/ts2pant/tests/iteration-builder.test.mts
@@ -19,7 +19,6 @@ describe("iteration builder", () => {
   // Patch 2 unskips this list-builder widening case.
   it(
     "listConstProjection inlines loop-local const into the comprehension",
-    { skip: "Patch 2 implements for-of list builders with loop-local consts" },
     async () => {
       const output = await emitFixture("listConstProjection");
       assert.match(
@@ -33,7 +32,6 @@ describe("iteration builder", () => {
   // Patch 2 unskips this list-builder widening case.
   it(
     "listCompoundGuard folds both conjuncts into guards",
-    { skip: "Patch 2 implements compound for-of list-builder guards" },
     async () => {
       const output = await emitFixture("listCompoundGuard");
       assert.match(
@@ -47,7 +45,6 @@ describe("iteration builder", () => {
   // Patch 2 unskips this list-builder widening case.
   it(
     "listNestedGuard folds nested if guards into the comprehension",
-    { skip: "Patch 2 implements nested for-of list-builder guards" },
     async () => {
       const output = await emitFixture("listNestedGuard");
       assert.match(
@@ -117,7 +114,6 @@ describe("iteration builder", () => {
   // Patch 2 unskips this preserved list-builder rejection.
   it(
     "listEarlyReturnInLoopRejected remains unsupported",
-    { skip: "Patch 2 verifies early-return loop rejection" },
     async () => {
       const output = await emitFixture("listEarlyReturnInLoopRejected");
       assert.match(output, /^> UNSUPPORTED: list-early-return-in-loop-rejected/mu);
@@ -128,7 +124,6 @@ describe("iteration builder", () => {
   // Patch 2 unskips this preserved list-builder rejection.
   it(
     "listBreakRejected remains unsupported",
-    { skip: "Patch 2 verifies break loop rejection" },
     async () => {
       const output = await emitFixture("listBreakRejected");
       assert.match(output, /^> UNSUPPORTED: list-break-rejected/mu);
@@ -139,7 +134,6 @@ describe("iteration builder", () => {
   // Patch 2 unskips this preserved list-builder rejection.
   it(
     "listNestedLoopRejected remains unsupported",
-    { skip: "Patch 2 verifies nested loop rejection" },
     async () => {
       const output = await emitFixture("listNestedLoopRejected");
       assert.match(output, /^> UNSUPPORTED: list-nested-loop-rejected/mu);
@@ -150,7 +144,6 @@ describe("iteration builder", () => {
   // Patch 2 unskips this preserved list-builder rejection.
   it(
     "listAccumulatorAliasRejected remains unsupported",
-    { skip: "Patch 2 verifies accumulator alias rejection" },
     async () => {
       const output = await emitFixture("listAccumulatorAliasRejected");
       assert.match(output, /^> UNSUPPORTED: list-accumulator-alias-rejected/mu);


### PR DESCRIPTION
## Patch 2: Widen for-of list builders for loop-local consts and compound guards

- Extend `recognizeForOfPushBody` so a loop body block may contain zero or more leading `const` declarations (simple identifiers, pure initializers, TDZ-clean, not reading the accumulator) followed by the existing direct or single-guarded push, and so an `if`-guarded push may itself nest a further `if`-guarded push, accumulating every guard expression in source order.
- In `recognizeForOfPush`, build the loop-local const bindings into the binder-extended scope using the existing capture-avoiding scoped-parameter discipline (the same hygienic `$N`/`inlineConstBindings` substitution used by the pure prelude), then lower the projection and each guard under that extended scope via `buildPureL1OrNull`; reject any loop-local const whose initializer is effectful, references the accumulator, or forward-references a later const.
- Keep every guard expression subject to the existing `isStaticallyBoolTyped` and effect-free screens, and keep the projection subject to `expressionHasSideEffects`; on any failure return null so the function falls through to the unchanged `for-of loop is not a recognized build-list comprehension` diagnostic.
- Preserve the emitted target exactly: `ir1Each(binder, src, guards, proj)` lowered through `lowerL1ToOpaque`, with guards in source order — so previously-supported for-of fixtures stay byte-identical.
- Reject break, continue beyond the single leading-guard form, early return, throw, nested loops, and a second accumulator inside the loop body (return null), and confirm via the negative fixtures that they keep their diagnostics.
- Unskip and implement the Patch 1 list positive/negative tests.

## Changes
- Extend `recognizeForOfPushBody` so a loop body block may contain zero or more leading `const` declarations (simple identifiers, pure initializers, TDZ-clean, not reading the accumulator) followed by the existing direct or single-guarded push, and so an `if`-guarded push may itself nest a further `if`-guarded push, accumulating every guard expression in source order.
- In `recognizeForOfPush`, build the loop-local const bindings into the binder-extended scope using the existing capture-avoiding scoped-parameter discipline (the same hygienic `$N`/`inlineConstBindings` substitution used by the pure prelude), then lower the projection and each guard under that extended scope via `buildPureL1OrNull`; reject any loop-local const whose initializer is effectful, references the accumulator, or forward-references a later const.
- Keep every guard expression subject to the existing `isStaticallyBoolTyped` and effect-free screens, and keep the projection subject to `expressionHasSideEffects`; on any failure return null so the function falls through to the unchanged `for-of loop is not a recognized build-list comprehension` diagnostic.
- Preserve the emitted target exactly: `ir1Each(binder, src, guards, proj)` lowered through `lowerL1ToOpaque`, with guards in source order — so previously-supported for-of fixtures stay byte-identical.
- Reject break, continue beyond the single leading-guard form, early return, throw, nested loops, and a second accumulator inside the loop body (return null), and confirm via the negative fixtures that they keep their diagnostics.
- Unskip and implement the Patch 1 list positive/negative tests.

## Files to Modify
- tools/ts2pant/src/translate-body.ts (modify): Generalize `recognizeForOfPushBody`/`recognizeForOfPush` to accept pure loop-local const bindings before the push and to collect compound/nested guards, threading loop-local const scope into projection/guard L1 lowering.
- tools/ts2pant/tests/iteration-builder.test.mts (modify): Unskip and implement the list positive tests (const projection, compound guard, nested guard) and the list/loop negative tests (early-return-in-loop, break, nested loop, scalar fold, accumulator alias).

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[paper] Allen et al. 1983 if-conversion (Conversion of Control Dependence to Data Dependence)** — https://dl.acm.org/doi/10.1145/567067.567085 — Each leading/nested loop-body guard is a control dependence that must become a data-dependence predicate on the comprehension; if-conversion is the canonical reduction, so compound and nested guards fold into the `each`'s guard list in source order rather than spawning bespoke control flow.
- **[paper] Flanagan et al. 1993 A-normal form / compiling with continuations** — https://dl.acm.org/doi/10.1145/155090.155113 — The widened loop body is an ANF-like prelude (loop-local const bindings) before a terminal push; the recognizer keeps those bindings explicit long enough to lower the projection under the binder-extended scope, then collapses them into the comprehension body.
- **[algorithm] Capture-avoiding substitution** — Loop-local consts must be inlined into the projection and guards through the existing hygienic scoped-parameter/`inlineConstBindings` substitution (Barendregt convention), never textual replacement, so a loop-local name cannot capture the comprehension binder or a parameter.
- **[paper] Meijer, Fokkinga & Paterson 1991 — Functional Programming with Bananas, Lenses, Envelopes and Barbed Wire** — https://maartenfokkinga.github.io/utwente/mmf91m.pdf — The for-of build-list is the map/filter catamorphism over a list; the widened body still lowers to a single `each` (a map with guards), preserving the recursion-scheme framing the Structured Iteration section already documents.
- **[pattern] Conservative recognizer with precise refusal** — The patch admits only pure loop-local consts plus guarded pushes; break/continue-beyond-guard/return/throw/nested-loop/second-accumulator/aliasing must each return null and keep producing an explicit diagnostic.

## Gameplan Specification

```
module ITERATION_BUILDER_COMPLETENESS.

ForOfFn.
Elem.
Source = [Elem].
src f: ForOfFn => Source.
proj f: ForOfFn, n: Elem => Elem.
guard f: ForOfFn, n: Elem => Bool.

Collection.
builder-kind f: ForOfFn => Collection.
list => Collection.
set => Collection.
list-result f: ForOfFn => [Elem].
set-result f: ForOfFn => [Elem].

LoopShape.
shape f: ForOfFn => LoopShape.
supported-shape s: LoopShape => Bool.
guarded-push => LoopShape.
const-then-push => LoopShape.
compound-guard-push => LoopShape.
early-exit => LoopShape.
nested-loop => LoopShape.
scalar-fold => LoopShape.
aliased => LoopShape.
map-build => LoopShape.
supported f: ForOfFn => Bool.

FoldFn.
FoldCombiner.
fadd => FoldCombiner.
fmul => FoldCombiner.
fand => FoldCombiner.
for => FoldCombiner.
fold-combiner g: FoldFn => FoldCombiner.
fold-identity-bearing c: FoldCombiner => Bool.
fold-supported g: FoldFn => Bool.
no-identity-reduce g: FoldFn => Bool.
---
all s: LoopShape | supported-shape s = cond
  s = guarded-push => true,
  s = const-then-push => true,
  s = compound-guard-push => true,
  true => false.
all f: ForOfFn | supported f <-> supported-shape (shape f).
all f: ForOfFn, supported f, builder-kind f = list
  | list-result f = (each n in (src f), guard f n | proj f n).
all f: ForOfFn, supported f, builder-kind f = set, e: Elem
  | e in (set-result f) <-> (some n in (src f), guard f n | e = proj f n).
all c: FoldCombiner | fold-identity-bearing c = cond
  c = fadd => true,
  c = fmul => true,
  c = fand => true,
  c = for => true,
  true => false.
all g: FoldFn, fold-supported g | fold-identity-bearing (fold-combiner g).
all g: FoldFn, no-identity-reduce g | ~(fold-supported g).
```

## Patch Specification

```
module ITERATION_BUILDER_COMPLETENESS_PATCH_2.

ForOfFn.
Elem.
Source = [Elem].
src f: ForOfFn => Source.
proj f: ForOfFn, n: Elem => Elem.
guard f: ForOfFn, n: Elem => Bool.
list-result f: ForOfFn => [Elem].

LoopShape.
shape f: ForOfFn => LoopShape.
supported-shape s: LoopShape => Bool.
guarded-push => LoopShape.
const-then-push => LoopShape.
compound-guard-push => LoopShape.
early-exit => LoopShape.
nested-loop => LoopShape.
scalar-fold => LoopShape.
aliased => LoopShape.
list-supported f: ForOfFn => Bool.
---
all s: LoopShape | supported-shape s = cond
  s = guarded-push => true,
  s = const-then-push => true,
  s = compound-guard-push => true,
  true => false.
all f: ForOfFn | list-supported f <-> supported-shape (shape f).
all f: ForOfFn, list-supported f | list-result f = (each n in (src f), guard f n | proj f n).
```


## Implementation Notes

- Loop-local consts are lowered only after the for-of binder has been added to `paramNames`, then each const gets a `freshHygienicBinder` name and is inlined into the final guard/projection IR with `substituteIR1ExprSubtree`. This keeps the emitted `ir1Each` target unchanged and avoids adding local rule declarations for loop-body temporaries.
- `recognizeForOfPushBody` now returns the matched push plus `localBindings`; it remains an AST-shape recognizer only. Purity, TDZ, accumulator-reference, static-bool, and L1-buildability checks all happen in `recognizeForOfPush`, where the full `L1BuildContext` is available.
- Compound `&&` guards are flattened syntactically before lowering, and nested `if` guards are prepended as the recursion unwinds, so emitted guard order follows source order. The existing `if (!P) continue; push(...)` form is preserved and also benefits from `&&` flattening.
- I added conservative accumulator read rejection for the projection and guards as well as loop-local const initializers. That is slightly stricter than the minimum Patch 2 prose for consts, but matches the alias/escape boundary and prevents comprehensions from depending on the mutable local builder value.
- Dependent Patch 3 can reuse the widened body recognizer, but note that `RecognizedPushBody` is still push-specific (`projExpr`) and `recognizePushStatement` now omits both `guardExprs` and `localBindings` from its return type. Set-builder support will likely want a parallel recognized body type or a shared terminal-write abstraction rather than overloading the push-only names.

Spec/Evidence Mapping:
- `guarded-push`, `const-then-push`, and `compound-guard-push` are supported by `recognizeForOfPushBody` plus `lowerForOfLoopLocalConstBindings` in `tools/ts2pant/src/translate-body.ts`; proved by `listConstProjection`, `listCompoundGuard`, and `listNestedGuard` in `tools/ts2pant/tests/iteration-builder.test.mts`.
- Unsupported `early-exit`, `nested-loop`, and `aliased` shapes still return `null` from the recognizer/extraction path and surface unsupported diagnostics; covered by the unskipped `listEarlyReturnInLoopRejected`, `listBreakRejected`, `listNestedLoopRejected`, and `listAccumulatorAliasRejected` tests.
- The list-result equation remains the existing `ir1Each(binder, src, guards, proj)` path through `tryBuildForOfComprehensionReturn` and `lowerL1ToOpaque`; existing for-of comprehension tests stayed passing, including byte-stability-sensitive direct/filtered/continue forms.
- Context consulted before implementation: `workstreams/ts2pant-body-completeness.md`, `tools/ts2pant/src/translate-body.ts`, `tools/ts2pant/src/ir1.ts`, `tools/ts2pant/src/pant-ast.ts`, `tools/ts2pant/src/types.ts`, and the ts2pant test harness files named in the patch prompt.
- Verification run: focused `tests/iteration-builder.test.mts`, `git diff --check`, `just ts2pant-test-unit`, and `just ts2pant-test-integration`.