### PR TITLE
[ts2pant-iteration-builder-completeness] Patch 5: Document for-of iteration builders and reconcile the workstream

### DIFF
--- a/tools/ts2pant/docs/transformations.md
+++ b/tools/ts2pant/docs/transformations.md
@@ -194,9 +194,9 @@ all x: T | ~(x in f args).
   to another variable, capturing it in a closure, passing it to another call, or
   reading it from a guard/value expression.
 - Unknown mutating methods on the accumulator.
-- Loop-backed builders outside the already-supported for-of build-list
-  comprehension path. Broader `for-of` and `forEach` builder completeness is a
-  separate iteration milestone.
+- Loop-backed builders use the Structured Iteration contracts below. `for-of`
+  list and Set builders are admitted only through that path; `forEach` builder
+  callbacks remain deferred.
 
 ## Uninterpreted Functions (General Function Calls)
 
@@ -532,7 +532,8 @@ the conditional therefore appears only at accessor equations' RHS positions.
 Envelopes and Barbed Wire"](https://maartenfokkinga.github.io/utwente/mmf91m.pdf), FPCA 1991;
 Lamport, *Specifying Systems* (TLA+ `\A x \in arr` idiom for per-element next-state).
 
-ts2pant accepts three shapes that are all instances of the catamorphism `foldr : (a -> b -> b) -> b -> [a] -> b`:
+ts2pant accepts these shapes as instances of the catamorphism
+`foldr : (a -> b -> b) -> b -> [a] -> b`:
 
 **Shape A — uniform iterator write (mutating).**
 `for (const x of arr) { x.p = e(x) }` and `arr.forEach(x => { x.p = e(x) })` become
