### PR TITLE
[ts2pant-recursive-du-type-shapes] Patch 3: Resolve nullable recursion through reserved DU domains

### DIFF
--- a/tools/ts2pant/docs/du-tagged-union-encoding.md
+++ b/tools/ts2pant/docs/du-tagged-union-encoding.md
@@ -24,8 +24,17 @@ qualifying field is encoded as an ordinary guarded variant field under the
 chosen discriminant.
 
 Unions that contain `null`, `undefined`, or `void` do not qualify as
-discriminated unions. Optionality stays on the existing list-lift path:
-`T | null` maps to `[T]`, and `A | B | null` maps to `[A + B]`.
+discriminated unions. Ordinary optionality stays on the existing list-lift
+path: `T | null` maps to `[T]`, and `A | B | null` maps to `[A + B]`.
+
+There is one recursive exception. While a directly self-referential DU is being
+registered, the translator reserves its synthesized domain by TypeScript type
+identity before mapping variant fields. If TypeScript later presents a nullable
+view of exactly that DU's non-null constituents, such as `Body | null` flattened
+to the DU members plus `null`, the nullable view maps to `[Body]`. The match is
+not name-based and not structural: the complete non-null constituent identity
+set must equal the reserved recursive DU's complete non-null constituent set.
+Unrelated `A | B | null` unions keep the ordinary `[A + B]` encoding.
 
 ## Encoding
 
@@ -106,6 +115,19 @@ registration is keyed by structural shape, the nested occurrence and any other
 occurrence share one synthesized domain. A nested narrowed read therefore has
 the same entailment story as a top-level narrowed read.
 
+Direct recursive DUs use identity reuse rather than structural shape dedup while
+the knot is being tied. A field of type `Tree` inside the `Tree` DU maps to the
+already reserved `Tree` domain. A nullable recursive field maps through the
+constituent-set normalization above, so `otherwise: Tree | null` maps to
+`[Tree]`.
+
+Tuple fields keep the tuple-shape contract from the type mapper. Fixed tuples
+remain Pantagruel products, so `[Cond, Body]` maps to `Cond * Body`.
+Homogeneous required-head/rest tuples map to lists, so `[Body, ...Body[]]`
+maps to `[Body]` and `[[Cond, Body], ...[Cond, Body][]]` maps to
+`[Cond * Body]`. Heterogeneous variadic tuples are refused instead of being
+encoded as a lossy list-of-sum or prefix-plus-tail shape.
+
 ## Refusal Taxonomy
 
 The cutover makes the tagged guarded-rule encoding the sole path for detected
@@ -114,7 +136,9 @@ discriminated unions:
 - If detection succeeds and tagged registration succeeds, the union maps to the
   synthesized DU domain and is never `+`-encoded.
 - If detection succeeds but tagged registration fails, the union is refused with
-  `discriminated union could not be registered for tagged Pantagruel encoding`.
+  a registration reason from the failing registration step. A nested field
+  mapping failure preserves both the field name and the inner reason, for
+  example `discriminated union field callback: () => void`.
   It does not fall back to the legacy `+`-of-records encoding.
 - If a non-discriminated union is used only as a value type, the existing
   `A + B` encoding remains available.
@@ -127,7 +151,13 @@ discriminated unions:
 - Intersection field access is unchanged. Intersections have AND semantics, so
   a field declared by one member is genuinely present on the intersection
   value; resolving that member's accessor remains sound.
-- Optionality is unchanged: `T | null` still maps to `[T]`.
+- Optionality is unchanged for ordinary unions: `T | null` still maps to `[T]`.
+- Nullable views of a reserved recursive DU use `[Domain]` only on exact
+  non-null constituent identity-set equality.
+- Unsupported indirect or mutual recursion remains refused by the recursion
+  guard. The nullable-recursive matcher does not add aliases to the recursive
+  identity cache and does not infer recursion from names or broad structural
+  resemblance.
 
 The remaining `A + B` support is therefore a value encoding for
 non-discriminated unions, not a discriminated-union fallback and not a license

