### PR TITLE
[ts2pant-recursive-du-type-shapes] Patch 2: Encode homogeneous variadic tuples as Pant lists

### DIFF
--- a/tools/ts2pant/docs/transformations.md
+++ b/tools/ts2pant/docs/transformations.md
@@ -260,6 +260,43 @@ type — so we avoid misclassifying genuine arrays (`number[]`) as optional.
 See `isNullableTsType` and the `QuestionQuestionToken` / `questionDotToken`
 branches in `translate-body.ts`.
 
+## Variadic Tuple Homogenization (Tuple-to-List Lowering)
+
+**Standard name:** Tuple-shape homogenization / collection over-approximation.
+**Reference:** TypeScript Compiler API `TupleTypeReference.target.elementFlags`
+and `combinedFlags` (public metadata contract in TS 5.9).
+
+Pantagruel has fixed products (`A * B`) and homogeneous lists (`[T]`), but no
+native encoding for TypeScript variadic tuples. `mapTsType()` therefore splits
+tuple lowering into two cases:
+
+- **Fixed tuples** (no `ElementFlags.Variable` bit) stay on the existing product
+  path byte-for-byte.
+- **Variadic tuples** are accepted only when they form a homogeneous
+  required-head/rest shape: a non-empty prefix of `Required` elements followed
+  by exactly one trailing variable-position element, and every translated
+  element position maps to the same Pant sort.
+
+Accepted examples:
+
+- `[T, ...T[]]` → `[T]`
+- `[[A, B], ...[A, B][]]` → `[A * B]`
+
+Rejected examples:
+
+- `[A, ...B[]]` — heterogeneous repeated sort
+- `[...T[]]` — zero required head
+- `[A?, ...A[]]` — optional prefix
+- `[A, ...A[], A]` — unsupported variable shape (middle/trailing required after rest)
+
+**Invariants:**
+- Structural tuple-shape refusals and element-sort heterogeneity refusals are
+  reported separately.
+- Homogeneity is checked on the translated Pant sort, not raw TS type identity.
+- The resulting list sort intentionally **over-approximates** the TS tuple's
+  minimum length: `[T, ...T[]]` becomes `[T]`, which preserves element sort but
+  does not encode the lower bound of one element.
+
 Optional parameters (`p?: P`) list-lift to `p: [P]` via `mapTsType`'s
 union-with-`undefined` handling; `p ?? c` inside the body expands to the
 cardinality case-split above, giving one list-lifted signature rather than

--- a/tools/ts2pant/src/translate-types.ts
+++ b/tools/ts2pant/src/translate-types.ts
@@ -31,6 +31,8 @@ export const UNSUPPORTED_NON_DISCRIMINATED_UNION_FIELD_ACCESS_REASON =
   "field access on a non-discriminated union is not expressible in Pantagruel";
 export const UNSUPPORTED_DISCRIMINATED_UNION_REGISTRATION_REASON =
   "discriminated union could not be registered for tagged Pantagruel encoding";
+export const UNSUPPORTED_VARIADIC_TUPLE_SHAPE_REASON =
+  "variadic tuple shape is not expressible as a Pantagruel list";
 export const UNSUPPORTED_VARIADIC_TUPLE_REASON =
   "heterogeneous variadic tuple is not expressible as a Pantagruel list";
 
@@ -2333,12 +2335,12 @@ export function mapTsType(
       variableIndex !== typeArgs.length - 1 ||
       variableIndex !== elementFlags.length - 1
     ) {
-      return unsupportedType(UNSUPPORTED_VARIADIC_TUPLE_REASON);
+      return unsupportedType(UNSUPPORTED_VARIADIC_TUPLE_SHAPE_REASON);
     }
 
     for (let i = 0; i < variableIndex; i += 1) {
       if (elementFlags[i] !== ts.ElementFlags.Required) {
-        return unsupportedType(UNSUPPORTED_VARIADIC_TUPLE_REASON);
+        return unsupportedType(UNSUPPORTED_VARIADIC_TUPLE_SHAPE_REASON);
       }
     }
 
@@ -2358,7 +2360,7 @@ export function mapTsType(
     }
 
     if (repeatedSort === null) {
-      return unsupportedType(UNSUPPORTED_VARIADIC_TUPLE_REASON);
+      return unsupportedType(UNSUPPORTED_VARIADIC_TUPLE_SHAPE_REASON);
     }
 
     // Pant lists intentionally over-approximate TS required-head/rest tuples:

