### PR TITLE
Close ts2pant body-completeness workstream with residual audits

### DIFF
--- a/tools/ts2pant/docs/body-completeness-residual-audit.md
+++ b/tools/ts2pant/docs/body-completeness-residual-audit.md
@@ -1,0 +1,189 @@
+# Body Completeness Residual Ownership Audit
+
+**Workstream:** ts2pant Body Completeness — Milestone 5
+(`residual-body-diagnostic-cleanup`). **Date:** 2026-07-13. **Status:**
+ownership audit; no translator behavior changed.
+
+## Outcome
+
+The post-M3 self-translation corpus has no remaining high-volume family that
+belongs to the bounded body transformations delivered by this workstream.
+Every normalized UNSUPPORTED bucket above the M5 threshold is now assigned to
+a semantic owner or an intentional refusal.
+
+The audit threshold is **more than 10 normalized diagnostic occurrences**.
+This resolves the workstream's suggested completion criterion and includes the
+two 11-count buckets. Counts are diagnostic occurrences, not necessarily unique
+functions: one function can emit the same reason more than once.
+
+## Method
+
+Run from `tools/ts2pant`:
+
+```sh
+NODE_OPTIONS=--max-old-space-size=6144 npx tsx scripts/corpus-diag.mts --summary-only
+```
+
+The audit then enumerated every function behind the high-volume structural
+reasons and classified its statement shape, local writes, loop exits, returned
+value, and downstream translation dependency. The owner table is encoded in
+`scripts/corpus-diag.mts`; a future high-volume reason that has not been audited
+is printed as `UNASSIGNED`.
+
+## Baseline
+
+- 866 top-level functions
+- 171 clean translations
+- 690 functions with UNSUPPORTED output
+- 5 build errors (`Function not found: visit`)
+
+The five errors are extraction/name-resolution failures, not body-lowering
+diagnostics, and are outside this workstream.
+
+## Owner table
+
+| Count | Normalized reason | Owner / disposition |
+| ---: | --- | --- |
+| 82 | `alias IR1ForeachCondStmt: discriminated union could not be registered for tagged Pantagruel encoding` | DU/type-shape encoding |
+| 60 | `early-return predicate has side effects` | guard/foreign-call purity |
+| 46 | `if-with-return block must contain only const bindings followed by a return` | generalized nested sequencing follow-up; decomposed below |
+| 42 | `for-of loop is not a recognized build-list comprehension` | generalized accumulator/search-loop follow-up; decomposed below |
+| 41 | `expression statement before return (only const / μ-search / if-early-return allowed)` | local-effect/statement SSA follow-up; decomposed below |
+| 34 | `early-return value has side effects` | guard/foreign-call purity |
+| 34 | `Map builder construction is not supported in this milestone` | Map-builder semantics follow-up |
+| 31 | `unsupported pure expression in const initializer` | expression/type lowering |
+| 22 | `local bindings or multiple statements before return` | generalized local-sequencing follow-up; decomposed below |
+| 19 | `Set builder from iterable is not supported` | collection-constructor semantics follow-up |
+| 19 | `switch default must end with return EXPR` | intentional until exhaustiveness/throw semantics exist |
+| 14 | `switch case must end with return EXPR` | intentional fall-through/break/throw refusal |
+| 13 | `statement is not supported by unified SSA body lowering` | statement-position SSA follow-up |
+| 11 | `branch call is not a recognized Map/Set effect` | branch-local collection-effect follow-up |
+| 11 | `let captured by closure that reassigns it is not supported` | intentional until closure conversion is modeled |
+
+The 19/14 switch rows are classified function-by-function in
+`switch-body-survey.md`. The 82-count DU row, 60/34 purity rows, and 31-count
+initializer row only surface at body translation; their missing semantics are
+not structural body transformations.
+
+## Structural bucket decomposition
+
+### Nested if-with-return blocks: 46 functions
+
+The label is a scanner boundary, not a single missing if-conversion rule.
+
+| Source shape | Functions | Disposition |
+| --- | ---: | --- |
+| Calls, foreign accessors, or downstream value lowering inside the branch | 24 | guard/foreign-call or expression lowering |
+| Loop/traversal inside the branch | 14 | generalized loop/local sequencing |
+| Further nested value/type control | 4 | genuine nested structural tail, but below the threshold |
+| Local mutation inside the branch | 2 | local-effect SSA |
+| `throw`/`try` control | 2 | intentional until exceptional control is modeled |
+
+Representative examples are
+`translate-body.ts:recognizeEarlyReturnArm` (calls and downstream value
+lowering), `translate-body.ts:translateBodyExpr` (loop traversal),
+`translate-types.ts:literalFromType` (the four-function nested-value tail),
+`index.ts:main` (mutation), and `pant-wasm.ts:ensureWasmLoaded` (`try`/`throw`).
+There is no greater-than-10 family of the bounded pure
+`const*; return value` shape M1 owns.
+
+### Unrecognized for-of loops: 42 functions
+
+| Source shape | Functions | Disposition |
+| --- | ---: | --- |
+| Writes one or more local list accumulators | 26 | generalized accumulator sequencing |
+| Search/validation loop with early exit | 10 | search/general-loop control, not a builder |
+| Writes a local Set | 5 | collection-constructor/effect semantics |
+| Nested or multiple loops | 1 | generalized loop sequencing |
+
+The 26 list-writing functions do not form another returned-list comprehension
+family. They include multi-accumulator record construction
+(`annotations.ts:extractAnnotations`), a builder consumed by `join`
+(`translate-types.ts:tupleCtorBaseName`), conditional parsing with `continue`
+(`emit.ts:parseCheckOutput`), and SSA program assembly returning a different
+record (`ir1-ssa-foreach.ts:lowerForeachShapeBAsGeneralLoop`). Even the small
+direct-result examples depend on foreign-call purity or richer conditional
+push semantics. M3's single returned accumulator with a comprehension target
+is already covered; these cases need a general accumulator-value pipeline.
+
+### Expression statements before return: 41 functions
+
+| Source shape | Functions | Disposition |
+| --- | ---: | --- |
+| Assignment or registration mutation | 15 | local-effect/statement SSA |
+| Local list write | 8 | generalized accumulator sequencing |
+| Other effectful expression | 7 | statement effects |
+| Local Set write | 5 | collection effects |
+| Frame or `try` effect | 4 | scoped/exceptional effects |
+| Foreign/runtime call | 2 | foreign/runtime effect modeling |
+
+Examples include SSA version allocation
+(`ir1-ssa-scalars.ts:nextScalarSsaWrite`), registration pushes
+(`ir1-build.ts:tryBuildL1PureSubExpression`), narrowing-frame management
+(`ir1-build-body.ts:withNarrowingFrame`), and wasm loading
+(`pant-wasm.ts:loadParser`). Admitting arbitrary expression statements in the
+pure prelude would erase exactly the effects that these functions depend on.
+
+### Local bindings or multiple statements: 22 functions
+
+| Source shape | Functions | Disposition |
+| --- | ---: | --- |
+| Loop/while-based sequencing | 15 | generalized local/loop sequencing |
+| Foreign-call sequencing | 2 | foreign-call effects |
+| Local mutation | 2 | local-effect SSA |
+| Multi-local value flow | 2 | generalized local sequencing |
+| Branch sequencing | 1 | generalized statement lowering |
+
+This is the fallback emitted after the bounded pure-prelude recognizers decline
+the body. The dominant functions are source scanners such as
+`translate-body.ts:extractReturnExpression`, `purity.ts:expressionIsPure`, and
+`translate-types.ts:detectDiscriminatedUnion`; they are not missing simple
+let-elimination.
+
+### Unified SSA statements: 13 generic occurrences
+
+The generic 13-count row and the four explicit `SwitchStatement` occurrences
+come from nine unique functions because some functions emit the reason more
+than once. Four are mutation-bearing visitor switches, three update local
+Map/cache state, one allocates a local collection write, and one uses another
+unsupported statement form. These require statement-position effect SSA. The
+four switches are also accounted for by the M4 switch survey.
+
+## Collection and closure boundaries
+
+- **Map construction (34):** these functions build registries, caches, and SSA
+  state. A faithful returned Map needs the guarded Stage-A membership / Stage-B
+  value rule pair and alias/overwrite semantics. M2 intentionally deferred
+  this to a Map-specific target; the count does not justify weakening that
+  boundary.
+- **Set-from-iterable construction (19):** these are seeded/cloned Sets rather
+  than M2's empty finite Set plus straight-line `.add` form. Their semantics
+  require iterating the seed and preserving membership, so they belong with
+  collection constructors.
+- **Branch-local Map/Set effects (11):** these are state changes in branches,
+  not pure expression calls. They belong with collection location SSA and
+  branch joins.
+- **Closure-captured reassigned lets (11):** closure conversion changes
+  environment and lifetime semantics. The existing dedicated diagnostic is an
+  intentional, precise refusal.
+
+## Verdict
+
+Close M5 as an audit-only reconciliation milestone and close the Body
+Completeness workstream. Do not create another behavior gameplan under this
+workstream: no remaining greater-than-10 source-shape family maps to the
+bounded if-conversion, let-elimination, record-return, local finite-builder, or
+structured-iteration targets it owns.
+
+Future work should start from the semantic owner rather than the coarse body
+diagnostic:
+
+- generalized accumulator and statement-position SSA;
+- Map construction and seeded collection constructors;
+- guard/foreign-call purity and expression lowering;
+- DU/type-shape encoding;
+- closure conversion or exceptional-control semantics only when demanded.
+
+Re-open Body Completeness only if a future corpus run prints `UNASSIGNED` above
+the threshold and inspection finds a bounded, unambiguous source family with a
+clear existing Pant target.

