### PR TITLE
[ts2pant-recursive-du-type-shapes] Patch 1: Characterize recursive nullable DU and variadic tuple shapes

### DIFF
--- a/tools/ts2pant/tests/fixtures/recursive-union/cases.ts
+++ b/tools/ts2pant/tests/fixtures/recursive-union/cases.ts
@@ -52,3 +52,31 @@ type Shape =
 export function shapeKind(s: Shape): string {
   return s.kind;
 }
+
+// Mirrors the essential `IR1ForeachCondStmt` / `IR1ForeachBody` shape without
+// importing the production IR1 types. The recursive branch is nullable so the
+// body field exercises the reserved-domain knot, while the tuple fields mirror
+// the required-head/rest variadics that Patch 2 and Patch 3 split apart.
+type ForeachCondStmt = {
+  kind: "cond-stmt";
+  arms: readonly [
+    readonly [string, ForeachBody],
+    ...ReadonlyArray<readonly [string, ForeachBody]>,
+  ];
+  otherwise: ForeachBody | null;
+};
+
+type ForeachBody =
+  | { kind: "assign"; value: number }
+  | ForeachCondStmt
+  | {
+      kind: "block";
+      stmts: readonly [ForeachBody, ...ForeachBody[]];
+    };
+
+/**
+ * @pant foreachBodyKind body = foreach-body--kind body.
+ */
+export function foreachBodyKind(body: ForeachBody): string {
+  return body.kind;
+}

--- a/tools/ts2pant/tests/integration/recursive-union.test.mts
+++ b/tools/ts2pant/tests/integration/recursive-union.test.mts
@@ -23,6 +23,23 @@ describe("recursive discriminated union integration", () => {
     await loadAst();
   });
 