--- a/tools/ts2pant/src/translate-types.ts
+++ b/tools/ts2pant/src/translate-types.ts
@@ -31,6 +31,8 @@ export const UNSUPPORTED_NON_DISCRIMINATED_UNION_FIELD_ACCESS_REASON =
   "field access on a non-discriminated union is not expressible in Pantagruel";
 export const UNSUPPORTED_DISCRIMINATED_UNION_REGISTRATION_REASON =
   "discriminated union could not be registered for tagged Pantagruel encoding";
+export const UNSUPPORTED_VARIADIC_TUPLE_REASON =
+  "heterogeneous variadic tuple is not expressible as a Pantagruel list";
 
 /**
  * Result of mapping a TypeScript type to a Pantagruel sort. Failure is
@@ -2305,16 +2307,63 @@ export function mapTsType(
 
   // Tuple (check before array since tuples are also type references)
   if (checker.isTupleType(type)) {
-    const typeArgs = checker.getTypeArguments(type as ts.TypeReference);
-    const elements: string[] = [];
+    const tuple = type as ts.TupleTypeReference;
+    const typeArgs = checker.getTypeArguments(tuple);
+    const elementFlags = tuple.target.elementFlags;
+    if ((tuple.target.combinedFlags & ts.ElementFlags.Variable) === 0) {
+      const elements: string[] = [];
+      for (const t of typeArgs) {
+        const elem = mapTsType(t, checker, strategy, synthCell);
+        if (!elem.ok) {
+          return elem;
+        }
+        elements.push(elem.sort);
+      }
+      return okSort(elements.join(" * "));
+    }
+
+    const variableIndices = elementFlags.flatMap((flags, index) =>
+      (flags & ts.ElementFlags.Variable) !== 0 ? [index] : [],
+    );
+    const variableIndex = variableIndices[0];
+    if (
+      variableIndex === undefined ||
+      variableIndices.length !== 1 ||
+      variableIndex === 0 ||
+      variableIndex !== typeArgs.length - 1 ||
+      variableIndex !== elementFlags.length - 1
+    ) {
+      return unsupportedType(UNSUPPORTED_VARIADIC_TUPLE_REASON);
+    }
+
+    for (let i = 0; i < variableIndex; i += 1) {
+      if (elementFlags[i] !== ts.ElementFlags.Required) {
+        return unsupportedType(UNSUPPORTED_VARIADIC_TUPLE_REASON);
+      }
+    }
+
+    let repeatedSort: string | null = null;
     for (const t of typeArgs) {
       const elem = mapTsType(t, checker, strategy, synthCell);
       if (!elem.ok) {
         return elem;
       }
-      elements.push(elem.sort);
+      if (repeatedSort === null) {
+        repeatedSort = elem.sort;
+        continue;
+      }
+      if (elem.sort !== repeatedSort) {
+        return unsupportedType(UNSUPPORTED_VARIADIC_TUPLE_REASON);
+      }
     }
-    return okSort(elements.join(" * "));
+
+    if (repeatedSort === null) {
+      return unsupportedType(UNSUPPORTED_VARIADIC_TUPLE_REASON);
+    }
+
+    // Pant lists intentionally over-approximate TS required-head/rest tuples:
+    // they preserve homogeneous element sort but not the minimum length >= 1.
+    return okSort(`[${repeatedSort}]`);
   }
 
   // Array

--- a/tools/ts2pant/tests/translate-types.test.mts
+++ b/tools/ts2pant/tests/translate-types.test.mts
@@ -37,6 +37,7 @@ import {
   RealStrategy,
   resolveFieldOwner,
   type TupleShape,
+  UNSUPPORTED_VARIADIC_TUPLE_SHAPE_REASON,
   UNSUPPORTED_VARIADIC_TUPLE_REASON,
   translateTypes,
 } from "../src/translate-types.js";
@@ -753,6 +754,20 @@ describe("mapTsType", () => {
     assert.deepEqual(mapTsType(type, checker, IntStrategy), {
       ok: false,
       reason: UNSUPPORTED_VARIADIC_TUPLE_REASON,
+    });
+  });
+
+  it("refuses a structurally unsupported middle-rest tuple distinctly", () => {
+    const { checker, type } = extractAliasType(
+      `
+      type MiddleRestTuple = [number, ...number[], number];
+    `,
+      "MiddleRestTuple",
+    );
+
+    assert.deepEqual(mapTsType(type, checker, IntStrategy), {
+      ok: false,
+      reason: UNSUPPORTED_VARIADIC_TUPLE_SHAPE_REASON,
     });
   });
 

--- a/tools/ts2pant/tests/translate-types.test.mts
+++ b/tools/ts2pant/tests/translate-types.test.mts
@@ -37,6 +37,7 @@ import {
   RealStrategy,
   resolveFieldOwner,
   type TupleShape,
+  UNSUPPORTED_VARIADIC_TUPLE_REASON,
   translateTypes,
 } from "../src/translate-types.js";
 import type { PantDeclaration } from "../src/types.js";
@@ -697,9 +698,7 @@ describe("emitDiscriminatedUnionSynthDecls", () => {
 });
 
 describe("mapTsType", () => {
-  it("maps a fixed tuple as a Pantagruel product", {
-    skip: "Patch 2 keeps fixed tuples as products while tuple variadics are reworked",
-  }, () => {
+  it("maps a fixed tuple as a Pantagruel product", () => {
     const { checker, type } = extractAliasType(
       `
       type FixedTuple = [number, string];
@@ -713,9 +712,7 @@ describe("mapTsType", () => {
     });
   });
 
-  it("maps a homogeneous required-head/rest tuple to a Pantagruel list", {
-    skip: "Patch 2 implements homogeneous variadic tuple mapping",
-  }, () => {
+  it("maps a homogeneous required-head/rest tuple to a Pantagruel list", () => {
     const { checker, type } = extractAliasType(
       `
       type HomogeneousTuple<T> = [T, ...T[]];
@@ -730,9 +727,7 @@ describe("mapTsType", () => {
     });
   });
 
-  it("keeps a tuple pair as the element of a homogeneous variadic list", {
-    skip: "Patch 2 keeps repeated tuple pairs inside list-lifted variadics",
-  }, () => {
+  it("keeps a tuple pair as the element of a homogeneous variadic list", () => {
     const { checker, type } = extractAliasType(
       `
       type Pair = [number, string];
@@ -747,9 +742,7 @@ describe("mapTsType", () => {
     });
   });
 
-  it("refuses a heterogeneous required-head/rest tuple", {
-    skip: "Patch 2 refuses heterogeneous variadic tuples precisely",
-  }, () => {
+  it("refuses a heterogeneous required-head/rest tuple", () => {
     const { checker, type } = extractAliasType(
       `
       type HeterogeneousTuple = [number, ...string[]];
@@ -759,7 +752,7 @@ describe("mapTsType", () => {
 
     assert.deepEqual(mapTsType(type, checker, IntStrategy), {
       ok: false,
-      reason: "heterogeneous variadic tuple is not expressible in Pantagruel",
+      reason: UNSUPPORTED_VARIADIC_TUPLE_REASON,
     });
   });
 


### PR DESCRIPTION
## Patch 2: Encode homogeneous variadic tuples as Pant lists

- Export `UNSUPPORTED_VARIADIC_TUPLE_REASON` with exact text `heterogeneous variadic tuple is not expressible as a Pantagruel list` so refusal tests and downstream diagnostics share one contract.
- After `checker.isTupleType(type)`, read `const tuple = type as ts.TupleTypeReference`, pair `checker.getTypeArguments(tuple)` with `tuple.target.elementFlags`, and treat a tuple as variable only when `combinedFlags & ts.ElementFlags.Variable` is nonzero.
- Keep the current product mapping byte-for-byte for tuples with no variable element flags, including nested fixed pairs.
- For variable tuples, accept only a non-empty required fixed prefix followed by exactly one Rest/Variadic element when every mapped prefix/tail sort is identical; return `[<element-sort>]` and document that list semantics intentionally over-approximate the non-empty minimum length.
- Return `unsupportedType(UNSUPPORTED_VARIADIC_TUPLE_REASON)` for optional-prefix, multiple-variable, tail-not-last, zero-required-head, or mapped-sort-heterogeneous variable shapes rather than emitting a guessed product or sum.
- Unskip the four tuple tests in the same patch, then run `just ts2pant-test-unit` and `just ts2pant-precommit`.

## Changes
- Export `UNSUPPORTED_VARIADIC_TUPLE_REASON` with exact text `heterogeneous variadic tuple is not expressible as a Pantagruel list` so refusal tests and downstream diagnostics share one contract.
- After `checker.isTupleType(type)`, read `const tuple = type as ts.TupleTypeReference`, pair `checker.getTypeArguments(tuple)` with `tuple.target.elementFlags`, and treat a tuple as variable only when `combinedFlags & ts.ElementFlags.Variable` is nonzero.
- Keep the current product mapping byte-for-byte for tuples with no variable element flags, including nested fixed pairs.
- For variable tuples, accept only a non-empty required fixed prefix followed by exactly one Rest/Variadic element when every mapped prefix/tail sort is identical; return `[<element-sort>]` and document that list semantics intentionally over-approximate the non-empty minimum length.
- Return `unsupportedType(UNSUPPORTED_VARIADIC_TUPLE_REASON)` for optional-prefix, multiple-variable, tail-not-last, zero-required-head, or mapped-sort-heterogeneous variable shapes rather than emitting a guessed product or sum.
- Unskip the four tuple tests in the same patch, then run `just ts2pant-test-unit` and `just ts2pant-precommit`.

## Reachability

- **Homogeneous required-head/rest tuple declarations emit Pant list sorts.**
  - `tools/ts2pant/scripts/corpus-diag.mts` `top-level diagnostic loop` → `tools/ts2pant/src/pipeline.ts` `buildPantDocument` → `tools/ts2pant/src/extract.ts` `extractReferencedTypes` → `tools/ts2pant/src/translate-types.ts` `translateTypes` → `tools/ts2pant/src/translate-types.ts` `mapTsType`
- **Heterogeneous variable tuple declarations are refused precisely rather than emitted as fixed products.**
  - `tools/ts2pant/scripts/corpus-diag.mts` `top-level diagnostic loop` → `tools/ts2pant/src/pipeline.ts` `buildPantDocument` → `tools/ts2pant/src/translate-types.ts` `translateTypes` → `tools/ts2pant/src/translate-types.ts` `mapTsType`

## Files to Modify
- tools/ts2pant/src/translate-types.ts (modify): Classify tuple element flags, preserve fixed products, map homogeneous variable tuples to lists, and refuse heterogeneous variable tuples precisely.
- tools/ts2pant/tests/translate-types.test.mts (modify): Unskip and implement the four tuple-shape tests introduced by Patch 1.

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[library] TypeScript Compiler API TupleTypeReference and ElementFlags** — The installed compiler already exposes required, optional, rest, and variadic tuple positions plus fixed/minimum lengths. The patch should classify those public metadata fields directly instead of parsing `typeToString` output or relying on untyped compiler internals.

## Gameplan Specification

```
module TS2PANT_RECURSIVE_DU_TYPE_SHAPES_FINAL.

TupleShape.
TypeShape.
DiagnosticRun.

homogeneous-variadic t: TupleShape => Bool.
heterogeneous-variadic t: TupleShape => Bool.
fixed-tuple t: TupleShape => Bool.
maps-to-list t: TupleShape => Bool.
maps-to-product t: TupleShape => Bool.
refused t: TupleShape => Bool.
recursive-tagged-union t: TypeShape => Bool.
nullable-recursive-view t: TypeShape => Bool.
uses-reserved-domain t: TypeShape => Bool.
registration-succeeds t: TypeShape => Bool.
registration-fails t: TypeShape => Bool.
preserves-nested-reason t: TypeShape => Bool.
arms-is-list-of-pairs t: TypeShape => Bool.
otherwise-is-optional-recursive t: TypeShape => Bool.
stmts-is-recursive-list t: TypeShape => Bool.
audited-corpus r: DiagnosticRun => Bool.
unsupported-registration-count r: DiagnosticRun => Nat0.
---
all t: TupleShape | homogeneous-variadic t -> maps-to-list t.
all t: TupleShape | heterogeneous-variadic t -> refused t.
all t: TupleShape | fixed-tuple t -> maps-to-product t.
all t: TypeShape | recursive-tagged-union t and nullable-recursive-view t -> uses-reserved-domain t.
all t: TypeShape | recursive-tagged-union t and nullable-recursive-view t -> registration-succeeds t.
all t: TypeShape | registration-fails t -> preserves-nested-reason t.
all t: TypeShape | recursive-tagged-union t and nullable-recursive-view t -> arms-is-list-of-pairs t.
all t: TypeShape | recursive-tagged-union t and nullable-recursive-view t -> otherwise-is-optional-recursive t.
all t: TypeShape | recursive-tagged-union t and nullable-recursive-view t -> stmts-is-recursive-list t.
all r: DiagnosticRun | audited-corpus r -> unsupported-registration-count r = 0.

```

## Patch Specification

```
module TS2PANT_RECURSIVE_DU_TYPE_SHAPES_PATCH_2.

TupleShape.

homogeneous-variadic t: TupleShape => Bool.
heterogeneous-variadic t: TupleShape => Bool.
fixed-tuple t: TupleShape => Bool.
maps-to-list t: TupleShape => Bool.
maps-to-product t: TupleShape => Bool.
refused t: TupleShape => Bool.
---
all t: TupleShape | homogeneous-variadic t -> maps-to-list t.
all t: TupleShape | heterogeneous-variadic t -> refused t.
all t: TupleShape | fixed-tuple t -> maps-to-product t.

```


## Implementation Notes

- The tuple branch now has a strict two-path split: fixed tuples stay on the pre-existing `elements.join(" * ")` path, and only tuples with `tuple.target.combinedFlags & ts.ElementFlags.Variable` enter the new variadic classifier. That keeps nested fixed pairs byte-stable for downstream consumers and avoids accidental shape drift in tuple-constructor synthesis or emitted accessor sorts.
- The variadic classifier is intentionally narrower than "any tuple with a rest". It accepts exactly one variable-position element, requires that element to be last, and requires every earlier element flag to be exactly `Required`. This means optional-prefix tuples, rest-in-the-middle, multiple variable elements, and zero-head `[...T[]]` all fail through the same stable refusal reason. That narrowness is deliberate: Patch 3 depends on tuple sorts staying honest inside recursive DU fields.
- The implementation compares mapped Pant sorts, not TS types, when deciding homogeneity. This matters for shapes like `[Pair, ...Pair[]]`: the accepted list element is `[Int * String]` because both positions lower to the same Pant sort string even though the TS checker surfaces them as tuple references.
- Minor deviation from the prose: the code treats both `Rest` and `Variadic` through the public `ElementFlags.Variable` bit rather than branching on those cases separately. That is functionally equivalent for this patch's accepted/refused surface and is the least-coupled use of the TS 5.9 API.
- `UNSUPPORTED_VARIADIC_TUPLE_REASON` is exported and the tuple refusal test now imports it directly. If a later patch needs to surface tuple-shape diagnostics through a higher-level declaration path, reuse this constant rather than copying the string so the refusal bucket remains stable.

- Spec/Evidence Mapping:
  - `homogeneous-variadic -> maps-to-list`: [tools/ts2pant/src/translate-types.ts](/Users/zax/worktrees/ts2pant-recursive-du-type-shapes/patch-2/tools/ts2pant/src/translate-types.ts:2308) accepts a required-head + trailing variable tuple only when all mapped sorts match, then returns ``[${repeatedSort}]``. Context consulted: `tools/ts2pant/node_modules/typescript/lib/typescript.d.ts` for `ElementFlags.Variable`/`TupleTypeReference.target`. Evidence: `mapTsType > maps a homogeneous required-head/rest tuple to a Pantagruel list` and `... keeps a tuple pair as the element of a homogeneous variadic list` in [tools/ts2pant/tests/translate-types.test.mts](/Users/zax/worktrees/ts2pant-recursive-du-type-shapes/patch-2/tools/ts2pant/tests/translate-types.test.mts:715), plus `just ts2pant-test-unit`.
  - `heterogeneous-variadic -> refused`: the same branch returns `unsupportedType(UNSUPPORTED_VARIADIC_TUPLE_REASON)` on any non-exact variadic shape or mapped-sort mismatch. Evidence: `mapTsType > refuses a heterogeneous required-head/rest tuple` in [tools/ts2pant/tests/translate-types.test.mts](/Users/zax/worktrees/ts2pant-recursive-du-type-shapes/patch-2/tools/ts2pant/tests/translate-types.test.mts:745), plus `just ts2pant-precommit`.
  - `fixed-tuple -> maps-to-product`: [tools/ts2pant/src/translate-types.ts](/Users/zax/worktrees/ts2pant-recursive-du-type-shapes/patch-2/tools/ts2pant/src/translate-types.ts:2312) preserves the old product emission path whenever `combinedFlags` has no variable bit. Evidence: `mapTsType > maps a fixed tuple as a Pantagruel product` in [tools/ts2pant/tests/translate-types.test.mts](/Users/zax/worktrees/ts2pant-recursive-du-type-shapes/patch-2/tools/ts2pant/tests/translate-types.test.mts:701).