--- a/tools/ts2pant/docs/free-call-decl-entailment-survey.md
+++ b/tools/ts2pant/docs/free-call-decl-entailment-survey.md
@@ -18,10 +18,11 @@ a shared js-stdlib rule**.
 
 ## Method
 
-Every `@pant`-bearing fixture function across `tools/ts2pant/tests/fixtures`
-(13 functions; `src/` dogfood files carry no `@pant` annotations) was built
-through the standard pipeline, emitted, and run through `pant --check`. Each
-function is flagged for whether its assertion involves a free or built-in call.
+Every `@pant`-bearing fixture function in the Milestone 3 survey set across
+`tools/ts2pant/tests/fixtures` (12 functions, covering 14 `@pant` assertions;
+`src/` dogfood files carry no `@pant` annotations) was built through the
+standard pipeline, emitted, and run through `pant --check`. Each function is
+flagged for whether its assertion involves a free or built-in call.
 
 ## Results
 

--- a/tools/ts2pant/docs/free-call-decl-entailment-survey.md
+++ b/tools/ts2pant/docs/free-call-decl-entailment-survey.md
@@ -1,0 +1,108 @@
+# Free-Call-Decl Entailment Survey (Milestone 3)
+
+**Workstream:** ts2pant Free-Call-Decl Synthesis — Milestone 3 (`entailment-survey`).
+**Date:** 2026-05-27. **Solver:** z3 4.15.4 via `pant --check` (default bound 3).
+**Status:** read-only measurement; no translator behavior changed.
+
+## Purpose
+
+Milestones 1–2 turned every structurally-accepted free/built-in call from
+`> UNSUPPORTED: free-call-decl` into a *declared* Pantagruel reference — local
+EUF heads for unknown user functions (M1) and qualified shared-module references
+for stdlib calls (M2). Those are **type-checking** wins. This survey measures the
+separate question — **entailment**: do the `@pant` assertions that involve a
+free/built-in call actually *prove* under z3, or do they merely parse/type-check?
+The answer drives the M4 go/no-go: M4 (`targeted-sound-axioms`) was gated on
+finding **≥5 distinct assertions blocked solely on a soundly-modelable axiom for
+a shared js-stdlib rule**.
+
+## Method
+
+Every `@pant`-bearing fixture function across `tools/ts2pant/tests/fixtures`
+(13 functions; `src/` dogfood files carry no `@pant` annotations) was built
+through the standard pipeline, emitted, and run through `pant --check`. Each
+function is flagged for whether its assertion involves a free or built-in call.
+
+## Results
+
+| # | Fixture > fn | Involves call? | Call kind | `--check` |
+|---|---|---|---|---|
+| 1 | validate-helper.ts > deposit | **yes** | free user fns as guards (`validateAmount`, `requireNonNegativeBalance`) | **entails** |
+| 2 | assert-guard.ts > deposit | **yes** | free `assert()` guard | **entails** |
+| 3 | apply-fee.ts > applyFee | no | field mutation | entails |
+| 4 | deposit.ts > deposit | no | field mutation | entails |
+| 5 | max.ts > larger | no | own rule | entails |
+| 6 | annotations.ts > add | no | arithmetic | entails |
+| 7 | annotations.ts > sum | no | arithmetic | **not entailed** (see below) |
+| 8 | annotations.ts > rangeCheck | no | comparison | entails |
+| 9 | annotations.ts > deposited | no | identity | entails |
+| 10 | expressions-map-params.ts > sumAt | **yes** | `Map.get` → synthesized Map encoding | **entails** |
+| 11 | expressions-set.ts > both | **yes** | `Set.has` → `in` membership | **entails** |
+| 12 | expressions-map.ts > congruence | **yes** | `Map.has` → membership predicate | **entails** |
+
+### The five call-involving assertions
+
+All five **entail**. None of them is closed by a js-stdlib EUF axiom; each entails
+for a reason that already exists in the translator:
+
+- **#1, #2 (guarded free calls).** The free user-function / `assert` calls are
+  guards; the post-state proof rests on the action/guard modeling, not on any
+  property of the called function. The opaque EUF head M1 synthesizes is not even
+  load-bearing for the assertion.
+- **#10 (`Map.get`), #11 (`Set.has`), #12 (`Map.has`).** These entail via the
+  **structured collection encoding** — McCarthy select/store for `Map`
+  (`entries`/`entriesKey` guarded rules) and `x in xs` membership for `Set`. That
+  encoding is *not* one of the M2 dispatch EUF heads; it predates this workstream
+  and is strictly higher-fidelity than an opaque head would be. (This is exactly
+  why M2 deliberately left `Set.has` on `in` and did not create `JS_SET`.)
+
+### The one non-entailment (#7) is not a stdlib gap
+
+`annotations.ts > sum` asserts `sum a b >= a` for `sum a b = a + b`. This is false
+for unconstrained `Int` (`b` may be negative) — a property-of-arithmetic
+non-entailment, not a missing-axiom-on-a-stdlib-rule. No call is involved.
+
+## Key finding: the M2 dispatch heads are unexercised
+
+**No `@pant` assertion anywhere in the corpus references a shared js-stdlib EUF
+rule** (`JS_MATH::*`, `JS_STRING::*`, `JS_ARRAY::from`, `JS_MAP::{values,entries,keys}`).
+The fixtures that *use* those dispatched built-ins — `constMathMax`,
+`constChainedPure`, `letMathMax`, `constStringMethod`, `methodCall`,
+`constReplaceLiteral`, `constArrayFromMap`, `constMapEntries`, `chainedArrayCount`
+— are **type-check-only fixtures with no assertion**. M2 made them *declared and
+type-checking*; nobody has yet written an entailment goal over them.
+
+## Per-rule blocked-assertion breakdown
+
+| Shared js-stdlib rule | Assertions blocked solely on a sound axiom |
+|---|---|
+| `JS_MATH::max-of` / `min-of` / `abs` | 0 |
+| `JS_STRING::*` (incl. `replace`) | 0 |
+| `JS_ARRAY::from` | 0 |
+| `JS_MAP::values` / `entries` / `keys` | 0 |
+| **Total** | **0** |
+
+## Verdict: do **not** proceed to Milestone 4
+
+The M4 gating criterion (≥5 assertions blocked solely on a soundly-modelable
+stdlib axiom) is met by **0** assertions — far below threshold. This is the
+workstream's documented **abort condition**: the entailment gaps that a structural
+axiom would close are not present, because (a) the dispatched-built-in fixtures
+carry no assertions, and (b) the collection assertions that exist already entail
+through the structured Map/Set encoding rather than an EUF head.
+
+**The free-call-decl workstream is therefore complete at M2.** The end-to-end
+story holds: structurally accepted → declared → type-checks, and *every*
+call-involving assertion that exists today already entails. The "where it matters,
+provable" clause has no unmet demand.
+
+## Re-open trigger (for the record)
+
+Revisit a *targeted* axiom (not a speculative milestone) only if a future `@pant`
+assertion is written that is blocked **solely** on a sound structural property of a
+dispatched head — e.g. `#(Array.from(m.values())) = <map cardinality>` (Map-size /
+values-length) or `JS_ARRAY::from` length non-negativity. At that point add the
+single axiom to the owning `samples/js-stdlib/*.pant` module with a soundness
+justification, guarding before/after with this survey's entailment set. String
+semantics (case folding, locale, surrogates) remain out of scope per the
+`JS_STRING.pant` refusal.

