### PR TITLE
[ts2pant-iteration-builder-completeness] Patch 4: Lower pure-body scalar accumulator folds

### DIFF
--- a/tools/ts2pant/src/translate-body.ts
+++ b/tools/ts2pant/src/translate-body.ts
@@ -229,6 +229,7 @@ type PreludeStmt =
   | { kind: "muSearch"; tsName: string; mu: MuSearch; localName?: string }
   | ({ kind: "forOf" } & RecognizedForOfPush)
   | ({ kind: "forOfSet" } & RecognizedForOfSetAdd)
+  | ({ kind: "forOfFold" } & RecognizedForOfScalarFold)
   | { kind: "builderPush"; accName: string; valueExpr: ts.Expression }
   | { kind: "builderSetAdd"; accName: string; valueExpr: ts.Expression }
   | { kind: "reassign"; tsName: string; valueExpr: ts.Expression }
@@ -255,6 +256,15 @@ export interface RecognizedForOfSetAdd {
   proj: IR1Expr;
   guards: IR1Expr[];
   accName: string;
+}
+
+export interface RecognizedForOfScalarFold {
+  binder: string;
+  src: IR1Expr;
+  contribution: IR1Expr;
+  guards: IR1Expr[];
+  accName: string;
+  info: ReduceOpInfo;
 }
 
 /** Names a binding introduces into scope (none for an early-return arm). */
@@ -1395,6 +1405,37 @@ function translatePureBody(
     ];
   }
 
+  const forOfScalarFold = tryBuildForOfScalarFoldReturn(
+    extracted,
+    checker,
+    strategy,
+    paramNames,
+    supply,
+    env,
+  );
+  if (forOfScalarFold !== null) {
+    if ("error" in forOfScalarFold) {
+      return [
+        {
+          kind: "unsupported",
+          reason: `${functionName} — ${forOfScalarFold.error}`,
+        },
+      ];
+    }
+    const argExprs = params.map((p) => ast.var(p.name));
+    const lhs = ast.app(ast.var(functionName), argExprs);
+    return [
+      ...forOfScalarFold.prelude.ruleDecls,
+      ...forOfScalarFold.loweredLets.propositions,
+      {
+        kind: "equation",
+        quantifiers: [] as OpaqueParam[],
+        lhs,
+        rhs: forOfScalarFold.rhs,
+      },
+    ];
+  }
+
   const localListBuilder = tryBuildLocalListBuilderReturn(
     extracted,
     checker,
@@ -1985,6 +2026,12 @@ interface ForOfSetBuilderResult {
   diagnostics: PropResult[];
 }
 
+interface ForOfScalarFoldResult {
+  prelude: LoweredPreludeBindings;
+  loweredLets: IR1SsaBodyLowerResult;
+  rhs: OpaqueExpr;
+}
+
 function tryBuildForOfComprehensionReturn(
   extracted: ExtractedBody,
   checker: ts.TypeChecker,
@@ -2244,6 +2291,111 @@ function tryBuildForOfSetComprehensionReturn(
     prelude,
     loweredLets,
     diagnostics: loweredLets.diagnostics,
+  };
+}
+
+function tryBuildForOfScalarFoldReturn(
+  extracted: ExtractedBody,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  paramNames: ReadonlyMap<string, string>,
+  supply: UniqueSupply,
+  env: AssumptionEnv,
+): ForOfScalarFoldResult | { error: string } | null {
+  const ast = getAst();
+  if (!ts.isExpression(extracted.returnExpr)) {
+    return null;
+  }
+  const returnedExpr = unwrapExpression(extracted.returnExpr);
+  if (!ts.isIdentifier(returnedExpr)) {
+    return null;
+  }
+  const accName = returnedExpr.text;
+  const forOfBindings = extracted.bindings.filter(
+    (binding): binding is Extract<PreludeStmt, { kind: "forOfFold" }> =>
+      binding.kind === "forOfFold" && binding.accName === accName,
+  );
+  if (forOfBindings.length === 0) {
+    return null;
+  }
+  if (forOfBindings.length !== 1) {
+    return { error: "for-of scalar fold must have one loop" };
+  }
+  const accDecls = extracted.bindings.filter(
+    (binding): binding is Extract<PreludeStmt, { kind: "const" }> =>
+      binding.kind === "const" && binding.tsName === accName,
+  );
+  if (accDecls.length !== 1) {
+    return {
+      error: "for-of scalar fold must return its local accumulator",
+    };
+  }
+  const forOf = forOfBindings[0]!;
+  const accDecl = accDecls[0]!;
+  const otherBindings = extracted.bindings.filter(
+    (binding) => binding !== forOf && binding !== accDecl,
+  );
+  if (otherBindings.length > 0) {
+    return {
+      error:
+        "for-of scalar fold must be exactly one accumulator let followed by one loop",
+    };
+  }
+  if (guardStatementsReadName(extracted.guardStmts, accName)) {
+    return {
+      error: "for-of scalar fold guard may not read the accumulator",
+    };
+  }
+
+  const prelude = lowerPreludeBindings(
+    otherBindings,
+    checker,
+    strategy,
+    paramNames,
+    supply,
+    env,
+    undefined,
+  );
+  if ("error" in prelude) {
+    return prelude;
+  }
+  const loweredLets = ir1SsaBodyLowerSuccess();
+  const folded = ast.eachComb(
+    [],
+    [
+      ast.gIn(forOf.binder, lowerL1ToOpaque(forOf.src)),
+      ...forOf.guards.map((guard) => ast.gExpr(lowerL1ToOpaque(guard))),
+    ],
+    makeCombiner(forOf.info.combiner),
+    lowerL1ToOpaque(forOf.contribution),
+  );
+
+  if (
+    forOf.info.identityText !== null &&
+    isIdentityInit(accDecl.initializer, forOf.info.identityText)
+  ) {
+    return { prelude, loweredLets, rhs: folded };
+  }
+
+  const init = buildPureL1OrNull(accDecl.initializer, {
+    checker,
+    strategy,
+    paramNames,
+    state: undefined,
+    supply,
+    env,
+  });
+  if (init === null) {
+    return { error: "for-of scalar fold initializer is not pure" };
+  }
+  const outerOp = translateOperator(forOf.info.outer);
+  if (outerOp === null) {
+    return { error: "for-of scalar fold outer operator translation failed" };
+  }
+  return {
+    prelude,
+    loweredLets,
+    rhs: ast.binop(outerOp, lowerL1ToOpaque(init), folded),
   };
 }
 
@@ -2931,6 +3083,118 @@ export function recognizeForOfSetAdd(
   );
 }
 