@@ -553,6 +554,71 @@ with `init` elided when it equals the combiner identity (0 for `+`, 1 for `*`, `
 `false` for `||`). `reduceRight` is accepted only for commutative combiners; non-commutative
 ops require acc on the left.
 
+**Shape D — pure for-of build-list (expression).**
+
+```ts
+const out = [];
+for (const x of xs) {
+  const y = f(x);
+  if (g1(x)) {
+    if (g2(y)) out.push(h(y));
+  }
+}
+return out;
+```
+
+becomes `each x in xs, g1 x, g2 (f x) | h (f x)`. The loop may contain
+pure loop-local `const` bindings before the accumulator write; those bindings
+are inlined into the projection and guards through the same capture-avoiding
+substitution discipline used by let-elimination. Compound `&&` guards and
+nested `if` guards are flattened into the comprehension guard list in source
+order, so the emitted target stays the existing `each binder in src, g1, g2 |
+proj` form rather than introducing a new list-builder construct.
+
+**Shape E — pure for-of Set builder (expression).**
+
+```ts
+const out = new Set<T>();
+for (const x of xs) {
+  if (g(x)) out.add(f(x));
+}
+return out;
+```
+
+uses the Set-as-list membership encoding from Local Collection Builders:
+
+```text
+all e: T | e in (fn args) <-> some x in xs, g x | e = f x.
+```
+
+The target is membership equivalence over `some`, never list equality against
+`each`. A Set is order-agnostic and deduplicates equal projected elements; list
+equality would over-constrain programs where two distinct source elements
+project to the same Set member. Membership is the observable contract that
+matches both TypeScript `Set` and ts2pant's `[T]` representation.
+
+**Shape F — pure for-of scalar fold (expression).**
+
+```ts
+let acc = init;
+for (const x of xs) {
+  if (g(x)) acc OP= f(x);
+}
+return acc;
+```
+
+becomes `init OP (combOP over each x in xs, g x | f x)` for the commutative
+identity-bearing subset: `+`, `*`, `&&`, `||`, plus `count++` as `+ over each
+... | 1`. When `init` is the combiner identity (`0`, `1`, `true`, `false`),
+the outer `init OP` is elided and the result is the bare reduce expression.
+The same source-order guard flattening and loop-local const inlining as Shape D
+apply before the fold projection is emitted.
+
+No-identity / nullable reduces such as conjoin/disjoin are excluded because
+they require an option-typed fold target rather than identity elision.
+Non-commutative accumulations are excluded because `combOP over each` is an
+order-insensitive reduction target.
+
 The unified loop milestone keeps the recursion-scheme framing explicit:
 bounded loops are catamorphisms and lower through `IR1SsaLoopBody` with a
 non-null `IR1SsaTerminationMetric` (counter metrics for counter/while,
@@ -562,7 +628,7 @@ folds it back to the post-state, so those loop bodies carry
 `terminationMetric: null`. L6+L7 closed both halves under the same loop-body
 contract.
 
-**Invariants** (post-IR1-SSA):
+**Invariants:**
 - Shape A and Shape B both lower through
   `lowerForeachShapeAAsGeneralLoop` / `lowerForeachShapeBAsGeneralLoop` in
   `src/ir1-ssa-foreach.ts`. The old `IR1SsaLoopSummary` path is gone; both
@@ -581,6 +647,24 @@ contract.
 - Shape B `foldLeaves` carry the `outerOp` binop and the comprehension
   `combiner` separately, so frame conditions for untouched properties still
   fire via the modified-rules set.
+- Shape D list-builder loop-local consts are pure, loop-scoped, and hygienic:
+  they inline into guards/projections via the substitution primitives rather
+  than escaping as Pant rule declarations.
+- Shape D/E/F guard extraction is ordered and conjunctive. `if (g1 && g2)` and
+  nested `if (g1) { if (g2) ... }` both contribute `g1, g2` to the emitted
+  comprehension in source order.
+- Shape E emits only membership facts for the returned Set/list value. It does
+  not constrain insertion order or duplicate insertions beyond `some`-based
+  membership equivalence.
+- Shape F admits only commutative identity-bearing combiners whose identity can
+  justify init elision. Nullable/no-identity folds and non-commutative updates
+  remain unsupported.
+- The pure for-of builder recognizers reject `break`, `continue` beyond the
+  leading-guard form, early `return`, `throw`, nested loops, accumulator
+  aliasing or escape, Map builders, Set `.delete` / `.clear`, multi-collection
+  loops, and any accumulator read from a guard or projected value. `forEach`
+  build-list callbacks are deferred; `forEach` still routes through the
+  mutating Shape A/B machinery where applicable.
 
 ## Functor-Lift Recognizer
 

--- a/workstreams/ts2pant-body-completeness.md
+++ b/workstreams/ts2pant-body-completeness.md
@@ -321,10 +321,14 @@ positives in the diagnostic output.
   and non-literal labels.
 
 **Open Questions**:
+- Resolved by the M3 gameplan: for-of Set builders are in scope and lower to
+  membership equivalence over a `some` comprehension, not list equality.
 - Resolved by the M3 gameplan: commutative identity-bearing scalar folds
   (`+`, `*`, `&&`, `||`, `count++`) are in M3, lowering to the Shape-C
   `combOP over each` reduce. No-identity / nullable reduces (conjoin/disjoin),
   which need an option-typed fold, are deferred to a later milestone.
+- Resolved by the M3 gameplan: forEach build-list callbacks and callback
+  `return` semantics are deferred. M3 is scoped to `for-of` statements.
 
 ---
 


### PR DESCRIPTION
## Patch 5: Document for-of iteration builders and reconcile the workstream

- Document the widened for-of list contract: loop-local const bindings inline into the comprehension projection via capture-avoiding substitution; compound/nested guards fold into the `each binder in src, g1, g2 | proj` guard list in source order.
- Document the for-of Set-builder target: `all e: T | e in (f args) <-> some n in src, guards | e = proj n`, and why membership equivalence (not list equality) is the sound encoding under deduplication.
- Document the scalar accumulator fold target: `acc = init OP (combOP over each n in src, guards | f n)` for commutative identity-bearing OP ∈ {+, *, &&, ||}, with init elided at the combiner identity, and why no-identity / nullable reduces (conjoin/disjoin) and non-commutative ops are excluded.
- Document the explicit exclusions: break/continue-beyond-leading-guard/return/throw, nested loops, accumulator aliasing/escape, no-identity/nullable reduces, non-commutative accumulations, Map builders, Set delete/clear, and multi-collection loops; note forEach is deferred.
- Update `workstreams/ts2pant-body-completeness.md`: change Milestone 2 status to COMPLETE (landed via PRs #357–#360), mark Milestone 3 planned with `gameplans/ts2pant-iteration-builder-completeness.json`, conform the DoD-4 assertion to the real fixture/file names, and record the resolved open questions (Set and commutative scalar folds in scope; no-identity reduces and forEach deferred).

## Changes
- Document the widened for-of list contract: loop-local const bindings inline into the comprehension projection via capture-avoiding substitution; compound/nested guards fold into the `each binder in src, g1, g2 | proj` guard list in source order.
- Document the for-of Set-builder target: `all e: T | e in (f args) <-> some n in src, guards | e = proj n`, and why membership equivalence (not list equality) is the sound encoding under deduplication.
- Document the scalar accumulator fold target: `acc = init OP (combOP over each n in src, guards | f n)` for commutative identity-bearing OP ∈ {+, *, &&, ||}, with init elided at the combiner identity, and why no-identity / nullable reduces (conjoin/disjoin) and non-commutative ops are excluded.
- Document the explicit exclusions: break/continue-beyond-leading-guard/return/throw, nested loops, accumulator aliasing/escape, no-identity/nullable reduces, non-commutative accumulations, Map builders, Set delete/clear, and multi-collection loops; note forEach is deferred.
- Update `workstreams/ts2pant-body-completeness.md`: change Milestone 2 status to COMPLETE (landed via PRs #357–#360), mark Milestone 3 planned with `gameplans/ts2pant-iteration-builder-completeness.json`, conform the DoD-4 assertion to the real fixture/file names, and record the resolved open questions (Set and commutative scalar folds in scope; no-identity reduces and forEach deferred).

## Files to Modify
- tools/ts2pant/docs/transformations.md (modify): Extend the Structured Iteration / Local Collection Builders sections with the widened for-of list-build contract and the for-of Set-builder membership target, with standard names, references, and invariants.
- workstreams/ts2pant-body-completeness.md (modify): Mark M2 complete and M3 planned with this gameplan path; reconcile the M3 Definition of Done and the DoD-4 acceptance assertion with the delivered scope, and record that scalar folds and forEach are deferred.

## Gameplan Specification

```
module ITERATION_BUILDER_COMPLETENESS.

ForOfFn.
Elem.
Source = [Elem].
src f: ForOfFn => Source.
proj f: ForOfFn, n: Elem => Elem.
guard f: ForOfFn, n: Elem => Bool.

Collection.
builder-kind f: ForOfFn => Collection.
list => Collection.
set => Collection.
list-result f: ForOfFn => [Elem].
set-result f: ForOfFn => [Elem].

LoopShape.
shape f: ForOfFn => LoopShape.
supported-shape s: LoopShape => Bool.
guarded-push => LoopShape.
const-then-push => LoopShape.
compound-guard-push => LoopShape.
early-exit => LoopShape.
nested-loop => LoopShape.
scalar-fold => LoopShape.
aliased => LoopShape.
map-build => LoopShape.
supported f: ForOfFn => Bool.

FoldFn.
FoldCombiner.
fadd => FoldCombiner.
fmul => FoldCombiner.
fand => FoldCombiner.
for => FoldCombiner.
fold-combiner g: FoldFn => FoldCombiner.
fold-identity-bearing c: FoldCombiner => Bool.
fold-supported g: FoldFn => Bool.
no-identity-reduce g: FoldFn => Bool.
---
all s: LoopShape | supported-shape s = cond
  s = guarded-push => true,
  s = const-then-push => true,
  s = compound-guard-push => true,
  true => false.
all f: ForOfFn | supported f <-> supported-shape (shape f).
all f: ForOfFn, supported f, builder-kind f = list
  | list-result f = (each n in (src f), guard f n | proj f n).
all f: ForOfFn, supported f, builder-kind f = set, e: Elem
  | e in (set-result f) <-> (some n in (src f), guard f n | e = proj f n).
all c: FoldCombiner | fold-identity-bearing c = cond
  c = fadd => true,
  c = fmul => true,
  c = fand => true,
  c = for => true,
  true => false.
all g: FoldFn, fold-supported g | fold-identity-bearing (fold-combiner g).
all g: FoldFn, no-identity-reduce g | ~(fold-supported g).
```

## Patch Specification

```
module ITERATION_BUILDER_COMPLETENESS_PATCH_5.

DocSection.
Decision.
documents d: DocSection, q: Decision => Bool.
list-loop-local-const => Decision.
list-compound-guard => Decision.
set-membership-target => Decision.
scalar-fold-target => Decision.
iteration-exclusions => Decision.
---
some d: DocSection | documents d list-loop-local-const.
some d: DocSection | documents d list-compound-guard.
some d: DocSection | documents d set-membership-target.
some d: DocSection | documents d scalar-fold-target.
some d: DocSection | documents d iteration-exclusions.
```


## Implementation Notes

- This patch is documentation-only. The behavioral implementation is entirely in ancestor patches 2-4; I did not change translator code, fixture code, or snapshots.
- The workstream document already contained most M2/M3 reconciliation from the planning commit on `master`. Patch 5 therefore adds only the missing local M3 open-question records for for-of Set membership and deferred forEach, rather than restating the whole milestone.
- In `tools/ts2pant/docs/transformations.md`, the Structured Iteration catalogue now treats loop-backed pure builders as Shapes D/E/F, after the existing Shape A/B/C contracts. I changed the old "three shapes" wording and the invariants heading so the section covers both IR1-SSA mutating iteration and pure-body builder recognition.
- The Local Collection Builders exclusions now point loop-backed builders to Structured Iteration instead of saying broader for-of builder completeness is still a separate future milestone. forEach builder callbacks remain explicitly deferred.

Spec/Evidence Mapping:
- `list-loop-local-const` / `list-compound-guard`: documented in `tools/ts2pant/docs/transformations.md` under "Shape D - pure for-of build-list" and the Shape D/E/F guard invariants. Required context: `tools/ts2pant/docs/transformations.md`, `tools/ts2pant/AGENTS.md`, `workstreams/ts2pant-body-completeness.md`.
- `set-membership-target`: documented in "Shape E - pure for-of Set builder"; the note explicitly calls out `some` membership equivalence and why list equality is unsound under deduplication.
- `scalar-fold-target`: documented in "Shape F - pure for-of scalar fold"; the note records identity elision and the exclusion of no-identity/nullable and non-commutative folds.
- `iteration-exclusions`: documented in the Structured Iteration invariants and reinforced by the Local Collection Builders exclusion update.
- Static/test evidence: `git diff --check` passed; `just ts2pant-test-unit` passed (1018 pass, 3 skipped); `just ts2pant-test-integration` passed (145 pass, 1 skipped).