--- a/tools/ts2pant/docs/switch-body-survey.md
+++ b/tools/ts2pant/docs/switch-body-survey.md
@@ -1,0 +1,106 @@
+# Switch Body Residual Survey
+
+**Workstream:** ts2pant Body Completeness — Milestone 4
+(`switch-body-completeness`). **Date:** 2026-07-13. **Status:** read-only
+measurement; no translator behavior changed.
+
+## Question
+
+Milestone 3 left switch-shaped diagnostics in the self-translation corpus.
+Milestone 4 was conditional on those residuals containing a meaningful family
+of bounded, no-fall-through value switches with a clear `cond` target. This
+survey classifies the residuals before committing to implementation.
+
+## Post-M3 baseline
+
+Run from `tools/ts2pant`:
+
+```sh
+NODE_OPTIONS=--max-old-space-size=6144 npx tsx scripts/corpus-diag.mts --summary-only
+```
+
+Result:
+
+- 866 top-level functions
+- 171 clean translations
+- 690 functions with UNSUPPORTED output
+- 5 build errors
+- `for-of loop is not a recognized build-list comprehension`: 42, down from
+  the post-M2 baseline of 52
+
+The switch-related buckets contain 47 functions:
+
+| Residual bucket | Count |
+| --- | ---: |
+| `switch default must end with return EXPR` | 19 |
+| `switch case must end with return EXPR` | 14 |
+| `switch case label must be a literal` | 7 |
+| unified SSA rejects `SwitchStatement` | 4 |
+| `switch block const has side effects` | 3 |
+
+## Classification
+
+Every residual was inspected against its TypeScript switch shape.
+
+| Shape | Count | Classification |
+| --- | ---: | --- |
+| Exhaustive switch whose `default` throws | 19 | Intentionally unsupported by the M4 boundary: a throw-only value arm has no Pant value and cannot be used as a `cond` otherwise branch. |
+| Empty/grouped case fall-through | 12 | Intentionally unsupported: the current switch-to-`cond` contract rejects fall-through, including grouped labels. |
+| `ts.SyntaxKind.*` computed/property-access case labels | 7 | Intentionally unsupported: M4 keeps non-literal labels out of scope because label evaluation and constant resolution are separate concerns. |
+| Statement-position visitor switch with local mutation and `break` | 4 | Not value-position switch lowering. These require statement/SSA effect modeling, not the existing switch-to-`cond` contract. |
+| Block-local calls classified as effectful | 3 | Owned by purity/foreign-call analysis rather than structural switch lowering. |
+| Complex block-return cases | 2 | `emit.ts:renderPropResult` and `ir1-lower.ts:lowerL1Expr` contain calls, nested conditionals, and collection operations; they are not the bounded pure block-return subset M4 proposed to admit. |
+
+The 19 exhaustive-throw functions are:
+
+- `brand-precondition.ts:compare`
+- `builtins.ts:moduleForNamespace`
+- `ir-emit.ts:{lowerBinop,lowerUnop,lowerCombiner,combinerToBinop}`
+- `ir1-printer.ts:{formatIR1SsaLocation,readExpressionKey,formatUnopWithSsaReads,locationAsPrimedRule,formatIR1Literal,formatUnop,binopGlyph,unopGlyph}`
+- `ir1-ssa-counter-loop.ts:{boundCmpToOpaque,combinerToOpaque}`
+- `ir1-ssa-scalars.ts:{lowerScalarBinop,lowerScalarUnop}`
+- `translate-body.ts:makeCombiner`
+
+The 12 fall-through functions are:
+
+- `index.ts:getStrategy`
+- `ir1-ssa-collections.ts:{collectionSsaReadExpr,lowerCollectionSsaExprToOpaque,isCollectionSsaExpr}`
+- `ir1-ssa-counter-loop.ts:{lastCounterValue,foldForBinop,exprReferencesVar,countTargetReads}`
+- `ir1-ssa-scalars.ts:{scalarSsaReadExpr,lowerScalarSsaExprToOpaque,isScalarSsaExpr}`
+- `ir1-substitute.ts:freeVarsIR1SsaLocation`
+
+The seven non-literal-label functions all switch on TypeScript compiler enum
+members:
+
+- `ir-build.ts:binopToReduceInfo`
+- `ir1-build.ts:{binaryOperatorToL1,compoundOpToBinop,explicitOpToBinop}`
+- `narrowing-recognizer.ts:discriminantFactFromEquality`
+- `translate-body.ts:binopToReduceInfo`
+- `translate-signature.ts:translateOperator`
+
+The four statement-position switches are
+`ir1-printer.ts:consumeScalarReadsForExpr` and
+`ir1-ssa-fixed-point.ts:{collectAllNames,collectFreeVars,collectIr1FreeVars}`.
+The three effectful-block cases are
+`ir1-printer.ts:{formatIR1Expr,formatIR1ExprWithSsaReads}` and
+`ir1-ssa-foreach.ts:lowerShapeAExpr`.
+
+## Verdict
+
+Do not create an M4 behavior gameplan. The bounded, no-fall-through value
+switches M4 proposed to add are already supported and covered by the existing
+switch fixtures. None of the 47 self-translation residuals belongs to that
+subset, so an implementation milestone would be vacuous and would not move a
+corpus bucket.
+
+Close M4 as measurement-only. Preserve the current precise refusals and route
+future demand by semantic owner:
+
+- exhaustive throw/default elimination needs an exhaustiveness-aware partial
+  value encoding;
+- grouped labels need explicit fall-through semantics;
+- `SyntaxKind` labels need constant/enum resolution;
+- visitor switches need statement-position SSA lowering;
+- effectful block values need purity/foreign-call admission.
+
+The next workstream action is M5's residual ownership pass, not switch lowering.