+export function recognizeForOfScalarFold(
+  stmt: ts.ForOfStatement,
+  accNames: ReadonlySet<string>,
+  ctx: L1BuildContext,
+): RecognizedForOfScalarFold | null {
+  const init = stmt.initializer;
+  if (
+    !ts.isVariableDeclarationList(init) ||
+    !(init.flags & ts.NodeFlags.Const) ||
+    init.declarations.length !== 1
+  ) {
+    return null;
+  }
+  const decl = init.declarations[0]!;
+  if (!ts.isIdentifier(decl.name)) {
+    return null;
+  }
+
+  const binderTsName = decl.name.text;
+  const binder = toPantTermName(binderTsName);
+  const scopedParams = new Map(ctx.paramNames);
+  scopedParams.set(binderTsName, binder);
+  const scopedCtx: L1BuildContext = { ...ctx, paramNames: scopedParams };
+
+  if (!forOfSourceIsExpressible(stmt, decl, ctx)) {
+    return null;
+  }
+  const src = buildPureL1OrNull(stmt.expression, ctx);
+  if (src === null) {
+    return null;
+  }
+
+  const fold = recognizeForOfScalarFoldBody(stmt.statement, accNames);
+  if (fold === null) {
+    return null;
+  }
+  const accNameSet = new Set([fold.accName]);
+  if (
+    expressionHasSideEffects(fold.valueExpr, ctx.checker) ||
+    expressionHasUnsupportedScalarFoldPropertyAccess(fold.valueExpr, ctx) ||
+    expressionReferencesNames(fold.valueExpr, accNameSet)
+  ) {
+    return null;
+  }
+  const contribution = buildPureL1OrNull(fold.valueExpr, scopedCtx);
+  if (contribution === null) {
+    return null;
+  }
+
+  const guards: IR1Expr[] = [];
+  for (const guardExpr of fold.guardExprs) {
+    if (
+      expressionReferencesNames(guardExpr, accNameSet) ||
+      !isStaticallyBoolTyped(guardExpr, ctx.checker) ||
+      !isEffectFree(guardExpr, ctx.checker, {
+        admitForeignBoolPredicates: true,
+      })
+    ) {
+      return null;
+    }
+    const guard = buildPureL1OrNull(guardExpr, scopedCtx);
+    if (guard === null) {
+      return null;
+    }
+    guards.push(guard);
+  }
+
+  return {
+    binder,
+    src,
+    contribution,
+    guards,
+    accName: fold.accName,
+    info: fold.info,
+  };
+}
+
+function expressionHasUnsupportedScalarFoldPropertyAccess(
+  expr: ts.Expression,
+  ctx: L1BuildContext,
+): boolean {
+  let found = false;
+  const visit = (node: ts.Node): void => {
+    if (found) {
+      return;
+    }
+    if (ts.isPropertyAccessExpression(node)) {
+      const receiverType = ctx.checker.getTypeAtLocation(node.expression);
+      if (isPrimitiveScalarType(receiverType)) {
+        found = true;
+        return;
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(expr);
+  return found;
+}
+
+function isPrimitiveScalarType(type: ts.Type): boolean {
+  const flags = type.getNonNullableType().flags;
+  return (
+    (flags &
+      (ts.TypeFlags.StringLike |
+        ts.TypeFlags.NumberLike |
+        ts.TypeFlags.BooleanLike |
+        ts.TypeFlags.BigIntLike |
+        ts.TypeFlags.ESSymbolLike)) !==
+    0
+  );
+}
+
 function recognizeForOfAccumulatorWrite(
   stmt: ts.ForOfStatement,
   accNames: ReadonlySet<string>,
@@ -3299,6 +3563,129 @@ function recognizeSetAddStatement(
   return { accName, valueExpr: expr.arguments[0]! };
 }
 
+interface RecognizedScalarFoldBody {
+  accName: string;
+  valueExpr: ts.Expression;
+  guardExprs: ts.Expression[];
+  info: ReduceOpInfo;
+}
+
+function recognizeForOfScalarFoldBody(
+  stmt: ts.Statement,
+  accNames: ReadonlySet<string>,
+): RecognizedScalarFoldBody | null {
+  if (ts.isBlock(stmt)) {
+    if (stmt.statements.length !== 1) {
+      return null;
+    }
+    return recognizeForOfScalarFoldBody(stmt.statements[0]!, accNames);
+  }
+  const bodyStmt = unwrapSingleStatementBlock(stmt);
+  if (bodyStmt === null) {
+    return null;
+  }
+  const direct = recognizeScalarFoldWriteStatement(bodyStmt, accNames);
+  if (direct !== null) {
+    return { ...direct, guardExprs: [] };
+  }
+  if (ts.isIfStatement(bodyStmt)) {
+    if (bodyStmt.elseStatement !== undefined) {
+      return null;
+    }
+    const guarded = recognizeForOfScalarFoldBody(
+      bodyStmt.thenStatement,
+      accNames,
+    );
+    if (guarded === null) {
+      return null;
+    }
+    return {
+      ...guarded,
+      guardExprs: [
+        ...flattenConjunctiveGuards(bodyStmt.expression),
+        ...guarded.guardExprs,
+      ],
+    };
+  }
+  return null;
+}
+
+function recognizeScalarFoldWriteStatement(
+  stmt: ts.Statement,
+  accNames: ReadonlySet<string>,
+): Omit<RecognizedScalarFoldBody, "guardExprs"> | null {
+  if (!ts.isExpressionStatement(stmt)) {
+    return null;
+  }
+  const expr = unwrapExpression(stmt.expression);
+  if (ts.isBinaryExpression(expr)) {
+    if (
+      expr.operatorToken.kind !== ts.SyntaxKind.EqualsToken &&
+      ts.isIdentifier(expr.left) &&
+      accNames.has(expr.left.text)
+    ) {
+      const op = COMPOUND_ASSIGN_TO_BINARY.get(expr.operatorToken.kind);
+      if (op === undefined) {
+        return null;
+      }
+      const info = strictCommutativeReduceInfo(op);
+      return info === null
+        ? null
+        : { accName: expr.left.text, valueExpr: expr.right, info };
+    }
+    if (
+      expr.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      ts.isIdentifier(expr.left) &&
+      accNames.has(expr.left.text)
+    ) {
+      const accName = expr.left.text;
+      const rhs = unwrapExpression(expr.right);
+      if (!ts.isBinaryExpression(rhs)) {
+        return null;
+      }
+      const info = strictCommutativeReduceInfo(rhs.operatorToken.kind);
+      if (info === null) {
+        return null;
+      }
+      const leftRoot = getRootIdentifier(rhs.left);
+      const rightRoot = getRootIdentifier(rhs.right);
+      if (leftRoot === accName && rightRoot !== accName) {
+        return { accName, valueExpr: rhs.right, info };
+      }
+      if (rightRoot === accName && leftRoot !== accName) {
+        return { accName, valueExpr: rhs.left, info };
+      }
+    }
+    return null;
+  }
+  if (ts.isPrefixUnaryExpression(expr) || ts.isPostfixUnaryExpression(expr)) {
+    if (
+      expr.operator !== ts.SyntaxKind.PlusPlusToken ||
+      !ts.isIdentifier(expr.operand) ||
+      !accNames.has(expr.operand.text)
+    ) {
+      return null;
+    }
+    const info = strictCommutativeReduceInfo(ts.SyntaxKind.PlusToken);
+    return info === null
+      ? null
+      : {
+          accName: expr.operand.text,
+          valueExpr: ts.factory.createNumericLiteral(1),
+          info,
+        };
+  }
+  return null;
+}
+
+function strictCommutativeReduceInfo(kind: ts.SyntaxKind): ReduceOpInfo | null {
+  const info = binopToReduceInfo(kind);
+  if (info === null || !info.commutative || info.identityText === null) {
+    return null;
+  }
+  return info;
+}
+
 function describeLocalListBuilderMutationRejection(
   stmt: ts.ExpressionStatement,
   accNames: ReadonlySet<string>,
@@ -3564,6 +3951,120 @@ function isAllowedSetAddReceiver(node: ts.Identifier): boolean {
   );
 }
 
+function describeForOfScalarFoldRejection(
+  stmt: ts.ForOfStatement,
+  accNames: ReadonlySet<string>,
+): string | null {
+  if (accNames.size === 0) {
+    return null;
+  }
+  const body = unwrapSingleStatementBlock(stmt.statement);
+  const statements =
+    body === null ? [] : ts.isBlock(body) ? [...body.statements] : [body];
+  if (statements.length !== 1) {
+    return null;
+  }
+  const stmt0 = unwrapSingleStatementBlock(statements[0]!);
+  if (stmt0 === null) {
+    return null;
+  }
+  if (ts.isIfStatement(stmt0) && stmt0.elseStatement === undefined) {
+    return describeForOfScalarFoldRejection(
+      ts.factory.createForOfStatement(
+        undefined,
+        stmt.initializer,
+        stmt.expression,
+        stmt0.thenStatement,
+      ),
+      accNames,
+    );
+  }
+  if (!ts.isExpressionStatement(stmt0)) {
+    return null;
+  }
+  const expr = unwrapExpression(stmt0.expression);
+  if (ts.isPrefixUnaryExpression(expr) || ts.isPostfixUnaryExpression(expr)) {
+    if (
+      expr.operator === ts.SyntaxKind.MinusMinusToken &&
+      ts.isIdentifier(expr.operand) &&
+      accNames.has(expr.operand.text)
+    ) {
+      return "for-of scalar fold uses non-commutative decrement";
+    }
+    return null;
+  }
+  if (!ts.isBinaryExpression(expr)) {
+    return null;
+  }
+  if (
+    expr.operatorToken.kind !== ts.SyntaxKind.EqualsToken &&
+    ts.isIdentifier(expr.left) &&
+    accNames.has(expr.left.text)
+  ) {
+    const op = COMPOUND_ASSIGN_TO_BINARY.get(expr.operatorToken.kind);
+    if (op !== undefined && strictCommutativeReduceInfo(op) === null) {
+      return "for-of scalar fold uses a non-commutative or unsupported operator";
+    }
+    return null;
+  }
+  if (
+    expr.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+    ts.isIdentifier(expr.left) &&
+    accNames.has(expr.left.text)
+  ) {
+    const accName = expr.left.text;
+    const rhs = unwrapExpression(expr.right);
+    if (isNullSeededScalarReduce(rhs, accName)) {
+      return "for-of scalar fold without an identity value is not supported";
+    }
+    if (ts.isBinaryExpression(rhs)) {
+      if (
+        (getRootIdentifier(rhs.left) === accName ||
+          getRootIdentifier(rhs.right) === accName) &&
+        strictCommutativeReduceInfo(rhs.operatorToken.kind) === null
+      ) {
+        return "for-of scalar fold uses a non-commutative or unsupported operator";
+      }
+    }
+  }
+  return null;
+}
+
+function isNullSeededScalarReduce(
+  expr: ts.Expression,
+  accName: string,
+): boolean {
+  const current = unwrapExpression(expr);
+  if (!ts.isConditionalExpression(current)) {
+    return false;
+  }
+  return (
+    expressionReferencesNames(current.condition, new Set([accName])) &&
+    expressionMentionsNullish(current.condition) &&
+    (expressionReferencesNames(current.whenTrue, new Set([accName])) ||
+      expressionReferencesNames(current.whenFalse, new Set([accName])))
+  );
+}
+
+function expressionMentionsNullish(expr: ts.Expression): boolean {
+  let found = false;
+  const visit = (node: ts.Node): void => {
+    if (found) {
+      return;
+    }
+    if (
+      node.kind === ts.SyntaxKind.NullKeyword ||
+      node.kind === ts.SyntaxKind.UndefinedKeyword
+    ) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(expr);
+  return found;
+}
+
 function recognizeIfContinue(stmt: ts.Statement): ts.Expression | null {
   const ifStmt = unwrapSingleStatementBlock(stmt);
   if (
@@ -3694,13 +4195,23 @@ function extractReturnExpression(
         ...ctx,
         paramNames: scopedParams,
       });
-      if (setRecognized === null) {
-        return null;
+      if (setRecognized !== null) {
+        bindings.push({ kind: "forOfSet", ...setRecognized });
+        i += 1;
+        lastLetDeclNames = new Set();
+        continue;
       }
-      bindings.push({ kind: "forOfSet", ...setRecognized });
-      i += 1;
-      lastLetDeclNames = new Set();
-      continue;
+      const scalarFold = recognizeForOfScalarFold(stmt, letNames, {
+        ...ctx,
+        paramNames: scopedParams,
+      });
+      if (scalarFold !== null) {
+        bindings.push({ kind: "forOfFold", ...scalarFold });
+        i += 1;
+        lastLetDeclNames = new Set();
+        continue;
+      }
+      return null;
     }
     if (
       ts.isIfStatement(stmt) ||
@@ -3932,6 +4443,7 @@ function preludeBindingReferencesTsName(
       );
     case "forOf":
     case "forOfSet":
+    case "forOfFold":
       return binding.accName === name;
     case "builderPush":
     case "builderSetAdd":
@@ -3981,6 +4493,7 @@ function describeRejectedBody(body: ts.Block, checker: ts.TypeChecker): string {
     const listBuilderAliases = new Set<string>();
     const setBuilderAliases = new Set<string>();
     const mapBuilderAliases = new Set<string>();
+    const scalarFoldAccNames = new Set<string>();
     while (i < lastIdx) {
       if (recognizeLetWhilePair(stmts, i, checker)) {
         i += 2;
@@ -4001,6 +4514,13 @@ function describeRejectedBody(body: ts.Block, checker: ts.TypeChecker): string {
         );
         if (collectionRejection !== null) {
           return collectionRejection;
+        }
+        const scalarRejection = describeForOfScalarFoldRejection(
+          stmt,
+          scalarFoldAccNames,
+        );
+        if (scalarRejection !== null) {
+          return scalarRejection;
         }
         return "for-of loop is not a recognized build-list comprehension";
       }
@@ -4025,6 +4545,9 @@ function describeRejectedBody(body: ts.Block, checker: ts.TypeChecker): string {
       if (ts.isVariableStatement(stmt)) {
         const declList = stmt.declarationList;
         if (declList.flags & ts.NodeFlags.Let) {
+          for (const name of bindingNamesFromDeclarationList(declList)) {
+            scalarFoldAccNames.add(name);
+          }
           const declaredNames = declaredIdentifierNames(declList);
           if (
             declaredNames === null ||
@@ -4793,6 +5316,13 @@ function lowerPreludeBindings(
             "for-of Set builder is only supported when returning its accumulator directly",
         };
       }
+      if (binding.kind === "forOfFold") {
+        return {
+          tag: "error",
+          error:
+            "for-of scalar fold is only supported when returning its accumulator directly",
+        };
+      }
       if (binding.kind === "builderPush") {
         return {
           tag: "error",
@@ -4950,10 +5480,18 @@ function validatePreludeBindings(
       if (expressionReferencesNames(binding.mu.predicateTsExpr, predBlocked)) {
         return { error: "while-loop predicate references a later binding" };
       }
-    } else if (binding.kind === "forOf" || binding.kind === "forOfSet") {
+    } else if (
+      binding.kind === "forOf" ||
+      binding.kind === "forOfSet" ||
+      binding.kind === "forOfFold"
+    ) {
       const blockedIr1Names = blockedNamesForIR1(bindings.slice(idx + 1));
+      const loopExprs =
+        binding.kind === "forOfFold"
+          ? [binding.src, binding.contribution, ...binding.guards]
+          : [binding.src, binding.proj, ...binding.guards];
       if (
-        [binding.src, binding.proj, ...binding.guards].some((expr) =>
+        loopExprs.some((expr) =>
           ir1ExprReferencesAnyName(expr, blockedIr1Names),
         )
       ) {
@@ -5203,6 +5741,7 @@ export function lowerNestedPureBlockReturnToL1(
     if (
       binding.kind === "forOf" ||
       binding.kind === "forOfSet" ||
+      binding.kind === "forOfFold" ||
       binding.kind === "builderPush" ||
       binding.kind === "builderSetAdd" ||
       binding.kind === "reassign" ||

--- a/tools/ts2pant/tests/fixtures/constructs/expressions-iteration-builder.ts
+++ b/tools/ts2pant/tests/fixtures/constructs/expressions-iteration-builder.ts
@@ -85,7 +85,7 @@ function setAddForOf(items: IterationItem[]): Set<string> {
  * Pure additive scalar fold.
  * Target Pantagruel encoding: identity plus `+ over each`.
  *
- * @pant sum-int-fold items = + over each item in items | iteration-item--count item.
+ * @pant sum-int-fold items = (+ over each item in items | iteration-item--count item).
  */
 // biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
 function sumIntFold(items: IterationItem[]): number {
@@ -100,7 +100,7 @@ function sumIntFold(items: IterationItem[]): number {
  * Guarded count fold.
  * Target Pantagruel encoding: guarded `+ over each` of one per matching item.
  *
- * @pant count-guarded-fold items = + over each item in items, iteration-item--active item | 1.
+ * @pant count-guarded-fold items = (+ over each item in items, iteration-item--active item | 1).
  */
 // biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
 function countGuardedFold(items: IterationItem[]): number {
@@ -117,7 +117,7 @@ function countGuardedFold(items: IterationItem[]): number {
  * Boolean-and scalar fold.
  * Target Pantagruel encoding: `and over each`.
  *
- * @pant all-active-fold items = and over each item in items | iteration-item--active item.
+ * @pant all-active-fold items = (and over each item in items | iteration-item--active item).
  */
 // biome-ignore lint/correctness/noUnusedVariables: unexported fixture corpus
 function allActiveFold(items: IterationItem[]): boolean {

--- a/tools/ts2pant/tests/integration/iteration-builder.test.mts
+++ b/tools/ts2pant/tests/integration/iteration-builder.test.mts
@@ -29,32 +29,23 @@ async function checkFixture(functionName: string): Promise<void> {
 
 describe("iteration builder integration", () => {
   // Patch 2 unskips these list-builder checker stubs.
-  it(
-    "list builder positives pass pant --check",
-    { skip: "Patch 2 implements for-of list builder widening" },
-    async () => {
-      await checkFixture("listConstProjection");
-      await checkFixture("listCompoundGuard");
-      await checkFixture("listNestedGuard");
-    },
-  );
+  it("list builder positives pass pant --check", {
+    skip: "Patch 2 implements for-of list builder widening",
+  }, async () => {
+    await checkFixture("listConstProjection");
+    await checkFixture("listCompoundGuard");
+    await checkFixture("listNestedGuard");
+  });
 
   // Patch 3 unskips this Set-builder checker stub.
-  it(
-    "setAddForOf passes pant --check",
-    async () => {
-      await checkFixture("setAddForOf");
-    },
-  );
+  it("setAddForOf passes pant --check", async () => {
+    await checkFixture("setAddForOf");
+  });
 
   // Patch 4 unskips these scalar-fold checker stubs.
-  it(
-    "scalar fold positives pass pant --check",
-    { skip: "Patch 4 implements scalar fold lowering" },
-    async () => {
-      await checkFixture("sumIntFold");
-      await checkFixture("countGuardedFold");
-      await checkFixture("allActiveFold");
-    },
-  );
+  it("scalar fold positives pass pant --check", async () => {
+    await checkFixture("sumIntFold");
+    await checkFixture("countGuardedFold");
+    await checkFixture("allActiveFold");
+  });
 });

--- a/tools/ts2pant/tests/iteration-builder.test.mts
+++ b/tools/ts2pant/tests/iteration-builder.test.mts
@@ -57,37 +57,31 @@ describe("iteration builder", () => {
   });
 
   // Patch 4 unskips this scalar-fold case.
-  it("sumIntFold lowers to init plus a sum comprehension", {
-    skip: "Patch 4 implements additive scalar folds",
-  }, async () => {
+  it("sumIntFold lowers to init plus a sum comprehension", async () => {
     const output = await emitFixture("sumIntFold");
     assert.match(
       output,
-      /^sum-int-fold items = \+ over each item in items \| iteration-item--count item\.$/mu,
+      /^sum-int-fold items = \(\+ over each item in items \| iteration-item--count item\)\.$/mu,
     );
     assert.doesNotMatch(output, /UNSUPPORTED/u);
   });
 
   // Patch 4 unskips this scalar-fold case.
-  it("countGuardedFold folds the guard into the sum comprehension", {
-    skip: "Patch 4 implements guarded count folds",
-  }, async () => {
+  it("countGuardedFold folds the guard into the sum comprehension", async () => {
     const output = await emitFixture("countGuardedFold");
     assert.match(
       output,
-      /^count-guarded-fold items = \+ over each item in items, iteration-item--active item \| 1\.$/mu,
+      /^count-guarded-fold items = \(\+ over each item in items, iteration-item--active item \| 1\)\.$/mu,
     );
     assert.doesNotMatch(output, /UNSUPPORTED/u);
   });
 
   // Patch 4 unskips this scalar-fold case.
-  it("allActiveFold lowers to an and comprehension", {
-    skip: "Patch 4 implements boolean-and scalar folds",
-  }, async () => {
+  it("allActiveFold lowers to an and comprehension", async () => {
     const output = await emitFixture("allActiveFold");
     assert.match(
       output,
-      /^all-active-fold items = and over each item in items \| iteration-item--active item\.$/mu,
+      /^all-active-fold items = \(and over each item in items \| iteration-item--active item\)\.$/mu,
     );
     assert.doesNotMatch(output, /UNSUPPORTED/u);
   });
@@ -162,18 +156,14 @@ describe("iteration builder", () => {
   });
 
   // Patch 4 unskips this preserved scalar-fold rejection.
-  it("conjoinNoIdentityRejected remains unsupported", {
-    skip: "Patch 4 verifies no-identity fold rejection",
-  }, async () => {
+  it("conjoinNoIdentityRejected remains unsupported", async () => {
     const output = await emitFixture("conjoinNoIdentityRejected");
     assert.match(output, /^> UNSUPPORTED: conjoin-no-identity-rejected/mu);
     assert.match(output, /identity|null|fold|unsupported/u);
   });
 
   // Patch 4 unskips this preserved scalar-fold rejection.
-  it("foldNonCommutativeRejected remains unsupported", {
-    skip: "Patch 4 verifies non-commutative fold rejection",
-  }, async () => {
+  it("foldNonCommutativeRejected remains unsupported", async () => {
     const output = await emitFixture("foldNonCommutativeRejected");
     assert.match(output, /^> UNSUPPORTED: fold-non-commutative-rejected/mu);
     assert.match(output, /commutative|fold|unsupported/u);


### PR DESCRIPTION
## Patch 4: Lower pure-body scalar accumulator folds

- Recognize, in the pure-body prelude, a single `let acc = init;` immediately followed by a `for (const x of src)` whose body is `acc OP= f(x)`, `acc = acc OP f(x)`, `acc++`/`acc--`, or a single `if (g) <one of those>`, where `acc` is the returned identifier and is not otherwise read or written; OP ∈ {+, *, &&, ||} (with `++`/`--` canonicalising to `+= 1`/`-= 1` on `+`).
- Map OP to the existing Shape-C combiner (`combAdd`/`combMul`/`combAnd`/`combOr` via `eachComb`) and emit `acc = init OP (combOP over each n in src[, g] | f n)`, eliding `init` when it equals the combiner identity (0 for +, 1 for *, true for &&, false for ||), reusing the Shape-C identity-elision logic.
- Lower `f(x)` (the per-element contribution) and the optional guard `g` under the binder-extended scope via `buildPureL1OrNull`, rejecting effectful or unsupported contributions/guards.
- Reject, with a precise diagnostic, no-identity / nullable reduces (null-seeded `out = out===null ? e : OP(out,e)` as in conjoin/disjoin), non-commutative accumulations (`-=`, `/=`, or `acc = f(x) - acc`), accumulator aliasing/escape, a second accumulator, and break/continue-beyond-leading-guard/return/throw/nested-loop in the loop body — these fall through to null or an explicit reason, never to a `combOP over each` reduce.
- Keep this path strictly additive: bodies that are not the recognized fold triple continue through the existing prelude rejection unchanged, so previously-supported translations stay byte-identical.
- Unskip and implement the Patch 1 scalar-fold positive tests and the no-identity / non-commutative negative tests.

## Changes
- Recognize, in the pure-body prelude, a single `let acc = init;` immediately followed by a `for (const x of src)` whose body is `acc OP= f(x)`, `acc = acc OP f(x)`, `acc++`/`acc--`, or a single `if (g) <one of those>`, where `acc` is the returned identifier and is not otherwise read or written; OP ∈ {+, *, &&, ||} (with `++`/`--` canonicalising to `+= 1`/`-= 1` on `+`).
- Map OP to the existing Shape-C combiner (`combAdd`/`combMul`/`combAnd`/`combOr` via `eachComb`) and emit `acc = init OP (combOP over each n in src[, g] | f n)`, eliding `init` when it equals the combiner identity (0 for +, 1 for *, true for &&, false for ||), reusing the Shape-C identity-elision logic.
- Lower `f(x)` (the per-element contribution) and the optional guard `g` under the binder-extended scope via `buildPureL1OrNull`, rejecting effectful or unsupported contributions/guards.
- Reject, with a precise diagnostic, no-identity / nullable reduces (null-seeded `out = out===null ? e : OP(out,e)` as in conjoin/disjoin), non-commutative accumulations (`-=`, `/=`, or `acc = f(x) - acc`), accumulator aliasing/escape, a second accumulator, and break/continue-beyond-leading-guard/return/throw/nested-loop in the loop body — these fall through to null or an explicit reason, never to a `combOP over each` reduce.
- Keep this path strictly additive: bodies that are not the recognized fold triple continue through the existing prelude rejection unchanged, so previously-supported translations stay byte-identical.
- Unskip and implement the Patch 1 scalar-fold positive tests and the no-identity / non-commutative negative tests.

## Files to Modify
- tools/ts2pant/src/translate-body.ts (modify): Recognize a `let acc = init;` + `for (const x of src) [if (g)] acc OP= f(x);` + `return acc` triple in the pure-body prelude and add a `tryBuildForOfScalarFoldReturn` emission path producing the Shape-C reduce.
- tools/ts2pant/tests/iteration-builder.test.mts (modify): Unskip and implement the scalar-fold positive tests (sum, guarded count, boolean-and) and the no-identity / non-commutative negative tests.

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[paper] Meijer, Fokkinga & Paterson 1991 — Functional Programming with Bananas, Lenses, Envelopes and Barbed Wire** — https://maartenfokkinga.github.io/utwente/mmf91m.pdf — A scalar accumulator fold is the foldr catamorphism with a monoid combiner; the commutative identity-bearing OPs (+, *, &&, ||) form monoids whose unit is the elided init, which is precisely why no-identity reduces (conjoin/disjoin) fall outside this lowering.
- **[paper] Allen et al. 1983 if-conversion (Conversion of Control Dependence to Data Dependence)** — https://dl.acm.org/doi/10.1145/567067.567085 — A single `if (g) acc OP= f(x)` guard folds into the comprehension predicate exactly as in the list/Set cases — the guarded accumulation becomes `combOP over each n in src, g | f n`.
- **[pattern] Conservative recognizer with precise refusal** — The patch admits only the commutative identity-bearing fold triple; null-seeded/no-identity reduces, non-commutative ops, aliasing, and any control flow must keep an explicit rejection so the option-typed fold target is left to a later milestone.

## Gameplan Specification

```
module ITERATION_BUILDER_COMPLETENESS.

ForOfFn.
Elem.
Source = [Elem].
src f: ForOfFn => Source.
proj f: ForOfFn, n: Elem => Elem.
guard f: ForOfFn, n: Elem => Bool.

Collection.
builder-kind f: ForOfFn => Collection.
list => Collection.
set => Collection.
list-result f: ForOfFn => [Elem].
set-result f: ForOfFn => [Elem].

LoopShape.
shape f: ForOfFn => LoopShape.
supported-shape s: LoopShape => Bool.
guarded-push => LoopShape.
const-then-push => LoopShape.
compound-guard-push => LoopShape.
early-exit => LoopShape.
nested-loop => LoopShape.
scalar-fold => LoopShape.
aliased => LoopShape.
map-build => LoopShape.
supported f: ForOfFn => Bool.

FoldFn.
FoldCombiner.
fadd => FoldCombiner.
fmul => FoldCombiner.
fand => FoldCombiner.
for => FoldCombiner.
fold-combiner g: FoldFn => FoldCombiner.
fold-identity-bearing c: FoldCombiner => Bool.
fold-supported g: FoldFn => Bool.
no-identity-reduce g: FoldFn => Bool.
---
all s: LoopShape | supported-shape s = cond
  s = guarded-push => true,
  s = const-then-push => true,
  s = compound-guard-push => true,
  true => false.
all f: ForOfFn | supported f <-> supported-shape (shape f).
all f: ForOfFn, supported f, builder-kind f = list
  | list-result f = (each n in (src f), guard f n | proj f n).
all f: ForOfFn, supported f, builder-kind f = set, e: Elem
  | e in (set-result f) <-> (some n in (src f), guard f n | e = proj f n).
all c: FoldCombiner | fold-identity-bearing c = cond
  c = fadd => true,
  c = fmul => true,
  c = fand => true,
  c = for => true,
  true => false.
all g: FoldFn, fold-supported g | fold-identity-bearing (fold-combiner g).
all g: FoldFn, no-identity-reduce g | ~(fold-supported g).
```

## Patch Specification

```
module ITERATION_BUILDER_COMPLETENESS_PATCH_4.

FoldFn.
Combiner.
op-add => Combiner.
op-mul => Combiner.
op-and => Combiner.
op-or => Combiner.
fold-combiner f: FoldFn => Combiner.
identity-bearing c: Combiner => Bool.
fold-supported f: FoldFn => Bool.
no-identity-reduce f: FoldFn => Bool.
non-commutative f: FoldFn => Bool.
---
all c: Combiner | identity-bearing c = cond
  c = op-add => true,
  c = op-mul => true,
  c = op-and => true,
  c = op-or => true,
  true => false.
all f: FoldFn, fold-supported f | identity-bearing (fold-combiner f).
all f: FoldFn, no-identity-reduce f | ~(fold-supported f).
all f: FoldFn, non-commutative f | ~(fold-supported f).
```


## Implementation Notes

- Added a new prelude binding kind, `forOfFold`, rather than routing these loops through the existing `stmt`/SSA fallback. That keeps the pure-body fold triple structurally separate from mutating Shape B/C machinery and lets `tryBuildForOfScalarFoldReturn` enforce the exact `let` + single `for-of` + `return acc` shape before emitting an equation.
- The for-of fold recognizer intentionally uses a stricter operator gate than array `.reduce`: `strictCommutativeReduceInfo` admits only `+`, `*`, `&&`, and `||` with known identities. Existing `.reduce` still supports subtraction/division as outer ops over additive/multiplicative combiners; this patch does not extend that behavior to for-of local accumulator loops.
- `acc++` is supported as an additive count contribution of `1`; `acc--` is deliberately rejected as the decrement spelling of non-commutative `-= 1`. The gameplan text mentioned both spellings, but FC-7 and the patch spec require non-commutative folds to remain unsupported.
- The recognizer screens primitive scalar property reads in fold contributions, so an older `sumLengths(xs: string[]) { total += x.length }` for-of-comprehension negative fixture stays rejected instead of producing an undeclared `length` rule. Interface field projections such as `item.count` still go through the normal L1/member lowering path.
- Diagnostic support was added to `describeRejectedBody` for fold-shaped but unsupported loops. Null-seeded conditional reductions report an identity/no-identity fold reason, and non-commutative updates report a non-commutative fold reason; unrelated unrecognized for-of loops still keep the existing build-list-comprehension diagnostic.
- The positive scalar fixtures' `@pant` annotations were parenthesized around `eachComb` expressions because the checker accepts the emitted equation form as `f xs = (+ over each ...)`, while an unparenthesized annotation after `check` parsed ambiguously.

Spec/Evidence Mapping:
- `fold-supported -> identity-bearing(fold-combiner)`: implemented by `strictCommutativeReduceInfo` and `tryBuildForOfScalarFoldReturn`; covered by `sumIntFold`, `countGuardedFold`, and `allActiveFold` in `tools/ts2pant/tests/iteration-builder.test.mts` plus the unskipped scalar integration check.
- `no-identity-reduce -> ~(fold-supported)`: implemented by refusing null-seeded conditional reductions and surfacing `for-of scalar fold without an identity value is not supported`; covered by `conjoinNoIdentityRejected`.
- `non-commutative -> ~(fold-supported)`: implemented by rejecting `-=`, `/=`, `acc = f(x) - acc`, and decrement-shaped updates through the strict operator gate and rejection describer; covered by `foldNonCommutativeRejected`.
- Required context consulted while implementing: `workstreams/ts2pant-body-completeness.md`, the for-of/list/Set recognizer and Shape-C reduce machinery in `tools/ts2pant/src/translate-body.ts`, the `eachComb`/comprehension AST contracts in `tools/ts2pant/src/pant-ast.ts`, `tools/ts2pant/src/ir1.ts`, `REFERENCE.md`, and the iteration-builder/local-builder/integration test harness files.
- Verification run after implementation: focused iteration-builder/for-of tests, `just ts2pant-test-unit`, `just ts2pant-test-integration`, `npx tsc --noEmit`, and `just ts2pant-precommit`. Precommit still prints the pre-existing `src/purity.ts` nursery warning about a regex missing `u`, but exits successfully.