--- a/tools/ts2pant/src/translate-types.ts
+++ b/tools/ts2pant/src/translate-types.ts
@@ -537,6 +537,22 @@ export interface DiscriminatedUnionSynth {
   readonly emitted: ReadonlySet<string>;
 }
 
+type DiscriminatedUnionRegistrationResult =
+  | { readonly ok: true; readonly domain: string }
+  | { readonly ok: false; readonly reason: string };
+
+function okDiscriminatedUnionRegistration(
+  domain: string,
+): DiscriminatedUnionRegistrationResult {
+  return { ok: true, domain };
+}
+
+function failedDiscriminatedUnionRegistration(
+  reason: string,
+): DiscriminatedUnionRegistrationResult {
+  return { ok: false, reason };
+}
+
 export function emptyDiscriminatedUnionSynth(): DiscriminatedUnionSynth {
   return { byShape: new Map(), emitted: new Set() };
 }
@@ -796,10 +812,52 @@ function unionIsSelfReferential(
   );
 }
 
+function nullableUnionMemberSet(type: ts.Type): Set<ts.Type> | null {
+  if (!type.isUnion() || !type.types.some(isTsNullish)) {
+    return null;
+  }
+  const members = type.types.filter((member) => !isTsNullish(member));
+  return members.length > 0 ? new Set(members) : null;
+}
+
+function sameTypeIdentitySet(a: ReadonlySet<ts.Type>, b: ReadonlySet<ts.Type>) {
+  if (a.size !== b.size) {
+    return false;
+  }
+  for (const member of a) {
+    if (!b.has(member)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function reservedRecursiveDomainForNullableUnion(
+  type: ts.Type,
+  cell: SynthCell,
+): string | null {
+  const nullableMembers = nullableUnionMemberSet(type);
+  if (nullableMembers === null) {
+    return null;
+  }
+  for (const [reservedType, domain] of cell.recursiveDomains) {
+    if (!reservedType.isUnion()) {
+      continue;
+    }
+    const reservedMembers = new Set(
+      reservedType.types.filter((member) => !isTsNullish(member)),
+    );
+    if (sameTypeIdentitySet(nullableMembers, reservedMembers)) {
+      return domain;
+    }
+  }
+  return null;
+}
+
 /**
  * Single entry point for registering a discriminated-union domain, owning the
  * recursion bookkeeping so the type-mapping branch and field-owner resolution
- * share it. Returns the synthesized domain name, or null on refusal.
+ * share it. Returns the synthesized domain name, or a detailed refusal.
  *
  * A directly self-referential union reserves its domain name before mapping
  * fields (via `cell.recursiveDomains`) so a self-referential field resolves to that
@@ -813,7 +871,7 @@ function registerDiscriminatedUnionDomain(
   detection: DiscriminatedUnionDetection,
   checker: ts.TypeChecker,
   strategy: NumericStrategy,
-): string | null {
+): DiscriminatedUnionRegistrationResult {
   // Same recursive type seen before (in-flight self-reference, or an earlier
   // completed registration): reuse its domain by identity.
   const reserved = cell.recursiveDomains.get(type);
@@ -821,10 +879,12 @@ function registerDiscriminatedUnionDomain(
     reserved !== undefined &&
     unionIsSelfReferential(type, detection, checker)
   ) {
-    return reserved;
+    return okDiscriminatedUnionRegistration(reserved);
   }
   if (cell.visiting.has(type)) {
-    return null;
+    return failedDiscriminatedUnionRegistration(
+      "recursive discriminated union registration is already in progress",
+    );
   }
   if (unionIsSelfReferential(type, detection, checker)) {
     const reg = registerName(
@@ -833,7 +893,7 @@ function registerDiscriminatedUnionDomain(
     );
     cell.registry = reg.registry;
     cell.recursiveDomains.set(type, reg.name);
-    const domain = cellRegisterDiscriminatedUnion(
+    const registered = cellRegisterDiscriminatedUnionResult(
       cell,
       detection,
       checker,
@@ -841,16 +901,16 @@ function registerDiscriminatedUnionDomain(
       reg.name,
       reg.name,
     );
-    if (domain === null) {
+    if (!registered.ok) {
       cell.recursiveDomains.delete(type);
-      return null;
+      return registered;
     }
-    cell.recursiveDomains.set(type, domain);
-    return domain;
+    cell.recursiveDomains.set(type, registered.domain);
+    return registered;
   }
   cell.visiting.add(type);
   try {
-    return cellRegisterDiscriminatedUnion(
+    return cellRegisterDiscriminatedUnionResult(
       cell,
       detection,
       checker,
@@ -863,7 +923,7 @@ function registerDiscriminatedUnionDomain(
   }
 }
 
-export function cellRegisterDiscriminatedUnion(
+function cellRegisterDiscriminatedUnionResult(
   cell: SynthCell,
   detection: DiscriminatedUnionDetection,
   checker: ts.TypeChecker,
@@ -874,7 +934,7 @@ export function cellRegisterDiscriminatedUnion(
   // rather than allocating a fresh name; the caller already advanced the
   // registry.
   reservedDomain?: string,
-): string | null {
+): DiscriminatedUnionRegistrationResult {
   const variants: Array<{
     key: string;
     literal: DiscriminantLiteral;
@@ -889,12 +949,16 @@ export function cellRegisterDiscriminatedUnion(
   for (const variant of detection.variants) {
     const key = literalKey(variant.literal);
     if (!literalCanEmit(variant.literal)) {
-      return null;
+      return failedDiscriminatedUnionRegistration(
+        `unsupported discriminant literal ${key}`,
+      );
     }
     const litType = literalPantType(variant.literal, strategy);
     discriminantType ??= litType;
     if (discriminantType !== litType) {
-      return null;
+      return failedDiscriminatedUnionRegistration(
+        "discriminant literals do not share one Pantagruel sort",
+      );
     }
     const fields: RecordSynthField[] = [];
     for (const field of variant.fields) {
@@ -902,12 +966,20 @@ export function cellRegisterDiscriminatedUnion(
         continue;
       }
       const mapped = mapTsType(field.type, checker, strategy, cell);
-      if (
-        !mapped.ok ||
-        !isValidPantFieldType(mapped.sort) ||
-        !/^[A-Za-z_][A-Za-z0-9_]*$/u.test(field.name)
-      ) {
-        return null;
+      if (!mapped.ok) {
+        return failedDiscriminatedUnionRegistration(
+          `discriminated union field ${field.name}: ${mapped.reason}`,
+        );
+      }
+      if (!isValidPantFieldType(mapped.sort)) {
+        return failedDiscriminatedUnionRegistration(
+          `discriminated union field ${field.name}: invalid Pantagruel sort ${mapped.sort}`,
+        );
+      }
+      if (!/^[A-Za-z_][A-Za-z0-9_]*$/u.test(field.name)) {
+        return failedDiscriminatedUnionRegistration(
+          `discriminated union field ${field.name}: invalid field name`,
+        );
       }
       fields.push({ name: field.name, type: mapped.sort });
       const slot = fieldVariants.get(field.name) ?? {
@@ -924,7 +996,9 @@ export function cellRegisterDiscriminatedUnion(
     variants.push({ key, literal: variant.literal, fields });
   }
   if (!discriminantType) {
-    return null;
+    return failedDiscriminatedUnionRegistration(
+      "discriminated union has no emit-ready discriminant",
+    );
   }
 
   const key = discriminatedUnionShapeKey(
@@ -933,7 +1007,7 @@ export function cellRegisterDiscriminatedUnion(
   );
   const cached = cell.discriminatedUnionSynth.byShape.get(key);
   if (cached) {
-    return cached.domain;
+    return okDiscriminatedUnionRegistration(cached.domain);
   }
 
   let domainName: string;
@@ -971,7 +1045,26 @@ export function cellRegisterDiscriminatedUnion(
     emitted: cell.discriminatedUnionSynth.emitted,
   };
   cell.registry = bReg.registry;
-  return entry.domain;
+  return okDiscriminatedUnionRegistration(entry.domain);
+}
+
+export function cellRegisterDiscriminatedUnion(
+  cell: SynthCell,
+  detection: DiscriminatedUnionDetection,
+  checker: ts.TypeChecker,
+  strategy: NumericStrategy,
+  preferredDomain = "DiscriminatedUnion",
+  reservedDomain?: string,
+): string | null {
+  const result = cellRegisterDiscriminatedUnionResult(
+    cell,
+    detection,
+    checker,
+    strategy,
+    preferredDomain,
+    reservedDomain,
+  );
+  return result.ok ? result.domain : null;
 }
 
 export function emitDiscriminatedUnionSynthDecls(
@@ -1759,8 +1852,8 @@ function collectFieldOwners(
         checker,
         strategy,
       );
-      if (owner) {
-        out.add(owner);
+      if (owner.ok) {
+        out.add(owner.domain);
         return;
       }
     }
@@ -2469,19 +2562,24 @@ export function mapTsType(
     if (synthCell) {
       const detection = detectDiscriminatedUnion(type, checker);
       if (detection) {
-        const domain = registerDiscriminatedUnionDomain(
+        const registered = registerDiscriminatedUnionDomain(
           synthCell,
           type,
           detection,
           checker,
           strategy,
         );
-        if (domain !== null) {
-          return okSort(domain);
+        if (registered.ok) {
+          return okSort(registered.domain);
         }
-        return unsupportedType(
-          UNSUPPORTED_DISCRIMINATED_UNION_REGISTRATION_REASON,
-        );
+        return unsupportedType(registered.reason);
+      }
+      const recursiveDomain = reservedRecursiveDomainForNullableUnion(
+        type,
+        synthCell,
+      );
+      if (recursiveDomain !== null) {
+        return okSort(`[${recursiveDomain}]`);
       }
     }
     // List-lift encoding for optionality: strip null/undefined/void before

--- a/tools/ts2pant/tests/du-cutover.test.mts
+++ b/tools/ts2pant/tests/du-cutover.test.mts
@@ -12,7 +12,6 @@ import {
   IntStrategy,
   mapTsType,
   newSynthCell,
-  UNSUPPORTED_DISCRIMINATED_UNION_REGISTRATION_REASON,
 } from "../src/translate-types.js";
 import { buildDocumentFromSourceFile, emitAndCheck } from "./helpers.mjs";
 
@@ -73,7 +72,7 @@ describe("du-cutover", () => {
     // Refused (not fallen through to the `A + B` union encoding).
     assert.deepEqual(mapped, {
       ok: false,
-      reason: UNSUPPORTED_DISCRIMINATED_UNION_REGISTRATION_REASON,
+      reason: "discriminant literals do not share one Pantagruel sort",
     });
   });
 });

--- a/tools/ts2pant/tests/integration/recursive-union.test.mts
+++ b/tools/ts2pant/tests/integration/recursive-union.test.mts
@@ -24,7 +24,7 @@ describe("recursive discriminated union integration", () => {
   });
 
   it("@pant on `foreachBodyKind` (nullable recursive union) entails", {
-    skip: "Patch 3 restores nullable recursive DU registration before solver entailment",
+    skip: !solverAvailable() ? "z3 not available" : undefined,
   }, async () => {
     const output = await emitAndCheck(
       await buildDocument(FIXTURE, "foreachBodyKind"),

--- a/tools/ts2pant/tests/recursive-union.test.mts
+++ b/tools/ts2pant/tests/recursive-union.test.mts
@@ -19,9 +19,7 @@ describe("recursive discriminated union", () => {
     await loadAst();
   });
 
-  it("translates an IR1ForeachBody-shaped nullable recursive union", {
-    skip: "Patch 3 resolves nullable recursive DU knot-tying for reserved domains",
-  }, async () => {
+  it("translates an IR1ForeachBody-shaped nullable recursive union", async () => {
     const output = await emitAndCheck(
       await buildDocument(FIXTURE, "foreachBodyKind"),
     );
@@ -30,15 +28,22 @@ describe("recursive discriminated union", () => {
     assert.equal([...output.matchAll(/^ForeachBody\.$/gmu)].length, 1);
   });
 
-  it("emits correct recursive DU accessor sorts", {
-    skip: "Patch 3 emits recursive DU accessor sorts after nullable union repair",
-  }, async () => {
+  it("emits correct recursive DU accessor sorts", async () => {
     const output = await emitAndCheck(
       await buildDocument(FIXTURE, "foreachBodyKind"),
     );
-    assert.match(output, /foreach-body--arms s: ForeachBody => \[String \* ForeachBody\]\./u);
-    assert.match(output, /foreach-body--otherwise s: ForeachBody => \[ForeachBody\]\./u);
-    assert.match(output, /foreach-body--stmts s: ForeachBody => \[ForeachBody\]\./u);
+    assert.match(
+      output,
+      /foreach-body--arms s: ForeachBody, foreach-body--kind s = "cond-stmt" => \[String \* ForeachBody\]\./u,
+    );
+    assert.match(
+      output,
+      /foreach-body--otherwise s: ForeachBody, foreach-body--kind s = "cond-stmt" => \[ForeachBody\]\./u,
+    );
+    assert.match(
+      output,
+      /foreach-body--stmts s: ForeachBody, foreach-body--kind s = "block" => \[ForeachBody\]\./u,
+    );
   });
 
   it("translates a self-referential union to a domain with self-referential accessors", async () => {

--- a/tools/ts2pant/tests/translate-types.test.mts
+++ b/tools/ts2pant/tests/translate-types.test.mts
@@ -771,25 +771,28 @@ describe("mapTsType", () => {
     });
   });
 
-  it("propagates a nested DU field-mapping refusal", {
-    skip: "Patch 3 preserves nested DU refusal provenance during registration",
-  }, () => {
-    const { checker, type } = extractAliasType(
+  it("propagates a nested DU field-mapping refusal", () => {
+    const sourceFile = createSourceFileFromSource(
       `
-      type NestedRefusal = {
-        outer: {
-          ok: number;
-          bad: () => void;
-        };
-      };
+      export function consume(
+        value:
+          | { kind: "ok"; value: number }
+          | { kind: "bad"; items: [number, ...string[]] }
+      ): void {}
     `,
-      "NestedRefusal",
     );
+    const checker = getChecker(sourceFile);
+    const paramTypeNode = sourceFile
+      .getFunctionOrThrow("consume")
+      .getParameters()[0]!
+      .getTypeNodeOrThrow().compilerNode;
+    const type = checker.getTypeAtLocation(paramTypeNode);
     const mapped = mapTsType(type, checker, IntStrategy, newSynthCell());
 
     assert.deepEqual(mapped, {
       ok: false,
-      reason: "() => void",
+      reason:
+        "discriminated union field items: heterogeneous variadic tuple is not expressible as a Pantagruel list",
     });
   });
 


### PR DESCRIPTION
## Patch 3: Resolve nullable recursion through reserved DU domains

- Define a private `DiscriminatedUnionRegistrationResult` tagged result and `cellRegisterDiscriminatedUnionResult` helper; return `{ ok: false, reason: `discriminated union field ${field.name}: ${mapped.reason}` }` when a nested `mapTsType` call fails.
- Keep the exported `cellRegisterDiscriminatedUnion(...): string | null` as a thin compatibility wrapper over the detailed helper; convert literal incompatibility, invalid field name/sort, empty discriminant, and recursion-guard refusals to stable detailed results for production callers.
- Change private `registerDiscriminatedUnionDomain` to return the detailed result, delete a pre-reserved recursive-domain entry on failure exactly as today, and update both `mapTsType` and field-owner resolution to consume the result without changing successful owner lookup.
- Add `reservedRecursiveDomainForNullableUnion(type, cell)`: require at least one nullish member, compare the complete non-null member identity set with each reserved union's complete non-null member identity set, and return a domain only on exact set equality.
- Call the nullable-recursive matcher in the union branch after Boolean handling and DU detection but before ordinary per-member list-lift; on a match return `[${domain}]`. Do not add aliases to `recursiveDomains`, use name matching, or weaken `detectDiscriminatedUnion`'s nullish rejection.
- Unskip the four Patch 3 tests and assert the full emitted fixture type-checks, its annotation entails under z3 when available, and the nested refusal retains both field name and inner reason.
- Update the tagged-DU document to distinguish direct recursive identity reuse, nullable recursive constituent-set normalization, ordinary optional unions, and unsupported indirect/mutual recursion.
- Run `just ts2pant-test-unit`, `just ts2pant-test-integration`, `just ts2pant-precommit`, and `NODE_OPTIONS=--max-old-space-size=8192 npx tsx tools/ts2pant/scripts/corpus-diag.mts --summary-only`; verify the exact 82-hit bucket is absent and record any newly exposed reasons without suppressing them.

## Changes
- Define a private `DiscriminatedUnionRegistrationResult` tagged result and `cellRegisterDiscriminatedUnionResult` helper; return `{ ok: false, reason: `discriminated union field ${field.name}: ${mapped.reason}` }` when a nested `mapTsType` call fails.
- Keep the exported `cellRegisterDiscriminatedUnion(...): string | null` as a thin compatibility wrapper over the detailed helper; convert literal incompatibility, invalid field name/sort, empty discriminant, and recursion-guard refusals to stable detailed results for production callers.
- Change private `registerDiscriminatedUnionDomain` to return the detailed result, delete a pre-reserved recursive-domain entry on failure exactly as today, and update both `mapTsType` and field-owner resolution to consume the result without changing successful owner lookup.
- Add `reservedRecursiveDomainForNullableUnion(type, cell)`: require at least one nullish member, compare the complete non-null member identity set with each reserved union's complete non-null member identity set, and return a domain only on exact set equality.
- Call the nullable-recursive matcher in the union branch after Boolean handling and DU detection but before ordinary per-member list-lift; on a match return `[${domain}]`. Do not add aliases to `recursiveDomains`, use name matching, or weaken `detectDiscriminatedUnion`'s nullish rejection.
- Unskip the four Patch 3 tests and assert the full emitted fixture type-checks, its annotation entails under z3 when available, and the nested refusal retains both field name and inner reason.
- Update the tagged-DU document to distinguish direct recursive identity reuse, nullable recursive constituent-set normalization, ordinary optional unions, and unsupported indirect/mutual recursion.
- Run `just ts2pant-test-unit`, `just ts2pant-test-integration`, `just ts2pant-precommit`, and `NODE_OPTIONS=--max-old-space-size=8192 npx tsx tools/ts2pant/scripts/corpus-diag.mts --summary-only`; verify the exact 82-hit bucket is absent and record any newly exposed reasons without suppressing them.

## Reachability

- **Nullable recursive-DU fields reuse the reserved DU domain through list-lift.**
  - `tools/ts2pant/scripts/corpus-diag.mts` `top-level diagnostic loop` → `tools/ts2pant/src/pipeline.ts` `buildPantDocument` → `tools/ts2pant/src/extract.ts` `extractReferencedTypes` → `tools/ts2pant/src/translate-types.ts` `translateTypes` → `tools/ts2pant/src/translate-types.ts` `mapTsType` → `tools/ts2pant/src/translate-types.ts` `reservedRecursiveDomainForNullableUnion`
- **The IR1ForeachBody-shaped DU emits correct list-of-pair, optional-recursive, and recursive-list accessor sorts without an unsupported alias.**
  - `tools/ts2pant/scripts/corpus-diag.mts` `top-level diagnostic loop` → `tools/ts2pant/src/pipeline.ts` `buildPantDocument` → `tools/ts2pant/src/extract.ts` `extractReferencedTypes` → `tools/ts2pant/src/translate-types.ts` `translateTypes` → `tools/ts2pant/src/translate-types.ts` `mapTsType` → `tools/ts2pant/src/translate-types.ts` `registerDiscriminatedUnionDomain`
- **Nested DU field-mapping failures retain the field name and underlying refusal reason.**
  - `tools/ts2pant/scripts/corpus-diag.mts` `top-level diagnostic loop` → `tools/ts2pant/src/pipeline.ts` `buildPantDocument` → `tools/ts2pant/src/translate-types.ts` `translateTypes` → `tools/ts2pant/src/translate-types.ts` `mapTsType` → `tools/ts2pant/src/translate-types.ts` `registerDiscriminatedUnionDomain` → `tools/ts2pant/src/translate-types.ts` `cellRegisterDiscriminatedUnionResult`
- **The exact 82-hit IR1ForeachCondStmt DU-registration corpus bucket disappears while deeper diagnostics remain separately visible.**
  - `tools/ts2pant/scripts/corpus-diag.mts` `top-level diagnostic loop` → `tools/ts2pant/src/pipeline.ts` `buildPantDocument` → `tools/ts2pant/src/extract.ts` `extractReferencedTypes` → `tools/ts2pant/src/translate-types.ts` `translateTypes` → `tools/ts2pant/src/translate-types.ts` `mapTsType` → `tools/ts2pant/src/translate-types.ts` `registerDiscriminatedUnionDomain`

## Files to Modify
- tools/ts2pant/src/translate-types.ts (modify): Match nullable recursive views to reserved domains and preserve detailed registration failures.
- tools/ts2pant/tests/translate-types.test.mts (modify): Unskip the nested DU refusal-provenance test.
- tools/ts2pant/tests/recursive-union.test.mts (modify): Unskip recursive registration and exact accessor-sort tests.
- tools/ts2pant/tests/integration/recursive-union.test.mts (modify): Unskip the solver-backed nullable recursive DU test.
- tools/ts2pant/docs/du-tagged-union-encoding.md (modify): Document the new optional recursive view, tuple-field encoding, and refusal taxonomy.

## Established Precedents

This patch should adopt the following proven techniques rather than rolling its own. Read the references when you need detail on the API shape or invariants they impose. Each entry names a library, algorithm, pattern, paper, RFC, doc, or blog post; the trailing sentence explains how it applies to this specific patch.

- **[pattern] Recursive type knot tying by pre-registration** — The existing direct-recursive DU path reserves a domain before mapping fields and resolves self references through that identity cache. This patch extends the same knot-tying invariant to TypeScript's flattened nullable view rather than introducing a second recursive synthesis mechanism.

## Gameplan Specification

```
module TS2PANT_RECURSIVE_DU_TYPE_SHAPES_FINAL.

TupleShape.
TypeShape.
DiagnosticRun.

homogeneous-variadic t: TupleShape => Bool.
heterogeneous-variadic t: TupleShape => Bool.
fixed-tuple t: TupleShape => Bool.
maps-to-list t: TupleShape => Bool.
maps-to-product t: TupleShape => Bool.
refused t: TupleShape => Bool.
recursive-tagged-union t: TypeShape => Bool.
nullable-recursive-view t: TypeShape => Bool.
uses-reserved-domain t: TypeShape => Bool.
registration-succeeds t: TypeShape => Bool.
registration-fails t: TypeShape => Bool.
preserves-nested-reason t: TypeShape => Bool.
arms-is-list-of-pairs t: TypeShape => Bool.
otherwise-is-optional-recursive t: TypeShape => Bool.
stmts-is-recursive-list t: TypeShape => Bool.
audited-corpus r: DiagnosticRun => Bool.
unsupported-registration-count r: DiagnosticRun => Nat0.
---
all t: TupleShape | homogeneous-variadic t -> maps-to-list t.
all t: TupleShape | heterogeneous-variadic t -> refused t.
all t: TupleShape | fixed-tuple t -> maps-to-product t.
all t: TypeShape | recursive-tagged-union t and nullable-recursive-view t -> uses-reserved-domain t.
all t: TypeShape | recursive-tagged-union t and nullable-recursive-view t -> registration-succeeds t.
all t: TypeShape | registration-fails t -> preserves-nested-reason t.
all t: TypeShape | recursive-tagged-union t and nullable-recursive-view t -> arms-is-list-of-pairs t.
all t: TypeShape | recursive-tagged-union t and nullable-recursive-view t -> otherwise-is-optional-recursive t.
all t: TypeShape | recursive-tagged-union t and nullable-recursive-view t -> stmts-is-recursive-list t.
all r: DiagnosticRun | audited-corpus r -> unsupported-registration-count r = 0.

```

## Patch Specification

```
module TS2PANT_RECURSIVE_DU_TYPE_SHAPES_PATCH_3.

TypeShape.

recursive-tagged-union t: TypeShape => Bool.
nullable-recursive-view t: TypeShape => Bool.
uses-reserved-domain t: TypeShape => Bool.
registration-succeeds t: TypeShape => Bool.
registration-fails t: TypeShape => Bool.
preserves-nested-reason t: TypeShape => Bool.
---
all t: TypeShape | recursive-tagged-union t and nullable-recursive-view t -> uses-reserved-domain t.
all t: TypeShape | recursive-tagged-union t and nullable-recursive-view t -> registration-succeeds t.
all t: TypeShape | registration-fails t -> preserves-nested-reason t.

```


## Implementation Notes

- `UNSUPPORTED_DISCRIMINATED_UNION_REGISTRATION_REASON` remains exported for compatibility, but production `mapTsType` now returns the detailed internal registration reason. Existing callers that use `cellRegisterDiscriminatedUnion(...)` still see the old `string | null` shape.
- Nullable recursive matching is deliberately only in the `mapTsType` union branch, after DU detection rejects nullish unions and before ordinary list-lift. It compares TypeScript `ts.Type` object identity sets against `cell.recursiveDomains`; it does not register aliases, infer by name, or structurally compare unrelated unions.
- The nested-refusal test uses a heterogeneous variadic tuple field because function-typed fields can be represented by the checker as a named/compiler object sort and may not force a `MapTsTypeResult` failure. The important assertion is field provenance plus the inner mapper reason.
- DU registration failures now expose deeper corpus buckets. The audited 82-hit `alias IR1ForeachCondStmt: discriminated union could not be registered for tagged Pantagruel encoding` bucket is gone; newly visible reasons include nested `__unsupported_anon_record__`, invalid `escapedText` Pant sort, and recursion-guard provenance on TypeScript AST parent fields. These were intentionally not suppressed.
- `just ts2pant-precommit` passed, but Biome printed an unrelated nursery warning in `tools/ts2pant/src/purity.ts` about a regex missing the `u` flag. I did not change that file because the recipe exits successfully and it is outside this patch.

Spec/Evidence Mapping:
- `recursive-tagged-union ∧ nullable-recursive-view -> uses-reserved-domain`: implemented by `reservedRecursiveDomainForNullableUnion` in `tools/ts2pant/src/translate-types.ts`; covered by `tools/ts2pant/tests/recursive-union.test.mts`.
- `recursive-tagged-union ∧ nullable-recursive-view -> registration-succeeds`: implemented by the recursive DU reservation path plus nullable list-lift reuse; covered by unit fixture emission/typecheck and `tools/ts2pant/tests/integration/recursive-union.test.mts` z3 entailment when available.
- `registration-fails -> preserves-nested-reason`: implemented by `cellRegisterDiscriminatedUnionResult`; covered by `tools/ts2pant/tests/translate-types.test.mts`.
- `audited-corpus -> unsupported-registration-count = 0`: verified with `NODE_OPTIONS=--max-old-space-size=8192 npx tsx tools/ts2pant/scripts/corpus-diag.mts --summary-only`.