+  it("@pant on `foreachBodyKind` (nullable recursive union) entails", {
+    skip: "Patch 3 restores nullable recursive DU registration before solver entailment",
+  }, async () => {
+    const output = await emitAndCheck(
+      await buildDocument(FIXTURE, "foreachBodyKind"),
+    );
+    const result = runCheck(output);
+    const entailments = result.checks.filter(
+      (c) =>
+        c.message.startsWith("OK: Entailed:") ||
+        c.message.startsWith("FAIL: Not entailed:"),
+    );
+    assert.ok(entailments.length >= 1, "expected an entailment result");
+    assert.ok(result.passed, `pant --check failed:\n${result.output}`);
+    assert.ok(entailments.every((c) => c.passed));
+  });
+
   for (const fn of ["treeKind", "leafValue", "leftChildKind"]) {
     it(`@pant on \`${fn}\` (recursive union) entails`, {
       skip: !solverAvailable() ? "z3 not available" : undefined,

--- a/tools/ts2pant/tests/recursive-union.test.mts
+++ b/tools/ts2pant/tests/recursive-union.test.mts
@@ -19,6 +19,28 @@ describe("recursive discriminated union", () => {
     await loadAst();
   });
 
+  it("translates an IR1ForeachBody-shaped nullable recursive union", {
+    skip: "Patch 3 resolves nullable recursive DU knot-tying for reserved domains",
+  }, async () => {
+    const output = await emitAndCheck(
+      await buildDocument(FIXTURE, "foreachBodyKind"),
+    );
+    assert.doesNotMatch(output, /UNSUPPORTED/u);
+    assert.match(output, /^ForeachBody\.$/mu);
+    assert.equal([...output.matchAll(/^ForeachBody\.$/gmu)].length, 1);
+  });
+
+  it("emits correct recursive DU accessor sorts", {
+    skip: "Patch 3 emits recursive DU accessor sorts after nullable union repair",
+  }, async () => {
+    const output = await emitAndCheck(
+      await buildDocument(FIXTURE, "foreachBodyKind"),
+    );
+    assert.match(output, /foreach-body--arms s: ForeachBody => \[String \* ForeachBody\]\./u);
+    assert.match(output, /foreach-body--otherwise s: ForeachBody => \[ForeachBody\]\./u);
+    assert.match(output, /foreach-body--stmts s: ForeachBody => \[ForeachBody\]\./u);
+  });
+
   it("translates a self-referential union to a domain with self-referential accessors", async () => {
     // `Tree`'s `node` variant has `left`/`right`: `Tree`. DU synthesis once
     // recursed forever (stack overflow), then refused; it now reserves the

--- a/tools/ts2pant/tests/translate-types.test.mts
+++ b/tools/ts2pant/tests/translate-types.test.mts
@@ -76,6 +76,16 @@ function extractFirstAlias(source: string) {
   return { alias, checker, sourceFile };
 }
 
+function extractAliasType(source: string, aliasName: string) {
+  const sourceFile = createSourceFileFromSource(source);
+  const checker = getChecker(sourceFile);
+  const aliasNode = sourceFile
+    .getTypeAliasOrThrow(aliasName)
+    .getTypeNodeOrThrow().compilerNode;
+  const type = checker.getTypeAtLocation(aliasNode);
+  return { checker, sourceFile, type };
+}
+
 function emitSynthDeclsOnly(cell: ReturnType<typeof newSynthCell>) {
   return cellEmitSynth(cell).decls;
 }
@@ -687,6 +697,94 @@ describe("emitDiscriminatedUnionSynthDecls", () => {
 });
 
 describe("mapTsType", () => {
+  it("maps a fixed tuple as a Pantagruel product", {
+    skip: "Patch 2 keeps fixed tuples as products while tuple variadics are reworked",
+  }, () => {
+    const { checker, type } = extractAliasType(
+      `
+      type FixedTuple = [number, string];
+    `,
+      "FixedTuple",
+    );
+
+    assert.deepEqual(mapTsType(type, checker, IntStrategy), {
+      ok: true,
+      sort: "Int * String",
+    });
+  });
+
+  it("maps a homogeneous required-head/rest tuple to a Pantagruel list", {
+    skip: "Patch 2 implements homogeneous variadic tuple mapping",
+  }, () => {
+    const { checker, type } = extractAliasType(
+      `
+      type HomogeneousTuple<T> = [T, ...T[]];
+      type NumberTuple = HomogeneousTuple<number>;
+    `,
+      "NumberTuple",
+    );
+
+    assert.deepEqual(mapTsType(type, checker, IntStrategy), {
+      ok: true,
+      sort: "[Int]",
+    });
+  });
+
+  it("keeps a tuple pair as the element of a homogeneous variadic list", {
+    skip: "Patch 2 keeps repeated tuple pairs inside list-lifted variadics",
+  }, () => {
+    const { checker, type } = extractAliasType(
+      `
+      type Pair = [number, string];
+      type RepeatedPairTuple = [Pair, ...Pair[]];
+    `,
+      "RepeatedPairTuple",
+    );
+
+    assert.deepEqual(mapTsType(type, checker, IntStrategy), {
+      ok: true,
+      sort: "[Int * String]",
+    });
+  });
+
+  it("refuses a heterogeneous required-head/rest tuple", {
+    skip: "Patch 2 refuses heterogeneous variadic tuples precisely",
+  }, () => {
+    const { checker, type } = extractAliasType(
+      `
+      type HeterogeneousTuple = [number, ...string[]];
+    `,
+      "HeterogeneousTuple",
+    );
+
+    assert.deepEqual(mapTsType(type, checker, IntStrategy), {
+      ok: false,
+      reason: "heterogeneous variadic tuple is not expressible in Pantagruel",
+    });
+  });
+
+  it("propagates a nested DU field-mapping refusal", {
+    skip: "Patch 3 preserves nested DU refusal provenance during registration",
+  }, () => {
+    const { checker, type } = extractAliasType(
+      `
+      type NestedRefusal = {
+        outer: {
+          ok: number;
+          bad: () => void;
+        };
+      };
+    `,
+      "NestedRefusal",
+    );
+    const mapped = mapTsType(type, checker, IntStrategy, newSynthCell());
+
+    assert.deepEqual(mapped, {
+      ok: false,
+      reason: "() => void",
+    });
+  });
+
   it("maps `any` to the shared Opaque sort", async () => {
     await loadAst();
     const cell = newSynthCell();


### PR DESCRIPTION
## Patch 1: Characterize recursive nullable DU and variadic tuple shapes

- Use explicit Node test skip reasons that name Patch 2 or Patch 3; do not weaken existing assertions or run implementation-dependent tests in this patch.
- In direct mapper tests, obtain each alias type through the existing TypeScript checker helper and assert exact `MapTsTypeResult` sorts/reasons for fixed `[A, B]`, homogeneous `[T, ...T[]]`, homogeneous repeated pair tuples, and heterogeneous `[A, ...B[]]`.
- Add a nested-field refusal fixture whose inner anonymous record contains an unmappable function field, so the desired DU diagnostic proves preservation of a real `MapTsTypeResult.reason`.
- Mirror the essential `IR1ForeachCondStmt`/`IR1ForeachBody` shape without importing production IR1: the condition arms and block statements use required-head/rest tuples, and `otherwise` is nullable recursive.
- Assert the synthesized declaration has no `UNSUPPORTED`, has only one recursive ForeachBody DU domain, and exposes the expected `arms`, `otherwise`, and `stmts` return sorts; leave those tests skipped until Patch 3.
- Run `just ts2pant-test-unit` to prove the dormant characterization is non-functional.

## Changes
- Use explicit Node test skip reasons that name Patch 2 or Patch 3; do not weaken existing assertions or run implementation-dependent tests in this patch.
- In direct mapper tests, obtain each alias type through the existing TypeScript checker helper and assert exact `MapTsTypeResult` sorts/reasons for fixed `[A, B]`, homogeneous `[T, ...T[]]`, homogeneous repeated pair tuples, and heterogeneous `[A, ...B[]]`.
- Add a nested-field refusal fixture whose inner anonymous record contains an unmappable function field, so the desired DU diagnostic proves preservation of a real `MapTsTypeResult.reason`.
- Mirror the essential `IR1ForeachCondStmt`/`IR1ForeachBody` shape without importing production IR1: the condition arms and block statements use required-head/rest tuples, and `otherwise` is nullable recursive.
- Assert the synthesized declaration has no `UNSUPPORTED`, has only one recursive ForeachBody DU domain, and exposes the expected `arms`, `otherwise`, and `stmts` return sorts; leave those tests skipped until Patch 3.
- Run `just ts2pant-test-unit` to prove the dormant characterization is non-functional.

## Files to Modify
- tools/ts2pant/tests/translate-types.test.mts (modify): Add skipped direct mapper tests for homogeneous/fixed/heterogeneous tuple cases and nested DU refusal provenance.
- tools/ts2pant/tests/fixtures/recursive-union/cases.ts (modify): Add the minimal ForeachCondStmt/ForeachBody recursive fixture and annotated `foreachBodyKind` function.
- tools/ts2pant/tests/recursive-union.test.mts (modify): Add skipped production-pipeline tests for recursive registration and exact emitted field sorts.
- tools/ts2pant/tests/integration/recursive-union.test.mts (modify): Add a skipped solver-backed entailment test for `foreachBodyKind`.

## Gameplan Specification

```
module TS2PANT_RECURSIVE_DU_TYPE_SHAPES_FINAL.

TupleShape.
TypeShape.
DiagnosticRun.

homogeneous-variadic t: TupleShape => Bool.
heterogeneous-variadic t: TupleShape => Bool.
fixed-tuple t: TupleShape => Bool.
maps-to-list t: TupleShape => Bool.
maps-to-product t: TupleShape => Bool.
refused t: TupleShape => Bool.
recursive-tagged-union t: TypeShape => Bool.
nullable-recursive-view t: TypeShape => Bool.
uses-reserved-domain t: TypeShape => Bool.
registration-succeeds t: TypeShape => Bool.
registration-fails t: TypeShape => Bool.
preserves-nested-reason t: TypeShape => Bool.
arms-is-list-of-pairs t: TypeShape => Bool.
otherwise-is-optional-recursive t: TypeShape => Bool.
stmts-is-recursive-list t: TypeShape => Bool.
audited-corpus r: DiagnosticRun => Bool.
unsupported-registration-count r: DiagnosticRun => Nat0.
---
all t: TupleShape | homogeneous-variadic t -> maps-to-list t.
all t: TupleShape | heterogeneous-variadic t -> refused t.
all t: TupleShape | fixed-tuple t -> maps-to-product t.
all t: TypeShape | recursive-tagged-union t and nullable-recursive-view t -> uses-reserved-domain t.
all t: TypeShape | recursive-tagged-union t and nullable-recursive-view t -> registration-succeeds t.
all t: TypeShape | registration-fails t -> preserves-nested-reason t.
all t: TypeShape | recursive-tagged-union t and nullable-recursive-view t -> arms-is-list-of-pairs t.
all t: TypeShape | recursive-tagged-union t and nullable-recursive-view t -> otherwise-is-optional-recursive t.
all t: TypeShape | recursive-tagged-union t and nullable-recursive-view t -> stmts-is-recursive-list t.
all r: DiagnosticRun | audited-corpus r -> unsupported-registration-count r = 0.

```

## Patch Specification

```
module TS2PANT_RECURSIVE_DU_TYPE_SHAPES_PATCH_1.

> Patch 1 introduces dormant characterization surfaces only.
> The declarations name the two shape classes under test; no translator behavior changes.

TupleShape.
RecursiveDuShape.
---
true.

```


## Implementation Notes

- No production translator code changed in Patch 1. This patch is deliberately test-only: it adds dormant characterization coverage that documents the current failure shape without changing runtime behavior.
- The tuple cases pull alias types through the TypeScript checker helper rather than relying on syntax-only inspection. That keeps the assertions aligned with the live `MapTsTypeResult` contract and avoids coupling to parser text.
- The nested refusal fixture uses an anonymous inner record with an unmappable function field so the failure path preserves a real inner `MapTsTypeResult.reason`. Dependent patches should keep that provenance intact when they thread tuple and recursive-DU logic through anonymous-record synthesis.
- The recursive fixture intentionally mirrors only the minimal `IR1ForeachCondStmt` / `IR1ForeachBody` shape needed to exercise the bug: required-head/rest tuples for `arms` and `stmts`, plus a nullable recursive `otherwise`. Patch 3 should preserve the single reserved-domain identity for this fixture and avoid broadening the recursive-DU recognizer.
- All recursive-DU and solver-backed assertions are skipped on purpose in this patch. They are present as executable documentation for Patch 3, not as live coverage yet.
- Verification performed: `just ts2pant-test-unit` passed with the new tests skipped, confirming the added characterization does not perturb the existing unit suite.

- Spec/Evidence Mapping:
  - `homogeneous-variadic -> maps-to-list`, `fixed-tuple -> maps-to-product`, `heterogeneous-variadic -> refused`: [`tools/ts2pant/tests/translate-types.test.mts`](file:///Users/zax/worktrees/ts2pant-recursive-du-type-shapes/patch-1/tools/ts2pant/tests/translate-types.test.mts) skipped assertions; `just ts2pant-test-unit` proved they stay dormant in this patch.
  - `registration-fails -> preserves-nested-reason`: same test file’s nested refusal fixture and assertion.
  - `recursive-tagged-union` / `nullable-recursive-view` shape capture: [`tools/ts2pant/tests/fixtures/recursive-union/cases.ts`](file:///Users/zax/worktrees/ts2pant-recursive-du-type-shapes/patch-1/tools/ts2pant/tests/fixtures/recursive-union/cases.ts) defines the minimal `ForeachBody` fixture for Patch 3.
  - `audited-corpus` / `unsupported-registration-count = 0`: intentionally not exercised yet; the skipped recursive-union and integration tests in [`tools/ts2pant/tests/recursive-union.test.mts`](file:///Users/zax/worktrees/ts2pant-recursive-du-type-shapes/patch-1/tools/ts2pant/tests/recursive-union.test.mts) and [`tools/ts2pant/tests/integration/recursive-union.test.mts`](file:///Users/zax/worktrees/ts2pant-recursive-du-type-shapes/patch-1/tools/ts2pant/tests/integration/recursive-union.test.mts) are the future evidence points for that clause.