--- a/tools/ts2pant/scripts/corpus-diag.mts
+++ b/tools/ts2pant/scripts/corpus-diag.mts
@@ -11,6 +11,67 @@ import { IntStrategy } from "../src/translate-types.js";
 
 const SRC_DIR = resolve(import.meta.dirname, "../src");
 const SUMMARY_ONLY = process.argv.includes("--summary-only");
+const OWNER_THRESHOLD = 10;
+
+// M5 ownership is deliberately attached to normalized diagnostic contracts,
+// not inferred from source syntax. A new high-volume reason therefore appears
+// as UNASSIGNED until its semantic owner is audited explicitly.
+const RESIDUAL_OWNERS = new Map<string, string>([
+  [
+    "alias IR1ForeachCondStmt: discriminated union could not be registered for tagged Pantagruel encoding",
+    "DU/type-shape encoding",
+  ],
+  ["early-return predicate has side effects", "guard/foreign-call purity"],
+  ["early-return value has side effects", "guard/foreign-call purity"],
+  [
+    "if-with-return block must contain only const bindings followed by a return",
+    "follow-up: generalized nested sequencing",
+  ],
+  [
+    "for-of loop is not a recognized build-list comprehension",
+    "follow-up: generalized accumulator/search loops",
+  ],
+  [
+    "expression statement before return (only const / μ-search / if-early-return allowed)",
+    "follow-up: local-effect/statement SSA",
+  ],
+  [
+    "Map builder construction is not supported in this milestone",
+    "follow-up: Map builder semantics",
+  ],
+  [
+    "unsupported pure expression in const initializer",
+    "expression/type lowering",
+  ],
+  [
+    "local bindings or multiple statements before return",
+    "follow-up: generalized local sequencing",
+  ],
+  [
+    "Set builder from iterable is not supported",
+    "follow-up: collection constructor semantics",
+  ],
+  [
+    "switch default must end with `return EXPR`",
+    "intentional: switch exhaustiveness/throw semantics",
+  ],
+  [
+    "switch case must end with `return EXPR` (no fall-through, no break/throw cases in M1)",
+    "intentional: switch fall-through/break/throw semantics",
+  ],
+  [
+    "statement is not supported by unified SSA body lowering",
+    "follow-up: statement-position SSA",
+  ],
+  [
+    "branch call is not a recognized Map/Set effect",
+    "follow-up: branch-local collection effects",
+  ],
+  [
+    "let captured by closure that reassigns it is not supported",
+    "intentional: closure conversion",
+  ],
+]);
 
 interface DiagnosticResult {
   file: string;
@@ -145,6 +206,15 @@ for (const [reason, count] of [...unsupportedBuckets.entries()].sort(
   (a, b) => b[1] - a[1] || a[0].localeCompare(b[0]),
 )) {
   console.log(`${count}\t${reason}`);
+}
+
+console.log(`\nOWNERSHIP (normalized buckets > ${OWNER_THRESHOLD}):`);
+for (const [reason, count] of [...unsupportedBuckets.entries()]
+  .filter(([, count]) => count > OWNER_THRESHOLD)
+  .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))) {
+  console.log(
+    `${count}\t${RESIDUAL_OWNERS.get(reason) ?? "UNASSIGNED"}\t${reason}`,
+  );
 }
 
 if (errorBuckets.size > 0) {

--- a/tools/ts2pant/tests/integration/iteration-builder.test.mts
+++ b/tools/ts2pant/tests/integration/iteration-builder.test.mts
@@ -29,9 +29,7 @@ async function checkFixture(functionName: string): Promise<void> {
 
 describe("iteration builder integration", () => {
   // Patch 2 unskips these list-builder checker stubs.
-  it("list builder positives pass pant --check", {
-    skip: "Patch 2 implements for-of list builder widening",
-  }, async () => {
+  it("list builder positives pass pant --check", async () => {
     await checkFixture("listConstProjection");
     await checkFixture("listCompoundGuard");
     await checkFixture("listNestedGuard");

--- a/workstreams/ts2pant-body-completeness.md
+++ b/workstreams/ts2pant-body-completeness.md
@@ -1,5 +1,7 @@
 # Workstream: ts2pant Body Completeness
 
+**Status:** COMPLETE (Milestone 5 ownership audit, 2026-07-13)
+
 ## Vision
 
 Make ts2pant's TypeScript body lowering accept the common, unambiguous
@@ -266,11 +268,11 @@ Follow-on iteration completeness: once straight-line builders are expressible,
 
 ---
 
-### Milestone 3: iteration-builder-completeness — PLANNED
+### Milestone 3: iteration-builder-completeness — COMPLETE (PRs #365–#369)
 
-> Planned by `gameplans/ts2pant-iteration-builder-completeness.json` (5 patches:
-> 2 INFRA + 3 BEHAVIOR chained 2→3→4). Concrete scope, fixed by the post-M2
-> survey: (a) widen the for-of build-list recognizer to admit pure loop-local
+> Landed via `gameplans/ts2pant-iteration-builder-completeness.json` (PRs
+> #365–#369). The implementation (a) widened the for-of build-list recognizer
+> to admit pure loop-local
 > `const` bindings before the push and compound/nested guards, reusing the
 > existing `each binder in src, guards | proj` comprehension; (b) for-of Set
 > builders via a membership-equivalence assertion over a `some` comprehension
@@ -279,7 +281,10 @@ Follow-on iteration completeness: once straight-line builders are expressible,
 > identity-bearing OP ∈ {+, *, &&, ||} (and `count++`), reusing the Shape-C
 > `combOP over each` reduce with identity-elision. No-identity / nullable
 > reduces (conjoin/disjoin) and `forEach` callbacks are deferred (see Decisions
-> Made and Open Questions).
+> Made and Open Questions). The post-M3 diagnostic reports 866 functions, 171
+> clean, 690 unsupported, and 5 errors; the targeted for-of bucket moved from
+> 52 to 42. The iteration-builder integration suite now runs all list, Set, and
+> scalar-fold `pant --check` cases with no skips.
 
 **Definition of Done**:
 - For-of list builders whose loop body has pure loop-local `const` bindings
@@ -312,13 +317,13 @@ Switch/statement-position cleanup can proceed with fewer loop-shaped false
 positives in the diagnostic output.
 
 **Operator Actions Before Next Milestone**:
-- Re-run the corpus diagnostic and inspect the remaining switch buckets:
+- Done: re-ran the corpus diagnostic and inspected the remaining switch buckets:
   `switch default must end with return`, `switch case must end with return`,
   `switch case label must be a literal`, and
   `statement is not supported by unified SSA body lowering: SwitchStatement`.
-- Decide whether M4 should admit a bounded switch value shape or remain a
-  measurement-only milestone if switch residuals are dominated by fall-through
-  and non-literal labels.
+- Done: the 47 switch residuals contain no bounded-pure value-switch family.
+  M4 is measurement-only; see
+  `tools/ts2pant/docs/switch-body-survey.md`.
 
 **Open Questions**:
 - Resolved by the M3 gameplan: for-of Set builders are in scope and lower to
@@ -332,43 +337,62 @@ positives in the diagnostic output.
 
 ---
 
-### Milestone 4: switch-body-completeness
+### Milestone 4: switch-body-completeness — COMPLETE (MEASUREMENT-ONLY, 2026-07-13)
+
+> Survey report: `tools/ts2pant/docs/switch-body-survey.md`. The post-M3 corpus
+> contains 47 switch-related residuals: 19 exhaustive `default` throws, 12
+> grouped-label fall-through cases, 7 `ts.SyntaxKind.*` non-literal labels, 4
+> statement-position visitor switches with mutation/`break`, 3 effectful block
+> bodies, and 2 complex non-pure block bodies. None belongs to the bounded,
+> no-fall-through pure value-switch subset this milestone proposed to add.
+> **Decision: no behavior gameplan.** Existing supported switch fixtures already
+> exercise the switch-to-`cond` contract, and every residual has a different
+> semantic owner or is intentionally unsupported.
 
 **Definition of Done**:
-- Switch bodies in value position support every bounded no-fall-through shape
-  with a clear `cond` target: terminal return, block-return, and nested pure
-  block-return case/default bodies.
-- Switch statements in supported pure-body preludes and supported unified SSA
-  body positions lower through the same switch-to-cond contract where the
-  semantics are equivalent.
-- Non-literal labels, default-not-last, fall-through-by-empty-case,
-  break-only/throw-only value cases, and side-effectful discriminants remain
-  rejected with existing or sharper diagnostics.
-- The switch case/default residual buckets move down in the post-M4 corpus
-  diagnostic.
+- The post-M3 switch residuals are classified by source shape and semantic
+  owner in a committed report.
+- The survey confirms that bounded no-fall-through pure value switches already
+  lower through the existing switch-to-`cond` contract.
+- Non-literal labels, default-not-last, grouped-label/empty-case fall-through,
+  break-only/throw-only value cases, statement-position mutation switches, and
+  effectful block values remain rejected with precise diagnostics.
+- No vacuous behavior gameplan is created for a milestone with zero in-scope
+  corpus examples.
 
 **Why this is a safe pause point**:
-The milestone extends the existing switch-to-cond contract without changing
-the rejection policy for semantically ambiguous switch forms. Stopping here
-leaves the translator with a stronger value-position switch lowering but no
-unsound fall-through modeling.
+The measurement preserves the existing switch-to-cond contract and its
+conservative refusal boundaries. Stopping here avoids adding unrelated enum
+resolution, fall-through, throw/exhaustiveness, or statement-SSA semantics
+under a misleading body-completeness label.
 
 **Unlocks**:
-Final body-completeness cleanup can target the residual structural buckets
-that remain after nested blocks, builders, loops, and switches have been
-removed from the top ranking.
+Final body-completeness cleanup can classify the remaining structural buckets
+without treating intentionally unsupported switch shapes as an implementation
+gap.
 
 **Operator Actions Before Next Milestone**:
-- Re-run the corpus diagnostic and classify the remaining structural buckets
-  into: body-completeness owned, other-workstream owned, and intentionally
-  unsupported.
-- If body-completeness-owned residuals are no longer among the top buckets,
+- Done: re-ran the corpus diagnostic and classified the remaining structural
+  buckets into: body-completeness owned, other-workstream owned, and
+  intentionally unsupported.
+- Done: body-completeness-owned residuals are no longer among the top buckets;
   skip M5 and mark the workstream complete after reconciling the acceptance
-  suite.
+  suite through M5's audit-only closeout.
 
 ---
 
-### Milestone 5: residual-body-diagnostic-cleanup
+### Milestone 5: residual-body-diagnostic-cleanup — COMPLETE (AUDIT-ONLY, 2026-07-13)
+
+> Audit report: `tools/ts2pant/docs/body-completeness-residual-audit.md`.
+> The completion threshold is more than 10 normalized diagnostic occurrences.
+> All 15 buckets above that threshold have an explicit owner in
+> `tools/ts2pant/scripts/corpus-diag.mts`; a new unaudited high-volume reason is
+> printed as `UNASSIGNED`. Function-level decomposition of the coarse
+> 46/42/41/22/13 structural labels found no remaining high-volume bounded pure-body
+> family. **Decision: no behavior gameplan.** The residuals require generalized
+> statement/effect SSA, accumulator/Map/seeded-collection semantics,
+> guard/foreign/type work, or intentionally deferred closure/exception/switch
+> semantics.
 
 **Definition of Done**:
 - Every remaining structural body-lowering bucket above a small threshold
@@ -382,6 +406,12 @@ removed from the top ranking.
   other-workstream residuals.
 - The final corpus diagnostic no longer has a structural body-lowering bucket
   above the threshold that lacks an owner.
+
+The transformation catalogue and ts2pant development guide already describe
+the transformations delivered by M1-M3: if-conversion, hygienic
+let-elimination, record returns, local collection builders, and structured
+iteration. M5 adds no translator transformation, so no new algorithm entry is
+needed.
 
 **Why this is a safe pause point**:
 This is the terminal reconciliation milestone. It does not need to close every
@@ -407,7 +437,7 @@ type/opaque precision rather than structural body sequencing.
 
 | Question | Notes | Resolve By |
 |----------|-------|------------|
-| What post-M1 bucket threshold defines "workstream complete"? | Suggested threshold: no body-completeness-owned normalized bucket above 10 functions, but this should be confirmed after M1/M2 because bucket normalization may split or merge shapes. | M4 operator review |
+| ~~What post-M1 bucket threshold defines "workstream complete"?~~ | RESOLVED (M5 audit): more than 10 normalized diagnostic occurrences. Counts are occurrences rather than necessarily unique functions; every bucket above the threshold must have an explicit owner, and the diagnostic prints new high-volume reasons as `UNASSIGNED`. | Resolved |
 | ~~Should scalar local folds be part of `iteration-builder-completeness`?~~ | RESOLVED (M3 gameplan): yes for commutative identity-bearing folds (`+`, `*`, `&&`, `||`, `count++`) via the Shape-C `combOP over each` reduce; no-identity/nullable reduces (conjoin/disjoin) deferred to a later option-typed-fold milestone. The post-M2 survey found only 3 scalar folds in the for-of bucket, all no-identity. | Resolved |
 | ~~Is `forEach` callback `return` behavior in scope?~~ | RESOLVED (M3 gameplan): deferred. No `forEach` instances in the for-of bucket; `forEach` routes through the mutating Shape A/B machinery, and callback `return` only exits the callback. Revisit once the for-of widening is the established target. | Resolved |
 
@@ -424,6 +454,8 @@ type/opaque precision rather than structural body sequencing.
 | M3's first loop family is the for-of list-build widening (loop-local consts + compound/nested guards). | The post-M2 survey of the 52 for-of failures found list-push-extended dominant (30); the M2 operator action mandated choosing the largest family that reuses the established builder target, and this reuses the for-of `each` comprehension with no new target-language construct. |
 | M3 includes for-of Set builders, lowered to membership-equivalence over a `some` comprehension, not list equality. | A Set deduplicates and is order-agnostic; equating it to `each n in src | proj n` over-constrains the result when two distinct elements project equal. `all e: T | e in (f args) <-> some n in src, guards | e = proj n` is the faithful, checker-supported encoding and matches M2's Set-as-list membership philosophy. |
 | M3 includes commutative identity-bearing scalar folds but defers no-identity reduces and forEach. | `+`/`*`/`&&`/`||` (and `count++`) form monoids whose unit is the elided init, mapping cleanly onto the Shape-C `combOP over each` reduce. conjoin/disjoin are null-seeded no-identity reduces needing an option-typed fold target; forEach routes through the mutating Shape A/B path. Both are deferred to keep M3 a clean, atomic extension of the comprehension target. |
+| M4 closes as measurement-only; no switch behavior gameplan is warranted. | The post-M3 survey found 47 switch residuals, all outside the bounded-pure value-switch subset: exhaustive throw defaults, fall-through, computed enum labels, statement-position mutation, or effectful/complex blocks. The already-supported subset has fixtures and no remaining corpus bucket, so an implementation gameplan would be vacuous. |
+| M5 closes as an audit-only ownership reconciliation at a greater-than-10 threshold. | The coarse structural labels decompose into generalized effects/SSA, internal accumulators, searches, collection constructors, closure conversion, or other-workstream dependencies. No high-volume family remains inside the bounded body targets delivered by M1-M3, and the diagnostic now exposes any future high-volume unassigned reason. |
 
 ## Definition of Done (Acceptance Suite)
 
@@ -498,30 +530,35 @@ not need to read source to decide pass/fail.
     `tools/ts2pant/src/translate-body.ts` (`recognizeForOfPush`/`recognizeForOfPushBody`,
     `tryBuildForOfSetComprehensionReturn`, `tryBuildForOfScalarFoldReturn`).
 
-- **DoD-5 — Switch value bodies preserve conservative switch semantics**
-  - **Assert**: Supported no-fall-through switch value fixtures emit `cond`
-    output, while fall-through, non-literal labels, side-effectful
-    discriminants, and default-not-last cases remain unsupported.
-  - **Verify by** `cmd`: Run `just ts2pant-test-unit` and inspect switch body
-    fixture snapshots.
-  - **Expected**: Positive switch fixtures contain `cond`; negative switch
-    fixtures retain their precise UNSUPPORTED diagnostics.
-  - **Traces to**: Milestone 4 — switch body lowering in
-    `tools/ts2pant/src/ir1-build.ts`.
+- **DoD-5 — Switch residuals are measured and conservatively owned**
+  - **Assert**: Every post-M3 switch diagnostic is classified as an existing
+    supported shape, an intentional refusal, or work owned by enum resolution,
+    fall-through/throw semantics, statement-position SSA, or purity analysis.
+  - **Verify by** `cmd`: Run
+    `NODE_OPTIONS=--max-old-space-size=6144 npx tsx tools/ts2pant/scripts/corpus-diag.mts --summary-only`
+    and compare the switch buckets with
+    `tools/ts2pant/docs/switch-body-survey.md`; run `just ts2pant-test-unit` to
+    retain the existing positive and negative switch fixtures.
+  - **Expected**: The report accounts for all 47 switch residuals; supported
+    bounded value switches still emit `cond`, while fall-through, non-literal
+    labels, throw-only defaults, and statement-position mutation remain
+    explicitly unsupported.
+  - **Traces to**: Milestone 4 — switch-body residual survey and the existing
+    switch-to-`cond` contract in `tools/ts2pant/src/ir1-build.ts`.
 
 - **DoD-6 — Body-completeness residuals are measured and owned**
   - **Assert**: The final corpus diagnostic has no structural
     body-completeness-owned bucket above the workstream threshold that lacks an
     owner or intentional-unsupported note.
   - **Verify by** `cmd`: Run
-    `NODE_OPTIONS=--max-old-space-size=6144 npx tsx tools/ts2pant/scripts/corpus-diag.mts`
+    `NODE_OPTIONS=--max-old-space-size=6144 npx tsx tools/ts2pant/scripts/corpus-diag.mts --summary-only`
     and compare the top buckets against the owner table documented by M5.
   - **Expected**: Every structural body bucket above threshold is either
     absent, below threshold, implemented, or explicitly assigned/documented;
-    DU, guard/foreign, and type/opaque buckets are not counted against this
-    workstream.
+    the ownership section contains no `UNASSIGNED`; DU, guard/foreign, and
+    type/opaque buckets are not counted against this workstream.
   - **Traces to**: Milestone 5 — `tools/ts2pant/scripts/corpus-diag.mts` and
-    body residual documentation.
+    `tools/ts2pant/docs/body-completeness-residual-audit.md`.
 
 - **DoD-7 — Workspace-level verification passes**
   - **Assert**: The final body-completeness state passes the ts2pant unit and


### PR DESCRIPTION
## Summary

- mark the ts2pant body-completeness workstream complete through the landed iteration-builder milestone and measurement-only M4/M5 closeout
- add the switch residual, body-completeness ownership, and free-call entailment survey reports
- extend the corpus diagnostic with explicit owners for every normalized bucket above 10 occurrences, leaving future unknown buckets visibly `UNASSIGNED`
- enable the previously skipped list-builder integration check now that the iteration-builder patches have landed

## Why

The workstream document still described landed iteration work as planned and left the switch/body-residual milestones unresolved. The audits show that the remaining high-volume failures are owned by DU/type-shape, guard/purity, generalized SSA/sequencing, collection semantics, or intentional refusal boundaries rather than the bounded body transformations delivered by this workstream.

This change makes that terminal state reproducible and prevents a future high-volume diagnostic from disappearing into an unowned aggregate.

## Impact

There is no translator behavior change. The corpus tool gains an ownership summary, one existing integration test is now active, and the workstream/report documentation records the measured residual boundaries and follow-up owners.

## Validation

- pre-commit ts2pant suite: 1,021 unit tests; 1,018 passing and 3 intentional skips
- integration suite: 146 tests passed, 0 skipped, including all iteration-builder cases
- `NODE_OPTIONS=--max-old-space-size=6144 npx tsx scripts/corpus-diag.mts --summary-only`: 866 functions, 171 clean, 690 unsupported, 5 extraction errors; every bucket above 10 has an explicit owner and none is `UNASSIGNED`
- `git diff --cached --check`
