### PR TITLE
[ts2pant-iteration-builder-completeness] Patch 3: Lower for-of Set builders to membership equivalence

### DIFF
--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -3051,13 +3051,6 @@ interface RecognizedPushBody {
   }>;
 }
 
-function recognizeForOfPushBody(
-  stmt: ts.Statement,
-  accNames: ReadonlySet<string>,
-): RecognizedPushBody | null {
-  return recognizeForOfWriteBody(stmt, accNames, recognizePushStatement);
-}
-
 function recognizeForOfWriteBody(
   stmt: ts.Statement,
   accNames: ReadonlySet<string>,
@@ -3435,7 +3428,8 @@ function describeForOfCollectionBuilderRejection(
         const receiver = callee.expression.text;
         const method = callee.name.text;
         if (mapNames.has(receiver)) {
-          reason = "Map builder construction is not supported in this milestone";
+          reason =
+            "Map builder construction is not supported in this milestone";
           return;
         }
         if (setNames.has(receiver) && method !== "add") {

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -2058,7 +2058,8 @@ function tryBuildForOfComprehensionReturn(
     )
   ) {
     return {
-      error: "for-of Set builder may not read the accumulator inside the loop",
+      error:
+        "for-of build-list comprehension may not read the accumulator inside the loop",
     };
   }
   const otherBindings = extracted.bindings.filter(
@@ -3505,6 +3506,11 @@ function describeForOfCollectionBuilderRejection(
         if (mapNames.has(receiver)) {
           reason =
             "Map builder construction is not supported in this milestone";
+          return;
+        }
+        if (setAliases.has(receiver)) {
+          reason =
+            "collection builder accumulator alias or escape is not supported";
           return;
         }
         if (setNames.has(receiver) && method !== "add") {

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -228,6 +228,7 @@ type PreludeStmt =
     }
   | { kind: "muSearch"; tsName: string; mu: MuSearch; localName?: string }
   | ({ kind: "forOf" } & RecognizedForOfPush)
+  | ({ kind: "forOfSet" } & RecognizedForOfSetAdd)
   | { kind: "builderPush"; accName: string; valueExpr: ts.Expression }
   | { kind: "builderSetAdd"; accName: string; valueExpr: ts.Expression }
   | { kind: "reassign"; tsName: string; valueExpr: ts.Expression }
@@ -241,6 +242,14 @@ type PreludeStmt =
     };
 
 export interface RecognizedForOfPush {
+  binder: string;
+  src: IR1Expr;
+  proj: IR1Expr;
+  guards: IR1Expr[];
+  accName: string;
+}
+
+export interface RecognizedForOfSetAdd {
   binder: string;
   src: IR1Expr;
   proj: IR1Expr;
@@ -1300,6 +1309,74 @@ function translatePureBody(
     ];
   }
 
+  const forOfSetComprehension = tryBuildForOfSetComprehensionReturn(
+    node,
+    extracted,
+    checker,
+    strategy,
+    paramNames,
+    supply,
+    env,
+  );
+  if (forOfSetComprehension !== null) {
+    if ("error" in forOfSetComprehension) {
+      return [
+        {
+          kind: "unsupported",
+          reason: `${functionName} — ${forOfSetComprehension.error}`,
+        },
+      ];
+    }
+    if (forOfSetComprehension.diagnostics.length > 0) {
+      return forOfSetComprehension.diagnostics;
+    }
+    const argExprs = params.map((p) => ast.var(p.name));
+    const resultApp = ast.app(ast.var(functionName), argExprs);
+    const binder = allocSetMembershipBinder(supply, params, {
+      prelude: forOfSetComprehension.prelude,
+      added: [
+        forOfSetComprehension.forOf.src,
+        ...forOfSetComprehension.forOf.guards,
+        forOfSetComprehension.forOf.proj,
+      ],
+      extraUsedNames: [forOfSetComprehension.forOf.binder],
+    });
+    const binderVar = ast.var(binder);
+    const memberExpr = ast.binop(ast.opIn(), binderVar, resultApp);
+    const someBody = ast.binop(
+      ast.opEq(),
+      binderVar,
+      applyOpaqueAliases(
+        lowerL1ToOpaque(forOfSetComprehension.forOf.proj),
+        supply,
+      ),
+    );
+    const someExpr = ast.exists(
+      [],
+      [
+        ast.gIn(
+          forOfSetComprehension.forOf.binder,
+          lowerL1ToOpaque(forOfSetComprehension.forOf.src),
+        ),
+        ...forOfSetComprehension.forOf.guards.map((guard) =>
+          ast.gExpr(lowerL1ToOpaque(guard)),
+        ),
+      ],
+      someBody,
+    );
+    return [
+      ...forOfSetComprehension.prelude.ruleDecls,
+      ...forOfSetComprehension.loweredLets.propositions,
+      {
+        kind: "assertion",
+        quantifiers: [
+          ast.param(binder, ast.tName(forOfSetComprehension.elemType)),
+        ] as OpaqueParam[],
+        body: ast.binop(ast.opIff(), memberExpr, someExpr),
+      },
+    ];
+  }
+
   const localListBuilder = tryBuildLocalListBuilderReturn(
     extracted,
     checker,
@@ -1882,6 +1959,14 @@ interface LocalSetBuilderResult {
   diagnostics: PropResult[];
 }
 
+interface ForOfSetBuilderResult {
+  elemType: string;
+  forOf: RecognizedForOfSetAdd;
+  prelude: LoweredPreludeBindings;
+  loweredLets: IR1SsaBodyLowerResult;
+  diagnostics: PropResult[];
+}
+
 function tryBuildForOfComprehensionReturn(
   extracted: ExtractedBody,
   checker: ts.TypeChecker,
@@ -1992,6 +2077,130 @@ function tryBuildForOfComprehensionReturn(
     prelude,
     loweredLets,
     each: ir1Each(forOf.binder, forOf.src, forOf.guards, forOf.proj),
+  };
+}
+
+function tryBuildForOfSetComprehensionReturn(
+  node: ts.FunctionDeclaration | ts.MethodDeclaration,
+  extracted: ExtractedBody,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  paramNames: ReadonlyMap<string, string>,
+  supply: UniqueSupply,
+  env: AssumptionEnv,
+): ForOfSetBuilderResult | { error: string } | null {
+  if (!ts.isExpression(extracted.returnExpr)) {
+    return null;
+  }
+  const returnedExpr = unwrapExpression(extracted.returnExpr);
+  if (!ts.isIdentifier(returnedExpr)) {
+    return null;
+  }
+  const accName = returnedExpr.text;
+  const forOfBindings = extracted.bindings.filter(
+    (binding): binding is Extract<PreludeStmt, { kind: "forOfSet" }> =>
+      binding.kind === "forOfSet" && binding.accName === accName,
+  );
+  if (forOfBindings.length === 0) {
+    return null;
+  }
+  if (forOfBindings.length !== 1) {
+    return { error: "for-of Set builder must have one loop" };
+  }
+
+  const accDecls = extracted.bindings.filter(
+    (binding): binding is Extract<PreludeStmt, { kind: "const" }> =>
+      binding.kind === "const" &&
+      binding.tsName === accName &&
+      isEmptySetConstructor(binding.initializer),
+  );
+  if (accDecls.length !== 1) {
+    return {
+      error: "for-of Set builder must return its empty Set accumulator",
+    };
+  }
+  if (guardStatementsReadName(extracted.guardStmts, accName)) {
+    return {
+      error: "for-of Set builder guard may not read the accumulator",
+    };
+  }
+  if (
+    extracted.bindings.some(
+      (binding) =>
+        (binding.kind === "reassign" && binding.tsName === accName) ||
+        (binding.kind === "stmt" && nodeWritesName(binding.stmt, accName)),
+    )
+  ) {
+    return {
+      error: "for-of Set builder accumulator has unsupported writes",
+    };
+  }
+
+  const sig = checker.getSignatureFromDeclaration(node);
+  const returnType =
+    sig === undefined
+      ? checker.getTypeAtLocation(returnedExpr)
+      : checker.getReturnTypeOfSignature(sig);
+  const elemType = setElementSort(
+    returnType,
+    checker,
+    strategy,
+    supply.synthCell,
+  );
+  if (elemType === null) {
+    return {
+      error:
+        "for-of Set builder return type must be Set<T> or ReadonlySet<T> with a supported element type",
+    };
+  }
+
+  const forOf = forOfBindings[0]!;
+  const otherBindings = extracted.bindings.filter(
+    (binding) => binding !== forOf && binding !== accDecls[0],
+  );
+  const prelude = lowerPreludeBindings(
+    otherBindings,
+    checker,
+    strategy,
+    paramNames,
+    supply,
+    env,
+    undefined,
+  );
+  if ("error" in prelude) {
+    return prelude;
+  }
+  if (prelude.arms.length > 0) {
+    return {
+      error: "for-of Set builder with early returns is not supported",
+    };
+  }
+  const loweredLets =
+    prelude.letStmts.length === 0
+      ? ir1SsaBodyLowerSuccess()
+      : lowerL1BodyToSsaProps(
+          ir1Block(prelude.letStmts as [IR1Stmt, ...IR1Stmt[]]),
+          [],
+          {
+            applyConst: (e) => applyOpaqueAliases(e, supply),
+          },
+        );
+  if (loweredLets.diagnostics.length > 0) {
+    const first = loweredLets.diagnostics[0];
+    return {
+      error:
+        first?.kind === "unsupported"
+          ? first.reason
+          : "for-of Set builder prelude did not lower",
+    };
+  }
+
+  return {
+    elemType,
+    forOf,
+    prelude,
+    loweredLets,
+    diagnostics: loweredLets.diagnostics,
   };
 }
 
@@ -2315,10 +2524,17 @@ function tryBuildLocalSetBuilderReturn(
 function allocSetMembershipBinder(
   supply: UniqueSupply,
   params: Array<{ name: string; type: string }>,
-  builder: LocalSetBuilderResult,
+  builder: {
+    prelude: LoweredPreludeBindings;
+    added: IR1Expr[];
+    extraUsedNames?: readonly string[];
+  },
 ): string {
   const usedNames = new Set<string>(params.map((p) => p.name));
   for (const name of builder.prelude.scopedParams.values()) {
+    usedNames.add(name);
+  }
+  for (const name of builder.extraUsedNames ?? []) {
     usedNames.add(name);
   }
   for (const expr of builder.added) {
@@ -2618,6 +2834,36 @@ export function recognizeForOfPush(
   accNames: ReadonlySet<string>,
   ctx: L1BuildContext,
 ): RecognizedForOfPush | null {
+  return recognizeForOfAccumulatorWrite(
+    stmt,
+    accNames,
+    ctx,
+    recognizePushStatement,
+  );
+}
+
+export function recognizeForOfSetAdd(
+  stmt: ts.ForOfStatement,
+  accNames: ReadonlySet<string>,
+  ctx: L1BuildContext,
+): RecognizedForOfSetAdd | null {
+  return recognizeForOfAccumulatorWrite(
+    stmt,
+    accNames,
+    ctx,
+    recognizeSetAddStatement,
+  );
+}
+
+function recognizeForOfAccumulatorWrite(
+  stmt: ts.ForOfStatement,
+  accNames: ReadonlySet<string>,
+  ctx: L1BuildContext,
+  recognizeWrite: (
+    stmt: ts.Statement,
+    accNames: ReadonlySet<string>,
+  ) => { accName: string; valueExpr: ts.Expression } | null,
+): RecognizedForOfPush | null {
   const init = stmt.initializer;
   if (
     !ts.isVariableDeclarationList(init) ||
@@ -2646,7 +2892,11 @@ export function recognizeForOfPush(
     return null;
   }
 
-  const push = recognizeForOfPushBody(stmt.statement, accNames);
+  const push = recognizeForOfWriteBody(
+    stmt.statement,
+    accNames,
+    recognizeWrite,
+  );
   if (push === null) {
     return null;
   }
@@ -2658,14 +2908,14 @@ export function recognizeForOfPush(
   if (localBindings === null) {
     return null;
   }
-  if (expressionHasSideEffects(push.projExpr, ctx.checker)) {
+  if (expressionHasSideEffects(push.valueExpr, ctx.checker)) {
     return null;
   }
   const accNameSet = new Set(accNames);
-  if (expressionReferencesNames(push.projExpr, accNameSet)) {
+  if (expressionReferencesNames(push.valueExpr, accNameSet)) {
     return null;
   }
-  const proj = buildPureL1OrNull(push.projExpr, localBindings.scopedCtx);
+  const proj = buildPureL1OrNull(push.valueExpr, localBindings.scopedCtx);
   if (proj === null) {
     return null;
   }
@@ -2793,7 +3043,7 @@ function buildPureL1OrNull(
 
 interface RecognizedPushBody {
   accName: string;
-  projExpr: ts.Expression;
+  valueExpr: ts.Expression;
   guardExprs: ts.Expression[];
   localBindings: Array<{
     tsName: string;
@@ -2804,6 +3054,17 @@ interface RecognizedPushBody {
 function recognizeForOfPushBody(
   stmt: ts.Statement,
   accNames: ReadonlySet<string>,
+): RecognizedPushBody | null {
+  return recognizeForOfWriteBody(stmt, accNames, recognizePushStatement);
+}
+
+function recognizeForOfWriteBody(
+  stmt: ts.Statement,
+  accNames: ReadonlySet<string>,
+  recognizeWrite: (
+    stmt: ts.Statement,
+    accNames: ReadonlySet<string>,
+  ) => { accName: string; valueExpr: ts.Expression } | null,
 ): RecognizedPushBody | null {
   if (ts.isBlock(stmt)) {
     const localBindings: RecognizedPushBody["localBindings"] = [];
@@ -2836,7 +3097,11 @@ function recognizeForOfPushBody(
 
     const remaining = stmt.statements.slice(idx);
     if (remaining.length === 1) {
-      const body = recognizeForOfPushBody(remaining[0]!, accNames);
+      const body = recognizeForOfWriteBody(
+        remaining[0]!,
+        accNames,
+        recognizeWrite,
+      );
       return body === null
         ? null
         : {
@@ -2851,7 +3116,7 @@ function recognizeForOfPushBody(
     if (guard === null) {
       return null;
     }
-    const push = recognizePushStatement(remaining[1]!, accNames);
+    const push = recognizeWrite(remaining[1]!, accNames);
     if (push === null) {
       return null;
     }
@@ -2867,7 +3132,7 @@ function recognizeForOfPushBody(
     return null;
   }
 
-  const direct = recognizePushStatement(bodyStmt, accNames);
+  const direct = recognizeWrite(bodyStmt, accNames);
   if (direct !== null) {
     return { ...direct, guardExprs: [], localBindings: [] };
   }
@@ -2876,9 +3141,10 @@ function recognizeForOfPushBody(
     if (bodyStmt.elseStatement !== undefined) {
       return null;
     }
-    const guardedPush = recognizeForOfPushBody(
+    const guardedPush = recognizeForOfWriteBody(
       bodyStmt.thenStatement,
       accNames,
+      recognizeWrite,
     );
     if (guardedPush === null) {
       return null;
@@ -2919,7 +3185,7 @@ function unwrapSingleStatementBlock(stmt: ts.Statement): ts.Statement | null {
 function recognizePushStatement(
   stmt: ts.Statement,
   accNames: ReadonlySet<string>,
-): Omit<RecognizedPushBody, "guardExprs" | "localBindings"> | null {
+): { accName: string; valueExpr: ts.Expression } | null {
   if (!ts.isExpressionStatement(stmt)) {
     return null;
   }
@@ -2937,7 +3203,7 @@ function recognizePushStatement(
   if (!accNames.has(accName)) {
     return null;
   }
-  return { accName, projExpr: expr.arguments[0]! };
+  return { accName, valueExpr: expr.arguments[0]! };
 }
 
 function recognizeSetAddStatement(
@@ -3065,7 +3331,9 @@ function describeLocalMapBuilderBodyRejection(
     return null;
   }
 
+  const setAccNames = new Set<string>();
   const mapAccNames = new Set<string>();
+  const setAliases = new Set<string>();
   const aliases = new Set<string>();
   const last = stmts[stmts.length - 1]!;
   const scanStmts = ts.isReturnStatement(last) ? stmts.slice(0, -1) : stmts;
@@ -3079,13 +3347,32 @@ function describeLocalMapBuilderBodyRejection(
         if (binding.kind !== "const") {
           continue;
         }
-        if (isMapConstructor(binding.initializer)) {
+        if (isEmptySetConstructor(binding.initializer)) {
+          setAccNames.add(binding.tsName);
+        } else if (isMapConstructor(binding.initializer)) {
           mapAccNames.add(binding.tsName);
+        } else if (
+          expressionReferencesNames(binding.initializer, setAccNames)
+        ) {
+          setAliases.add(binding.tsName);
         } else if (
           expressionReferencesNames(binding.initializer, mapAccNames)
         ) {
           aliases.add(binding.tsName);
         }
+      }
+      continue;
+    }
+    if (ts.isForOfStatement(stmt)) {
+      const rejection = describeForOfCollectionBuilderRejection(
+        stmt,
+        setAccNames,
+        setAliases,
+        mapAccNames,
+        aliases,
+      );
+      if (rejection !== null) {
+        return rejection;
       }
       continue;
     }
@@ -3100,6 +3387,75 @@ function describeLocalMapBuilderBodyRejection(
     if (rejection !== null) {
       return rejection;
     }
+  }
+  return null;
+}
+
+function describeForOfCollectionBuilderRejection(
+  stmt: ts.ForOfStatement,
+  setAccNames: ReadonlySet<string>,
+  setAliases: ReadonlySet<string>,
+  mapAccNames: ReadonlySet<string>,
+  mapAliases: ReadonlySet<string>,
+): string | null {
+  const setNames = new Set([...setAccNames, ...setAliases]);
+  const mapNames = new Set([...mapAccNames, ...mapAliases]);
+  let reason: string | null = null;
+
+  const visit = (node: ts.Node): void => {
+    if (reason !== null) {
+      return;
+    }
+    if (
+      ts.isArrowFunction(node) ||
+      ts.isFunctionExpression(node) ||
+      ts.isFunctionDeclaration(node) ||
+      ts.isMethodDeclaration(node) ||
+      ts.isGetAccessorDeclaration(node) ||
+      ts.isSetAccessorDeclaration(node)
+    ) {
+      return;
+    }
+    if (ts.isCallExpression(node)) {
+      for (const arg of node.arguments) {
+        if (
+          expressionReferencesNames(arg, setNames) ||
+          expressionReferencesNames(arg, mapNames)
+        ) {
+          reason =
+            "collection builder accumulator alias or escape is not supported";
+          return;
+        }
+      }
+      const callee = node.expression;
+      if (
+        ts.isPropertyAccessExpression(callee) &&
+        ts.isIdentifier(callee.expression)
+      ) {
+        const receiver = callee.expression.text;
+        const method = callee.name.text;
+        if (mapNames.has(receiver)) {
+          reason = "Map builder construction is not supported in this milestone";
+          return;
+        }
+        if (setNames.has(receiver) && method !== "add") {
+          reason = `Set builder mutation .${method} is not supported`;
+          return;
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(stmt.statement);
+  if (reason !== null) {
+    return reason;
+  }
+  if (nodeReferencesNames(stmt.statement, setNames)) {
+    return "Set builder may not read the accumulator inside the loop";
+  }
+  if (nodeReferencesNames(stmt.statement, mapNames)) {
+    return "Map builder construction is not supported in this milestone";
   }
   return null;
 }
@@ -3193,7 +3549,7 @@ function extractReturnExpression(
         bindings.push({
           kind: "builderPush",
           accName: push.accName,
-          valueExpr: push.projExpr,
+          valueExpr: push.valueExpr,
         });
         i += 1;
         lastLetDeclNames = new Set();
@@ -3224,10 +3580,20 @@ function extractReturnExpression(
         ...ctx,
         paramNames: scopedParams,
       });
-      if (recognized === null) {
+      if (recognized !== null) {
+        bindings.push({ kind: "forOf", ...recognized });
+        i += 1;
+        lastLetDeclNames = new Set();
+        continue;
+      }
+      const setRecognized = recognizeForOfSetAdd(stmt, emptySetAccNames, {
+        ...ctx,
+        paramNames: scopedParams,
+      });
+      if (setRecognized === null) {
         return null;
       }
-      bindings.push({ kind: "forOf", ...recognized });
+      bindings.push({ kind: "forOfSet", ...setRecognized });
       i += 1;
       lastLetDeclNames = new Set();
       continue;
@@ -3474,6 +3840,16 @@ function describeRejectedBody(body: ts.Block, checker: ts.TypeChecker): string {
         continue;
       }
       if (ts.isForOfStatement(stmt)) {
+        const collectionRejection = describeForOfCollectionBuilderRejection(
+          stmt,
+          emptySetAccNames,
+          setBuilderAliases,
+          emptyMapAccNames,
+          mapBuilderAliases,
+        );
+        if (collectionRejection !== null) {
+          return collectionRejection;
+        }
         return "for-of loop is not a recognized build-list comprehension";
       }
       // An if-shaped statement that didn't match recognizeEarlyReturnArm:
@@ -4258,6 +4634,13 @@ function lowerPreludeBindings(
             "for-of loop is only supported as a build-list comprehension returned directly",
         };
       }
+      if (binding.kind === "forOfSet") {
+        return {
+          tag: "error",
+          error:
+            "for-of Set builder is only supported when returning its accumulator directly",
+        };
+      }
       if (binding.kind === "builderPush") {
         return {
           tag: "error",
@@ -4415,7 +4798,7 @@ function validatePreludeBindings(
       if (expressionReferencesNames(binding.mu.predicateTsExpr, predBlocked)) {
         return { error: "while-loop predicate references a later binding" };
       }
-    } else if (binding.kind === "forOf") {
+    } else if (binding.kind === "forOf" || binding.kind === "forOfSet") {
     } else if (binding.kind === "builderPush") {
       if (expressionReferencesNames(binding.valueExpr, blockedNames)) {
         return { error: "list builder push references a later binding" };
@@ -4630,6 +5013,7 @@ export function lowerNestedPureBlockReturnToL1(
   for (const binding of extracted.bindings) {
     if (
       binding.kind === "forOf" ||
+      binding.kind === "forOfSet" ||
       binding.kind === "builderPush" ||
       binding.kind === "builderSetAdd" ||
       binding.kind === "reassign" ||

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -1343,24 +1343,34 @@ function translatePureBody(
     });
     const binderVar = ast.var(binder);
     const memberExpr = ast.binop(ast.opIn(), binderVar, resultApp);
+    const someBinder = allocForOfSomeBinder(supply, params, {
+      prelude: forOfSetComprehension.prelude,
+      forOf: forOfSetComprehension.forOf,
+      extraUsedNames: [binder],
+    });
+    const someBinderVar = ir1Var(someBinder);
+    const someProj = substituteIR1ExprSubtree(
+      forOfSetComprehension.forOf.proj,
+      ir1Var(forOfSetComprehension.forOf.binder),
+      someBinderVar,
+    );
+    const someGuards = forOfSetComprehension.forOf.guards.map((guard) =>
+      substituteIR1ExprSubtree(
+        guard,
+        ir1Var(forOfSetComprehension.forOf.binder),
+        someBinderVar,
+      ),
+    );
     const someBody = ast.binop(
       ast.opEq(),
       binderVar,
-      applyOpaqueAliases(
-        lowerL1ToOpaque(forOfSetComprehension.forOf.proj),
-        supply,
-      ),
+      applyOpaqueAliases(lowerL1ToOpaque(someProj), supply),
     );
     const someExpr = ast.exists(
       [],
       [
-        ast.gIn(
-          forOfSetComprehension.forOf.binder,
-          lowerL1ToOpaque(forOfSetComprehension.forOf.src),
-        ),
-        ...forOfSetComprehension.forOf.guards.map((guard) =>
-          ast.gExpr(lowerL1ToOpaque(guard)),
-        ),
+        ast.gIn(someBinder, lowerL1ToOpaque(forOfSetComprehension.forOf.src)),
+        ...someGuards.map((guard) => ast.gExpr(lowerL1ToOpaque(guard))),
       ],
       someBody,
     );
@@ -2154,10 +2164,24 @@ function tryBuildForOfSetComprehensionReturn(
     };
   }
 
+  const validation = validatePreludeBindings(extracted.bindings, checker);
+  if (validation !== null) {
+    return validation;
+  }
+
   const forOf = forOfBindings[0]!;
   const otherBindings = extracted.bindings.filter(
     (binding) => binding !== forOf && binding !== accDecls[0],
   );
+  if (
+    otherBindings.some((binding) =>
+      preludeBindingReferencesTsName(binding, accName),
+    )
+  ) {
+    return {
+      error: "for-of Set builder accumulator alias or escape is not supported",
+    };
+  }
   const prelude = lowerPreludeBindings(
     otherBindings,
     checker,
@@ -2546,6 +2570,39 @@ function allocSetMembershipBinder(
   let binder = allocComprehensionBinder(supply, "x");
   while (usedNames.has(binder)) {
     binder = allocComprehensionBinder(supply, "x");
+  }
+  return binder;
+}
+
+function allocForOfSomeBinder(
+  supply: UniqueSupply,
+  params: Array<{ name: string; type: string }>,
+  builder: {
+    prelude: LoweredPreludeBindings;
+    forOf: RecognizedForOfSetAdd;
+    extraUsedNames?: readonly string[];
+  },
+): string {
+  const usedNames = new Set<string>(params.map((p) => p.name));
+  for (const name of builder.prelude.scopedParams.values()) {
+    usedNames.add(name);
+  }
+  for (const name of builder.extraUsedNames ?? []) {
+    usedNames.add(name);
+  }
+  for (const expr of [
+    builder.forOf.src,
+    ...builder.forOf.guards,
+    builder.forOf.proj,
+  ]) {
+    for (const name of freeVarsIR1Expr(expr)) {
+      usedNames.add(name);
+    }
+  }
+
+  let binder = allocComprehensionBinder(supply, "n");
+  while (usedNames.has(binder)) {
+    binder = allocComprehensionBinder(supply, "n");
   }
   return binder;
 }
@@ -3409,6 +3466,16 @@ function describeForOfCollectionBuilderRejection(
     ) {
       return;
     }
+    if (ts.isIdentifier(node)) {
+      if (setNames.has(node.text) && !isAllowedSetAddReceiver(node)) {
+        reason = "Set builder may not read the accumulator inside the loop";
+        return;
+      }
+      if (mapNames.has(node.text)) {
+        reason = "Map builder construction is not supported in this milestone";
+        return;
+      }
+    }
     if (ts.isCallExpression(node)) {
       for (const arg of node.arguments) {
         if (
@@ -3445,13 +3512,25 @@ function describeForOfCollectionBuilderRejection(
   if (reason !== null) {
     return reason;
   }
-  if (nodeReferencesNames(stmt.statement, setNames)) {
-    return "Set builder may not read the accumulator inside the loop";
-  }
-  if (nodeReferencesNames(stmt.statement, mapNames)) {
-    return "Map builder construction is not supported in this milestone";
-  }
   return null;
+}
+
+function isAllowedSetAddReceiver(node: ts.Identifier): boolean {
+  const parent = node.parent;
+  if (
+    parent === undefined ||
+    !ts.isPropertyAccessExpression(parent) ||
+    parent.expression !== node ||
+    parent.name.text !== "add"
+  ) {
+    return false;
+  }
+  const grandparent = parent.parent;
+  return (
+    grandparent !== undefined &&
+    ts.isCallExpression(grandparent) &&
+    grandparent.expression === parent
+  );
 }
 
 function recognizeIfContinue(stmt: ts.Statement): ts.Expression | null {
@@ -3804,6 +3883,54 @@ function guardStatementsReadName(
 ): boolean {
   const names = new Set([name]);
   return guardStmts.some((stmt) => nodeReferencesNames(stmt, names));
+}
+
+function preludeBindingReferencesTsName(
+  binding: PreludeStmt,
+  name: string,
+): boolean {
+  const names = new Set([name]);
+  switch (binding.kind) {
+    case "const":
+      return expressionReferencesNames(binding.initializer, names);
+    case "muSearch":
+      return (
+        expressionReferencesNames(binding.mu.initTsExpr, names) ||
+        expressionReferencesNames(binding.mu.predicateTsExpr, names) ||
+        expressionReferencesNames(binding.mu.stepExpr, names)
+      );
+    case "forOf":
+    case "forOfSet":
+      return binding.accName === name;
+    case "builderPush":
+    case "builderSetAdd":
+      return (
+        binding.accName === name ||
+        expressionReferencesNames(binding.valueExpr, names)
+      );
+    case "reassign":
+      return (
+        binding.tsName === name ||
+        expressionReferencesNames(binding.valueExpr, names)
+      );
+    case "stmt":
+      return nodeReferencesNames(binding.stmt, names);
+    case "earlyReturn":
+      return (
+        expressionReferencesNames(binding.predicateExpr, names) ||
+        (binding.valueExpr !== undefined &&
+          expressionReferencesNames(binding.valueExpr, names)) ||
+        binding.blockBindings.some((blockBinding) =>
+          expressionReferencesNames(blockBinding.initializer, names),
+        ) ||
+        (binding.nestedBlock !== undefined &&
+          nodeReferencesNames(binding.nestedBlock, names))
+      );
+    default: {
+      const _exhaustive: never = binding;
+      return _exhaustive;
+    }
+  }
 }
 
 function describeRejectedBody(body: ts.Block, checker: ts.TypeChecker): string {
@@ -4793,6 +4920,14 @@ function validatePreludeBindings(
         return { error: "while-loop predicate references a later binding" };
       }
     } else if (binding.kind === "forOf" || binding.kind === "forOfSet") {
+      const blockedIr1Names = blockedNamesForIR1(bindings.slice(idx + 1));
+      if (
+        [binding.src, binding.proj, ...binding.guards].some((expr) =>
+          ir1ExprReferencesAnyName(expr, blockedIr1Names),
+        )
+      ) {
+        return { error: "for-of loop references a later binding" };
+      }
     } else if (binding.kind === "builderPush") {
       if (expressionReferencesNames(binding.valueExpr, blockedNames)) {
         return { error: "list builder push references a later binding" };
@@ -4859,6 +4994,35 @@ function validatePreludeBindings(
     }
   }
   return null;
+}
+
+function blockedNamesForIR1(bindings: readonly PreludeStmt[]): Set<string> {
+  const names = new Set<string>();
+  for (const binding of bindings) {
+    if (binding.kind === "const" || binding.kind === "muSearch") {
+      names.add(binding.tsName);
+      names.add(toPantTermName(binding.tsName));
+      if (binding.localName !== undefined) {
+        names.add(binding.localName);
+      }
+    }
+  }
+  return names;
+}
+
+function ir1ExprReferencesAnyName(
+  expr: IR1Expr,
+  names: ReadonlySet<string>,
+): boolean {
+  if (names.size === 0) {
+    return false;
+  }
+  for (const name of freeVarsIR1Expr(expr)) {
+    if (names.has(name)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 type BindingInitResult = { value: OpaqueExpr } | { error: string };

--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -1369,8 +1369,16 @@ function translatePureBody(
     const someExpr = ast.exists(
       [],
       [
-        ast.gIn(someBinder, lowerL1ToOpaque(forOfSetComprehension.forOf.src)),
-        ...someGuards.map((guard) => ast.gExpr(lowerL1ToOpaque(guard))),
+        ast.gIn(
+          someBinder,
+          applyOpaqueAliases(
+            lowerL1ToOpaque(forOfSetComprehension.forOf.src),
+            supply,
+          ),
+        ),
+        ...someGuards.map((guard) =>
+          ast.gExpr(applyOpaqueAliases(lowerL1ToOpaque(guard), supply)),
+        ),
       ],
       someBody,
     );
@@ -2043,6 +2051,16 @@ function tryBuildForOfComprehensionReturn(
   }
 
   const forOf = forOfBindings[0]!;
+  const accIr1Names = blockedNamesForIR1(accDecls);
+  if (
+    [forOf.src, forOf.proj, ...forOf.guards].some((expr) =>
+      ir1ExprReferencesAnyName(expr, accIr1Names),
+    )
+  ) {
+    return {
+      error: "for-of Set builder may not read the accumulator inside the loop",
+    };
+  }
   const otherBindings = extracted.bindings.filter(
     (binding) => binding !== forOf && binding !== accDecls[0],
   );
@@ -3477,16 +3495,6 @@ function describeForOfCollectionBuilderRejection(
       }
     }
     if (ts.isCallExpression(node)) {
-      for (const arg of node.arguments) {
-        if (
-          expressionReferencesNames(arg, setNames) ||
-          expressionReferencesNames(arg, mapNames)
-        ) {
-          reason =
-            "collection builder accumulator alias or escape is not supported";
-          return;
-        }
-      }
       const callee = node.expression;
       if (
         ts.isPropertyAccessExpression(callee) &&
@@ -3501,6 +3509,23 @@ function describeForOfCollectionBuilderRejection(
         }
         if (setNames.has(receiver) && method !== "add") {
           reason = `Set builder mutation .${method} is not supported`;
+          return;
+        }
+        if (
+          setNames.has(receiver) &&
+          node.arguments.some((arg) => expressionReferencesNames(arg, setNames))
+        ) {
+          reason = "Set builder may not read the accumulator inside the loop";
+          return;
+        }
+      }
+      for (const arg of node.arguments) {
+        if (
+          expressionReferencesNames(arg, setNames) ||
+          expressionReferencesNames(arg, mapNames)
+        ) {
+          reason =
+            "collection builder accumulator alias or escape is not supported";
           return;
         }
       }

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-iteration-builder.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-iteration-builder.ts
@@ -214,6 +214,34 @@ function setDeleteForOfRejected(items: IterationItem[]): Set<string> {
 }
 
 /**
+ * Out-of-scope control: Set accumulator aliases must not flow into the lowered
+ * prelude around the loop builder.
+ */
+// biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
+function setAccumulatorAliasForOfRejected(items: IterationItem[]): Set<string> {
+  const out = new Set<string>();
+  const alias = out;
+  for (const item of items) {
+    out.add(item.id);
+  }
+  return out;
+}
+
+/**
+ * Out-of-scope control: recognized for-of builder pieces may not reference a
+ * binding declared later in the prelude.
+ */
+// biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
+function setTdzSourceForOfRejected(items: IterationItem[]): Set<string> {
+  const out = new Set<string>();
+  for (const item of laterItems) {
+    out.add(item.id);
+  }
+  const laterItems = items;
+  return out;
+}
+
+/**
  * Out-of-scope scalar fold: null-seeded conjoin has no identity-bearing target
  * in the current scalar fold lowering.
  */

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-iteration-builder.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-iteration-builder.ts
@@ -228,6 +228,19 @@ function setAccumulatorAliasForOfRejected(items: IterationItem[]): Set<string> {
 }
 
 /**
+ * Out-of-scope control: Set builder projections may not read the accumulator
+ * they are defining.
+ */
+// biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
+function setAccumulatorReadForOfRejected(items: IterationItem[]): Set<number> {
+  const out = new Set<number>();
+  for (const _item of items) {
+    out.add(out.size);
+  }
+  return out;
+}
+
+/**
  * Out-of-scope control: recognized for-of builder pieces may not reference a
  * binding declared later in the prelude.
  */

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-iteration-builder.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-iteration-builder.ts
@@ -222,7 +222,7 @@ function setAccumulatorAliasForOfRejected(items: IterationItem[]): Set<string> {
   const out = new Set<string>();
   const alias = out;
   for (const item of items) {
-    out.add(item.id);
+    alias.add(item.id);
   }
   return out;
 }

--- a/tools/ts2pant/tests/integration/iteration-builder.test.mts
+++ b/tools/ts2pant/tests/integration/iteration-builder.test.mts
@@ -42,7 +42,6 @@ describe("iteration builder integration", () => {
   // Patch 3 unskips this Set-builder checker stub.
   it(
     "setAddForOf passes pant --check",
-    { skip: "Patch 3 implements for-of Set add builders" },
     async () => {
       await checkFixture("setAddForOf");
     },

--- a/tools/ts2pant/tests/iteration-builder.test.mts
+++ b/tools/ts2pant/tests/iteration-builder.test.mts
@@ -58,7 +58,6 @@ describe("iteration builder", () => {
   // Patch 3 unskips this Set-builder case.
   it(
     "setAddForOf emits membership equivalence over a some-comprehension",
-    { skip: "Patch 3 implements for-of Set add builders" },
     async () => {
       const output = await emitFixture("setAddForOf");
       assert.match(
@@ -154,7 +153,6 @@ describe("iteration builder", () => {
   // Patch 3 unskips this preserved Map-builder rejection.
   it(
     "mapBuilderForOfRejected remains unsupported",
-    { skip: "Patch 3 verifies Map builder rejection" },
     async () => {
       const output = await emitFixture("mapBuilderForOfRejected");
       assert.match(output, /^> UNSUPPORTED: map-builder-for-of-rejected/mu);
@@ -165,7 +163,6 @@ describe("iteration builder", () => {
   // Patch 3 unskips this preserved Set-builder rejection.
   it(
     "setDeleteForOfRejected remains unsupported",
-    { skip: "Patch 3 verifies Set delete rejection" },
     async () => {
       const output = await emitFixture("setDeleteForOfRejected");
       assert.match(output, /^> UNSUPPORTED: set-delete-for-of-rejected/mu);

--- a/tools/ts2pant/tests/iteration-builder.test.mts
+++ b/tools/ts2pant/tests/iteration-builder.test.mts
@@ -17,178 +17,156 @@ async function emitFixture(functionName: string): Promise<string> {
 
 describe("iteration builder", () => {
   // Patch 2 unskips this list-builder widening case.
-  it(
-    "listConstProjection inlines loop-local const into the comprehension",
-    async () => {
-      const output = await emitFixture("listConstProjection");
-      assert.match(
-        output,
-        /^list-const-projection items = \(each item in items \| iteration-item--label item\)\.$/mu,
-      );
-      assert.doesNotMatch(output, /UNSUPPORTED/u);
-    },
-  );
+  it("listConstProjection inlines loop-local const into the comprehension", async () => {
+    const output = await emitFixture("listConstProjection");
+    assert.match(
+      output,
+      /^list-const-projection items = \(each item in items \| iteration-item--label item\)\.$/mu,
+    );
+    assert.doesNotMatch(output, /UNSUPPORTED/u);
+  });
 
   // Patch 2 unskips this list-builder widening case.
-  it(
-    "listCompoundGuard folds both conjuncts into guards",
-    async () => {
-      const output = await emitFixture("listCompoundGuard");
-      assert.match(
-        output,
-        /^list-compound-guard items = \(each item in items, iteration-item--active item, iteration-item--ready item \| item\)\.$/mu,
-      );
-      assert.doesNotMatch(output, /UNSUPPORTED/u);
-    },
-  );
+  it("listCompoundGuard folds both conjuncts into guards", async () => {
+    const output = await emitFixture("listCompoundGuard");
+    assert.match(
+      output,
+      /^list-compound-guard items = \(each item in items, iteration-item--active item, iteration-item--ready item \| item\)\.$/mu,
+    );
+    assert.doesNotMatch(output, /UNSUPPORTED/u);
+  });
 
   // Patch 2 unskips this list-builder widening case.
-  it(
-    "listNestedGuard folds nested if guards into the comprehension",
-    async () => {
-      const output = await emitFixture("listNestedGuard");
-      assert.match(
-        output,
-        /^list-nested-guard items = \(each item in items, iteration-item--active item, iteration-item--ready item \| iteration-item--id item\)\.$/mu,
-      );
-      assert.doesNotMatch(output, /UNSUPPORTED/u);
-    },
-  );
+  it("listNestedGuard folds nested if guards into the comprehension", async () => {
+    const output = await emitFixture("listNestedGuard");
+    assert.match(
+      output,
+      /^list-nested-guard items = \(each item in items, iteration-item--active item, iteration-item--ready item \| iteration-item--id item\)\.$/mu,
+    );
+    assert.doesNotMatch(output, /UNSUPPORTED/u);
+  });
 
   // Patch 3 unskips this Set-builder case.
-  it(
-    "setAddForOf emits membership equivalence over a some-comprehension",
-    async () => {
-      const output = await emitFixture("setAddForOf");
-      assert.match(
-        output,
-        /x in set-add-for-of items <-> \(some item in items \| x = iteration-item--id item\)/u,
-      );
-      assert.doesNotMatch(output, /UNSUPPORTED/u);
-    },
-  );
+  it("setAddForOf emits membership equivalence over a some-comprehension", async () => {
+    const output = await emitFixture("setAddForOf");
+    assert.match(
+      output,
+      /x in set-add-for-of items <-> \(some n[0-9]* in items \| x = iteration-item--id n[0-9]*\)/u,
+    );
+    assert.doesNotMatch(output, /UNSUPPORTED/u);
+  });
 
   // Patch 4 unskips this scalar-fold case.
-  it(
-    "sumIntFold lowers to init plus a sum comprehension",
-    { skip: "Patch 4 implements additive scalar folds" },
-    async () => {
-      const output = await emitFixture("sumIntFold");
-      assert.match(
-        output,
-        /^sum-int-fold items = \+ over each item in items \| iteration-item--count item\.$/mu,
-      );
-      assert.doesNotMatch(output, /UNSUPPORTED/u);
-    },
-  );
+  it("sumIntFold lowers to init plus a sum comprehension", {
+    skip: "Patch 4 implements additive scalar folds",
+  }, async () => {
+    const output = await emitFixture("sumIntFold");
+    assert.match(
+      output,
+      /^sum-int-fold items = \+ over each item in items \| iteration-item--count item\.$/mu,
+    );
+    assert.doesNotMatch(output, /UNSUPPORTED/u);
+  });
 
   // Patch 4 unskips this scalar-fold case.
-  it(
-    "countGuardedFold folds the guard into the sum comprehension",
-    { skip: "Patch 4 implements guarded count folds" },
-    async () => {
-      const output = await emitFixture("countGuardedFold");
-      assert.match(
-        output,
-        /^count-guarded-fold items = \+ over each item in items, iteration-item--active item \| 1\.$/mu,
-      );
-      assert.doesNotMatch(output, /UNSUPPORTED/u);
-    },
-  );
+  it("countGuardedFold folds the guard into the sum comprehension", {
+    skip: "Patch 4 implements guarded count folds",
+  }, async () => {
+    const output = await emitFixture("countGuardedFold");
+    assert.match(
+      output,
+      /^count-guarded-fold items = \+ over each item in items, iteration-item--active item \| 1\.$/mu,
+    );
+    assert.doesNotMatch(output, /UNSUPPORTED/u);
+  });
 
   // Patch 4 unskips this scalar-fold case.
-  it(
-    "allActiveFold lowers to an and comprehension",
-    { skip: "Patch 4 implements boolean-and scalar folds" },
-    async () => {
-      const output = await emitFixture("allActiveFold");
-      assert.match(
-        output,
-        /^all-active-fold items = and over each item in items \| iteration-item--active item\.$/mu,
-      );
-      assert.doesNotMatch(output, /UNSUPPORTED/u);
-    },
-  );
+  it("allActiveFold lowers to an and comprehension", {
+    skip: "Patch 4 implements boolean-and scalar folds",
+  }, async () => {
+    const output = await emitFixture("allActiveFold");
+    assert.match(
+      output,
+      /^all-active-fold items = and over each item in items \| iteration-item--active item\.$/mu,
+    );
+    assert.doesNotMatch(output, /UNSUPPORTED/u);
+  });
 
   // Patch 2 unskips this preserved list-builder rejection.
-  it(
-    "listEarlyReturnInLoopRejected remains unsupported",
-    async () => {
-      const output = await emitFixture("listEarlyReturnInLoopRejected");
-      assert.match(output, /^> UNSUPPORTED: list-early-return-in-loop-rejected/mu);
-      assert.match(output, /for-of|return|loop/u);
-    },
-  );
+  it("listEarlyReturnInLoopRejected remains unsupported", async () => {
+    const output = await emitFixture("listEarlyReturnInLoopRejected");
+    assert.match(
+      output,
+      /^> UNSUPPORTED: list-early-return-in-loop-rejected/mu,
+    );
+    assert.match(output, /for-of|return|loop/u);
+  });
 
   // Patch 2 unskips this preserved list-builder rejection.
-  it(
-    "listBreakRejected remains unsupported",
-    async () => {
-      const output = await emitFixture("listBreakRejected");
-      assert.match(output, /^> UNSUPPORTED: list-break-rejected/mu);
-      assert.match(output, /for-of|break|loop/u);
-    },
-  );
+  it("listBreakRejected remains unsupported", async () => {
+    const output = await emitFixture("listBreakRejected");
+    assert.match(output, /^> UNSUPPORTED: list-break-rejected/mu);
+    assert.match(output, /for-of|break|loop/u);
+  });
 
   // Patch 2 unskips this preserved list-builder rejection.
-  it(
-    "listNestedLoopRejected remains unsupported",
-    async () => {
-      const output = await emitFixture("listNestedLoopRejected");
-      assert.match(output, /^> UNSUPPORTED: list-nested-loop-rejected/mu);
-      assert.match(output, /for-of|nested|loop/u);
-    },
-  );
+  it("listNestedLoopRejected remains unsupported", async () => {
+    const output = await emitFixture("listNestedLoopRejected");
+    assert.match(output, /^> UNSUPPORTED: list-nested-loop-rejected/mu);
+    assert.match(output, /for-of|nested|loop/u);
+  });
 
   // Patch 2 unskips this preserved list-builder rejection.
-  it(
-    "listAccumulatorAliasRejected remains unsupported",
-    async () => {
-      const output = await emitFixture("listAccumulatorAliasRejected");
-      assert.match(output, /^> UNSUPPORTED: list-accumulator-alias-rejected/mu);
-      assert.match(output, /alias|accumulator|builder/u);
-    },
-  );
+  it("listAccumulatorAliasRejected remains unsupported", async () => {
+    const output = await emitFixture("listAccumulatorAliasRejected");
+    assert.match(output, /^> UNSUPPORTED: list-accumulator-alias-rejected/mu);
+    assert.match(output, /alias|accumulator|builder/u);
+  });
 
   // Patch 3 unskips this preserved Map-builder rejection.
-  it(
-    "mapBuilderForOfRejected remains unsupported",
-    async () => {
-      const output = await emitFixture("mapBuilderForOfRejected");
-      assert.match(output, /^> UNSUPPORTED: map-builder-for-of-rejected/mu);
-      assert.match(output, /Map|map|builder/u);
-    },
-  );
+  it("mapBuilderForOfRejected remains unsupported", async () => {
+    const output = await emitFixture("mapBuilderForOfRejected");
+    assert.match(output, /^> UNSUPPORTED: map-builder-for-of-rejected/mu);
+    assert.match(output, /Map|map|builder/u);
+  });
 
   // Patch 3 unskips this preserved Set-builder rejection.
-  it(
-    "setDeleteForOfRejected remains unsupported",
-    async () => {
-      const output = await emitFixture("setDeleteForOfRejected");
-      assert.match(output, /^> UNSUPPORTED: set-delete-for-of-rejected/mu);
-      assert.match(output, /Set|delete|builder/u);
-    },
-  );
+  it("setDeleteForOfRejected remains unsupported", async () => {
+    const output = await emitFixture("setDeleteForOfRejected");
+    assert.match(output, /^> UNSUPPORTED: set-delete-for-of-rejected/mu);
+    assert.match(output, /Set|delete|builder/u);
+  });
+
+  it("setAccumulatorAliasForOfRejected remains unsupported", async () => {
+    const output = await emitFixture("setAccumulatorAliasForOfRejected");
+    assert.match(
+      output,
+      /^> UNSUPPORTED: set-accumulator-alias-for-of-rejected/mu,
+    );
+    assert.match(output, /alias|escape|accumulator|builder/u);
+  });
+
+  it("setTdzSourceForOfRejected remains unsupported", async () => {
+    const output = await emitFixture("setTdzSourceForOfRejected");
+    assert.match(output, /^> UNSUPPORTED: set-tdz-source-for-of-rejected/mu);
+    assert.match(output, /later binding|for-of/u);
+  });
 
   // Patch 4 unskips this preserved scalar-fold rejection.
-  it(
-    "conjoinNoIdentityRejected remains unsupported",
-    { skip: "Patch 4 verifies no-identity fold rejection" },
-    async () => {
-      const output = await emitFixture("conjoinNoIdentityRejected");
-      assert.match(output, /^> UNSUPPORTED: conjoin-no-identity-rejected/mu);
-      assert.match(output, /identity|null|fold|unsupported/u);
-    },
-  );
+  it("conjoinNoIdentityRejected remains unsupported", {
+    skip: "Patch 4 verifies no-identity fold rejection",
+  }, async () => {
+    const output = await emitFixture("conjoinNoIdentityRejected");
+    assert.match(output, /^> UNSUPPORTED: conjoin-no-identity-rejected/mu);
+    assert.match(output, /identity|null|fold|unsupported/u);
+  });
 
   // Patch 4 unskips this preserved scalar-fold rejection.
-  it(
-    "foldNonCommutativeRejected remains unsupported",
-    { skip: "Patch 4 verifies non-commutative fold rejection" },
-    async () => {
-      const output = await emitFixture("foldNonCommutativeRejected");
-      assert.match(output, /^> UNSUPPORTED: fold-non-commutative-rejected/mu);
-      assert.match(output, /commutative|fold|unsupported/u);
-    },
-  );
+  it("foldNonCommutativeRejected remains unsupported", {
+    skip: "Patch 4 verifies non-commutative fold rejection",
+  }, async () => {
+    const output = await emitFixture("foldNonCommutativeRejected");
+    assert.match(output, /^> UNSUPPORTED: fold-non-commutative-rejected/mu);
+    assert.match(output, /commutative|fold|unsupported/u);
+  });
 });

--- a/tools/ts2pant/tests/iteration-builder.test.mts
+++ b/tools/ts2pant/tests/iteration-builder.test.mts
@@ -51,7 +51,7 @@ describe("iteration builder", () => {
     const output = await emitFixture("setAddForOf");
     assert.match(
       output,
-      /x in set-add-for-of items <-> \(some n[0-9]* in items \| x = iteration-item--id n[0-9]*\)/u,
+      /x in set-add-for-of items <-> \(some (n[0-9]*) in items \| x = iteration-item--id \1\)/u,
     );
     assert.doesNotMatch(output, /UNSUPPORTED/u);
   });
@@ -146,10 +146,19 @@ describe("iteration builder", () => {
     assert.match(output, /alias|escape|accumulator|builder/u);
   });
 
+  it("setAccumulatorReadForOfRejected remains unsupported", async () => {
+    const output = await emitFixture("setAccumulatorReadForOfRejected");
+    assert.match(
+      output,
+      /^> UNSUPPORTED: set-accumulator-read-for-of-rejected/mu,
+    );
+    assert.match(output, /read the accumulator/u);
+  });
+
   it("setTdzSourceForOfRejected remains unsupported", async () => {
     const output = await emitFixture("setTdzSourceForOfRejected");
     assert.match(output, /^> UNSUPPORTED: set-tdz-source-for-of-rejected/mu);
-    assert.match(output, /later binding|for-of/u);
+    assert.match(output, /later binding/u);
   });
 
   // Patch 4 unskips this preserved scalar-fold rejection.


### PR DESCRIPTION
## Patch 3: Lower for-of Set builders to membership equivalence

- Reuse the widened loop-body recognizer from Patch 2 but match `s.add(proj(x))` (via `recognizeSetAddStatement`) against the local empty-`Set` accumulator (`isEmptySetConstructor`), with the same loop-local-const and guard handling, producing a recognized (binder, src, guards, proj) tuple plus the Set element sort from `setElementSort`.
- Add `tryBuildForOfSetComprehensionReturn`, dispatched in `translatePureBody` after the list for-of path, emitting one `assertion` PropResult: `all e: T | e in (f args) <-> some n in src, guards | e = proj n`, where `e` is a fresh membership binder from `allocSetMembershipBinder` and `T` is the Set element sort. An empty source still satisfies the equivalence vacuously; no separate empty-case branch is needed because the `some` over an empty/guarded source is false.
- Allocate the membership binder and comprehension binder through the existing `UniqueSupply`/`NameRegistry` discipline so they cannot collide with parameters or each other.
- Reject, with a precise diagnostic, for-of loops that: build a Map (`m.set(k, v)`), use Set `.delete`/`.clear`, alias or escape the Set accumulator, read the accumulator inside the loop or a guard, or add to more than one collection. These fall through to null / an explicit reason, never to the Set comprehension.
- Unskip and implement the Patch 1 Set positive test and the Map-builder/Set-delete negative tests.

## Changes
- Reuse the widened loop-body recognizer from Patch 2 but match `s.add(proj(x))` (via `recognizeSetAddStatement`) against the local empty-`Set` accumulator (`isEmptySetConstructor`), with the same loop-local-const and guard handling, producing a recognized (binder, src, guards, proj) tuple plus the Set element sort from `setElementSort`.
- Add `tryBuildForOfSetComprehensionReturn`, dispatched in `translatePureBody` after the list for-of path, emitting one `assertion` PropResult: `all e: T | e in (f args) <-> some n in src, guards | e = proj n`, where `e` is a fresh membership binder from `allocSetMembershipBinder` and `T` is the Set element sort. An empty source still satisfies the equivalence vacuously; no separate empty-case branch is needed because the `some` over an empty/guarded source is false.
- Allocate the membership binder and comprehension binder through the existing `UniqueSupply`/`NameRegistry` discipline so they cannot collide with parameters or each other.
- Reject, with a precise diagnostic, for-of loops that: build a Map (`m.set(k, v)`), use Set `.delete`/`.clear`, alias or escape the Set accumulator, read the accumulator inside the loop or a guard, or add to more than one collection. These fall through to null / an explicit reason, never to the Set comprehension.
- Unskip and implement the Patch 1 Set positive test and the Map-builder/Set-delete negative tests.

## Files to Modify
- tools/ts2pant/src/translate-body.ts (modify): Recognize for-of Set `.add` builders at the extraction site against `emptySetAccNames`, and add a `tryBuildForOfSetComprehensionReturn` emission path in `translatePureBody` producing the membership-equivalence assertion; keep Map/delete/clear/alias rejected.
- tools/ts2pant/tests/iteration-builder.test.mts (modify): Unskip and implement the for-of Set positive test and the Map-builder/Set-delete negative tests.

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[paper] Meijer, Fokkinga & Paterson 1991 — Functional Programming with Bananas, Lenses, Envelopes and Barbed Wire** — https://maartenfokkinga.github.io/utwente/mmf91m.pdf — The for-of Set builder is the same map/filter catamorphism as the list case; only the observation differs — membership of the result rather than ordered list equality — so the recognized (src, guards, proj) is shared and the lowering changes only at the emission step.
- **[documentation] Jackson, Software Abstractions (Alloy set/multiplicity semantics)** — https://softwareabstractions.org/ — Pantagruel models a Set as `[T]` observed by membership; the faithful target is the membership-equivalence assertion (order- and duplicate-agnostic), exactly the set-as-list discipline M2's straight-line Set builder established, never a list-equality `each` which would over-constrain under deduplication.
- **[pattern] Conservative recognizer with precise refusal** — The patch admits only `new Set<T>()` + `.add` against the returned accumulator; Map construction, `.delete`/`.clear`, aliasing, and multi-collection loops must each keep an explicit rejection so the guarded Map rule-pair contract is not approximated inside a Set lowering.

## Gameplan Specification

```
module ITERATION_BUILDER_COMPLETENESS.

ForOfFn.
Elem.
Source = [Elem].
src f: ForOfFn => Source.
proj f: ForOfFn, n: Elem => Elem.
guard f: ForOfFn, n: Elem => Bool.

Collection.
builder-kind f: ForOfFn => Collection.
list => Collection.
set => Collection.
list-result f: ForOfFn => [Elem].
set-result f: ForOfFn => [Elem].

LoopShape.
shape f: ForOfFn => LoopShape.
supported-shape s: LoopShape => Bool.
guarded-push => LoopShape.
const-then-push => LoopShape.
compound-guard-push => LoopShape.
early-exit => LoopShape.
nested-loop => LoopShape.
scalar-fold => LoopShape.
aliased => LoopShape.
map-build => LoopShape.
supported f: ForOfFn => Bool.

FoldFn.
FoldCombiner.
fadd => FoldCombiner.
fmul => FoldCombiner.
fand => FoldCombiner.
for => FoldCombiner.
fold-combiner g: FoldFn => FoldCombiner.
fold-identity-bearing c: FoldCombiner => Bool.
fold-supported g: FoldFn => Bool.
no-identity-reduce g: FoldFn => Bool.
---
all s: LoopShape | supported-shape s = cond
  s = guarded-push => true,
  s = const-then-push => true,
  s = compound-guard-push => true,
  true => false.
all f: ForOfFn | supported f <-> supported-shape (shape f).
all f: ForOfFn, supported f, builder-kind f = list
  | list-result f = (each n in (src f), guard f n | proj f n).
all f: ForOfFn, supported f, builder-kind f = set, e: Elem
  | e in (set-result f) <-> (some n in (src f), guard f n | e = proj f n).
all c: FoldCombiner | fold-identity-bearing c = cond
  c = fadd => true,
  c = fmul => true,
  c = fand => true,
  c = for => true,
  true => false.
all g: FoldFn, fold-supported g | fold-identity-bearing (fold-combiner g).
all g: FoldFn, no-identity-reduce g | ~(fold-supported g).
```

## Patch Specification

```
module ITERATION_BUILDER_COMPLETENESS_PATCH_3.

ForOfFn.
Elem.
Source = [Elem].
src f: ForOfFn => Source.
proj f: ForOfFn, n: Elem => Elem.
guard f: ForOfFn, n: Elem => Bool.
set-supported f: ForOfFn => Bool.
set-result f: ForOfFn => [Elem].
map-build-rejected f: ForOfFn => Bool.
set-delete-rejected f: ForOfFn => Bool.
---
all f: ForOfFn, set-supported f, e: Elem
  | e in (set-result f) <-> (some n in (src f), guard f n | e = proj f n).
all f: ForOfFn, map-build-rejected f | ~(set-supported f).
all f: ForOfFn, set-delete-rejected f | ~(set-supported f).
```


## Implementation Notes

- The Patch 2 loop recognizer was generalized by parameterizing the terminal accumulator write. `recognizeForOfPush` keeps its public shape, while `recognizeForOfSetAdd` reuses the same body/local-const/guard handling with `recognizeSetAddStatement`; dependent patches should prefer extending the shared `recognizeForOfAccumulatorWrite` helper rather than adding another parallel body walker.
- Set loop lowering emits the `some` expression directly with `ast.exists([], [ast.gIn(...), ...guards], ...)` instead of adding a typed IR1 existential. This preserves the established source-bound comprehension spelling (`some item in items, guards | ...`) because the loop binder's type is the source element type, not the returned Set element type.
- `allocSetMembershipBinder` now accepts a small structural input (`prelude`, `added`, optional `extraUsedNames`) rather than `LocalSetBuilderResult`. This keeps straight-line Set builders and for-of Set builders on the same collision-avoidance path; the for-of path passes the source/projection/guards plus the comprehension binder as used names.
- One diagnostic gotcha: `Map`-returning for-of builder fixtures can be classified as mutating before pure-body extraction runs. The existing mutating-body local Map-builder rejection hook was extended to inspect for-of bodies so Map builders and Set delete/clear cases still produce builder-specific unsupported diagnostics.
- The Patch 3 integration stub for `setAddForOf` was unskipped in addition to the dedicated unit tests. Patch 2 and Patch 4 integration stubs remain skipped because they are outside this patch's ownership.

Spec/Evidence Mapping:
- Set membership equivalence: implemented in `tryBuildForOfSetComprehensionReturn` and the `translatePureBody` dispatch immediately after list for-of lowering; proven by `iteration-builder.test.mts` `setAddForOf emits membership equivalence over a some-comprehension` and `iteration-builder.integration.test.mts` `setAddForOf passes pant --check`.
- Map/Set negative clauses: preserved by extraction fallthrough plus `describeForOfCollectionBuilderRejection`, including the mutating-body diagnostic hook; proven by `mapBuilderForOfRejected remains unsupported` and `setDeleteForOfRejected remains unsupported`.
- Required context checked before implementation: `workstreams/ts2pant-body-completeness.md`, `tools/ts2pant/src/translate-body.ts`, `tools/ts2pant/src/ir1.ts`, `tools/ts2pant/src/pant-ast.ts`, `tools/ts2pant/src/types.ts`, and the iteration/local-collection/integration test harness files.
- Verification run after implementation: `npm run build`, `just ts2pant-test-unit`, and `just ts2pant-test-integration`.